### PR TITLE
Work around Bl-923: L10NSharp Crash when accessed from javascript

### DIFF
--- a/src/BloomExe/web/I18NHandler.cs
+++ b/src/BloomExe/web/I18NHandler.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using Bloom.Collection;
 using L10NSharp;
@@ -38,8 +40,19 @@ namespace Bloom.web
 						{
 							foreach (string key in post.Keys)
 							{
-								var translation = LocalizationManager.GetDynamicString("Bloom", key, post[key]);
-								if (!d.ContainsKey(key)) d.Add(key, translation);
+								try
+								{
+									if (!d.ContainsKey(key))
+									{
+										var translation = LocalizationManager.GetDynamicString("Bloom", key, post[key]);
+										d.Add(key, translation);
+									}
+								}
+								catch (Exception error)
+								{
+									Debug.Fail("Debug Only:" +error.Message+Environment.NewLine+"A bug reported at this location is BL-923");
+									//Until BL-923 is fixed (hard... it's a race condition, it's better to swallow this for users
+								}
 							}
 						}
 


### PR DESCRIPTION
I could not reproduce the bug immediately after it happened to me, even after removing my localization files. Looking at the l10nsharp code, the only way I can see us getting this error ("Collection was modified; enumeration operation may not execute.") is by re-entering the code on a different thread.

We could make the Bloom server be thread-safe, but we could also do that to L10nsharp.

Meanwhile, this patch catches the error and swallows it for users.

Needs review: previously, the code got the translation, then decided whether it needed the translation or not. Now it first decides if it needs it. Is there something I'm missing about the original approach?