### PR TITLE
BL-899: Make overflowing boxes actually overflow to help people see what's up

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.css
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.css
@@ -207,7 +207,11 @@ TEXTAREA.province {
   height: 33px;
 }
 .overflow {
-  background-color: rgba(255, 0, 0, 0.7) !important;
+  color: red !important;
+  border: solid thin red !important;
+}
+.overflow p:empty:after {
+  content: '¶';
 }
 .Layout-Problem-Detected:before,
 .Layout-Problem-Detected:after {

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -241,7 +241,12 @@ TEXTAREA.province
 
 .overflow
 {
-	background-color: rgba(255, 0, 0, .7) !important; //a little transparency is helpful for troublshooting
+	//background-color: rgba(255, 0, 0, .7) !important; //a little transparency is helpful for troublshooting
+	color:red !important;
+	border: solid thin red !important; //NB: can't afford to go "thick" because it throws off the calculation
+	 p:empty:after{ //br:after would be great but it doesn't work
+		content:'¶';
+	}
 }
 .Layout-Problem-Detected{
 	//border: dashed thick green !important;

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -716,8 +716,9 @@ jQuery.fn.IsOverflowing = function () {
 
     //console.log('s='+element.scrollHeight+' c='+element.clientHeight);
 
+    // 
     return element.scrollHeight > element.clientHeight + focusedBorderFudgeFactor + growFromCenterVerticalFudgeFactor + shortBoxFudgeFactor ||
-            element.scrollWidth > element.clientWidth + focusedBorderFudgeFactor ||
+            element.scrollWidth > element.clientWidth  ||
         elemBottom > parentBottom + focusedBorderFudgeFactor;
 };
 

--- a/src/BloomBrowserUI/bookLayout/basePage.css
+++ b/src/BloomBrowserUI/bookLayout/basePage.css
@@ -85,7 +85,7 @@ TEXTAREA,
 TD {
   resize: none;
   /*don't show those cute little resize controls in Firefox 4 and greater*/
-  overflow: hidden;
+  overflow: visible;
   font-size: 143%;
   line-height: 1.5em;
   min-height: 1.8em;

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -71,7 +71,7 @@ TEXTAREA, .bloom-editable, TD
 {
 	resize: none;
 	/*don't show those cute little resize controls in Firefox 4 and greater*/
-	overflow: hidden;
+	overflow: visible;
 	font-size: 143%;
 	line-height: @defaultLineHeight;
 	min-height:  @defaultLineHeight + .3em;


### PR DESCRIPTION
Fixes BL-899:	"Initially after resizing, overflow indicator is stuck on unless you up-arrow so it all shows."

This is a wee bit experimental. Let's see if we like it.