### PR TITLE
BL-846 Format Dialog doesn't always close when another box gets focus

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
@@ -510,6 +510,8 @@ var StyleEditor = (function () {
         }
         this._previousBox = targetBox;
 
+        $('#format-toolbar').remove(); // in case there's still one somewhere else
+
         // put the format button in the editable text box itself, so that it's always in the right place.
         // unfortunately it will be subject to deletion because this is an editable box. But we can mark it as uneditable, so that
         // the user won't see resize and drag controls when they click on it

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -519,6 +519,8 @@ class StyleEditor {
         }
         this._previousBox = targetBox;
 
+        $('#format-toolbar').remove(); // in case there's still one somewhere else
+
         // put the format button in the editable text box itself, so that it's always in the right place.
         // unfortunately it will be subject to deletion because this is an editable box. But we can mark it as uneditable, so that
         // the user won't see resize and drag controls when they click on it


### PR DESCRIPTION
If you have the format dialog open in a text box and click in
another text box not currently in focus at exactly the point the
gear icon will appear in that box, focus shifts to the new box but
the format dialog for the original text box remains open.  The fix
makes sure that the focus event triggers the removal of any open
format dialogs as it shifts the gear icon from one box to the other.