### PR TITLE
BL-642, Don't use <base> in temp files

### DIFF
--- a/src/BloomBrowserUI/bookEdit/EditViewFrame.htm
+++ b/src/BloomBrowserUI/bookEdit/EditViewFrame.htm
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
   <head>
     <meta charset="UTF-8">
@@ -17,7 +17,8 @@
       $(document).ready(function () {
        // The iframe communication channel needs to be initialized before the child documents are loaded.
        interIframeChannel = new interIframeChannel();
-       document.getElementById('page').src = '/bloom/currentPageContent';
+       // {simulatedPageFileInBookFolder} is replaced by EditingModel.GetXmlDocumentForEditScreenWebPage().
+       document.getElementById('page').src = '{simulatedPageFileInBookFolder}';
        document.getElementById('accordion').src = '/bloom/accordionContent';
       });
     </script>

--- a/src/BloomBrowserUI/bookEdit/EditViewFrame.jade
+++ b/src/BloomBrowserUI/bookEdit/EditViewFrame.jade
@@ -18,7 +18,8 @@ html
 			$(document).ready(function () {
 				// The iframe communication channel needs to be initialized before the child documents are loaded.
 				interIframeChannel = new interIframeChannel();
-				document.getElementById('page').src = '/bloom/currentPageContent';
+				// {simulatedPageFileInBookFolder} is replaced by EditingModel.GetXmlDocumentForEditScreenWebPage().
+				document.getElementById('page').src = '{simulatedPageFileInBookFolder}';
 				document.getElementById('accordion').src = '/bloom/accordionContent';
 			});
 		style(type='text/css')

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -385,6 +385,7 @@
     <Compile Include="ImageProcessing\ImageServer.cs" />
     <Compile Include="UpdateVersionTable.cs" />
     <Compile Include="WebLibraryIntegration\BookDownloadSupport.cs" />
+    <Compile Include="web\SimulatedPageFile.cs" />
     <Compile Include="web\I18NHandler.cs" />
     <Compile Include="web\ReadersHandler.cs" />
     <Compile Include="Wizard\WinForms\WizardControl.cs">

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -370,7 +370,7 @@ namespace Bloom.Book
 			return pageDom;
 		}
 
-		public XmlDocument GetPreviewXmlDocumentForFirstPage()
+		public HtmlDom GetPreviewXmlDocumentForFirstPage()
 		{
 			if (_log.ErrorEncountered)
 			{
@@ -380,7 +380,7 @@ namespace Bloom.Book
 			var bookDom = GetBookDomWithStyleSheets("previewMode.css","thumbnail.css");
 
 			HideEverythingButFirstPageAndRemoveScripts(bookDom.RawDom);
-			return bookDom.RawDom;
+			return bookDom;
 		}
 
 		private static void HideEverythingButFirstPageAndRemoveScripts(XmlDocument bookDom)
@@ -1604,7 +1604,7 @@ namespace Bloom.Book
 			return -1;
 		}
 
-		public XmlDocument GetDomForPrinting(PublishModel.BookletPortions bookletPortion, BookCollection currentBookCollection, BookServer bookServer)
+		public HtmlDom GetDomForPrinting(PublishModel.BookletPortions bookletPortion, BookCollection currentBookCollection, BookServer bookServer)
 		{
 			var printingDom = GetBookDomWithStyleSheets("previewMode.css", "origami.css");
 			//dom.LoadXml(OurHtmlDom.OuterXml);
@@ -1621,7 +1621,7 @@ namespace Bloom.Book
 			//when we make a PDF, because we wan the PDF to use the original hi-res versions
 
 			var pathSafeForWkHtml2Pdf = Palaso.IO.FileUtils.MakePathSafeFromEncodingProblems(FolderPath);
-			BookStorage.SetBaseForRelativePaths(printingDom, pathSafeForWkHtml2Pdf, false);
+			BookStorage.SetBaseForRelativePaths(printingDom, pathSafeForWkHtml2Pdf);
 
 			switch (bookletPortion)
 			{
@@ -1638,7 +1638,7 @@ namespace Bloom.Book
 			}
 			AddCoverColor(printingDom, Color.White);
 			AddPreviewJScript(printingDom);
-			return printingDom.RawDom;
+			return printingDom;
 		}
 
 		/// <summary>

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -262,7 +262,7 @@ namespace Bloom.Book
 			AssertIsAlreadyInitialized();
 			string tempPath = Path.GetTempFileName();
 			MakeCssLinksAppropriateForStoredFile(dom);
-			SetBaseForRelativePaths(dom, string.Empty, false);// remove any dependency on this computer, and where files are on it.
+			SetBaseForRelativePaths(dom, string.Empty);// remove any dependency on this computer, and where files are on it.
 			//CopyXMatterStylesheetsIntoFolder
 			return XmlHtmlConverter.SaveDOMAsHtml5(dom.RawDom, tempPath);
 		}
@@ -278,7 +278,7 @@ namespace Bloom.Book
 
 			HtmlDom relocatableDom = Dom.Clone();
 
-			SetBaseForRelativePaths(relocatableDom, _folderPath, true);
+			SetBaseForRelativePaths(relocatableDom, _folderPath);
 			EnsureHasLinksToStylesheets(relocatableDom);
 			UpdateStyleSheetLinkPaths(relocatableDom, _fileLocator, log);
 
@@ -295,7 +295,7 @@ namespace Bloom.Book
 		{
 			var relocatableDom = dom.Clone();
 
-			SetBaseForRelativePaths(relocatableDom, _folderPath, true);
+			SetBaseForRelativePaths(relocatableDom, _folderPath);
 			EnsureHasLinksToStylesheets(relocatableDom);
 			UpdateStyleSheetLinkPaths(relocatableDom, _fileLocator, log);
 
@@ -504,28 +504,23 @@ namespace Bloom.Book
 			return string.Empty;
 		}
 
-		public static void SetBaseForRelativePaths(HtmlDom dom, string folderPath, bool pointAtEmbeddedServer)
+		public static void SetBaseForRelativePaths(HtmlDom dom, string folderPath)
 		{
 			string path = "";
 			if (!string.IsNullOrEmpty(folderPath))
 			{
-				if (pointAtEmbeddedServer && Settings.Default.ImageHandler == "http" && ImageServer.IsAbleToUsePort)
-				{
-					//this is only used by relative paths, and only img src's are left relative.
-					//we are redirecting through our build-in httplistener in order to shrink
-					//big images before giving them to gecko which has trouble with really hi-res ones
-					var uri = folderPath + Path.DirectorySeparatorChar;
-					uri = uri.Replace(":", "%3A");
-					uri = uri.Replace('\\', '/');
-					uri = ImageServer.PathEndingInSlash + uri;
-					path = uri;
-				}
-				else
-				{
-					path = "file://" + folderPath + Path.DirectorySeparatorChar;
-				}
+				//this is only used by relative paths, and only img src's are left relative.
+				//we are redirecting through our build-in httplistener in order to make white backgrounds transparent
+				// and possibly shrink
+				//big images before giving them to gecko which has trouble with really hi-res ones
+				//Some clients don't want low-res images and can suppress this by setting HtmlDom.UseOriginalImages.
+				var uri = folderPath + Path.DirectorySeparatorChar;
+				uri = uri.Replace(":", "%3A");
+				uri = uri.Replace('\\', '/');
+				uri = ImageServer.PathEndingInSlash + uri;
+				path = uri;
 			}
-			dom.SetBaseForRelativePaths(path);
+			dom.BaseForRelativePaths = path;
 		}
 
 

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -22,6 +22,7 @@ namespace Bloom.Book
 	/// </summary>
 	public class HtmlDom
 	{
+		public const string RelativePathAttrName = "data-base";
 		private XmlDocument _dom;
 
 		public HtmlDom()
@@ -107,35 +108,27 @@ namespace Bloom.Book
 			}
 		}
 
+		/// <summary>
+		/// This property records the folder in which the browser needs to find files referred to using
+		/// non-absolute locations.
+		/// This method is designed to be used in conjunction with EnhancedImageServer.MakeSimulatedPageFileInBookFolder().
+		/// which generates URLs that give the browser the content of this DOM, and also handles derived urls
+		/// relative to that one.
+		/// </summary>
+		/// <remarks>Originally, this method created a 'base' element in the DOM, and a real
+		/// temporary file would typically be created. The base element caused the browser to
+		/// redirect things in much the way described above. However, this strategy fails
+		/// for internal links within the document: a url like #mybookmark is translated
+		/// into localhost://c:/users/someone/bloom/mycollection/mybookfolder#mybookmark, with no
+		/// document specified at all, and passed to the server, which fails to find anything.</remarks>
+		/// <param name="path"></param>
+		public string BaseForRelativePaths { get; set; }
 
-
-
-		public void SetBaseForRelativePaths(string path)
-		{
-			var head = _dom.SelectSingleNodeHonoringDefaultNS("//head");
-			if (head == null)
-			{
-				var folder = "";
-				if (path.Length > 0) // not unit tests
-					folder = Path.GetDirectoryName(path);
-				Guard.AgainstNull(head,
-					"Expected the DOM to already have a head element in file: " + path +
-					". If possible, please send the entire folder '" + folder +
-					"' to the developers. You may need to move this folder to another location or delete it in order to keep working.");
-			}
-			foreach (XmlNode baseNode in head.SafeSelectNodes("base"))
-			{
-				head.RemoveChild(baseNode);
-			}
-
-			if (path.Trim() != "") //jim (BL-323) reported a problem with  <base href="">
-			{
-				var baseElement = _dom.CreateElement("base");
-
-				baseElement.SetAttribute("href", path);
-				head.AppendChild(baseElement);
-			}
-		}
+		/// <summary>
+		/// Set this for DOMs that should not get the on-screen enhancements (transparency, possibly compression)
+		/// of images. Typically for generating print-quality PDFs.
+		/// </summary>
+		internal bool UseOriginalImages { get; set; }
 
 
 		public void AddStyleSheet(string locateFile)

--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -31,7 +31,10 @@ namespace Bloom
 		private string _url;
 		private XmlDocument _rootDom; // root DOM we navigate the browser to; typically a shell with other doms in iframes
 		private XmlDocument _pageEditDom; // DOM, dypically in an iframe of _rootDom, which we are editing.
-		private IDisposable _dependent; // Something we keep track of to dispose when the browser is disposed. Currently may be TempFile or SimulatedPageFile
+		// A temporary object needed just as long as it is the content of this browser.
+		// Currently may be a TempFile (a real filesystem file) or a SimulatedPageFile (just a dictionary entry).
+		// It gets disposed when the Browser goes away.
+		private IDisposable _dependentContent;
 		private PasteCommand _pasteCommand;
 		private CopyCommand _copyCommand;
 		private  UndoCommand _undoCommand;
@@ -290,10 +293,10 @@ namespace Bloom
 				}
 				_jsErrorHandler = null;
 
-				if (_dependent != null)
+				if (_dependentContent != null)
 				{
-					_dependent.Dispose();
-					_dependent = null;
+					_dependentContent.Dispose();
+					_dependentContent = null;
 				}
 				if (components != null)
 				{
@@ -629,11 +632,11 @@ namespace Bloom
 
 		private void SetNewDependent(IDisposable dependent)
 		{
-			if(_dependent!=null)
+			if(_dependentContent!=null)
 			{
 				try
 				{
-					_dependent.Dispose();
+					_dependentContent.Dispose();
 				}
 				catch(Exception)
 				{
@@ -644,7 +647,7 @@ namespace Bloom
 				}
 
 			}
-			_dependent = dependent;
+			_dependentContent = dependent;
 		}
 
 

--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -12,6 +12,8 @@ using System.Reflection;
 using System.Text;
 using System.Windows.Forms;
 using System.Xml;
+using Bloom.Book;
+using Bloom.web;
 using Gecko;
 using Gecko.DOM;
 using Gecko.Events;
@@ -29,7 +31,7 @@ namespace Bloom
 		private string _url;
 		private XmlDocument _rootDom; // root DOM we navigate the browser to; typically a shell with other doms in iframes
 		private XmlDocument _pageEditDom; // DOM, dypically in an iframe of _rootDom, which we are editing.
-		private TempFile _tempHtmlFile;
+		private IDisposable _dependent; // Something we keep track of to dispose when the browser is disposed. Currently may be TempFile or SimulatedPageFile
 		private PasteCommand _pasteCommand;
 		private CopyCommand _copyCommand;
 		private  UndoCommand _undoCommand;
@@ -288,10 +290,10 @@ namespace Bloom
 				}
 				_jsErrorHandler = null;
 
-				if (_tempHtmlFile != null)
+				if (_dependent != null)
 				{
-					_tempHtmlFile.Dispose();
-					_tempHtmlFile = null;
+					_dependent.Dispose();
+					_dependent = null;
 				}
 				if (components != null)
 				{
@@ -451,14 +453,14 @@ namespace Bloom
 		public void OnOpenPageInSystemBrowser(object sender, EventArgs e)
 		{
 			Debug.Assert(!InvokeRequired);
-			var  temp = Palaso.IO.TempFile.WithExtension(".htm");
-			var src = _url.FromLocalhost();
-			File.Copy(src, temp.Path,true); //we make a copy because once Bloom leaves this page, it will delete it, which can be an annoying thing to have happen your editor
-
+			// An earlier version of this method made a new temp file in hopes that it would go on working
+			// in the browser even after Bloom closed. This has gotten steadily less feasible as we depend
+			// more on the http server. With the <base> element now removed, an independent page file will
+			// have even more missing links. I don't think it's worth making a separate temp file any more.
 			if (Palaso.PlatformUtilities.Platform.IsWindows)
-				Process.Start("Firefox.exe", '"' + temp.Path.ToLocalhost() + '"');
+				Process.Start("Firefox.exe", '"' + _url + '"');
 			else
-				Process.Start("xdg-open", temp.Path.ToLocalhost()); ;
+				Process.Start("xdg-open", _url);
 		}
 
 		public void OnOpenPageInStylizer(object sender, EventArgs e)
@@ -558,7 +560,7 @@ namespace Bloom
 			_url = url; //TODO: fix up this hack. We found that deleting the pdf while we're still showing it is a bad idea.
 			if(cleanupFileAfterNavigating && !_url.EndsWith(".pdf"))
 			{
-				SetNewTempFile(TempFile.TrackExisting(url));
+				SetNewDependent(TempFile.TrackExisting(url));
 			}
 			UpdateDisplay();
 		}
@@ -566,15 +568,20 @@ namespace Bloom
 		[DefaultValue(true)]
 		public bool ScaleToFullWidthOfPage { get; set; }
 
-		//NB: make sure the <base> is set correctly, 'cause you don't know where this method will
-		//save the file before navigating to it.
-		public void Navigate(XmlDocument dom, XmlDocument editDom = null)
+		// NB: make sure you called HtmlDom.SetBaseForRelativePaths() if the temporary document might contain
+		// references to files in the directory of the original HTML file it is derived from,
+		// 'cause that provides the information needed
+		// to fake out the browser about where the 'file' is so internal references work.
+		public void Navigate(HtmlDom htmlDom, HtmlDom htmlEditDom = null)
 		{
 			if (InvokeRequired)
 			{
-				Invoke(new Action<XmlDocument, XmlDocument>(Navigate), dom, editDom);
+				Invoke(new Action<HtmlDom, HtmlDom>(Navigate), htmlDom, htmlEditDom);
 				return;
 			}
+
+			XmlDocument dom = htmlDom.RawDom;
+			XmlDocument editDom = htmlEditDom == null ? null : htmlEditDom.RawDom;
 
 			_rootDom = dom;//.CloneNode(true); //clone because we want to modify it a bit
 			_pageEditDom = editDom ?? dom;
@@ -592,8 +599,9 @@ namespace Bloom
 				}
 			}
 			XmlHtmlConverter.MakeXmlishTagsSafeForInterpretationAsHtml(dom);
-			SetNewTempFile(TempFileUtils.CreateHtm5FromXml(dom));
-			_url = _tempHtmlFile.Path.ToLocalhost();
+			var fakeTempFile = EnhancedImageServer.MakeSimulatedPageFileInBookFolder(htmlDom);
+			SetNewDependent(fakeTempFile);
+			_url = fakeTempFile.Key;
 			UpdateDisplay();
 		}
 
@@ -607,8 +615,8 @@ namespace Bloom
 
 			var tf = TempFile.CreateAndGetPathButDontMakeTheFile();
 			File.WriteAllText(tf.Path,html);
-			SetNewTempFile(tf);
-			_url = _tempHtmlFile.Path;
+			SetNewDependent(tf);
+			_url = tf.Path;
 			UpdateDisplay();
 		}
 
@@ -619,13 +627,13 @@ namespace Bloom
 			return string.Format("-moz-transform: scale({0}); -moz-transform-origin: 0 0", scale.ToString(CultureInfo.InvariantCulture));
 		}
 
-		private void SetNewTempFile(TempFile tempFile)
+		private void SetNewDependent(IDisposable dependent)
 		{
-			if(_tempHtmlFile!=null)
+			if(_dependent!=null)
 			{
 				try
 				{
-					_tempHtmlFile.Dispose();
+					_dependent.Dispose();
 				}
 				catch(Exception)
 				{
@@ -636,7 +644,7 @@ namespace Bloom
 				}
 
 			}
-			_tempHtmlFile = tempFile;
+			_dependent = dependent;
 		}
 
 

--- a/src/BloomExe/CollectionTab/LibraryBookView.cs
+++ b/src/BloomExe/CollectionTab/LibraryBookView.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using Bloom.Book;
 using Bloom.SendReceive;
+using Bloom.web;
 using Gecko;
 
 namespace Bloom.CollectionTab
@@ -106,7 +107,7 @@ namespace Bloom.CollectionTab
 				_readmeBrowser.Visible = false;
 				//_previewBrowser.Visible = true;
 				_splitContainerForPreviewAndAboutBrowsers.Visible = true;
-				_previewBrowser.Navigate(_bookSelection.CurrentSelection.GetPreviewHtmlFileForWholeBook().RawDom);
+				_previewBrowser.Navigate(_bookSelection.CurrentSelection.GetPreviewHtmlFileForWholeBook());
 				_splitContainerForPreviewAndAboutBrowsers.Panel2Collapsed = true;
 				if (_bookSelection.CurrentSelection.HasAboutBookInformationToShow)
 				{

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -518,7 +518,7 @@ namespace Bloom.Edit
 			XmlHtmlConverter.MakeXmlishTagsSafeForInterpretationAsHtml(_domForCurrentPage.RawDom);
 			if (_currentPage != null)
 				_currentPage.Dispose();
-			_currentPage = EnhancedImageServer.MakeSimulatedPageFileInBookFolder(_domForCurrentPage);
+			_currentPage = EnhancedImageServer.MakeSimulatedPageFileInBookFolder(_domForCurrentPage, true);
 
 			if (_currentlyDisplayedBook.BookInfo.ReaderToolsAvailable)
 				_server.AccordionContent = MakeAccordionContent();

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -372,7 +372,7 @@ namespace Bloom.Edit
 				HtmlDom domForCurrentPage = _model.GetXmlDocumentForCurrentPage();
 				var dom = _model.GetXmlDocumentForEditScreenWebPage();
 				_browser1.Focus();
-				_browser1.Navigate(dom.RawDom, domForCurrentPage.RawDom);
+				_browser1.Navigate(dom, domForCurrentPage);
 				_pageListView.Focus();
 				_browser1.Focus();
 				// So far, the most reliable way I've found to detect that the page is fully loaded and we can call

--- a/src/BloomExe/Edit/PageListView.cs
+++ b/src/BloomExe/Edit/PageListView.cs
@@ -18,7 +18,7 @@ namespace Bloom.Edit
 		private bool _dontForwardSelectionEvent;
 		private IPage _pageWeThinkShouldBeSelected;
 
-		public PageListView(PageSelection pageSelection,  RelocatePageEvent relocatePageEvent, EditingModel model,HtmlThumbNailer thumbnailProvider, NavigationIsolator isolator )
+		public PageListView(PageSelection pageSelection,  RelocatePageEvent relocatePageEvent, EditingModel model,HtmlThumbNailer thumbnailProvider, NavigationIsolator isolator)
 		{
 			_pageSelection = pageSelection;
 			_model = model;

--- a/src/BloomExe/Edit/TemplatePagesView.cs
+++ b/src/BloomExe/Edit/TemplatePagesView.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using System.Text;
 using System.Windows.Forms;
 using Bloom.Book;
+using Bloom.web;
 using Gecko;
 using L10NSharp;
 using Palaso.Xml;
@@ -171,7 +172,7 @@ namespace Bloom.Edit
 			}
 			//_browser.WebBrowser.DocumentCompleted += WebBrowser_DocumentCompleted;
 			//_verticalScrollDistance = _browser.VerticalScrollDistance;
-			_browser.Navigate(pageDoc, null);
+			_browser.Navigate(dom, null);
 		}
 
 		private static string ItemId(IPage page)

--- a/src/BloomExe/Edit/ThumbNailList.cs
+++ b/src/BloomExe/Edit/ThumbNailList.cs
@@ -140,7 +140,7 @@ namespace Bloom.Edit
 
 		public void UpdateThumbnailAsync(IPage page)
 		{
-			XmlDocument pageDom = page.Book.GetPreviewXmlDocumentForPage(page).RawDom;
+			var pageDom = page.Book.GetPreviewXmlDocumentForPage(page);
 			var thumbnailOptions = new HtmlThumbNailer.ThumbnailOptions()
 			{
 				BackgroundColor = Palette.TextAgainstDarkBackground,

--- a/src/BloomExe/Edit/WebThumbNailList.cs
+++ b/src/BloomExe/Edit/WebThumbNailList.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Xml;
 using Bloom.Book;
 using Bloom.Properties;
+using Bloom.web;
 using Gecko;
 using Palaso.Xml;
 #if !__MonoCS__
@@ -597,7 +598,7 @@ namespace Bloom.Edit
 			}
 			_browser.WebBrowser.DocumentCompleted += WebBrowser_DocumentCompleted;
 			_verticalScrollDistance = _browser.VerticalScrollDistance;
-			_browser.Navigate(pageDoc, null);
+			_browser.Navigate(dom, null);
 			return result;
 		}
 

--- a/src/BloomExe/ImageProcessing/ImageServer.cs
+++ b/src/BloomExe/ImageProcessing/ImageServer.cs
@@ -80,7 +80,7 @@ namespace Bloom.ImageProcessing
 				r = r.Replace("thumbnail", "");
 				if (File.Exists(r))
 				{
-					info.ReplyWithImage(_cache.GetPathToResizedImage(r));
+						info.ReplyWithImage(_cache.GetPathToResizedImage(r));
 					return true;
 				}
 			}

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -186,7 +186,7 @@ namespace Bloom
 							Browser.SetUpXulRunner();
 								Browser.XulRunnerShutdown += OnXulRunnerShutdown;
 							var transfer = new BookTransfer(new BloomParseClient(), ProjectContext.CreateBloomS3Client(),
-								_applicationContainer.HtmlThumbnailer, new BookDownloadStartingEvent())/*not hooked to anything*/;
+								_applicationContainer.HtmlThumbnailer, new BookDownloadStartingEvent()) /*not hooked to anything*/;
 							transfer.UploadFolder(args[1], _applicationContainer);
 							return;
 						}

--- a/src/BloomExe/TempFiles.cs
+++ b/src/BloomExe/TempFiles.cs
@@ -63,26 +63,7 @@ namespace BloomTemp
 		{
 			var temp = TempFile.WithFilenameInTempFolder("tempHtml.htm");
 
-			var settings = GetXmlWriterSettingsForHtml5();
-
-			// Enhance JohnT: no reason to go to disk for this intermediate version.
-			var sb = new StringBuilder();
-			using (var writer = XmlWriter.Create(sb, settings))
-			{
-				dom.WriteContentTo(writer);
-				writer.Close();
-			}
-			// xml output will produce things like <title /> or <div /> for empty elements, which are not valid HTML 5 and produce
-			// weird results; for example, the browser interprets <title /> as the beginning of an element that is not terminated
-			// until the end of the whole document. Thus, everything becomes part of the title. This then causes errors in our
-			// thumbnail generation because gecko thinks the document has an empty  body (the real one is lost inside the title).
-			// Also, embedded controls (like ReaderTools.htm) now pass through this xml-to-html conversion, and this file contains
-			// several more kinds of empty element, some of which have attributes.
-			// There are probably more elements than these which may not be empty. However we can't just use [^ ]* in place of title|div
-			// because there are some elements that never have content like <br /> which should NOT be converted.
-			// It seems safest to just list the ones that can occur empty in Bloom...if we can't find a more reliable way to convert to HTML5.
-			string xhtml =  sb.ToString();
-			File.WriteAllText(temp.Path, CleanupHtml5(xhtml));
+			File.WriteAllText(temp.Path, CreateHtml5StringFromXml(dom));
 
 			return temp;
 		}
@@ -119,6 +100,15 @@ namespace BloomTemp
 			return settings;
 		}
 
+		// xml output will produce things like <title /> or <div /> for empty elements, which are not valid HTML 5 and produce
+		// weird results; for example, the browser interprets <title /> as the beginning of an element that is not terminated
+		// until the end of the whole document. Thus, everything becomes part of the title. This then causes errors in our
+		// thumbnail generation because gecko thinks the document has an empty  body (the real one is lost inside the title).
+		// Also, embedded controls (like ReaderTools.htm) now pass through this xml-to-html conversion, and this file contains
+		// several more kinds of empty element, some of which have attributes.
+		// There are probably more elements than these which may not be empty. However we can't just use [^ ]* in place of title|div
+		// because there are some elements that never have content like <br /> which should NOT be converted.
+		// It seems safest to just list the ones that can occur empty in Bloom...if we can't find a more reliable way to convert to HTML5.
 		public static string CleanupHtml5(string xhtml)
 		{
 			var re = new Regex("<(title|div|i|table|td|span|style) ([^<]*)/>");

--- a/src/BloomExe/web/SimulatedPageFile.cs
+++ b/src/BloomExe/web/SimulatedPageFile.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Bloom.web
+{
+	/// <summary>
+	/// A SimulatedPageFile is used in connection with simulating a current-page file that needs
+	/// to (seem to) be in the book folder so local hrefs work. We don't actually put files there
+	/// (see EnhancedImageServer.MakeSimulatedPageFileInBookFolder for more), but rather
+	/// store some data in the our file server object.
+	/// The particular purpose of the SimulatedPageFile is to manage the lifetime for which
+	/// the simulated page is kept in the server. It can be passed to the Browser which will
+	/// Dispose() it when no longer needed.
+	/// (In that regard, it is used in rather the same way as a TempFile object is used to
+	/// make sure that a temp file gets deleted when the Browser no longer needs it.)
+	/// </summary>
+	public class SimulatedPageFile : IDisposable
+	{
+		public void Dispose()
+		{
+			EnhancedImageServer.RemoveSimulatedPageFile(Key);
+		}
+
+		/// <summary>
+		/// The key under which the server stores the data that should be discarded
+		/// when this object gets disposed.
+		/// </summary>
+		public string Key { get; set; }
+	}
+}

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -93,7 +93,7 @@ namespace BloomTests.Book
 			//warning: we're neutering part of what the code under test is trying to do here:
 			_fileLocator.Setup(x => x.CloneAndCustomize(It.IsAny<IEnumerable<string>>())).Returns(_fileLocator.Object);
 
-			_thumbnailer = new Moq.Mock<HtmlThumbNailer>(new object[] { new NavigationIsolator() });
+			_thumbnailer = new Moq.Mock<HtmlThumbNailer>(new object[] { new NavigationIsolator()});
 			_pageSelection = new Mock<PageSelection>();
 			_pageListChangedEvent = new PageListChangedEvent();
 	  }

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -36,32 +36,6 @@ namespace BloomTests.Book
 		}
 
 		[Test]
-		public void SetBaseForRelativePaths_NoHead_Throw()
-		{
-			var dom = new HtmlDom(
-						  @"<html></html>");
-			Assert.Throws<ArgumentNullException>(() => dom.SetBaseForRelativePaths("theBase"));
-		}
-		[Test]
-		public void SetBaseForRelativePaths_NoExistingBase_Adds()
-		{
-			var dom = new HtmlDom(
-						  @"<html><head/></html>");
-			dom.SetBaseForRelativePaths("theBase");
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("html/head/base[@href='theBase']", 1);
-		}
-		[Test]
-		public void SetBaseForRelativePaths_HasExistingBase_Replaces()
-		{
-			var dom = new HtmlDom(
-						  @"<html><head><base href='original'/></head></html>");
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("html/head/base[@href='original']", 1);
-			dom.SetBaseForRelativePaths("new");
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("html/head/base[@href='original']", 0);
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("html/head/base[@href='new']", 1);
-		}
-
-		[Test]
 		public void RemoveMetaValue_IsThere_RemovesIt()
 		{
 			var dom = new HtmlDom(

--- a/src/BloomTests/web/EnhancedImageServerTests.cs
+++ b/src/BloomTests/web/EnhancedImageServerTests.cs
@@ -4,13 +4,15 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using Bloom.Book;
+using BloomTemp;
 using NUnit.Framework;
 using Palaso.IO;
-using Palaso.TestUtilities;
 using Bloom;
 using Bloom.ImageProcessing;
 using Bloom.web;
 using Palaso.Reporting;
+using TemporaryFolder = Palaso.TestUtilities.TemporaryFolder;
 
 namespace BloomTests.web
 {
@@ -100,5 +102,38 @@ namespace BloomTests.web
 			return file;
 		}
 
+		[Test]
+		public void CanRetrieveContentOfFakeTempFile_ButOnlyUntilDisposed()
+		{
+			using (var server = CreateImageServer())
+			{
+				var html = @"<html ><head></head><body>here it is</body></html>";
+				var dom = new HtmlDom(html);
+				dom.BaseForRelativePaths =_folder.Path.ToLocalhost();
+				string url;
+				using (var fakeTempFile = EnhancedImageServer.MakeSimulatedPageFileInBookFolder(dom))
+				{
+					url = fakeTempFile.Key;
+					var transaction = new PretendRequestInfo(url);
+
+					// Execute
+					server.MakeReply(transaction);
+
+					// Verify
+					// Whitespace inserted by CreateHtml5StringFromXml seems to vary across versions and platforms.
+					// I would rather verify the actual output, but don't want this test to be fragile, and the
+					// main point is that we get a file with the DOM content.
+					Assert.That(transaction.ReplyContents,
+						Is.EqualTo(TempFileUtils.CreateHtml5StringFromXml(dom.RawDom)));
+				}
+				var transactionFail = new PretendRequestInfo(url);
+
+				// Execute
+				server.MakeReply(transactionFail);
+
+				// Verify
+				Assert.That(transactionFail.StatusCode, Is.EqualTo(404));
+			}
+		}
 	}
 }


### PR DESCRIPTION
BL-642, Don't use <base> in temp files

The goal here is to use smarts in our
local server instead of <base> to find
images that the HTML refers to
just using filenames (without paths).
Works for the full html document
because it is in the same folder.
The core change is in
HtmlDom.BaseForRelativePaths and in
EnhancedImageServer.MakeSimulatedPageFileInBookFolder()
(see comment there).
The temp 'file' now only exists in the
local server memory, but the url
makes it seem to be in the book folder.

Since we're not using base, all temp
files that need to pretend to be in
the book folder must now use the
local server. This resulted in
changes to how we handle cases
where we want to use the full-resolution
images, like PDF generation.