### PR TITLE
Fix BL-651 "[Linux] Calendar setup ... entry boxes are mis-registered"

### DIFF
--- a/DistFiles/factoryCollections/Templates/Wall Calendar/configuration.css
+++ b/DistFiles/factoryCollections/Templates/Wall Calendar/configuration.css
@@ -17,7 +17,7 @@ INPUT.year
 {
 	/*+placement:shift -2px 16px;*/
 	position: relative;
-	left: -2px;
+	left: 0px;
 	top: 16px;
 	font-size: x-large;
 	width: 81px;
@@ -26,7 +26,7 @@ INPUT.year
 }
 DIV#monthNames
 {
-	width: 221px;
+	width: 240px;
 	/*[empty]height:;*/
 	/*+placement:shift 243px -200px;*/
 	position: relative;
@@ -60,8 +60,10 @@ LABEL
 #monthNames LABEL
 {
 	width: 28px;
-	height: 9px;
-	margin-top: 5px;
+}
+#monthNames INPUT
+{
+	width: 200px;
 }
 LABEL.year
 {


### PR DESCRIPTION
There doesn't seem to be any way to get identical output on
1) Windows 7, 2) Linux X display, and 3) Linux xephyr display.
This change seems to be about the best compromise, showing minimal
change on Windows 7 and acceptable display on Linux.
