### PR TITLE
BL-785: prefer to find xMatter files in Factory-XMatter

### DIFF
--- a/src/BloomExe/BloomFileLocator.cs
+++ b/src/BloomExe/BloomFileLocator.cs
@@ -16,15 +16,18 @@ namespace Bloom
 		private readonly IEnumerable<string> _factorySearchPaths;
 		private readonly List<string> _bookSpecificSearchPaths;
 		private readonly IEnumerable<string> _userInstalledSearchPaths;
+		private readonly IEnumerable<string> _afterXMatterSearchPaths;
 
-		public BloomFileLocator(CollectionSettings collectionSettings, XMatterPackFinder xMatterPackFinder, IEnumerable<string> factorySearchPaths, IEnumerable<string> userInstalledSearchPaths)
+		public BloomFileLocator(CollectionSettings collectionSettings, XMatterPackFinder xMatterPackFinder, IEnumerable<string> factorySearchPaths, IEnumerable<string> userInstalledSearchPaths,
+			IEnumerable<string> afterXMatterSearchPaths = null)
 			: base(factorySearchPaths.Concat( userInstalledSearchPaths))//review: is this even used, since we override GetSearchPaths()?
 		{
 			_bookSpecificSearchPaths = new List<string>();
 			_collectionSettings = collectionSettings;
 			_xMatterPackFinder = xMatterPackFinder;
 			_factorySearchPaths = factorySearchPaths;
-			_userInstalledSearchPaths = userInstalledSearchPaths;;
+			_userInstalledSearchPaths = userInstalledSearchPaths;
+			_afterXMatterSearchPaths = afterXMatterSearchPaths;
 		}
 
 		public override void AddPath(string path)
@@ -53,11 +56,26 @@ namespace Bloom
 			//One particular bug that came out of that was when a custom xmatter (because of a previous bug) snuck into the
 			//Sample "Vaccinations" book, then *that* copy of the xmatter was always used, becuase it was found first.
 
-			foreach (var xMatterInfo in _xMatterPackFinder.All)
+			// So, first we want to try the factory xmatter paths. These have precedence over factory templates.
+			foreach (var xMatterInfo in _xMatterPackFinder.Factory)
 			{
 				//NB: if we knew what the xmatter pack they wanted, we could limit to that. for now, we just iterate over all of
 				//them and rely (reasonably) on the names being unique
 
+				//this is a bit weird... we include the parent, in case they're looking for the xmatter *folder*, and the folder
+				//itself, in case they're looking for something inside it
+				yield return xMatterInfo.PathToFolder;
+				yield return Path.GetDirectoryName(xMatterInfo.PathToFolder);
+			}
+
+			// On the other hand the remaining factory stuff has precedence over non-factory XMatter.
+			foreach (var searchPath in _afterXMatterSearchPaths)
+			{
+				yield return searchPath;
+			}
+
+			foreach (var xMatterInfo in _xMatterPackFinder.NonFactory)
+			{
 				//this is a bit weird... we include the parent, in case they're looking for the xmatter *folder*, and the folder
 				//itself, in case they're looking for something inside it
 				yield return xMatterInfo.PathToFolder;
@@ -87,7 +105,7 @@ namespace Bloom
 
 		public override IFileLocator CloneAndCustomize(IEnumerable<string> addedSearchPaths)
 		{
-			var locator= new BloomFileLocator(_collectionSettings, _xMatterPackFinder,_factorySearchPaths, _userInstalledSearchPaths);
+			var locator= new BloomFileLocator(_collectionSettings, _xMatterPackFinder,_factorySearchPaths, _userInstalledSearchPaths, _afterXMatterSearchPaths);
 			foreach (var path in _bookSpecificSearchPaths)
 			{
 				locator.AddPath(path);

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -136,7 +136,7 @@ namespace Bloom
 
 				builder.Register<LibraryModel>(c => new LibraryModel(editableCollectionDirectory, c.Resolve<CollectionSettings>(), c.Resolve<SendReceiver>(), c.Resolve<BookSelection>(), c.Resolve<SourceCollectionsList>(), c.Resolve<BookCollection.Factory>(), c.Resolve<EditBookCommand>(),c.Resolve<CreateFromSourceBookCommand>(),c.Resolve<BookServer>(), c.Resolve<CurrentEditableCollectionSelection>())).InstancePerLifetimeScope();
 
-				builder.Register<IChangeableFileLocator>(c => new BloomFileLocator(c.Resolve<CollectionSettings>(), c.Resolve<XMatterPackFinder>(), GetFactoryFileLocations(),GetFoundFileLocations())).InstancePerLifetimeScope();
+				builder.Register<IChangeableFileLocator>(c => new BloomFileLocator(c.Resolve<CollectionSettings>(), c.Resolve<XMatterPackFinder>(), GetFactoryFileLocations(),GetFoundFileLocations(), GetAfterXMatterFileLocations())).InstancePerLifetimeScope();
 
 				builder.Register<LanguageSettings>(c =>
 													{
@@ -227,12 +227,13 @@ namespace Bloom
 
 
 		/// <summary>
-		/// Give the locations of the bedrock files/folders that come with Bloom. These will have priority
+		/// Give the locations of the bedrock files/folders that come with Bloom. These will have priority.
+		/// (But compare GetAfterXMatterFileLocations, for further paths that are searched after factory XMatter).
 		/// </summary>
 		public static IEnumerable<string> GetFactoryFileLocations()
 		{
 			//bookLayout has basepage.css. We have it first because it will find its way to many other folders, but this is the authoritative one
-			yield return FileLocator.GetDirectoryDistributedWithApplication("BloomBrowserUI","bookLayout");
+			yield return FileLocator.GetDirectoryDistributedWithApplication("BloomBrowserUI", "bookLayout");
 
 			//hack to get the distfiles folder itself
 			yield return Path.GetDirectoryName(FileLocator.GetDirectoryDistributedWithApplication("localization"));
@@ -256,7 +257,15 @@ namespace Bloom
 
 			yield return FileLocator.GetDirectoryDistributedWithApplication("xMatter");
 
-			//yield return FileLocator.GetDirectoryDistributedWithApplication("xMatter", "Factory-XMatter");
+		}
+
+		/// <summary>
+		/// Per BL-785, we want to search xMatter/*-XMatter folders (handled by the XMatterPackFinder) before we search
+		/// the template folders.
+		/// </summary>
+		/// <returns></returns>
+		public static IEnumerable<string> GetAfterXMatterFileLocations()
+		{
 			var templatesDir = Path.Combine(FactoryCollectionsDirectory, "Templates");
 
 			yield return templatesDir;

--- a/src/BloomTests/BloomFileLocatorTests.cs
+++ b/src/BloomTests/BloomFileLocatorTests.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Bloom;
+using Bloom.Book;
+using Bloom.Collection;
+using NUnit.Framework;
+using Palaso.IO;
+using Palaso.TestUtilities;
+
+namespace BloomTests
+{
+	/// <summary>
+	/// As yet this is a very incomplete set of tests for this class, but it makes sure we don't regress on problems we've encountered,
+	/// and documents at least some of the things we think important.
+	/// </summary>
+	[TestFixture]
+	public class BloomFileLocatorTests
+	{
+		private BloomFileLocator _fileLocator;
+		private XMatterPackFinder _xMatterFinder;
+		private TemporaryFolder _xMatterParentFolder;
+		private TemporaryFolder _xMatterFolder;
+
+		[SetUp]
+		public void Setup()
+		{
+			var locations = new List<string>();
+			locations.Add(FileLocator.GetDirectoryDistributedWithApplication("xMatter"));
+			_xMatterParentFolder = new TemporaryFolder("UserCollection");
+			_xMatterFolder = new TemporaryFolder(_xMatterParentFolder, "User-XMatter");
+			locations.Add(_xMatterParentFolder.Path);
+			File.WriteAllText(Path.Combine(_xMatterFolder.Path, "SomeRandomXYZABCStyles.css"), "Some arbitrary test data");
+			File.WriteAllText(Path.Combine(_xMatterFolder.Path, "Decodable Reader.css"), "Fake DR test data");
+			//locations.Add(XMatterAppDataFolder);
+			//locations.Add(XMatterCommonDataFolder);
+			_xMatterFinder = new XMatterPackFinder(locations);
+			_fileLocator = new BloomFileLocator(new CollectionSettings(), _xMatterFinder, ProjectContext.GetFactoryFileLocations(), ProjectContext.GetFoundFileLocations(),
+				ProjectContext.GetAfterXMatterFileLocations());
+		}
+
+		[TearDown]
+		public void Teardown()
+		{
+			_xMatterFolder.Dispose();
+			_xMatterParentFolder.Dispose();
+		}
+
+		/// <summary>
+		/// This factory CSS is also found in various factory templates.
+		/// </summary>
+		[Test]
+		public void FactoryXMatterStylesheets_AreFoundInFactoryXMatter()
+		{
+			var path = _fileLocator.LocateFile("Factory-XMatter.css");
+			Assert.That(Path.GetDirectoryName(path), Is.StringContaining("Factory-XMatter"));
+		}
+
+		/// <summary>
+		/// It's not just one xMatter folder that has things we want to find before factory templates.
+		/// </summary>
+		[Test]
+		public void BigBookXMatterStylesheets_AreFoundInBigBookXMatter()
+		{
+			var path = _fileLocator.LocateFile("BigBook-XMatter.css");
+			Assert.That(Path.GetDirectoryName(path), Is.StringContaining("BigBook-XMatter"));
+		}
+
+		/// <summary>
+		/// This file is found in a 'non-factory' xMatter location because the test set things
+		/// up that way. It's also found in one of the Template folders that are searched
+		/// AFTER factory xMatter. This test forced breaking the xMatterPackFinder list into
+		/// factory and non-factory.
+		/// </summary>
+		[Test]
+		public void TemplateFilesAreFoundInFactoryLocation()
+		{
+			var path = _fileLocator.LocateFile("Decodable Reader.css");
+			Assert.That(Path.GetDirectoryName(path), Is.StringContaining("Decodable Reader"));
+		}
+
+		/// <summary>
+		/// This is a very special case; there is an editMode.css in xMatter/BigBook-XMatter
+		/// which should NOT be returned, as well as the correct one in BloomBrowserUI.
+		/// This test forced BloomFileLocator to have a special list of folders to search
+		/// AFTER (factory) xMatter folders.
+		/// This test may need to be adjusted if we conclude that we really don't need
+		/// BigBook-XMatter/editMode.css and remove it.
+		/// </summary>
+		[Test]
+		public void BloomBrowserUIIsPrefferedOverFactorXMatter()
+		{
+			var path = _fileLocator.LocateFile("editMode.css");
+			Assert.That(Path.GetDirectoryName(path), Is.StringContaining("BloomBrowserUI"));
+		}
+
+		/// <summary>
+		/// Make sure we DO search the remaining xmatter paths.
+		/// </summary>
+		[Test]
+		public void CanFindFileInUserXMatter()
+		{
+			var path = _fileLocator.LocateFile("SomeRandomXYZABCStyles.css");
+			Assert.That(Path.GetDirectoryName(path), Is.StringContaining("User-XMatter"));
+		}
+	}
+}

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -132,6 +132,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BloomFileLocatorTests.cs" />
     <Compile Include="Book\BookCollectionTests.cs" />
     <Compile Include="Book\BookInfoTests.cs" />
     <Compile Include="Book\HtmlDomTests.cs" />

--- a/src/BloomTests/Book/BookCollectionTests.cs
+++ b/src/BloomTests/Book/BookCollectionTests.cs
@@ -25,7 +25,8 @@ namespace BloomTests.Book
 		{
 			Palaso.Reporting.ErrorReport.IsOkToInteractWithUser = false;
 			_folder  =new TemporaryFolder("BookCollectionTests");
-			_fileLocator = new BloomFileLocator(new CollectionSettings(), new XMatterPackFinder(new string[] {}), ProjectContext.GetFactoryFileLocations(), ProjectContext.GetFoundFileLocations());
+			_fileLocator = new BloomFileLocator(new CollectionSettings(), new XMatterPackFinder(new string[] {}), ProjectContext.GetFactoryFileLocations(),
+				ProjectContext.GetFoundFileLocations(), ProjectContext.GetAfterXMatterFileLocations());
 			_collection = new BookCollection(_folder.Path, BookCollection.CollectionType.TheOneEditableCollection, new BookSelection());
 		}
 

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -40,7 +40,7 @@ namespace BloomTests.Book
 
 			var xmatterFinder = new XMatterPackFinder(new []{FileLocator.GetDirectoryDistributedWithApplication("xMatter")});
 
-			_fileLocator = new BloomFileLocator(collectionSettings, xmatterFinder, ProjectContext.GetFactoryFileLocations(), ProjectContext.GetFoundFileLocations());
+			_fileLocator = new BloomFileLocator(collectionSettings, xmatterFinder, ProjectContext.GetFactoryFileLocations(), ProjectContext.GetFoundFileLocations(), ProjectContext.GetAfterXMatterFileLocations());
 
 
 			_starter = new BookStarter(_fileLocator, dir => new BookStorage(dir, _fileLocator, new BookRenamedEvent(), collectionSettings), _librarySettings.Object);


### PR DESCRIPTION
This is the original source for files that are copied to other
places in individual templates that are also distributed
with the application. We want live editing to use the most
original version so we see changes when editing that.
