### PR TITLE
BL-944: PDF viewer running out of memory too soon

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1039,6 +1039,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent Condition="'$(OS)'=='Windows_NT'">
+"$(DevEnvDir)..\..\VC\bin\editbin.exe" /largeaddressaware "$(TargetPath)"
 copy /Y "$(SolutionDir)\lib\msvcr100.dll" $(OutDir)
 copy /Y "$(SolutionDir)\lib\libtidy.dll" $(OutDir)
 copy /Y "$(SolutionDir)\lib\dotnet\Interop.AcroPDFLib.dll" $(OutDir)


### PR DESCRIPTION
This is a "Windows-only" fix. The "largeaddressaware" switch is a linker command that allows geckofx to access up to 2GB of memory.  See https://bitbucket.org/geckofx/geckofx-29.0/issue/181/enable-largeaddressaware-was-strange-out