### PR TITLE
Bl 1125 add topic

### DIFF
--- a/DistFiles/localization/Bloom.en.tmx
+++ b/DistFiles/localization/Bloom.en.tmx
@@ -1112,6 +1112,12 @@
         <seg>This book is locked down as shell. Are you sure you want to change the picture?</seg>
       </tuv>
     </tu>
+    <tu tuid="EditTab.TopicButton">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Choose Topic...</seg>
+      </tuv>
+    </tu>
     <tu tuid="EditTab.LayoutMode.ChangeLayout">
       <prop type="x-nolongerused">true</prop>
       <prop type="x-dynamic">true</prop>

--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.css
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.css
@@ -123,6 +123,12 @@
 .frontCover .bottomBlock .coverBottomBookTopic .bloom-content1:not(.bloom-contentNational1) {
   color: gray;
 }
+.frontCover .bottomBlock .coverBottomBookTopic .bloom-editable:not(:empty) ~ #topicButton {
+  display: none;
+}
+.frontCover .bottomBlock .coverBottomBookTopic #topicButton {
+  display: inline;
+}
 .frontCover .bottomBlock .publishMode .coverBottomBookTopic .bloom-contentNational2 {
   display: none;
 }
@@ -261,6 +267,9 @@ BODY[editmode="translation"] .titlePage #originalContributions .bloom-contentNat
 BODY[editmode="translation"] .titlePage #funding .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
+}
+BODY[editmode="translation"] .frontCover .bottomBlock .coverBottomBookTopic #topicButton {
+  display: none;
 }
 .titlePage {
   text-align: center;

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
@@ -123,6 +123,12 @@
 .frontCover .bottomBlock .coverBottomBookTopic .bloom-content1:not(.bloom-contentNational1) {
   color: gray;
 }
+.frontCover .bottomBlock .coverBottomBookTopic .bloom-editable:not(:empty) ~ #topicButton {
+  display: none;
+}
+.frontCover .bottomBlock .coverBottomBookTopic #topicButton {
+  display: inline;
+}
 .frontCover .bottomBlock .publishMode .coverBottomBookTopic .bloom-contentNational2 {
   display: none;
 }
@@ -261,6 +267,9 @@ BODY[editmode="translation"] .titlePage #originalContributions .bloom-contentNat
 BODY[editmode="translation"] .titlePage #funding .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
+}
+BODY[editmode="translation"] .frontCover .bottomBlock .coverBottomBookTopic #topicButton {
+  display: none;
 }
 .titlePage {
   text-align: center;

--- a/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
+++ b/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
@@ -123,6 +123,12 @@
 .frontCover .bottomBlock .coverBottomBookTopic .bloom-content1:not(.bloom-contentNational1) {
   color: gray;
 }
+.frontCover .bottomBlock .coverBottomBookTopic .bloom-editable:not(:empty) ~ #topicButton {
+  display: none;
+}
+.frontCover .bottomBlock .coverBottomBookTopic #topicButton {
+  display: inline;
+}
 .frontCover .bottomBlock .publishMode .coverBottomBookTopic .bloom-contentNational2 {
   display: none;
 }
@@ -261,6 +267,9 @@ BODY[editmode="translation"] .titlePage #originalContributions .bloom-contentNat
 BODY[editmode="translation"] .titlePage #funding .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
+}
+BODY[editmode="translation"] .frontCover .bottomBlock .coverBottomBookTopic #topicButton {
+  display: none;
 }
 .titlePage {
   text-align: center;

--- a/DistFiles/xMatter/bloom-xmatter-common.css
+++ b/DistFiles/xMatter/bloom-xmatter-common.css
@@ -123,6 +123,12 @@
 .frontCover .bottomBlock .coverBottomBookTopic .bloom-content1:not(.bloom-contentNational1) {
   color: gray;
 }
+.frontCover .bottomBlock .coverBottomBookTopic .bloom-editable:not(:empty) ~ #topicButton {
+  display: none;
+}
+.frontCover .bottomBlock .coverBottomBookTopic #topicButton {
+  display: inline;
+}
 .frontCover .bottomBlock .publishMode .coverBottomBookTopic .bloom-contentNational2 {
   display: none;
 }
@@ -261,6 +267,9 @@ BODY[editmode="translation"] .titlePage #originalContributions .bloom-contentNat
 BODY[editmode="translation"] .titlePage #funding .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
+}
+BODY[editmode="translation"] .frontCover .bottomBlock .coverBottomBookTopic #topicButton {
+  display: none;
 }
 .titlePage {
   text-align: center;

--- a/DistFiles/xMatter/bloom-xmatter-common.less
+++ b/DistFiles/xMatter/bloom-xmatter-common.less
@@ -159,6 +159,14 @@
                     color: gray;
                 }
             }
+            .bloom-editable:not(:empty) {
+                ~ #topicButton {
+                    display: none;
+                }
+            }
+            #topicButton {
+                display: inline;
+            }
         }
 
         .publishMode {
@@ -348,6 +356,15 @@ BODY[editmode="translation"] {
             .bloom-contentNational1 {
                 display: inherit;
                 min-height: 3em; // two lines
+            }
+        }
+    }
+    .frontCover {
+        .bottomBlock {
+            .coverBottomBookTopic {
+                #topicButton {
+                    display: none;
+                }
             }
         }
     }

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -128,8 +128,9 @@ function MakeHelpBubble(targetElement, elementWithBubbleAttributes) {
         adjust: { method: 'none' }
         };
 
-    if (target.hasClass('coverBottomBookTopic'))
-        pos.adjust = { y: -20 };
+    // Anybody know why this was here!? BL-1125 complains about this very thing.
+    //if (target.hasClass('coverBottomBookTopic'))
+    //    pos.adjust = { y: -20 };
 
     //temporarily disabling this; the problem is that its more natural to put the hint on enclosing 'translationgroup' element, but those elements are *never* empty.
     //maybe we could have this logic, but change this logic so that for all items within a translation group, they get their a hint from a parent, and then use this isempty logic

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -1552,14 +1552,20 @@ function SetupElements(container) {
 
     SetOverlayForImagesWithoutMetadata(container);
 
-    //note, the normal way is for the user to click the link on the qtip.
-    //But clicking on the exiting topic may be natural too, and this prevents
-    //them from editing it by hand.
-    $(container).find("div[data-book='topic']").click(function () {
-        if ($(this).css('cursor') == 'not-allowed')
-            return;
-        TopicChooser.showTopicChooser();
-    });
+    if(IsFrontCover(container)) {
+        //note, the normal way is for the user to click the link on the qtip.
+        //But clicking on the exiting topic may be natural too, and this prevents
+        //them from editing it by hand.
+        $(container).find("div[data-book='topic']").click(function () {
+            if ($(this).css('cursor') == 'not-allowed')
+                return;
+            ChooseTopic();
+        });
+
+        if(!HasTopic(container)) {
+            AddTopicButton();
+        }
+    }
 
     // Copy source texts out to their own div, where we can make a bubble with tabs out of them
     // We do this because if we made a bubble out of the div, that would suck up the vernacular editable area, too,
@@ -1661,6 +1667,38 @@ function FixUpOnFirstInput() {
             selection.modify("extend", "backward", "character");
         }
     }
+}
+
+function HasTopic(container) {
+    var result = false;
+    $(container).find('.bloom-editable[data-book="topic"]').each(function () {
+        if($(this).text().trim().length > 0) {
+            result = true;
+        }
+    });
+    return result;
+}
+
+function IsFrontCover(container) {
+    return $(container).find('.frontCover').length != 0;
+}
+
+function AddTopicButton() {
+    var topicDiv = $('.coverBottomBookTopic')[0];
+    var button = document.createElement('button');
+    $(button).attr('id', "topicButton");
+    $(button).attr('type', 'button');
+    $(button).addClass('bloom-ui');
+    $(button).attr('onClick', 'ChooseTopic()');
+    $(button).text("Choose Topic...");
+    $(topicDiv).append(button);
+    localizationManager.asyncGetTextInLang("EditTab.TopicButton", "Choose Topic...", "UI").done(function(translation) {
+        $("#topicButton").text(translation);
+    });
+}
+
+function ChooseTopic() {
+    TopicChooser.showTopicChooser();
 }
 
 


### PR DESCRIPTION
Puts the topic qtip back where it belongs next to the topic instead of above it.
If there is no topic already chosen and we are NOT in translation mode,
this will add a button labeled "Choose Topic..." to the front cover in edit mode.
Choosing a topic will hide the button.