### PR TITLE
BL-1010 Deleting resized split on custom page produces error

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/origami.js
+++ b/src/BloomBrowserUI/bookEdit/js/origami.js
@@ -115,6 +115,8 @@ function closeClickHandler() {
     var myComponent = $(this).closest('.split-pane-component');
     var sibling = myComponent.siblings('.split-pane-component').first('div');
     var toReplace = myComponent.parent().parent();
+    var parentHeight = toReplace.height();
+    var parentWidth = toReplace.width();
     var positionClass = toReplace.attr('class');
     toReplace.replaceWith(sibling);
 
@@ -124,6 +126,8 @@ function closeClickHandler() {
         return (css.match (/(^|\s)position-\S+/g) || []).join(' ');
     });
     sibling.addClass(positionClass);
+    sibling.height(parentHeight);
+    sibling.width(parentWidth);
 }
 
 function getSplitPaneHtml(verticalOrHorizontal) {


### PR DESCRIPTION
This also corrects BL-1043 which is essentially a duplicate. Creating
a split on a custom page, resizing it and then deleting it resulted in
the remaining split from the pair to be the wrong size.  This
occurred with either vertical or horizontal splits.  The fix provided
here saves the width and height of the original parent and applies it
to the updated sibling which is replacing it, as it currently saves the
class.