### PR TITLE
Ignore failing unit test on Windows

### DIFF
--- a/src/BloomTests/WebLibraryIntegration/ProxyManagerTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/ProxyManagerTests.cs
@@ -134,6 +134,7 @@ namespace BloomTests.WebLibraryIntegration
 		}
 
 		[Test]
+		[Platform(Exclude="Win", Reason="Environment variables on Windows are case-insensitive")]
 		public void BothEnvironmentVariables_UsesLowercaseVariable()
 		{
 			Environment.SetEnvironmentVariable("http_proxy", "http://example1.com");


### PR DESCRIPTION
Environment variables on Windows are not case-sensitive which makes
this test pointless for Windows.
