### PR TITLE
Fix BookMergingTests

### DIFF
--- a/environ
+++ b/environ
@@ -75,5 +75,9 @@ export \
 # (See FWNX-1216.)  Tom Hindle suggested this hack as a stopgap.
 export MALLOC_CHECK_=0
 
+# set HGRCPATH so that we ignore ~/.hgrc files which might have content that is
+# incompatible with our version of Mercurial
+export HGRCPATH=
+
 #sets keyboard input method to none
 unset XMODIFIERS


### PR DESCRIPTION
Two tests were failing on my machine because Mercurial read the ~/.hgrc
file and couldn't load some enable extensions. This change sets the
HGRCPATH environment variable to the empty path which prevents loading
the ~/.hgrc file.
