### PR TITLE
Better transparency, no shrinking, hands-off jpegs

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -342,7 +342,7 @@
     <Compile Include="HtmlLabel.Designer.cs">
       <DependentUpon>HtmlLabel.cs</DependentUpon>
     </Compile>
-    <Compile Include="ImageProcessing\LowResImageCache.cs" />
+    <Compile Include="ImageProcessing\RuntimeImageProcessor.cs" />
     <Compile Include="CollectionTab\IBloomTabArea.cs" />
     <Compile Include="CollectionTab\ListHeader.cs">
       <SubType>UserControl</SubType>

--- a/src/BloomExe/ImageProcessing/ImageServer.cs
+++ b/src/BloomExe/ImageProcessing/ImageServer.cs
@@ -24,10 +24,10 @@ namespace Bloom.ImageProcessing
 	/// </summary>
 	public class ImageServer : ServerBase
 	{
-		private LowResImageCache _cache;
+		private RuntimeImageProcessor _cache;
 		private bool _useCache;
 
-		public ImageServer(LowResImageCache cache)
+		public ImageServer(RuntimeImageProcessor cache)
 		{
 			_cache = cache;
 			_useCache = Settings.Default.ImageHandler != "off";

--- a/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
+++ b/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
@@ -17,11 +17,11 @@ namespace Bloom.ImageProcessing
 	/// or even gives up on displaying the image altogether (worse on slow machines).
 	/// This cache takes requests for images and returns lo-res versions of them.
 	/// </summary>
-	public class RuntimeImageProcessor :IDisposable
+	public class RuntimeImageProcessor : IDisposable
 	{
 		private readonly BookRenamedEvent _bookRenamedEvent;
-		public int TargetDimension=500;
-		private Dictionary<string,string> _paths;
+		public int TargetDimension = 500;
+		private Dictionary<string, string> _paths;
 		private string _cacheFolder;
 
 		private ImageAttributes _transparentImageAttributes;
@@ -46,7 +46,7 @@ namespace Bloom.ImageProcessing
 
 		public void Dispose()
 		{
-			if (_paths == null)
+			if(_paths == null)
 				return;
 
 			TryToDeleteCachedImages();
@@ -60,21 +60,21 @@ namespace Bloom.ImageProcessing
 
 		private void TryToDeleteCachedImages()
 		{
-//operate on a copy to avoid "Collection was modified; enumeration operation may not execute"
+			//operate on a copy to avoid "Collection was modified; enumeration operation may not execute"
 			//if someone is still using use while we're being disposed
 			var pathsToDelete = new List<string>();
 			pathsToDelete.AddRange(_paths.Values);
-			foreach (var path in pathsToDelete)
+			foreach(var path in pathsToDelete)
 			{
 				try
 				{
-					if (File.Exists(path))
+					if(File.Exists(path))
 					{
 						File.Delete(path);
 						Debug.WriteLine("RuntimeImageProcessor Successfully deleted: " + path);
 					}
 				}
-				catch (Exception e)
+				catch(Exception e)
 				{
 					Debug.WriteLine("RuntimeImageProcessor Dispose(): " + e.Message);
 				}
@@ -91,41 +91,41 @@ namespace Bloom.ImageProcessing
 		public string GetPathToResizedImage(string originalPath)
 		{
 			//don't mess with Bloom UI images
-			if (new[] {"/img/","placeHolder", "Button"}.Any(s => originalPath.Contains(s)))
+			if(new[] { "/img/", "placeHolder", "Button" }.Any(s => originalPath.Contains(s)))
 				return originalPath;
 
 			string resizedPath;
-//			if(_paths.TryGetValue(originalPath, out resizedPath))
-//			{
-//				if (File.Exists(resizedPath) && new FileInfo(originalPath).LastWriteTimeUtc <= new FileInfo(resizedPath).LastWriteTimeUtc)
-//				{
-//						return resizedPath;
-//				}
-//				else
-//				{
-//					_paths.Remove(originalPath);
-//				}
-//			}
-			using (var originalImage = PalasoImage.FromFile(originalPath))
+			//			if(_paths.TryGetValue(originalPath, out resizedPath))
+			//			{
+			//				if (File.Exists(resizedPath) && new FileInfo(originalPath).LastWriteTimeUtc <= new FileInfo(resizedPath).LastWriteTimeUtc)
+			//				{
+			//						return resizedPath;
+			//				}
+			//				else
+			//				{
+			//					_paths.Remove(originalPath);
+			//				}
+			//			}
+			using(var originalImage = PalasoImage.FromFile(originalPath))
 			{
-				if (ImageUtils.AppearsToBeJpeg(originalImage))
+				if(ImageUtils.AppearsToBeJpeg(originalImage))
 				{
 					return originalImage.OriginalFilePath;
 				}
 				double shrinkFactor = 1.0;
 				//if its a small image, like a creative commons logo, we don't try and resize it
-				if (originalImage.Image.Width > TargetDimension || originalImage.Image.Height > TargetDimension)
+				if(originalImage.Image.Width > TargetDimension || originalImage.Image.Height > TargetDimension)
 				{
 					var maxDimension = Math.Max(originalImage.Image.Width, originalImage.Image.Height);
 					//enhance: if we had a way of knowing what the target dimension actually was, we'd use that, of course
-					shrinkFactor = (TargetDimension/(double) maxDimension);
+					shrinkFactor = (TargetDimension / (double)maxDimension);
 				}
 
-				var destWidth = (int) (shrinkFactor*originalImage.Image.Width);
-				var destHeight = (int) (shrinkFactor*originalImage.Image.Height);
-				using (var b = new Bitmap(destWidth, destHeight))
+				var destWidth = (int)(shrinkFactor * originalImage.Image.Width);
+				var destHeight = (int)(shrinkFactor * originalImage.Image.Height);
+				using(var b = new Bitmap(destWidth, destHeight))
 				{
-					using (Graphics g = Graphics.FromImage((Image) b))
+					using(Graphics g = Graphics.FromImage((Image)b))
 					{
 						//in version 1.0, we used .NearestNeighbor. But if there is a border line down the right size (as is common for thumbnails that,
 						//are, for example, re-inserted into Teacher's Guides), then the line gets cut off. So I switched it to HighQualityBicubic
@@ -149,20 +149,20 @@ namespace Bloom.ImageProcessing
 					//but then some startup thread cleared and deleted it? (we are now running on a thread responding to the http request)
 
 					Exception error = null;
-					for (int i = 0; i < 5; i++) //try up to five times, a second apart
+					for(int i = 0; i < 5; i++) //try up to five times, a second apart
 					{
 						try
 						{
 							error = null;
 
-							if (!Directory.Exists(Path.GetDirectoryName(temp)))
+							if(!Directory.Exists(Path.GetDirectoryName(temp)))
 							{
 								Directory.CreateDirectory(Path.GetDirectoryName(temp));
 							}
 							b.Save(temp, originalImage.Image.RawFormat);
 							break;
 						}
-						catch (Exception e)
+						catch(Exception e)
 						{
 							Logger.WriteEvent("Error in LowResImage while trying to write image.");
 							Logger.WriteEvent(e.Message);
@@ -170,7 +170,7 @@ namespace Bloom.ImageProcessing
 							Thread.Sleep(1000); //wait a second before trying again
 						}
 					}
-					if (error != null)
+					if(error != null)
 					{
 						//NB: this will be on a non-UI thread, so it probably won't work well!
 						ErrorReport.NotifyUserOfProblem(error,
@@ -179,15 +179,15 @@ namespace Bloom.ImageProcessing
 						return originalPath;
 					}
 
-//					try
-//					{
-//						_paths.Add(originalPath, temp); //remember it so we can reuse if they show it again, and later delete
-//					}
-//					catch (ArgumentException)
-//					{
-//						// it happens sometimes that though it wasn't in the _paths when we entered, it is now
-//						// I haven't tracked it down... possibly we get a new request for the image while we're busy compressing it?
-//					}
+					//					try
+					//					{
+					//						_paths.Add(originalPath, temp); //remember it so we can reuse if they show it again, and later delete
+					//					}
+					//					catch (ArgumentException)
+					//					{
+					//						// it happens sometimes that though it wasn't in the _paths when we entered, it is now
+					//						// I haven't tracked it down... possibly we get a new request for the image while we're busy compressing it?
+					//					}
 
 					return temp;
 				}

--- a/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
+++ b/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Palaso.Reporting;
+using Palaso.UI.WindowsForms.ImageToolbox;
+
+namespace Bloom.ImageProcessing
+{
+	/// <summary>
+	/// Gecko struggles with hi-res images intented for printing. Gecko chews up memory, makes for slow drawing,
+	/// or even gives up on displaying the image altogether (worse on slow machines).
+	/// This cache takes requests for images and returns lo-res versions of them.
+	/// </summary>
+	public class RuntimeImageProcessor :IDisposable
+	{
+		private readonly BookRenamedEvent _bookRenamedEvent;
+		public int TargetDimension=500;
+		private Dictionary<string,string> _paths;
+		private string _cacheFolder;
+
+		private ImageAttributes _transparentImageAttributes;
+
+		public RuntimeImageProcessor(BookRenamedEvent bookRenamedEvent)
+		{
+			_bookRenamedEvent = bookRenamedEvent;
+			_paths = new Dictionary<string, string>();
+			_cacheFolder = Path.Combine(Path.GetTempPath(), "Bloom");
+			_bookRenamedEvent.Subscribe(OnBookRenamed);
+			_transparentImageAttributes = new ImageAttributes();
+			_transparentImageAttributes.SetColorKey(Color.FromArgb(253, 253, 253), Color.White);
+		}
+
+		private void OnBookRenamed(KeyValuePair<string, string> fromPathAndToPath)
+		{
+			//Note, we don't pay attention to what the change was, we just purge the whole cache
+
+			TryToDeleteCachedImages();
+			_paths = new Dictionary<string, string>();
+		}
+
+		public void Dispose()
+		{
+			if (_paths == null)
+				return;
+
+			TryToDeleteCachedImages();
+
+			//NB: this turns out to be dangerous. Without it, we still delete all we can, leave some files around
+			//each time, and then deleting them on the next run
+			//			_cacheFolder.Dispose();
+
+			GC.SuppressFinalize(this);
+		}
+
+		private void TryToDeleteCachedImages()
+		{
+//operate on a copy to avoid "Collection was modified; enumeration operation may not execute"
+			//if someone is still using use while we're being disposed
+			var pathsToDelete = new List<string>();
+			pathsToDelete.AddRange(_paths.Values);
+			foreach (var path in pathsToDelete)
+			{
+				try
+				{
+					if (File.Exists(path))
+					{
+						File.Delete(path);
+						Debug.WriteLine("RuntimeImageProcessor Successfully deleted: " + path);
+					}
+				}
+				catch (Exception e)
+				{
+					Debug.WriteLine("RuntimeImageProcessor Dispose(): " + e.Message);
+				}
+			}
+			_paths = null;
+		}
+
+		private DateTime GetModifiedDateTime(string path)
+		{
+			var f = new FileInfo(path);
+			return f.LastWriteTimeUtc;
+		}
+
+		public string GetPathToResizedImage(string originalPath)
+		{
+			//don't mess with Bloom UI images
+			if (new[] {"/img/","placeHolder", "Button"}.Any(s => originalPath.Contains(s)))
+				return originalPath;
+
+			string resizedPath;
+//			if(_paths.TryGetValue(originalPath, out resizedPath))
+//			{
+//				if (File.Exists(resizedPath) && new FileInfo(originalPath).LastWriteTimeUtc <= new FileInfo(resizedPath).LastWriteTimeUtc)
+//				{
+//						return resizedPath;
+//				}
+//				else
+//				{
+//					_paths.Remove(originalPath);
+//				}
+//			}
+			using (var originalImage = PalasoImage.FromFile(originalPath))
+			{
+				if (ImageUtils.AppearsToBeJpeg(originalImage))
+				{
+					return originalImage.OriginalFilePath;
+				}
+				double shrinkFactor = 1.0;
+				//if its a small image, like a creative commons logo, we don't try and resize it
+				if (originalImage.Image.Width > TargetDimension || originalImage.Image.Height > TargetDimension)
+				{
+					var maxDimension = Math.Max(originalImage.Image.Width, originalImage.Image.Height);
+					//enhance: if we had a way of knowing what the target dimension actually was, we'd use that, of course
+					shrinkFactor = (TargetDimension/(double) maxDimension);
+				}
+
+				var destWidth = (int) (shrinkFactor*originalImage.Image.Width);
+				var destHeight = (int) (shrinkFactor*originalImage.Image.Height);
+				using (var b = new Bitmap(destWidth, destHeight))
+				{
+					using (Graphics g = Graphics.FromImage((Image) b))
+					{
+						//in version 1.0, we used .NearestNeighbor. But if there is a border line down the right size (as is common for thumbnails that,
+						//are, for example, re-inserted into Teacher's Guides), then the line gets cut off. So I switched it to HighQualityBicubic
+						g.InterpolationMode = InterpolationMode.HighQualityBicubic; //.NearestNeighbor;//or smooth it: HighQualityBicubic
+						var destRect = new Rectangle(0, 0, destWidth, destHeight);
+						lock(_transparentImageAttributes)
+						{
+							g.DrawImage(originalImage.Image, destRect, 0, 0, originalImage.Image.Width, originalImage.Image.Height,
+								GraphicsUnit.Pixel, _transparentImageAttributes);
+						}
+					}
+
+					var temp = Path.Combine(_cacheFolder, Path.GetRandomFileName() + Path.GetExtension(originalPath));
+
+
+					//Hatton July 2012:
+					//Once or twice I saw a GDI+ error on the Save below, when the app 1st launched.
+					//I verified that if there is an IO error, that's what it you get (a GDI+ error).
+					//I looked once, and the %temp%/Bloom directory wasn't there, so that's what I think caused the error.
+					//It's not clear why the temp/bloom directory isn't there... possibly it was there a moment ago
+					//but then some startup thread cleared and deleted it? (we are now running on a thread responding to the http request)
+
+					Exception error = null;
+					for (int i = 0; i < 5; i++) //try up to five times, a second apart
+					{
+						try
+						{
+							error = null;
+
+							if (!Directory.Exists(Path.GetDirectoryName(temp)))
+							{
+								Directory.CreateDirectory(Path.GetDirectoryName(temp));
+							}
+							b.Save(temp, originalImage.Image.RawFormat);
+							break;
+						}
+						catch (Exception e)
+						{
+							Logger.WriteEvent("Error in LowResImage while trying to write image.");
+							Logger.WriteEvent(e.Message);
+							error = e;
+							Thread.Sleep(1000); //wait a second before trying again
+						}
+					}
+					if (error != null)
+					{
+						//NB: this will be on a non-UI thread, so it probably won't work well!
+						ErrorReport.NotifyUserOfProblem(error,
+							"Bloom is having problem saving a low-res version to your temp directory, at " + temp +
+							"\r\n\r\nYou might want to quit and restart Bloom. In the meantime, Bloom will try to use the full-res images.");
+						return originalPath;
+					}
+
+//					try
+//					{
+//						_paths.Add(originalPath, temp); //remember it so we can reuse if they show it again, and later delete
+//					}
+//					catch (ArgumentException)
+//					{
+//						// it happens sometimes that though it wasn't in the _paths when we entered, it is now
+//						// I haven't tracked it down... possibly we get a new request for the image while we're busy compressing it?
+//					}
+
+					return temp;
+				}
+			}
+		}
+	}
+}

--- a/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
+++ b/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
@@ -21,7 +21,7 @@ namespace Bloom.ImageProcessing
 	{
 		private readonly BookRenamedEvent _bookRenamedEvent;
 		public int TargetDimension = 500;
-		private Dictionary<string, string> _paths;
+		private Dictionary<string, string> _originalPathToProcessedVersionPath;
 		private string _cacheFolder;
 
 		private ImageAttributes _transparentImageAttributes;
@@ -29,7 +29,7 @@ namespace Bloom.ImageProcessing
 		public RuntimeImageProcessor(BookRenamedEvent bookRenamedEvent)
 		{
 			_bookRenamedEvent = bookRenamedEvent;
-			_paths = new Dictionary<string, string>();
+			_originalPathToProcessedVersionPath = new Dictionary<string, string>();
 			_cacheFolder = Path.Combine(Path.GetTempPath(), "Bloom");
 			_bookRenamedEvent.Subscribe(OnBookRenamed);
 			_transparentImageAttributes = new ImageAttributes();
@@ -41,15 +41,16 @@ namespace Bloom.ImageProcessing
 			//Note, we don't pay attention to what the change was, we just purge the whole cache
 
 			TryToDeleteCachedImages();
-			_paths = new Dictionary<string, string>();
+			_originalPathToProcessedVersionPath = new Dictionary<string, string>();
 		}
 
 		public void Dispose()
 		{
-			if(_paths == null)
+			if (_originalPathToProcessedVersionPath == null)
 				return;
 
 			TryToDeleteCachedImages();
+			_originalPathToProcessedVersionPath = null;
 
 			//NB: this turns out to be dangerous. Without it, we still delete all we can, leave some files around
 			//each time, and then deleting them on the next run
@@ -60,136 +61,139 @@ namespace Bloom.ImageProcessing
 
 		private void TryToDeleteCachedImages()
 		{
-			//operate on a copy to avoid "Collection was modified; enumeration operation may not execute"
-			//if someone is still using use while we're being disposed
-			var pathsToDelete = new List<string>();
-			pathsToDelete.AddRange(_paths.Values);
-			foreach(var path in pathsToDelete)
+			lock (this)
 			{
-				try
+				foreach(var path in _originalPathToProcessedVersionPath.Values)
 				{
-					if(File.Exists(path))
+					try
 					{
-						File.Delete(path);
-						Debug.WriteLine("RuntimeImageProcessor Successfully deleted: " + path);
+						if (File.Exists(path))
+						{
+							File.Delete(path);
+							Debug.WriteLine("RuntimeImageProcessor Successfully deleted: " + path);
+						}
+					}
+					catch (Exception e)
+					{
+						Debug.WriteLine("RuntimeImageProcessor Dispose(): " + e.Message);
 					}
 				}
-				catch(Exception e)
-				{
-					Debug.WriteLine("RuntimeImageProcessor Dispose(): " + e.Message);
-				}
+				_originalPathToProcessedVersionPath.Clear();
 			}
-			_paths = null;
-		}
-
-		private DateTime GetModifiedDateTime(string path)
-		{
-			var f = new FileInfo(path);
-			return f.LastWriteTimeUtc;
 		}
 
 		public string GetPathToResizedImage(string originalPath)
 		{
 			//don't mess with Bloom UI images
-			if(new[] { "/img/", "placeHolder", "Button" }.Any(s => originalPath.Contains(s)))
+			if (new[] {"/img/", "placeHolder", "Button"}.Any(s => originalPath.Contains(s)))
 				return originalPath;
 
-			string resizedPath;
-			//			if(_paths.TryGetValue(originalPath, out resizedPath))
-			//			{
-			//				if (File.Exists(resizedPath) && new FileInfo(originalPath).LastWriteTimeUtc <= new FileInfo(resizedPath).LastWriteTimeUtc)
-			//				{
-			//						return resizedPath;
-			//				}
-			//				else
-			//				{
-			//					_paths.Remove(originalPath);
-			//				}
-			//			}
-			using(var originalImage = PalasoImage.FromFile(originalPath))
+			lock (this)
 			{
-				if(ImageUtils.AppearsToBeJpeg(originalImage))
+				string pathToProcessedVersion;
+				if (_originalPathToProcessedVersionPath.TryGetValue(originalPath, out pathToProcessedVersion))
 				{
-					return originalImage.OriginalFilePath;
-				}
-				double shrinkFactor = 1.0;
-				//if its a small image, like a creative commons logo, we don't try and resize it
-				if(originalImage.Image.Width > TargetDimension || originalImage.Image.Height > TargetDimension)
-				{
-					var maxDimension = Math.Max(originalImage.Image.Width, originalImage.Image.Height);
-					//enhance: if we had a way of knowing what the target dimension actually was, we'd use that, of course
-					shrinkFactor = (TargetDimension / (double)maxDimension);
+					if (File.Exists(pathToProcessedVersion) &&
+					    new FileInfo(originalPath).LastWriteTimeUtc <= new FileInfo(pathToProcessedVersion).LastWriteTimeUtc)
+					{
+						return pathToProcessedVersion;
+					}
+					else
+					{
+						_originalPathToProcessedVersionPath.Remove(originalPath);
+					}
 				}
 
-				var destWidth = (int)(shrinkFactor * originalImage.Image.Width);
-				var destHeight = (int)(shrinkFactor * originalImage.Image.Height);
-				using(var b = new Bitmap(destWidth, destHeight))
+				using (var originalImage = PalasoImage.FromFile(originalPath))
 				{
-					using(Graphics g = Graphics.FromImage((Image)b))
+					//if it's a jpeg, we don't resize, we don't mess with transparency, nothing. These things
+					//are scary in .net. Just send the original back and wash our hands of it.
+					if (ImageUtils.AppearsToBeJpeg(originalImage))
 					{
-						//in version 1.0, we used .NearestNeighbor. But if there is a border line down the right size (as is common for thumbnails that,
-						//are, for example, re-inserted into Teacher's Guides), then the line gets cut off. So I switched it to HighQualityBicubic
-						g.InterpolationMode = InterpolationMode.HighQualityBicubic; //.NearestNeighbor;//or smooth it: HighQualityBicubic
-						var destRect = new Rectangle(0, 0, destWidth, destHeight);
-						lock(_transparentImageAttributes)
-						{
-							g.DrawImage(originalImage.Image, destRect, 0, 0, originalImage.Image.Width, originalImage.Image.Height,
-								GraphicsUnit.Pixel, _transparentImageAttributes);
-						}
+						return originalImage.OriginalFilePath;
 					}
 
-					var temp = Path.Combine(_cacheFolder, Path.GetRandomFileName() + Path.GetExtension(originalPath));
+					double shrinkFactor = 1.0;
 
+#if ShrinkLargeImages // at the moment, we're suspecting that it may be better to let the browser do the shrinking
 
-					//Hatton July 2012:
-					//Once or twice I saw a GDI+ error on the Save below, when the app 1st launched.
-					//I verified that if there is an IO error, that's what it you get (a GDI+ error).
-					//I looked once, and the %temp%/Bloom directory wasn't there, so that's what I think caused the error.
-					//It's not clear why the temp/bloom directory isn't there... possibly it was there a moment ago
-					//but then some startup thread cleared and deleted it? (we are now running on a thread responding to the http request)
-
-					Exception error = null;
-					for(int i = 0; i < 5; i++) //try up to five times, a second apart
+					//if its a small image, like a creative commons logo, we don't try and resize it
+					if (originalImage.Image.Width > TargetDimension || originalImage.Image.Height > TargetDimension)
 					{
+						var maxDimension = Math.Max(originalImage.Image.Width, originalImage.Image.Height);
+						//enhance: if we had a way of knowing what the target dimension actually was, we'd use that, of course
+						shrinkFactor = (TargetDimension/(double) maxDimension);
+					}
+#endif
+					var destWidth = (int) (shrinkFactor*originalImage.Image.Width);
+					var destHeight = (int) (shrinkFactor*originalImage.Image.Height);
+
+					using (var processedBitmap = new Bitmap(destWidth, destHeight))
+					{
+						using (Graphics g = Graphics.FromImage((Image) processedBitmap))
+						{
+							//in version 1.0, we used .NearestNeighbor. But if there is a border line down the right size (as is common for thumbnails that,
+							//are, for example, re-inserted into Teacher's Guides), then the line gets cut off. So I switched it to HighQualityBicubic
+							g.InterpolationMode = InterpolationMode.HighQualityBicubic; //.NearestNeighbor;//or smooth it: HighQualityBicubic
+							var destRect = new Rectangle(0, 0, destWidth, destHeight);
+							lock (_transparentImageAttributes)
+							{
+								g.DrawImage(originalImage.Image, destRect, 0, 0, originalImage.Image.Width, originalImage.Image.Height,
+									GraphicsUnit.Pixel, _transparentImageAttributes);
+							}
+						}
+
+						var pathToProcessedImage = Path.Combine(_cacheFolder, Path.GetRandomFileName() + Path.GetExtension(originalPath));
+
+						//Hatton July 2012:
+						//Once or twice I saw a GDI+ error on the Save below, when the app 1st launched.
+						//I verified that if there is an IO error, that's what you get (a GDI+ error).
+						//I looked once, and the %temp%/Bloom directory wasn't there, so that's what I think caused the error.
+						//It's not clear why the temp/bloom directory isn't there... possibly it was there a moment ago
+						//but then some startup thread cleared and deleted it? (we are now running on a thread responding to the http request)
+
+						Exception error = null;
+						for (int i = 0; i < 5; i++) //try up to five times, a second apart
+						{
+							try
+							{
+								error = null;
+
+								if (!Directory.Exists(Path.GetDirectoryName(pathToProcessedImage)))
+								{
+									Directory.CreateDirectory(Path.GetDirectoryName(pathToProcessedImage));
+								}
+								processedBitmap.Save(pathToProcessedImage, originalImage.Image.RawFormat);
+								break;
+							}
+							catch (Exception e)
+							{
+								Logger.WriteEvent("Error in RuntimeImageProcessor while trying to write image.");
+								Logger.WriteEvent(e.Message);
+								error = e;
+								Thread.Sleep(1000); //wait a second before trying again
+							}
+						}
+						if (error != null)
+						{
+							//NB: I tested that even though we're in a non-UI thread, this shows up fine (libpalaso marshalls it to the UI thread)
+							ErrorReport.NotifyUserOfProblem(error,
+								"Bloom is having problem saving a processed version to your temp directory, at " + pathToProcessedImage +
+								"\r\n\r\nYou might want to quit and restart Bloom. In the meantime, Bloom will use unprocessed image.");
+							return originalPath;
+						}
+
 						try
 						{
-							error = null;
-
-							if(!Directory.Exists(Path.GetDirectoryName(temp)))
-							{
-								Directory.CreateDirectory(Path.GetDirectoryName(temp));
-							}
-							b.Save(temp, originalImage.Image.RawFormat);
-							break;
+							_originalPathToProcessedVersionPath.Add(originalPath, pathToProcessedImage); //remember it so we can reuse if they show it again, and later delete
 						}
-						catch(Exception e)
+						catch (ArgumentException)
 						{
-							Logger.WriteEvent("Error in LowResImage while trying to write image.");
-							Logger.WriteEvent(e.Message);
-							error = e;
-							Thread.Sleep(1000); //wait a second before trying again
+							// it happens sometimes that though it wasn't in the _originalPathToProcessedVersionPath when we entered, it is now
+							// I haven't tracked it down... possibly we get a new request for the image while we're busy compressing it?
 						}
+						return pathToProcessedImage;
 					}
-					if(error != null)
-					{
-						//NB: this will be on a non-UI thread, so it probably won't work well!
-						ErrorReport.NotifyUserOfProblem(error,
-							"Bloom is having problem saving a low-res version to your temp directory, at " + temp +
-							"\r\n\r\nYou might want to quit and restart Bloom. In the meantime, Bloom will try to use the full-res images.");
-						return originalPath;
-					}
-
-					//					try
-					//					{
-					//						_paths.Add(originalPath, temp); //remember it so we can reuse if they show it again, and later delete
-					//					}
-					//					catch (ArgumentException)
-					//					{
-					//						// it happens sometimes that though it wasn't in the _paths when we entered, it is now
-					//						// I haven't tracked it down... possibly we get a new request for the image while we're busy compressing it?
-					//					}
-
-					return temp;
 				}
 			}
 		}

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -210,7 +210,7 @@ namespace Bloom
 //				}
 //				else
 //				{
-					_httpServer = new EnhancedImageServer(new LowResImageCache(bookRenameEvent));
+					_httpServer = new EnhancedImageServer(new RuntimeImageProcessor(bookRenameEvent));
 //				}
 					builder.Register((c => _httpServer)).AsSelf().SingleInstance();
 

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -27,7 +27,7 @@ namespace Bloom.web
 
 		public BloomServer(CollectionSettings collectionSettings, BookCollection booksInProjectLibrary,
 						   SourceCollectionsList sourceCollectionsesList, HtmlThumbNailer thumbNailer)
-			:base(new LowResImageCache(new BookRenamedEvent()))
+			:base(new RuntimeImageProcessor(new BookRenamedEvent()))
 		{
 			_collectionSettings = collectionSettings;
 			_booksInProjectLibrary = booksInProjectLibrary;

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -27,7 +27,7 @@ namespace Bloom.web
 
 		public CollectionSettings CurrentCollectionSettings { get; set; }
 
-		public EnhancedImageServer(LowResImageCache cache): base(cache)
+		public EnhancedImageServer(RuntimeImageProcessor cache): base(cache)
 		{
 		}
 

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -149,7 +149,7 @@
     <Compile Include="Chorus\MergingTests.cs" />
     <Compile Include="Edit\ConfiguratorTest.cs" />
     <Compile Include="FluentAssertXml.cs" />
-    <Compile Include="LowResImageProcessing\LowResImageCacheTests.cs" />
+    <Compile Include="LowResImageProcessing\RuntimeImageProcessingTests.cs" />
     <Compile Include="NavigationIsolatorTests.cs" />
     <Compile Include="NewCollectionWizardTests.cs" />
     <Compile Include="PageEditingModelTests.cs" />

--- a/src/BloomTests/LowResImageProcessing/ImageServerTests.cs
+++ b/src/BloomTests/LowResImageProcessing/ImageServerTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using Palaso.IO;
 using Palaso.TestUtilities;
 
-namespace BloomTests.LowResImageProcessing
+namespace BloomTests.RuntimeImageProcessing
 {
 	[TestFixture]
 	public class ImageServerTests
@@ -53,7 +53,7 @@ namespace BloomTests.LowResImageProcessing
 
 		private ImageServer CreateImageServer()
 		{
-			return new ImageServer(new LowResImageCache(new BookRenamedEvent()));
+			return new ImageServer(new RuntimeImageProcessor(new BookRenamedEvent()));
 		}
 		private TempFile MakeTempImage()
 		{

--- a/src/BloomTests/LowResImageProcessing/RuntimeImageProcessingTests.cs
+++ b/src/BloomTests/LowResImageProcessing/RuntimeImageProcessingTests.cs
@@ -8,15 +8,15 @@ using Palaso.IO;
 
 using Bloom.ImageProcessing;
 
-namespace BloomTests.LowResImageProcessing
+namespace BloomTests.RuntimeImageProcessing
 {
 	[TestFixture]
-	public class LowResImageCacheTests
+	public class RuntimeImageProcessingTests
 	{
 		[Test]
 		public void GetWideImage_ReturnsShrunkImageWithCorrectProportions()
 		{
-			using (var cache = new LowResImageCache(new BookRenamedEvent()) { TargetDimension = 100 })
+			using (var cache = new RuntimeImageProcessor(new BookRenamedEvent()) { TargetDimension = 100 })
 			using (var file = MakeTempPNGImage(200,80))
 			{
 				using(var img = Image.FromFile(cache.GetPathToResizedImage(file.Path)))
@@ -27,10 +27,11 @@ namespace BloomTests.LowResImageProcessing
 			}
 		}
 
-		[Test]
+		/* we're not shrinking at the moment
+		 [Test]
 		public void GetJPG_ReturnsShrunkJPG()
 		{
-			using (var cache = new LowResImageCache(new BookRenamedEvent()) { TargetDimension = 100 })
+			using (var cache = new RuntimeImageProcessor(new BookRenamedEvent()) { TargetDimension = 100 })
 			using (var file = MakeTempJPGImage(200, 80))
 			{
 				var pathToResizedImage = cache.GetPathToResizedImage(file.Path);
@@ -45,12 +46,12 @@ namespace BloomTests.LowResImageProcessing
 					Assert.AreEqual(40, img.Height);
 				}
 			}
-		}
+		}*/
 
 		[Test]
 		public void GetTinyImage_DoesNotChangeSize()
 		{
-			using (var cache = new LowResImageCache(new BookRenamedEvent()) { TargetDimension = 100 })
+			using (var cache = new RuntimeImageProcessor(new BookRenamedEvent()) { TargetDimension = 100 })
 			using (var file = MakeTempPNGImage(10,10))
 			{
 				using (var img = Image.FromFile(cache.GetPathToResizedImage(file.Path)))

--- a/src/BloomTests/web/EnhancedImageServerTests.cs
+++ b/src/BloomTests/web/EnhancedImageServerTests.cs
@@ -86,7 +86,7 @@ namespace BloomTests.web
 
 		private static EnhancedImageServer CreateImageServer()
 		{
-			return new EnhancedImageServer(new LowResImageCache(new BookRenamedEvent()));
+			return new EnhancedImageServer(new RuntimeImageProcessor(new BookRenamedEvent()));
 		}
 
 		private TempFile MakeTempImage()


### PR DESCRIPTION
Now that we deliver images over http (instead of "file:///" links), we get around the problem of gecko giving up on large local files too easily. Now, we can deliver very large images (I tried up to 9mb jpeg) directly, at gecko does a good job of showing a low-quality image quickly and then enhancing it a it gets time. So, for jpegs, we now don't touch the image at all, except to read it and push it over the wire.

Now, for PNGs, we do still redraw them in order to introduce transparency. It it is conceivable that we should still shrink png images, but it's not clear if we should, so I'm going with no shrinking for now as the simpler operation, and then we can reintroduce it if testing shows it is needed. The code is still there #if'd out.
