### PR TITLE
Ensure ToolStrip items all display for Edit view (BL-961)

### DIFF
--- a/src/BloomExe/Edit/EditingView.Designer.cs
+++ b/src/BloomExe/Edit/EditingView.Designer.cs
@@ -401,7 +401,7 @@
 			this._menusToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this._contentLanguagesDropdown,
             this._layoutChoices});
-			this._menusToolStrip.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Table;
+			this._menusToolStrip.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
 			this._L10NSharpExtender.SetLocalizableToolTip(this._menusToolStrip, null);
 			this._L10NSharpExtender.SetLocalizationComment(this._menusToolStrip, null);
 			this._L10NSharpExtender.SetLocalizationPriority(this._menusToolStrip, L10NSharp.LocalizationPriority.NotLocalizable);


### PR DESCRIPTION
Mono doesn't implement the Table style. The Flow style looks the same
for this code as Table style on Windows, and Mono does implement the
Flow style.