### PR TITLE
Allow multiple test runs at the same time

### DIFF
--- a/src/BloomTests/WebLibraryIntegration/BloomParseClientTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BloomParseClientTests.cs
@@ -41,27 +41,36 @@ namespace BloomTests.WebLibraryIntegration
 		[Test]
 		public void CreateDeleteAndLogin()
 		{
-			if (_client.LogIn("mytest@example.com", "nonsense"))
+			var accountInstanceId = Guid.NewGuid().ToString();
+			var account = string.Format("mytest-{0}@example.com", accountInstanceId);
+			var titleCaseAccount = string.Format("Mytest-{0}@example.com", accountInstanceId);
+			var titleCaseDomain = string.Format("Mytest-{0}@Example.com", accountInstanceId);;
+
+			if (_client.LogIn(account, "nonsense"))
 				_client.DeleteCurrentUser();
-			Assert.That(_client.LogIn("mytest@example.com", "nonsense"), Is.False);
-			Assert.That(_client.UserExists("mytest@example.com"), Is.False);
-			_client.CreateUser("mytest@example.com", "nonsense");
-			Assert.That(_client.LogIn("mytest@example.com", "nonsense"), Is.True);
-			Assert.That(_client.LogIn("Mytest@example.com", "nonsense"), Is.True, "login is not case-independent");
-			Assert.That(_client.UserExists("mytest@example.com"), Is.True);
-			Assert.That(_client.UserExists("Mytest@example.com"), Is.True, "UserExists is not case-independent");
+			Assert.That(_client.LogIn(account, "nonsense"), Is.False);
+			Assert.That(_client.UserExists(account), Is.False);
+
+			_client.CreateUser(account, "nonsense");
+			Assert.That(_client.LogIn(account, "nonsense"), Is.True);
+			Assert.That(_client.LogIn(titleCaseAccount, "nonsense"), Is.True, "login is not case-independent");
+			Assert.That(_client.UserExists(account), Is.True);
+			Assert.That(_client.UserExists(titleCaseAccount), Is.True, "UserExists is not case-independent");
+
 			_client.DeleteCurrentUser();
 			Assert.That(_client.LoggedIn, Is.False);
-			Assert.That(_client.UserExists("mytest@example.com"), Is.False);
-			Assert.That(_client.LogIn("mytest@example.com", "nonsense"), Is.False);
-			_client.CreateUser("Mytest@Example.com", "nonsense");
-			Assert.That(_client.LogIn("Mytest@example.com", "nonsense"), Is.True, "CreateUser is not case-independent");
-			Assert.That(_client.LogIn("mytest@example.com", "nonsense"), Is.True, "CreateUser is not case-independent");
-			Assert.That(_client.UserExists("Mytest@Example.com"), Is.True);
-			Assert.That(_client.UserExists("Mytest@example.com"), Is.True, "UserExists is not case-independent");
+			Assert.That(_client.UserExists(account), Is.False);
+			Assert.That(_client.LogIn(account, "nonsense"), Is.False);
+
+			_client.CreateUser(titleCaseDomain, "nonsense");
+			Assert.That(_client.LogIn(titleCaseAccount, "nonsense"), Is.True, "CreateUser is not case-independent");
+			Assert.That(_client.LogIn(account, "nonsense"), Is.True, "CreateUser is not case-independent");
+			Assert.That(_client.UserExists(titleCaseDomain), Is.True);
+			Assert.That(_client.UserExists(titleCaseAccount), Is.True, "UserExists is not case-independent");
+
 			_client.DeleteCurrentUser();
 			Assert.That(_client.LoggedIn, Is.False);
-			Assert.That(_client.LogIn("mytest@example.com", "nonsense"), Is.False);
+			Assert.That(_client.LogIn(account, "nonsense"), Is.False);
 		}
 
 		[Test]

--- a/src/BloomTests/WebLibraryIntegration/BloomS3ClientTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BloomS3ClientTests.cs
@@ -36,7 +36,7 @@ namespace BloomTests.WebLibraryIntegration
 
 		private string MakeBook()
 		{
-			var f = new TemporaryFolder(_workFolder, "unittest");
+			var f = new TemporaryFolder(_workFolder, "unittest-" + Guid.NewGuid());
 			File.WriteAllText(Path.Combine(f.FolderPath, "one.htm"), "test");
 			File.WriteAllText(Path.Combine(f.FolderPath, "one.css"), "test");
 			return f.FolderPath;
@@ -55,11 +55,14 @@ namespace BloomTests.WebLibraryIntegration
 			string srcBookPath = MakeBook();
 			var storageKeyOfBookFolder = UploadBook(srcBookPath);
 
-			Assert.AreEqual(Directory.GetFiles(srcBookPath).Count(), _client.GetCountOfAllFilesInBucket());
+			// It's possible that another unit test uploads a book at the same time, so we can't
+			// test for strict equality.
+			Assert.That(_client.GetCountOfAllFilesInBucket(), Is.AtLeast(Directory.GetFiles(srcBookPath).Count()));
 
+			var expectedDir = Path.GetFileName(srcBookPath);
 			foreach (var file in Directory.GetFiles(srcBookPath))
 			{
-				Assert.IsTrue(_client.FileExists(storageKeyOfBookFolder, "unittest", Path.GetFileName(file)));
+				Assert.IsTrue(_client.FileExists(storageKeyOfBookFolder, expectedDir, Path.GetFileName(file)));
 			}
 		}
 

--- a/src/BloomTests/WebLibraryIntegration/BookTransferTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BookTransferTests.cs
@@ -27,7 +27,7 @@ namespace BloomTests.WebLibraryIntegration
 		[SetUp]
 		public void Setup()
 		{
-			_workFolder = new TemporaryFolder("unittest");
+			_workFolder = new TemporaryFolder("unittest-" + Guid.NewGuid());
 			_workFolderPath = _workFolder.FolderPath;
 			Assert.AreEqual(0,Directory.GetDirectories(_workFolderPath).Count(),"Some stuff was left over from a previous test");
 			Assert.AreEqual(0, Directory.GetFiles(_workFolderPath).Count(),"Some stuff was left over from a previous test");


### PR DESCRIPTION
Now that we have the tests running on both Windows and Linux some
of the tests randomly fail. It looks like it's caused by a race
condition when the same test runs multiple times at the same time.
This change improves several of the tests that interact with
Amazon S3 by adding a random part to the username and directory
name.
