### PR TITLE
BL-765: Make a way to upload and download templates

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -890,21 +890,28 @@ namespace Bloom.Book
 		/// </summary>
 		public bool RecordedAsLockedDown
 		{
-			get
-			{
-				var node = OurHtmlDom.SafeSelectNodes(String.Format("//meta[@name='lockedDownAsShell' and @content='true']"));
-				return node.Count > 0;
-			}
+			get { return IsLockedDown(OurHtmlDom); }
 			set
 			{
-				if (value)
-				{
-					OurHtmlDom.UpdateMetaElement("lockedDownAsShell", "true");
-				}
-				else
-				{
-					OurHtmlDom.RemoveMetaElement("lockedDownAsShell");
-				}
+				RecordAsLockedDown(OurHtmlDom, value);
+			}
+		}
+
+		public static bool IsLockedDown(HtmlDom dom)
+		{
+			var node = dom.SafeSelectNodes(String.Format("//meta[@name='lockedDownAsShell' and @content='true']"));
+			return node.Count > 0;
+		}
+
+		public static void RecordAsLockedDown(HtmlDom dom, bool locked)
+		{
+			if (locked)
+			{
+				dom.UpdateMetaElement("lockedDownAsShell", "true");
+			}
+			else
+			{
+				dom.RemoveMetaElement("lockedDownAsShell");
 			}
 		}
 

--- a/src/BloomExe/Book/BookStarter.cs
+++ b/src/BloomExe/Book/BookStarter.cs
@@ -347,9 +347,9 @@ namespace Bloom.Book
 			//but things from Basic Book are normally not.
 			var x = GetMetaValue(storage.Dom, "DerivativesAreSuitableForMakingShells", "false");
 #else
-			var x = "false";
+			var x = false;
 #endif
-			storage.Dom.UpdateMetaElement("SuitableForMakingShells", x);
+			storage.MetaData.IsSuitableForMakingShells = x;
 		}
 
 

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -213,6 +213,17 @@ namespace BloomTests.Book
 			_starter.CreateBookOnDiskFromTemplate(source, _projectFolder.Path);
 		}
 
+		[Test]
+		public void CreateBookOnDiskFromTemplate_OriginalIsTemplate_CopyIsNotTemplate()
+		{
+			var source = FileLocator.GetDirectoryDistributedWithApplication("factoryCollections", "Templates",
+																			"Basic Book");
+			var originalMetaData = BookMetaData.FromFolder(source);
+			Assert.That(originalMetaData.IsSuitableForMakingShells);
+			var path = _starter.CreateBookOnDiskFromTemplate(source, _projectFolder.Path);
+			var newMetaData = BookMetaData.FromFolder(path);
+			Assert.That(newMetaData.IsSuitableForMakingShells, Is.False);
+		}
 
 		[Test]
 		public void CreateBookOnDiskFromTemplate_FromFactoryA5_CreatesWithCoverAndTitle()

--- a/src/BloomTests/WebLibraryIntegration/BookTransferTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BookTransferTests.cs
@@ -77,10 +77,16 @@ namespace BloomTests.WebLibraryIntegration
 		/// <param name="uploader"></param>
 		/// <param name="data"></param>
 		/// <returns></returns>
-		public Tuple<string, string> UploadAndDownLoadNewBook(string bookName, string id, string uploader, string data)
+		public Tuple<string, string> UploadAndDownLoadNewBook(string bookName, string id, string uploader, string data, bool isTemplate = false)
 		{
 			//  Create a book folder with meta.json that includes an uploader and id and some other files.
 			var originalBookFolder = MakeBook(bookName, id, uploader, data);
+			if (isTemplate)
+			{
+				var metadata = BookMetaData.FromFolder(originalBookFolder);
+				metadata.IsSuitableForMakingShells = true;
+				metadata.WriteToFolder(originalBookFolder);
+			}
 			int fileCount = Directory.GetFiles(originalBookFolder).Length;
 
 			Login();
@@ -135,13 +141,44 @@ namespace BloomTests.WebLibraryIntegration
 			// Data uploaded with the same id but a different uploader should form a distinct book; the Jill data
 			// should not overwrite the Jack data. Likewise, data uploaded with a distinct Id by the same uploader should be separate.
 			var jacksFirstData = File.ReadAllText(firstPair.Item2.CombineForPath("one.htm"));
-			Assert.That(jacksFirstData, Is.EqualTo("Jack's data"));
+			// We use stringContaining here because upload does make some changes...for example connected with marking the
+			// book as lockedDown.
+			Assert.That(jacksFirstData, Is.StringContaining("Jack's data"));
 			var jillsData = File.ReadAllText(secondPair.Item2.CombineForPath("one.htm"));
-			Assert.That(jillsData, Is.EqualTo("Jill's data"));
+			Assert.That(jillsData, Is.StringContaining("Jill's data"));
 			var jacksSecondData = File.ReadAllText(thirdPair.Item2.CombineForPath("one.htm"));
-			Assert.That(jacksSecondData, Is.EqualTo("Jack's other data"));
+			Assert.That(jacksSecondData, Is.StringContaining("Jack's other data"));
 
 			// Todo: verify that we got three distinct book records in parse.com
+		}
+
+		/// <summary>
+		/// These two tests were worth writing but I don't think they are worth running every time.
+		/// Real uploads are slow and we get occasional failures when S3 is slow or something similar.
+		/// Use these tests if you are messing with the upload, download, or locking code.
+		/// </summary>
+		[Test, Ignore("slow and unlikely to fail")]
+		public void RoundTripBookLocksIt()
+		{
+			var pair = UploadAndDownLoadNewBook("first", "book1", "Jack", "Jack's data");
+			var originalFolder = pair.Item1;
+			var newFolder = pair.Item2;
+			var originalHtml = BookStorage.FindBookHtmlInFolder(originalFolder);
+			var newHtml = BookStorage.FindBookHtmlInFolder(newFolder);
+			AssertThatXmlIn.HtmlFile(originalHtml).HasNoMatchForXpath("//meta[@name='lockedDownAsShell' and @content='true']");
+			AssertThatXmlIn.HtmlFile(newHtml).HasAtLeastOneMatchForXpath("//meta[@name='lockedDownAsShell' and @content='true']");
+		}
+
+		[Test, Ignore("slow and unlikely to fail")]
+		public void RoundTripOfTemplateBookDoesNotLockIt()
+		{
+			var pair = UploadAndDownLoadNewBook("first", "book1", "Jack", "Jack's data", true);
+			var originalFolder = pair.Item1;
+			var newFolder = pair.Item2;
+			var originalHtml = BookStorage.FindBookHtmlInFolder(originalFolder);
+			var newHtml = BookStorage.FindBookHtmlInFolder(newFolder);
+			AssertThatXmlIn.HtmlFile(originalHtml).HasNoMatchForXpath("//meta[@name='lockedDownAsShell' and @content='true']");
+			AssertThatXmlIn.HtmlFile(newHtml).HasNoMatchForXpath("//meta[@name='lockedDownAsShell' and @content='true']");
 		}
 
 		[Test]
@@ -169,7 +206,7 @@ namespace BloomTests.WebLibraryIntegration
 			var newBookFolder = _transfer.DownloadBook(s3Id, dest);
 
 			var firstData = File.ReadAllText(newBookFolder.CombineForPath("one.htm"));
-			Assert.That(firstData, Is.EqualTo("something new"), "We should have overwritten the changed file");
+			Assert.That(firstData, Is.StringContaining("something new"), "We should have overwritten the changed file");
 			Assert.That(File.Exists(newBookFolder.CombineForPath("two.css")), Is.True, "We should have added the new file");
 			Assert.That(File.Exists(newBookFolder.CombineForPath("one.css")), Is.False, "We should have deleted the obsolete file");
 			// Verify that metadata was overwritten, new record not created.


### PR DESCRIPTION
Previous attempts to mark uploads and downloads as books
ready for localization left us with no way to actually put a template
in the library.
