### PR TITLE
BL-982 Format dialog showing a code when it should show a language name

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
@@ -764,7 +764,12 @@ var StyleEditor = (function () {
         if (this.shouldSetDefaultRule()) {
             return localizationManager.getText('BookEditor.DefaultForText', 'This formatting is the default for all text boxes with \'{0}\' style', styleName);
         }
-        var lang = $(this.boxBeingEdited).attr('lang');
+
+        //BL-982 Use language name that appears on text windows
+        var iso = $(this.boxBeingEdited).attr('lang');
+        var lang = localizationManager.getLanguageName(iso);
+        if (!lang)
+            lang = iso;
         return localizationManager.getText('BookEditor.ForTextInLang', 'This formatting is for all {0} text boxes with \'{1}\' style', lang, styleName);
     };
 

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -810,7 +810,11 @@ class StyleEditor {
         if (this.shouldSetDefaultRule()) {
             return localizationManager.getText('BookEditor.DefaultForText', 'This formatting is the default for all text boxes with \'{0}\' style', styleName);
         }
-        var lang = $(this.boxBeingEdited).attr('lang');
+        //BL-982 Use language name that appears on text windows
+        var iso = $(this.boxBeingEdited).attr('lang');
+        var lang = localizationManager.getLanguageName(iso);
+        if (!lang)
+            lang = iso;
         return localizationManager.getText('BookEditor.ForTextInLang', 'This formatting is for all {0} text boxes with \'{1}\' style', lang, styleName);
     }
 


### PR DESCRIPTION
Made change so that it looks up the language name and uses that
in the message.  The name used now matches the name that appears
in the lower right in shadow within each text box.