### PR TITLE
Fix BL-912: immediate title page response to change of settings

### DIFF
--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
@@ -84,7 +84,7 @@
             <div data-library="dialect" class="langName"></div>
           </div>
           <div class="bloom-translationGroup">
-            <div data-library="languageLocation" class="langName"></div>
+            <div data-library="languageLocation" class="langName bloom-writeOnly"></div>
           </div>
         </div>
       </div>

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.htm
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.htm
@@ -67,7 +67,7 @@
             <div data-library="dialect" class="langName"></div>
           </div>
           <div class="bloom-translationGroup">
-            <div data-library="languageLocation" class="langName"></div>
+            <div data-library="languageLocation" class="langName bloom-writeOnly"></div>
           </div>
         </div>
       </div>

--- a/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.htm
+++ b/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.htm
@@ -67,7 +67,7 @@
             <div data-library="dialect" class="langName"></div>
           </div>
           <div class="bloom-translationGroup">
-            <div data-library="languageLocation" class="langName"></div>
+            <div data-library="languageLocation" class="langName bloom-writeOnly"></div>
           </div>
         </div>
       </div>

--- a/DistFiles/xMatter/bloom-xmatter-mixins.jade
+++ b/DistFiles/xMatter/bloom-xmatter-mixins.jade
@@ -142,7 +142,7 @@ mixin factoryStandard-titlePage
 				.langName('data-library'='dialect')
 			+field-prototypeDeclaredExplicity
 				//- review: notice that we have a translation group, but nothing is translatable, just static list of language name? Probably not what we want.
-				.langName(data-library='languageLocation')
+				.langName(data-library='languageLocation').bloom-writeOnly
 
 mixin standard-blankInsideFrontCover
 	+page-cover('Inside Front Cover').cover.coverColor.insideFrontCover.bloom-frontMatter(data-export='front-matter-inside-front-cover')#BA00DE13-734C-4036-9901-7040275B9000

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -457,7 +457,7 @@ namespace Bloom.Book
 			string elementName = "*";
 			try
 			{
-				string query = String.Format(".//{0}[(@data-book or @data-library or @data-collection)]", elementName);
+				string query = String.Format(".//{0}[(@data-book or @data-library or @data-collection) and not(contains(@class,'bloom-writeOnly'))]", elementName);
 
 				XmlNodeList nodesOfInterest = sourceElement.SafeSelectNodes(query);
 

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -20,14 +20,16 @@ namespace Bloom.Collection
 		private readonly CollectionSettings _collectionSettings;
 		private XMatterPackFinder _xmatterPackFinder;
 		private readonly QueueRenameOfCollection _queueRenameOfCollection;
+		private readonly PageRefreshEvent _pageRefreshEvent;
 		private bool _restartRequired;
 		private bool _loaded;
 
-		public CollectionSettingsDialog(CollectionSettings collectionSettings, XMatterPackFinder xmatterPackFinder, QueueRenameOfCollection queueRenameOfCollection)
+		public CollectionSettingsDialog(CollectionSettings collectionSettings, XMatterPackFinder xmatterPackFinder, QueueRenameOfCollection queueRenameOfCollection, PageRefreshEvent pageRefreshEvent)
 		{
 			_collectionSettings = collectionSettings;
 			_xmatterPackFinder = xmatterPackFinder;
 			_queueRenameOfCollection = queueRenameOfCollection;
+			_pageRefreshEvent = pageRefreshEvent;
 			InitializeComponent();
 			if(_collectionSettings.IsSourceCollection)
 			{
@@ -214,6 +216,7 @@ namespace Bloom.Collection
 			}
 			_collectionSettings.Save();
 			Close();
+			_pageRefreshEvent.Raise(null);
 			DialogResult = AnyReasonToRestart() ? DialogResult.Yes : DialogResult.OK;
 		}
 

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -56,6 +56,7 @@ namespace Bloom.Edit
 			PageListChangedEvent pageListChangedEvent,
 			RelocatePageEvent relocatePageEvent,
 			BookRefreshEvent bookRefreshEvent,
+			PageRefreshEvent pageRefreshEvent,
 			DuplicatePageCommand duplicatePageCommand,
 			DeletePageCommand deletePageCommand,
 			SelectedTabChangedEvent selectedTabChangedEvent,
@@ -80,6 +81,7 @@ namespace Bloom.Edit
 			templateInsertionCommand.InsertPage += new EventHandler(OnInsertTemplatePage);
 
 			bookRefreshEvent.Subscribe((book) => OnBookSelectionChanged(null, null));
+			pageRefreshEvent.Subscribe((book) => RethinkPageAndReloadIt(null));
 			selectedTabChangedEvent.Subscribe(OnTabChanged);
 			selectedTabAboutToChangeEvent.Subscribe(OnTabAboutToChange);
 			duplicatePageCommand.Implementer = OnDuplicatePage;
@@ -586,10 +588,10 @@ namespace Bloom.Edit
 			// listen for events raised by javascript
 			_view.AddMessageEventListener("saveAccordionSettingsEvent", SaveAccordionSettings);
 			_view.AddMessageEventListener("setModalStateEvent", SetModalState);
-			_view.AddMessageEventListener("preparePageForEditingAfterOrigamiChangesEvent", PreparePageForEditingAfterOrigamiChanges);
+			_view.AddMessageEventListener("preparePageForEditingAfterOrigamiChangesEvent", RethinkPageAndReloadIt);
 		}
 
-		private void PreparePageForEditingAfterOrigamiChanges(string obj)
+		private void RethinkPageAndReloadIt(string obj)
 		{
 			SaveNow();
 

--- a/src/BloomExe/Event.cs
+++ b/src/BloomExe/Event.cs
@@ -165,6 +165,19 @@ namespace Bloom
 		}
 	}
 
+	/// <summary>
+	/// Anything displaying a book should re-load it the current page
+	/// </summary>
+	public class PageRefreshEvent : Event<object>
+	{
+		public PageRefreshEvent()
+			: base("PageRefreshEvent", LoggingLevel.Minor)
+		{
+
+		}
+	}
+
+
 	public class RelocatePageInfo
 	{
 		public IPage Page;

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -84,6 +84,7 @@ namespace Bloom
 					typeof(LibraryClosing),
 					typeof(PageListChangedEvent),  // REMOVE+++++++++++++++++++++++++++
 					typeof(BookRefreshEvent),
+					typeof(PageRefreshEvent),
 					typeof(BookDownloadStartingEvent),
 					typeof(BookSelection),
 					typeof(CurrentEditableCollectionSelection),


### PR DESCRIPTION
Previously, you had to change pages and come back before the location would be updated. So the first step was to make a PageRefresh event that the settings could call. However, this lead to another problem, which is that the old location text would get sucked into the dataset, and then pushed back out. It was overriding the newly updated "location" value. It overrode it because the computed location value is currently in "neutral" language, "*", but on the page it goes into a box that asks for the national language. If there is none in the language, fine, the "*" one is copied in. But during refresh, the national language one gets sucked in, so now, as the new page is constructed, that sucked in (old) version of "location" wins out over the generic "*" version.

A otherwise reasonable fix would have been to change the template to specify lang="*". However I'm reluctant to do that because the lang is also used to choose the font. I took the safer route of introducing a "bloom-writeOnly" class on this element, so it never gets sucked in.