### PR TITLE
Fix BL-843 "Update Book" corrupts custom pages

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -740,6 +740,9 @@ namespace Bloom.Book
 			progress.WriteStatus("Updating pages that were based on Basic Book...");
 			foreach (XmlElement templatePageDiv in templateDom.SafeSelectNodes("//body/div"))
 			{
+				if (templatePageDiv.GetOptionalStringAttribute("class", "").Contains("customPage"))
+					return; // we sure don't want to revert this page to its blank custom state
+
 				var templateId = templatePageDiv.GetStringAttribute("id");
 				if (string.IsNullOrEmpty(templateId))
 					return;


### PR DESCRIPTION
Update Book was written before we had custom pages, so it blindly tries to make pages conform to their ancestor in the BasicBook template. This commit excludes pages with the "customPage" class from that process.
