### PR TITLE
BL-928 Restrict Json uploaded to parse.com

### DIFF
--- a/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
@@ -359,7 +359,7 @@ namespace Bloom.WebLibraryIntegration
 					metadata.BookOrder = _s3Client.BookOrderUrl;
 					progress.WriteStatus(LocalizationManager.GetString("PublishTab.Upload.UploadingBookMetadata", "Uploading book metadata", "In this step, Bloom is uploading things like title, languages, & topic tags to the bloomlibrary.org database."));
 					// Do this after uploading the books, since the ThumbnailUrl is generated in the course of the upload.
-					var response = _parseClient.SetBookRecord(metadata.Json);
+					var response = _parseClient.SetBookRecord(metadata.WebDataJson);
 					parseId = response.ResponseUri.LocalPath;
 					int index = parseId.LastIndexOf('/');
 					parseId = parseId.Substring(index + 1);


### PR DESCRIPTION
Prevent uploading a field that was recently added to BookMetaData
but which is not relevant to our website, and thus allow uploads
to work again even though Parse.com does not find the field.
Provides a general way to contro which fields get uploaded;
in future, new metadata fields should only be uploaded if actually
useful to the web site.