### PR TITLE
BL-663 Predefine Heading1 and Heading2 styles

### DIFF
--- a/DistFiles/factoryCollections/Sample Shells/Vaccinations/Basic Book.css
+++ b/DistFiles/factoryCollections/Sample Shells/Vaccinations/Basic Book.css
@@ -579,3 +579,12 @@ DIV.customPage.A5Portrait.bloom-monolingual DIV.bloom-translationGroup
 /*.customPage.bloom-bilingual DIV.bloom-translationGroup*/
 /*{*/
 /*}*/
+
+/* Predefined styles user can apply. Must not be !important otherwise they beat user mods; must be as specific as possible so they otherwise win */
+TEXTAREA.Heading1-style,  DIV.bloom-editable.Heading1-style{
+	font-size: 16pt;
+}
+TEXTAREA.Heading2-style,  DIV.bloom-editable.Heading2-style {
+	font-size: 13pt;
+	font-weight: bold;
+}

--- a/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.css
+++ b/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.css
@@ -579,3 +579,12 @@ DIV.customPage.A5Portrait.bloom-monolingual DIV.bloom-translationGroup
 /*.customPage.bloom-bilingual DIV.bloom-translationGroup*/
 /*{*/
 /*}*/
+
+/* Predefined styles user can apply. Must not be !important otherwise they beat user mods; must be as specific as possible so they otherwise win */
+TEXTAREA.Heading1-style,  DIV.bloom-editable.Heading1-style{
+	font-size: 16pt;
+}
+TEXTAREA.Heading2-style,  DIV.bloom-editable.Heading2-style {
+	font-size: 13pt;
+	font-weight: bold;
+}

--- a/src/BloomBrowserUI/bookEdit/js/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/js/StyleEditor.ts
@@ -182,23 +182,52 @@ class StyleEditor {
     }
 
     // Get the names that should be offered in the styles combo box.
-    // Basically any defined styles without dots in their definition (except the first one).
+    // Basically any defined styles without dots in their definition (except the first one)
+    // that come from stylesheets in the book folder (e.g., we don't want ones from editMode.css).
     // (We don't allow users to create styles with dot or any other special characters.)
+    // As a special case, styles defined on DIV.bloom-editable are allowed; this lets us predefine
+    // styles like Heading1 and Heading2 and make their selectors specific enough to work,
+    // but not impossible to override with a custom definition.
+    // Figuring out the book folder is problematic, since the page file does not actually live there.
+    // One stylesheet that is guaranteed to exist in the book folder for any editable book
+    // (created by the Book.cs constructor) is languageDisplay.css. So we look for that.
+    // (Also we use sheets with null href, that is, those in the page html file itself.)
     getFormattingStyles(): string[] {
         var result = [];
+        var folderPrefix;
+        for (var j = 0; j < document.styleSheets.length; j++) {
+            var href = <string>(<StyleSheet>(<any>document.styleSheets[j])).href;
+            if (href == null) continue;
+            var pos = href.indexOf("languageDisplay.css");
+            if (pos >= 0) {
+                folderPrefix = href.substring(0, pos);
+                break;
+            }
+        }
         for (var i = 0; i < document.styleSheets.length; i++) {
             var sheet = <StyleSheet>(<any>document.styleSheets[i]);
+            if (sheet.href != null && !sheet.href.startsWith(folderPrefix)) continue;
             var rules: CSSRuleList = (<any>sheet).cssRules;
             if (rules) {
                 for (var j = 0; j < rules.length; j++) {
                     var index = rules[j].cssText.indexOf('{');
                     if (index == -1) continue;
                     var label = rules[j].cssText.substring(0, index);
-                    var index2 = label.indexOf("-style");
-                    if (index2 > 0 && label.startsWith(".")) {
-                        var name = label.substring(1, index2);
-                        if (name.indexOf(".") == -1) {
-                            result.push(name);
+                    var index2 = label.lastIndexOf("-style");
+                    if (index2 > 0) {
+                        if (label.startsWith(".")) {
+                            var name = label.substring(1, index2);
+                            if (name.indexOf(".") == -1 && result.indexOf(name) == -1) {
+                                result.push(name);
+                            }
+                        } else {
+                            var index3 = label.lastIndexOf('.');
+                            var name = label.substring(index3 + 1, index2);
+                            var previous = label.substring(0, index3);
+                            var index4 = previous.indexOf("DIV.bloom-editable");
+                            if (index4 >= 0 && result.indexOf(name) == -1) {
+                                result.push(name);
+                            }
                         }
                     }
                 }
@@ -347,7 +376,7 @@ class StyleEditor {
     }
 
     getPointSizes() {
-        return ['7', '8', '9', '10', '11', '12', '14', '16', '18', '20', '22', '24', '26', '28', '36', '48', '72']; // Same options as Word 2010
+        return ['7', '8', '9', '10', '11', '12', '13', '14', '16', '18', '20', '22', '24', '26', '28', '36', '48', '72']; // Same options as Word 2010, plus 13 since used in heading2
     }
 
     getLineSpaceOptions() {

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -513,6 +513,16 @@ namespace Bloom.Book
 				if (!fileName.StartsWith("xx"))
 					//I use xx  as a convenience to temporarily turn off stylesheets during development
 				{
+					if (fileName == href)
+					{
+						// a local file ref, use the one in the book folder if it exists.
+						var localPath = Path.Combine(folderPath, fileName);
+						if (File.Exists(localPath))
+						{
+							linkNode.SetAttribute("href", localPath.ToLocalhost());
+							continue;
+						}
+					}
 					var path = fileLocator.LocateOptionalFile(fileName);
 
 					//we want these stylesheets to come from the book folder


### PR DESCRIPTION
Several other changes enable this.
- Define Heading1 and Heading2 in Basic Book.css
- Make the style finder skip files not in the book folder
  (gets rid of heading1 and heading2 from editMode.css)
  (also avoids user applying styles not defined in book's own folder)
  - required a change so that for css files that ARE in the book
    folder, we use those versions
- Make the style finder accept style rules containing
  DIV.bloom-editable
