### PR TITLE
Add SuppressFinalize calls to Dispose()

### DIFF
--- a/src/Bloom-ChorusPlugin/HtmlFileForMerging.cs
+++ b/src/Bloom-ChorusPlugin/HtmlFileForMerging.cs
@@ -36,6 +36,8 @@ namespace Bloom_ChorusPlugin
 		public void Dispose()
 		{
 			xmlFile.Dispose();
+
+			GC.SuppressFinalize(this);
 		}
 	}
 }

--- a/src/BloomExe/ApplicationContainer.cs
+++ b/src/BloomExe/ApplicationContainer.cs
@@ -88,6 +88,8 @@ namespace Bloom
 			{
 				_container.Dispose();
 				_container = null;
+
+				GC.SuppressFinalize(this);
 			}
 
 			public ProjectContext CreateProjectContext(string projectPath)

--- a/src/BloomExe/Collection/NaturalSortComparer.cs
+++ b/src/BloomExe/Collection/NaturalSortComparer.cs
@@ -94,6 +94,8 @@ namespace Bloom.Collection
 		{
 			table.Clear();
 			table = null;
+
+			GC.SuppressFinalize(this);
 		}
 	}
 }

--- a/src/BloomExe/HtmlThumbNailer.cs
+++ b/src/BloomExe/HtmlThumbNailer.cs
@@ -570,6 +570,8 @@ namespace Bloom
 			}
 			_browserCacheForDifferentPaperSizes.Clear();
 			_theOnlyOneAllowed = null;
+
+			GC.SuppressFinalize(this);
 		}
 
 		/// <summary>

--- a/src/BloomExe/ImageProcessing/LowResImageCache.cs
+++ b/src/BloomExe/ImageProcessing/LowResImageCache.cs
@@ -48,6 +48,8 @@ namespace Bloom.ImageProcessing
 			//NB: this turns out to be dangerous. Without it, we still delete all we can, leave some files around
 			//each time, and then deleting them on the next run
 			//			_cacheFolder.Dispose();
+
+			GC.SuppressFinalize(this);
 		}
 
 		private void TryToDeleteCachedImages()

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -414,6 +414,8 @@ namespace Bloom
 			if (_httpServer != null)
 				_httpServer.Dispose();
 			_httpServer = null;
+
+			GC.SuppressFinalize(this);
 		}
 
 		/// <summary>

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -207,6 +207,8 @@ namespace Bloom.Publish
 
 				}
 			}
+
+			GC.SuppressFinalize(this);
 		}
 
 		public BookletPortions BookletPortion { get; set; }

--- a/src/BloomExe/SendReceive/SendReceiver.cs
+++ b/src/BloomExe/SendReceive/SendReceiver.cs
@@ -134,6 +134,8 @@ namespace Bloom.SendReceive
 			if(_chorusSystem!=null)
 				_chorusSystem.Dispose();
 			_chorusSystem = null;
+
+			GC.SuppressFinalize(this);
 		}
 	}
 }

--- a/src/BloomExe/TempFiles.cs
+++ b/src/BloomExe/TempFiles.cs
@@ -179,7 +179,9 @@ namespace BloomTemp
 
 		public void Dispose()
 		{
-		   DeleteFolderThatMayBeInUse(_path);
+			DeleteFolderThatMayBeInUse(_path);
+
+			GC.SuppressFinalize(this);
 		}
 
 		[Obsolete("It's better to wrap the use of this in a using() so that it is automatically cleaned up, even if a test fails.")]

--- a/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
@@ -413,6 +413,8 @@ namespace Bloom.WebLibraryIntegration
 				_amazonS3.Dispose();
 				_amazonS3 = null;
 			}
+
+			GC.SuppressFinalize(this);
 		}
 
 	}

--- a/src/BloomTests/ToPalaso/MostRecentPathsTests.cs
+++ b/src/BloomTests/ToPalaso/MostRecentPathsTests.cs
@@ -37,6 +37,8 @@ namespace BloomTests.ToPalaso
 			public void Dispose()
 			{
 				File.Delete(FileName);
+
+				GC.SuppressFinalize(this);
 			}
 		}
 


### PR DESCRIPTION
Best practices suggest to add a SuppressFinalize call to the Dispose()
method. This tells the garbage collector that it doesn't have to call
the expensive finalizer on this object.
