### PR TITLE
BL-822 Text entry is not usable

### DIFF
--- a/src/BloomExe/MiscUI/ProblemReporterDialog.cs
+++ b/src/BloomExe/MiscUI/ProblemReporterDialog.cs
@@ -121,6 +121,10 @@ namespace Bloom.MiscUI
 		private void UpdateDisplay(object sender, EventArgs e)
 		{
 			UpdateDisplay();
+#if __MonoCS__
+			// For some fonts that don't render properly in Mono BL-822
+			Refresh();
+#endif
 		}
 
 		private void UpdateDisplay()


### PR DESCRIPTION
Very similar to WS-62 with a very similar change and
similar comments. On Linux systems, with specific fonts
such as Arial 12pt, entry into a text box displays with
characters oddly compressed and occasionally invisible.
This change corrects the display of those characters.

The JIRA  also reports issues with the cursor position.
Once displayed properly, the issue is somewhat less
apparent, but can still be seen towards the end of the
line. This change does not address that part of the
problem.  Changing the font by a point can be a workaround.