### PR TITLE
BL-967 & BL-609 image import problems

### DIFF
--- a/DistFiles/ReleaseNotes.md
+++ b/DistFiles/ReleaseNotes.md
@@ -1,4 +1,14 @@
-﻿## 3.0.93 BETA
+﻿## 3.1
+
+### Fixes
+
+- Fixed a problem where many PDF viewer programs showed ugly lines around parts images. This fix will only help with images imported from now on, not retractively.
+- Pasted images are now named "image1",2,3, etc.
+- Pasted images are no longer added with a temporary gibberish name; the original names are maintained.
+- Stopped compressing pngs (could return someday, but for now it's hard on people with slower machines, and sometimes increases the size)
+- Bloom now tries to detect when you are importing a jpeg that really should be tiff/bmp/png, and puts up an informative dialog that lets you repent or plow forward.
+
+## 3.0.93 BETA
 
 ### A couple known problems
 - If upgrading from Bloom 2, the Windows installer loses one of Bloom's files. It will now notify you that this happened and ask you do reinstall and choose "repair".

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -590,9 +590,9 @@ function UpdateOverlay(container, img) {
 // TODO: internationalize
 function SetAlternateTextOnImages(element) {
     if ($(element).attr('src').length > 0) { //don't show this on the empty license image when we don't know the license yet
-        $(element).attr('alt', 'This picture, ' + $(element).attr('src') + ', is missing or was loading too slowly.');
-    }
-    else {
+        var nameWithoutQueryString = $(element).attr('src').split("?")[0];
+        $(element).attr('alt', 'This picture, ' + nameWithoutQueryString + ', is missing or was loading too slowly.');
+    } else {
         $(element).attr('alt', '');//don't be tempted to show something like a '?' unless you fix the result when you have a custom book license on top of that '?'
     }
 }

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -211,6 +211,12 @@
     <Compile Include="CollectionTab\HistoryAndNotesDialog.Designer.cs">
       <DependentUpon>HistoryAndNotesDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="Edit\JpegWarningDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Edit\JpegWarningDialog.Designer.cs">
+      <DependentUpon>JpegWarningDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="Edit\WebThumbNailList.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -221,6 +227,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Extensions.cs" />
+    <Compile Include="ImageProcessing\ImageUtils.cs" />
     <Compile Include="JavaScriptErrorHandler.cs" />
     <Compile Include="MiscUI\DontShowThisAgainButton.cs">
       <SubType>Component</SubType>
@@ -566,6 +573,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="CollectionTab\HistoryAndNotesDialog.resx">
       <DependentUpon>HistoryAndNotesDialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Edit\JpegWarningDialog.resx">
+      <DependentUpon>JpegWarningDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Edit\WebThumbNailList.resx">
       <DependentUpon>WebThumbNailList.cs</DependentUpon>

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1411,41 +1411,10 @@ namespace Bloom.Book
 				XmlElement divElement = editedPageDom.SelectSingleNodeHonoringDefaultNS("//div[contains(@class, 'bloom-page')]");
 				string pageDivId = divElement.GetAttribute("id");
 				var page = GetPageFromStorage(pageDivId);
-				/*
-				 * there are too many non-semantic variations that are introduced by various processes (e.g. self closing of empy divs, handling of non-ascii)
-				 * var selfClosingVersion = divElement.InnerXml.Replace("\"></div>", "\"/>");
-					if (page.InnerXml == selfClosingVersion)
-					{
-						return;
-					}
-				 */
 
-				page.InnerXml = divElement.InnerXml;
+				HtmlDom.ProcessPageAfterEditing(page, divElement);	
 
-				//Enhance: maybe we should just copy over all attributes?
-				page.SetAttribute("class", divElement.GetAttribute("class"));
-				//The SIL LEAD SHRP templates rely on "lang" on some ancestor to trigger the correct rules in labels.css.
-				//Those get set by putting data-metalanguage on Page, which then leads to a lang='xyz'. Let's save that
-				//back to the html in keeping with our goal of having the page look right if you were to just open the 
-				//html file in Firefox.
-				page.SetAttribute("lang", divElement.GetAttribute("lang"));
-
-				// strip out any elements that are part of bloom's UI; we don't want to save them in the document or show them in thumbnails etc.
-				// Thanks to http://stackoverflow.com/questions/1390568/how-to-match-attributes-that-contain-a-certain-string for the xpath.
-				// The idea is to match class attriutes which have class bloom-ui, but may have other classes. We don't want to match
-				// classes where bloom-ui is a substring, though, if there should be any. So we wrap spaces around the class attribute
-				// and then see whether it contains bloom-ui surrounded by spaces.
-				foreach (var node in page.SafeSelectNodes("//*[contains(concat(' ', @class, ' '), ' bloom-ui ')]").Cast<XmlNode>().ToArray())
-					node.ParentNode.RemoveChild(node);
-
-				// Upon save, make sure we are not in layout mode.  Otherwise we show the sliders.
-				foreach (var node in page.SafeSelectNodes(".//*[contains(concat(' ', @class, ' '), ' origami-layout-mode ')]").Cast<XmlNode>().ToArray())
-				{
-					string currentValue = node.Attributes["class"].Value;
-					node.Attributes["class"].Value = currentValue.Replace("origami-layout-mode", "");
-				}
-
-				 _bookData.SuckInDataFromEditedDom(editedPageDom);//this will do an updatetitle
+				_bookData.SuckInDataFromEditedDom(editedPageDom);//this will do an updatetitle
 				// When the user edits the styles on a page, the new or modified rules show up in a <style/> element with title "userModifiedStyles". Here we copy that over to the book DOM.
 				 var userModifiedStyles = editedPageDom.SelectSingleNode("html/head/style[@title='userModifiedStyles']");
 				if (userModifiedStyles != null)

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -579,7 +579,7 @@ namespace Bloom.Book
 			XmlDomExtensions.RemoveStyleSheetIfFound(RawDom, path);
 		}
 
-		/* The following, to us normal url query parameters to say if we wanted transparency,
+		/* The following, to use normal url query parameters to say if we wanted transparency,
 		 * was a nice idea, but turned out to not be necessary. I'm leave the code here in 
 		 * case in the future we do find a need to add query parameters.
 		public  void SetImagesForMode(bool editMode)

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -578,5 +578,58 @@ namespace Bloom.Book
 		{
 			XmlDomExtensions.RemoveStyleSheetIfFound(RawDom, path);
 		}
+
+		/* The following, to us normal url query parameters to say if we wanted transparency,
+		 * was a nice idea, but turned out to not be necessary. I'm leave the code here in 
+		 * case in the future we do find a need to add query parameters.
+		public  void SetImagesForMode(bool editMode)
+		{
+			SetImagesForMode((XmlNode)RawDom, editMode);
+		}
+
+		public static void SetImagesForMode(XmlNode pageNode, bool editMode)
+		{
+			foreach(XmlElement imgNode in pageNode.SafeSelectNodes(".//img"))
+			{
+				var src = imgNode.GetAttribute("src");
+				const string kTransparent = "?makeWhiteTransparent=true";
+				src = src.Replace(kTransparent, "");
+				if (editMode)
+					src = src + kTransparent;
+				imgNode.SetAttribute("src",src);
+			}
+		}
+		*/
+
+		public static void ProcessPageAfterEditing(XmlElement page, XmlElement divElement)
+		{
+			page.InnerXml = divElement.InnerXml;
+
+			//Enhance: maybe we should just copy over all attributes?
+			page.SetAttribute("class", divElement.GetAttribute("class"));
+			//The SIL LEAD SHRP templates rely on "lang" on some ancestor to trigger the correct rules in labels.css.
+			//Those get set by putting data-metalanguage on Page, which then leads to a lang='xyz'. Let's save that
+			//back to the html in keeping with our goal of having the page look right if you were to just open the 
+			//html file in Firefox.
+			page.SetAttribute("lang", divElement.GetAttribute("lang"));
+
+			// strip out any elements that are part of bloom's UI; we don't want to save them in the document or show them in thumbnails etc.
+			// Thanks to http://stackoverflow.com/questions/1390568/how-to-match-attributes-that-contain-a-certain-string for the xpath.
+			// The idea is to match class attriutes which have class bloom-ui, but may have other classes. We don't want to match
+			// classes where bloom-ui is a substring, though, if there should be any. So we wrap spaces around the class attribute
+			// and then see whether it contains bloom-ui surrounded by spaces.
+			foreach(
+				var node in page.SafeSelectNodes("//*[contains(concat(' ', @class, ' '), ' bloom-ui ')]").Cast<XmlNode>().ToArray())
+				node.ParentNode.RemoveChild(node);
+
+			// Upon save, make sure we are not in layout mode.  Otherwise we show the sliders.
+			foreach(
+				var node in
+					page.SafeSelectNodes(".//*[contains(concat(' ', @class, ' '), ' origami-layout-mode ')]").Cast<XmlNode>().ToArray())
+			{
+				string currentValue = node.Attributes["class"].Value;
+				node.Attributes["class"].Value = currentValue.Replace("origami-layout-mode", "");
+			}
+		}
 	}
 }

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -12,6 +12,7 @@ using Bloom.ToPalaso.Experimental;
 using Bloom.web;
 using BloomTemp;
 using DesktopAnalytics;
+using L10NSharp;
 using Newtonsoft.Json;
 using Palaso.IO;
 using Palaso.Progress;
@@ -857,7 +858,8 @@ namespace Bloom.Edit
 			}
 			catch (Exception e)
 			{
-				ErrorReport.NotifyUserOfProblem(e, "Could not change the picture");
+				var msg = LocalizationManager.GetString("Errors.ProblemImportingPicture","Bloom had a problem importing this picture.");
+				ErrorReport.NotifyUserOfProblem(e, msg+Environment.NewLine+e.Message);
 			}
 		}
 

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -574,7 +574,7 @@ namespace Bloom.Edit
 				Cursor = Cursors.WaitCursor;
 
 				//nb: Taglib# requires an extension that matches the file content type.
-				if (ImageUtils.ShouldSaveAsJpeg(clipboardImage))
+				if (ImageUtils.AppearsToBeJpeg(clipboardImage))
 				{
 					if(ShouldBailOutBecauseUserAgreedNotToUseJpeg(clipboardImage))
 						return;
@@ -740,7 +740,7 @@ namespace Bloom.Edit
 
 		private bool ShouldBailOutBecauseUserAgreedNotToUseJpeg(PalasoImage imageInfo)
 		{
-			if(ImageUtils.ShouldSaveAsJpeg(imageInfo) && JpegWarningDialog.ShouldWarnAboutJpeg(imageInfo.Image))
+			if(ImageUtils.AppearsToBeJpeg(imageInfo) && JpegWarningDialog.ShouldWarnAboutJpeg(imageInfo.Image))
 			{
 				using(var jpegDialog = new JpegWarningDialog())
 				{

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Windows.Forms;
 using Bloom.Book;
 using Bloom.CollectionTab;
+using Bloom.ImageProcessing;
 using Bloom.Properties;
 using Bloom.web;
 using L10NSharp;
@@ -551,7 +552,7 @@ namespace Bloom.Edit
 				return;
 			}
 
-			Image clipboardImage = null;
+			PalasoImage clipboardImage = null;
 			try
 			{
 				clipboardImage = GetImageFromClipboard();
@@ -562,6 +563,7 @@ namespace Bloom.Edit
 					return;
 				}
 
+
 				var target = (GeckoHtmlElement) ge.Target.CastToGeckoElement();
 				if (target.ClassName.Contains("licenseImage"))
 					return;
@@ -571,21 +573,46 @@ namespace Bloom.Edit
 					return;
 				Cursor = Cursors.WaitCursor;
 
-				//nb: later, code closer to the the actual book folder will
-				//improve this file name. Taglib# requires an extension that matches the file content type, however.
-				using (var temp = TempFile.WithExtension("png"))
+				//nb: Taglib# requires an extension that matches the file content type.
+				if (ImageUtils.ShouldSaveAsJpeg(clipboardImage))
 				{
-					clipboardImage.Save(temp.Path, ImageFormat.Png);
-//                    using (var progressDialog = new ProgressDialogBackground())
-//                    {
-//                        progressDialog.ShowAndDoWork((progress, args) =>
-//                                                         {
-//                                                             ImageUpdater.CompressImage(temp.Path, progress);
-//                                                         });
-//                    }
-					using (var palasoImage = PalasoImage.FromFile(temp.Path))
+					if(ShouldBailOutBecauseUserAgreedNotToUseJpeg(clipboardImage))
+						return;
+					Logger.WriteMinorEvent("[Paste Image] Pasting jpeg image {0}", clipboardImage.OriginalFilePath);
+					_model.ChangePicture(imageElement, clipboardImage, new NullProgress());
+				}
+				else
+				{
+					//At this point, it could be a bmp, tiff, or PNG. We want it to be a PNG.
+					if(clipboardImage.OriginalFilePath == null) //they pasted an image, not a path
 					{
-						_model.ChangePicture(imageElement, palasoImage, new NullProgress());
+						Logger.WriteMinorEvent("[Paste Image] Pasting image directly from clipboard (e.g. screenshot)");
+						_model.ChangePicture(imageElement, clipboardImage, new NullProgress());
+					}
+					//they pasted a path to a png
+					else if(Path.GetExtension(clipboardImage.OriginalFilePath).ToLower() == ".png")
+					{
+						Logger.WriteMinorEvent("[Paste Image] Pasting png file {0}", clipboardImage.OriginalFilePath);
+						_model.ChangePicture(imageElement, clipboardImage, new NullProgress());
+					}
+					else // they pasted a path to some other bitmap format
+					{
+						var pathToPngVersion = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(clipboardImage.FileName) + ".png");
+						Logger.WriteMinorEvent("[Paste Image] Saving {0} ({1}) as {2} and converting to PNG", clipboardImage.FileName,
+							clipboardImage.OriginalFilePath, pathToPngVersion);
+						if (File.Exists(pathToPngVersion))
+						{
+							File.Delete(pathToPngVersion);
+						}
+						using(var temp = TempFile.TrackExisting(pathToPngVersion))
+						{
+							clipboardImage.Image.Save(pathToPngVersion, ImageFormat.Png);
+
+							using (var palasoImage = PalasoImage.FromFile(temp.Path))
+							{
+								_model.ChangePicture(imageElement, palasoImage, new NullProgress());
+							}
+						}
 					}
 				}
 			}
@@ -601,7 +628,7 @@ namespace Bloom.Edit
 			Cursor = Cursors.Default;
 		}
 
-		private static Image GetImageFromClipboard()
+		private static PalasoImage GetImageFromClipboard()
 		{
 			return BloomClipboard.GetImageFromClipboard();
 		}
@@ -685,9 +712,12 @@ namespace Bloom.Edit
 			{
 				if (DialogResult.OK == dlg.ShowDialog())
 				{
+
 					// var path = MakePngOrJpgTempFileForImage(dlg.ImageInfo.Image);
 					try
 					{
+						if(ShouldBailOutBecauseUserAgreedNotToUseJpeg(dlg.ImageInfo))
+							return;
 						_model.ChangePicture(imageElement, dlg.ImageInfo, new NullProgress());
 					}
 					catch (System.IO.IOException error)
@@ -706,6 +736,21 @@ namespace Bloom.Edit
 			}
 			Logger.WriteMinorEvent("Emerged from ImageToolboxDialog Editor Dialog");
 			Cursor = Cursors.Default;
+		}
+
+		private bool ShouldBailOutBecauseUserAgreedNotToUseJpeg(PalasoImage imageInfo)
+		{
+			if(ImageUtils.ShouldSaveAsJpeg(imageInfo) && JpegWarningDialog.ShouldWarnAboutJpeg(imageInfo.Image))
+			{
+				using(var jpegDialog = new JpegWarningDialog())
+				{
+					return jpegDialog.ShowDialog() == DialogResult.Cancel;
+				}
+			}
+			else
+			{
+				return false;
+			}
 		}
 
 		public void UpdateThumbnailAsync(IPage page)

--- a/src/BloomExe/Edit/JpegWarningDialog.Designer.cs
+++ b/src/BloomExe/Edit/JpegWarningDialog.Designer.cs
@@ -1,0 +1,146 @@
+﻿namespace Bloom.Edit
+{
+	partial class JpegWarningDialog
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if(disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this.components = new System.ComponentModel.Container();
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(JpegWarningDialog));
+			this._L10NSharpExtender = new L10NSharp.UI.L10NSharpExtender(this.components);
+			this._photographRadioButton = new System.Windows.Forms.RadioButton();
+			this._cancelRadioButton = new System.Windows.Forms.RadioButton();
+			this._okButton = new System.Windows.Forms.Button();
+			this._warningText = new System.Windows.Forms.TextBox();
+			((System.ComponentModel.ISupportInitialize)(this._L10NSharpExtender)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// _L10NSharpExtender
+			// 
+			this._L10NSharpExtender.LocalizationManagerId = "Bloom";
+			this._L10NSharpExtender.PrefixForNewItems = "EditTab.JpegWarningDialog";
+			// 
+			// _photographRadioButton
+			// 
+			this._photographRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+			this._photographRadioButton.AutoSize = true;
+			this._photographRadioButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this._L10NSharpExtender.SetLocalizableToolTip(this._photographRadioButton, null);
+			this._L10NSharpExtender.SetLocalizationComment(this._photographRadioButton, null);
+			this._L10NSharpExtender.SetLocalizingId(this._photographRadioButton, "EditTab.JpegWarningDialog.Photograph");
+			this._photographRadioButton.Location = new System.Drawing.Point(12, 213);
+			this._photographRadioButton.Name = "_photographRadioButton";
+			this._photographRadioButton.Size = new System.Drawing.Size(120, 19);
+			this._photographRadioButton.TabIndex = 0;
+			this._photographRadioButton.Text = "Use the JPEG file";
+			this._photographRadioButton.UseVisualStyleBackColor = true;
+			// 
+			// _cancelRadioButton
+			// 
+			this._cancelRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+			this._cancelRadioButton.AutoSize = true;
+			this._cancelRadioButton.Checked = true;
+			this._cancelRadioButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this._L10NSharpExtender.SetLocalizableToolTip(this._cancelRadioButton, null);
+			this._L10NSharpExtender.SetLocalizationComment(this._cancelRadioButton, null);
+			this._L10NSharpExtender.SetLocalizingId(this._cancelRadioButton, "EditTab.JpegWarningDialog.DoNotUse");
+			this._cancelRadioButton.Location = new System.Drawing.Point(12, 235);
+			this._cancelRadioButton.Name = "_cancelRadioButton";
+			this._cancelRadioButton.Size = new System.Drawing.Size(123, 19);
+			this._cancelRadioButton.TabIndex = 1;
+			this._cancelRadioButton.TabStop = true;
+			this._cancelRadioButton.Text = "Cancel this import";
+			this._cancelRadioButton.UseVisualStyleBackColor = true;
+			// 
+			// _okButton
+			// 
+			this._okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this._okButton.AutoSize = true;
+			this._okButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+			this._okButton.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this._L10NSharpExtender.SetLocalizableToolTip(this._okButton, null);
+			this._L10NSharpExtender.SetLocalizationComment(this._okButton, "");
+			this._L10NSharpExtender.SetLocalizingId(this._okButton, "Common.OK");
+			this._okButton.Location = new System.Drawing.Point(484, 257);
+			this._okButton.Name = "_okButton";
+			this._okButton.Size = new System.Drawing.Size(86, 26);
+			this._okButton.TabIndex = 3;
+			this._okButton.Text = "OK";
+			this._okButton.UseVisualStyleBackColor = true;
+			this._okButton.Click += new System.EventHandler(this._okButton_Click);
+			// 
+			// _warningText
+			// 
+			this._warningText.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this._warningText.BackColor = System.Drawing.SystemColors.Control;
+			this._warningText.Font = new System.Drawing.Font("Segoe UI", 9F);
+			this._L10NSharpExtender.SetLocalizableToolTip(this._warningText, null);
+			this._L10NSharpExtender.SetLocalizationComment(this._warningText, null);
+			this._L10NSharpExtender.SetLocalizationPriority(this._warningText, L10NSharp.LocalizationPriority.NotLocalizable);
+			this._L10NSharpExtender.SetLocalizingId(this._warningText, "notused");
+			this._warningText.Location = new System.Drawing.Point(12, 12);
+			this._warningText.Multiline = true;
+			this._warningText.Name = "_warningText";
+			this._warningText.ReadOnly = true;
+			this._warningText.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+			this._warningText.Size = new System.Drawing.Size(558, 195);
+			this._warningText.TabIndex = 6;
+			this._warningText.Text = "This is set in code.";
+			// 
+			// JpegWarningDialog
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(582, 295);
+			this.Controls.Add(this._warningText);
+			this.Controls.Add(this._okButton);
+			this.Controls.Add(this._cancelRadioButton);
+			this.Controls.Add(this._photographRadioButton);
+			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+			this._L10NSharpExtender.SetLocalizableToolTip(this, null);
+			this._L10NSharpExtender.SetLocalizationComment(this, null);
+			this._L10NSharpExtender.SetLocalizingId(this, "JpegWarningDialog.WindowTitle");
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "JpegWarningDialog";
+			this.Text = "JPEG Warning";
+			((System.ComponentModel.ISupportInitialize)(this._L10NSharpExtender)).EndInit();
+			this.ResumeLayout(false);
+			this.PerformLayout();
+
+		}
+
+		#endregion
+
+		private L10NSharp.UI.L10NSharpExtender _L10NSharpExtender;
+		private System.Windows.Forms.RadioButton _photographRadioButton;
+		private System.Windows.Forms.RadioButton _cancelRadioButton;
+		private System.Windows.Forms.Button _okButton;
+		private System.Windows.Forms.TextBox _warningText;
+	}
+}

--- a/src/BloomExe/Edit/JpegWarningDialog.cs
+++ b/src/BloomExe/Edit/JpegWarningDialog.cs
@@ -38,7 +38,8 @@ Please select from one of the following, then click “OK”:").Replace("\r\n","
 			var bmp = image as Bitmap;
 			if (bmp == null)
 				return false;
-			return HasLotsOfWhiteSpace(bmp) && (IsGreyScale(bmp) || !HasLotsOfColor(bmp));
+			//Note: currently I can't justify why initially I was testing for greyscale.... maybe the logic will return...
+			return HasLotsOfWhiteSpace(bmp) && (/*IsGreyScale(bmp) || */!HasLotsOfColor(bmp));
 		}
 		private static bool IsGreyScale(Bitmap bmp)
 		{
@@ -67,6 +68,9 @@ Please select from one of the following, then click “OK”:").Replace("\r\n","
 		}
 		private static int GetNumberOfColors(Bitmap bmp, int lineNumber)
 		{
+			if(lineNumber >= bmp.Height)
+				return 0; //guard against math errors by the caller
+
 			var colors = new HashSet<int>();
 			for(var x = 0; x < bmp.Width; x++)
 			{
@@ -82,6 +86,8 @@ Please select from one of the following, then click “OK”:").Replace("\r\n","
 		private static bool GetIsGrey(Bitmap bmp, int lineNumber)
 		{
 			const int thresholdForGrey = 20;
+			if (lineNumber >= bmp.Height)
+				return false; //guard against math errors by the caller
 			for(int x = 0; x < bmp.Width; x++)
 			{
 				var pixelColor = bmp.GetPixel(x, lineNumber);
@@ -93,6 +99,9 @@ Please select from one of the following, then click “OK”:").Replace("\r\n","
 		}
 		private static double GetPercentWhiteOfLine(Bitmap bmp, int lineNumber)
 		{
+			if(lineNumber >= bmp.Height)
+				return 0; //guard against math errors by the caller
+
 			const int maxCombinedRgbValueToBeConsideredWhite = 3 * 253; // true white is 255. We'll count off-white as well
 			int whiteCount=0;
 			for (int x = 0; x < bmp.Width; x++)

--- a/src/BloomExe/Edit/JpegWarningDialog.cs
+++ b/src/BloomExe/Edit/JpegWarningDialog.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using L10NSharp;
+
+namespace Bloom.Edit
+{
+	public partial class JpegWarningDialog : Form
+	{
+		public JpegWarningDialog()
+		{
+			InitializeComponent();
+			_warningText.Text = LocalizationManager.GetString("EditTab.JpegWarningDialog.WarningText",
+				@"The file you’ve chosen is a “jpeg” file. JPEGs are perfect for photographs and color artwork. However, JPEGs are a big problem for black and white line art. Problems include:
+• Fuzziness and grey dots.
+• Large file sizes, making the book hard to share.
+• If there are many large JPEGs, Bloom may not have enough memory to make PDFs.
+
+Note: Because JPEG is “lossy”, converting a JPEG to PNG, TIFF, or bmp actually makes things even worse. If this is black and white line art, you want to get an original scan in one of those formats.
+
+Please select from one of the following, then click “OK”:").Replace("\r\n","\n").Replace("\n", Environment.NewLine);
+		}
+
+		private void _okButton_Click(object sender, EventArgs e)
+		{
+			DialogResult = _cancelRadioButton.Checked ? DialogResult.Cancel : DialogResult.OK;
+			Close();
+		}
+
+		/// <summary>
+		/// Tells whether the supplied image looks suspiciously like a file that 
+		/// would be better off as a PNG. Not particularly smart, but fast.
+		/// </summary>
+		public static Boolean ShouldWarnAboutJpeg(Image image)
+		{
+			var bmp = image as Bitmap;
+			if (bmp == null)
+				return false;
+			return HasLotsOfWhiteSpace(bmp) && (IsGreyScale(bmp) || !HasLotsOfColor(bmp));
+		}
+		private static bool IsGreyScale(Bitmap bmp)
+		{
+			var sampleLinePercentages = new[] { 20, 50, 70 };
+			return
+				sampleLinePercentages.Any(sampleLine => GetIsGrey(bmp, (int)(bmp.Height * (sampleLine / 100.0))));
+		}
+		private static bool HasLotsOfColor(Bitmap bmp)
+		{
+			//what's a good threshold? 
+			//Higher than one would think, as we want to detect pictures that don't have color just because they were
+			//mistakenly made into a jpeg.
+			//A  drawing with just 4 colors had 62 once ran through jpeg.
+			// Just turning the bloom placeholder flower into jpeg gives us 10 "colors" (different shades of grey)
+			const int threshold = 100; 
+			var sampleLinePercentages = new[] { 20, 50, 70 };
+			return
+				sampleLinePercentages.Any(sampleLine => GetNumberOfColors(bmp, (int)(bmp.Height * (sampleLine/100.0))) > threshold);
+		}
+		private static bool HasLotsOfWhiteSpace(Bitmap bmp)
+		{
+			const double threshold = .5; // we'll warn if any of the samples we take of the image show > 50% white
+			var sampleLinePercentages = new[] { 20, 50, 70 };
+			return
+				sampleLinePercentages.Any(sampleLine => GetPercentWhiteOfLine(bmp, (int)(bmp.Height * (sampleLine / 100.0))) > threshold);
+		}
+		private static int GetNumberOfColors(Bitmap bmp, int lineNumber)
+		{
+			var colors = new HashSet<int>();
+			for(var x = 0; x < bmp.Width; x++)
+			{
+				var pixel = bmp.GetPixel(x, lineNumber);
+				int pixelColor = pixel.ToArgb();
+				if (!colors.Contains(pixelColor))
+				{
+					colors.Add(pixelColor);
+				}
+			}
+			return colors.Count;
+		}
+		private static bool GetIsGrey(Bitmap bmp, int lineNumber)
+		{
+			const int thresholdForGrey = 20;
+			for(int x = 0; x < bmp.Width; x++)
+			{
+				var pixelColor = bmp.GetPixel(x, lineNumber);
+				var rgbDelta = Math.Abs(pixelColor.R - pixelColor.G) + Math.Abs(pixelColor.G - pixelColor.B) + Math.Abs(pixelColor.B - pixelColor.R);
+				if (rgbDelta > thresholdForGrey)
+					return false;
+			}
+			return true;
+		}
+		private static double GetPercentWhiteOfLine(Bitmap bmp, int lineNumber)
+		{
+			const int maxCombinedRgbValueToBeConsideredWhite = 3 * 253; // true white is 255. We'll count off-white as well
+			int whiteCount=0;
+			for (int x = 0; x < bmp.Width; x++)
+			{
+				var pixelColor = bmp.GetPixel(x, lineNumber);
+				//we'll add up the R, G, and B 
+				if ((pixelColor.R + pixelColor.G + pixelColor.B) > maxCombinedRgbValueToBeConsideredWhite)
+					++whiteCount;
+			}
+			return ((double)whiteCount)/(double)bmp.Width;
+		}
+	}
+}

--- a/src/BloomExe/Edit/JpegWarningDialog.resx
+++ b/src/BloomExe/Edit/JpegWarningDialog.resx
@@ -1,0 +1,380 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="_L10NSharpExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAMAMDAAAAAAIACoJQAANgAAACAgAAAAACAAqBAAAN4lAAAQEAAAAAAgAGgEAACGNgAAKAAAADAA
+        AABgAAAAAQAgAAAAAAAAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACIAAABeAAAAhgAA
+        AKkAAAC7AAAAygAAAMcAAAC7AAAAowAAAH8AAABVAAAAFwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC4AAACNAAAA3gAA
+        AP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/gAAANEAAAB9AAAAHwAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAABSAAAAygAA
+        AP8AAAD/AAAA/wECBP8PEi3/GyBP/yUsbf8rMn3/LjaH/y01hf8qMXv/JCpp/xkdSf8NDyb/AQEC/wAA
+        AP8AAAD/AAAA/QAAALYAAAA9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARAAA
+        ANQAAAD/AAAA/wQFDP8dIlX/ND6a/0ZSzf9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/RFDG/zE5j/8YHEb/AgIG/wAAAP8AAAD/AAAAvQAAACwAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        ABAAAACkAAAA/wAAAP8HCBP/KDB2/0ZSzf9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/Qk7D/yEnYf8DAwj/AAAA/wAAAPsAAACEAAAABAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAMgAAAN4AAAD/AQEC/x8lW/9EUcn/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9ATLz/FxtC/wAA
+        AP8AAAD/AAAAwgAAABsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAABGAAAA8wAAAP8HCBT/NkCf/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/y42hf8DAwj/AAAA/wAAAOAAAAApAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEkAAAD5AAAA/w8SLP9CTsP/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v88Rq//CAkX/wAAAP8AAADqAAAAKwAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANwAAAPUAAAD/FBc6/0ZSzP9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/QUy+/wwOIv8AAAD/AAAA4wAA
+        ABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAA4wAAAP8QEy7/RlPO/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0FN
+        v/8ICRf/AAAA/wAAAMQAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC0AAAA/wkK
+        Gv9DT8T/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v88R7D/AwMI/wAAAP8AAACFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AFYAAAD/AgIF/zlDqP9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/LjaF/wAAAP8AAAD7AAAALAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAACQAAAOQAAAD/JCpp/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/xcbQv8AAAD/AAAAvQAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAawAAAP8KCx3/R1PP/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0BM
+        vf8DAwj/AAAA/wAAAD0AAAAAAAAAAAAAAAAAAAAEAAAA4QAAAP8vOIr/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v8iKGT/AAAA/wAAALcAAAAAAAAAAAAAAAAAAABOAAAA/woMHf9IVdP/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9CTsP/AgMH/wAAAP4AAAAhAAAAAAAAAAAAAACqAAAA/yYs
+        bv9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/GB1H/wAAAP8AAAB8AAAAAAAA
+        AAoAAAD4AAAA/z5Jtv9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/MTqQ/wAA
+        AP8AAADTAAAAAAAAAEYAAAD/CQoZ/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/RFDG/wEBAv8AAAD/AAAAGAAAAIQAAAD/Gh9N/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/w0QJ/8AAAD/AAAAVgAAAK8AAAD/Jy5x/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/xkeS/8AAAD/AAAAgQAAANUAAAD/MTqQ/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/yQqaf8AAAD/AAAApgAA
+        AOkAAAD/OEKk/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/yoy
+        fP8AAAD/AAAAuwAAAPUAAAD/O0Wt/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/y42h/8AAAD/AAAAyAAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v80PZj/AAAA/wAA
+        AP9IVdP/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v8xOpD/AAAA/wAAAP9FUcn/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v8xOY//AAAA/wAAAP8/Srn/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAA
+        AP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v8oMHb/AAAA/wAAAP81P5z/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84
+        iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v8dIlb/AAAA/wAAAP8qMXr/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v8MDyT/AAAA/wAA
+        AP8ZHkr/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0JO
+        wv8AAAH/AAAA/wAAAP8GBxL/SVbV/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/ysyff8AAAD/AAAAwAAAAOYAAAD/N0Gi/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAA
+        AP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/w8SLf8AAAD/AAAAXwAAAIsAAAD/HCFT/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84
+        iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/NkCf/wAAAP8AAADvAAAADAAAACkAAAD+AgIF/0FN
+        v/9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtX/ERQx/wAAAP8AAACFAAAAAAAA
+        AAAAAACyAAAA/x0jVv9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v8tNYT/AAAA/wAA
+        APMAAAAUAAAAAAAAAAAAAAA2AAAA/gEBAv86RKn/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0BM
+        vP8FBg//AAAA/wAAAHUAAAAAAAAAAAAAAAAAAAAAAAAAowAAAP8MDyT/RlPO/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAA
+        AP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/R1TR/xATMP8AAAD/AAAA0QAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAFwAAAO0AAAD/HCFR/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84
+        iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtX/Gh9M/wAAAP8AAAD0AAAAKQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AE0AAAD+AAAA/ycucf9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1f8fJVv/AAAA/wAAAP4AAABZAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAACFAAAA/wAAAf8sM4D/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/R1TR/xoeTP8AAAD/AAAA/wAAAHEAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAngAAAP8AAAH/Ji1v/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9ATL3/EBMv/wAAAP8AAAD+AAAAcAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAJoAAAD/AAAA/xke
+        Sv9FUcr/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAA
+        AP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbV/y01hf8FBg//AAAA/wAA
+        APQAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAEAAAB+AAAA/QAAAP8KDB7/Nj+d/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y84
+        iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v82QJ//ERQx/wAA
+        AP8AAAD/AAAA0QAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAARgAAAOcAAAD/AAAA/xgdR/89R7L/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/PEew/0lW1v9JVtb/SVbW/0lW1v9DT8T/KzN//w8S
+        Lf8AAAD/AAAA/wAAAPMAAAB2AAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAACSAAAA+wAAAP8BAQL/FRk9/zA5
+        jv9GUsz/SVbW/0lW1v9JVtb/SVbW/y84iv8AAAD/AAAA0gAAAP8AAAD/LDSC/zQ9mP8qMXr/HiNX/w0P
+        Jf8AAAH/AAAA/wAAAP8AAADwAAAAhQAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJQAA
+        AJwAAAD5AAAA/wAAAP8BAQP/EBMw/yAmX/8sM4D/NT6a/yAmX/8AAAD/AAAA0gAAAP8AAAD/AAAA/wAA
+        AP8AAAD/AAAA/wAAAP8AAAD9AAAAwAAAAGAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAXAAAAcQAAANIAAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA0gAA
+        AP8AAAD8AAAA7gAAAN0AAAC5AAAAkAAAAFUAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAYQAAAJkAAAC/AAAA5AAA
+        AO8AAAD/AAAA0v//8B///wAA//8AAf//AAD//AAAP/8AAP/wAAAP/wAA/8AAAAP/AAD/gAAAAf8AAP8A
+        AAAA/wAA/gAAAAB/AAD8AAAAAD8AAPgAAAAAHwAA8AAAAAAPAADwAAAAAA8AAOAAAAAABwAA4AAAAAAH
+        AADAAAAAAAMAAMAAAAAAAwAAgAAAAAADAACAAAAAAAEAAIAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAYAAAAAAAAABgAAAAAAAAAPAAAAAAAAA
+        B8AAAAAAAAAH4AAAAAAAAA/wAAAAAAAAH/AAAAAAAAA/+AAAAAAAAH/8AAAAAAAA//8AAAAAAAH//4AA
+        AAAAB///wAAAAAAP///wAAAAAH////4AAAAD/////8AAACgAAAAgAAAAQAAAAAEAIAAAAAAAABAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        ACUAAABzAAAApwEBBMsBAgXeAQIF3AEBA8kAAACiAAAAagAAAB0AAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAA
+        AHkBAQXZAAAA/wICBfwPESz7Gh5M/x0iVv8dIlb/GR1I/w0QKPsBAQL+AAAA/gEBBNAAAABqAAAABgAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAA
+        AGcBAQPqAQEC/hofTP8yOpH/RlLN/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0RQyP8vN4r/FhpB/gAA
+        Af8BAQPfAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAwBAQOyAAAA/xcbQ/49SLP/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/OUOn/xIVNfwAAAD/AAAAmQAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAcAQEE1wMDCPwyOpH/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/ysyff8BAQP9AQEDxAAAAA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAACgEBBdQICRf7PEav/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/zZAn/8EBQ37AQEDuwAAAAMAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAEBAQOuBAUN+z9KuP9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/zlDqP8BAgT9AAAAjQAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAXQEBA/02QJ//SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/y43
+        iP8AAAD+AAAAPAAAAAAAAAAAAAAAAAAAAAgCAgbmIihj/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/xgdSPwCAgbNAAAAAQAAAAAAAAAAAAAAcwQFDPpFUcn/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/P0u5/wEBA/0AAABUAAAAAAAAAAUBAgTuJCpp/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/Gx9O/gECBdQAAAAAAAAASQAAAP8+Srf/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v81P5z/AAAA/wAAACoAAACQCAkX+klW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0dTz/8CAgX9AAAAbwEB
+        BMcYHEb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/w4Q
+        KfsAAACkAQIE7CIoZP9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/GR1J/wEBBMwBAQL5Jy5x/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v8eI1j/AQIF3QAAAP8nLnH/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/wAAAP8AAAD/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/yIoZP8CAgTmAAAA/ycucf9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/AAAA/wAAAP9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/Iihl/wICBOYAAAD/Jy5x/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0hV0/8AAAD/AAAA/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v8iKGX/AgIE5gAAAP8nLnH/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/PEav/wAAAP8AAAD/RFDI/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/yIoZf8CAgTmAAAA/ycu
+        cf9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v8oMHb/AAAA/wAA
+        AP8xOpD/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/Iihl/wIC
+        BOYAAAD/Jy5x/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/w0Q
+        KfoAAAKkAQEFxhcbRf1JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v8iKGX/AgIE5gAAAP8nLnH/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v82QJ//AAAB/gAAADAAAABOAQEC/T5Jtv9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/yIoZf8CAgTmAAAA/ycucf9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbV/w4QKPkCAgWmAAAAAAAAAAADAwXIFxtD+0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/Iihl/wICBOYAAAD/Jy5x/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v8mLXD/AQEC+gAAAB8AAAAAAAAAAAAAADkAAAH+LziK/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v8iKGX/AgIE5gAAAP8nLnH/SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/MzyV/wAAAf4AAABwAAAAAAAAAAAAAAAAAAAAAAAAAJICAgb8OUOo/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/yIoZf8CAgTmAAAA/ycucf9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/zQ9mP8DAwj8AAACoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwEB
+        BL4GBxD7OUOo/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/Iihl/wICBOYAAAD/Jy5x/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v8oL3X/AQEC/gEBA7cAAAAGAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAADwEBBM0CAgX9LzeK/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v8iKGX/AgIE5gAA
+        AP8nLnH/SVbW/0lW1v9JVtb/SVbW/0lW1v87Raz/EhY2/QAAAP8AAACMAAAAAwAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAqcAAAD/GBxG/j9KuP9JVtb/SVbW/0lW1v9JVtb/SVbW/yIo
+        Zf8CAgTmAAAA/ycucf9JVtb/SVbW/0lW1f83QaL/GB1H/gAAAf8BAQPiAAAAVQAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAGgBAQPtAQEC/h0iVf86Rav/SVbW/0lW
+        1v9JVtb/Iihl/wICBOYAAAD/BQUN/yAmX/8VGT/+BQUN+wAAAP8BAQPlAAAAcAAAAAYAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAACBAQED7QAA
+        AP8GCBP6FxxE/yIoY/8AAAH/AAEB+AAAAP8AAAD/AQIE6AEBA74AAACCAAAAPgAAAAIAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAFAAAASAAAAIsBAQPEAQEE6wAAAP8AAAHu//gf///AA///AAD//AAAP/gAAB/wAAAP4AAAB+AA
+        AAfAAAADwAAAA4AAAAGAAAABAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB
+        gAAAAYAAAAPAAAAHwAAAB+AAAA/wAAAf+AAAf/4AAf//AAf//+AoAAAAEAAAACAAAAABACAAAAAAAAAE
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACIJCxmQCwwe0gsOJN4NDyTdCgwd0gcJ
+        GIkAAAAdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwgKGZcSFTPnOEGj/0hV0/9JVtb/SVbW/0hV
+        0/82P53+DxIt5wkJGooAAAABAAAAAAAAAAAAAAAAAAAAAwkLG70uNYX1SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v8pMHjzCQoasgAAAAEAAAAAAAAAAAoMHZcwOI31SVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/yszffIKDB6BAAAAAAAAAB8ZHEbkSVbW/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/FBg74AAAABUKCxycPEav/0lW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/zZAoP4IChmGCw0g2UlW1v9JVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9IVdP/Cwwf0Q4QKOFJVtb/SVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/w0PJN0QEi7lSVbW/0lW
+        1v9JVtb/SVbW/0lW1v9JVtb/DxIt+xgcR/1JVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v8PESrgEBIu5UlW
+        1v9JVtb/SVbW/0lW1v9JVtb/SVbW/w4QKPQWGkHzSVbW/0lW1v9JVtb/SVbW/0lW1v9JVtb/DxEq4BAS
+        LuVJVtb/SVbW/0lW1v9JVtb/SVbW/0lW1v8LDiLfDxEr4ElW1v9JVtb/SVbW/0lW1v9JVtb/SVbW/w8R
+        KuAQEi7lSVbW/0lW1v9JVtb/SVbW/0lW1v81P5z6CgobhQoMHpk5Ran9SVbW/0lW1v9JVtb/SVbW/0lW
+        1v8PESrgEBIu5UlW1v9JVtb/SVbW/0lW1v9DT8T/DA4i2QAAAAgAAAAPDRAn3kVRyf9JVtb/SVbW/0lW
+        1v9JVtb/DxEq4BASLuVJVtb/SVbW/0lW1v9BTL7/DA8l5AAABisAAAAAAAAAAAUFCTgOEivmQ0/E/0lW
+        1v9JVtb/SVbW/w8RKuAQEi7lSVbW/0NPxf8mLG7xCAsZ1gAAACQAAAAAAAAAAAAAAAAAAAAAAAAGLgkK
+        G9spMHjzRFDI/0lW1v8PESrgAAAA/w0PJN0LDB3CBgYOWgAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAEBQgPYwoMHsYNDyXeAAAA//gfAADgBwAAwAMAAIABAACAAQAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAGAAAADwAAAB+AAAB/4AAA=
+</value>
+  </data>
+</root>

--- a/src/BloomExe/Edit/PageEditingModel.cs
+++ b/src/BloomExe/Edit/PageEditingModel.cs
@@ -1,13 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Xml;
-using Bloom.Book;
-using Bloom.ToPalaso;
+using Bloom.ImageProcessing;
 using Palaso.Progress;
 using Palaso.UI.WindowsForms.ImageToolbox;
 using Palaso.Xml;
@@ -19,14 +12,14 @@ namespace Bloom.Edit
 	{
 		public void ChangePicture(string bookFolderPath, GeckoHtmlElement img, PalasoImage imageInfo, IProgress progress)
 		{
-			var imageFileName = ProcessAndCopyImage(imageInfo, bookFolderPath);
+			var imageFileName = ImageUtils.ProcessAndSaveImageIntoFolder(imageInfo, bookFolderPath);
 			img.SetAttribute("src", imageFileName);
 			UpdateMetdataAttributesOnImgElement(img, imageInfo);
 		}
 
 
 		/// <summary>
-		/// for testing.... todo: maybe they should test ProcessAndCopyImage() directly, instead
+		/// for testing.... todo: maybe they should test ProcessAndSaveImageIntoFolder() directly, instead
 		/// </summary>
 		public void ChangePicture(string bookFolderPath, XmlDocument dom, string imageId, PalasoImage imageInfo)
 		{
@@ -34,144 +27,14 @@ namespace Bloom.Edit
 			var matches = dom.SafeSelectNodes("//img[@id='" + imageId + "']");
 			XmlElement img = matches[0] as XmlElement;
 
-			var imageFileName = ProcessAndCopyImage(imageInfo, bookFolderPath);
+			var imageFileName = ImageUtils.ProcessAndSaveImageIntoFolder(imageInfo, bookFolderPath);
 			img.SetAttribute("src", imageFileName);
 
 		}
 
-		/// <summary>
-		/// Makes the image png if it's not a jpg, makes white transparent, compresses it, and saves in the book's folder.
-		/// Replaces any file with the same name.
-		/// </summary>
-		/// <returns>The name of the file, now in the book's folder.</returns>
-		private string ProcessAndCopyImage(PalasoImage imageInfo, string bookFolderPath)
-		{
+	
 
-			var isJpeg = ShouldSaveAsJpeg(imageInfo);
-			try
-			{
-
-					using (Bitmap image = new Bitmap(imageInfo.Image))
-						//nb: there are cases (undefined) where we get out of memory if we are not operating on a copy
-					{
-						//photographs don't work if you try to make the white transparent
-						if (!isJpeg && image is Bitmap)
-						{
-							((Bitmap) image).MakeTransparent(Color.White);
-								//make white look realistic against background
-						}
-
-						string imageFileName = GetImageFileName(bookFolderPath, imageInfo, isJpeg);
-						var dest = Path.Combine(bookFolderPath, imageFileName);
-						if (File.Exists(dest))
-						{
-							try
-							{
-								File.Delete(dest);
-							}
-							catch (System.IO.IOException error)
-							{
-								throw new ApplicationException("Bloom could not replace the image " + imageFileName +
-															   ", probably because Bloom itself has it locked.");
-							}
-						}
-						image.Save(dest, isJpeg ? ImageFormat.Jpeg : ImageFormat.Png);
-						if (!isJpeg)
-						{
-							using (var dlg = new ProgressDialogBackground())
-							{
-								dlg.ShowAndDoWork((progress, args) => ImageUpdater.CompressImage(dest, progress));
-							}
-						}
-						imageInfo.Metadata.Write(dest);
-
-						return imageFileName;
-				}
-			}
-			catch (System.IO.IOException)
-			{
-				throw; //these are informative on their own
-			}
-			catch (Exception error)
-			{
-				if (!string.IsNullOrEmpty(imageInfo.FileName) && File.Exists(imageInfo.OriginalFilePath))
-				{
-					var megs = new System.IO.FileInfo(imageInfo.OriginalFilePath).Length / (1024 * 1000);
-					if (megs > 2)
-					{
-						var msg = string.Format("Bloom was not able to prepare that picture for including in the book. \r\nThis is a rather large image to be adding to a book --{0} Megs--.", megs);
-						if(isJpeg)
-						{
-							msg += "\r\nNote, this file is a jpeg, which is normally used for photographs, not line-drawings (png, tiff, bmp). Bloom can handle smallish jpegs, large ones are difficult to handle, especialy if memory is limitted.";
-						}
-						throw new ApplicationException(msg, error);
-					}
-				}
-
-				throw new ApplicationException("Bloom was not able to prepare that picture for including in the book. Is it too large, or an odd format?\r\n" + imageInfo.FileName, error);
-			}
-		}
-
-
-		private static string GetImageFileName(string bookFolderPath, PalasoImage imageInfo, bool isJpeg)
-		{
-			string s;
-			if(string.IsNullOrEmpty(imageInfo.FileName) || imageInfo.FileName.StartsWith("tmp"))
-			{
-				// Some images, like from a scanner or camera, won't have a name yet.  Some will need a number
-				// in order to differentiate from what is already there. We don't try and be smart somehow and
-				// know when to just replace the existing one with the same name... some other process will have
-				// to remove unused images.
-
-				s = "image";
-				int i = 0;
-				string suffix = "";
-				string extension = isJpeg ? ".jpg" : ".png";
-
-				while (File.Exists(Path.Combine(bookFolderPath, s + suffix + extension)))
-				{
-					++i;
-					suffix = i.ToString();
-				}
-
-				return s + suffix + extension;
-			}
-			else
-			{
-				var extension = isJpeg ? ".jpg" : ".png";
-				return Path.GetFileNameWithoutExtension(imageInfo.FileName) + extension;
-			}
-		}
-
-
-		private bool ShouldSaveAsJpeg(PalasoImage imageInfo)
-		{
-			/*
-			 * Note, each guid is VERY SIMILAR. The difference is only in the last 2 digits of the 1st group.
-			   Undefined  B96B3CA9
-				MemoryBMP  B96B3CAA
-				BMP    B96B3CAB
-				EMF    B96B3CAC
-				WMF    B96B3CAD
-				JPEG    B96B3CAE
-				PNG    B96B3CAF
-				GIF    B96B3CB0
-				TIFF    B96B3CB1
-				EXIF    B96B3CB2
-				Icon    B96B3CB5
-			 */
-			if(ImageFormat.Jpeg.Guid == imageInfo.Image.RawFormat.Guid)
-				return true;
-
-			if(ImageFormat.Jpeg.Equals(imageInfo.Image.PixelFormat))//review
-				return true;
-
-			if(string.IsNullOrEmpty(imageInfo.FileName))
-				return false;
-
-			return  new []{".jpg", ".jpeg"}.Contains(Path.GetExtension(imageInfo.FileName).ToLower());
-		}
-
+		
 		public void UpdateMetdataAttributesOnImgElement(GeckoHtmlElement img, PalasoImage imageInfo)
 		{
 			UpdateMetadataAttributesOnImage(img, imageInfo);

--- a/src/BloomExe/ImageProcessing/ImageServer.cs
+++ b/src/BloomExe/ImageProcessing/ImageServer.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.Net;
-using System.Threading;
-using System.Windows.Forms;
 using Bloom.web;
-using Palaso.Code;
-using Palaso.IO;
 using Palaso.Reporting;
 using Bloom.Properties;
 
@@ -84,13 +79,10 @@ namespace Bloom.ImageProcessing
 			{
 				info.ContentType = r.EndsWith(".png") ? "image/png" : "image/jpeg";
 				r = r.Replace("thumbnail", "");
-				//if (r.Contains("thumb"))
+				if (File.Exists(r))
 				{
-					if (File.Exists(r))
-					{
-						info.ReplyWithImage(_cache.GetPathToResizedImage(r));
-						return true;
-					}
+					info.ReplyWithImage(_cache.GetPathToResizedImage(r));
+					return true;
 				}
 			}
 			return false;

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -53,19 +53,9 @@ namespace Bloom.ImageProcessing
 			var isJpeg = AppearsToBeJpeg(imageInfo);
 			try
 			{
+				//nb: there are cases (undefined) where we get out of memory if we are not operating on a copy
 				using (var image = new Bitmap(imageInfo.Image))
-					//nb: there are cases (undefined) where we get out of memory if we are not operating on a copy
 				{
-					//photographs don't work if you try to make the white transparent
-					if (!isJpeg && image is Bitmap)
-					{
-						//I (Hatton) have decided to stop storing images with transparency. It caused visual problems
-						//with many pdf readers. We can bring the benefits of this back, without the costs, by having
-						// our server deliver a transparent version on-the-fly when making a thumbnail, preview, or edit page.
-
-						/*((Bitmap)image).MakeTransparent(Color.White);//make white look realistic against background*/
-					}
-
 					var imageFileName = GetFileNameToUseForSavingImage(bookFolderPath, imageInfo, isJpeg);
 					var destinationPath = Path.Combine(bookFolderPath, imageFileName);
 					using (var tmp = new TempFile())
@@ -108,7 +98,7 @@ namespace Bloom.ImageProcessing
 						var msg = string.Format("Bloom was not able to prepare that picture for including in the book. \r\nThis is a rather large image to be adding to a book --{0} Megs--.", megs);
 						if(isJpeg)
 						{
-							msg += "\r\nNote, this file is a jpeg, which is normally used for photographs, not line-drawings (png, tiff, bmp). Bloom can handle smallish jpegs, large ones are difficult to handle, especialy if memory is limitted.";
+							msg += "\r\nNote, this file is a jpeg, which is normally used for photographs, not line-drawings (png, tiff, bmp). Bloom can handle smallish jpegs, large ones are difficult to handle, especialy if memory is limited.";
 						}
 						throw new ApplicationException(msg, error);
 					}

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Palaso.UI.WindowsForms.ImageToolbox;
+using Logger = Palaso.Reporting.Logger;
+using TempFile = Palaso.IO.TempFile;
+
+namespace Bloom.ImageProcessing
+{
+	class ImageUtils
+	{
+		public static bool ShouldSaveAsJpeg(PalasoImage imageInfo)
+		{
+			/*
+			 * Note, each guid is VERY SIMILAR. The difference is only in the last 2 digits of the 1st group.
+			   Undefined  B96B3CA9
+				MemoryBMP  B96B3CAA
+				BMP    B96B3CAB
+				EMF    B96B3CAC
+				WMF    B96B3CAD
+				JPEG    B96B3CAE
+				PNG    B96B3CAF
+				GIF    B96B3CB0
+				TIFF    B96B3CB1
+				EXIF    B96B3CB2
+				Icon    B96B3CB5
+			 */
+			if(ImageFormat.Jpeg.Guid == imageInfo.Image.RawFormat.Guid)
+				return true;
+
+			if(ImageFormat.Jpeg.Equals(imageInfo.Image.PixelFormat))//review
+				return true;
+
+			if(string.IsNullOrEmpty(imageInfo.FileName))
+				return false;
+
+			return new[] { ".jpg", ".jpeg" }.Contains(Path.GetExtension(imageInfo.FileName).ToLower());
+		}
+
+		/// <summary>
+		/// Makes the image a png if it's not a jpg and saves in the book's folder.
+		/// If the image has a filename, replaces any file with the same name.
+		/// </summary>
+		/// <returns>The name of the file, now in the book's folder.</returns>
+		public static string ProcessAndSaveImageIntoFolder(PalasoImage imageInfo, string bookFolderPath)
+		{
+			LogMemoryUsage();
+
+			var isJpeg = ShouldSaveAsJpeg(imageInfo);
+			try
+			{
+				using (var image = new Bitmap(imageInfo.Image))
+					//nb: there are cases (undefined) where we get out of memory if we are not operating on a copy
+				{
+					//photographs don't work if you try to make the white transparent
+					if (!isJpeg && image is Bitmap)
+					{
+						//I (Hatton) have decided to stop storing images with transparency. It caused visual problems
+						//with many pdf readers. We can bring the benefits of this back, without the costs, by having
+						// our server deliver a transparent version on-the-fly when making a thumbnail, preview, or edit page.
+
+						/*((Bitmap)image).MakeTransparent(Color.White);//make white look realistic against background*/
+					}
+
+					var imageFileName = GetFileNameToUseForSavingImage(bookFolderPath, imageInfo, isJpeg);
+					var destinationPath = Path.Combine(bookFolderPath, imageFileName);
+					using (var tmp = new TempFile())
+					{
+						image.Save(tmp.Path, isJpeg ? ImageFormat.Jpeg : ImageFormat.Png);
+						Palaso.IO.FileUtils.ReplaceFileWithUserInteractionIfNeeded(tmp.Path, destinationPath, null);
+					}
+
+					if (!isJpeg)
+					{
+						//I (Hatton) have decided to stop compressing images until we have a suite of 
+						//tests based on a number of image exemplars. Compression can be great, but it 
+						//can also lead to very long waits; this is a "first, do no harm" decision
+						/*using (var dlg = new ProgressDialogBackground())
+						{
+							dlg.ShowAndDoWork((progress, args) => ImageUpdater.CompressImage(dest, progress));
+						}*/
+					}
+					imageInfo.Metadata.Write(destinationPath);
+
+					return imageFileName;
+				}
+			}
+			catch (IOException)
+			{
+				throw; //these are informative on their own
+			}
+			catch (OutOfMemoryException error)
+			{
+				//Enhance: it would be great if we could bring up that problem dialog ourselves, and offer this picture as an attachment
+				throw new ApplicationException("Bloom ran out of memory while trying to import the picture. We suggest that you quit Bloom, run it again, and then try importing this picture again. If that fails, please go to the Help menu and choose 'Report a Problem'", error);
+			}
+			catch(Exception error)
+			{
+				if(!string.IsNullOrEmpty(imageInfo.FileName) && File.Exists(imageInfo.OriginalFilePath))
+				{
+					var megs = new System.IO.FileInfo(imageInfo.OriginalFilePath).Length / (1024 * 1000);
+					if(megs > 2)
+					{
+						var msg = string.Format("Bloom was not able to prepare that picture for including in the book. \r\nThis is a rather large image to be adding to a book --{0} Megs--.", megs);
+						if(isJpeg)
+						{
+							msg += "\r\nNote, this file is a jpeg, which is normally used for photographs, not line-drawings (png, tiff, bmp). Bloom can handle smallish jpegs, large ones are difficult to handle, especialy if memory is limitted.";
+						}
+						throw new ApplicationException(msg, error);
+					}
+				}
+
+				throw new ApplicationException("Bloom was not able to prepare that picture for including in the book. We'd like to investigate, so if possible, would you please email it to issues@bloomlibrary.org?" + System.Environment.NewLine+ imageInfo.FileName, error);
+			}
+		}
+
+
+		private static string GetFileNameToUseForSavingImage(string bookFolderPath, PalasoImage imageInfo, bool isJpeg)
+		{
+			var extension = isJpeg ? ".jpg" : ".png";
+			if(string.IsNullOrEmpty(imageInfo.FileName) || imageInfo.FileName.StartsWith("tmp"))
+			{
+				// Some images, like from a scanner or camera, won't have a name yet.  Some will need a number
+				// in order to differentiate from what is already there. We don't try and be smart somehow and
+				// know when to just replace the existing one with the same name... some other process will have
+				// to remove unused images.
+
+				const string s = "image";
+				var i = 0;
+				var suffix = "";
+
+				while(File.Exists(Path.Combine(bookFolderPath, s + suffix + extension)))
+				{
+					++i;
+					suffix = i.ToString(CultureInfo.InvariantCulture);
+				}
+
+				return s + suffix + extension;
+			}
+			else
+			{
+				return Path.GetFileNameWithoutExtension(imageInfo.FileName) + extension;
+			}
+		}
+
+		private static void LogMemoryUsage()
+		{
+			using (var proc = Process.GetCurrentProcess())
+			{
+				const int bytesPerMegabyte = 1048576;
+				Logger.WriteEvent("Paged Memory: " + proc.PagedMemorySize64 / bytesPerMegabyte + " MB");
+				Logger.WriteEvent("Peak Paged Memory: " + proc.PeakPagedMemorySize64 / bytesPerMegabyte + " MB");
+				Logger.WriteEvent("Peak Virtual Memory: " + proc.PeakVirtualMemorySize64 / bytesPerMegabyte + " MB");
+				Logger.WriteEvent("GC Total Memory: " + GC.GetTotalMemory(false) / bytesPerMegabyte + " MB");
+			}
+		}
+	}
+}

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -13,7 +13,7 @@ namespace Bloom.ImageProcessing
 {
 	class ImageUtils
 	{
-		public static bool ShouldSaveAsJpeg(PalasoImage imageInfo)
+		public static bool AppearsToBeJpeg(PalasoImage imageInfo)
 		{
 			/*
 			 * Note, each guid is VERY SIMILAR. The difference is only in the last 2 digits of the 1st group.
@@ -50,7 +50,7 @@ namespace Bloom.ImageProcessing
 		{
 			LogMemoryUsage();
 
-			var isJpeg = ShouldSaveAsJpeg(imageInfo);
+			var isJpeg = AppearsToBeJpeg(imageInfo);
 			try
 			{
 				using (var image = new Bitmap(imageInfo.Image))

--- a/src/BloomExe/ImageProcessing/LowResImageCache.cs
+++ b/src/BloomExe/ImageProcessing/LowResImageCache.cs
@@ -4,9 +4,10 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.IO;
+using System.Linq;
 using System.Threading;
-using BloomTemp;
 using Palaso.Reporting;
+using Palaso.UI.WindowsForms.ImageToolbox;
 
 namespace Bloom.ImageProcessing
 {
@@ -78,12 +79,16 @@ namespace Bloom.ImageProcessing
 
 		private DateTime GetModifiedDateTime(string path)
 		{
-			FileInfo f = new FileInfo(path);
+			var f = new FileInfo(path);
 			return f.LastWriteTimeUtc;
 		}
 
 		public string GetPathToResizedImage(string originalPath)
 		{
+			//don't mess with Bloom UI images
+			if (new[] {"/img/","placeHolder", "Button"}.Any(s => originalPath.Contains(s)))
+				return originalPath;
+
 			string resizedPath;
 			if(_paths.TryGetValue(originalPath, out resizedPath))
 			{
@@ -96,25 +101,28 @@ namespace Bloom.ImageProcessing
 					_paths.Remove(originalPath);
 				}
 			}
-
-			var original = Image.FromFile(originalPath);
-			try
+			using (var originalImage = PalasoImage.FromFile(originalPath))
 			{
-				if (original.Width > TargetDimension || original.Height > TargetDimension)
+				if (!originalPath.Contains("Button") && !ImageUtils.AppearsToBeJpeg(originalImage))
 				{
-					var maxDimension = Math.Max(original.Width, original.Height);
+					((Bitmap)originalImage.Image).MakeTransparent(Color.White); //instead of white, show the background color
+				}
+
+				if (originalImage.Image.Width > TargetDimension || originalImage.Image.Height > TargetDimension)
+				{
+					var maxDimension = Math.Max(originalImage.Image.Width, originalImage.Image.Height);
 					double shrinkFactor = (TargetDimension/(double) maxDimension);
 
-					var destWidth = (int) (shrinkFactor*original.Width);
-					var destHeight = (int) (shrinkFactor*original.Height);
+					var destWidth = (int) (shrinkFactor*originalImage.Image.Width);
+					var destHeight = (int) (shrinkFactor*originalImage.Image.Height);
 					using (var b = new Bitmap(destWidth, destHeight))
 					{
-						using (Graphics g = Graphics.FromImage((Image)b))
+						using (Graphics g = Graphics.FromImage((Image) b))
 						{
 							//in version 1.0, we used .NearestNeighbor. But if there is a border line down the right size (as is common for thumbnails that,
 							//are, for example, re-inserted into Teacher's Guides), then the line gets cut off. So I switched it to HighQualityBicubic
-							g.InterpolationMode = InterpolationMode.HighQualityBicubic;//.NearestNeighbor;//or smooth it: HighQualityBicubic
-							g.DrawImage(original, 0, 0, destWidth, destHeight);
+							g.InterpolationMode = InterpolationMode.HighQualityBicubic; //.NearestNeighbor;//or smooth it: HighQualityBicubic
+							g.DrawImage(originalImage.Image, 0, 0, destWidth, destHeight);
 						}
 
 						var temp = Path.Combine(_cacheFolder, Path.GetRandomFileName() + Path.GetExtension(originalPath));
@@ -127,8 +135,8 @@ namespace Bloom.ImageProcessing
 						//It's not clear why the temp/bloom directory isn't there... possibly it was there a moment ago
 						//but then some startup thread cleared and deleted it? (we are now running on a thread responding to the http request)
 
-						Exception error=null;
-						for (int i = 0; i < 5; i++ )//try up to five times, a second apart
+						Exception error = null;
+						for (int i = 0; i < 5; i++) //try up to five times, a second apart
 						{
 							try
 							{
@@ -138,7 +146,7 @@ namespace Bloom.ImageProcessing
 								{
 									Directory.CreateDirectory(Path.GetDirectoryName(temp));
 								}
-								b.Save(temp, original.RawFormat);
+								b.Save(temp, originalImage.Image.RawFormat);
 								break;
 							}
 							catch (Exception e)
@@ -146,19 +154,21 @@ namespace Bloom.ImageProcessing
 								Logger.WriteEvent("Error in LowResImage while trying to write image.");
 								Logger.WriteEvent(e.Message);
 								error = e;
-								Thread.Sleep(1000);//wait a second before trying again
+								Thread.Sleep(1000); //wait a second before trying again
 							}
 						}
-						if(error!=null)
+						if (error != null)
 						{
 							//NB: this will be on a non-UI thread, so it probably won't work well!
-							ErrorReport.NotifyUserOfProblem(error, "Bloom is having problem saving a low-res version to your temp directory, at "+temp+"\r\n\r\nYou might want to quit and restart Bloom. In the meantime, Bloom will try to use the full-res images.");
+							ErrorReport.NotifyUserOfProblem(error,
+								"Bloom is having problem saving a low-res version to your temp directory, at " + temp +
+								"\r\n\r\nYou might want to quit and restart Bloom. In the meantime, Bloom will try to use the full-res images.");
 							return originalPath;
 						}
 
 						try
 						{
-							_paths.Add(originalPath, temp);//remember it so we can reuse if they show it again, and later delete
+							_paths.Add(originalPath, temp); //remember it so we can reuse if they show it again, and later delete
 						}
 						catch (Exception)
 						{
@@ -173,10 +183,6 @@ namespace Bloom.ImageProcessing
 				{
 					return originalPath;
 				}
-			}
-			finally
-			{
-				original.Dispose();
 			}
 		}
 	}

--- a/src/BloomExe/Workspace/BloomClipboard.cs
+++ b/src/BloomExe/Workspace/BloomClipboard.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using System.IO;
+using Palaso.UI.WindowsForms.ImageToolbox;
 
 namespace Bloom.Workspace
 {
@@ -72,19 +73,25 @@ namespace Bloom.Workspace
 #endif
 		}
 
-		public static Image GetImageFromClipboard()
+		public static PalasoImage GetImageFromClipboard()
 		{
 #if __MonoCS__
 			if (GtkUtils.GtkClipboard.ContainsImage())
-				return GtkUtils.GtkClipboard.GetImage();
+				return PalasoImage.FromImage(GtkUtils.GtkClipboard.GetImage());
 
 			if (GtkUtils.GtkClipboard.ContainsText())
-				return GtkUtils.GtkClipboard.GetImageFromText();
+			{
+				//REVIEW: I can find no documentation on GtkClipboard. If ContainsText means we have a file
+				//	path, then it would be better to do PalasoImage.FromFile(); on the file path
+				return PalasoImage.FromImage(GtkUtils.GtkClipboard.GetImageFromText());
+			}
 
 			return null;
 #else
 			if (Clipboard.ContainsImage())
-				return Clipboard.GetImage();
+			{
+				return PalasoImage.FromImage(Clipboard.GetImage());
+			}
 
 			var dataObject = Clipboard.GetDataObject();
 			if (dataObject == null)
@@ -97,7 +104,7 @@ namespace Bloom.Workspace
 				var o = dataObject.GetData("PNG") as Stream;
 				try
 				{
-					return Image.FromStream(o);
+					return PalasoImage.FromImage(Image.FromStream(o));
 				}
 				catch (Exception)
 				{}
@@ -114,7 +121,7 @@ namespace Bloom.Workspace
 				{
 					try
 					{
-						return Image.FromFile(file);
+						return PalasoImage.FromFile(file);
 					}
 					catch (Exception)
 					{}
@@ -127,7 +134,7 @@ namespace Bloom.Workspace
 
 			try
 			{
-				return Image.FromStream(new FileStream(Clipboard.GetText(), FileMode.Open));
+				return PalasoImage.FromImage( Image.FromStream(new FileStream(Clipboard.GetText(), FileMode.Open)));
 			}
 			catch (Exception)
 			{}


### PR DESCRIPTION
Addresses BL-967 by being careful about file types and doing less

- fix situation where we would save a jpg as pngs
- pasted images are now named "image1",2,3, etc.
- images are no longer added with a temporary gibberish name; the original names are maintained.
- don't compress pngs (could return someday, but for now it's hard on people with slower machines, and sometimes increases the size)
- don't make pngs transparent (made pdfs ugly). Could return again, but this time as a run-time feature of the server delivering images
- simple heuristically-driven detection of images that look like they shouldn't really be jpegs, based on amount of white, number of colors, and grayscale vs. color.
- New dialog that warns people before adding suspicious jpegs.
- Log now contains record of memory used, in case of memory error
- New, localizable error when adding an image leads to an out-of-memory-error

-----

Fix BL-609 PDF shows lines around images transparent boundaries

Until recently, all images were made transparent when imported into Bloom. We stopped doing that in a recent commit. With this commit, we restore white-becomes-transparent but only at runtime, never saving these. Thus we have our cake (good looking covers) and eat it too (PDFs don't have the transparency-boundary visual artifacts).

----

Refactor more DOM manipulation out of Book and into HtmlDom

This commit is part of this PR because initially these classes were involved in the transparency work. I ended up not needing those changes, but meanwhile had done some good refactoring, so I'm keeping it.
