### PR TITLE
BL-1085: Add mime info for bloom-desktop-unstable

### DIFF
--- a/debian/bloom-desktop-unstable.sharedmimeinfo
+++ b/debian/bloom-desktop-unstable.sharedmimeinfo
@@ -1,7 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
 	<mime-type type="application/bloom-collection">
 		<comment>Bloom Book Collection</comment>
 		<glob pattern="*.bloomCollection"/>
+	</mime-type>
+	<mime-type type="application/bloom">
+		<comment>Bloom books</comment>
+		<sub-class-of type="application/zip"/>
+		<glob pattern="*.bloompack"/>
 	</mime-type>
 </mime-info>

--- a/debian/bloom-desktop.sharedmimeinfo
+++ b/debian/bloom-desktop.sharedmimeinfo
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
-	<mime-type type="application/bloom">
-		<comment>Bloom books</comment>
-		<sub-class-of type="application/zip"/>
-		<glob pattern="*.bloompack"/>
-	</mime-type>
-</mime-info>


### PR DESCRIPTION
We won't know for sure if this fixes the problem until the Linux package is built.