### PR TITLE
Fix BL-734 & BL-712, allow windows UNC paths

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -328,7 +328,9 @@ namespace Bloom.Book
 			{
 				Logger.WriteEvent("Renaming folder from '{0}' to '{1}'", FolderPath, newFolderPath);
 
-				Palaso.IO.DirectoryUtilities.MoveDirectorySafely(FolderPath, newFolderPath);
+				//This one can't handle network paths and isn't necessary, since we know these are on the same volume:
+				//Palaso.IO.DirectoryUtilities.MoveDirectorySafely(FolderPath, newFolderPath);
+				Directory.Move(FolderPath, newFolderPath);
 
 				_fileLocator.RemovePath(FolderPath);
 				_fileLocator.AddPath(newFolderPath);


### PR DESCRIPTION
There may be more path-related issues that will turn up with testing,
but this gets us past the obvious creation/editing/saving of a book
on //localhost, so that testing can commence.

This can be merged now, but half of the fix is in libpalaso, PR 131.
