### PR TITLE
Limit tab button widths by truncating text (BL-1212)

### DIFF
--- a/src/BloomExe/Workspace/WorkspaceView.Designer.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.Designer.cs
@@ -417,6 +417,7 @@
 			this._collectionTab.SelectedFont = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
 			this._collectionTab.SelectedTextColor = System.Drawing.Color.WhiteSmoke;
 			this._collectionTab.Size = new System.Drawing.Size(103, 71);
+			this._collectionTab.TextChanged += HandleTabTextChanged;
 			this._collectionTab.Text = "Collections";
 			this._collectionTab.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
 			// 
@@ -438,6 +439,7 @@
 			this._editTab.SelectedFont = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
 			this._editTab.SelectedTextColor = System.Drawing.Color.WhiteSmoke;
 			this._editTab.Size = new System.Drawing.Size(69, 71);
+			this._editTab.TextChanged += HandleTabTextChanged;
 			this._editTab.Text = "Edit";
 			this._editTab.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
 			// 
@@ -461,6 +463,7 @@
 			this._publishTab.SelectedFont = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
 			this._publishTab.SelectedTextColor = System.Drawing.Color.WhiteSmoke;
 			this._publishTab.Size = new System.Drawing.Size(83, 71);
+			this._publishTab.TextChanged += HandleTabTextChanged;
 			this._publishTab.Text = "Publish";
 			this._publishTab.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
 			// 

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -143,10 +143,6 @@ namespace Bloom.Workspace
 			SetTabVisibility(_publishTab, false);
 			SetTabVisibility(_editTab, false);
 
-			_collectionTab.TextChanged += HandleTabTextChanged;
-			_editTab.TextChanged += HandleTabTextChanged;
-			_publishTab.TextChanged += HandleTabTextChanged;
-
 //			if (Program.StartUpWithFirstOrNewVersionBehavior)
 //			{
 //				_tabStrip.SelectedTab = _infoTab;
@@ -188,13 +184,59 @@ namespace Bloom.Workspace
 		/// Adjust the tool panel location when the chosen localization changes.
 		/// See https://jira.sil.org/browse/BL-1212 for what can happen if we
 		/// don't adjust.  At the moment, we only widen, we never narrow the
-		/// area allotted to the tab buttons.
+		/// overall area allotted to the tab buttons.  Button widths adjust
+		/// themselves automatically to their Text width.  There doesn't seem
+		/// to be a built-in mechanism to limit the width to a given maximum
+		/// so we implement such an operation ourselves.
 		/// </summary>
 		void HandleTabTextChanged(object sender, EventArgs e)
 		{
+			var btn = sender as Messir.Windows.Forms.TabStripButton;
+			if (btn != null)
+			{
+				const string kEllipsis = "\u2026";
+				// Preserve the original string as the tooltip.
+				if (!btn.Text.EndsWith(kEllipsis))
+					btn.ToolTipText = btn.Text;
+				// Ensure the button width is no more than 110 pixels.
+				if (btn.Width > 110)
+				{
+					using (Graphics g = btn.Owner.CreateGraphics())
+					{
+						btn.Text = ShortenStringToFit(btn.Text, 110, btn.Width, btn.Font, g);
+					}
+				}
+			}
 			AdjustToolPanelLocation(false);
 		}
 
+		/// <summary>
+		/// Ensure that the TabStripItem or Control or Whatever is no wider than desired by
+		/// truncating the Text as needed, with an ellipsis appended to show truncation has
+		/// occurred.
+		/// </summary>
+		/// <returns>the possibly shortened string</returns>
+		/// <param name="text">the string to shorten if necessary</param>
+		/// <param name="maxWidth">the maximum item width allowed</param>
+		/// <param name="originalWidth">the original item width (with the original string)</param>
+		/// <param name="font">the font to use</param>
+		/// <param name="g">the relevant Graphics object for drawing/measuring</param>
+		/// <remarks>Would this be a good library method somewhere?  Where?</remarks>
+		public static string ShortenStringToFit(string text, int maxWidth, int originalWidth, Font font, Graphics g)
+		{
+			const string kEllipsis = "\u2026";
+			var txtWidth = g.MeasureString(text, font).Width;
+			var padding = originalWidth - txtWidth;
+			while (txtWidth + padding > maxWidth)
+			{
+				var len = text.Length - 2;
+				if (len <= 0)
+					break;	// I can't conceive this happening, but I'm also paranoid.
+				text = text.Substring(0, len) + kEllipsis;	// trim, add ellipsis
+				txtWidth = g.MeasureString(text, font).Width;
+			}
+			return text;
+		}
 
 		private void _applicationUpdateCheckTimer_Tick(object sender, EventArgs e)
 		{


### PR DESCRIPTION
The original button text is preserved in the button tooltip.