### PR TITLE
Force paint of buttons with better tooltip by enable/disable

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -312,6 +312,13 @@ namespace Bloom.Edit
 				Application.Idle += new EventHandler(VisibleNowAddSlowContents);
 				Cursor = Cursors.WaitCursor;
 				Logger.WriteEvent("Entered Edit Tab");
+
+				if (Palaso.PlatformUtilities.Platform.IsLinux)
+				{
+					// This hack fixes a problem related to the better tooltip preventing the buttons from repainting.
+					// We do not have this problem in Windows, so no reason for extra overhead.
+					CycleEditButtons();
+				}
 			}
 			else
 			{

--- a/src/BloomExe/ToPalaso/BetterToolTip.cs
+++ b/src/BloomExe/ToPalaso/BetterToolTip.cs
@@ -20,6 +20,9 @@ namespace Bloom.ToPalaso
 	/// EnhancedToolTip supports the ToolTipWhenDisabled and SizeOfToolTipWhenDisabled
 	/// extender properties that can be used to show tooltip messages when the associated
 	/// control is disabled.
+	///
+	/// There is a problem with this class on Linux.  The transparent overlay seems to
+	/// prevent buttons from getting repainted. (https://jira.sil.org/browse/BL-348)
 	/// </summary>
 	public class BetterToolTip : ToolTip, ILocalizableComponent
 	{


### PR DESCRIPTION
This is more of a hack than a solution.  On Linux, the buttons
are not getting repainted when they have a disabled tooltip.
BL-348
