### PR TITLE
Error setting metadata of image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,4 +23,5 @@
 *.patch -whitespace
 *.svg -whitespace
 *.xml -whitespace
+*.htm -whitespace
 changelog -whitespace


### PR DESCRIPTION
Do not crash if inserting an image in a format that does not
support metadata. The first part of this fix is in libpalaso.
