### PR TITLE
Remove IDisposable from NaturalSortComparer

### DIFF
--- a/src/BloomExe/Collection/NaturalSortComparer.cs
+++ b/src/BloomExe/Collection/NaturalSortComparer.cs
@@ -8,7 +8,7 @@ namespace Bloom.Collection
 	/// From James McCormack, http://zootfroot.blogspot.com/2009/09/natural-sort-compare-with-linq-orderby.html
 	/// </summary>
 	/// <typeparam name="T"></typeparam>
-	public class NaturalSortComparer<T> : IComparer<string>, IDisposable
+	public class NaturalSortComparer<T> : IComparer<string>
 	{
 		private bool isAscending;
 
@@ -90,12 +90,5 @@ namespace Bloom.Collection
 
 		private Dictionary<string, string[]> table = new Dictionary<string, string[]>();
 
-		public void Dispose()
-		{
-			table.Clear();
-			table = null;
-
-			GC.SuppressFinalize(this);
-		}
 	}
 }


### PR DESCRIPTION
There is no reason that NaturalSortComparer should implement
IDisposable - it doesn't deal with unamanged objects or other
objects implement IDisposable. Having it derive from IDisposable
requires us to call the Dispose() method if we want to follow
best practices.
