### PR TITLE
BL-1138 Book counts inaccurate after switch from DR

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/readerToolsModel.js
+++ b/src/BloomBrowserUI/bookEdit/js/readerToolsModel.js
@@ -1,4 +1,4 @@
-/// <reference path="interIframeChannel.ts" />
+﻿/// <reference path="interIframeChannel.ts" />
 /// <reference path="getIframeChannel.ts" />
 /// <reference path="synphonyApi.ts" />
 /// <reference path="libsynphony/bloom_lib.d.ts" />
@@ -724,7 +724,7 @@ var ReaderToolsModel = (function () {
 
     ReaderToolsModel.updateWholeBookCounts = function (pageSource) {
         model.bookPageWords = JSON.parse(pageSource);
-        model.displayBookTotals();
+        model.doMarkup();
     };
 
     ReaderToolsModel.prototype.displayBookTotals = function () {

--- a/src/BloomBrowserUI/bookEdit/js/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/js/readerToolsModel.ts
@@ -745,7 +745,7 @@ class ReaderToolsModel {
   static updateWholeBookCounts(pageSource: string): void {
 
     model.bookPageWords = JSON.parse(pageSource);
-    model.displayBookTotals();
+    model.doMarkup();
   }
 
   displayBookTotals(): void {


### PR DESCRIPTION
Leveled Reader Tool's This Book counts inaccurate when used from
Decodable.  When you create a new page with the decodable reader
tab visible, enter text, and then switch to the leveled reader tab,
the counts are wrong until another word is entered.  This is because
the doMarkup code adds in the current page information, but it
is not added in with the call from updateWholeBookCounts.