### PR TITLE
 Fix uploading of problems to JIRA (BL-821)

### DIFF
--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -3,7 +3,6 @@
   <repository path="../src/Bloom-ChorusPlugin/packages.config" />
   <repository path="../src/BloomExe/packages.config" />
   <repository path="../src/BloomTests/packages.config" />
-  <repository path="..\src\BloomBrowserUI\packages.config" />
   <repository path="..\src\Bloom-ChorusPlugin\packages.config" />
   <repository path="..\src\BloomExe\packages.config" />
   <repository path="..\src\BloomTests\packages.config" />

--- a/src/BloomBrowserUI/packages.config
+++ b/src/BloomBrowserUI/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="jasmine.TypeScript.DefinitelyTyped" version="0.1.5" targetFramework="net45" />
-</packages>

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -63,9 +63,6 @@
     <AssemblyName>Bloom</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Atlassian.Jira">
-      <HintPath>..\..\packages\Atlassian.SDK.2.4.0\lib\Atlassian.Jira.dll</HintPath>
-    </Reference>
     <Reference Include="Autofac">
       <HintPath>..\..\packages\Autofac.2.6.3.862\lib\NET35\Autofac.dll</HintPath>
     </Reference>
@@ -156,6 +153,9 @@
     <Reference Include="DesktopAnalytics">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\DesktopAnalytics.1.1.3\lib\net40\DesktopAnalytics.dll</HintPath>
+    </Reference>
+    <Reference Include="TechTalk.JiraRestClient">
+      <HintPath>..\..\packages\TechTalk.JiraRestClient.RestSharp105.2.3.0.1\lib\net40-Client\TechTalk.JiraRestClient.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/BloomExe/HtmlThumbNailer.cs
+++ b/src/BloomExe/HtmlThumbNailer.cs
@@ -62,7 +62,7 @@ namespace Bloom
 
 			_syncControl = new Control();
 			_syncControl.CreateControl();
-						}
+		}
 
 		public void RemoveFromCache(string key)
 		{

--- a/src/BloomExe/MiscUI/ProblemReporterDialog.Designer.cs
+++ b/src/BloomExe/MiscUI/ProblemReporterDialog.Designer.cs
@@ -283,7 +283,7 @@
 
 		private L10NSharp.UI.L10NSharpExtender _L10NSharpExtender;
 		private System.Windows.Forms.Label label1;
-		private System.Windows.Forms.TextBox _description;
+		protected System.Windows.Forms.TextBox _description;
 		private System.Windows.Forms.TextBox _name;
 		private System.Windows.Forms.Label label2;
 		private System.Windows.Forms.TextBox _email;

--- a/src/BloomExe/MiscUI/ProblemReporterDialog.cs
+++ b/src/BloomExe/MiscUI/ProblemReporterDialog.cs
@@ -25,14 +25,13 @@ namespace Bloom.MiscUI
 	{
 		public delegate ProblemReporterDialog Factory(Control targetOfScreenshot);//autofac uses this
 
-		private enum State { WaitingForSubmission, ZippingUpBook, Submitting, CouldNotAutomaticallySubmit, Success }
+		protected enum State { WaitingForSubmission, ZippingUpBook, Submitting, CouldNotAutomaticallySubmit, Success }
 
 		private readonly BookSelection _bookSelection;
 		private Bitmap _screenshot;
-		private State _state;
+		protected State _state;
 		private string _emailableReportFilePath;
-		private string _jiraProjectKey = "BL";
-		private bool _closeAfterSubmittingForUnitTest;
+		protected string _jiraProjectKey = "BL";
 		private Issue _jiraIssue;
 
 		public ProblemReporterDialog(Control targetOfScreenshot, BookSelection bookSelection)
@@ -111,7 +110,7 @@ namespace Bloom.MiscUI
 			}
 		}
 
-		private void ChangeState(State state)
+		protected virtual void ChangeState(State state)
 		{
 			_state = state;
 			UpdateDisplay();
@@ -127,7 +126,7 @@ namespace Bloom.MiscUI
 #endif
 		}
 
-		private void UpdateDisplay()
+		protected virtual void UpdateDisplay()
 		{
 			_submitButton.Enabled = !string.IsNullOrWhiteSpace(_name.Text.Trim()) && !string.IsNullOrWhiteSpace(_email.Text.Trim()) &&
 								   !string.IsNullOrWhiteSpace(_description.Text.Trim());
@@ -184,10 +183,6 @@ namespace Bloom.MiscUI
 					_status.HTML = string.Format("<span style='color:blue'>" + message + "</span><br/><a href='{0}'>{1}</a>", _jiraIssue.Jira.Url + "browse/" + _jiraIssue.Key.Value, _jiraIssue.Key.Value);
 
 					Cursor = Cursors.Default;
-					if (_closeAfterSubmittingForUnitTest)
-					{
-						_okButton_Click(this, null);
-					}
 					break;
 
 				default:
@@ -195,7 +190,7 @@ namespace Bloom.MiscUI
 			}
 		}
 
-		private void _okButton_Click(object sender, EventArgs e)
+		protected void _okButton_Click(object sender, EventArgs e)
 		{
 			if (_state == State.Success)
 			{
@@ -410,17 +405,6 @@ namespace Bloom.MiscUI
 		private void _cancelButton_Click(object sender, EventArgs e)
 		{
 			Close();
-		}
-
-		public void SetupForUnitTest(string jiraProjectKey)
-		{
-			this.Load += (sender, e) =>
-			{
-				_jiraProjectKey = jiraProjectKey;
-				_description.Text = "created by unit test of " + Assembly.GetAssembly(this.GetType()).FullName;
-				_closeAfterSubmittingForUnitTest = true;
-				_okButton_Click(sender, e);
-			};
 		}
 
 		private void _seeDetails_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Analytics" version="2.0.0" targetFramework="net40-Client" />
-  <package id="Atlassian.SDK" version="2.4.0" targetFramework="net40-Client" />
   <package id="Autofac" version="2.6.3.862" targetFramework="net40-Client" />
   <package id="AWSSDK.xplatform" version="2.3.6.0" targetFramework="net40-Client" />
   <package id="DesktopAnalytics" version="1.1.3" targetFramework="net40-Client" />
@@ -10,4 +9,5 @@
   <package id="Moq" version="4.0.10827" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net40-Client" />
   <package id="RestSharp" version="105.0.1" targetFramework="net40-Client" />
+  <package id="TechTalk.JiraRestClient.RestSharp105" version="2.3.0.1" targetFramework="net40-Client" />
 </packages>

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -10,7 +10,6 @@ using L10NSharp;
 using Palaso.IO;
 using Bloom.Collection;
 using Bloom.ImageProcessing;
-using Atlassian.Jira.Remote;
 
 namespace Bloom.web
 {

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -78,6 +78,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Moq, Version=4.2.1409.1722, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp, Version=105.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\RestSharp.105.0.1\lib\net4\RestSharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -107,9 +115,6 @@
     <Reference Include="PalasoUIWindowsForms">
       <HintPath>..\..\lib\dotnet\PalasoUIWindowsForms.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp">
-      <HintPath>..\..\packages\RestSharp.104.4.0\lib\net4\RestSharp.dll</HintPath>
-    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
@@ -126,9 +131,6 @@
     </Reference>
     <Reference Include="Geckofx-Winforms" Condition="'$(OS)'=='Windows_NT'">
       <HintPath>..\..\lib\dotnet\Geckofx-Winforms.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq">
-      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -229,7 +229,10 @@ namespace BloomTests.Book
 					Language2Iso639Code = "en",
 					Language3Iso639Code = "fr"
 				});
-			using (var htmlThumbNailer = new Moq.Mock<HtmlThumbNailer>(new object[] { new NavigationIsolator() }).Object)
+			// We can't use a Moq here (at least with Moq 4.2.1409.1722) for HtmlThumbNailer since
+			// that doesn't call Dispose, causing other tests to fail.
+			// using (var htmlThumbNailer = new Moq.Mock<HtmlThumbNailer>(new object[] { new NavigationIsolator() }).Object)
+			using (var htmlThumbNailer = new HtmlThumbNailer(new NavigationIsolator()))
 			{
 				var book = new Bloom.Book.Book(new BookInfo(folder, true), storage, new Moq.Mock<ITemplateFinder>().Object,
 					collectionSettings,

--- a/src/BloomTests/packages.config
+++ b/src/BloomTests/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="2.6.3.862" targetFramework="net40" />
-  <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
+  <package id="Moq" version="4.2.1409.1722" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
   <package id="NUnit.Runners.Net4" version="2.6.3" targetFramework="net40" />
+  <package id="RestSharp" version="105.0.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This is done by switching to a different library to access JIRA.
This was necessary because of a mono bug that prevents the
deserialization of data received from Jira.

Additionally on Linux we have to use http instead of https, again
because of a bug in mono.