### PR TITLE
Bl 1121 preserve credits across language changes

### DIFF
--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
@@ -20,10 +20,12 @@
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable bloom-nodefaultstylerule Title-On-Cover-style" data-book="bookTitle">
           </div>
         </div>
-        <div class="bloom-imageContainer"><img src="placeHolder.png" data-book="coverImage"/></div>
-        <div class="creditsWrapper">
-          <div lang="V" contenteditable="true" class="bloom-content1 bloom-editable smallCoverCredits Cover-Default-style" data-book="smallCoverCredits" data-metalanguage="V">
-            <label class="bubble">*You may use this space for author/illustrator, or anything else.</label>
+        <div class="bloom-imageContainer"><img src="placeHolder.png" data-book="coverImage"/>
+          <!--NB: don't convert this to an inline label; that interferes with the bloom-copyFromOtherLanguageIfNecessary,-->
+          <!-- because it is never empty-->
+        </div>
+        <div data-hint="label.bubble *You may use this space for author/illustrator, or anything else." class="creditsWrapper">
+          <div lang="V" contenteditable="true" class="bloom-content1 bloom-editable smallCoverCredits bloom-copyFromOtherLanguageIfNecessary Cover-Default-style" data-book="smallCoverCredits" data-metalanguage="V">
           </div>
         </div>
         <div class="bottomBlock">
@@ -70,12 +72,12 @@
         </div>
         <div class="bloom-translationGroup" id="originalContributions">
           <label class="bubble">The contributions made by writers, illustrators, editors, etc., in {lang}</label>
-          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable credits bloom-readOnlyInTranslationMode Original-Contributors-On-Title-Page-style" data-book="originalContributions">
+          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable credits bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary Original-Contributors-On-Title-Page-style" data-book="originalContributions">
           </div>
         </div>
         <div class="bloom-translationGroup" id="funding">
           <label class="bubble">Use this to acknowledge any funding agencies.</label>
-          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable funding Funding-On-Title-Page-style" data-book="funding">
+          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable funding Funding-On-Title-Page-style bloom-copyFromOtherLanguageIfNecessary" data-book="funding">
           </div>
         </div>
         <div id="languageInformation">

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
@@ -92,7 +92,7 @@
   display: inherit;
   text-align: center;
   line-height: 1.7em;
-  min-height: 1.7;
+  min-height: 1.7em;
   height: auto;
 }
 .frontCover .bottomBlock {

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.htm
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.htm
@@ -20,10 +20,12 @@
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable bloom-nodefaultstylerule Title-On-Cover-style" data-book="bookTitle">
           </div>
         </div>
-        <div class="bloom-imageContainer"><img src="placeHolder.png" data-book="coverImage"/></div>
-        <div class="creditsWrapper">
-          <div lang="V" contenteditable="true" class="bloom-content1 bloom-editable smallCoverCredits Cover-Default-style" data-book="smallCoverCredits" data-metalanguage="V">
-            <label class="bubble">*You may use this space for author/illustrator, or anything else.</label>
+        <div class="bloom-imageContainer"><img src="placeHolder.png" data-book="coverImage"/>
+          <!--NB: don't convert this to an inline label; that interferes with the bloom-copyFromOtherLanguageIfNecessary,-->
+          <!-- because it is never empty-->
+        </div>
+        <div data-hint="label.bubble *You may use this space for author/illustrator, or anything else." class="creditsWrapper">
+          <div lang="V" contenteditable="true" class="bloom-content1 bloom-editable smallCoverCredits bloom-copyFromOtherLanguageIfNecessary Cover-Default-style" data-book="smallCoverCredits" data-metalanguage="V">
           </div>
         </div>
         <div class="bottomBlock">
@@ -53,12 +55,12 @@
         </div>
         <div class="bloom-translationGroup" id="originalContributions">
           <label class="bubble">The contributions made by writers, illustrators, editors, etc., in {lang}</label>
-          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable credits bloom-readOnlyInTranslationMode Original-Contributors-On-Title-Page-style" data-book="originalContributions">
+          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable credits bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary Original-Contributors-On-Title-Page-style" data-book="originalContributions">
           </div>
         </div>
         <div class="bloom-translationGroup" id="funding">
           <label class="bubble">Use this to acknowledge any funding agencies.</label>
-          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable funding Funding-On-Title-Page-style" data-book="funding">
+          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable funding Funding-On-Title-Page-style bloom-copyFromOtherLanguageIfNecessary" data-book="funding">
           </div>
         </div>
         <div id="languageInformation">

--- a/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
+++ b/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
@@ -92,7 +92,7 @@
   display: inherit;
   text-align: center;
   line-height: 1.7em;
-  min-height: 1.7;
+  min-height: 1.7em;
   height: auto;
 }
 .frontCover .bottomBlock {

--- a/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.htm
+++ b/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.htm
@@ -20,10 +20,12 @@
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable bloom-nodefaultstylerule Title-On-Cover-style" data-book="bookTitle">
           </div>
         </div>
-        <div class="bloom-imageContainer"><img src="placeHolder.png" data-book="coverImage"/></div>
-        <div class="creditsWrapper">
-          <div lang="V" contenteditable="true" class="bloom-content1 bloom-editable smallCoverCredits Cover-Default-style" data-book="smallCoverCredits" data-metalanguage="V">
-            <label class="bubble">*You may use this space for author/illustrator, or anything else.</label>
+        <div class="bloom-imageContainer"><img src="placeHolder.png" data-book="coverImage"/>
+          <!--NB: don't convert this to an inline label; that interferes with the bloom-copyFromOtherLanguageIfNecessary,-->
+          <!-- because it is never empty-->
+        </div>
+        <div data-hint="label.bubble *You may use this space for author/illustrator, or anything else." class="creditsWrapper">
+          <div lang="V" contenteditable="true" class="bloom-content1 bloom-editable smallCoverCredits bloom-copyFromOtherLanguageIfNecessary Cover-Default-style" data-book="smallCoverCredits" data-metalanguage="V">
           </div>
         </div>
         <div class="bottomBlock">
@@ -53,12 +55,12 @@
         </div>
         <div class="bloom-translationGroup" id="originalContributions">
           <label class="bubble">The contributions made by writers, illustrators, editors, etc., in {lang}</label>
-          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable credits bloom-readOnlyInTranslationMode Original-Contributors-On-Title-Page-style" data-book="originalContributions">
+          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable credits bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary Original-Contributors-On-Title-Page-style" data-book="originalContributions">
           </div>
         </div>
         <div class="bloom-translationGroup" id="funding">
           <label class="bubble">Use this to acknowledge any funding agencies.</label>
-          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable funding Funding-On-Title-Page-style" data-book="funding">
+          <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable funding Funding-On-Title-Page-style bloom-copyFromOtherLanguageIfNecessary" data-book="funding">
           </div>
         </div>
         <div id="languageInformation">

--- a/DistFiles/xMatter/bloom-xmatter-common.css
+++ b/DistFiles/xMatter/bloom-xmatter-common.css
@@ -92,7 +92,7 @@
   display: inherit;
   text-align: center;
   line-height: 1.7em;
-  min-height: 1.7;
+  min-height: 1.7em;
   height: auto;
 }
 .frontCover .bottomBlock {

--- a/DistFiles/xMatter/bloom-xmatter-common.less
+++ b/DistFiles/xMatter/bloom-xmatter-common.less
@@ -123,7 +123,7 @@
             display: inherit;
             text-align: center;
             line-height: 1.7em;
-            min-height: 1.7;
+            min-height: 1.7em;
             height: auto;
         }
     }

--- a/DistFiles/xMatter/bloom-xmatter-mixins.jade
+++ b/DistFiles/xMatter/bloom-xmatter-mixins.jade
@@ -106,10 +106,11 @@ mixin factoryStandard-outsideFrontCover
 		.bloom-imageContainer
 			img(src="placeHolder.png", data-book='coverImage')
 
-		.creditsWrapper
+			//NB: don't convert this to an inline label; that interferes with the bloom-copyFromOtherLanguageIfNecessary,
+			// because it is never empty
+		.creditsWrapper(data-hint='label.bubble *You may use this space for author/illustrator, or anything else.')
 			//- 'V' means this field is only available in the vernacular
-			+field-mono-meta('V', "smallCoverCredits").smallCoverCredits.Cover-Default-style
-				label.bubble *You may use this space for author/illustrator, or anything else.
+			+field-mono-meta('V', "smallCoverCredits").smallCoverCredits.bloom-copyFromOtherLanguageIfNecessary.Cover-Default-style
 		.bottomBlock
 			.coverBottomLangName.Cover-Default-style(data-book='languagesOfBook')
 			+chooser-topic.coverBottomBookTopic
@@ -138,10 +139,10 @@ mixin factoryStandard-titlePage
 			+editable(kLanguageForPrototypeOnly).Title-On-Title-Page-style(data-book='bookTitle')
 		+field-prototypeDeclaredExplicity#originalContributions
 			label.bubble The contributions made by writers, illustrators, editors, etc., in {lang}
-			+editable(kLanguageForPrototypeOnly).credits.bloom-readOnlyInTranslationMode.Original-Contributors-On-Title-Page-style(data-book='originalContributions')
+			+editable(kLanguageForPrototypeOnly).credits.bloom-readOnlyInTranslationMode.bloom-copyFromOtherLanguageIfNecessary.Original-Contributors-On-Title-Page-style(data-book='originalContributions')
 		+field-prototypeDeclaredExplicity#funding
 			label.bubble Use this to acknowledge any funding agencies.
-			+editable(kLanguageForPrototypeOnly).funding.Funding-On-Title-Page-style(data-book='funding')
+			+editable(kLanguageForPrototypeOnly).funding.Funding-On-Title-Page-style.bloom-copyFromOtherLanguageIfNecessary(data-book='funding')
 		#languageInformation
 			.languagesOfBook(data-book='languagesOfBook')
 			//- review: can we get rid of these "langName" classes?

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -763,7 +763,12 @@ namespace Bloom.Book
 			string s = "";
 
 			if ((languageCodeOfTargetField == _collectionSettings.Language2Iso639Code || //is it a national language?
-				 languageCodeOfTargetField == _collectionSettings.Language3Iso639Code))
+				 languageCodeOfTargetField == _collectionSettings.Language3Iso639Code) ||
+				//this one is a kludge as we clearly have this case of a vernacular field that people have used
+				//to hold stuff that should be copied to every shell. So we can either remove the restriction of the
+				//first two clauses in this if statement, or add another bloom-___ class in order to make execptions.
+				//Today, I'm not seing the issue clearly enough, so I'm just going to path this one exisint hole.
+				 classes.Contains("smallCoverCredits"))
 			{
 				formToCopyFromSinceOursIsMissing =
 					data.TextVariables[key].TextAlternatives.GetBestAlternative(new[] {languageCodeOfTargetField, "*", "en", "fr", "es", "pt"});


### PR DESCRIPTION
Fix BL-1121 by making a number of fields to be copied when empty

The problem appears to be related to fields that are in a language, like credits, but which we really don't want to not show at all if the shell is used for some other language. These kinds of fields can be marked with a special class, bloom-copyFromOtherLanguageIfNecessary. This commit applies that to a few more fields. So far so good. However the original implementation didn't take into account the case of fields that are vernacular, like the front cover credits. I don't feel like I'm in a position to revisit that at the moment, so I made an exception for that one field. See the comments in the code.