### PR TITLE
BL-831 Unit Test Hangs

### DIFF
--- a/src/BloomTests/Edit/ConfiguratorTest.cs
+++ b/src/BloomTests/Edit/ConfiguratorTest.cs
@@ -173,14 +173,15 @@ namespace BloomTests.Edit
 		}
 
 		[Test]
-		[Platform(Exclude="Linux", Reason="Currently failing on Linux (BL-831)")]
 		public void WhenCollectedNoLocalDataThenLocalDataIsEmpty()
 		{
 			var first = new Configurator(_libraryFolder.Path, new NavigationIsolator());
-			dynamic j = new DynamicJson();
-			j.library = new DynamicJson();
-			j.library.librarystuff = "foo";
-			first.CollectJsonData(j.ToString());
+			var stringRep = DynamicJson.Serialize(new
+				{
+					library = new {librarystuff = "foo"}
+				});
+
+			first.CollectJsonData(stringRep.ToString());
 			AssertEmpty(first.LocalData);
 		}
 


### PR DESCRIPTION
Fixes the one unit test that was a true failure.  The others
are Jenkins only environment failures that work fine when
run on developers systems.  This one runs into problems
because the ToString isn't supported for a type "object" and
clearly states that it doesn't.  It also isn't called in the
code base that way.  This creates the same string another
equivalent way and verifies that the LocalData segment is empty.