### PR TITLE
BL-1033/1034 Small pics cycled red overflow

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -775,7 +775,6 @@ function AddOverflowHandler(container) {
         var minHeight = parseInt($(this).css("min-height"), 10);
         var overflowy = $(this).css("overflow-y");
         if (overflowy == 'hidden') {
-            // why don't we do this all the time!?
             $(this).css("min-height", lineHeight); // BL-1034 premature scroll bars
         }
         if (lineHeight > minHeight) {

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -773,6 +773,11 @@ function AddOverflowHandler(container) {
     $(container).find(".bloom-editable").each(function (e) {
         var lineHeight = parseInt($(this).css("line-height"), 10);
         var minHeight = parseInt($(this).css("min-height"), 10);
+        var overflowy = $(this).css("overflow-y");
+        if (overflowy == 'hidden') {
+            // why don't we do this all the time!?
+            $(this).css("min-height", lineHeight); // BL-1034 premature scroll bars
+        }
         if (lineHeight > minHeight) {
             $(this).addClass('Layout-Problem-Detected');
             $(this).attr("LayoutProblem", "min-height is less than lineHeight");

--- a/src/BloomBrowserUI/bookLayout/basePage.css
+++ b/src/BloomBrowserUI/bookLayout/basePage.css
@@ -294,6 +294,9 @@ H2 {
   z-index: 1000;
   overflow: hidden;
 }
+.customPage .bloom-editable {
+  overflow-y: hidden;
+}
 .customPage .split-pane-component {
   min-height: 1.5em;
 }

--- a/src/BloomBrowserUI/bookLayout/basePage.css
+++ b/src/BloomBrowserUI/bookLayout/basePage.css
@@ -291,8 +291,8 @@ H2 {
 .customPage .bloom-imageContainer {
   width: 99%;
   height: 98%;
-  /*above so buttons show*/
   z-index: 1000;
+  overflow: hidden;
 }
 .customPage .split-pane-component {
   min-height: 1.5em;

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -286,8 +286,10 @@ H2 {
 	.bloom-imageContainer {
 		width: 99%;
 		height: 98%;
-		/*above so buttons show*/
+		// above so buttons show
 		z-index: 1000;
+		// Solves BL-1033 small picture frames cycling red overflow
+        overflow: hidden;
 	}
 	.split-pane-component {
 		//Enhance: this doesn't buy us much... it would be more helpful if the minimum was

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -291,6 +291,9 @@ H2 {
 		// Solves BL-1033 small picture frames cycling red overflow
         overflow: hidden;
 	}
+    .bloom-editable {
+        overflow-y: hidden;
+    }
 	.split-pane-component {
 		//Enhance: this doesn't buy us much... it would be more helpful if the minimum was
 		// the min-height of the child


### PR DESCRIPTION
For BL-1033, the pics were cycling due to trying to show scrollbars. But the pics are already resizing to the correct size for the box, so no point in having scrollbars. I made the scrollbars stop happening and the pics are fine.

For BL-1034, the CustomPage textboxes were getting vertical scrollbars too soon primarily because of a basePage rule for min-height of 1.8em. Our normal pages want the average textbox to have a minimum size so things get spaced out well, but here the user is determining the spacing and if he wants to squash things together, I suppose we shouldn't complain too much. I just set the min-height to be equal to the line-height if the vertical scrollbars have been turned off. In the case of the CustomPage here, it doesn't matter if extra text is shown because it won't be visible outside the nearest divider anyway.