### PR TITLE
Book Titles for SHRP books

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -150,9 +150,16 @@ namespace Bloom.Book
 				
 				if (string.IsNullOrEmpty(display))
 				{
+					//the SIL-LEAD project, SHRP (around 2012-2016) had books that just had an English name, before we changed Bloom
+					//to not show English names. But the order was also critical. So we want those old books to go ahead and use their
+					//English names.
+					var englishTitle = title.GetExactAlternative("en").ToLower();
+					var SHRPMatches = new string[] {"p1", "p2", "p3", "p4", "SHRP"};
+					var couldBeOldStyleUgandaSHRPBook = SHRPMatches.Any(m => englishTitle.Contains(m.ToLower()));
+
 					//if this book is one of the ones we're editing in our collection, it really
 					//needs a title in our main language, it would be confusing to show a title from some other langauge
-					if (IsEditable ||  title.Empty)
+					if(!couldBeOldStyleUgandaSHRPBook && (IsEditable || title.Empty))
 					{
 						display = LocalizationManager.GetString("CollectionTab.TitleMissing", "Title Missing",
 							"Shown as the thumbnail caption when the book doesn't have a title");

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -139,6 +139,18 @@ namespace BloomTests.Book
 			Assert.AreEqual("aa", textarea2.InnerText);
 		}
 
+		[Test]
+		public void UpdateFieldsAndVariables_HasBookTitleTemplateWithVernacularPlaceholder_CreatesTitleForVernacular()
+		{
+			var dom = new HtmlDom(@"<html ><head></head><body>
+				<div id='bloomDataDiv'>
+						<div data-book='bookTitleTemplate' lang='{V}'>the title</div>
+				</div>
+				</body></html>");
+			var data = new BookData(dom, _collectionSettings, null);
+			data.UpdateVariablesAndDataDivThroughDOM();
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-book='bookTitle' and @lang='"+_collectionSettings.Language1Iso639Code+"' and text()='the title']",1);
+		}
 
 		[Test]
 		public void UpdateFieldsAndVariables_VernacularTitleChanged_TitleCopiedToParagraphAnotherPage()


### PR DESCRIPTION
1) Allow you to have lang={V} in the declaration of the book title template.
2) Bloom has been changed to prefer "No Title" or somesuch if the vernacular title is missing. But we have hundreds of books with only English in the SIL-LEAD/SHRP project. Fortunately these books have a set pattern for names, so this commit detects the situation and allows the English name to be displayed.