### PR TITLE
Fix BL-398: Right-To-Left order in PDF Booklets

### DIFF
--- a/DistFiles/ReleaseNotes.md
+++ b/DistFiles/ReleaseNotes.md
@@ -1,4 +1,15 @@
-﻿## 3.0.69 BETA (Windows Only)
+﻿## 3.0.70 BETA (Windows Only)
+
+If the Vernacular language is right-to-left, PDF Booklets will be ordered so that they work back-to-front.
+Fixed "sticky" scrollbar on page template list and Art Of Reading gallery.
+Fixed problems with opening books over a network.
+Fixed problems with the front-cover language.
+Fixed problem with booklet pdfs.
+Language picker: when picking a language and there are more than 2 countries, now says, .e.g. "4 countries".
+Language picker: when picking a language, you can now have major spelling differences and it will still find the language.
+Book colors will now always stay the same (until we add the option of selecting the color you want).
+
+## 3.0.69 BETA (Windows Only)
 
 The Help menu now has has a "Report Problem" command.
 Now installs the newly updated Andika version 5.

--- a/src/BloomExe/Publish/PdfMaker.cs
+++ b/src/BloomExe/Publish/PdfMaker.cs
@@ -28,19 +28,20 @@ namespace Bloom.Publish
 		/// </summary>
 		public bool ShowCropMarks;
 
-		/// <summary>
-		///
-		/// </summary>
+		///  <summary>
+		/// 
+		///  </summary>
 		/// <param name="inputHtmlPath"></param>
 		/// <param name="outputPdfPath"></param>
 		/// <param name="paperSizeName">A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,B0,B1,B10,B2,B3,B4,B5,B6,B7,B8,B9,C5E,Comm10E,DLE,Executive,Folio,Ledger,Legal,Letter,Tabloid</param>
 		/// <param name="landscape"> </param>
+		/// <param name="layoutPagesForRightToLeft"></param>
 		/// <param name="booketLayoutMethod"> </param>
 		/// <param name="bookletPortion"></param>
 		/// <param name="worker">If not null, the Background worker which is running this task, and may be queried to determine whether a cancel is being attempted</param>
 		/// <param name="doWorkEventArgs">The event passed to the worker when it was started. If a cancel is successful, it's Cancel property should be set true.</param>
 		/// <param name="owner">A control which can be used to invoke parts of the work which must be done on the ui thread.</param>
-		public void MakePdf(string inputHtmlPath, string outputPdfPath, string paperSizeName, bool landscape, PublishModel.BookletLayoutMethod booketLayoutMethod, PublishModel.BookletPortions bookletPortion, BackgroundWorker worker, DoWorkEventArgs doWorkEventArgs, Control owner)
+		public void MakePdf(string inputHtmlPath, string outputPdfPath, string paperSizeName, bool landscape, bool layoutPagesForRightToLeft, PublishModel.BookletLayoutMethod booketLayoutMethod, PublishModel.BookletPortions bookletPortion, BackgroundWorker worker, DoWorkEventArgs doWorkEventArgs, Control owner)
 		{
 			Guard.Against(Path.GetExtension(inputHtmlPath) != ".htm",
 						  "wkhtmtopdf will croak if the input file doesn't have an htm extension.");
@@ -73,7 +74,7 @@ namespace Bloom.Publish
 			if (bookletPortion != PublishModel.BookletPortions.AllPagesNoBooklet)
 			{
 				//remake the pdf by reording the pages (and sometimes rotating, shrinking, etc)
-				MakeBooklet(outputPdfPath, paperSizeName, booketLayoutMethod);
+				MakeBooklet(outputPdfPath, paperSizeName, booketLayoutMethod, layoutPagesForRightToLeft);
 			}
 		}
 
@@ -108,13 +109,14 @@ namespace Bloom.Publish
 			return 1.04;
 		}
 
-		/// <summary>
-		///
-		/// </summary>
+		///  <summary>
+		/// 
+		///  </summary>
 		/// <param name="pdfPath">this is the path where it already exists, and the path where we leave the transformed version</param>
 		/// <param name="incomingPaperSize"></param>
 		/// <param name="booketLayoutMethod"></param>
-		private void MakeBooklet(string pdfPath, string incomingPaperSize, PublishModel.BookletLayoutMethod booketLayoutMethod)
+		/// <param name="layoutPagesForRightToLeft"></param>
+		private void MakeBooklet(string pdfPath, string incomingPaperSize, PublishModel.BookletLayoutMethod booketLayoutMethod, bool layoutPagesForRightToLeft)
 		{
 			//TODO: we need to let the user chose the paper size, as they do in PdfDroplet.
 			//For now, just assume a size double the original
@@ -150,8 +152,6 @@ namespace Bloom.Publish
 					throw new ApplicationException("PdfMaker.MakeBooklet() does not contain a map from " + incomingPaperSize + " to a PdfSharp paper size.");
 			}
 
-
-
 			using (var incoming = new TempFile())
 			{
 				File.Delete(incoming.Path);
@@ -177,7 +177,7 @@ namespace Bloom.Publish
 				}
 				var paperTarget = new PaperTarget("ZZ"/*we're not displaying this anyhwere, so we don't need to know the name*/, pageSize);
 				var pdf = XPdfForm.FromFile(incoming.Path);//REVIEW: this whole giving them the pdf and the file too... I checked once and it wasn't wasting effort...the path was only used with a NullLayout option
-				method.Layout(pdf, incoming.Path, pdfPath, paperTarget, /*TODO: rightToLeft*/ false, ShowCropMarks);
+				method.Layout(pdf, incoming.Path, pdfPath, paperTarget, layoutPagesForRightToLeft, ShowCropMarks);
 			}
 		}
 	}

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -107,7 +107,7 @@ namespace Bloom.Publish
 					else
 						layoutMethod = BookSelection.CurrentSelection.GetDefaultBookletLayout();
 
-					_pdfMaker.MakePdf(tempHtml.Path, PdfFilePath, PageLayout.SizeAndOrientation.PageSizeName, PageLayout.SizeAndOrientation.IsLandScape,
+					_pdfMaker.MakePdf(tempHtml.Path, PdfFilePath, PageLayout.SizeAndOrientation.PageSizeName, PageLayout.SizeAndOrientation.IsLandScape, LayoutPagesForRightToLeft,
 									  layoutMethod, BookletPortion, worker, doWorkEventArgs, View);
 				}
 			}
@@ -121,6 +121,11 @@ namespace Bloom.Publish
 			}
 		}
 
+		private bool LayoutPagesForRightToLeft
+		{
+			get { return _collectionSettings.IsLanguage1Rtl;  }
+
+		}
 
 		private TempFile MakeFinalHtmlForPdfMaker()
 		{

--- a/src/BloomTests/PdfMakerTests.cs
+++ b/src/BloomTests/PdfMakerTests.cs
@@ -47,7 +47,7 @@ namespace BloomTests
 				File.WriteAllText(input.Path, "<html><body>Hello</body></html>");
 				File.Delete(output.Path);
 				RunMakePdf((worker, args, owner) =>
-					maker.MakePdf(input.Path, output.Path, "a5", false, PublishModel.BookletLayoutMethod.SideFold,
+					maker.MakePdf(input.Path, output.Path, "a5", false,false, PublishModel.BookletLayoutMethod.SideFold,
 						PublishModel.BookletPortions.AllPagesNoBooklet, worker, args, owner));
 				//we don't actually have a way of knowing it did a booklet
 				Assert.IsTrue(File.Exists(output.Path));
@@ -78,7 +78,7 @@ namespace BloomTests
 				File.WriteAllText(input.Path, "<html><body>Hello</body></html>");
 				File.Delete(output.Path);
 				RunMakePdf((worker, args, owner) =>
-					maker.MakePdf(input.Path, output.Path, "A5", false, PublishModel.BookletLayoutMethod.SideFold, PublishModel.BookletPortions.BookletPages, worker, args, owner));
+					maker.MakePdf(input.Path, output.Path, "A5", false, false, PublishModel.BookletLayoutMethod.SideFold, PublishModel.BookletPortions.BookletPages, worker, args, owner));
 				//we don't actually have a way of knowing it did a booklet
 				Assert.IsTrue(File.Exists(output.Path));
 			}
@@ -97,7 +97,7 @@ namespace BloomTests
 				File.WriteAllText(input.Path, "<html><body>北京</body></html>");
 				File.Delete(output.Path);
 				RunMakePdf((worker, args, owner) =>
-					maker.MakePdf(input.Path, output.Path, "A5", false, PublishModel.BookletLayoutMethod.SideFold, PublishModel.BookletPortions.BookletPages, worker, args, owner));
+					maker.MakePdf(input.Path, output.Path, "A5", false, false, PublishModel.BookletLayoutMethod.SideFold, PublishModel.BookletPortions.BookletPages, worker, args, owner));
 				//we don't actually have a way of knowing it did a booklet
 				Assert.IsTrue(File.Exists(output.Path));
 			}
@@ -113,7 +113,7 @@ namespace BloomTests
 				File.WriteAllText(input.Path, "<META HTTP-EQUIV=\"content-type\" CONTENT=\"text/html; charset=utf-8\"><html><body>എന്റെ ബുക്ക്</body></html>");
 				File.Delete(output.Path);
 				RunMakePdf((worker, args, owner) =>
-					maker.MakePdf(input.Path, output.Path, "A5", false, PublishModel.BookletLayoutMethod.SideFold, PublishModel.BookletPortions.BookletPages, worker, args, owner));
+					maker.MakePdf(input.Path, output.Path, "A5", false, false, PublishModel.BookletLayoutMethod.SideFold, PublishModel.BookletPortions.BookletPages, worker, args, owner));
 				//we don't actually have a way of knowing it did a booklet
 				Assert.IsTrue(File.Exists(output.Path));
 			}


### PR DESCRIPTION
When Language1 (e.g. the vernacular is marked as RTL), and we make
a booklet, now asks PdfDroplet to lay out the pages accordingly.
