### PR TITLE
BL-705: Restrict the range of pages 'printed' to make PDF

### DIFF
--- a/src/BloomExe/Publish/ConversionOrder.cs
+++ b/src/BloomExe/Publish/ConversionOrder.cs
@@ -48,6 +48,10 @@ namespace GeckofxHtmlToPdf
 		//[Args.ArgsMemberSwitch("R", "-margin-right")]
 		public string RightMargin { get; set; }
 
+		[Description("1-based index of last page to print;-1 to print all")]
+		[DefaultValue(-1)]
+		public int LastPage { get; set; }
+
 		private double GetMillimeters(string distance)
 		{
 			//TODO: convert to mm. For now, just strips "mm"

--- a/src/BloomExe/Publish/GeckofxHtmlToPDFComponent.cs
+++ b/src/BloomExe/Publish/GeckofxHtmlToPDFComponent.cs
@@ -228,6 +228,12 @@ namespace GeckofxHtmlToPdf
 
 			printSettings.SetPrintBGColorsAttribute(true);
 			printSettings.SetPrintBGImagesAttribute(true);
+			if (_conversionOrder.LastPage > 0)
+			{
+				printSettings.SetPrintRangeAttribute(1); // specified range
+				printSettings.SetStartPageRangeAttribute(1);
+				printSettings.SetEndPageRangeAttribute(_conversionOrder.LastPage);
+			}
 
 
 			//TODO: doesn't seem to do anything. Probably a problem in the geckofx wrapper

--- a/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfComponent.cs
+++ b/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfComponent.cs
@@ -19,7 +19,7 @@ namespace Bloom.Publish
 	class MakePdfUsingGeckofxHtmlToPdfComponent
 	{
 		public void MakePdf(string inputHtmlPath, string outputPdfPath, string paperSizeName,
-			bool landscape, Control owner, BackgroundWorker worker, DoWorkEventArgs doWorkEventArgs)
+			bool landscape, Control owner, BackgroundWorker worker, DoWorkEventArgs doWorkEventArgs, int pageCount)
 		{
 			ConversionProgress progress = null;
 			try
@@ -37,7 +37,12 @@ namespace Bloom.Publish
 					Landscape = landscape,
 					InputHtmlPath = inputHtmlPath,
 					OutputPdfPath = tempOutput.Path,
-					PageSizeName = paperSizeName
+					PageSizeName = paperSizeName,
+					// We always want to print all the pages. However, for a reason we have not been able to determine,
+					// Gecko sometimes adds a blank page at the end (so far observed only when printing the interior
+					// pages of an A5 booklet). This messes up the PDFDroplet page arrangement. Explicitly specifying
+					// the page range by using the LastPage property prevents this. See BL-705.
+					LastPage = pageCount
 				};
 				using (var waitHandle = new AutoResetEvent(false))
 				{

--- a/src/BloomExe/Publish/PdfMaker.cs
+++ b/src/BloomExe/Publish/PdfMaker.cs
@@ -40,7 +40,10 @@ namespace Bloom.Publish
 		/// <param name="worker">If not null, the Background worker which is running this task, and may be queried to determine whether a cancel is being attempted</param>
 		/// <param name="doWorkEventArgs">The event passed to the worker when it was started. If a cancel is successful, it's Cancel property should be set true.</param>
 		/// <param name="owner">A control which can be used to invoke parts of the work which must be done on the ui thread.</param>
-		public void MakePdf(string inputHtmlPath, string outputPdfPath, string paperSizeName, bool landscape, PublishModel.BookletLayoutMethod booketLayoutMethod, PublishModel.BookletPortions bookletPortion, BackgroundWorker worker, DoWorkEventArgs doWorkEventArgs, Control owner)
+		/// <param name="pageCount">optional count of pages in document. If -1, ignored.</param>
+		public void MakePdf(string inputHtmlPath, string outputPdfPath, string paperSizeName, bool landscape, PublishModel.BookletLayoutMethod booketLayoutMethod,
+			PublishModel.BookletPortions bookletPortion, BackgroundWorker worker, DoWorkEventArgs doWorkEventArgs, Control owner,
+			int pageCount = -1)
 		{
 			Guard.Against(Path.GetExtension(inputHtmlPath) != ".htm",
 						  "wkhtmtopdf will croak if the input file doesn't have an htm extension.");
@@ -51,7 +54,7 @@ namespace Bloom.Publish
 			for (int i = 0; i < 4; i++)
 			{
 				new MakePdfUsingGeckofxHtmlToPdfComponent().MakePdf(inputHtmlPath, outputPdfPath, paperSizeName, landscape,
-					owner, worker, doWorkEventArgs);
+					owner, worker, doWorkEventArgs, pageCount);
 
 				if (doWorkEventArgs.Cancel || (doWorkEventArgs.Result != null && doWorkEventArgs.Result is Exception))
 					return;

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -96,7 +96,8 @@ namespace Bloom.Publish
 
 			try
 			{
-				using(var tempHtml = MakeFinalHtmlForPdfMaker())
+				int pageCount;
+				using(var tempHtml = MakeFinalHtmlForPdfMaker(out pageCount))
 				{
 					if (doWorkEventArgs.Cancel)
 						return;
@@ -108,7 +109,7 @@ namespace Bloom.Publish
 						layoutMethod = BookSelection.CurrentSelection.GetDefaultBookletLayout();
 
 					_pdfMaker.MakePdf(tempHtml.Path, PdfFilePath, PageLayout.SizeAndOrientation.PageSizeName, PageLayout.SizeAndOrientation.IsLandScape,
-									  layoutMethod, BookletPortion, worker, doWorkEventArgs, View);
+									  layoutMethod, BookletPortion, worker, doWorkEventArgs, View, pageCount);
 				}
 			}
 			catch (Exception e)
@@ -122,11 +123,11 @@ namespace Bloom.Publish
 		}
 
 
-		private TempFile MakeFinalHtmlForPdfMaker()
+		private TempFile MakeFinalHtmlForPdfMaker(out int pageCount)
 		{
 			PdfFilePath = GetPdfPath(Path.GetFileName(_currentlyLoadedBook.FolderPath));
 
-			XmlDocument dom = BookSelection.CurrentSelection.GetDomForPrinting(BookletPortion, _currentBookCollectionSelection.CurrentSelection, _bookServer);
+			XmlDocument dom = BookSelection.CurrentSelection.GetDomForPrinting(BookletPortion, _currentBookCollectionSelection.CurrentSelection, _bookServer, out pageCount);
 
 			HtmlDom.AddPublishClassToBody(dom);
 			HtmlDom.AddHidePlaceHoldersClassToBody(dom);
@@ -329,7 +330,8 @@ namespace Bloom.Publish
 
 //			System.Diagnostics.Process.Start(tempHtml.Path);
 
-			var htmlFilePath = MakeFinalHtmlForPdfMaker().Path;
+			int pageCount;
+			var htmlFilePath = MakeFinalHtmlForPdfMaker(out pageCount).Path;
 			if (Palaso.PlatformUtilities.Platform.IsWindows)
 				Process.Start("Firefox.exe", htmlFilePath);
 			else


### PR DESCRIPTION
Restrict the range of pages printed to the ones that actually exist,
which prevents Gecko adding an extra blank one.
