### PR TITLE
Fix extra pages in PDF of big books (BL-561)

### DIFF
--- a/DistFiles/xMatter/BigBook-XMatter/BigBook-XMatter.css
+++ b/DistFiles/xMatter/BigBook-XMatter/BigBook-XMatter.css
@@ -3,6 +3,7 @@
 {
 	/*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
 	height: 188.2mm;
+	position: absolute; /* see https://jira.sil.org/browse/BL-561; Without this we get an extra page in the PDF. */
 }
 .Title-On-Cover-style
 {


### PR DESCRIPTION
On Linux the PDF of big books had extra pages for the front matters.
A similar fix as for BL-390 is needed in this case as well.
