### PR TITLE
Fix BL-1060, Trying to save page in the wrong book

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -13,6 +13,7 @@ using Bloom.Collection;
 using Bloom.Edit;
 using Bloom.Properties;
 using Bloom.Publish;
+using L10NSharp;
 using MarkdownSharp;
 using Palaso.Code;
 using Palaso.Extensions;
@@ -1473,7 +1474,8 @@ namespace Bloom.Book
 			}
 			catch (Exception error)
 			{
-				Palaso.Reporting.ErrorReport.NotifyUserOfProblem(error, "Bloom had trouble saving a page. Please click Details below and report this to us. Then quit Bloom, run it again, and check to see if the page you just edited is missing anything. Sorry!");
+				var msg = LocalizationManager.GetString("Errors.CouldNotSavePage", "Bloom had trouble saving a page. Please click Details below and report this to us. Then quit Bloom, run it again, and check to see if the page you just edited is missing anything. Sorry!");
+				Palaso.Reporting.ErrorReport.NotifyUserOfProblem(error, msg);
 			}
 		}
 


### PR DESCRIPTION
Though we could never reproduce this bug, it did get reported several times. The last time, I had the user's collection, and found that Book A was being asked to save a page that came from book B. I'm unable to see how this is possible, or to reproduce it. However I did add in a bunch more logging which might help when the situation happens again. But even when it happens, we won't have the same failure because now it gets which book should do the saving from the page itself, rather than the "current book".