### PR TITLE
 Refactor timer handling in Browser and EditingView

### DIFF
--- a/src/BloomExe/Browser.Designer.cs
+++ b/src/BloomExe/Browser.Designer.cs
@@ -7,8 +7,6 @@
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-
-
         #region Component Designer generated code
 
         /// <summary> 
@@ -18,13 +16,7 @@
         private void InitializeComponent()
         {
 			this.components = new System.ComponentModel.Container();
-			this._updateCommandsTimer = new System.Windows.Forms.Timer(this.components);
 			this.SuspendLayout();
-			// 
-			// _updateCommandsTimer
-			// 
-			this._updateCommandsTimer.Enabled = true;
-			this._updateCommandsTimer.Tick += new System.EventHandler(this.OnUpdateDisplayTick);
 			// 
 			// Browser
 			// 
@@ -38,6 +30,5 @@
 
         #endregion
 
-		private System.Windows.Forms.Timer _updateCommandsTimer;
     }
 }

--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -202,11 +202,7 @@ namespace Bloom
 					_browser.Undo();
 				}
 			};
-			//none of these worked
-/*            _browser.DomKeyPress+=new GeckoDomKeyEventHandler((sender, args) => UpdateEditButtons());
-			_browser.DomClick += new GeckoDomEventHandler((sender, args) => UpdateEditButtons());
-			_browser.DomFocus += new GeckoDomEventHandler((sender, args) => UpdateEditButtons());
-  */      }
+		}
 
 		public void SaveHTML(string path)
 		{
@@ -218,7 +214,7 @@ namespace Bloom
 			_browser.SaveDocument(path, "text/html");
 		}
 
-		private void UpdateEditButtons()
+		public void UpdateEditButtons()
 		{
 			if (_copyCommand == null)
 				return;
@@ -283,21 +279,24 @@ namespace Bloom
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (_jsCallHook != null)
+			if (disposing)
 			{
-				_jsCallHook.JavaScriptError -= _jsCallHook_JavaScriptError;
-				_jsCallHook = null;
-			}
-			_jsErrorHandler = null;
+				if (_jsCallHook != null)
+				{
+					_jsCallHook.JavaScriptError -= _jsCallHook_JavaScriptError;
+					_jsCallHook = null;
+				}
+				_jsErrorHandler = null;
 
-			if (_tempHtmlFile != null)
-			{
-				_tempHtmlFile.Dispose();
-				_tempHtmlFile = null;
-			}
-			if (disposing && (components != null))
-			{
-				components.Dispose();
+				if (_tempHtmlFile != null)
+				{
+					_tempHtmlFile.Dispose();
+					_tempHtmlFile = null;
+				}
+				if (components != null)
+				{
+					components.Dispose();
+				}
 			}
 			base.Dispose(disposing);
 			_disposed = true;
@@ -339,14 +338,12 @@ namespace Bloom
 			_browser.Navigated += CleanupAfterNavigation;//there's also a "document completed"
 			_browser.DocumentCompleted += new EventHandler<GeckoDocumentCompletedEventArgs>(_browser_DocumentCompleted);
 
-			_updateCommandsTimer.Enabled = true;//hack
-
 			GeckoPreferences.User["mousewheel.withcontrolkey.action"] = 3;
 			GeckoPreferences.User["browser.zoom.full"] = true;
 
-			//in firefox 14, at least, there was a bug such that if you have more than one lang on the page, all are check with English
-			//until we get past that, it's just annoying
-
+			// in firefox 14, at least, there was a bug such that if you have more than one lang on
+			// the page, all are check with English
+			// until we get past that, it's just annoying
 			GeckoPreferences.User["layout.spellcheckDefault"] = 0;
 
 			RaiseGeckoReady();
@@ -386,9 +383,12 @@ namespace Bloom
 			Debug.Assert(!InvokeRequired);
 			//Remove everything from the clipboard except the unicode text (e.g. remove messy html from ms word)
 			var originalText = BloomClipboard.GetText(TextDataFormat.UnicodeText);
-			//setting clears everything else:
-			BloomClipboard.SetText(originalText, TextDataFormat.UnicodeText);
-			_browser.Paste();
+			if (!string.IsNullOrEmpty(originalText))
+			{
+				//setting clears everything else:
+				BloomClipboard.SetText(originalText, TextDataFormat.UnicodeText);
+				_browser.Paste();
+			}
 		}
 
 		/// <summary>

--- a/src/BloomExe/Browser.resx
+++ b/src/BloomExe/Browser.resx
@@ -117,7 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="_updateCommandsTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/src/BloomExe/Edit/EditingView.Designer.cs
+++ b/src/BloomExe/Edit/EditingView.Designer.cs
@@ -13,9 +13,24 @@
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
+			if (disposing)
+			{
+				if (_editButtonsUpdateTimer != null)
+				{
+					_editButtonsUpdateTimer.Stop();
+					_editButtonsUpdateTimer.Dispose();
+					_editButtonsUpdateTimer = null;
+				}
+
+				if (_handleMessageTimer != null)
+				{
+					_handleMessageTimer.Stop();
+					_handleMessageTimer.Dispose();
+					_handleMessageTimer = null;
+				}
+
+				if (components != null)
+					components.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -70,7 +85,6 @@
 			// 
 			// _editButtonsUpdateTimer
 			// 
-			this._editButtonsUpdateTimer.Enabled = true;
 			this._editButtonsUpdateTimer.Tick += new System.EventHandler(this._editButtonsUpdateTimer_Tick);
 			// 
 			// _handleMessageTimer
@@ -496,7 +510,6 @@
 			this.Margin = new System.Windows.Forms.Padding(4);
 			this.Name = "EditingView";
 			this.Size = new System.Drawing.Size(1200, 561);
-			this.Load += new System.EventHandler(this.EditingView_Load);
 			((System.ComponentModel.ISupportInitialize)(this._L10NSharpExtender)).EndInit();
 			this._splitContainer1.Panel2.ResumeLayout(false);
 			((System.ComponentModel.ISupportInitialize)(this._splitContainer1)).EndInit();

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -162,6 +162,8 @@ namespace Bloom.Edit
 			_splitContainer1.Select();
 			//_browser1.Select();
 			_browser1.WebBrowser.Select();
+
+			_editButtonsUpdateTimer.Enabled = Parent != null;
 		}
 
 		public Bitmap ToolStripBackground { get; set; }
@@ -869,6 +871,7 @@ namespace Bloom.Edit
 
 		public void UpdateEditButtons()
 		{
+			_browser1.UpdateEditButtons();
 			UpdateButtonEnabled(_cutButton, _cutCommand);
 			UpdateButtonEnabled(_copyButton, _copyCommand);
 			UpdateButtonEnabled(_pasteButton, _pasteCommand);
@@ -886,6 +889,7 @@ namespace Bloom.Edit
 
 		private void CycleEditButtons()
 		{
+			_browser1.UpdateEditButtons();
 			CycleOneButton(_cutButton, _cutCommand);
 			CycleOneButton(_copyButton, _copyCommand);
 			CycleOneButton(_pasteButton, _pasteCommand);
@@ -907,6 +911,12 @@ namespace Bloom.Edit
 			//doesn't work because the forecolor is ignored when disabled...
 			button.ForeColor = button.Enabled ? _enabledToolbarColor : _disabledToolbarColor; //.DimGray;
 			button.Invalidate();
+		}
+
+		protected override void OnParentChanged(EventArgs e)
+		{
+			base.OnParentChanged(e);
+			_editButtonsUpdateTimer.Enabled = Parent != null;
 		}
 
 		private void _editButtonsUpdateTimer_Tick(object sender, EventArgs e)
@@ -943,14 +953,19 @@ namespace Bloom.Edit
 			_duplicatePageCommand.Execute();
 		}
 
-		private void EditingView_Load(object sender, EventArgs e)
+		protected override void OnLoad(EventArgs e)
 		{
+			base.OnLoad(e);
+
 			//Why the check for null? In bl-283, user had been in settings dialog, which caused a closing down, but something
 			//then did a callback to this view, such that ParentForm was null, and this died
 			Debug.Assert(ParentForm != null);
 			if (ParentForm != null)
 			{
 				ParentForm.Activated += new EventHandler(ParentForm_Activated);
+				ParentForm.Deactivate += (sender, e1) => {
+					_editButtonsUpdateTimer.Enabled = false;
+				};
 			}
 		}
 


### PR DESCRIPTION
- Enable the timer only while EditingView is active
- Properly dispose the timer
- Remove Browser._updateCommandsTimer. Instead do what it used to
  do from EditingView._editButtonsUpdateTimer.

I tried these changes while working on BL-866. Although it doesn't
fix the problem I think it is still an improvement.