### PR TITLE
Update libpalaso and chorus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ lib/dotnet/Chorus*.*
 DistFiles/exiftool.exe
 Copy*.bat
 DistFiles/wkhtmltopdf/
+lib/wkhtmltopdf/
 lib/wkhtmltopdf-*.zip
 .nuget/NuGet.exe
 LibChorus.*

--- a/build/getDependencies-windows.sh
+++ b/build/getDependencies-windows.sh
@@ -209,6 +209,6 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/bt54/latest.last
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt54/latest.lastSuccessful/PdfSharp.dll ../lib/dotnet/PdfSharp.dll
 # extract downloaded zip files
 unzip -uqo ../Downloads/wkhtmltopdf-0.10.0_rc2.zip -d ../lib
-unzip -uqo ../Downloads/Mercurial.zip -d ../Mercurial
+unzip -uqo ../Downloads/Mercurial.zip -d ../.
 unzip -uqo ../Downloads/xulrunner-11.0.en-US.win32.zip -d ../lib
 # End of script

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -101,9 +101,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\DotNetZip.Reduced.1.9.1.8\lib\net20\Ionic.Zip.Reduced.dll</HintPath>
     </Reference>
-    <Reference Include="L10NSharp, Version=2.0.9.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="L10NSharp, Version=2.0.14.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\L10NSharp.2.0.9\lib\net40-Client\L10NSharp.dll</HintPath>
+      <HintPath>..\..\packages\L10NSharp.2.0.14\lib\net40-Client\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="LibChorus">
       <HintPath>..\..\lib\dotnet\LibChorus.dll</HintPath>

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -6,7 +6,7 @@
   <package id="DesktopAnalytics" version="1.1.2" targetFramework="net40-Client" />
   <package id="DotNetZip.Reduced" version="1.9.1.8" targetFramework="net40-Client" />
   <package id="HtmlAgilityPack" version="1.4.3" />
-  <package id="L10NSharp" version="2.0.9" targetFramework="net40-Client" />
+  <package id="L10NSharp" version="2.0.14" targetFramework="net40-Client" />
   <package id="Moq" version="4.0.10827" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net40-Client" />
   <package id="PdfDroplet" version="2.3.14.0" targetFramework="net40-Client" />


### PR DESCRIPTION
This fixes a problem in which certain versions of Bloom2
had a newer version of libpalaso and therefore had problems
upgrading to the latest version.

Do not merge until the TeamCity tags for libpalaso and chorus
which are currently bloom2test are changed to bloom2.
