### PR TITLE
Disable checking for updates on Linux

### DIFF
--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -78,7 +78,7 @@ namespace Bloom.Workspace
 			_model.UpdateDisplay += new System.EventHandler(OnUpdateDisplay);
 			InitializeComponent();
 
-#if !DEBUG
+#if !__MonoCS__ && !DEBUG
 			_sparkleApplicationUpdater.CheckOnFirstApplicationIdle();
 #endif
 			_toolStrip.Renderer = new NoBorderToolStripRenderer();


### PR DESCRIPTION
On Linux Bloom gets installed through the package manager which
regularly checks for new versions. Having the application check
for new versions instead will not work because the user doesn't
have permission to replace the existing executable, and the current
code would replace it with the Windows instead of the Linux version.
Seems better to leave the update job to the system package manager.
