### PR TITLE
Bl 1027 nice context menu error; also .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ node_modules/
 *.usertasks
 Andika-R.ttf
 *~
+Bloom/


### PR DESCRIPTION
1st commit .gitignores the Squirrel directory
2nd commit gives a nicer error message if Firefox is not in the PATH
    If in Linux, the message doesn't specify Firefox, but System Browser, since we don't specifically call Firefox