### PR TITLE
BL-993 Change limit for using small buttons on image hovering

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -512,7 +512,7 @@ function SetupDeletable(containerDiv) {
 function SetupImageContainer(containerDiv) {
     $(containerDiv).mouseenter(function () {
         var buttonModifier = "largeImageButton";
-        if ($(this).height() < 80) {
+        if ($(this).height() < 95) {
             buttonModifier = 'smallImageButton';
         }
         $(this).prepend('<button class="pasteImageButton ' + buttonModifier + '" title="' + localizationManager.getText("EditTab.Image.PasteImage") + '"></button>');


### PR DESCRIPTION
The limit for using small buttons on hovering over images needed raising some. The new value triggers small buttons for Story Primer's icons and works well with both A5 and A4 sizes on the screen.