### PR TITLE
BL-674, 717 Format Dialog

### DIFF
--- a/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.htm
+++ b/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.htm
@@ -27,7 +27,7 @@
       <div class="marginBox">
         <div class="bloom-imageContainer bloom-leadingElement"><img src="placeHolder.png" alt="Could not load the picture"/>
         </div>
-        <div class="bloom-translationGroup bloom-trailingElement Normal-style">
+        <div class="bloom-translationGroup bloom-trailingElement normal-style">
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable">
           </div>
         </div>
@@ -36,13 +36,13 @@
     <div class="A5Portrait bloom-page numberedPage bloom-combinedPage imageInMiddle" data-page="extra" id="5dcd48df-e9ab-4a07-afd4-6a24d0398383">
       <div lang="en" class="pageLabel">Picture in Middle</div>
       <div class="marginBox">
-        <div class="bloom-translationGroup bloom-trailingElement Normal-style">
+        <div class="bloom-translationGroup bloom-trailingElement normal-style">
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable">
           </div>
         </div>
         <div class="bloom-imageContainer bloom-leadingElement"><img src="placeHolder.png" alt="Could not load the picture"/>
         </div>
-        <div class="bloom-translationGroup bloom-trailingElement Normal-style">
+        <div class="bloom-translationGroup bloom-trailingElement normal-style">
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable">
           </div>
         </div>
@@ -51,7 +51,7 @@
     <div class="A5Portrait bloom-page numberedPage bloom-combinedPage imageOnBottom" data-page="extra" id="5dcd48df-e9ab-4a07-afd4-6a24d0398384">
       <div lang="en" class="pageLabel">Picture On Bottom</div>
       <div class="marginBox">
-        <div class="bloom-translationGroup bloom-trailingElement Normal-style">
+        <div class="bloom-translationGroup bloom-trailingElement normal-style">
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable">
           </div>
         </div>
@@ -69,7 +69,7 @@
     <div class="A5Portrait bloom-page numberedPage textWholePage" data-page="extra" id="d31c38d8-c1cb-4eb9-951b-d2840f6a8bdb">
       <div lang="en" class="pageLabel">Just Text</div>
       <div class="marginBox">
-        <div class="bloom-translationGroup bloom-trailingElement Normal-style">
+        <div class="bloom-translationGroup bloom-trailingElement normal-style">
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable">
           </div>
         </div>
@@ -80,7 +80,7 @@
       <div class="marginBox">
         <div class="bloom-imageContainer bloom-leadingElement"><img src="placeHolder.png" alt="Could not load the picture"/>
         </div>
-        <div class="bloom-translationGroup bloom-trailingElement Big-Words-style">
+        <div class="bloom-translationGroup bloom-trailingElement BigWords-style">
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable">
           </div>
         </div>

--- a/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.jade
+++ b/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.jade
@@ -7,7 +7,7 @@ mixin image-leading
 //- items marked with 'bloom-trailingElement' will be on the right page of a side-by-side layout
 mixin field-trailing
 	//- Is default-style needed? Yes, but it needs to be normal-style. (BL-26)
-	+field(attributes).bloom-trailingElement.Normal-style
+	+field(attributes).bloom-trailingElement.normal-style
 
 doctype html
 html
@@ -55,7 +55,7 @@ html
 
 		+page-choice('Picture & Word').pictureAndWordPage#FD115DFF-0415-4444-8E76-3D2A18DBBD27
 			+image-leading
-			+field(attributes).bloom-trailingElement.Big-Words-style
+			+field(attributes).bloom-trailingElement.BigWords-style
 
 		+page-choice-layout('Custom').customPage#5dcd48df-e9ab-4a07-afd4-6a24d0398386
 			.split-pane-component-inner

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
@@ -98,7 +98,7 @@ var StyleEditor = (function () {
         // In case this is one of those books, we'll replace it with 'normal-style'
         if (styleName == 'default-style') {
             $(target).removeClass(styleName);
-            styleName = 'normal-style';
+            styleName = 'normal-style'; // This will be capitalized before presenting it to the user.
             $(target).addClass(styleName);
         }
         return styleName;
@@ -172,6 +172,7 @@ var StyleEditor = (function () {
     // Only the last class in a sequence is used; this lets us predefine
     // styles like DIV.bloom-editing.Heading1 and make their selectors specific enough to work,
     // but not impossible to override with a custom definition.
+    // N.B. these are not the final user-visible versions of style names, but the internal version.
     StyleEditor.prototype.getFormattingStyles = function () {
         var result = [];
         for (var i = 0; i < document.styleSheets.length; i++) {
@@ -199,7 +200,7 @@ var StyleEditor = (function () {
         // But our default template doesn't define it; by default it just has default properties.
         // Make sure it's available to choose again.
         if (result.indexOf('normal') == -1) {
-            result.push('normal');
+            result.push('normal'); // This will be capitalized before presenting it to the user.
         }
         return result;
     };
@@ -505,8 +506,11 @@ var StyleEditor = (function () {
         formatButton.click(function () {
             iframeChannel.simpleAjaxGet('/bloom/availableFontNames', function (fontData) {
                 editor.boxBeingEdited = targetBox;
+
+                // This line is needed inside the click function to keep from using a stale version of 'styleName'
+                // and chopping off 6 characters each time!
+                styleName = StyleEditor.GetStyleNameForElement(targetBox);
                 styleName = styleName.substr(0, styleName.length - 6); // strip off '-style'
-                styleName = styleName.replace(/-/g, ' '); //show users a space instead of dashes
                 var current = editor.getFormatValues();
 
                 //alert('font: ' + fontName + ' size: ' + sizeString + ' height: ' + lineHeight + ' space: ' + wordSpacing);
@@ -816,6 +820,10 @@ var StyleEditor = (function () {
             if (current == items[i])
                 selected = ' selected';
             var text = items[i];
+            text = text.replace(/-/g, ' '); //show users a space instead of dashes
+            if (text == 'normal') {
+                text = 'Normal'; // capitalize for user
+            }
             if (maxlength && text.length > maxlength) {
                 text = text.substring(0, maxlength) + "...";
             }

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -115,7 +115,7 @@ class StyleEditor {
         // In case this is one of those books, we'll replace it with 'normal-style'
         if (styleName == 'default-style') {
             $(target).removeClass(styleName);
-            styleName = 'normal-style';
+            styleName = 'normal-style'; // This will be capitalized before presenting it to the user.
             $(target).addClass(styleName);
         }
         return styleName;
@@ -188,6 +188,7 @@ class StyleEditor {
     // Only the last class in a sequence is used; this lets us predefine
     // styles like DIV.bloom-editing.Heading1 and make their selectors specific enough to work,
     // but not impossible to override with a custom definition.
+    // N.B. these are not the final user-visible versions of style names, but the internal version.
     getFormattingStyles(): string[] {
         var result = [];
         for (var i = 0; i < document.styleSheets.length; i++) {
@@ -213,14 +214,14 @@ class StyleEditor {
         // But our default template doesn't define it; by default it just has default properties.
         // Make sure it's available to choose again.
         if (result.indexOf('normal') == -1) {
-            result.push('normal');
+            result.push('normal'); // This will be capitalized before presenting it to the user.
         }
         return result;
     }
 
     // Get the existing rule for the specified style.
     // Will return null if the style has no definition, OR if it already has a user-defined version
-    getPredefinedStyle(target: string) {
+    getPredefinedStyle(target: string): CSSRule {
         var result = null;
         for (var i = 0; i < document.styleSheets.length; i++) {
             var sheet = <StyleSheet>(<any>document.styleSheets[i]);
@@ -514,8 +515,10 @@ class StyleEditor {
         formatButton.click(function () {
             iframeChannel.simpleAjaxGet('/bloom/availableFontNames', function (fontData) {
                 editor.boxBeingEdited = targetBox;
+                // This line is needed inside the click function to keep from using a stale version of 'styleName'
+                // and chopping off 6 characters each time!
+                styleName = StyleEditor.GetStyleNameForElement(targetBox);
                 styleName = styleName.substr(0, styleName.length - 6); // strip off '-style'
-                styleName = styleName.replace(/-/g, ' '); //show users a space instead of dashes
                 var current = editor.getFormatValues();
 
                 //alert('font: ' + fontName + ' size: ' + sizeString + ' height: ' + lineHeight + ' space: ' + wordSpacing);
@@ -859,6 +862,10 @@ class StyleEditor {
             var selected: string = "";
             if (current == items[i]) selected = ' selected';
             var text = items[i];
+            text = text.replace(/-/g, ' '); //show users a space instead of dashes
+            if (text == 'normal') {
+                text = 'Normal'; // capitalize for user
+            }
             if (maxlength && text.length > maxlength) {
                 text = text.substring(0, maxlength) + "...";
             }


### PR DESCRIPTION
- Picture & Word now uses BigWords style
- 'normal-style' is presented to the user as 'Normal'
- fixed a bug where the Format Dialog current style kept getting chopped off each time
  the dialog was opened on the text box
