### PR TITLE
Fix BL-756: "multilingual settings" instead of "one language"

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -326,9 +326,13 @@ namespace Bloom.Edit
 					}
 				}
 				//update the selections
-				_contentLanguages.Where(l => l.Iso639Code == _collectionSettings.Language2Iso639Code).First().Selected =
+				_contentLanguages.First(l => l.Iso639Code == _collectionSettings.Language2Iso639Code).Selected =
 					_bookSelection.CurrentSelection.MultilingualContentLanguage2 ==_collectionSettings.Language2Iso639Code;
 
+				//the first language is always selected. This covers the common situation in shellbook collections where
+				//we have English as both the 1st and national language. https://jira.sil.org/browse/BL-756
+				_contentLanguages.First(l => l.Iso639Code == _collectionSettings.Language1Iso639Code).Selected = true;
+					
 
 				var contentLanguageMatchingNatLan2 =
 					_contentLanguages.Where(l => l.Iso639Code == _collectionSettings.Language3Iso639Code).FirstOrDefault();


### PR DESCRIPTION
The problem was when both Lang1 and Lang2 were the same (e.g. English)
the code would say that lang2 was unselected by default, thus also
deselecting lang1.
