### PR TITLE
Use a Label control to display "Submitting to server..." (BL-1004)

### DIFF
--- a/src/BloomExe/MiscUI/ProblemReporterDialog.Designer.cs
+++ b/src/BloomExe/MiscUI/ProblemReporterDialog.Designer.cs
@@ -43,6 +43,7 @@
 			this._seeDetails = new System.Windows.Forms.LinkLabel();
 			this._cancelButton = new System.Windows.Forms.Button();
 			this._status = new Bloom.HtmlLabel();
+			this._submitMsg = new System.Windows.Forms.Label();
 			((System.ComponentModel.ISupportInitialize)(this._L10NSharpExtender)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this._screenshotHolder)).BeginInit();
 			this.SuspendLayout();
@@ -241,6 +242,22 @@
 			this._status.Size = new System.Drawing.Size(337, 84);
 			this._status.TabIndex = 28;
 			// 
+			// _submitMsg
+			// 
+			this._submitMsg.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+				| System.Windows.Forms.AnchorStyles.Right)));
+			this._submitMsg.BackColor = System.Drawing.SystemColors.Control;
+			this._submitMsg.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this._submitMsg.Text = "";
+			this._L10NSharpExtender.SetLocalizableToolTip(this._submitMsg, null);
+			this._L10NSharpExtender.SetLocalizationComment(this._submitMsg, null);
+			this._L10NSharpExtender.SetLocalizingId(this._submitMsg, "ReportProblemDialog.SubmitLabel");
+			this._submitMsg.Location = new System.Drawing.Point(21, 406);
+			this._submitMsg.Name = "_submitMsg";
+			this._submitMsg.Size = new System.Drawing.Size(337, 84);
+			this._submitMsg.TabIndex = 29;
+			this._submitMsg.Visible = false;
+			// 
 			// ProblemReporterDialog
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -260,6 +277,7 @@
 			this.Controls.Add(this.label1);
 			this.Controls.Add(this._cancelButton);
 			this.Controls.Add(this._status);
+			this.Controls.Add(this._submitMsg);
 			this._L10NSharpExtender.SetLocalizableToolTip(this, null);
 			this._L10NSharpExtender.SetLocalizationComment(this, null);
 			this._L10NSharpExtender.SetLocalizingId(this, "ReportProblemDialog.WindowTitle");
@@ -295,5 +313,6 @@
 		private System.Windows.Forms.LinkLabel _seeDetails;
 		private HtmlLabel _status;
 		private System.Windows.Forms.Button _cancelButton;
+		private System.Windows.Forms.Label _submitMsg;
 	}
 }

--- a/src/BloomExe/MiscUI/ProblemReporterDialog.cs
+++ b/src/BloomExe/MiscUI/ProblemReporterDialog.cs
@@ -46,6 +46,14 @@ namespace Bloom.MiscUI
 
 			InitializeComponent();
 
+			// The GeckoFx-based _status control refuses to display the "Submitting to server..." message
+			// on Linux, although it displays just fine on Windows.  Even moving the actual process of
+			// submitting the information to another thread doesn't help -- the message still doesn't
+			// display.  Substituting a normal Label control for that particular messages works just fine.
+			// See https://jira.sil.org/browse/BL-1004 for details.
+			_submitMsg.Text = LocalizationManager.GetString ("ReportProblemDialog.Submitting", "Submitting to server...",
+				"This is shown while Bloom is sending the problem report to our server.");
+
 			if (targetOfScreenshot != null)
 			{
 				//important to do this early, before this dialog obstructs the application
@@ -143,12 +151,14 @@ namespace Bloom.MiscUI
 			{
 				case State.WaitingForSubmission:
 					_status.Visible = false;
+					_submitMsg.Visible = false;
 					_seeDetails.Visible = true;
 					Cursor = Cursors.Default;
 					break;
 
 				case State.ZippingUpBook:
 					_seeDetails.Visible = false;
+					_submitMsg.Visible = false;
 					_status.Visible = true;
 					_status.HTML = LocalizationManager.GetString("ReportProblemDialog.Zipping", "Zipping up book...",
 						"This is shown while Bloom is creating the problem report. It's generally too fast to see, unless you include a large book.");
@@ -158,15 +168,15 @@ namespace Bloom.MiscUI
 
 				case State.Submitting:
 					_seeDetails.Visible = false;
-					_status.Visible = true;
-					_status.HTML = LocalizationManager.GetString("ReportProblemDialog.Submitting", "Submitting to server...",
-						"This is shown while Bloom is sending the problem report to our server.");
+					_status.Visible = false;
+					_submitMsg.Visible = true;
 					_submitButton.Enabled = false;
 					Cursor = Cursors.WaitCursor;
 					break;
 
 				case State.CouldNotAutomaticallySubmit:
 					_seeDetails.Visible = false;
+					_submitMsg.Visible = false;
 					_status.Visible = true;
 					var message = LocalizationManager.GetString("ReportProblemDialog.CouldNotSendToServer",
 						"Bloom was not able to submit your report directly to our server. Please retry or email {0} to {1}.");
@@ -179,6 +189,7 @@ namespace Bloom.MiscUI
 
 				case State.Success:
 					_seeDetails.Visible = false;
+					_submitMsg.Visible = false;
 					_status.Visible = true;
 					_submitButton.Enabled = true;
 					_submitButton.Text = LocalizationManager.GetString("ReportProblemDialog.Close", "Close", "Shown in the button that closes the dialog after a successful report submission.");


### PR DESCRIPTION
The Geckofx-based control refuses to display this message despite three or four different approaches (including multithreading) to get it to work.  Using a separate control is simple, even if not elegant.