### PR TITLE
Fix printing on Linux to use gtklp (BL-1192)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
 Package: bloom-desktop-unstable
 Architecture: all
 Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
- mono-sil, libgdiplus-sil, geckofx29,
+ mono-sil, libgdiplus-sil, geckofx29, gtklp,
  chmsee, libtidy5,
  fonts-sil-andika,
  optipng,


### PR DESCRIPTION
This provides the equivalent of the print dialog shown on Windows.
The print system used by Ubuntu Linux (CUPS) handles PDF files
automatically, presumably by using ghostscript as needed.