### PR TITLE
BL-1179 Keep Custom license RightsStatement from duplicating

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -245,11 +245,13 @@ namespace Bloom.Edit
 			var rights = metadata.License.RightsStatement;
 			metadata.License.RightsStatement = rights;
 
-			string idOfLanguageUsed;
-			string description = metadata.License.GetDescription(_model.LicenseDescriptionLanguagePriorities, out idOfLanguageUsed).Replace("'", "\\'");
 			// BL-1179: For a Custom license, GetDescription just returns the RightsStatement in language "und"; don't duplicate it.
-			if (idOfLanguageUsed == "und")
-				description = string.Empty;
+			string description = string.Empty;
+			if (!(metadata.License is CustomLicense))
+			{
+				string idOfLanguageUsed;
+				description = metadata.License.GetDescription(_model.LicenseDescriptionLanguagePriorities, out idOfLanguageUsed).Replace("'", "\\'");
+			}
 
 			string licenseImageName = licenseImage == null ? string.Empty : "license.png";
 			string result =

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -244,9 +244,13 @@ namespace Bloom.Edit
 			//note that the only way currently to recognize a custom license is that RightsStatement is non-empty while description is empty
 			var rights = metadata.License.RightsStatement;
 			metadata.License.RightsStatement = rights;
-			string idOfLanguageUsed;
 
+			string idOfLanguageUsed;
 			string description = metadata.License.GetDescription(_model.LicenseDescriptionLanguagePriorities, out idOfLanguageUsed).Replace("'", "\\'");
+			// BL-1179: For a Custom license, GetDescription just returns the RightsStatement in language "und"; don't duplicate it.
+			if (idOfLanguageUsed == "und")
+				description = string.Empty;
+
 			string licenseImageName = licenseImage == null ? string.Empty : "license.png";
 			string result =
 				string.Format(


### PR DESCRIPTION
LicenseInfo.GetDescription() for a Custom license just returns the RightsStatement, which led to duplication. Bloom now detects this condition and prevents the duplication.