### PR TITLE
BL-546 Decodable Reader Tool PUA character display issue

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/readerToolsModel.js
+++ b/src/BloomBrowserUI/bookEdit/js/readerToolsModel.js
@@ -320,6 +320,9 @@ var ReaderToolsModel = (function () {
                 longestWord = w.Name;
         }
 
+        var div = $('div.wordList');
+        div.css('font-family', model.fontName);
+
         ReaderToolsModel.updateElementContent("wordList", result);
 
         $.divsToColumnsBasedOnLongestWord('word', longestWord);
@@ -353,6 +356,8 @@ var ReaderToolsModel = (function () {
             var letter = letters[i];
             result += '<div class="letter">' + letter + '</div>';
         }
+        var div = $('div.letterList');
+        div.css('font-family', model.fontName);
 
         ReaderToolsModel.updateElementContent("letterList", result);
 

--- a/src/BloomBrowserUI/bookEdit/js/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/js/readerToolsModel.ts
@@ -340,6 +340,9 @@ class ReaderToolsModel {
       if (w.Name.length > longestWord.length) longestWord = w.Name;
     }
 
+    var div = $('div.wordList');
+    div.css('font-family', model.fontName);
+
     ReaderToolsModel.updateElementContent("wordList", result);
 
     $.divsToColumnsBasedOnLongestWord('word', longestWord);
@@ -372,6 +375,8 @@ class ReaderToolsModel {
       var letter = letters[i];
       result += '<div class="letter">' + letter + '</div>';
     }
+    var div = $('div.letterList');
+    div.css('font-family', model.fontName);
 
     ReaderToolsModel.updateElementContent("letterList", result);
 


### PR DESCRIPTION
Decodable reader tool not displaying characters and words with
PUA characters.  If the user set the font for the current
languages to Charis SIL and entered PUA characters into
the Letters and Letters Combination, they displayed
correctly on the Stages Setup screen, but not on the
accordion screen displaying the letters and words for
the current stage.  The fix applies the user specified
font to the letters and words divs on the accordion screen
as they are applied on the setup screen.