### PR TITLE
BL-524: Stop crashing but report, while we figure out what's going on

### DIFF
--- a/src/BloomExe/HtmlThumbNailer.cs
+++ b/src/BloomExe/HtmlThumbNailer.cs
@@ -192,10 +192,11 @@ namespace Bloom
 			}
 			catch (Exception e)
 			{
-				Debug.Fail("Reproduction of BL-524: Crash making thumbnail?");
+				//Debug.Fail("Reproduction of BL-524: Crash making thumbnail?");
 				//otherwise, don't tell the user, just log and send exception if they're online
 				Logger.WriteEvent("***Error making thumbnail, possible bl-524 reproduction, swallowed. "+ e.Message);
 				Analytics.ReportException(e);
+				return new Size(0,0); // this tells the caller we failed
 			}
 
 			Guard.AgainstNull(browser.Document.ActiveElement, "browser.Document.ActiveElement");
@@ -251,6 +252,9 @@ namespace Bloom
 					return false;
 
 				var browserSize = SetWidthAndHeight(browser);
+				if (browserSize.Height == 0) //happens when we run into the as-yet-unreproduced-or-fixed bl-254
+					return false; // will try again later
+
 				try
 				{
 					Logger.WriteMinorEvent("HtmlThumNailer ({2}): browser.GetBitmap({0},{1})", browserSize.Width,


### PR DESCRIPTION
Since the user reports this is happening often, and  it looks like a timing bug, but we haven't been able to reproduce, this change catches the exception and causes a retry later.
