### PR TITLE
Re-enable interactive L10NSharp dialogs (BL-656)

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -681,9 +681,6 @@ namespace Bloom
 											"SIL/Bloom",
 											Resources.Bloom, "issues@bloomlibrary.org", "Palaso.UI");
 
-				// Linux was just having too many issues with the L10NSharp Dialog
-				LocalizationManager.EnableClickingOnControlToBringUpLocalizationDialog = Palaso.PlatformUtilities.Platform.IsWindows;
-
 				Settings.Default.UserInterfaceLanguage = LocalizationManager.UILanguageId;
 			}
 			catch (Exception error)

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -192,9 +192,7 @@ namespace Bloom.Workspace
 		{
 			//when we need to use Ctrl+Shift to display stuff, we don't want it also firing up the localization dialog (which shouldn't be done by a user under settings protection anyhow)
 
-			LocalizationManager.EnableClickingOnControlToBringUpLocalizationDialog =
-				!SettingsProtectionSettings.Default.NormallyHidden
-				&& Palaso.PlatformUtilities.Platform.IsWindows;
+			LocalizationManager.EnableClickingOnControlToBringUpLocalizationDialog = !SettingsProtectionSettings.Default.NormallyHidden;
 		}
 
 		private void SetupUILanguageMenu()
@@ -226,18 +224,15 @@ namespace Bloom.Workspace
 				}
 			}
 
-			if (Palaso.PlatformUtilities.Platform.IsWindows)
+			_uiLanguageMenu.DropDownItems.Add(new ToolStripSeparator());
+			var menu = _uiLanguageMenu.DropDownItems.Add(LocalizationManager.GetString("CollectionTab.menuToBringUpLocalizationDialog","More..."));
+			menu.Click += new EventHandler((a, b) =>
 			{
-				_uiLanguageMenu.DropDownItems.Add(new ToolStripSeparator());
-				var menu = _uiLanguageMenu.DropDownItems.Add(LocalizationManager.GetString("CollectionTab.menuToBringUpLocalizationDialog","More..."));
-				menu.Click += new EventHandler((a, b) =>
-				{
-					_localizationManager.ShowLocalizationDialogBox(false);
-					SetupUILanguageMenu();
-					LocalizationManager.ReapplyLocalizationsToAllObjectsInAllManagers(); //review: added this based on its name... does it help?
-					_localizationChangedEvent.Raise(null);
-				});
-			}
+				_localizationManager.ShowLocalizationDialogBox(false);
+				SetupUILanguageMenu();
+				LocalizationManager.ReapplyLocalizationsToAllObjectsInAllManagers(); //review: added this based on its name... does it help?
+				_localizationChangedEvent.Raise(null);
+			});
 		}
 
 


### PR DESCRIPTION
The issues that caused the dialogs to be disabled have either been fixed (in Mono and L10NSharp), or else can't be reproduced.