### PR TITLE
BL-673: Sample Texts folder opens under existing open windows

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,8 @@ Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  mono-sil, libgdiplus-sil, geckofx29,
  chmsee,
  fonts-sil-andika,
- optipng
+ optipng,
+ wmctrl
 Suggests: art-of-reading
 Description: Literacy materials development for language communities
  Bloom Desktop is an application that dramatically "lowers the bar" for

--- a/src/BloomExe/web/ReadersHandler.cs
+++ b/src/BloomExe/web/ReadersHandler.cs
@@ -289,7 +289,24 @@ namespace Bloom.web
 			var path = Path.Combine(Path.GetDirectoryName(CurrentBook.CollectionSettings.SettingsFilePath), "Sample Texts");
 			if (!Directory.Exists(path))
 				Directory.CreateDirectory(path);
+
 			PathUtilities.OpenDirectoryInExplorer(path);
+
+			// BL-673: Make sure the folder comes to the front in Linux
+			if (Palaso.PlatformUtilities.Platform.IsLinux)
+			{
+				// allow the external process to execute
+				System.Threading.Thread.Sleep(100);
+
+				// if the system has wmctrl installed, use it to bring the folder to the front
+				Process.Start(new ProcessStartInfo()
+					{
+						FileName = "wmctrl",
+						Arguments = "-a \"Sample Texts\"",
+						UseShellExecute = false,
+						ErrorDialog = false // do not show a message if not successful
+					});
+			}
 		}
 	}
 }


### PR DESCRIPTION
There is no way to bring another program to the front using just Mono on Linux. Actually, the same goes for Windows - you have to use API calls to reliably bring it to the front. However, if the Linux system has a package called "xdotools" installed, it can be done easily.
