### PR TITLE
Don't lowercase filenames on Linux before opening the file

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -434,10 +434,16 @@ namespace Bloom.Book
 
 		public void AddStyleSheetIfMissing(string path)
 		{
+			// Remember, Linux filenames are case sensitive.
+			var pathToCheck = path;
+			if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+				pathToCheck = pathToCheck.ToLowerInvariant();
 			foreach (XmlElement link in _dom.SafeSelectNodes("//link[@rel='stylesheet']"))
 			{
-				var fileName = link.GetStringAttribute("href").ToLower();
-				if (fileName == path.ToLower())
+				var fileName = link.GetStringAttribute("href");
+				if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+					fileName = fileName.ToLowerInvariant();
+				if (fileName == pathToCheck)
 					return;
 			}
 			_dom.AddStyleSheet(path.Replace("file://", ""));
@@ -446,23 +452,30 @@ namespace Bloom.Book
 		public IEnumerable<string> GetTemplateStyleSheets()
 		{
 			var stylesheetsToIgnore = new List<string>();
-			stylesheetsToIgnore.Add("basepage.css");
-			stylesheetsToIgnore.Add("languagedisplay.css");
-			stylesheetsToIgnore.Add("editmode.css");
-			stylesheetsToIgnore.Add("editoriginalmode.css");
-			stylesheetsToIgnore.Add("previewmode.css");
-			stylesheetsToIgnore.Add("settingsCollectionStyles.css".ToLower());
-			stylesheetsToIgnore.Add("customCollectionStyles.css".ToLower());
-			stylesheetsToIgnore.Add("customBookStyles.css".ToLower());
-			stylesheetsToIgnore.Add("xmatter");
+			// Remember, Linux filenames are case sensitive!
+			stylesheetsToIgnore.Add("basePage.css");
+			stylesheetsToIgnore.Add("languageDisplay.css");
+			stylesheetsToIgnore.Add("editMode.css");
+			stylesheetsToIgnore.Add("editOriginalMode.css");
+			stylesheetsToIgnore.Add("previewMode.css");
+			stylesheetsToIgnore.Add("settingsCollectionStyles.css");
+			stylesheetsToIgnore.Add("customCollectionStyles.css");
+			stylesheetsToIgnore.Add("customBookStyles.css");
+			stylesheetsToIgnore.Add("XMatter");
 
 			foreach (XmlElement link in _dom.SafeSelectNodes("//link[@rel='stylesheet']"))
 			{
-				var fileName = link.GetStringAttribute("href").ToLower();
+				var fileName = link.GetStringAttribute("href");
+				var nameToCheck = fileName;
+				if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+					nameToCheck = fileName.ToLowerInvariant();
 				bool match = false;
 				foreach (var nameOrFragment in stylesheetsToIgnore)
 				{
-					if (fileName.Contains(nameOrFragment))
+					var nameStyle = nameOrFragment;
+					if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+						nameStyle = nameStyle.ToLowerInvariant();
+					if (nameToCheck.Contains(nameStyle))
 					{
 						match = true;
 						break;

--- a/src/BloomExe/Book/ImageUpdater.cs
+++ b/src/BloomExe/Book/ImageUpdater.cs
@@ -73,14 +73,13 @@ namespace Bloom.Book
 		public static void UpdateImgMetdataAttributesToMatchImage(string folderPath, XmlElement imgElement, IProgress progress, Metadata metadata)
 		{
 			//see also PageEditingModel.UpdateMetadataAttributesOnImage(), which does the same thing but on the browser dom
-			var fileName = imgElement.GetOptionalStringAttribute("src", string.Empty).ToLower();
-
+			var fileName = imgElement.GetOptionalStringAttribute("src", string.Empty);
 			var end = fileName.IndexOf('?');
 			if (end > 0)
 			{
 				fileName = fileName.Substring(0, end);
 			}
-			if (fileName == "placeholder.png" || fileName == "license.png")
+			if (fileName.ToLowerInvariant() == "placeholder.png" || fileName.ToLowerInvariant() == "license.png")
 				return;
 			if (string.IsNullOrEmpty(fileName))
 			{

--- a/src/BloomExe/Book/SizeAndOrientation.cs
+++ b/src/BloomExe/Book/SizeAndOrientation.cs
@@ -94,7 +94,7 @@ namespace Bloom.Book
 		public static SizeAndOrientation FromString(string name)
 		{
 			var nameLower = name.ToLower();
-			var startOfOrientationName = Math.Max(nameLower.ToLower().IndexOf("landscape"), nameLower.ToLower().IndexOf("portrait"));
+			var startOfOrientationName = Math.Max(nameLower.IndexOf("landscape"), nameLower.IndexOf("portrait"));
 			if(startOfOrientationName == -1)
 			{
 				Debug.Fail("No orientation name found in '"+nameLower+"'");
@@ -105,14 +105,14 @@ namespace Bloom.Book
 					};
 			}
 			int startOfAlternativeName=-1;
-			if(nameLower.ToLower().Contains("landscape"))
+			if(nameLower.Contains("landscape"))
 				startOfAlternativeName = startOfOrientationName + "landscape".Length;
 			else
 				startOfAlternativeName = startOfOrientationName + "portrait".Length;
 
 			return new SizeAndOrientation()
 					{
-						IsLandScape = nameLower.ToLower().Contains("landscape"),
+						IsLandScape = nameLower.Contains("landscape"),
 						PageSizeName = nameLower.Substring(0, startOfOrientationName).ToUpperFirstLetter(),
 						//AlternativeName = name.Substring(startOfAlternativeName, nameLower.Length - startOfAlternativeName)
 					};
@@ -133,8 +133,7 @@ namespace Bloom.Book
 					fileName.ToLower().Contains("matter") || fileName.ToLower().Contains("languagedisplay"))
 					continue;
 
-				fileName = fileName.Replace("file://", "").Replace("%5C", "/");
-				fileName = fileName.Replace("file://", "").Replace("%20", " ");
+				fileName = fileName.Replace("file://", "").Replace("%5C", "/").Replace("%20", " ");
 				var path = fileLocator.LocateFile(fileName);
 				if(string.IsNullOrEmpty(path))
 				{

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -938,6 +938,7 @@ namespace Bloom.Edit
 
 		public string GetFontAvailabilityMessage()
 		{
+			// REVIEW: does this ToLower() do the right thing on Linux, where filenames are case sensitive?
 			var name = _collectionSettings.DefaultLanguage1FontName.ToLower();
 
 			if(null == FontFamily.Families.FirstOrDefault(f => f.Name.ToLower() == name))

--- a/src/BloomExe/Edit/PageEditingModel.cs
+++ b/src/BloomExe/Edit/PageEditingModel.cs
@@ -169,7 +169,7 @@ namespace Bloom.Edit
 			if(string.IsNullOrEmpty(imageInfo.FileName))
 				return false;
 
-			return  new []{"jpg", "jpeg"}.Contains(Path.GetExtension(imageInfo.FileName).ToLower());
+			return  new []{".jpg", ".jpeg"}.Contains(Path.GetExtension(imageInfo.FileName).ToLower());
 		}
 
 		public void UpdateMetdataAttributesOnImgElement(GeckoHtmlElement img, PalasoImage imageInfo)

--- a/src/BloomExe/WebLibraryIntegration/BookDownloadSupport.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookDownloadSupport.cs
@@ -68,7 +68,7 @@ namespace Bloom.WebLibraryIntegration
 				return;
 			var root = Registry.CurrentUser.CreateSubKey(@"Software\Classes");
 			var key = root.CreateSubKey(@"bloom\shell\open\command");
-			key.SetValue("", CommandToLaunchBloom);
+			key.SetValue("", CommandToLaunchBloomOnWindows);
 
 			key = root.CreateSubKey("bloom");
 			key.SetValue("", "BLOOM:URL Protocol");
@@ -80,7 +80,7 @@ namespace Bloom.WebLibraryIntegration
 			var key = root.OpenSubKey(@"bloom\shell\open\command");
 			if (key == null)
 				return false;
-			var wanted = CommandToLaunchBloom;
+			var wanted = CommandToLaunchBloomOnWindows;
 			if (wanted != (key.GetValue("") as string).ToLowerInvariant())
 				return false;
 			key = root.OpenSubKey("bloom");
@@ -91,7 +91,7 @@ namespace Bloom.WebLibraryIntegration
 			return true;
 		}
 
-		private string CommandToLaunchBloom
+		private string CommandToLaunchBloomOnWindows
 		{
 			get { return Application.ExecutablePath.ToLowerInvariant() + " \"%1\""; }
 		}


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/BL-828 "[Linux] Vaccination Shell
has lost the License info for Front Cover Image".  This inspired me to
go looking for similar problems elsewhere in the Bloom code.  The actual
fix for the code is in ImageUpdater.cs.
