### PR TITLE
Fix BL-685: problems with getting proper language displayed on cover

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -86,6 +86,8 @@ namespace Bloom.Book
 			_bookData = new BookData(OurHtmlDom,
 					_collectionSettings, UpdateImageMetadataAttributes);
 
+			InjectStringListingActiveLanguagesOfBook(); 
+
 			if (IsEditable && !HasFatalError)
 			{
 				_bookData.SynchronizeDataItemsThroughoutDOM();

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -103,7 +103,7 @@ namespace Bloom.Collection
 			set
 			{
 				_language1Iso639Code = value;
-				Language1Name = GetLanguage1Name(Language2Iso639Code);
+				Language1Name = GetLanguage1Name_NoCache(Language2Iso639Code);
 			}
 		}
 
@@ -125,6 +125,11 @@ namespace Bloom.Collection
 			if(!string.IsNullOrEmpty(this.Language1Name))
 				return Language1Name;
 
+			return GetLanguage1Name_NoCache(inLanguage);
+		}
+
+		private string GetLanguage1Name_NoCache(string inLanguage)
+		{
 			Iso639LanguageCode exactLanguageMatch = _lookupIsoCode.GetExactLanguageMatch(Language1Iso639Code);
 			if (exactLanguageMatch == null)
 				return "L1-Unknown-" + Language1Iso639Code;

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -109,12 +109,22 @@ namespace BloomTests.Book
 			_thumbnailer.Object.Dispose();
 		}
 
-		private Bloom.Book.Book CreateBook()
+		private Bloom.Book.Book CreateBook(CollectionSettings collectionSettings)
 		{
-			_collectionSettings = new CollectionSettings(new NewCollectionSettings() { PathToSettingsFile = CollectionSettings.GetPathForNewSettings(_testFolder.Path, "test"), Language1Iso639Code = "xyz", Language2Iso639Code = "en", Language3Iso639Code = "fr" });
+			_collectionSettings = collectionSettings;
 			return new Bloom.Book.Book(_metadata, _storage.Object, _templateFinder.Object,
 				_collectionSettings,
 				_thumbnailer.Object, _pageSelection.Object, _pageListChangedEvent, new BookRefreshEvent());
+		}
+
+		private Bloom.Book.Book CreateBook()
+		{
+			return CreateBook(CreateDefaultCollectionsSettings());
+		}
+
+		private CollectionSettings CreateDefaultCollectionsSettings()
+		{
+			return new CollectionSettings(new NewCollectionSettings() { PathToSettingsFile = CollectionSettings.GetPathForNewSettings(_testFolder.Path, "test"), Language1Iso639Code = "xyz", Language2Iso639Code = "en", Language3Iso639Code = "fr" });
 		}
 
 //        [Test]
@@ -1199,6 +1209,16 @@ namespace BloomTests.Book
 			var book = CreateBook();
 			var title = (XmlElement)book.RawDom.SelectSingleNodeHonoringDefaultNS("//title");
 			Assert.AreEqual("original", title.InnerText);
+		}
+
+		[Test]
+		public void Constructor_LanguagesOfBookIsSet()
+		{
+			var collectionSettings = CreateDefaultCollectionsSettings();
+			collectionSettings.Language1Iso639Code = "en";
+			var book = CreateBook(collectionSettings);
+			var langs = book.RawDom.SelectSingleNode("//div[@id='bloomDataDiv']/div[@data-book='languagesOfBook']") as XmlElement;
+			Assert.AreEqual("English", langs.InnerText);
 		}
 
 		private void MakeSamplePngImageWithMetadata(string path)

--- a/src/BloomTests/Collection/CollectionSettingsTests.cs
+++ b/src/BloomTests/Collection/CollectionSettingsTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Bloom.Collection;
+using NUnit.Framework;
+
+namespace BloomTests.Collection
+{
+	[TestFixture]
+	public class CollectionSettingsTests
+	{
+		/// <summary>
+		/// This is a regression test related to https://jira.sil.org/browse/BL-685.
+		/// Apparently calculating the name is expensive, so it is cached. This
+		/// test ensures that the cache doesn't keep the name from tracking the iso.
+		/// </summary>
+		[Test]
+		public void Language1IsoCodeChanged_NameChangedToo()
+		{
+			var info = new NewCollectionSettings()
+			{
+				Language1Iso639Code = "fr"
+			};
+			var settings = new CollectionSettings(info);
+			Assert.AreEqual("French", settings.GetLanguage1Name("en"));
+			settings.Language1Iso639Code = "en";
+			Assert.AreEqual("English", settings.GetLanguage1Name("en"));
+		}
+	}
+}


### PR DESCRIPTION
The real fix here was just to have the Bloom constructor call
InjectStringListingActiveLanguagesOfBook(). Before this only happened
if you did an UpdateBook or fiddled with the multilingual settings.
The rest is just adding tests and small renaming for clarity.
