### PR TITLE
Give a good error message if the called for xmatter is missing

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -13,6 +13,7 @@ using Bloom.Collection;
 using Bloom.Edit;
 using Bloom.Properties;
 using Bloom.Publish;
+using L10NSharp;
 using MarkdownSharp;
 using Palaso.Code;
 using Palaso.Extensions;
@@ -423,14 +424,21 @@ namespace Bloom.Book
 
 		public virtual string StoragePageFolder { get { return _storage.FolderPath; } }
 
+		private string GetGenericBrokenBookRecommendationString()
+		{
+			return LocalizationManager.GetString("Errors.BrokenBook",
+				"Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong. Consider using the 'Report a Problem' command under the 'Help' menu.");
+		}
+		
 		private HtmlDom GetPageListingErrorsWithBook(string contents)
 		{
 			var builder = new StringBuilder();
-			builder.Append("<html><body>");
-			builder.AppendLine("<p>This book (" + StoragePageFolder + ") has errors.");
-			builder.AppendLine(
-				"This doesn't mean your work is lost, but it does mean that something is out of date or has gone wrong, and that someone needs to find and fix the problem (and your book).</p>");
+			builder.Append("<html><body style='font-family:arial,sans'>");
 
+			builder.AppendLine("<p>" + GetGenericBrokenBookRecommendationString() + "</p>");
+
+			builder.AppendFormat("<p>" + _storage.ErrorMessages + "</p>");
+			
 			foreach (var line in contents.Split(new []{'\n'}))
 			{
 				builder.AppendFormat("<li>{0}</li>\n", WebUtility.HtmlEncode(line));
@@ -442,10 +450,11 @@ namespace Bloom.Book
 		private HtmlDom GetErrorDom()
 		{
 			var builder = new StringBuilder();
-			builder.Append("<html><body>");
-			builder.AppendLine("<p>This book (" + FolderPath + ") has errors.");
-			builder.AppendLine(
-				"This doesn't mean your work is lost, but it does mean that something is out of date or has gone wrong, and that someone needs to find and fix the problem (and your book).</p>");
+			builder.Append("<html><body style='font-family:arial,sans'>");
+			
+			builder.AppendLine(GetGenericBrokenBookRecommendationString());
+
+			builder.AppendFormat("<p>" + _storage.ErrorMessages + "</p>");
 
 			builder.Append(((StringBuilderProgress)_log).Text);
 
@@ -982,7 +991,7 @@ namespace Bloom.Book
 
 		public virtual bool HasFatalError
 		{
-			get { return _log.ErrorEncountered; }
+			get { return _log.ErrorEncountered || !string.IsNullOrEmpty(_storage.ErrorMessages); }
 		}
 
 

--- a/src/BloomExe/Book/XMatterHelper.cs
+++ b/src/BloomExe/Book/XMatterHelper.cs
@@ -31,9 +31,7 @@ namespace Bloom.Book
 		/// <param name="nameOfXMatterPack">e.g. "Factory", "SILIndonesia"</param>
 		/// <param name="fileLocator">The locator needs to be able tell use the path to an xmater html file, given its name</param>
 		public XMatterHelper(HtmlDom bookDom, string nameOfXMatterPack, IFileLocator fileLocator)
-		{
-
-			
+		{		
 			_bookDom = bookDom;
 			_nameOfXMatterPack = nameOfXMatterPack;
 
@@ -43,7 +41,7 @@ namespace Bloom.Book
 			{
 				directoryPath = fileLocator.LocateDirectoryWithThrow(directoryName);
 			}
-			catch (Exception error)
+			catch(ApplicationException error)
 			{
 				var errorTemplate = LocalizationManager.GetString("Errors.XMatterNotFound",
 					"This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a BloomPack that will give you '{0}', or go to Settings:Book Making and change to another Front/Back Matter Pack.");

--- a/src/BloomExe/Book/XMatterHelper.cs
+++ b/src/BloomExe/Book/XMatterHelper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
+using L10NSharp;
 using Palaso.Extensions;
 using Palaso.IO;
 using Palaso.Progress;
@@ -31,6 +32,8 @@ namespace Bloom.Book
 		/// <param name="fileLocator">The locator needs to be able tell use the path to an xmater html file, given its name</param>
 		public XMatterHelper(HtmlDom bookDom, string nameOfXMatterPack, IFileLocator fileLocator)
 		{
+
+			
 			_bookDom = bookDom;
 			_nameOfXMatterPack = nameOfXMatterPack;
 
@@ -42,8 +45,13 @@ namespace Bloom.Book
 			}
 			catch (Exception error)
 			{
+				var errorTemplate = LocalizationManager.GetString("Errors.XMatterNotFound",
+					"This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a BloomPack that will give you '{0}', or go to Settings:Book Making and change to another Front/Back Matter Pack.");
+				var msg = string.Format(errorTemplate, nameOfXMatterPack);
+
+				ErrorReport.NotifyUserOfProblem(new ShowOncePerSessionBasedOnExactMessagePolicy(), msg);
 				//NB: we don't want to put up a dialog for each one; one failure here often means 20 more are coming as the other books are loaded!
-				throw new ApplicationException(String.Format("Could not find xmatter pack directory named " + directoryName), error);
+				throw new ApplicationException(msg);
 			}
 			string htmName = nameOfXMatterPack + "-XMatter.htm";
 			PathToXMatterHtml = directoryPath.CombineForPath(htmName);


### PR DESCRIPTION
This PR also makes the 2 messages encountered in this scenario localizable, and makes the edit and publish tabs be disabled if the select book has this kind of error. Previously, that happened only if the book's html could not validate.