### PR TITLE
Set explicit size for Creative Commons License Logos

### DIFF
--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.css
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.css
@@ -226,6 +226,12 @@
 .verso #versoLicenseAndCopyright .licenseBlock {
   margin-bottom: 2em;
 }
+.credits .licenseAndCopyrightBlock img,
+.verso .licenseAndCopyrightBlock img,
+.credits #versoLicenseAndCopyright img,
+.verso #versoLicenseAndCopyright img {
+  height: 31px;
+}
 .credits .originalAcknowledgments .bloom-contentNational1,
 .verso .originalAcknowledgments .bloom-contentNational1 {
   display: block !important;

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
@@ -226,6 +226,12 @@
 .verso #versoLicenseAndCopyright .licenseBlock {
   margin-bottom: 2em;
 }
+.credits .licenseAndCopyrightBlock img,
+.verso .licenseAndCopyrightBlock img,
+.credits #versoLicenseAndCopyright img,
+.verso #versoLicenseAndCopyright img {
+  height: 31px;
+}
 .credits .originalAcknowledgments .bloom-contentNational1,
 .verso .originalAcknowledgments .bloom-contentNational1 {
   display: block !important;

--- a/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
+++ b/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
@@ -226,6 +226,12 @@
 .verso #versoLicenseAndCopyright .licenseBlock {
   margin-bottom: 2em;
 }
+.credits .licenseAndCopyrightBlock img,
+.verso .licenseAndCopyrightBlock img,
+.credits #versoLicenseAndCopyright img,
+.verso #versoLicenseAndCopyright img {
+  height: 31px;
+}
 .credits .originalAcknowledgments .bloom-contentNational1,
 .verso .originalAcknowledgments .bloom-contentNational1 {
   display: block !important;

--- a/DistFiles/xMatter/bloom-xmatter-common.less
+++ b/DistFiles/xMatter/bloom-xmatter-common.less
@@ -302,6 +302,9 @@
         .licenseBlock{
             margin-bottom: @MarginBetweenBlocks;
         }
+        img{
+            height: 31px;
+        }
     }
 
     .originalAcknowledgments .bloom-contentNational1 {


### PR DESCRIPTION
Previously, LibPalaso was giving us little images, so the img never had a height or width, it just came out right. But the current version of libpalaso will be giving us large, print-ready images, so we need to explicitly declare the size.