### PR TITLE
Make S3 tests more robust

### DIFF
--- a/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
@@ -132,12 +132,13 @@ namespace Bloom.WebLibraryIntegration
 			return _amazonS3.ListObjects(request).S3Objects.Count>0;
 		}
 
-		public void EmptyUnitTestBucket()
+		public void EmptyUnitTestBucket(string prefix)
 		{
 			var matchingFilesResponse = _amazonS3.ListObjects(new ListObjectsRequest()
 			{
 				//NB: this one intentionally hard-codes the folder it can delete, to protect from accidents
 				BucketName = UnitTestBucketName,
+				Prefix = prefix,
 			});
 			if (matchingFilesResponse.S3Objects.Count == 0)
 				return;

--- a/src/BloomTests/WebLibraryIntegration/BloomS3ClientTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BloomS3ClientTests.cs
@@ -14,6 +14,7 @@ namespace BloomTests.WebLibraryIntegration
 		private BloomS3Client _client;
 		private TemporaryFolder _workFolder;
 		private string _workFolderPath;
+		private string _storageKeyOfBookFolder;
 
 		[SetUp]
 		public void Setup()
@@ -23,16 +24,17 @@ namespace BloomTests.WebLibraryIntegration
 			Assert.AreEqual(0,Directory.GetDirectories(_workFolderPath).Count(),"Some stuff was left over from a previous test");
 			Assert.AreEqual(0, Directory.GetFiles(_workFolderPath).Count(),"Some stuff was left over from a previous test");
 
+			_storageKeyOfBookFolder = Guid.NewGuid().ToString();
 			_client = new BloomS3Client(BloomS3Client.UnitTestBucketName);
-			_client.EmptyUnitTestBucket();
 		}
 
 		[TearDown]
 		public void TearDown()
 		{
 			_workFolder.Dispose();
+			_client.EmptyUnitTestBucket(_storageKeyOfBookFolder);
+			_client.Dispose();
 		}
-
 
 		private string MakeBook()
 		{
@@ -44,9 +46,8 @@ namespace BloomTests.WebLibraryIntegration
 
 		private string UploadBook(string path)
 		{
-			string storageKeyOfBookFolder = Guid.NewGuid().ToString();
-			_client.UploadBook(storageKeyOfBookFolder, path, new NullProgress());
-			return storageKeyOfBookFolder;
+			_client.UploadBook(_storageKeyOfBookFolder, path, new NullProgress());
+			return _storageKeyOfBookFolder;
 		}
 
 		[Test]


### PR DESCRIPTION
Our previous implementation of the S3ClientTests had the problem
that at the beginning of each test we emptied the test bucket.
This can cause test failures if the unit tests run at the same
time on multiple machines.

The new implementation only deletes the books the test uploaded.
This allows multiple tests to run in parallel, but has the
disadvantage that we might leave behind some test data if the
developer stops a debug session while debugging the unit tests.
However, I think this will happen rarely and it won't cause other
tests to fail.