### PR TITLE
Remove specific version number for L10NSharp

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -89,8 +89,8 @@
       <HintPath>..\..\lib\dotnet\Interop.Acrobat.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="L10NSharp, Version=2.0.13.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\L10NSharp.2.0.13\lib\net40-Client\L10NSharp.dll</HintPath>
+    <Reference Include="L10NSharp">
+      <HintPath>..\..\lib\dotnet\L10NSharp.dll</HintPath>
     </Reference>
     <Reference Include="LibChorus">
       <HintPath>..\..\lib\dotnet\LibChorus.dll</HintPath>

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -7,7 +7,6 @@
   <package id="DotNetZip.Reduced" version="1.9.1.8" targetFramework="net40-Client" />
   <package id="HtmlAgilityPack" version="1.4.3" />
   <package id="ICSharpCode.SharpZipLib.dll" version="0.85.4.369" targetFramework="net40-Client" />
-  <package id="L10NSharp" version="2.0.13" targetFramework="net40-Client" />
   <package id="Moq" version="4.0.10827" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net40-Client" />
   <package id="PdfDroplet" version="2.3.14.0" targetFramework="net40-Client" />


### PR DESCRIPTION
There is no reason to specify the version number here because
we get L10NSharp from the libpalaso build on TeamCity.
