### PR TITLE
Fix BL-1060, Trying to save page in the wrong book

### DIFF
--- a/build/getDependencies-windows.sh
+++ b/build/getDependencies-windows.sh
@@ -90,7 +90,7 @@ rm -rf ../src/BloomBrowserUI/bookEdit/test/libsynphony
 #     revision: bloom-3.0.tcbuildtag
 #     paths: {"pdfjs-viewer.zip!**"=>"DistFiles/pdf"}
 #     VCS: https://github.com/mozilla/pdf.js.git [gh-pages]
-# [3] build: chorus-win32-master NoStrongName (bt437)
+# [3] build: chorus-win32-master-nostrongname Continuous (bt437)
 #     project: Chorus
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=bt437
 #     clean: false
@@ -103,7 +103,7 @@ rm -rf ../src/BloomBrowserUI/bookEdit/test/libsynphony
 #     clean: false
 #     revision: bloom-3.0.tcbuildtag
 #     paths: {"xulrunner-29.0.1.en-US.win32.zip!**"=>"lib"}
-# [5] build: palaso-win32-master Continuous nostrongname (bt436)
+# [5] build: palaso-win32-master-nostrongname Continuous (bt436)
 #     project: libpalaso
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=bt436
 #     clean: false
@@ -123,7 +123,7 @@ rm -rf ../src/BloomBrowserUI/bookEdit/test/libsynphony
 #     clean: false
 #     revision: bloom-3.0.tcbuildtag
 #     paths: {"*.*"=>"lib/dotnet"}
-#     VCS: https://github.com/hatton/TidyManaged.git [master]
+#     VCS: https://github.com/BloomBooks/TidyManaged.git [master]
 
 # make sure output directories exist
 mkdir -p ../.
@@ -160,6 +160,9 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/ChorusHub.exe ../lib/dotnet/ChorusHub.exe
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/ChorusHubApp.exe ../lib/dotnet/ChorusHubApp.exe
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/ChorusMerge.exe ../lib/dotnet/ChorusMerge.exe
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/debug/Chorus.exe ../lib/dotnet/Chorus.exe
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/debug/ChorusHub.exe ../lib/dotnet/ChorusHub.exe
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/debug/ChorusMerge.exe ../lib/dotnet/ChorusMerge.exe
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/Autofac.dll ../lib/dotnet/Autofac.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/LibChorus.TestUtilities.dll ../lib/dotnet/LibChorus.TestUtilities.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/LibChorus.dll ../lib/dotnet/LibChorus.dll
@@ -167,6 +170,9 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/Palaso.dll ../lib/dotnet/Palaso.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/PalasoUIWindowsForms.dll ../lib/dotnet/PalasoUIWindowsForms.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/Vulcan.Uczniowie.HelpProvider.dll ../lib/dotnet/Vulcan.Uczniowie.HelpProvider.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/debug/Autofac.dll ../lib/dotnet/Autofac.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/debug/LibChorus.TestUtilities.dll ../lib/dotnet/LibChorus.TestUtilities.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/debug/LibChorus.dll ../lib/dotnet/LibChorus.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/icu.net.dll ../lib/dotnet/icu.net.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/icudt40.dll ../lib/dotnet/icudt40.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt437/bloom-3.0.tcbuildtag/icuin40.dll ../lib/dotnet/icuin40.dll

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -13,6 +13,7 @@ using Bloom.Collection;
 using Bloom.Edit;
 using Bloom.Properties;
 using Bloom.Publish;
+using L10NSharp;
 using MarkdownSharp;
 using Palaso.Code;
 using Palaso.Extensions;
@@ -1473,7 +1474,8 @@ namespace Bloom.Book
 			}
 			catch (Exception error)
 			{
-				Palaso.Reporting.ErrorReport.NotifyUserOfProblem(error, "Bloom had trouble saving a page. Please click Details below and report this to us. Then quit Bloom, run it again, and check to see if the page you just edited is missing anything. Sorry!");
+				var msg = LocalizationManager.GetString("Errors.CouldNotSavePage", "Bloom had trouble saving a page. Please click Details below and report this to us. Then quit Bloom, run it again, and check to see if the page you just edited is missing anything. Sorry!");
+				Palaso.Reporting.ErrorReport.NotifyUserOfProblem(error, msg);
 			}
 		}
 


### PR DESCRIPTION
Though we could never reproduce this bug, it did get reported several times. The last time, I had the user's collection, and found that Book A was being asked to save a page that came from book B. I'm unable to see how this is possible, or to reproduce it. However I did add in a bunch more logging which might help when the situation happens again. But even when it happens, we won't have the same failure because now it gets which book should do the saving from the page itself, rather than the "current book".