### PR TITLE
BL-838 Decodable Reader Letters are wrong if changed

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/readerToolsModel.js
+++ b/src/BloomBrowserUI/bookEdit/js/readerToolsModel.js
@@ -333,6 +333,10 @@ var ReaderToolsModel = (function () {
         if (stages.length === 0)
             return;
 
+        if (this.stageNumber > 0) {
+            this.stageGraphemes = this.getKnownGraphemes(this.stageNumber); //BL-838
+        }
+
         // Letters up through current stage
         var letters = this.stageGraphemes;
 

--- a/src/BloomBrowserUI/bookEdit/js/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/js/readerToolsModel.ts
@@ -352,6 +352,10 @@ class ReaderToolsModel {
     var stages = this.synphony.getStages();
     if (stages.length === 0) return;
 
+    if (this.stageNumber > 0) {
+      this.stageGraphemes = this.getKnownGraphemes(this.stageNumber); //BL-838
+    }
+
     // Letters up through current stage
     var letters = this.stageGraphemes;
 


### PR DESCRIPTION
If you change the letters of a stage and then close the
dialog, the accordion tool doesn't update to show the
new letters.