### PR TITLE
Allow more HTTP interpreted characters in pathnames (BL-951)

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -515,10 +515,7 @@ namespace Bloom.Book
 				//big images before giving them to gecko which has trouble with really hi-res ones
 				//Some clients don't want low-res images and can suppress this by setting HtmlDom.UseOriginalImages.
 				var uri = folderPath + Path.DirectorySeparatorChar;
-				uri = uri.Replace(":", "%3A");
-				uri = uri.Replace('\\', '/');
-				uri = ImageServer.PathEndingInSlash + uri;
-				path = uri;
+				path = uri.ToLocalhost();
 			}
 			dom.BaseForRelativePaths = path; // We actually don't WANT any base elements in the DOM
 		}

--- a/src/BloomExe/Extensions.cs
+++ b/src/BloomExe/Extensions.cs
@@ -11,17 +11,50 @@ namespace Bloom
 			// don't do this if it is done already
 			if (fileName.StartsWith(ServerBase.PathEndingInSlash)) return fileName;
 
-			// BL-117, PH: With the newer xulrunner, javascript code with parenthesis in the URL is not working correctly.
-			fileName = fileName.Replace("(", "%28").Replace(")", "%29");
-
-			return ServerBase.PathEndingInSlash + fileName.Replace(":", "%3A").Replace("\\", "/");
+			return ServerBase.PathEndingInSlash + fileName.EscapeCharsForHttp().Replace(System.IO.Path.DirectorySeparatorChar, '/');
 		}
 
 		public static string FromLocalhost(this string uri)
 		{
 			if (uri.StartsWith(ServerBase.PathEndingInSlash))
-				uri = uri.Substring(ServerBase.PathEndingInSlash.Length).Replace("%3A", ":");
+				uri = uri.Substring(ServerBase.PathEndingInSlash.Length).UnescapeCharsForHttp();
 			return uri;
+		}
+
+		/// <summary>
+		/// Escapes a number of characters that need it for url/http processing.  A much larger
+		/// number could be handled, but the general case (escape all non-ASCII chars as well
+		/// as several more ASCII chars) is much more complicated, and the following appears
+		/// to suffice for our needs in communicating to our own localhost processor.
+		/// </summary>
+		/// <remarks>
+		/// Note that calls to EscapeCharsForHttp() must be matched by an equal number of
+		/// subsequent calls to UnescapeCharsForHttp().  (Normally each is called once.)
+		/// </remarks>
+		public static string EscapeCharsForHttp(this string fileName)
+		{
+			fileName = fileName.Replace("%","%25");
+
+			// BL-117, PH: With the newer xulrunner, javascript code with parenthesis in the URL is not working correctly.
+			fileName = fileName.Replace("(", "%28").Replace(")", "%29");
+
+			return fileName.Replace(":", "%3A").Replace("#","%23").Replace("?","%3F");
+		}
+
+		/// <summary>
+		/// Remove the escaping of characters that need it for url/http processing to restore
+		/// a valid file pathname.  As noted above, a general treatment of unescaping would
+		/// be much more complicated, having to deal with surrogate pairs represented in UTF-8
+		/// and not just a handful of escaped ASCII characters.
+		/// </summary>
+		/// <remarks>
+		/// Note that calls to UnescapeCharsForHttp() must be matched by an equal number of
+		/// previous calls to EscapeCharsForHttp().  (Normally each is called once.)
+		/// </remarks>
+		public static string UnescapeCharsForHttp(this string uri)
+		{
+			// Include the quoting for space in case someone wants to unescape a raw url string.
+			return uri.Replace("%20", " ").Replace("%3A", ":").Replace("%23","#").Replace("%3F","?").Replace("%28","(").Replace("%29",")").Replace("%25","%");
 		}
 
 		public static int ToInt(this bool value)

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -162,8 +162,7 @@ namespace Bloom.web
 			var simulatedPageFileName = Path.ChangeExtension(Guid.NewGuid().ToString(), ".tmp");
 			var pathToSimulatedPageFile = simulatedPageFileName; // a default, if there is no special folder
 			if (dom.BaseForRelativePaths != null)
-				pathToSimulatedPageFile = Path.Combine(dom.BaseForRelativePaths, simulatedPageFileName).Replace('\\', '/');
-			pathToSimulatedPageFile = RemoveLocalhostReferenceFromPath(pathToSimulatedPageFile);
+				pathToSimulatedPageFile = Path.Combine(dom.BaseForRelativePaths.FromLocalhost(), simulatedPageFileName);
 			FixStyleLinkReferences(dom);
 			var html5String = TempFileUtils.CreateHtml5StringFromXml(dom.RawDom);
 			using (var writer = File.CreateText(pathToSimulatedPageFile))
@@ -173,17 +172,6 @@ namespace Bloom.web
 			}
 			var uri = new Uri(pathToSimulatedPageFile);
 			return new SimulatedPageFile() { Key = uri.AbsoluteUri };
-		}
-
-		private static string RemoveLocalhostReferenceFromPath(string path)
-		{
-			if (String.IsNullOrEmpty(path) || !path.StartsWith(PathEndingInSlash))
-				return path;
-			path = path.Substring(PathEndingInSlash.Length - 1);
-			path = Regex.Replace(path, "^/([A-Z])%3A/", "$1:/");
-			if (path.StartsWith("//"))
-				path = path.Substring(1);
-			return path;
 		}
 
 		private static void FixStyleLinkReferences(HtmlDom dom)
@@ -199,7 +187,7 @@ namespace Bloom.web
 					var href = attrs["href"];
 					if (href == null)
 						continue;
-					href.Value = RemoveLocalhostReferenceFromPath(href.Value);
+					href.Value = href.Value.FromLocalhost();
 				}
 			}
 		}

--- a/src/BloomExe/web/ServerBase.cs
+++ b/src/BloomExe/web/ServerBase.cs
@@ -249,13 +249,11 @@ namespace Bloom.web
 
 		protected static string GetLocalPathWithoutQuery(IRequestInfo info)
 		{
+			// Note that LocalPathWithoutQuery removes all % escaping from the URL.
 			var r = info.LocalPathWithoutQuery;
 			const string slashBloomSlash = "/bloom/";
 			if (r.StartsWith(slashBloomSlash))
 				r = r.Substring(slashBloomSlash.Length);
-			r = r.Replace("%3A", ":");
-			r = r.Replace("%20", " ");
-			r = r.Replace("%27", "'");
 			return r;
 		}
 

--- a/src/BloomTests/PretendRequestInfo.cs
+++ b/src/BloomTests/PretendRequestInfo.cs
@@ -16,7 +16,7 @@ namespace Bloom.web
 		public PretendRequestInfo(string url)
 		{
 			RawUrl = url;
-			LocalPathWithoutQuery = url.Replace("http://localhost:8089", "");
+			LocalPathWithoutQuery = url.Replace("http://localhost:8089", "").UnescapeCharsForHttp();
 		}
 
 		public string LocalPathWithoutQuery { get; set; }


### PR DESCRIPTION
More characters could be added to the list of escaped characters,
but most of them are rarely if ever used in filenames, and many
of them are not legal for filenames in Windows.  See the JIRA issue
(https://jira.sil.org/browse/BL-951) for a list of ASCII characters
possibly escaped in Urls.