### PR TITLE
Fix BL-799: hovering on format cog makes the source bubble disappear

### DIFF
--- a/DistFiles/localization/Bloom.en.tmx
+++ b/DistFiles/localization/Bloom.en.tmx
@@ -1023,6 +1023,7 @@
     </tu>
     <tu tuid="EditTab.FormatDialogTip">
       <prop type="x-dynamic">true</prop>
+      <prop type="x-nolongerused">true</prop>
       <tuv xml:lang="en">
         <seg>Adjust formatting for style</seg>
       </tuv>

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
@@ -514,8 +514,11 @@ var StyleEditor = (function () {
         // the user won't see resize and drag controls when they click on it
         $(targetBox).append('<div id="formatButton" contenteditable="false" class="bloom-ui"><img  contenteditable="false" src="' + editor._supportFilesRoot + '/img/cogGrey.svg"></div>');
         var formatButton = $('#formatButton');
+
+        /* we removed this for BL-799, plus it was always getting in the way, once the format popup was opened
         var txt = localizationManager.getText('EditTab.FormatDialogTip', 'Adjust formatting for style');
         editor.AddQtipToElement(formatButton, txt, 1500);
+        */
         formatButton.click(function () {
             iframeChannel.simpleAjaxGet('/bloom/availableFontNames', function (fontData) {
                 editor.boxBeingEdited = targetBox;

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -522,8 +522,10 @@ class StyleEditor {
         // the user won't see resize and drag controls when they click on it
         $(targetBox).append('<div id="formatButton" contenteditable="false" class="bloom-ui"><img  contenteditable="false" src="' + editor._supportFilesRoot + '/img/cogGrey.svg"></div>');
         var formatButton = $('#formatButton');
+        /* we removed this for BL-799, plus it was always getting in the way, once the format popup was opened 
         var txt = localizationManager.getText('EditTab.FormatDialogTip', 'Adjust formatting for style');
         editor.AddQtipToElement(formatButton, txt, 1500);
+        */
         formatButton.click(function () {
             iframeChannel.simpleAjaxGet('/bloom/availableFontNames', function (fontData) {
                 editor.boxBeingEdited = targetBox;

--- a/src/BloomExe/Book/RuntimeInformationInjector.cs
+++ b/src/BloomExe/Book/RuntimeInformationInjector.cs
@@ -172,7 +172,7 @@ namespace Bloom.Book
 
 			// tool tips for style editor
 			AddTranslationToDictionaryUsingKey(d, "BookEditor.FontSizeTip", "Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.");
-			AddTranslationToDictionaryUsingKey(d, "EditTab.FormatDialogTip", "Adjust formatting for style");
+			//No longer used. See BL-799 AddTranslationToDictionaryUsingKey(d, "EditTab.FormatDialogTip", "Adjust formatting for style");
 			AddTranslationToDictionaryUsingKey(d, "EditTab.FormatDialog.WordSpacingNormal", "Normal");
 			AddTranslationToDictionaryUsingKey(d, "EditTab.FormatDialog.WordSpacingWide", "Wide");
 			AddTranslationToDictionaryUsingKey(d, "EditTab.FormatDialog.WordSpacingExtraWide", "Extra Wide");


### PR DESCRIPTION
For now we'll just not have the tooltip on the cog. It was also in the way once the format dialog came up. In the future, we could move it to qtip2, so that it wouldn't interfere with the qtip being used by the source language bubble, and change somebody's zindex so it doesn't interfere with the format dialog.
