### PR TITLE
BL-664: Use culture-invariant parse to compare version numbers

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Reflection;
@@ -195,10 +196,10 @@ namespace Bloom.Book
 				return "";// "This file lacks the following required element: <meta name='BloomFormatVersion' content='x.y'>";
 
 			float versionFloat = 0;
-			if (!float.TryParse(versionString, out versionFloat))
+			if (!float.TryParse(versionString, NumberStyles.Float, CultureInfo.InvariantCulture, out versionFloat))
 				return "This file claims a version number that isn't really a number: " + versionString;
 
-			if (versionFloat > float.Parse(kBloomFormatVersion))
+			if (versionFloat > float.Parse(kBloomFormatVersion, CultureInfo.InvariantCulture))
 				return string.Format("This book or template was made with a newer version of Bloom. Download the latest version of Bloom from bloomlibrary.org (format {0} vs. {1})", versionString, kBloomFormatVersion);
 
 			return null;


### PR DESCRIPTION
Prevents e.g. French culture choking on '2.0'
