### PR TITLE
Increase height for editing menu toolstrip (BL-961)

### DIFF
--- a/src/BloomExe/Edit/EditingView.Designer.cs
+++ b/src/BloomExe/Edit/EditingView.Designer.cs
@@ -406,9 +406,9 @@
 			this._L10NSharpExtender.SetLocalizationComment(this._menusToolStrip, null);
 			this._L10NSharpExtender.SetLocalizationPriority(this._menusToolStrip, L10NSharp.LocalizationPriority.NotLocalizable);
 			this._L10NSharpExtender.SetLocalizingId(this._menusToolStrip, "EditTab._menusToolStrip");
-			this._menusToolStrip.Location = new System.Drawing.Point(294, 20);
+			this._menusToolStrip.Location = new System.Drawing.Point(294, 16);
 			this._menusToolStrip.Name = "_menusToolStrip";
-			this._menusToolStrip.Size = new System.Drawing.Size(165, 42);
+			this._menusToolStrip.Size = new System.Drawing.Size(165, 50);
 			this._menusToolStrip.TabIndex = 2;
 			this._menusToolStrip.Text = "toolStrip1";
 			// 


### PR DESCRIPTION
This is necessary (but not sufficient) to fix BL-961.  The Hindi
menu strings were generating a height of 24 pixels each.  Leaving
two extra pixels in height seems prudent.  A fix to Mono is also
needed as it defaults to horizontal display of tall buttons for
Table style layout.