### PR TITLE
Fix crash in New Collection Wizard

### DIFF
--- a/src/BloomExe/Wizard/WinForms/WizardControl.cs
+++ b/src/BloomExe/Wizard/WinForms/WizardControl.cs
@@ -70,6 +70,12 @@ namespace Bloom.Wizard.WinForms
 			set;
 		}
 
+		public string CancelButtonText
+		{
+			get { return _cancelButton.Text; }
+			set { _cancelButton.Text = value; }
+		}
+
 		public Icon TitleIcon
 		{
 			get;

--- a/src/BloomExe/Wizard/WizardAdapterControl.cs
+++ b/src/BloomExe/Wizard/WizardAdapterControl.cs
@@ -153,6 +153,8 @@ namespace Bloom.Wizard
 				SetNextButtonText = (value) => _winformsWizard.NextButtonText = value;
 				GetFinishButtonText= () => _winformsWizard.FinishButtonText;
 				SetFinishButtonText= (value) => _winformsWizard.FinishButtonText = value;
+				GetCancelButtonText = () => _winformsWizard.CancelButtonText;
+				SetCancelButtonText = (value) => _winformsWizard.CancelButtonText = value;
 				GetIcon = () => _winformsWizard.TitleIcon;
 				SetIcon = (icon) => _winformsWizard.TitleIcon = icon;
 


### PR DESCRIPTION
A recent change on the Windows side added a field to set the text
for the cancel button but didn't implement the Linux side.
This fixes BL-570/BL-571.
