### PR TITLE
Fix BL-625, where imageInMiddle pages looked wrong when multilingual

### DIFF
--- a/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.css
+++ b/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.css
@@ -327,26 +327,26 @@ DIV.imageOnTop.A5Portrait.bloom-trilingual DIV.bloom-translationGroup {
   left: 0;
 }
 .imageInMiddle .bloom-translationGroup:nth-of-type(1) .bloom-editable {
-  margin-bottom: 10;
+  margin-bottom: 10px;
 }
 .imageInMiddle .bloom-translationGroup:nth-of-type(3) {
   left: 0;
   bottom: 0;
 }
 .imageInMiddle .bloom-translationGroup:nth-of-type(3) .bloom-editable {
-  margin-top: 10;
+  margin-top: 10px;
 }
 .imageInMiddle .bloom-editable {
   width: 100%;
 }
 .imageInMiddle.bloom-monolingual .bloom-editable {
-  height: calc(100% - 10) !important;
+  height: calc(100% - 10px) !important;
 }
 .imageInMiddle.bloom-bilingual .bloom-editable {
-  height: calc(50% - 10 - 1px) !important;
+  height: calc(50% - 10px - 1px) !important;
 }
 .imageInMiddle.bloom-trilingual .bloom-editable {
-  height: calc(33% - 10 - 1px) !important;
+  height: calc(33% - 10px - 1px) !important;
 }
 .imageOnBottom .bloom-imageContainer {
   height: 45%;

--- a/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.less
+++ b/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.less
@@ -349,7 +349,7 @@ DIV.imageOnTop.A5Portrait.bloom-trilingual DIV.bloom-translationGroup
 		position: absolute;
 	}
 
-	@SpaceBetweenMultilingualAlternatives: 10;
+	@SpaceBetweenMultilingualAlternatives: 10px;
 
 	// ----- the top GROUP -----
 	.bloom-translationGroup:nth-of-type(1) {


### PR DESCRIPTION
The problem was that the CSS "calc" was failing because of lack of units on the SpaceBetweenMultilingualAlternatives variable.
