### PR TITLE
Work around BL-938: Crash after changing UI Language

### DIFF
--- a/src/BloomExe/ToPalaso/BetterToolTip.cs
+++ b/src/BloomExe/ToPalaso/BetterToolTip.cs
@@ -6,10 +6,12 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;
 using L10NSharp;
 using L10NSharp.UI;
+using Palaso.Code;
 
 namespace Bloom.ToPalaso
 {
@@ -63,8 +65,19 @@ namespace Bloom.ToPalaso
 			}
 
 			UpdateAllControlsList(control, value);
-
-			base.SetToolTip(control, value);
+			Guard.AgainstNull(control,"control");
+			Guard.AgainstNull(value,"value");
+			try
+			{
+				base.SetToolTip(control, value);
+			}
+			catch (NullReferenceException)
+			{
+#if DEBUG
+				Debug.Fail("Debug Only: If you just changed the UI language, this is a BL-937 Reproduction");
+#endif
+				//for the user, swallow
+			}
 		}
 
 		private void UpdateAllControlsList(Control control, string value)


### PR DESCRIPTION
This happens under difficult to reproduce situations, where some combination of changing UI language and opening a new collection leads to L10NSharp trying to change the text of the "Duplicate This Page" tooltip and then, farther into .net, getting a null reference exception. Assumption is that something (L10NSharp?) is holding onto the control that has been garbage collected, so doesn't appreciate being woken up to get a new label.

For now, this just detects the situation and swallows it in release mode.