### PR TITLE
BL-867 Infinite messages when starting Bloom

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -603,7 +603,11 @@ namespace Bloom.CollectionTab
 						source = source.Substring(firstLine.Length);
 						// Rather arbitrary, but 4 are pretty sure to fit, and trying to measure an
 						// empty string might be a problem.
-						fits = source.Substring(0, 4);
+						if (source.Length > 4)
+							fits = source.Substring(0, 4);
+						else
+							fits = source;
+
 						tooBig = source;
 					}
 					else


### PR DESCRIPTION
The method LibraryListView.ShortenTitleIfNeeded() is throwing an ArgumentOutOfRangeException that is not being handled.