### PR TITLE
BL-987: Lower Linux memory use by changing thumbnail image rendering

### DIFF
--- a/src/BloomBrowserUI/bookEdit/BookPagesThumbnailList/BookPagesThumbnailList.htm
+++ b/src/BloomBrowserUI/bookEdit/BookPagesThumbnailList/BookPagesThumbnailList.htm
@@ -17,7 +17,7 @@
             });
             fireCSharpEvent("gridReordered", ids);
         };
-        jQuery(document).ready(function () {
+        jQuery().ready(function () {
             $('.gridly').gridly({
                 base: 35, // px
                 gutter: 10, // px

--- a/src/BloomExe/Edit/WebThumbNailList.cs
+++ b/src/BloomExe/Edit/WebThumbNailList.cs
@@ -552,6 +552,15 @@ namespace Bloom.Edit
 			var dom = new HtmlDom(htmlText);
 			dom = firstRealPage.Book.GetHtmlDomReadyToAddPages(dom);
 			var pageDoc = dom.RawDom;
+
+			// BL-987: Add styles to optimize performance on Linux
+			if (Palaso.PlatformUtilities.Platform.IsLinux)
+			{
+				var style = pageDoc.CreateElement("style");
+				style.InnerXml = "img { image-rendering: optimizeSpeed; image-rendering: -moz-crisp-edges; image-rendering: crisp-edges; }";
+				pageDoc.GetElementsByTagName("head")[0].AppendChild(style);
+			}
+
 			var body = pageDoc.GetElementsByTagName("body")[0];
 			var gridlyParent = body.FirstChild; // too simplistic?
 			int pageNumber = 0;


### PR DESCRIPTION
The CSS image-rendering attribute dramatically lowers the memory usage on Linux, but seems to not have the same affect on Windows. If it is applied on Windows, the image quality is degraded but the memory usage stays the same.