### PR TITLE
BL-935, BloomPack zip should round-trip non-ascii filenames

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -304,6 +304,7 @@ namespace Bloom.CollectionTab
 				var entryName = fileName.Substring(dirNameOffest);  // Makes the name in zip based on the folder
 				entryName = ZipEntry.CleanName(entryName);          // Removes drive from name and fixes slash direction
 				ZipEntry newEntry = new ZipEntry(entryName) { DateTime = fi.LastWriteTime };
+				newEntry.IsUnicodeText = true; // encode filename and comment in UTF8
 				byte[] bookContent = {};
 
 				// if this is a ReaderTools book, call GetBookReplacedWithTemplate() to get the contents


### PR DESCRIPTION
Our zip library is capable of storing zip entries with names in
UTF-8, but needed to be told to do so.