### PR TITLE
BL-569, prevent re-ordering in locked-down books

### DIFF
--- a/src/BloomExe/Book/Page.cs
+++ b/src/BloomExe/Book/Page.cs
@@ -91,8 +91,17 @@ namespace Bloom.Book
 
 		public bool CanRelocate
 		{
-			//review: for now, we're conflating "required" with "can't move"
-			get { return !Required; }
+			get
+			{
+				if(Required)
+					//review: for now, we're conflating "required" with "can't move"
+					return false; // front and back matter and similar can't move
+				// For now, can't move pages while translating a book.
+				// Enhance: possibly we may want to allow moving pages ADDED to the original book?
+				if (Book.LockedDown)
+					return false;
+				return true;
+			}
 		}
 
 		public Book Book { get; set; }

--- a/src/BloomExe/Edit/WebThumbNailList.cs
+++ b/src/BloomExe/Edit/WebThumbNailList.cs
@@ -707,6 +707,11 @@ namespace Bloom.Edit
 						"That change is not allowed. Front matter and back matter pages must remain where they are");
 					var caption = LocalizationManager.GetString("PageList.CantMoveXMatterCaption",
 						"Invalid Move");
+					if (_pages[i].Book.LockedDown)
+					{
+						msg = LocalizationManager.GetString("PageList.CantMoveVernacular",
+							"Pages can't be re-ordered when you are translating a book");
+					}
 					MessageBox.Show(msg, caption);
 					UpdateItems(_pages); // reset to old state
 					return;

--- a/src/BloomExe/Edit/WebThumbNailList.cs
+++ b/src/BloomExe/Edit/WebThumbNailList.cs
@@ -709,8 +709,8 @@ namespace Bloom.Edit
 						"Invalid Move");
 					if (_pages[i].Book.LockedDown)
 					{
-						msg = LocalizationManager.GetString("PageList.CantMoveVernacular",
-							"Pages can't be re-ordered when you are translating a book");
+						msg = LocalizationManager.GetString("PageList.CantMoveWhenTranslating",
+							"Pages can not be re-ordered when you are translating a book");
 					}
 					MessageBox.Show(msg, caption);
 					UpdateItems(_pages); // reset to old state


### PR DESCRIPTION
User should not re-order pages when translating a book