### PR TITLE
Remove workarounds for BL-316

### DIFF
--- a/src/BloomExe/CollectionCreating/KindOfCollectionControl.cs
+++ b/src/BloomExe/CollectionCreating/KindOfCollectionControl.cs
@@ -14,11 +14,6 @@ namespace Bloom.CollectionCreating
 		public KindOfCollectionControl()
 		{
 			InitializeComponent();
-
-			//this is a work-around https://jira.sil.org/browse/BL-316 until we figure out why l10nsharp is dropping this one item
-			_sourceCollectionDescription.Text =
-				LocalizationManager.GetString("NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription",
-						"A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org and optionally make a BloomPack to give to others so that they can make vernacular books with your shells.");
 		}
 
 		private void _radioNormalVernacularCollection_CheckedChanged(object sender, System.EventArgs e)

--- a/src/BloomExe/CollectionTab/MakeReaderTemplateBloomPackDlg.cs
+++ b/src/BloomExe/CollectionTab/MakeReaderTemplateBloomPackDlg.cs
@@ -17,11 +17,6 @@ namespace Bloom.CollectionTab
 		{
 			InitializeComponent();
 			_willCarrySettingsOriginal = _willCarrySettingsLabel.Text;
-
-
-			//another work around for the problem described in https://jira.sil.org/browse/BL-316
-			_willCarrySettingsLabel.Text = LocalizationManager.GetString("ReaderTemplateBloomPackDialog.ExplanationParagraph",
-				"In addition, this BloomPack will carry your latest decodable and leveled reader settings for the \"{0}\" language. Anyone opening this BloomPack , who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this BloomPack. They will also get the current set of words for use in decodable readers.");
 		}
 
 		public void SetLanguage(string name)


### PR DESCRIPTION
Don't seem to be needed any more.
Presume L10NSharp has been fixed at some point.
