### PR TITLE
BL-862 Error accessing downloaded book in Linux

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -520,7 +520,7 @@ namespace Bloom.Book
 				//TODO: see long comment on ProjectContextGetFileLocations() about linking to the right version of a css
 
 				//TODO: what cause this to get encoded this way? Saw it happen when creating wall calendar
-				href = href.Replace("%5C", "/");
+				href = FileUtils.NormalizePath(href.Replace("%5C", "/"));
 
 				var fileName = FileUtils.NormalizePath(Path.GetFileName(href));
 				if (!fileName.StartsWith("xx"))


### PR DESCRIPTION
When a book downloaded from BloomLibrary is accessed,
either by the attempt to open immediately after downloading
or by clicking on the book, an exception was thrown saying
it was unable to find the ../customCollectionStyles.css file.
This was because the href ..\customCollectionStyles.css in
the book html needed to be normalized prior to using it to
locate the file.