### PR TITLE
Fix an error in NuGet.targets

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -37,7 +37,7 @@
 		<NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">"$(NuGetExePath)"</NuGetCommand>
 		<NuGetCommand Condition=" '$(OS)' != 'Windows_NT' ">mono --runtime=v4.0.30319 $(NuGetExePath)</NuGetCommand>
 
-		<PackageOutputDir Condition="$(PackageOutputDir) == ''">$(TargetDir.Trim('\\', '/')</PackageOutputDir>
+		<PackageOutputDir Condition="$(PackageOutputDir) == ''">$(TargetDir).Trim('\\', '/')</PackageOutputDir>
 
 		<RequireConsentSwitch Condition=" $(RequireRestoreConsent) == 'true' ">-RequireConsent</RequireConsentSwitch>
 		<NonInteractiveSwitch Condition=" '$(VisualStudioVersion)' != '' AND '$(OS)' == 'Windows_NT' ">-NonInteractive</NonInteractiveSwitch>


### PR DESCRIPTION
The missing parenthesis prevents building with newer versions of
MonoDevelop/xbuild.
