### PR TITLE
BL-1040 Show book name while editing

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryBookView.cs
+++ b/src/BloomExe/CollectionTab/LibraryBookView.cs
@@ -18,6 +18,7 @@ namespace Bloom.CollectionTab
 		private readonly SendReceiver _sendReceiver;
 		private readonly CreateFromSourceBookCommand _createFromSourceBookCommand;
 		private readonly EditBookCommand _editBookCommand;
+		private Shell _shell;
 		private bool _reshowPending = false;
 		private bool _visible;
 
@@ -56,11 +57,24 @@ namespace Bloom.CollectionTab
 			LoadBook();
 		}
 
+		private void UpdateTitleBar()
+		{
+			if (this.ParentForm != null)
+			{
+				_shell = (Shell)this.ParentForm;
+			}
+			if (_shell != null)
+			{
+				_shell.SetWindowText((_bookSelection.CurrentSelection == null) ? null : _bookSelection.CurrentSelection.TitleBestForUserDisplay);
+			}
+		}
+
 		void OnBookSelectionChanged(object sender, EventArgs e)
 		{
 			try
 			{
 				LoadBook();
+				UpdateTitleBar();
 			}
 			catch (Exception error)
 			{
@@ -86,6 +100,7 @@ namespace Bloom.CollectionTab
 			{
 				_reshowPending = true;
 			}
+			UpdateTitleBar();
 		}
 
 		private void ShowBook()

--- a/src/BloomExe/Shell.cs
+++ b/src/BloomExe/Shell.cs
@@ -134,7 +134,7 @@ namespace Bloom
 			}
 			if(_collectionSettings.IsSourceCollection)
 			{
-				formattedText += "SOURCE COLLECTION";
+				formattedText += " SOURCE COLLECTION";
 			}
 			Text = formattedText;
 		}

--- a/src/BloomExe/Shell.cs
+++ b/src/BloomExe/Shell.cs
@@ -79,7 +79,7 @@ namespace Bloom
 
 			this.Controls.Add(this._workspaceView);
 
-			SetWindowText();
+			SetWindowText(null);
 		}
 
 		protected override void OnHandleCreated(EventArgs e)
@@ -125,13 +125,18 @@ namespace Bloom
 			base.OnClosing(e);
 		}
 
-		private void SetWindowText()
+		public void SetWindowText(string bookName)
 		{
-			Text = string.Format("{0} - Bloom {1} Built on {2}", _workspaceView.Text, GetShortVersionInfo(), GetBuiltOnDate());
+			string formattedText = string.Format("{0} - Bloom {1} Built on {2}", _workspaceView.Text, GetShortVersionInfo(), GetBuiltOnDate());
+			if (bookName != null)
+			{
+				formattedText = string.Format("{0} - {1}", bookName, formattedText);
+			}
 			if(_collectionSettings.IsSourceCollection)
 			{
-				Text += "SOURCE COLLECTION";
+				formattedText += "SOURCE COLLECTION";
 			}
+			Text = formattedText;
 		}
 
 		public static string GetBuiltOnDate()


### PR DESCRIPTION
This change adds the bookname to the application title bar.
When the application starts or a book has been deleted so that
there is no selection, the title appears without a book name.
Otherwise, any time a book is selected, it appears first, followed
by the collection name, followed by the release and build
date information.