### PR TITLE
Fix BL-777, where the languagetip was showing in the wrong edit box.

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
@@ -1,4 +1,4 @@
-﻿/// <reference path="../../lib/jquery.d.ts" />
+/// <reference path="../../lib/jquery.d.ts" />
 /// <reference path="../../lib/jquery-ui.d.ts" />
 /// <reference path="../../lib/localizationManager.ts" />
 /// <reference path="../../lib/jquery.i18n.custom.ts" />
@@ -494,7 +494,7 @@ var StyleEditor = (function () {
         this._previousBox = targetBox;
 
         // put the format button in the editable text box itself, so that it's always in the right place.
-        // unfortanately it will be subject to deletion becuase this is an editable box. But we can mark it as unedtable, so that
+        // unfortunately it will be subject to deletion because this is an editable box. But we can mark it as uneditable, so that
         // the user won't see resize and drag controls when they click on it
         $(targetBox).append('<div id="formatButton" contenteditable="false" class="bloom-ui"><img  contenteditable="false" src="' + editor._supportFilesRoot + '/img/cogGrey.svg"></div>');
         var formatButton = $('#formatButton');
@@ -601,8 +601,6 @@ var StyleEditor = (function () {
                 });
             });
         });
-
-        editor.AttachLanguageTip($(targetBox));
     };
 
     StyleEditor.prototype.getButtonIds = function () {
@@ -1082,21 +1080,6 @@ var StyleEditor = (function () {
         // Now update tooltip
         //var toolTip = this.GetToolTip(target, styleName);
         //this.AddQtipToElement($('#formatButton'), toolTip);
-    };
-
-    //Attach and detach a language tip which is used when the applicable edittable div has focus.
-    //This works around a couple FF bugs with the :after pseudoelement.  See BL-151.
-    StyleEditor.prototype.AttachLanguageTip = function (targetBox) {
-        if ($(targetBox).attr('data-languagetipcontent')) {
-            $(targetBox).after('<div class="languageTip bloom-ui">' + $(targetBox).attr('data-languagetipcontent') + '</div>');
-        }
-    };
-
-    StyleEditor.prototype.DetachLanguageTip = function (element) {
-        //we're placing these controls *after* the target, not inside it; that's why we go up to parent
-        $(element).parent().find(".languageTip.bloom-ui").each(function () {
-            $(this).remove();
-        });
     };
 
     StyleEditor.CleanupElement = function (element) {

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -646,8 +646,6 @@ class StyleEditor {
                 });
             });
         });
-
-        editor.AttachLanguageTip($(targetBox));
     }
 
     getButtonIds() {
@@ -1108,21 +1106,6 @@ class StyleEditor {
         //var toolTip = this.GetToolTip(target, styleName);
         //this.AddQtipToElement($('#formatButton'), toolTip);
 
-    }
-
-    //Attach and detach a language tip which is used when the applicable edittable div has focus.
-    //This works around a couple FF bugs with the :after pseudoelement.  See BL-151.
-    private AttachLanguageTip(targetBox) {
-        if ($(targetBox).attr('data-languagetipcontent')) {
-            $(targetBox).after('<div class="languageTip bloom-ui">' + $(targetBox).attr('data-languagetipcontent') + '</div>');
-        }
-    }
-
-    DetachLanguageTip(element) {
-        //we're placing these controls *after* the target, not inside it; that's why we go up to parent
-        $(element).parent().find(".languageTip.bloom-ui").each(function () {
-            $(this).remove();
-        });
     }
 
     static CleanupElement(element) {

--- a/src/BloomBrowserUI/bookEdit/css/editMode.css
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.css
@@ -354,11 +354,8 @@ DIV.bloom-editable.Heading2-style {
   text-align: center;
 }
 /*Put in little grey language tooltips in the bottom-right of the editable divs*/
-/*.languageTip is used when the box has focus to work around a couple FF bugs.  See BL-151.*/
-/*The :after pseudoelement is used when the box does not have focus.*/
-/*The goal is to have them appear exactly the same so nothing changes when focus is gained/lost.*/
 .languageTip,
-.bloom-editable[contentEditable=true][data-languageTipContent]:not([data-languageTipContent='']):not(:focus):after {
+.bloom-editable[contentEditable=true][data-languageTipContent]:not([data-languageTipContent='']):after {
   position: absolute;
   right: 0;
   bottom: 0px;
@@ -375,7 +372,7 @@ DIV.bloom-editable.Heading2-style {
   margin-right: 1px;
   text-align: right;
 }
-.bloom-editable[contentEditable=true][data-languageTipContent]:not([data-languageTipContent='']):not(:focus):after {
+.bloom-editable[contentEditable=true][data-languageTipContent]:not([data-languageTipContent='']):after {
   content: attr(data-languageTipContent);
   bottom: 0px;
   margin-right: 2px;

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -406,10 +406,7 @@ TEXTAREA.Heading2-style,  DIV.bloom-editable.Heading2-style {
 	text-align: center;
 }
 /*Put in little grey language tooltips in the bottom-right of the editable divs*/
-/*.languageTip is used when the box has focus to work around a couple FF bugs.  See BL-151.*/
-/*The :after pseudoelement is used when the box does not have focus.*/
-/*The goal is to have them appear exactly the same so nothing changes when focus is gained/lost.*/
-.languageTip, .bloom-editable[contentEditable=true][data-languageTipContent]:not([data-languageTipContent='']):not(:focus):after
+.languageTip, .bloom-editable[contentEditable=true][data-languageTipContent]:not([data-languageTipContent='']):after
 {
 	position: absolute;
 	right: 0;
@@ -427,7 +424,7 @@ TEXTAREA.Heading2-style,  DIV.bloom-editable.Heading2-style {
 	margin-right: 1px;
 	text-align: right;
 }
-.bloom-editable[contentEditable=true][data-languageTipContent]:not([data-languageTipContent='']):not(:focus):after
+.bloom-editable[contentEditable=true][data-languageTipContent]:not([data-languageTipContent='']):after
 {
 	content: attr(data-languageTipContent);
 	bottom: 0px;

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -1509,10 +1509,6 @@ function SetupElements(container) {
         $(this).focus(function() {
            editor.AttachToBox(this);
         });
-
-        $(this).focusout(function () {
-            editor.DetachLanguageTip(this);
-        });
     });
 
     $(container).find('.bloom-editable').longPress();


### PR DESCRIPTION
A previous workaround for 2 gecko bugs worked like this: If the focus
is in the text box, hide :after tag that was showing the language name,
and instead add a separate div inside the translation group. But in
doing so, it had no way of being in the right place
for bi and tri-lingual modes.

Due to a previous fix (PR#173), this is all unneeded now, and this
commit just takes us back to just relying on the css-positioned
language tag.
