### PR TITLE
Several refactorings

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -220,7 +220,7 @@ namespace Bloom.Book
 			string tempPath = SaveHtml(Dom);
 
 
-			string errors = ValidateBook(tempPath);
+			string errors = ValidateBook(Dom, tempPath);
 			if (!string.IsNullOrEmpty(errors))
 			{
 				Logger.WriteEvent("Errors saving book {0}: {1}", PathToExistingHtml, errors);
@@ -367,7 +367,7 @@ namespace Bloom.Book
 			}
 
 
-			return ValidateBook(PathToExistingHtml);
+			return ValidateBook(_dom, PathToExistingHtml);
 		}
 
 		/// <summary>
@@ -525,12 +525,15 @@ namespace Bloom.Book
 
 		public static string ValidateBook(string path)
 		{
-			Debug.WriteLine(string.Format("ValidateBook({0})", path));
 			var dom = new HtmlDom(XmlHtmlConverter.GetXmlDomFromHtmlFile(path, false));//with throw if there are errors
+			return ValidateBook(dom, path);
+		}
+
+		private static string ValidateBook(HtmlDom dom, string path)
+		{
+			Debug.WriteLine(string.Format("ValidateBook({0})", path));
 			var msg= GetMessageIfVersionIsIncompatibleWithThisBloom(dom);
-			if (!string.IsNullOrEmpty(msg))
-				return msg;
-			return dom.ValidateBook(path);
+			return !string.IsNullOrEmpty(msg) ? msg : dom.ValidateBook(path);
 		}
 
 

--- a/src/BloomExe/CollectionTab/LibraryListView.Designer.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.Designer.cs
@@ -31,7 +31,6 @@ namespace Bloom.CollectionTab
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
 			this._sourcePaneMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
 			this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-			this._keepFocusTimer = new System.Windows.Forms.Timer(this.components);
 			this._L10NSharpExtender = new L10NSharp.UI.L10NSharpExtender(this.components);
 			this._vernacularCollectionMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
 			this.makeReaderTemplateBloomPackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -643,7 +642,6 @@ namespace Bloom.CollectionTab
 		private System.Windows.Forms.Label pretendLabel;
 		private System.Windows.Forms.Label label9;
 		private System.Windows.Forms.Panel _dividerPanel;
-		private System.Windows.Forms.Timer _keepFocusTimer;
 		private L10NSharp.UI.L10NSharpExtender _L10NSharpExtender;
 		private Palaso.UI.WindowsForms.SettingProtection.SettingsProtectionHelper _settingsProtectionHelper;
 		private System.Windows.Forms.ContextMenuStrip _sourcePaneMenuStrip;

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -972,30 +972,6 @@ namespace Bloom.CollectionTab
 			_vernacularCollectionMenuStrip.Show(_menuTriangle, new Point(0, 0));
 		}
 
-		/// <summary>
-		/// Occasionally, when select a book, the Bloom App itself loses focus. I assume this is a gecko-related issue.
-		/// You can see it happen because the title bar of the application changes to the Windows unselected color (lighter).
-		/// And then, if you click on a tab, the click is swallowed selecting the app, and you have to click again.
-		///
-		/// So, this occasionally checks that the Workspace control has focus, and if it doesn't, pulls it back here.
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-//		private void _keepFocusTimer_Tick(object sender, EventArgs e)
-//		{
-//			if(Visible)
-//			{
-//				var findForm = FindForm();//visible is worthless, but FindForm() happily does fail when we aren't visible.
-//
-//				if (findForm != null && !findForm.ContainsFocus)
-//				{
-//				//	Focus();
-//
-//					//Debug.WriteLine("Grabbing back focus");
-//				}
-//			}
-//		}
-
 		private class ButtonInfo
 		{
 			public ButtonInfo(Button button, bool thumbnailRefreshNeeded)

--- a/src/BloomExe/CollectionTab/LibraryListView.resx
+++ b/src/BloomExe/CollectionTab/LibraryListView.resx
@@ -440,9 +440,6 @@
   <metadata name="_sourcePaneMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>919, 17</value>
   </metadata>
-  <metadata name="_keepFocusTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>416, 17</value>
-  </metadata>
   <metadata name="_L10NSharpExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>561, 17</value>
   </metadata>

--- a/src/BloomExe/NavigationIsolator.cs
+++ b/src/BloomExe/NavigationIsolator.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms;
 using Bloom.Book;
 using Gecko;
 using Timer = System.Windows.Forms.Timer;
+using Gecko.Events;
 
 namespace Bloom
 {
@@ -230,7 +231,13 @@ namespace Bloom
 			_browser.Navigate(url);
 		}
 
-		private void RaiseNavigated(object sender, EventArgs args)
+		private void RaiseNavigated(object sender, GeckoNavigatedEventArgs args)
+		{
+			if (Navigated != null)
+				Navigated(this, new EventArgs());
+		}
+
+		private void RaiseDocumentCompleted(object sender, GeckoDocumentCompletedEventArgs args)
 		{
 			if (Navigated != null)
 				Navigated(this, new EventArgs());
@@ -247,15 +254,15 @@ namespace Bloom
 		{
 			// Todo: May need changes for Gecko29
 			_browser.Navigated += RaiseNavigated;
-			_browser.DocumentCompleted += RaiseNavigated;
+			_browser.DocumentCompleted += RaiseDocumentCompleted;
 		}
 
 		public void RemoveEventHandlers()
 		{
 			if (_browser.IsDisposed)
 				return; // don't try to do anything to it.
-			_browser.Navigated += RaiseNavigated;
-			_browser.DocumentCompleted += RaiseNavigated;
+			_browser.Navigated -= RaiseNavigated;
+			_browser.DocumentCompleted -= RaiseDocumentCompleted;
 		}
 
 		/// <summary>

--- a/src/BloomExe/XmlHtmlConverter.cs
+++ b/src/BloomExe/XmlHtmlConverter.cs
@@ -75,7 +75,7 @@ namespace Bloom
 					var errors = tidy.CleanAndRepair();
 					if (!string.IsNullOrEmpty(errors))
 					{
-						throw new ApplicationException(errors + "\r\n\r\n" + content);
+						throw new ApplicationException(string.Format("{0}{2}{2}{1}", errors, content, Environment.NewLine));
 					}
 					var newContents = tidy.Save();
 					try
@@ -87,7 +87,8 @@ namespace Bloom
 					}
 					catch (Exception e)
 					{
-						var exceptionWithHtmlContents = new Exception(e.Message + "\r\n\r\n" + newContents);
+						var exceptionWithHtmlContents = new Exception(string.Format("{0}{2}{2}{1}",
+							e.Message, newContents, Environment.NewLine));
 						throw exceptionWithHtmlContents;
 					}
 				}


### PR DESCRIPTION
- Remove commented code and timer variable
- Fix line endings in exception
- Use separate event handlers for gecko events
    
We raise the same event for two gecko events. Having two internal event handlers makes this a little bit more obvious when debugging and makes it possible to set a trace point outputting the information that geckofx gives us as argument.

- Use existing DOM instead of calling tidy again
    
The previous code re-read the HTML file and called tidy even though we already read the DOM before.