### PR TITLE
BL-962: Fix some "file missing" messages

### DIFF
--- a/src/BloomExe/Book/ImageUpdater.cs
+++ b/src/BloomExe/Book/ImageUpdater.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -8,6 +7,7 @@ using System.Xml;
 using Palaso.CommandLineProcessing;
 using Palaso.Extensions;
 using Palaso.IO;
+using Palaso.Network;
 using Palaso.Progress;
 using Palaso.Reporting;
 using Palaso.UI.WindowsForms.ClearShare;
@@ -87,6 +87,8 @@ namespace Bloom.Book
 				//Debug.Fail(" (Debug only) img has no or empty src attribute");
 				return; // they have bigger problems, which aren't appropriate to deal with here.
 			}
+
+			fileName = HttpUtilityFromMono.UrlDecode(fileName);
 			if (metadata == null)
 			{
 				progress.WriteStatus("Reading metadata from " + fileName);

--- a/src/BloomExe/web/IRequestInfo.cs
+++ b/src/BloomExe/web/IRequestInfo.cs
@@ -12,6 +12,7 @@ namespace Bloom.web
 		void ReplyWithFileContent(string path);
 		void ReplyWithImage(string path);
 		void WriteError(int errorCode);
+		void WriteError(int errorCode, string errorDescription);
 		System.Collections.Specialized.NameValueCollection GetQueryString();
 		System.Collections.Specialized.NameValueCollection GetPostData();
 	}

--- a/src/BloomExe/web/RequestInfo.cs
+++ b/src/BloomExe/web/RequestInfo.cs
@@ -125,11 +125,16 @@ namespace Bloom.web
 			//_actualContext.Response.Close();
 		}
 
-		public void WriteError(int errorCode)
+		public void WriteError(int errorCode, string errorDescription)
 		{
 			_actualContext.Response.StatusCode = errorCode;
-			_actualContext.Response.StatusDescription = "File not found";
+			_actualContext.Response.StatusDescription = errorDescription;
 			_actualContext.Response.Close();
+		}
+
+		public void WriteError(int errorCode)
+		{
+			WriteError(errorCode, "File not found");
 		}
 
 		/// <summary>

--- a/src/BloomExe/web/ServerBase.cs
+++ b/src/BloomExe/web/ServerBase.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) 2014 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
+using System.IO;
 using System.Net;
 using System.Threading;
 using System.Windows.Forms;
 using Palaso.Reporting;
 using Palaso.Code;
-using System.Net.Sockets;
 
 namespace Bloom.web
 {
@@ -254,7 +254,15 @@ namespace Bloom.web
 
 		protected virtual bool ProcessRequest(IRequestInfo info)
 		{
-			if (info.LocalPathWithoutQuery.EndsWith("testconnection"))
+			// process request for directory index
+			var requestedPath = info.LocalPathWithoutQuery.Substring(7);
+			if (info.RawUrl.EndsWith("/") && (Directory.Exists(requestedPath)))
+			{
+				info.WriteError(403, "Directory listing denied");
+				return true;
+			}
+
+			if (requestedPath.EndsWith("testconnection"))
 			{
 				info.WriteCompleteOutput("OK");
 				return true;

--- a/src/BloomTests/PretendRequestInfo.cs
+++ b/src/BloomTests/PretendRequestInfo.cs
@@ -1,6 +1,5 @@
 // Copyright (c) 2014 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
-using System;
 using System.Collections.Specialized;
 using System.Text;
 
@@ -12,6 +11,7 @@ namespace Bloom.web
 		public string ReplyImagePath;
 		//public HttpListenerContext Context; //todo: could we mock a context and then all but do away with this pretend class by subclassing the real one?
 		public long StatusCode;
+		public string StatusDescription;
 
 		public PretendRequestInfo(string url)
 		{
@@ -45,6 +45,12 @@ namespace Bloom.web
 		public void ReplyWithImage(string path)
 		{
 			ReplyImagePath = path;
+		}
+
+		public void WriteError(int errorCode, string errorDescription)
+		{
+			StatusCode = errorCode;
+			StatusDescription = errorDescription;
 		}
 
 		public void WriteError(int errorCode)


### PR DESCRIPTION
2:26:12 PM	Book.UpdateImgMetdataAttributesToMatchImage() Image C:\Users\Hopper\Documents\Bloom\OT Kings\King Rehoboam Shames the Elders Rejects Wise Adv\OTK%201Kings%2012_8.jpg is missing 

2:26:19 PM	**EnhancedImageServer: File Missing: C:/Users/Hopper/Documents/Bloom/OT Kings/King Rehoboam Shames the Elders Rejects Wise Adv/ 

The first example above needs to be urldecoded, and the second is a request for the directory index, which should be denied by the server.