### PR TITLE
BL-757: final fixes to delete/duplicate menu items

### DIFF
--- a/src/BloomExe/Edit/ConfirmRemovePageDialog.designer.cs
+++ b/src/BloomExe/Edit/ConfirmRemovePageDialog.designer.cs
@@ -120,7 +120,7 @@
 			this.deleteBtn.Name = "deleteBtn";
 			this.deleteBtn.Size = new System.Drawing.Size(75, 26);
 			this.deleteBtn.TabIndex = 0;
-			this.deleteBtn.Text = "&Delete";
+			this.deleteBtn.Text = "&Remove";
 			this.deleteBtn.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
 			this.deleteBtn.UseVisualStyleBackColor = true;
 			this.deleteBtn.Click += new System.EventHandler(this.deleteBtn_Click);
@@ -153,7 +153,7 @@
 			this.ShowIcon = false;
 			this.ShowInTaskbar = false;
 			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Really Delete Page?";
+			this.Text = "Really Remove Page?";
 			this.tableLayout.ResumeLayout(false);
 			this.tableLayout.PerformLayout();
 			((System.ComponentModel.ISupportInitialize)(this.pictureRecycleBin)).EndInit();

--- a/src/BloomExe/Edit/PageListView.cs
+++ b/src/BloomExe/Edit/PageListView.cs
@@ -41,9 +41,13 @@ namespace Bloom.Edit
 				var dupItem = new MenuItem(dupPage, (sender, eventArgs) => _model.DuplicatePage(page));
 				args.ContextMenu.MenuItems.Add(dupItem);
 				var removePage = LocalizationManager.GetString("EditTab._deletePageButton", "Remove Page"); // same ID as button in toolbar
-				var removeItem = new MenuItem(removePage, (sender, eventArgs) => _model.DeletePage(page));
+				var removeItem = new MenuItem(removePage, (sender, eventArgs) =>
+				{
+					if (ConfirmRemovePageDialog.Confirm())
+					_model.DeletePage(page);
+				});
 				args.ContextMenu.MenuItems.Add(removeItem);
-				dupItem.Enabled = removeItem.Enabled = page != null && !page.Required;
+				dupItem.Enabled = removeItem.Enabled = page != null && !page.Required && !_model.CurrentBook.LockedDown;
 			};
 		}
 


### PR DESCRIPTION
- Both disabled if book is locked down
- Use Confirm dialog for delete
- Use 'Remove' consistently in Confirm dialog
