### PR TITLE
Change indentation settings for html and tmx files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,8 +5,10 @@
 *.h     diff=cpp
 *.idh   diff=cpp
 
-# Different settings for javascript files
-*.js whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2
+# Different settings for javascript, html and tmx files
+*.js   whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2
+*.htm* whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2
+*.tmx  whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2
 
 # Don't check (nor fix) whitespace for generated files
 *.csproj -whitespace


### PR DESCRIPTION
html and tmx files should be indented with 2 spaces instead of
tabs.
