### PR TITLE
Fix wrong icon in Linux (BL-779)

### DIFF
--- a/src/BloomExe/Collection/BloomPack/BloomPackInstallDialog.Designer.cs
+++ b/src/BloomExe/Collection/BloomPack/BloomPackInstallDialog.Designer.cs
@@ -128,7 +128,6 @@
 			this.Controls.Add(this._message);
 			this.Controls.Add(this._okButton);
 			this.Controls.Add(this.pictureBox1);
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
 			this._L10NSharpExtender.SetLocalizableToolTip(this, null);
 			this._L10NSharpExtender.SetLocalizationComment(this, null);
 			this._L10NSharpExtender.SetLocalizingId(this, "BloomPackInstallDialog.BloomPackInstallation");

--- a/src/BloomExe/Collection/BloomPack/BloomPackInstallDialog.cs
+++ b/src/BloomExe/Collection/BloomPack/BloomPackInstallDialog.cs
@@ -26,6 +26,13 @@ namespace Bloom.Collection.BloomPack
 			_okButton.Enabled = false;
 		}
 
+		protected override void OnHandleCreated(EventArgs e)
+		{
+			base.OnHandleCreated(e);
+
+			// BL-552, BL-779: a bug in Mono requires us to wait to set Icon until handle created.
+			this.Icon = global::Bloom.Properties.Resources.Bloom;
+		}
 
 		private void _okButton_Click(object sender, EventArgs e)
 		{

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -64,8 +64,13 @@ namespace Bloom.Collection
 			_useImageServer.CheckStateChanged += new EventHandler(_useImageServer_CheckedChanged);
 
 			UpdateDisplay();
+		}
 
-			// BL-375: Remove conditional compile code from designer file
+		protected override void OnHandleCreated(EventArgs e)
+		{
+			base.OnHandleCreated(e);
+
+			// BL-552, BL-779: a bug in Mono requires us to wait to set Icon until handle created.
 			this.Icon = global::Bloom.Properties.Resources.Bloom;
 		}
 

--- a/src/BloomExe/CollectionChoosing/OpenAndCreateCollectionDialog.Designer.cs
+++ b/src/BloomExe/CollectionChoosing/OpenAndCreateCollectionDialog.Designer.cs
@@ -65,9 +65,6 @@
             this.BackColor = System.Drawing.Color.White;
             this.ClientSize = new System.Drawing.Size(820, 383);
             this.Controls.Add(this._openAndCreateControl);
-#if !__MonoCS__
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-#endif			
             this._L10NSharpExtender.SetLocalizableToolTip(this, null);
             this._L10NSharpExtender.SetLocalizationComment(this, null);
             this._L10NSharpExtender.SetLocalizingId(this, "OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle");

--- a/src/BloomExe/CollectionChoosing/OpenAndCreateCollectionDialog.cs
+++ b/src/BloomExe/CollectionChoosing/OpenAndCreateCollectionDialog.cs
@@ -1,7 +1,8 @@
-﻿using System.Windows.Forms;
+﻿using System;
+using System.Windows.Forms;
+using L10NSharp;
 using Bloom.CollectionCreating;
 using Bloom.Properties;
-using L10NSharp;
 
 namespace Bloom.CollectionChoosing
 {
@@ -25,7 +26,13 @@ namespace Bloom.CollectionChoosing
 																};
 		}
 
+		protected override void OnHandleCreated(EventArgs e)
+		{
+			base.OnHandleCreated(e);
 
+			// BL-552, BL-779: a bug in Mono requires us to wait to set Icon until handle created.
+			this.Icon = global::Bloom.Properties.Resources.Bloom;
+		}
 
 		public string SelectedPath
 		{

--- a/src/BloomExe/Shell.cs
+++ b/src/BloomExe/Shell.cs
@@ -89,8 +89,13 @@ namespace Bloom
 			this.Controls.Add(this._workspaceView);
 
 			SetWindowText();
+		}
 
-			// BL-552: Program icon wrong on Linux
+		protected override void OnHandleCreated(EventArgs e)
+		{
+			base.OnHandleCreated(e);
+
+			// BL-552, BL-779: a bug in Mono requires us to wait to set Icon until handle created.
 			this.Icon = global::Bloom.Properties.Resources.Bloom;
 		}
 

--- a/src/BloomExe/SplashScreen.Designer.cs
+++ b/src/BloomExe/SplashScreen.Designer.cs
@@ -190,7 +190,6 @@
 			this.Controls.Add(this._longVersionInfo);
 			this.Cursor = System.Windows.Forms.Cursors.AppStarting;
 			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
 			this.MinimizeBox = false;
 			this.Name = "SplashScreen";
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/src/BloomExe/SplashScreen.cs
+++ b/src/BloomExe/SplashScreen.cs
@@ -65,5 +65,13 @@ namespace Bloom
 										Palette.SILInternationalBlue,5, ButtonBorderStyle.Solid,
 										Palette.SILInternationalBlue,5, ButtonBorderStyle.Solid);
 		}
+
+		protected override void OnHandleCreated(EventArgs e)
+		{
+			base.OnHandleCreated(e);
+
+			// BL-552, BL-779: a bug in Mono requires us to wait to set Icon until handle created.
+			this.Icon = global::Bloom.Properties.Resources.Bloom;
+		}
 	}
 }


### PR DESCRIPTION
In release builds we occasionally tried to set the icon before
the handle was created. Due to a mono bug this didn't work.
This change sets the icon after the handle got created.
