### PR TITLE
BL-663 Predefine Heading1 and Heading2 styles

### DIFF
--- a/DistFiles/xMatter/BigBook-XMatter/editMode.css
+++ b/DistFiles/xMatter/BigBook-XMatter/editMode.css
@@ -461,15 +461,16 @@ UL.toolbox LI
 	display: inline-block;
 	width: 162px;
 }
-.heading1-style
-{
-	font-weight: bold;
-	font-size: 14pt;
+/* Predefined styles user can apply. Must not be !important otherwise they beat user mods; must be as specific as possible so they otherwise win.
+	A lower-case version of these styles was previously defined as part of an experiment in allowing the user to drag things onto a page;
+	that may need adjustment for the renaming if it is revived.
+*/
+TEXTAREA.Heading1-style,  DIV.bloom-editable.Heading1-style{
+	font-size: 16pt;
 }
-.heading2-style
-{
-	font-weight: bold;
+TEXTAREA.Heading2-style,  DIV.bloom-editable.Heading2-style {
 	font-size: 13pt;
+	font-weight: bold;
 }
 .centered
 {

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -183,8 +183,10 @@ class StyleEditor {
     }
 
     // Get the names that should be offered in the styles combo box.
-    // Basically any defined styles without dots in their definition (except the first one).
-    // (We don't allow users to create styles with dot or any other special characters.)
+    // Basically any defined rules for classes that end in -style.
+    // Only the last class in a sequence is used; this lets us predefine
+    // styles like DIV.bloom-editing.Heading1 and make their selectors specific enough to work,
+    // but not impossible to override with a custom definition.
     getFormattingStyles(): string[] {
         var result = [];
         for (var i = 0; i < document.styleSheets.length; i++) {
@@ -194,21 +196,53 @@ class StyleEditor {
                 for (var j = 0; j < rules.length; j++) {
                     var index = rules[j].cssText.indexOf('{');
                     if (index == -1) continue;
-                    var label = rules[j].cssText.substring(0, index);
-                    var index2 = label.indexOf("-style");
-                    if (index2 > 0 && label.startsWith(".")) {
-                        var name = label.substring(1, index2);
-                        if (name.indexOf(".") == -1) {
+                    var label = rules[j].cssText.substring(0, index).trim();
+                    var index2 = label.lastIndexOf('-style');
+                    if (index2 !== -1 && index2 == label.length - '-style'.length) { // ends in -style
+                        var index3 = label.lastIndexOf('.');
+                        var name = label.substring(index3+1, index2);
+                        if (result.indexOf(name) == -1) {
                             result.push(name);
                         }
                     }
                 }
             }
         }
-        // It's bizarre not to offer 'normal' since that's the standard initial style.
-        // But in fact our default template doesn't define it.
+        // 'normal' is the standard initial style for at least origami pages.
+        // But our default template doesn't define it; by default it just has default properties.
+        // Make sure it's available to choose again.
         if (result.indexOf('normal') == -1) {
             result.push('normal');
+        }
+        return result;
+    }
+
+    // Get the existing rule for the specified style.
+    // Will return null if the style has no definition, OR if it already has a user-defined version
+    getPredefinedStyle(target: string) {
+        var result = null;
+        for (var i = 0; i < document.styleSheets.length; i++) {
+            var sheet = <StyleSheet>(<any>document.styleSheets[i]);
+            var rules: CSSRuleList = (<any>sheet).cssRules;
+            if (rules) {
+                for (var j = 0; j < rules.length; j++) {
+                    var index = rules[j].cssText.indexOf('{');
+                    if (index == -1) continue;
+                    var label = rules[j].cssText.substring(0, index).trim();
+                    if (label.indexOf(target) >= 0) {
+                        // We have a rule for our target!
+                        // Is this the user-defined stylesheet?
+                        if ((<StyleSheet>(<any>document.styleSheets[i]).ownerNode).title == "userModifiedStyles") {
+                            return null; // style already has a user definition
+                        } else {
+                            // return the last one we find.
+                            // This is not strictly sound, there COULD be many rules for this style which each
+                            // contribute different properties. Choosing not to handle this case.
+                            result = rules[j];
+                        }
+                    }
+                }
+            }
         }
         return result;
     }
@@ -253,7 +287,15 @@ class StyleEditor {
                 styleAndLang = styleName + ":not([lang])";
         }
         for (var i = 0; i < x.length; i++) {
-            if (x[i].cssText.indexOf(styleAndLang) > -1) {
+            var index = x[i].cssText.indexOf('{');
+            if (index == -1) continue;
+            var match = x[i].cssText.substring(0, index);
+            // if we're not ignoring language, we simply need a match for styleAndLang, which includes a lang component.
+            // if we're ignoring language, we must find a rule that doesn't specify language at all, even if we
+            // have one that does.
+            // It's probably pathological to worry about the style name occurring in the body of some other rule,
+            // especially with the -style suffix, but it seems safer not to risk it.
+            if (match.indexOf(styleAndLang) > -1 && (!ignoreLanguage || match.indexOf('[lang') == -1)) {
                 return <CSSStyleRule> x[i];
             }
         }
@@ -348,7 +390,7 @@ class StyleEditor {
     }
 
     getPointSizes() {
-        return ['7', '8', '9', '10', '11', '12', '14', '16', '18', '20', '22', '24', '26', '28', '36', '48', '72']; // Same options as Word 2010
+        return ['7', '8', '9', '10', '11', '12', '13', '14', '16', '18', '20', '22', '24', '26', '28', '36', '48', '72']; // Same options as Word 2010, plus 13 since used in heading2
     }
 
     getLineSpaceOptions() {
@@ -550,8 +592,6 @@ class StyleEditor {
                 $('#word-space-select').change(function () { editor.changeWordSpace(); });
                 editor.AddQtipToElement($('#word-space-select').parent(), localizationManager.getText('EditTab.StyleEditor.WordSpacingToolTip', 'Change the spacing between words'), 1500);
                 if (editor.authorMode) {
-                    $('#border-select').change(function() { editor.changeBorderSelect(); });
-                    editor.AddQtipToElement($('#border-select').parent(), localizationManager.getText('EditTab.StyleEditor.BorderToolTip', 'Change the border and background'), 1500);
                     $('#styleSelect').change(function() { editor.selectStyle(); });
                     (<alphanumInterface>$('#style-select-input')).alphanum({ allowSpace: false, preventLeadingNumeric: true });
                     $('#style-select-input').on('input', function() { editor.styleInputChanged(); }); // not .change(), only fires on loss of focus
@@ -562,19 +602,13 @@ class StyleEditor {
                         return false;
                     });
                     $('#create-button').click(function() { editor.createStyle(); });
-                    var buttonIds = ['bold', 'italic', 'underline', 'position-leading', 'position-center', 'border-none', 'border-black', 'border-black-round', 'border-gray', 'border-gray-round', 'background-none', 'background-gray'];
+                    var buttonIds = editor.getButtonIds();
                     for (var idIndex = 0; idIndex < buttonIds.length; idIndex++) {
                         var button = $('#' + buttonIds[idIndex]);
                         button.click(function() { editor.buttonClick(this); });
                         button.addClass('propButton');
                     }
-                    editor.selectButton('bold', current.bold);
-                    editor.selectButton('italic', current.italic);
-                    editor.selectButton('underline', current.underline);
-                    editor.selectButton('position-center', current.center);
-                    editor.selectButton('position-leading', !current.center);
-                    editor.selectButton('border-' + current.borderChoice, true);
-                    editor.selectButton('background-' + current.backColor, true);
+                    editor.selectButtons(current);
                     new WebFXTabPane($('#tabRoot').get(0), false, function(n) {
                         editor.tabSelected(n);
                     });
@@ -603,6 +637,19 @@ class StyleEditor {
         });
 
         editor.AttachLanguageTip($(targetBox), bottom);
+    }
+
+    getButtonIds() {
+        return ['bold', 'italic', 'underline', 'position-leading', 'position-center', 'border-none', 'border-black', 'border-black-round', 'border-gray', 'border-gray-round', 'background-none', 'background-gray'];
+    }
+    selectButtons(current) {
+        this.selectButton('bold', current.bold);
+        this.selectButton('italic', current.italic);
+        this.selectButton('underline', current.underline);
+        this.selectButton('position-center', current.center);
+        this.selectButton('position-leading', !current.center);
+        this.selectButton('border-' + current.borderChoice, true);
+        this.selectButton('background-' + current.backColor, true);
     }
 
     makeCharactersContent(fonts, current): string {
@@ -777,6 +824,15 @@ class StyleEditor {
     createStyle() {
         var typedStyle = $('#style-select-input').val();
         StyleEditor.SetStyleNameForElement(this.boxBeingEdited, typedStyle + '-style');
+        this.updateStyle();
+
+        // Insert it into our list and the option control on the second page.
+        this.insertOption(typedStyle);
+        //$('#styleSelect option:eq(' + typedStyle + ')').prop('selected', true);
+        $('#styleSelect').val(typedStyle);
+    }
+
+    updateStyle() {
         this.changeFont();
         this.changeSize();
         this.changeLineheight();
@@ -787,11 +843,6 @@ class StyleEditor {
         this.changeUnderline();
         this.changeBackground();
         this.changePosition();
-
-        // Insert it into our list and the option control on the second page.
-        this.insertOption(typedStyle);
-        //$('#styleSelect option:eq(' + typedStyle + ')').prop('selected', true);
-        $('#styleSelect').val(typedStyle);
         this.styleStateChange('initial'); // go back to initial state so user knows it worked
     }
 
@@ -943,20 +994,61 @@ class StyleEditor {
         this.cleanupAfterStyleChange();
     }
 
+    getSettings(ruleInput: string) : string[] {
+        var index1 = ruleInput.indexOf('{');
+        var rule = ruleInput;
+        if (index1 >= 0) {
+            rule = rule.substring(index1 + 1, rule.length);
+            rule = rule.replace("}", "").trim();
+        }
+        return rule.split(";");
+    }
+
     selectStyle() {
         var style = $('#styleSelect').val();
         $('#style-select-input').val(""); // we've chosen a style from the list, so we aren't creating a new one.
         StyleEditor.SetStyleNameForElement(this.boxBeingEdited, style + "-style");
+        var predefined = this.getPredefinedStyle(style + "-style");
+        if (predefined) {
+            // doesn't exist in user-defined yet; need to copy it there
+            // (so it works even if from a stylesheet not part of the book)
+            // and make defined settings !important so they win over anything else.
+            var rule = this.getStyleRule(true);
+            var settings = this.getSettings(predefined.cssText);
+            for (var j = 0; j < settings.length; j++) {
+                var parts = settings[j].split(':');
+                if (parts.length != 2) continue; // often a blank item after last semi-colon
+                var selector = parts[0].trim();
+                var val = parts[1].trim();
+                var index2 = val.indexOf('!');
+                if (index2 >= 0) {
+                    val = val.substring(0, index2);
+                }
+                // per our standard convention, font-family is only ever specified for a specific language.
+                // If we're applying a style, we're in author mode, and all other settings apply to all languages.
+                // Even if we weren't in author mode, the factory definition of a style should be language-neutral,
+                // so we'd want to insert it into our book that way.
+                if (selector == 'font-family') {
+                    this.getStyleRule(false).style.setProperty(selector, val, "important");
+                } else {
+                    // review: may be desirable to do something if val is not one of the values
+                    // we can generate, or just possibly if selector is not one of the ones we manipulate.
+                    rule.style.setProperty(selector, val, "important");
+                }
+            }
+        }
+        // Now update all the controls to reflect the effect of applying this style.
         var current = this.getFormatValues();
-        // There's no point in updating the style definition as a side effect of updating the controls.
-        // Doing so might well even make a real change, because the controls can only be an approximation
-        // of the settings that can be achieved using raw stylesheet editing.
         this.ignoreControlChanges = true;
         $('#font-select').val(current.fontName);
         $('#size-select').val(current.ptSize);
         $('#line-height-select').val(current.lineHeight);
         $('#word-space-select').val(current.wordSpacing);
-        $('#border-select').val(current.borderChoice);
+        var buttonIds = this.getButtonIds();
+        for (var i = 0; i < buttonIds.length; i++) {
+            $('#' + buttonIds[i]).removeClass('selectedIcon');
+        }
+        this.selectButtons(current);
         this.ignoreControlChanges = false;
         this.cleanupAfterStyleChange();
     }

--- a/src/BloomBrowserUI/bookEdit/css/editMode.css
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.css
@@ -401,15 +401,12 @@ UL.toolbox LI
 	display: inline-block;
 	width: 162px;
 }
-.heading1-style
-{
-	font-weight: bold;
-	font-size: 14pt;
+TEXTAREA.Heading1-style,  DIV.bloom-editable.Heading1-style{
+	font-size: 16pt;
 }
-.heading2-style
-{
-	font-weight: bold;
+TEXTAREA.Heading2-style,  DIV.bloom-editable.Heading2-style {
 	font-size: 13pt;
+	font-weight: bold;
 }
 .centered
 {


### PR DESCRIPTION
Several other changes enable this.
- Replace defns of heading1 and heading2 in editMode.css
- Make the style finder smarter about only styles ending in -style,
  and ignoring anything before the last dot.
- When a style is first applied, copy its explicit settings
  into user-defined and make them !important.
