### PR TITLE
Allow user styles to effect divs that are not editable

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
@@ -288,27 +288,23 @@ var StyleEditor = (function () {
             else
                 styleAndLang = styleName + ":not([lang])";
         }
-        var bloomEditable = '.bloom-editable';
+
         for (var i = 0; i < ruleList.length; i++) {
-            if (!ruleList[i].cssText.startsWith(bloomEditable)) {
-                var oldText = ruleList[i].cssText;
-                this.ReplaceExistingStyle(styleSheet, i, bloomEditable + oldText);
-            }
             var index = ruleList[i].cssText.indexOf('{');
             if (index == -1)
                 continue;
-            var match = ruleList[i].cssText.substring(bloomEditable.length, index);
+            var match = ruleList[i].cssText;
 
             // if we're not ignoring language, we simply need a match for styleAndLang, which includes a lang component.
             // if we're ignoring language, we must find a rule that doesn't specify language at all, even if we
             // have one that does.
             // It's probably pathological to worry about the style name occurring in the body of some other rule,
             // especially with the -style suffix, but it seems safer not to risk it.
-            if (match.indexOf(styleAndLang) > -1 && (!ignoreLanguage || match.indexOf('[lang') == -1)) {
+            if (match.toLowerCase().indexOf(styleAndLang.toLowerCase()) > -1 && (!ignoreLanguage || match.indexOf('[lang') == -1)) {
                 return ruleList[i];
             }
         }
-        styleSheet.insertRule(bloomEditable + '.' + styleAndLang + "{ }", ruleList.length);
+        styleSheet.insertRule('.' + styleAndLang + "{ }", ruleList.length);
 
         return ruleList[ruleList.length - 1];
     };

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -300,26 +300,22 @@ class StyleEditor {
             else
                 styleAndLang = styleName + ":not([lang])";
         }
-        var bloomEditable = '.bloom-editable';
+
         for (var i = 0; i < ruleList.length; i++) {
-            if (!ruleList[i].cssText.startsWith(bloomEditable)) { // we might need to update old rules?
-                var oldText = ruleList[i].cssText;
-                this.ReplaceExistingStyle((<CSSStyleSheet>styleSheet), i, bloomEditable + oldText);
-            }
             var index = ruleList[i].cssText.indexOf('{');
             if (index == -1) continue;
-            var match = ruleList[i].cssText.substring(bloomEditable.length, index);
+            var match = ruleList[i].cssText;
             // if we're not ignoring language, we simply need a match for styleAndLang, which includes a lang component.
             // if we're ignoring language, we must find a rule that doesn't specify language at all, even if we
             // have one that does.
             // It's probably pathological to worry about the style name occurring in the body of some other rule,
             // especially with the -style suffix, but it seems safer not to risk it.
-            if (match.indexOf(styleAndLang) > -1 && (!ignoreLanguage || match.indexOf('[lang') == -1)) {
+            if (match.toLowerCase().indexOf(styleAndLang.toLowerCase()) > -1 && (!ignoreLanguage || match.indexOf('[lang') == -1)) {
                 return <CSSStyleRule> ruleList[i];
             }
         }
-        (<CSSStyleSheet>styleSheet).insertRule(bloomEditable + '.' + styleAndLang + "{ }", ruleList.length);
-
+        (<CSSStyleSheet>styleSheet).insertRule('.' + styleAndLang + "{ }", ruleList.length);
+       
         return <CSSStyleRule> ruleList[ruleList.length - 1]; //new guy is last
     }
 


### PR DESCRIPTION
I'm not clear why, but previously the StyleEditor code assumed and required that user modified style rules began with ".bloom-editable". This made it impossible to have make a page where, if the user modified the style of some editable box, other elements on the page would change as well, in order to keep the page consistent. The particular page for which this came up was the credits page, where a big chunk of the page is not .bloom-editable's.