### PR TITLE
In Decodable Reader, only normal-style defaults to large font

### DIFF
--- a/DistFiles/factoryCollections/Templates/Decodable Reader/Decodable Reader.css
+++ b/DistFiles/factoryCollections/Templates/Decodable Reader/Decodable Reader.css
@@ -2,11 +2,11 @@
  * The line height has to be specified on the bloom-editable div because the basic book template specifies
  * an absolute line-height of 1.3 which overrides anything we put on bloom-page.
  * I don't know why it doesn't work to put the font-size on bloom-editable, but it doesn't. */
-div.bloom-page {
-	font-size: 150%;
+div.bloom-page div.normal-style {
+	font-size: 22pt;
 }
-div.bloom-editable {
-	line-height: 1.5
+div.normal-style div.bloom-editable {
+	line-height: 1.5;
 }
 div.bloom-page div.pageLabel{
 	font-size: 10pt;


### PR DESCRIPTION
Other page elements including front/back matter were being affected
