### PR TITLE
Make BookTransferTests more robust

### DIFF
--- a/src/BloomExe/WebLibraryIntegration/BloomParseClient.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomParseClient.cs
@@ -14,7 +14,7 @@ namespace Bloom.WebLibraryIntegration
 {
 	public class BloomParseClient
 	{
-		private string kBaseUrl="https://api.parse.com/1/";
+		private readonly string kBaseUrl="https://api.parse.com/1/";
 		private readonly RestClient _client;
 		private string _sessionToken;
 		private string _userId;
@@ -28,6 +28,7 @@ namespace Bloom.WebLibraryIntegration
 		// REST key. Unit tests update these.
 		public string ApiKey = KeyManager.ParseApiKey;
 		public string ApplicationKey = KeyManager.ParseApplicationKey;
+		protected string ClassesLanguagePath = "classes/language";
 
 		public string UserId {get { return _userId; }}
 
@@ -216,14 +217,14 @@ namespace Bloom.WebLibraryIntegration
 		{
 			if (!LoggedIn)
 				throw new ApplicationException();
-			var getLangs = MakeGetRequest("classes/language");
+			var getLangs = MakeGetRequest(ClassesLanguagePath);
 			var response1 = _client.Execute(getLangs);
 			dynamic json = JObject.Parse(response1.Content);
-			if (json == null)
+			if (json == null || response1.StatusCode != HttpStatusCode.OK)
 				return;
 			foreach (var obj in json.results)
 			{
-				var request = MakeDeleteRequest("classes/language/" + obj.objectId);
+				var request = MakeDeleteRequest(ClassesLanguagePath + "/" + obj.objectId);
 				var response = _client.Execute(request);
 				if (response.StatusCode != HttpStatusCode.OK)
 					throw new ApplicationException(response.StatusDescription + " " + response.Content);
@@ -234,7 +235,7 @@ namespace Bloom.WebLibraryIntegration
 		{
 			if (!LoggedIn)
 				throw new ApplicationException();
-			var request = MakePostRequest("classes/language");
+			var request = MakePostRequest(ClassesLanguagePath);
 			var langjson = lang.Json;
 			request.AddParameter("application/json", langjson, ParameterType.RequestBody);
 			var response = _client.Execute(request);
@@ -259,7 +260,7 @@ namespace Bloom.WebLibraryIntegration
 
 		internal int LanguageCount(LanguageDescriptor lang)
 		{
-			var getLang = MakeGetRequest("classes/language");
+			var getLang = MakeGetRequest(ClassesLanguagePath);
 			getLang.AddParameter("where", lang.Json, ParameterType.QueryString);
 			var response = _client.Execute(getLang);
 			if (response.StatusCode != HttpStatusCode.OK)
@@ -273,7 +274,7 @@ namespace Bloom.WebLibraryIntegration
 
 		internal string LanguageId(LanguageDescriptor lang)
 		{
-			var getLang = MakeGetRequest("classes/language");
+			var getLang = MakeGetRequest(ClassesLanguagePath);
 			getLang.AddParameter("where", lang.Json, ParameterType.QueryString);
 			var response = _client.Execute(getLang);
 			if (response.StatusCode != HttpStatusCode.OK)
@@ -286,7 +287,7 @@ namespace Bloom.WebLibraryIntegration
 
 		internal dynamic GetLanguage(string objectId)
 		{
-			var getLang = MakeGetRequest("classes/language/" + objectId);
+			var getLang = MakeGetRequest(ClassesLanguagePath + "/" + objectId);
 			var response = _client.Execute(getLang);
 			if (response.StatusCode != HttpStatusCode.OK)
 				return null;


### PR DESCRIPTION
The previous test code had a race condition: when several instances
ran the GetLanguagePointers_CreatesLanguagesButDoesNotDuplicate at
the same time one instance could delete the languages that another
instance just created, causing spurious test failures. This
change creates a test specific random class path so that several
test instances can run in parallel.