### PR TITLE
Improve better tooltip

### DIFF
--- a/src/BloomExe/Command.cs
+++ b/src/BloomExe/Command.cs
@@ -36,7 +36,7 @@ namespace Bloom
 //				}
 //			}
 //        }
-	   public Action Implementer { get; set;}
+		public Action Implementer { get; set;}
 
 		public void Execute()
 		{

--- a/src/BloomExe/Edit/EditingView.Designer.cs
+++ b/src/BloomExe/Edit/EditingView.Designer.cs
@@ -281,6 +281,7 @@
 			this._undoButton.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
 			this._undoButton.TextDropShadow = false;
 			this._betterToolTip1.SetToolTip(this._undoButton, "Undo (Ctrl+z)");
+			this._betterToolTip1.SetToolTipWhenDisabled(this._undoButton, "There is nothing to undo");
 			this._undoButton.UseVisualStyleBackColor = false;
 			this._undoButton.Click += new System.EventHandler(this._undoButton_Click);
 			// 
@@ -402,6 +403,8 @@
 			this._copyButton.Text = "Copy";
 			this._copyButton.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
 			this._copyButton.TextDropShadow = false;
+			this._betterToolTip1.SetToolTip(this._copyButton, "Copy (Ctrl-c)");
+			this._betterToolTip1.SetToolTipWhenDisabled(this._copyButton, "You need to select some text before you can copy it");
 			this._copyButton.UseVisualStyleBackColor = false;
 			this._copyButton.Click += new System.EventHandler(this._copyButton_Click);
 			// 

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -349,13 +349,6 @@ namespace Bloom.Edit
 				Application.Idle += new EventHandler(VisibleNowAddSlowContents);
 				Cursor = Cursors.WaitCursor;
 				Logger.WriteEvent("Entered Edit Tab");
-
-				if (Palaso.PlatformUtilities.Platform.IsLinux)
-				{
-					// This hack fixes a problem related to the better tooltip preventing the buttons from repainting.
-					// We do not have this problem in Windows, so no reason for extra overhead.
-					CycleEditButtons();
-				}
 			}
 			else
 			{

--- a/src/BloomExe/ToPalaso/BetterToolTip.cs
+++ b/src/BloomExe/ToPalaso/BetterToolTip.cs
@@ -16,46 +16,47 @@ using Palaso.Code;
 namespace Bloom.ToPalaso
 {
 
-	[ProvideProperty("ToolTipWhenDisabled", typeof(Control)),
-	ProvideProperty("SizeOfToolTipWhenDisabled", typeof(Control))]
 	/// <summary>
-	/// EnhancedToolTip supports the ToolTipWhenDisabled and SizeOfToolTipWhenDisabled
+	/// BetterToolTip supports the ToolTipWhenDisabled and SizeOfToolTipWhenDisabled
 	/// extender properties that can be used to show tooltip messages when the associated
 	/// control is disabled.
 	///
 	/// There is a problem with this class on Linux.  The transparent overlay seems to
 	/// prevent buttons from getting repainted. (https://jira.sil.org/browse/BL-348)
 	/// </summary>
+	[ProvideProperty("ToolTipWhenDisabled", typeof(Control))]
+	[ProvideProperty("SizeOfToolTipWhenDisabled", typeof(Control))]
 	public class BetterToolTip : ToolTip, ILocalizableComponent
 	{
+		private string _toolTipTitle;
+		private ToolTipIcon _toolTipIcon;
+		private Dictionary<Control, string> _toolTipWhenDisabled = new Dictionary<Control, string>();
+		private List<Control> _allControlsHavingToolTips = new List<Control>();
+		private Dictionary<Control, BetterTooltipTransparentOverlay> _betterTooltipTransparentOverlay = new Dictionary<Control, BetterTooltipTransparentOverlay>();
+		private Dictionary<Control, PaintEventHandler> _paintEventHandlers = new Dictionary<Control, PaintEventHandler>();
+		private Dictionary<Control, EventHandler> _controlEnabledChangedHandlers = new Dictionary<Control, EventHandler>();
+		private Dictionary<Control, Size> _sizeOfToolTipWhenDisabledDictionary = new Dictionary<Control, Size>();
+
+
 		#region ========== Required constructor ==========
+
 		// This constructor is required for the Windows Forms Designer to instantiate
-		// an object of this class with New(Me.components).
-		// To verify this, just remove this constructor. Build it and then put the
-		// component on a form. Take a look at the Designer.vb file for InitializeComponents(),
-		// and search for the line where it instantiates this class.
-		public BetterToolTip(IContainer p_container)
-			: base()
+		// an object of this class.
+		public BetterToolTip(IContainer container)
 		{
 			// Required for Windows.Forms Class Composition Designer support
-			if (p_container != null)
+			if (container != null)
 			{
-				p_container.Add(this);
+				container.Add(this);
 			}
 
 			// Suscribes to Popup event listener
-			// Comment out following lines if you are okay with the same Title/Icon for disabled controls.
-			this.m_EvtPopup = new PopupEventHandler(EnhancedToolTip_Popup);
-			this.Popup += this.m_EvtPopup;
+			Popup += EnhancedToolTip_Popup;
 		}
+
 		#endregion
 
 		#region ========== ToolTipWhenDisabled extender property support ==========
-		private Dictionary<Control, string> m_ToolTipWhenDisabled = new Dictionary<Control, string>();
-		private List<Control> m_allControlsHavingToolTips = new List<Control>();
-		private Dictionary<Control, BetterTooltipTransparentOverlay> m_BetterTooltipTransparentOverlay = new Dictionary<Control, BetterTooltipTransparentOverlay>();
-		private Dictionary<Control, PaintEventHandler> m_EvtControlPaint = new Dictionary<Control, PaintEventHandler>();
-		private Dictionary<Control, EventHandler> m_EvtControlEnabledChanged = new Dictionary<Control, EventHandler>();
 
 		public new void SetToolTip(Control control, string value)
 		{
@@ -65,7 +66,7 @@ namespace Bloom.ToPalaso
 			}
 
 			UpdateAllControlsList(control, value);
-			Guard.AgainstNull(control,"control");
+			Guard.AgainstNull(control, "control");
 			//No: this can be null, it's OK: Guard.AgainstNull(value,"value");
 			try
 			{
@@ -84,134 +85,124 @@ namespace Bloom.ToPalaso
 		{
 			if (String.IsNullOrEmpty(value))
 			{
-				if (m_allControlsHavingToolTips.Contains(control))
-					m_allControlsHavingToolTips.Remove(control);
+				if (_allControlsHavingToolTips.Contains(control))
+					_allControlsHavingToolTips.Remove(control);
 			}
 			else
 			{
-				if (!m_allControlsHavingToolTips.Contains(control))
-					m_allControlsHavingToolTips.Add(control);
+				if (!_allControlsHavingToolTips.Contains(control))
+					_allControlsHavingToolTips.Add(control);
 			}
 		}
 
-		public void SetToolTipWhenDisabled(Control p_control, string value)
+		public void SetToolTipWhenDisabled(Control control, string value)
 		{
-			if (p_control == null)
+			if (control == null)
 			{
 				throw new ArgumentNullException("control");
 			}
 
-			UpdateAllControlsList(p_control, value);
+			UpdateAllControlsList(control, value);
 
 			if (!String.IsNullOrEmpty(value))
 			{
-				this.m_ToolTipWhenDisabled[p_control] = value;
-				if (!p_control.Enabled)
+				_toolTipWhenDisabled[control] = value;
+				if (!control.Enabled)
 				{
 					// When the control is disabled at design time, the EnabledChanged
 					// event won't fire. So, on the first Paint event, we should call
 					// PutOnBetterTooltipTransparentOverlay().
-					m_EvtControlPaint.Add(p_control, new PaintEventHandler(control_Paint));
-					p_control.Paint += m_EvtControlPaint[p_control];
+					_paintEventHandlers.Add(control, new PaintEventHandler(control_Paint));
+					control.Paint += _paintEventHandlers[control];
 				}
-				m_EvtControlEnabledChanged.Add(p_control, new EventHandler(control_EnabledChanged));
-				p_control.EnabledChanged += m_EvtControlEnabledChanged[p_control];
+				_controlEnabledChangedHandlers.Add(control, new EventHandler(control_EnabledChanged));
+				control.EnabledChanged += _controlEnabledChangedHandlers[control];
 			}
 			else
 			{
-				m_ToolTipWhenDisabled.Remove(p_control);
-				if (m_EvtControlEnabledChanged != null)
-				{
-					p_control.EnabledChanged -= m_EvtControlEnabledChanged[p_control];
-					m_EvtControlEnabledChanged.Remove(p_control);
-					m_EvtControlPaint.Remove(p_control);
-				}
+				_toolTipWhenDisabled.Remove(control);
+				control.EnabledChanged -= _controlEnabledChangedHandlers[control];
+				_controlEnabledChangedHandlers.Remove(control);
+				_paintEventHandlers.Remove(control);
 			}
 		}
 
 		private void control_Paint(object sender, PaintEventArgs e)
 		{
-			Control l_control;
+			Control control;
 
-			l_control = (Control)sender;
-			this.PutOnBetterTooltipTransparentOverlay(l_control);
+			control = (Control)sender;
+			PutOnBetterTooltipTransparentOverlay(control);
 			// Immediately remove the handler because we don't need it any longer.
-			if (m_EvtControlPaint != null)
+			if (_paintEventHandlers != null)
 			{
-				l_control.Paint -= m_EvtControlPaint[l_control];
+				control.Paint -= _paintEventHandlers[control];
 			}
 		}
 
 		private void control_EnabledChanged(object sender, EventArgs e)
 		{
-			Control l_control;
+			Control control;
 
-			l_control = (Control)sender;
-			if (l_control.Enabled)
+			control = (Control)sender;
+			if (control.Enabled)
 			{
-				this.TakeOffBetterTooltipTransparentOverlay(l_control);
+				TakeOffBetterTooltipTransparentOverlay(control);
 			}
 			else
 			{
-				this.PutOnBetterTooltipTransparentOverlay(l_control);
+				PutOnBetterTooltipTransparentOverlay(control);
 			}
 		}
 
-		[Category("Misc"),
-		Description("Determines the ToolTip shown when the mouse hovers over the disabled control."),
-		Localizable(true),
-		Editor("MultilineStringEditor", "UITypeEditor"),
-		DefaultValue("")]
-		public string GetToolTipWhenDisabled(Control p_control)
+		[Category("Misc")]
+		[Description("Determines the ToolTip shown when the mouse hovers over the disabled control.")]
+		[Localizable(true)]
+		[Editor("MultilineStringEditor", "UITypeEditor")]
+		[DefaultValue("")]
+		public string GetToolTipWhenDisabled(Control control)
 		{
-			if (p_control == null)
+			if (control == null)
 			{
 				throw new ArgumentNullException("control");
 			}
 
-			if (m_ToolTipWhenDisabled.ContainsKey(p_control))
+			if (_toolTipWhenDisabled.ContainsKey(control))
+				return _toolTipWhenDisabled[control];
+
+			return String.Empty;
+		}
+
+		private void PutOnBetterTooltipTransparentOverlay(Control control)
+		{
+			var transparentOverlay = new BetterTooltipTransparentOverlay();
+			transparentOverlay.Location = control.Location;
+			if (_sizeOfToolTipWhenDisabledDictionary.ContainsKey(control))
 			{
-				return m_ToolTipWhenDisabled[p_control];
+				transparentOverlay.Size = _sizeOfToolTipWhenDisabledDictionary[control];
 			}
 			else
 			{
-				return String.Empty;
+				transparentOverlay.Size = control.Size;
 			}
+			control.Parent.Controls.Add(transparentOverlay);
+			transparentOverlay.BringToFront();
+			_betterTooltipTransparentOverlay[control] = transparentOverlay;
+			SetToolTip(transparentOverlay, _toolTipWhenDisabled[control]);
 		}
 
-		private void PutOnBetterTooltipTransparentOverlay(Control p_control)
+		private void TakeOffBetterTooltipTransparentOverlay(Control control)
 		{
-			BetterTooltipTransparentOverlay l_ts;
-
-			l_ts = new BetterTooltipTransparentOverlay();
-			l_ts.Location = p_control.Location;
-			if (m_SizeOfToolTipWhenDisabled.ContainsKey(p_control))
+			if (_betterTooltipTransparentOverlay.ContainsKey(control))
 			{
-				l_ts.Size = this.m_SizeOfToolTipWhenDisabled[p_control];
-			}
-			else
-			{
-				l_ts.Size = p_control.Size;
-			}
-			p_control.Parent.Controls.Add(l_ts);
-			l_ts.BringToFront();
-			this.m_BetterTooltipTransparentOverlay[p_control] = l_ts;
-			this.SetToolTip(l_ts, m_ToolTipWhenDisabled[p_control]);
-		}
-
-		private void TakeOffBetterTooltipTransparentOverlay(Control p_control)
-		{
-			BetterTooltipTransparentOverlay l_ts;
-
-			if (m_BetterTooltipTransparentOverlay.ContainsKey(p_control))
-			{
-				l_ts = m_BetterTooltipTransparentOverlay[p_control];
-				p_control.Parent.Controls.Remove(l_ts);
-				this.SetToolTip(l_ts, String.Empty);
-				l_ts.Dispose();
-				m_BetterTooltipTransparentOverlay.Remove(p_control);
+				var transparentOverlay = _betterTooltipTransparentOverlay[control];
+				control.Parent.Controls.Remove(transparentOverlay);
+				SetToolTip(transparentOverlay, String.Empty);
+				transparentOverlay.Dispose();
+				_betterTooltipTransparentOverlay.Remove(control);
 			}
 		}
+
 		#endregion
 
 		#region L10NSharp ILocalizableComponent support
@@ -227,14 +218,14 @@ namespace Bloom.ToPalaso
 		public IEnumerable<LocalizingInfo> GetAllLocalizingInfoObjects(L10NSharpExtender extender)
 		{
 			var result = new List<LocalizingInfo>();
-			foreach (var ctrl in m_allControlsHavingToolTips)
+			foreach (var ctrl in _allControlsHavingToolTips)
 			{
 				var idPrefix = extender.GetLocalizingId(ctrl);
 				var normalTip = GetToolTip(ctrl);
 				if (!string.IsNullOrEmpty(normalTip))
 				{
 					var liNormal = new LocalizingInfo(ctrl, idPrefix + NORMAL_TIP)
-						{Text = normalTip, Category = LocalizationCategory.LocalizableComponent};
+						{ Text = normalTip, Category = LocalizationCategory.LocalizableComponent };
 					result.Add(liNormal);
 				}
 				var disabledTip = GetToolTipWhenDisabled(ctrl);
@@ -283,52 +274,50 @@ namespace Bloom.ToPalaso
 		#endregion
 
 		#region ========== Support for the oversized transparent sheet to cover multiple visual controls. ==========
-		private Dictionary<Control, Size> m_SizeOfToolTipWhenDisabled = new Dictionary<Control, Size>();
 
-		public void SetSizeOfToolTipWhenDisabled(Control p_control, Size value)
+		public void SetSizeOfToolTipWhenDisabled(Control control, Size value)
 		{
-			if (p_control == null)
+			if (control == null)
 			{
 				throw new ArgumentNullException("control");
 			}
 
 			if (!value.IsEmpty)
 			{
-				m_SizeOfToolTipWhenDisabled[p_control] = value;
+				_sizeOfToolTipWhenDisabledDictionary[control] = value;
 			}
 			else
 			{
-				m_SizeOfToolTipWhenDisabled.Remove(p_control);
+				_sizeOfToolTipWhenDisabledDictionary.Remove(control);
 			}
 		}
 
-		[Category("Misc"),
-		Description("Determines the size of the ToolTip when the control is disabled." +
-					 " Leave it to 0,0, unless you want the ToolTip to pop up over wider" +
-					 " rectangular area than this control."),
-		DefaultValue(typeof(Size), "0,0")]
-		public Size GetSizeOfToolTipWhenDisabled(Control p_control)
+		[Category("Misc")]
+		[Description("Determines the size of the ToolTip when the control is disabled." +
+			" Leave it to 0,0, unless you want the ToolTip to pop up over wider" +
+			" rectangular area than this control.")]
+		[DefaultValue(typeof(Size), "0,0")]
+		public Size GetSizeOfToolTipWhenDisabled(Control control)
 		{
-			if (p_control == null)
+			if (control == null)
 			{
 				throw new ArgumentNullException("control");
 			}
 
-			if (m_SizeOfToolTipWhenDisabled.ContainsKey(p_control))
+			if (_sizeOfToolTipWhenDisabledDictionary.ContainsKey(control))
 			{
-				return m_SizeOfToolTipWhenDisabled[p_control];
+				return _sizeOfToolTipWhenDisabledDictionary[control];
 			}
 			else
 			{
 				return Size.Empty;
 			}
 		}
+
 		#endregion
 
 		#region ========== Comment out this region if you are okay with the same Title/Icon for disabled controls. ==========
-		private PopupEventHandler m_EvtPopup;
 
-		private string m_strToolTipTitle;
 		/// <summary>
 		/// ToolTip title when control is disabled
 		/// </summary>
@@ -341,11 +330,10 @@ namespace Bloom.ToPalaso
 			set
 			{
 				base.ToolTipTitle = value;
-				this.m_strToolTipTitle = value;
+				_toolTipTitle = value;
 			}
 		}
 
-		private ToolTipIcon m_ToolTipIcon;
 		/// <summary>
 		/// ToolTip icon when control is disabled
 		/// </summary>
@@ -358,7 +346,7 @@ namespace Bloom.ToPalaso
 			set
 			{
 				base.ToolTipIcon = value;
-				this.m_ToolTipIcon = value;
+				_toolTipIcon = value;
 			}
 		}
 
@@ -371,20 +359,21 @@ namespace Bloom.ToPalaso
 			}
 			else
 			{
-				base.ToolTipTitle = this.m_strToolTipTitle;
-				base.ToolTipIcon = this.m_ToolTipIcon;
+				base.ToolTipTitle = _toolTipTitle;
+				base.ToolTipIcon = _toolTipIcon;
 			}
 		}
 
 		protected override void Dispose(bool disposing)
 		{
 			// Removing Popup Handler.
-			if (this.m_EvtPopup != null)
+			if (disposing)
 			{
-				this.Popup -= this.m_EvtPopup;
+				Popup -= EnhancedToolTip_Popup;
 			}
 			base.Dispose(disposing);
 		}
+
 		#endregion
 	}
 }

--- a/src/BloomExe/ToPalaso/BetterToolTip.cs
+++ b/src/BloomExe/ToPalaso/BetterToolTip.cs
@@ -20,9 +20,6 @@ namespace Bloom.ToPalaso
 	/// BetterToolTip supports the ToolTipWhenDisabled and SizeOfToolTipWhenDisabled
 	/// extender properties that can be used to show tooltip messages when the associated
 	/// control is disabled.
-	///
-	/// There is a problem with this class on Linux.  The transparent overlay seems to
-	/// prevent buttons from getting repainted. (https://jira.sil.org/browse/BL-348)
 	/// </summary>
 	[ProvideProperty("ToolTipWhenDisabled", typeof(Control))]
 	[ProvideProperty("SizeOfToolTipWhenDisabled", typeof(Control))]

--- a/src/BloomExe/ToPalaso/BetterToolTip.cs
+++ b/src/BloomExe/ToPalaso/BetterToolTip.cs
@@ -175,7 +175,7 @@ namespace Bloom.ToPalaso
 
 		private void PutOnBetterTooltipTransparentOverlay(Control control)
 		{
-			var transparentOverlay = new BetterTooltipTransparentOverlay();
+			var transparentOverlay = new BetterTooltipTransparentOverlay(control);
 			transparentOverlay.Location = control.Location;
 			if (_sizeOfToolTipWhenDisabledDictionary.ContainsKey(control))
 			{

--- a/src/BloomExe/ToPalaso/BetterTooltipTransparentOverlay.cs
+++ b/src/BloomExe/ToPalaso/BetterTooltipTransparentOverlay.cs
@@ -12,16 +12,16 @@ namespace Bloom.ToPalaso
 		public BetterTooltipTransparentOverlay()
 		{
 			// Disable painting the background.
-			this.SetStyle(ControlStyles.Opaque, true);
-			this.UpdateStyles();
+			SetStyle(ControlStyles.Opaque, true);
+			UpdateStyles();
 
 			// Make sure to set the AutoScaleMode property to None
 			// so that the location and size property don't automatically change
 			// when placed in a form that has different font than this.
-			this.AutoScaleMode = AutoScaleMode.None;
+			AutoScaleMode = AutoScaleMode.None;
 
 			// Tab stop on a transparent sheet makes no sense.
-			this.TabStop = false;
+			TabStop = false;
 		}
 
 		private const short WS_EX_TRANSPARENT = 0x20;
@@ -31,10 +31,10 @@ namespace Bloom.ToPalaso
 			[SecurityPermission(SecurityAction.LinkDemand, UnmanagedCode = true)]
 			get
 			{
-				CreateParams l_cp;
-				l_cp = base.CreateParams;
-				l_cp.ExStyle = (l_cp.ExStyle | WS_EX_TRANSPARENT);
-				return l_cp;
+				CreateParams createParams;
+				createParams = base.CreateParams;
+				createParams.ExStyle = (createParams.ExStyle | WS_EX_TRANSPARENT);
+				return createParams;
 			}
 		}
 	}}

--- a/src/BloomExe/ToPalaso/BetterTooltipTransparentOverlay.cs
+++ b/src/BloomExe/ToPalaso/BetterTooltipTransparentOverlay.cs
@@ -4,16 +4,27 @@ using System.Linq;
 using System.Security.Permissions;
 using System.Text;
 using System.Windows.Forms;
+using System.Drawing;
 
 namespace Bloom.ToPalaso
 {
 	class BetterTooltipTransparentOverlay : ContainerControl
 	{
-		public BetterTooltipTransparentOverlay()
+		private readonly Control _overlayedControl;
+
+		public BetterTooltipTransparentOverlay(Control overlayedControl)
 		{
-			// Disable painting the background.
-			SetStyle(ControlStyles.Opaque, true);
+			_overlayedControl = overlayedControl;
+
+			// We want our control to be transparent. However, this causes the parent
+			// background color to be painted instead of the control we're overlaying, so we
+			// need to do some special magic in OnPaint and draw the button we're overlaying.
+			// Originally the code set the Opaque style to prevent the background from painting,
+			// but on Linux that causes some pixels to not be redrawn when switching between
+			// tabs.
+			SetStyle(ControlStyles.SupportsTransparentBackColor, true);
 			UpdateStyles();
+			BackColor = Color.Transparent;
 
 			// Make sure to set the AutoScaleMode property to None
 			// so that the location and size property don't automatically change
@@ -31,10 +42,26 @@ namespace Bloom.ToPalaso
 			[SecurityPermission(SecurityAction.LinkDemand, UnmanagedCode = true)]
 			get
 			{
-				CreateParams createParams;
-				createParams = base.CreateParams;
+				// If we don't set the WS_EX_TRANSPARENT style the overlayed buttons don't
+				// paint properly on Windows.
+				CreateParams createParams = base.CreateParams;
 				createParams.ExStyle = (createParams.ExStyle | WS_EX_TRANSPARENT);
 				return createParams;
 			}
 		}
-	}}
+
+		protected override void OnPaint(PaintEventArgs e)
+		{
+			if (Parent == null)
+				return;
+
+			// Draw the control we're overlaying. On Linux it might not show properly
+			// otherwise, especially since it is disabled.
+			using (var behind = new Bitmap(Parent.ClientSize.Width, Parent.ClientSize.Height))
+			{
+				_overlayedControl.DrawToBitmap(behind, _overlayedControl.Bounds);
+				e.Graphics.DrawImage(behind, 0, 0);
+			}
+		}
+	}
+}

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -112,7 +112,7 @@ namespace Bloom.Workspace
 
 
 			_uiLanguageMenu.Visible = true;
-		   _settingsLauncherHelper.ManageComponent(_uiLanguageMenu);
+			_settingsLauncherHelper.ManageComponent(_uiLanguageMenu);
 
 			editBookCommand.Subscribe(OnEditBook);
 			sendReceiveCommand.Subscribe(OnSendReceive);


### PR DESCRIPTION
The copy/paste etc buttons used to have different colors on Linux, depending on whether they had a tooltip or not. This made it hard to distinguish enabled from disabled state.

This change fixes the appearance as well as the BetterTooltip class to properly paint transparency. It also
adds some missing tooltips.

This removes the workaround for BL-348 because it is no longer needed with this proper fix.