### PR TITLE
Make "Update Books" restore white to previously transparent-ified imgs

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using Bloom.Collection;
 using Bloom.Edit;
+using Bloom.ImageProcessing;
 using Bloom.Properties;
 using Bloom.Publish;
 using L10NSharp;
@@ -624,6 +625,7 @@ namespace Bloom.Book
 				ImageUpdater.UpdateAllHtmlDataAttributesForAllImgElements(FolderPath, OurHtmlDom, progress);
 				UpdatePageFromFactoryTemplates(OurHtmlDom, progress);
 				//ImageUpdater.CompressImages(FolderPath, progress);
+				ImageUtils.RemoveTransparencyOfImagesInFolder(FolderPath, progress);
 				Save();
 			}
 

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -5,6 +5,7 @@ using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using Palaso.Progress;
 using Palaso.UI.WindowsForms.ImageToolbox;
 using Logger = Palaso.Reporting.Logger;
 using TempFile = Palaso.IO.TempFile;
@@ -49,62 +50,68 @@ namespace Bloom.ImageProcessing
 		public static string ProcessAndSaveImageIntoFolder(PalasoImage imageInfo, string bookFolderPath)
 		{
 			LogMemoryUsage();
-
-			var isJpeg = AppearsToBeJpeg(imageInfo);
+			bool isJpeg = false;
 			try
 			{
+				isJpeg = AppearsToBeJpeg(imageInfo);
+				var imageFileName = GetFileNameToUseForSavingImage(bookFolderPath, imageInfo, isJpeg);
+				var destinationPath = Path.Combine(bookFolderPath, imageFileName);
+				imageInfo.Save(destinationPath);
+				return imageFileName;
+
+				/* I (Hatton) have decided to stop compressing images until we have a suite of 
+				tests based on a number of image exemplars. Compression can be great, but it 
+				can also lead to very long waits; this is a "first, do no harm" decision.
+
 				//nb: there are cases (undefined) where we get out of memory if we are not operating on a copy
 				using (var image = new Bitmap(imageInfo.Image))
 				{
-					var imageFileName = GetFileNameToUseForSavingImage(bookFolderPath, imageInfo, isJpeg);
-					var destinationPath = Path.Combine(bookFolderPath, imageFileName);
 					using (var tmp = new TempFile())
 					{
 						image.Save(tmp.Path, isJpeg ? ImageFormat.Jpeg : ImageFormat.Png);
 						Palaso.IO.FileUtils.ReplaceFileWithUserInteractionIfNeeded(tmp.Path, destinationPath, null);
 					}
 
-					if (!isJpeg)
-					{
-						//I (Hatton) have decided to stop compressing images until we have a suite of 
-						//tests based on a number of image exemplars. Compression can be great, but it 
-						//can also lead to very long waits; this is a "first, do no harm" decision
-						/*using (var dlg = new ProgressDialogBackground())
-						{
-							dlg.ShowAndDoWork((progress, args) => ImageUpdater.CompressImage(dest, progress));
-						}*/
-					}
-					imageInfo.Metadata.Write(destinationPath);
-
-					return imageFileName;
 				}
+
+				using (var dlg = new ProgressDialogBackground())
+				{
+					dlg.ShowAndDoWork((progress, args) => ImageUpdater.CompressImage(dest, progress));
+				}*/
 			}
 			catch (IOException)
 			{
 				throw; //these are informative on their own
 			}
-			catch (OutOfMemoryException error)
+				/* No. OutOfMemory is almost meaningless when it comes to image errors. Better not to confuse people
+			 * catch (OutOfMemoryException error)
 			{
 				//Enhance: it would be great if we could bring up that problem dialog ourselves, and offer this picture as an attachment
 				throw new ApplicationException("Bloom ran out of memory while trying to import the picture. We suggest that you quit Bloom, run it again, and then try importing this picture again. If that fails, please go to the Help menu and choose 'Report a Problem'", error);
-			}
-			catch(Exception error)
+			}*/
+			catch (Exception error)
 			{
-				if(!string.IsNullOrEmpty(imageInfo.FileName) && File.Exists(imageInfo.OriginalFilePath))
+				if (!string.IsNullOrEmpty(imageInfo.FileName) && File.Exists(imageInfo.OriginalFilePath))
 				{
-					var megs = new System.IO.FileInfo(imageInfo.OriginalFilePath).Length / (1024 * 1000);
-					if(megs > 2)
+					var megs = new System.IO.FileInfo(imageInfo.OriginalFilePath).Length/(1024*1000);
+					if (megs > 2)
 					{
-						var msg = string.Format("Bloom was not able to prepare that picture for including in the book. \r\nThis is a rather large image to be adding to a book --{0} Megs--.", megs);
-						if(isJpeg)
+						var msg =
+							string.Format(
+								"Bloom was not able to prepare that picture for including in the book. \r\nThis is a rather large image to be adding to a book --{0} Megs--.",
+								megs);
+						if (isJpeg)
 						{
-							msg += "\r\nNote, this file is a jpeg, which is normally used for photographs, not line-drawings (png, tiff, bmp). Bloom can handle smallish jpegs, large ones are difficult to handle, especialy if memory is limited.";
+							msg +=
+								"\r\nNote, this file is a jpeg, which is normally used for photographs, not line-drawings (png, tiff, bmp). Bloom can handle smallish jpegs, large ones are difficult to handle, especialy if memory is limited.";
 						}
 						throw new ApplicationException(msg, error);
 					}
 				}
 
-				throw new ApplicationException("Bloom was not able to prepare that picture for including in the book. We'd like to investigate, so if possible, would you please email it to issues@bloomlibrary.org?" + System.Environment.NewLine+ imageInfo.FileName, error);
+				throw new ApplicationException(
+					"Bloom was not able to prepare that picture for including in the book. We'd like to investigate, so if possible, would you please email it to issues@bloomlibrary.org?" +
+					System.Environment.NewLine + imageInfo.FileName, error);
 			}
 		}
 
@@ -146,6 +153,50 @@ namespace Bloom.ImageProcessing
 				Logger.WriteEvent("Peak Paged Memory: " + proc.PeakPagedMemorySize64 / bytesPerMegabyte + " MB");
 				Logger.WriteEvent("Peak Virtual Memory: " + proc.PeakVirtualMemorySize64 / bytesPerMegabyte + " MB");
 				Logger.WriteEvent("GC Total Memory: " + GC.GetTotalMemory(false) / bytesPerMegabyte + " MB");
+			}
+		}
+
+		//Up through Bloom 3.0, we would make white areas transparent when importing images, in order to make them
+		//look good against the colored background of a book cover.
+		//This caused problems with some PDF viewers, so in Bloom 3.1, we switched to only making them transparent at runtime.
+		//This method allows us to undo that transparency-making.
+		public static void RemoveTransparencyOfImagesInFolder(string folderPath, IProgress progress)
+		{
+			var imageFiles = Directory.GetFiles(folderPath, "*.png");
+			int completed = 0;
+			foreach(string path in imageFiles)
+			{
+
+				if(Path.GetFileName(path).ToLower() == "placeholder.png")
+					return;
+
+				progress.ProgressIndicator.PercentCompleted = (int)(100.0 * (float)completed / (float)imageFiles.Length);
+				using(var pi = PalasoImage.FromFile(path))
+				{
+					if(!ImageUtils.AppearsToBeJpeg(pi))
+					{
+						RemoveTransparency(path, progress);
+					}
+				}
+				completed++;
+			}
+		}
+
+		private static void RemoveTransparency(string path, IProgress progress)
+		{
+			progress.WriteStatus("RemovingTransparency from image: " + Path.GetFileName(path));
+			var original = Image.FromFile(path);
+			using(var b = new Bitmap(original.Width, original.Height))
+			{
+				b.SetResolution(original.HorizontalResolution, original.VerticalResolution);
+
+				using(Graphics g = Graphics.FromImage(b))
+				{
+					g.Clear(Color.White);
+					g.DrawImageUnscaled(original, 0, 0);
+				}
+				original.Dispose();
+				b.Save(path, ImageFormat.Png);
 			}
 		}
 	}


### PR DESCRIPTION
Up through Bloom 3.0, we would make white areas transparent when importing images, in order to make them look good against the colored background of a book cover. This caused problems with some PDF viewers, so in Bloom 3.1, we switched to only making them transparent at runtime. This commit allows us to undo that transparency-making.