### PR TITLE
BL-1013 Allow localization of xmatter pack descriptions

### DIFF
--- a/DistFiles/xMatter/Factory-XMatter/description-en.txt
+++ b/DistFiles/xMatter/Factory-XMatter/description-en.txt
@@ -1,1 +1,1 @@
-Designed to save paper, this puts the credits on the inside of the front cover.
+[V1]Designed to save paper, this puts the credits on the inside of the front cover.

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/description-en.txt
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/description-en.txt
@@ -1,2 +1,2 @@
-* Credits on the back of the title page.
+[V1]* Credits on the back of the title page.
 * Includes ISO 639 code on the credits page.

--- a/DistFiles/xMatter/Traditional-XMatter/description-en.txt
+++ b/DistFiles/xMatter/Traditional-XMatter/description-en.txt
@@ -1,1 +1,1 @@
-* Credits on the back of the title page.
+[V1]* Credits on the back of the title page.

--- a/src/BloomExe/Book/XMatterInfo.cs
+++ b/src/BloomExe/Book/XMatterInfo.cs
@@ -73,21 +73,9 @@ namespace Bloom.Book
 			var endIndex = fullDescription.IndexOf("]", StringComparison.InvariantCulture);
 			if (endIndex < 2)
 				return 0;
-			try
-			{
-				int result;
-				return Int32.TryParse(fullDescription.Substring(2, endIndex - 2),
-					NumberStyles.Integer, CultureInfo.InvariantCulture, out result) ? result : 0;
-			}
-			// Catch both known exceptions, since humans will create these version strings.
-			catch (FormatException)
-			{
-				return 0;
-			}
-			catch (OverflowException)
-			{
-				return 0;
-			}
+			int result;
+			return Int32.TryParse(fullDescription.Substring(2, endIndex - 2),
+				NumberStyles.Integer, CultureInfo.InvariantCulture, out result) ? result : 0;
 		}
 
 		private static string StripVersionOff(string fullDescription)

--- a/src/BloomExe/Book/XMatterInfo.cs
+++ b/src/BloomExe/Book/XMatterInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using L10NSharp;
 
 namespace Bloom.Book
 {
@@ -31,19 +32,66 @@ namespace Bloom.Book
 
 		public string GetDescription()
 		{
+			const string desc = "description-";
 			try
 			{
-				var path = Path.Combine(PathToFolder, "description-en.txt");
-				if(File.Exists(path))
-				{
-					return File.ReadAllText(path);
-				}
-				return "";
+				// try to read English XMatter pack description first
+				// we need version number at least
+				var pathEnglish = Path.Combine(PathToFolder, desc + "en.txt");
+				if (!File.Exists(pathEnglish))
+					return string.Empty;
+
+				var englishDescription = File.ReadAllText(pathEnglish);
+				if (!englishDescription.StartsWith("[V"))
+					return englishDescription;
+
+				// Once we put [V1] in the english description we could have translations
+				// for other UI languages.
+				var uiLangId = LocalizationManager.UILanguageId;
+				var enVersion = GetVersionNumberString(englishDescription);
+				englishDescription = StripVersionOff(englishDescription);
+				var pathUiLang = Path.Combine(PathToFolder, desc + uiLangId + ".txt");
+				if (uiLangId == "en" || !File.Exists(pathUiLang))
+					return englishDescription;
+
+				var uiLangDescription = File.ReadAllText(pathUiLang);
+				var uiVersion = GetVersionNumberString(uiLangDescription);
+				uiLangDescription = StripVersionOff(uiLangDescription);
+				return enVersion > uiVersion || uiVersion == 0 || uiLangDescription.Length < 2 ? englishDescription : uiLangDescription;
 			}
 			catch (Exception error)
 			{
 				return error.Message;
 			}
+		}
+
+		private static int GetVersionNumberString(string fullDescription)
+		{
+			if (!fullDescription.StartsWith("[V"))
+				return 0;
+			var endIndex = fullDescription.IndexOf("]", StringComparison.InvariantCulture);
+			if (endIndex < 2)
+				return 0;
+			try
+			{
+				return Convert.ToInt32(fullDescription.Substring(2, endIndex - 2));
+			}
+			// Catch both known exceptions, since humans will create these version strings.
+			catch (FormatException)
+			{
+				return 0;
+			}
+			catch (OverflowException)
+			{
+				return 0;
+			}
+		}
+
+		private static string StripVersionOff(string fullDescription)
+		{
+			if (!fullDescription.StartsWith("[V"))
+				return fullDescription;
+			return fullDescription.Substring(fullDescription.IndexOf("]", StringComparison.InvariantCulture) + 1);
 		}
 	}
 }

--- a/src/BloomExe/Book/XMatterInfo.cs
+++ b/src/BloomExe/Book/XMatterInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using L10NSharp;
 
@@ -74,7 +75,9 @@ namespace Bloom.Book
 				return 0;
 			try
 			{
-				return Convert.ToInt32(fullDescription.Substring(2, endIndex - 2));
+				int result;
+				return Int32.TryParse(fullDescription.Substring(2, endIndex - 2),
+					NumberStyles.Integer, CultureInfo.InvariantCulture, out result) ? result : 0;
 			}
 			// Catch both known exceptions, since humans will create these version strings.
 			catch (FormatException)
@@ -91,7 +94,10 @@ namespace Bloom.Book
 		{
 			if (!fullDescription.StartsWith("[V"))
 				return fullDescription;
-			return fullDescription.Substring(fullDescription.IndexOf("]", StringComparison.InvariantCulture) + 1);
+			var closeBracketIndex = fullDescription.IndexOf("]", StringComparison.InvariantCulture);
+			return (closeBracketIndex > 2 && fullDescription.Length > 4)
+				? fullDescription.Substring(closeBracketIndex + 1)
+				: fullDescription;
 		}
 	}
 }


### PR DESCRIPTION
Now localizers will be able to copy the description-en.txt file in an xmatter pack to description-xx.txt, where xx = another UI language code
and translate the English text.
If later, we change the English to [V2] or later, Bloom will use the English until the other UI language catches up.