### PR TITLE
Fix BL-945 governing book captions and initial titles

### DIFF
--- a/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.htm
+++ b/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.htm
@@ -4,7 +4,7 @@
     <meta charset="UTF-8"/>
     <meta name="Generator" content="Bloom"/>
     <meta name="BloomFormatVersion" content="2.0"/>
-    <meta name="defaultNameForDerivedBooks" content="My Book">
+    <meta name="defaultNameForDerivedBooks" content="Book">
     <meta name="bloomBookId" content="056B6F11-4A6C-4942-B2BC-8861E62B03B3">
     <meta name="pageTemplateSource" content="Basic Book">
     <title>'Basic Book'</title>
@@ -17,8 +17,6 @@
   <body>
     <div id="bloomDataDiv">
       <div data-book="bookTitle" lang="en">Basic Book</div>
-      <div data-book="bookTitle" lang="tpi">Nupela Buk</div>
-      <div data-book="bookTitle" lang="id">Buku Dasar</div>
       <div data-book="styleNumberSequence" lang="*">0</div>
     </div>
     <div class="A5Portrait bloom-page numberedPage bloom-combinedPage imageOnTop" data-page="extra" id="5dcd48df-e9ab-4a07-afd4-6a24d0398382">

--- a/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.jade
+++ b/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.jade
@@ -13,7 +13,8 @@ doctype html
 html
 	head
 		+metadata-standard()
-		meta(name='defaultNameForDerivedBooks', content='My Book')
+		//- This "Book" name is used for saving the file, until the user enters a title
+		meta(name='defaultNameForDerivedBooks', content='Book')
 		meta(name='bloomBookId', content='056B6F11-4A6C-4942-B2BC-8861E62B03B3')
 
 		//- Eventually, we'll remove Bloom's need for this.
@@ -24,8 +25,6 @@ html
 	body
 		+dataDiv
 			+bookVariable-title('en', 'Basic Book')
-			+bookVariable-title('tpi', 'Nupela Buk')
-			+bookVariable-title('id', 'Buku Dasar')
 			+bookVariable('styleNumberSequence', '*', '0')
 
 		//- NB: HTML 4 ids were not supposed to start with numbers. But for html 5, they

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -163,7 +163,7 @@ namespace Bloom.Book
 						var orderedPreferences = new List<string>();
 						orderedPreferences.Add(LocalizationManager.UILanguageId);
 
-						orderedPreferences.Add(_collectionSettings.Language1Iso639Code);
+						//already checked for this, previsouly. orderedPreferences.Add(_collectionSettings.Language1Iso639Code);
 						if (_collectionSettings.Language2Iso639Code != null)
 							orderedPreferences.Add(_collectionSettings.Language2Iso639Code);
 						if (_collectionSettings.Language3Iso639Code != null)
@@ -172,9 +172,8 @@ namespace Bloom.Book
 						orderedPreferences.Add("en");
 						orderedPreferences.Add("fr");
 						orderedPreferences.Add("es");
-
 						display = title.GetBestAlternativeString(orderedPreferences);
-						if (string.IsNullOrEmpty(display))
+						if (string.IsNullOrWhiteSpace(display))
 						{
 							display = title.GetFirstAlternative();
 							Debug.Assert(!string.IsNullOrEmpty(display), "by our logic, this shouldn't possible");

--- a/src/BloomExe/Book/BookStarter.cs
+++ b/src/BloomExe/Book/BookStarter.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml;
 using Bloom.Collection;
+using L10NSharp;
 using Palaso.Extensions;
 using Palaso.IO;
 using Palaso.Reporting;
@@ -49,7 +51,7 @@ namespace Bloom.Book
 		{
 			Logger.WriteEvent("BookStarter.CreateBookOnDiskFromTemplate({0}, {1})", sourceBookFolder, parentCollectionPath);
 
-			// We use the <meta name="defaultNameForDerivedBooks" to make the intial copy, and it gives us something
+			// We use the "initial name" to make the intial copy, and it gives us something
 			//to name the folder and file until such time as the user enters a title in for the book.
 			string initialBookName = GetInitialName(sourceBookFolder, parentCollectionPath);
 			var newBookFolder = Path.Combine(parentCollectionPath, initialBookName);
@@ -420,14 +422,21 @@ namespace Bloom.Book
 		private string GetInitialName(string sourcePath, string parentCollectionPath)
 		{
 			var storage = _bookStorageFactory(sourcePath);
-			var name = storage.Dom.GetMetaValue("defaultNameForDerivedBooks",  "Book");
+			/* we're experimenting with doing away with defaultNameForDerivedBooks
+				var name = storage.Dom.GetMetaValue("defaultNameForDerivedBooks",  "Book");
+				if (name == "My Book") //some older stuff has this
+					name = "Book";
+			*/
+			var name = LocalizationManager.GetString("EditTab.NewBookName", "Book",
+					"Default file and folder name when you make a new book, but haven't give it a title yet.");
+
 			int i = 0;
 			string suffix = "";
 
 			while (Directory.Exists(Path.Combine(parentCollectionPath, name+suffix)))
 			{
 				++i;
-				suffix = i.ToString();
+				suffix = i.ToString(CultureInfo.InvariantCulture);
 			}
 			return name+suffix;
 		}

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -59,8 +59,8 @@ namespace Bloom.Book
 			set
 			{
 				var t = value.Trim();
-				if (!String.IsNullOrEmpty(t))
-				{
+				//if (!String.IsNullOrEmpty(t))
+				//{
 					var makeSureItsThere = Head;
 					var titleNode = XmlUtils.GetOrCreateElement(_dom, "html/head", "title");
 					//ah, but maybe that contains html element in there, like <br/> where the user typed a return in the title,
@@ -73,7 +73,7 @@ namespace Bloom.Book
 					titleNode.InnerXml = "";
 					//and set the text again!
 					titleNode.InnerText = justTheText;
-				}
+				//}
 			}
 		}
 

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -155,8 +155,8 @@ namespace BloomTests.Book
 			Assert.That(spaceFixer.Replace(newStylenode, " "), Is.EqualTo(spaceFixer.Replace(styleNode, " ")));
 		}
 
-		//regression
-		[Test]
+		//For Bloom 3.1, we decided to retire this feature. Now, new books are just called "book"
+		/*[Test]
 		public void CreateBookOnDiskFromTemplate_FromFactoryVaccinations_InitialFolderNameIsCalledVaccinations()
 		{
 			var source = FileLocator.GetDirectoryDistributedWithApplication("factoryCollections", "Sample Shells",
@@ -167,7 +167,18 @@ namespace BloomTests.Book
 
 			//NB: although the clas under test here may produce a folder with the right name, the Book class may still mess it up based on variables
 			//But that is a different set of unit tests.
+		}*/
+
+		[Test]
+		public void CreateBookOnDiskFromTemplate_FromFactoryVaccinations_InitialFolderNameIsJustBook()
+		{
+			var source = FileLocator.GetDirectoryDistributedWithApplication("factoryCollections", "Sample Shells",
+																			"Vaccinations");
+
+			var path = _starter.CreateBookOnDiskFromTemplate(source, _projectFolder.Path);
+			Assert.AreEqual("Book", Path.GetFileName(path));
 		}
+
 
 		[Test]
 		public void CreateBookOnDiskFromTemplate_FromFactoryVaccinations_HasDataDivIntact()
@@ -227,7 +238,7 @@ namespace BloomTests.Book
 		}
 
 		[Test]
-		public void CreateBookOnDiskFromTemplate_OriginalIsTemplate_CopyHasNotTitle()
+		public void CreateBookOnDiskFromTemplate_OriginalIsTemplate_CopyHasNoTitle()
 		{
 			var source = FileLocator.GetDirectoryDistributedWithApplication("factoryCollections", "Templates",
 																			"Basic Book");

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -451,8 +451,8 @@ namespace BloomTests.Book
 			string firstPath = _starter.CreateBookOnDiskFromTemplate(GetShellBookFolder(), _projectFolder.Path);
 			string secondPath = _starter.CreateBookOnDiskFromTemplate(GetShellBookFolder(), _projectFolder.Path);
 
-			Assert.IsTrue(File.Exists(firstPath.CombineForPath("book.htm")));
-			Assert.IsTrue(File.Exists(secondPath.CombineForPath("book1.htm")));
+			Assert.IsTrue(File.Exists(firstPath.CombineForPath("Book.htm")));
+			Assert.IsTrue(File.Exists(secondPath.CombineForPath("Book1.htm")));
 			Assert.IsTrue(Directory.Exists(secondPath),"it clobbered the first one!");
 		}
 

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml;
 using Bloom;
@@ -226,6 +227,19 @@ namespace BloomTests.Book
 		}
 
 		[Test]
+		public void CreateBookOnDiskFromTemplate_OriginalIsTemplate_CopyHasNotTitle()
+		{
+			var source = FileLocator.GetDirectoryDistributedWithApplication("factoryCollections", "Templates",
+																			"Basic Book");
+			var path = _starter.CreateBookOnDiskFromTemplate(source, _projectFolder.Path);
+
+			var server = CreateBookServer();
+			var book = server.GetBookFromBookInfo(new BookInfo(path, true));
+			Assert.AreEqual("Title Missing",book.TitleBestForUserDisplay);
+			Assert.That(book.GetDataItem("Title").Empty);
+
+		}
+		[Test]
 		public void CreateBookOnDiskFromTemplate_FromFactoryA5_CreatesWithCoverAndTitle()
 		{
 			var source = FileLocator.GetDirectoryDistributedWithApplication("factoryCollections", "Templates",
@@ -424,10 +438,10 @@ namespace BloomTests.Book
 
 
 		[Test]
-		public void CreateBookOnDiskFromTemplate_ShellHasNoNameDirective_FileNameSameAsShell()
+		public void CreateBookOnDiskFromTemplate_ShellHasNoNameDirective_FileNameJust_Book_()
 		{
 			string folderPath = _starter.CreateBookOnDiskFromTemplate(GetShellBookFolder(), _projectFolder.Path);
-			Assert.AreEqual("guitar", Path.GetFileName(folderPath));
+			Assert.AreEqual("Book", Path.GetFileName(folderPath));
 		}
 
 
@@ -437,8 +451,8 @@ namespace BloomTests.Book
 			string firstPath = _starter.CreateBookOnDiskFromTemplate(GetShellBookFolder(), _projectFolder.Path);
 			string secondPath = _starter.CreateBookOnDiskFromTemplate(GetShellBookFolder(), _projectFolder.Path);
 
-			Assert.IsTrue(File.Exists(firstPath.CombineForPath("guitar.htm")));
-			Assert.IsTrue(File.Exists(secondPath.CombineForPath("guitar1.htm")));
+			Assert.IsTrue(File.Exists(firstPath.CombineForPath("book.htm")));
+			Assert.IsTrue(File.Exists(secondPath.CombineForPath("book1.htm")));
 			Assert.IsTrue(Directory.Exists(secondPath),"it clobbered the first one!");
 		}
 
@@ -450,25 +464,25 @@ namespace BloomTests.Book
 			string bookFolderPath = _starter.CreateBookOnDiskFromTemplate(source, _projectFolder.Path);
 			var path = GetPathToHtml(bookFolderPath);
 
-			Assert.AreEqual("My Book.htm", Path.GetFileName(path));
+			Assert.AreEqual("Book.htm", Path.GetFileName(path));
 			Assert.IsTrue(Directory.Exists(bookFolderPath));
 			Assert.IsTrue(File.Exists(path));
 		}
 
-		[Test]
-		public void CreateBookOnDiskFromTemplate_FromBasicBook_GetsExpectedEnglishTitleInDataDivAndJson()
-		{
-			var source = FileLocator.GetDirectoryDistributedWithApplication("factoryCollections", "Templates","Basic Book");
-
-			string bookFolderPath = _starter.CreateBookOnDiskFromTemplate(source, _projectFolder.Path);
-			var path = GetPathToHtml(bookFolderPath);
-
-			//see  <meta name="defaultNameForDerivedBooks" content="My Book" />
-			AssertThatXmlIn.HtmlFile(path).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='bookTitle' and @lang='en' and text()='My Book']",1);
-
-			var metadata = new BookInfo(bookFolderPath, false);
-			Assert.That(metadata.Title, Is.EqualTo("My Book"));
-		}
+//		[Test]
+//		public void CreateBookOnDiskFromTemplate_FromBasicBook_GetsExpectedEnglishTitleInDataDivAndJson()
+//		{
+//			var source = FileLocator.GetDirectoryDistributedWithApplication("factoryCollections", "Templates","Basic Book");
+//
+//			string bookFolderPath = _starter.CreateBookOnDiskFromTemplate(source, _projectFolder.Path);
+//			var path = GetPathToHtml(bookFolderPath);
+//
+//			//see  <meta name="defaultNameForDerivedBooks" content="My Book" />
+//			AssertThatXmlIn.HtmlFile(path).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='bookTitle' and @lang='en' and text()='My Book']",1);
+//
+//			var metadata = new BookInfo(bookFolderPath, false);
+//			Assert.That(metadata.Title, Is.EqualTo("My Book"));
+//		}
 
 		[Test]
 		public void CreateBookOnDiskFromTemplate_FromBasicBook_GetsNoDefaultNameMetaElement()
@@ -571,18 +585,18 @@ namespace BloomTests.Book
 		[Test]
 		public void CreateBookOnDiskFromTemplate_FromFactoryTemplate_SameNameAlreadyUsed_FindsUsableNumberSuffix()
 		{
-			Directory.CreateDirectory(_projectFolder.Combine("My Book"));
-			Directory.CreateDirectory(_projectFolder.Combine("My Book1"));
-			Directory.CreateDirectory(_projectFolder.Combine("My Book3"));
+			Directory.CreateDirectory(_projectFolder.Combine("Book"));
+			Directory.CreateDirectory(_projectFolder.Combine("Book1"));
+			Directory.CreateDirectory(_projectFolder.Combine("Book3"));
 
 			var source = FileLocator.GetDirectoryDistributedWithApplication("factoryCollections", "Templates",
 																			"Basic Book");
 
 			var path = _starter.CreateBookOnDiskFromTemplate(source, _projectFolder.Path);
 
-			Assert.AreEqual("My Book2", Path.GetFileName(path));
+			Assert.AreEqual("Book2", Path.GetFileName(path));
 			Assert.IsTrue(Directory.Exists(path));
-			Assert.IsTrue(File.Exists(Path.Combine(path, "My Book2.htm")));
+			Assert.IsTrue(File.Exists(Path.Combine(path, "Book2.htm")));
 		}
 
 		[Test]


### PR DESCRIPTION
In the past there were well-intentioned attempts to provide default title for new books. It turns out that this is fraught with unintended consequences that would just confuse the user. This PR overhauls this system, taking in to account differences such as:

- whether the book we're making is from a template (remove all titles, name the book's file "Book" until we have something better
- if we're making it from a Shell Book (leave all the titles)
- If we're just displaying a caption of a source book, in which case prefer the current UI Language but then keep digging in order of guess preferences until your find *some* label to show
- If we're just displaying a caption of one of the editable books in our collection, in which case just show "Title Missing" until they enter a title in the primary language of the collection

REVIEW appreciated, but please don't merge yet. There's a lot of code changing here, so I would rather get the next public beta out first.