### PR TITLE
Add .bloom-text-for-css to enable text-sensitive CSS rules.

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -1229,6 +1229,18 @@ function SetupElements(container) {
 
     SetBookCopyrightAndLicenseButtonVisibility(container);
 
+    //CSS normally can't get at the text in order to, for example, show something different if it is empty.
+    //This allows you to add .bloom-needs-data-text to a bloom-translationGroup in order to get
+    //its child bloom-editable's to have data-texts's on them
+    $(container).find(".bloom-translationGroup.bloom-text-for-css .bloom-editable").each(function () {
+        // initially fill it
+        $(this).attr('data-text', this.textContent);
+        // keep it up to date
+        $(this).on('blur paste input', function () {
+            $(this).attr('data-text', this.textContent);
+        });
+    });
+
     //in bilingual/trilingual situation, re-order the boxes to match the content languages, so that stylesheets don't have to
     $(container).find(".bloom-translationGroup").each(function () {
         var contentElements = $(this).find("textarea, div.bloom-editable");


### PR DESCRIPTION
CSS normally can't get at the text in order to, for example, show something different if it is empty.
With this, you can add .bloom-needs-data-text to a bloom-translationGroup in order to get
its child bloom-editable's to have data-texts attributes and then write css rules like this one, which shows a word-breaking symbol only if the prefix isn't empty:
    .prefix .bloom-editable:not([data-text=""]):after{ content:'-';  }
