### PR TITLE
BL-961 Layout menus do not show in some languages

### DIFF
--- a/src/BloomExe/Edit/EditingView.Designer.cs
+++ b/src/BloomExe/Edit/EditingView.Designer.cs
@@ -406,9 +406,9 @@
 			this._L10NSharpExtender.SetLocalizationComment(this._menusToolStrip, null);
 			this._L10NSharpExtender.SetLocalizationPriority(this._menusToolStrip, L10NSharp.LocalizationPriority.NotLocalizable);
 			this._L10NSharpExtender.SetLocalizingId(this._menusToolStrip, "EditTab._menusToolStrip");
-			this._menusToolStrip.Location = new System.Drawing.Point(294, 12);
+			this._menusToolStrip.Location = new System.Drawing.Point(294, 10);
 			this._menusToolStrip.Name = "_menusToolStrip";
-			this._menusToolStrip.Size = new System.Drawing.Size(165, 54);
+			this._menusToolStrip.Size = new System.Drawing.Size(165, 56);
 			this._menusToolStrip.TabIndex = 2;
 			this._menusToolStrip.Text = "toolStrip1";
 			// 


### PR DESCRIPTION
This is a slight adjustment for the final language that
still didn't work after Steve's previous change.  With
this change, Tegulu UI allows the menus to appear and
the other languages still work.