### PR TITLE
Add code to help track and maybe help the problem in BL-836

### DIFF
--- a/src/BloomExe/web/ReadersHandler.cs
+++ b/src/BloomExe/web/ReadersHandler.cs
@@ -30,6 +30,11 @@ namespace Bloom.web
 
 		public static bool HandleRequest(string localPath, IRequestInfo info, CollectionSettings currentCollectionSettings)
 		{
+			if (CurrentBook == null || CurrentBook.CollectionSettings == null)
+			{
+				Debug.Fail("BL-836 reproduction?");
+				return false;
+			}
 			var lastSep = localPath.IndexOf("/", StringComparison.Ordinal);
 			var lastSegment = (lastSep > -1) ? localPath.Substring(lastSep + 1) : localPath;
 


### PR DESCRIPTION
BL-836 is where at times the reader is getting an object = null. We can tell from the line number that it is either CurrentBook or CurrentBook.CollectionSettings. Possibly this is a timing problem. This commit doesn't attempt to get at the root problem, but catches it earlier with a debug message, and returns false,
