### PR TITLE
BL-788 [Trusty Linux] Print dialog opens behind Bloom window

### DIFF
--- a/src/BloomExe/Publish/PdfViewer.cs
+++ b/src/BloomExe/Publish/PdfViewer.cs
@@ -90,13 +90,29 @@ namespace Bloom.Publish
 				((AdobeReaderControl)_pdfViewerControl).Print();
 				return;
 			}
-#endif
+
 			var browser = ((GeckoWebBrowser)_pdfViewerControl);
 			using (AutoJSContext context = new AutoJSContext(browser.Window.JSContext))
 			{
 				string result;
 				context.EvaluateScript(@"window.print()", (nsISupports)browser.Document.DomObject, out result);
 			}
+#else
+			var browser = ((GeckoWebBrowser)_pdfViewerControl);
+			using (AutoJSContext context = new AutoJSContext(browser.Window.JSContext))
+			{
+				// BL-788 Print dialog appears behind Bloom on Linux
+				// Finally went to minimizing Bloom to allow the print window to be 
+				// displayed and then restore to the original size after the 
+				// Print or Cancel button is pushed on the print dialog.
+				var savedState = this.ParentForm.WindowState;
+				this.ParentForm.WindowState = FormWindowState.Minimized;
+				Application.DoEvents();
+				string result;
+				context.EvaluateScript(@"window.print()", (nsISupports)browser.Document.DomObject, out result);
+				this.ParentForm.WindowState = savedState;
+			}
+#endif
 		}
 	}
 }


### PR DESCRIPTION
The print dialog appears behind Bloom on Linux except for the
first time it is displayed.

This solution is a compromise since I was unable to find a way
to resolve the issue by bringing the print dialog to the foreground
in all cases.  This solution minimizes Bloom when the print button
is pressed on a Linux system.  The print dialog displays.  When the
user either presses cancel or print, Bloom is restored to the
foreground at the same size it was before Print was pressed.