### PR TITLE
Logging and error handling for a pp update

### DIFF
--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -60,7 +60,7 @@ namespace Bloom
 				}
 				else
 				{
-					updateUrl = InstallerSupport.SquirrelUpdateUrl;
+					updateUrl = InstallerSupport.GetSquirrelUpdateUrl();
 				}
 				if (string.IsNullOrEmpty(updateUrl))
 				{
@@ -133,7 +133,7 @@ namespace Bloom
 		{
 			if (OkToInitiateUpdateManager)
 			{
-				var updateUrl = InstallerSupport.SquirrelUpdateUrl;
+				var updateUrl = InstallerSupport.GetSquirrelUpdateUrl();
 				if (string.IsNullOrEmpty(updateUrl))
 					return;
 				UpdateInfo info;

--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -122,6 +122,13 @@ namespace Bloom
 			};
 		}
 
+		public static string ChannelName
+		{
+			get
+			{
+				return Assembly.GetEntryAssembly().ManifestModule.Name.Replace("Bloom", "").Replace(".exe", "").Trim();
+			}
+		}
 		internal static async void InitiateSquirrelNotifyUpdatesAvailable(Action<string> restartBloom)
 		{
 			if (OkToInitiateUpdateManager)

--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -1,15 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Bloom.MiscUI;
 using Bloom.Properties;
-using Bloom.Workspace;
 using L10NSharp;
 using Palaso.PlatformUtilities;
 using Squirrel;
@@ -39,7 +36,7 @@ namespace Bloom
 		/// a restart. This is the responsibility of the caller (typically the workspace view). It is passed the new
 		/// install directory.
 		/// </summary>
-		internal static async void InitiateSquirrelUpdate(BloomUpdateMessageVerbosity verbosity, Action<string> restartBloom)
+		internal static async void CheckForASquirrelUpdate(BloomUpdateMessageVerbosity verbosity, Action<string> restartBloom, bool autoUpdate)
 		{
 			if (OkToInitiateUpdateManager)
 			{
@@ -60,16 +57,39 @@ namespace Bloom
 				}
 				else
 				{
-					updateUrl = InstallerSupport.GetSquirrelUpdateUrl();
+					var result = InstallerSupport.LookupUrlOfSquirrelUpdate();
+
+					if (result.Error != null || string.IsNullOrEmpty(result.URL))
+					{
+						// no need to tell them we can't connect, if they didn't explicitly ask us to look for an update
+						if (verbosity != BloomUpdateMessageVerbosity.Verbose) return;
+
+						// but if they did, try and give them a hint about what went wrong
+						if (result.IsConnectivityError)
+						{
+
+							var failMsg = LocalizationManager.GetString("CollectionTab.UnableToCheckForUpdate",
+								"Could not connect to the server to check for an update. Are you connected to the internet?",
+								"Shown when Bloom tries to check for an update but can't, for example becuase it can't connect to the internet, or a problems with our server, etc.");
+							ShowFailureNotification(failMsg);
+
+						}
+						else if (result.Error == null)
+						{
+							Palaso.Reporting.ErrorReport.NotifyUserOfProblem(
+								"Bloom failed to find if there is an update available, for some unknown reason.");
+						}
+						else
+						{
+							ShowFailureNotification(result.Error.Message);
+						}
+						return;
+					}
+					updateUrl = result.URL;
 				}
-				if (string.IsNullOrEmpty(updateUrl))
+				if (!autoUpdate)
 				{
-					// For some reason we couldn't get one...possibly not online so can't get to UpdateVersionTable.
-					// Or we may not have created one for the current channel...for example, running a debug build not in the debugger.
-					var failNotifier = new ToastNotifier();
-					failNotifier.Image.Image = Resources.Bloom.ToBitmap();
-					var failMsg = LocalizationManager.GetString("CollectionTab.UnableToCheck", "Unable to check for update.", "Shown when Bloom tries to check for an update but can't, for example becuase it can't connect to the internet, or a problems with our server, etc.");
-					failNotifier.Show(failMsg, "", 5);
+					ApplicationUpdateSupport.InitiateSquirrelNotifyUpdatesAvailable(updateUrl, restartBloom);
 					return;
 				}
 
@@ -109,6 +129,13 @@ namespace Bloom
 			}
 		}
 
+		private static void ShowFailureNotification(string failMsg)
+		{
+			var failNotifier = new ToastNotifier();
+			failNotifier.Image.Image = Resources.Bloom.ToBitmap();
+			failNotifier.Show(failMsg, "", 5);
+		}
+
 		internal static void ArrangeToDisposeSquirrelManagerOnExit()
 		{
 			Application.ApplicationExit += (sender, args) =>
@@ -122,20 +149,25 @@ namespace Bloom
 			};
 		}
 
+		internal static string ChannelNameForUnitTests;
+
 		public static string ChannelName
 		{
 			get
 			{
-				return Assembly.GetEntryAssembly().ManifestModule.Name.Replace("Bloom", "").Replace(".exe", "").Trim();
+				if (ChannelNameForUnitTests != null)
+				{
+					return ChannelNameForUnitTests;
+				}
+				var s = Assembly.GetEntryAssembly().ManifestModule.Name.Replace("bloom", "").Replace("Bloom", "").Replace(".exe", "").Trim();
+				return (s == "") ? "Release" : s;
 			}
 		}
-		internal static async void InitiateSquirrelNotifyUpdatesAvailable(Action<string> restartBloom)
+
+		private static async void InitiateSquirrelNotifyUpdatesAvailable(string updateUrl, Action<string> restartBloom)
 		{
 			if (OkToInitiateUpdateManager)
 			{
-				var updateUrl = InstallerSupport.GetSquirrelUpdateUrl();
-				if (string.IsNullOrEmpty(updateUrl))
-					return;
 				UpdateInfo info;
 				ArrangeToDisposeSquirrelManagerOnExit();
 				using (_bloomUpdateManager = new UpdateManager(updateUrl, Application.ProductName, FrameworkVersion.Net45))
@@ -146,14 +178,18 @@ namespace Bloom
 				// Since this is in the async method _after_ the await we know the CheckForUpdate has finished.
 				_bloomUpdateManager = null;
 				if (NoUpdatesAvailable(info))
+				{
+					Palaso.Reporting.Logger.WriteEvent("Squirrel: No updateavailable.");
 					return; // none available.
+				}
 				var msg = LocalizationManager.GetString("CollectionTab.UpdatesAvailable", "A new version of Bloom is available.");
 				var action = LocalizationManager.GetString("CollectionTab.UpdateNow", "Update Now");
+				Palaso.Reporting.Logger.WriteEvent("Squirrel: Notifying that an update is available");
 				// Unfortunately, there's no good time to dispose of this object...according to its own comments
 				// it's not even safe to close it. It moves itself out of sight eventually if ignored.
 				var notifier = new ToastNotifier();
 				notifier.Image.Image = Resources.Bloom.ToBitmap();
-				notifier.ToastClicked += (sender, args) => InitiateSquirrelUpdate(BloomUpdateMessageVerbosity.Quiet, restartBloom);
+				notifier.ToastClicked += (sender, args) => CheckForASquirrelUpdate(BloomUpdateMessageVerbosity.Verbose, restartBloom, true);
 				notifier.Show(msg, action, 10);
 			}
 		}
@@ -195,6 +231,7 @@ namespace Bloom
 				var version = updateInfo.FutureReleaseEntry.Version;
 				var size = updateInfo.ReleasesToApply.Sum(x => x.Filesize)/1024;
 				var updatingMsg = String.Format(LocalizationManager.GetString("CollectionTab.Updating", "Downloading update to {0} ({1}K)"), version, size);
+				Palaso.Reporting.Logger.WriteEvent("Squirrel: "+updatingMsg);
 				updatingNotifier.Show(updatingMsg, "", 5);
 
 				await manager.DownloadReleases(updateInfo.ReleasesToApply, x => progress(x / 3 + 33));

--- a/src/BloomExe/InstallerSupport.cs
+++ b/src/BloomExe/InstallerSupport.cs
@@ -54,28 +54,31 @@ namespace Bloom
 			}
 		}
 
-		internal static string SquirrelUpdateUrl
+		/// <summary>
+		/// Note: this actually has to go out over the web to get the answer, and may fail
+		/// </summary>
+		/// <returns></returns>
+		internal static string GetSquirrelUpdateUrl()
 		{
-			get
+			if (_squirrelUpdateUrl == null)
 			{
-				if (_squirrelUpdateUrl == null)
+				try
 				{
-					try
-					{
-						_squirrelUpdateUrl = new UpdateVersionTable().GetAppcastUrl();
-					}
-					catch (WebException)
-					{
-					}
+					_squirrelUpdateUrl = new UpdateVersionTable().GetAppcastUrl();
 				}
-				return _squirrelUpdateUrl;
+				catch (WebException e)
+				{
+					//enhance: we could do some translation by looking at e.Status, which is one of WebExceptionStatus, e.g. WebExceptionStatus.ConnectFailure
+					Palaso.Reporting.Logger.WriteEvent("**Error in SquirrelUpdateUrl: " + e.Message);
+				}
 			}
+			return _squirrelUpdateUrl;
 		}
 
 		internal static void HandleSquirrelInstallEvent(string[] args)
 		{
 			bool firstTime = false;
-			var updateUrl = SquirrelUpdateUrl;
+			var updateUrl = GetSquirrelUpdateUrl();
 			// Should only be null if we're not online. Not sure how squirrel will handle that,
 			// but at least one of these operations is responsible for setting up shortcuts to the program,
 			// which we'd LIKE to work offline. Passing it a plausible url, even though it will presumably fail,

--- a/src/BloomExe/SplashScreen.cs
+++ b/src/BloomExe/SplashScreen.cs
@@ -57,7 +57,7 @@ namespace Bloom
 			//try really hard to become top most. See http://stackoverflow.com/questions/5282588/how-can-i-bring-my-application-window-to-the-front
 			TopMost = true;
 			Focus();
-			var channel = Assembly.GetEntryAssembly().ManifestModule.Name.Replace("Bloom", "").Replace(".exe", "").Trim();
+			var channel = ApplicationUpdateSupport.ChannelName;
 			_channelLabel.Visible = channel.ToLower() != "release";
 			_channelLabel.Text = LocalizationManager.GetDynamicString("Bloom", "SplashScreen." + channel, channel);
 			BringToFront();

--- a/src/BloomExe/UpdateVersionTable.cs
+++ b/src/BloomExe/UpdateVersionTable.cs
@@ -60,12 +60,7 @@ namespace Bloom
 
 		private string GetUrlOfTable()
 		{
-			// assemblyName is usually something like "BloomAlpha. In a developer debug build (or main stable release)
-			// it will be simply "Bloom." This allows each channel to have its own update table.
-			var assemblyName = Assembly.GetExecutingAssembly().GetName().Name;
-			if (assemblyName.StartsWith("Bloom"))
-				assemblyName = assemblyName.Substring("Bloom".Length);
-			return String.Format(URLOfTable, assemblyName);
+			return String.Format(URLOfTable, ApplicationUpdateSupport.ChannelName);
 		}
 	}
 }

--- a/src/BloomExe/UpdateVersionTable.cs
+++ b/src/BloomExe/UpdateVersionTable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Reflection;
+using Palaso.Reporting;
 
 namespace Bloom
 {
@@ -22,18 +23,57 @@ namespace Bloom
 		//unit tests can pre-set this
 		public  Version RunningVersion { get; set; }
 
+		public class UpdateTableLookupResult
+		{
+			public string URL;
+			public WebException Error;
+
+			public bool IsConnectivityError
+			{
+				get
+				{
+					return Error != null &&
+					       Error.Status == WebExceptionStatus.Timeout || Error.Status == WebExceptionStatus.NameResolutionFailure;
+				}
+			}
+		}
 
 		/// <summary>
 		/// Note! This will propogate network exceptions, so client can catch them and warn or not warn the user.
 		/// </summary>
 		/// <returns></returns>
-		public  string GetAppcastUrl()
+		public UpdateTableLookupResult LookupURLOfUpdate()
 		{
-			if (string.IsNullOrEmpty(TextContentsOfTable))
+			if (String.IsNullOrEmpty(TextContentsOfTable))
 			{
+				Logger.WriteEvent("Enter LookupURLOfUpdate()");
 				var client = new WebClient();
 				{
-					TextContentsOfTable =  client.DownloadString(GetUrlOfTable());
+					try
+					{
+						Logger.WriteMinorEvent("Channel is '" + ApplicationUpdateSupport.ChannelName + "'");
+						Logger.WriteMinorEvent("UpdateVersionTable looking for UpdateVersionTable URL: " + GetUrlOfTable());
+						TextContentsOfTable = client.DownloadString(GetUrlOfTable());
+						Logger.WriteMinorEvent("UpdateVersionTable contents are " + Environment.NewLine + TextContentsOfTable);
+					}
+					catch (WebException e)
+					{
+						Logger.WriteEvent("***Error in LookupURLOfUpdate: " + e.Message);
+						if (e.Status == WebExceptionStatus.ProtocolError)
+						{
+							var resp = e.Response as HttpWebResponse;
+							if (resp != null && resp.StatusCode == HttpStatusCode.NotFound)
+							{
+								Logger.WriteEvent(String.Format("***Error: UpdateVersionTable failed to find a file at {0} (channel='{1}'",
+									GetUrlOfTable(), ApplicationUpdateSupport.ChannelName));
+							}
+						}
+						else if (IsConnectionError(e))
+						{
+							Logger.WriteEvent("***Error: UpdateVersionTable could not connect to the server");
+						}
+						return new UpdateVersionTable.UpdateTableLookupResult() {Error = e};
+					}
 				}
 			}
 			if (RunningVersion == default(Version))
@@ -53,14 +93,24 @@ namespace Bloom
 				var lower = Version.Parse(parts[0]);
 				var upper = Version.Parse(parts[1]);
 				if (lower <= RunningVersion && upper >= RunningVersion)
-					return parts[2].Trim();
+					return new UpdateVersionTable.UpdateTableLookupResult() {URL = parts[2].Trim()};
 			}
-			return string.Empty;
+			return  new UpdateVersionTable.UpdateTableLookupResult() {URL = String.Empty};
 		}
 
 		private string GetUrlOfTable()
 		{
 			return String.Format(URLOfTable, ApplicationUpdateSupport.ChannelName);
+		}
+
+		private bool IsConnectionError(WebException ex)
+		{
+			return
+				ex.Status == WebExceptionStatus.Timeout ||
+				ex.Status == WebExceptionStatus.NameResolutionFailure;
+				//I'm not sure if you'd ever get one of these?
+//				ex.Status == WebExceptionStatus.ReceiveFailure ||
+	//			ex.Status == WebExceptionStatus.ConnectFailure;
 		}
 	}
 }

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -172,12 +172,9 @@ namespace Bloom.Workspace
 		private void _applicationUpdateCheckTimer_Tick(object sender, EventArgs e)
 		{
 			_applicationUpdateCheckTimer.Enabled = false;
-			//if (!Debugger.IsAttached)
+			if (!Debugger.IsAttached)
 			{
-				if (Settings.Default.AutoUpdate)
-					ApplicationUpdateSupport.InitiateSquirrelUpdate(ApplicationUpdateSupport.BloomUpdateMessageVerbosity.Quiet, newInstallDir => RestartBloom(newInstallDir));
-				else
-					ApplicationUpdateSupport.InitiateSquirrelNotifyUpdatesAvailable(newInstallDir => RestartBloom(newInstallDir));
+				ApplicationUpdateSupport.CheckForASquirrelUpdate(ApplicationUpdateSupport.BloomUpdateMessageVerbosity.Quiet, newInstallDir => RestartBloom(newInstallDir), Settings.Default.AutoUpdate);
 			}
 		}
 
@@ -495,8 +492,8 @@ namespace Bloom.Workspace
 			}
 			else
 			{
-				ApplicationUpdateSupport.InitiateSquirrelUpdate(ApplicationUpdateSupport.BloomUpdateMessageVerbosity.Verbose,
-					newInstallDir => RestartBloom(newInstallDir));
+				ApplicationUpdateSupport.CheckForASquirrelUpdate(ApplicationUpdateSupport.BloomUpdateMessageVerbosity.Verbose,
+					newInstallDir => RestartBloom(newInstallDir), Settings.Default.AutoUpdate);
 			}
 		}
 

--- a/src/BloomTests/UpdateVersionTableTests.cs
+++ b/src/BloomTests/UpdateVersionTableTests.cs
@@ -28,7 +28,9 @@ namespace BloomTests
 		public void ServerAddressIsBogus_ErrorIsCorrect()
 		{
 			var t = new UpdateVersionTable {URLOfTable = "http://notthere7blah/foo.txt"};
-			Assert.AreEqual(WebExceptionStatus.NameResolutionFailure, t.LookupURLOfUpdate().Error.Status);
+			//the jenkins server gets a ProtocolError, while my desktop gets a NameResolutionFailure
+			var e = t.LookupURLOfUpdate().Error.Status;
+			Assert.IsTrue(e  == WebExceptionStatus.NameResolutionFailure || e == WebExceptionStatus.ProtocolError );
 		}
 		[Test]
 		public void FileForThisChannelIsMissing_ErrorIsCorrect()


### PR DESCRIPTION
Add logging and enhanced error handling plus refactoring/clarifying

The central thing here was changing how we handle problems encountered when we look for the version table. We now create a result-object that has the url if we got one, and and the exception if we got one. The exception is logged and the user is notified at the point that we get it, instead of leaving it to clients. But clients get the full object, and can continue to decide what to do, as before.

This also normalized code for determining the channel name.

Logging happens so that if there is a problem, the log will tell us what happened.