### PR TITLE
Add NoLongerUsed to tmx files to match English

### DIFF
--- a/DistFiles/localization/Bloom.ar.tmx
+++ b/DistFiles/localization/Bloom.ar.tmx
@@ -176,6 +176,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.BookMakingTab.RightToLeft">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>Right To Left</seg>
       </tuv>
@@ -184,6 +185,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.BookMakingTab.RightToLeftTip">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>Select languages that are written from right to left</seg>
       </tuv>
@@ -1801,6 +1803,7 @@
       </tuv>
     </tu>
     <tu tuid="LeveledReaderTool.ConceptLoad">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Concept load</seg>
@@ -2919,6 +2922,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts1">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>About Word Lists and Sample TextsWhen you place text files in your sample texts folder, the Decodable Reader Tool can find words to suggest while you are creating your readers.</seg>
@@ -2928,6 +2932,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts2">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have a word list for you language yet? Consider using SIL's free WeSay software and the RapidWords.net technique to easily collect lots of words and get started on a dictionary.</seg>
@@ -2937,6 +2942,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts4">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have texts for your language yet? Check out SIL's free SayMore software. With it you can record people and then transcribe what they said.</seg>

--- a/DistFiles/localization/Bloom.es.tmx
+++ b/DistFiles/localization/Bloom.es.tmx
@@ -123,6 +123,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.BookMakingTab.Font">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>Font</seg>
       </tuv>
@@ -139,6 +140,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.BookMakingTab._aboutBookMakingSettingsButton">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>About These Settings</seg>
       </tuv>
@@ -198,6 +200,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.LanguageTab._aboutLanguageSettingsButton">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>About These Settings</seg>
       </tuv>
@@ -278,6 +281,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.ProjectInformationTab._aboutProjectInformationSetingsButton">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>About These Settings</seg>
       </tuv>
@@ -618,6 +622,7 @@
       </tuv>
     </tu>
     <tu tuid="ConfirmRecycleDialog.ConfirmRecycleWindowTitle">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>Confirm Delete</seg>
       </tuv>
@@ -635,6 +640,7 @@
       </tuv>
     </tu>
     <tu tuid="ConfirmRecycleDialog.deleteBtn">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>&amp;Delete</seg>
       </tuv>
@@ -1512,6 +1518,7 @@
       </tuv>
     </tu>
     <tu tuid="LoginDialog.label3">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>label3</seg>
       </tuv>

--- a/DistFiles/localization/Bloom.fr.tmx
+++ b/DistFiles/localization/Bloom.fr.tmx
@@ -3361,6 +3361,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts1">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>About Word Lists and Sample TextsWhen you place text files in your sample texts folder, the Decodable Reader Tool can find words to suggest while you are creating your readers.</seg>
@@ -3370,6 +3371,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts2">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have a word list for you language yet? Consider using SIL's free WeSay software and the RapidWords.net technique to easily collect lots of words and get started on a dictionary.</seg>
@@ -3379,6 +3381,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts4">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have texts for your language yet? Check out SIL's free SayMore software. With it you can record people and then transcribe what they said.</seg>

--- a/DistFiles/localization/Bloom.hi.tmx
+++ b/DistFiles/localization/Bloom.hi.tmx
@@ -1937,6 +1937,7 @@
       </tuv>
     </tu>
     <tu tuid="LeveledReaderTool.ConceptLoad">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Concept load</seg>
@@ -1964,6 +1965,7 @@
       </tuv>
     </tu>
     <tu tuid="LeveledReaderTool.HowToMakeLeveledReader">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>How to make a great leveled reader</seg>
@@ -2018,6 +2020,7 @@
       </tuv>
     </tu>
     <tu tuid="LeveledReaderTool.PatternAndRecognition">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Pattern and recognition</seg>
@@ -2081,6 +2084,7 @@
       </tuv>
     </tu>
     <tu tuid="LeveledReaderTool.TopicFamiliarity">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Topic familiarity</seg>
@@ -2182,6 +2186,7 @@
       </tuv>
     </tu>
     <tu tuid="LoginDialog.label3">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>label3</seg>
       </tuv>
@@ -3090,6 +3095,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts1">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>About Word Lists and Sample TextsWhen you place text files in your sample texts folder, the Decodable Reader Tool can find words to suggest while you are creating your readers.</seg>
@@ -3099,6 +3105,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts2">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have a word list for you language yet? Consider using SIL's free WeSay software and the RapidWords.net technique to easily collect lots of words and get started on a dictionary.</seg>
@@ -3108,6 +3115,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts4">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have texts for your language yet? Check out SIL's free SayMore software. With it you can record people and then transcribe what they said.</seg>

--- a/DistFiles/localization/Bloom.rw.tmx
+++ b/DistFiles/localization/Bloom.rw.tmx
@@ -157,6 +157,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.BookMakingTab.Font">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>Font</seg>
       </tuv>
@@ -173,6 +174,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.BookMakingTab._aboutBookMakingSettingsButton">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>About These Settings</seg>
       </tuv>
@@ -241,6 +243,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.LanguageTab._aboutLanguageSettingsButton">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>About These Settings</seg>
       </tuv>
@@ -321,6 +324,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.ProjectInformationTab._aboutProjectInformationSetingsButton">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>About These Settings</seg>
       </tuv>
@@ -660,6 +664,7 @@
       </tuv>
     </tu>
     <tu tuid="ConfirmRecycleDialog.ConfirmRecycleWindowTitle">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>Confirm Delete</seg>
       </tuv>
@@ -1700,6 +1705,7 @@
       </tuv>
     </tu>
     <tu tuid="LoginDialog.label3">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>label3</seg>
       </tuv>

--- a/DistFiles/localization/Bloom.ta.tmx
+++ b/DistFiles/localization/Bloom.ta.tmx
@@ -550,6 +550,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionTab.PNG Animal Stories - Copy">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>PNG Animal Stories - Copy</seg>
@@ -2063,6 +2064,7 @@
       </tuv>
     </tu>
     <tu tuid="LeveledReaderTool.TopicFamiliarity">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Topic familiarity</seg>
@@ -2164,6 +2166,7 @@
       </tuv>
     </tu>
     <tu tuid="LoginDialog.label3">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>label3</seg>
       </tuv>
@@ -3082,6 +3085,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts1">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>About Word Lists and Sample TextsWhen you place text files in your sample texts folder, the Decodable Reader Tool can find words to suggest while you are creating your readers.</seg>
@@ -3091,6 +3095,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts2">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have a word list for you language yet? Consider using SIL's free WeSay software and the RapidWords.net technique to easily collect lots of words and get started on a dictionary.</seg>
@@ -3100,6 +3105,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts4">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have texts for your language yet? Check out SIL's free SayMore software. With it you can record people and then transcribe what they said.</seg>

--- a/DistFiles/localization/Bloom.te.tmx
+++ b/DistFiles/localization/Bloom.te.tmx
@@ -1937,6 +1937,7 @@
       </tuv>
     </tu>
     <tu tuid="LeveledReaderTool.ConceptLoad">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Concept load</seg>
@@ -1964,6 +1965,7 @@
       </tuv>
     </tu>
     <tu tuid="LeveledReaderTool.HowToMakeLeveledReader">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>How to make a great leveled reader</seg>
@@ -2018,6 +2020,7 @@
       </tuv>
     </tu>
     <tu tuid="LeveledReaderTool.PatternAndRecognition">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Pattern and recognition</seg>
@@ -2081,6 +2084,7 @@
       </tuv>
     </tu>
     <tu tuid="LeveledReaderTool.TopicFamiliarity">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Topic familiarity</seg>
@@ -2182,6 +2186,7 @@
       </tuv>
     </tu>
     <tu tuid="LoginDialog.label3">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>label3</seg>
       </tuv>
@@ -3089,6 +3094,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts1">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>About Word Lists and Sample TextsWhen you place text files in your sample texts folder, the Decodable Reader Tool can find words to suggest while you are creating your readers.</seg>
@@ -3098,6 +3104,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts2">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have a word list for you language yet? Consider using SIL's free WeSay software and the RapidWords.net technique to easily collect lots of words and get started on a dictionary.</seg>
@@ -3107,6 +3114,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts4">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have texts for your language yet? Check out SIL's free SayMore software. With it you can record people and then transcribe what they said.</seg>

--- a/DistFiles/localization/Bloom.zh-Hans.tmx
+++ b/DistFiles/localization/Bloom.zh-Hans.tmx
@@ -31,6 +31,7 @@
       </tuv>
     </tu>
     <tu tuid="Accordion.LeveledReaderToolCheckbox">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Leveled Reader Tool</seg>
@@ -148,6 +149,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.BookMakingTab.Font">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>Default Font for Language 3</seg>
       </tuv>
@@ -164,6 +166,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.BookMakingTab._aboutBookMakingSettingsButton">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>About These Settings</seg>
       </tuv>
@@ -232,6 +235,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.LanguageTab._aboutLanguageSettingsButton">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>About These Settings</seg>
       </tuv>
@@ -312,6 +316,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionSettingsDialog.ProjectInformationTab._aboutProjectInformationSetingsButton">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>About These Settings</seg>
       </tuv>
@@ -492,6 +497,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionTab.PNG Animal Stories - Copy">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>PNG Animal Stories - Copy</seg>
@@ -543,6 +549,7 @@
       </tuv>
     </tu>
     <tu tuid="CollectionTab.Zaza Reader Templates">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Zaza Reader Templates</seg>
@@ -1742,6 +1749,7 @@
       </tuv>
     </tu>
     <tu tuid="LoginDialog.label3">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>label3</seg>
       </tuv>
@@ -2625,6 +2633,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts1">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>About Word Lists and Sample TextsWhen you place text files in your sample texts folder, the Decodable Reader Tool can find words to suggest while you are creating your readers.</seg>
@@ -2634,6 +2643,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts2">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have a word list for you language yet? Consider using SIL's free WeSay software and the RapidWords.net technique to easily collect lots of words and get started on a dictionary.</seg>
@@ -2643,6 +2653,7 @@
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.AboutSampleTexts4">
+      <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Don't have texts for your language yet? Check out SIL's free SayMore software. With it you can record people and then transcribe what they said.</seg>
@@ -3519,6 +3530,7 @@
       </tuv>
     </tu>
     <tu tuid="button3">
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>button3</seg>
       </tuv>


### PR DESCRIPTION
Along with the PR in L10NSharp, this should make sure that the localization dialog doesn't bring up any strings that are NoLongerUsed in the English tmx file.
