### PR TITLE
Update image overlays when copying copyright info

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -482,6 +482,8 @@ namespace Bloom.Edit
 							try
 							{
 								_model.CopyImageMetadataToWholeBook(dlg.Metadata);
+								// There might be more than one image on this page. Update overlays.
+								_model.RefreshDisplayOfCurrentPage();
 							}
 							catch (Exception e)
 							{


### PR DESCRIPTION
This fixes problems when multiple images are on the same page.
