### PR TITLE
BL-1222, don't make empty <u> elements for new langs

### DIFF
--- a/src/BloomExe/Book/TranslationGroupManager.cs
+++ b/src/BloomExe/Book/TranslationGroupManager.cs
@@ -245,7 +245,7 @@ namespace Bloom.Book
 		private static void StripOutText(XmlNode element)
 		{
 			var listToRemove = new List<XmlNode>();
-			foreach (XmlNode node in element.SelectNodes("descendant-or-self::*[(self::p or self::br) and not(contains(@class,'bloom-cloneToOtherLanguages'))]"))
+			foreach (XmlNode node in element.SelectNodes("descendant-or-self::*[(self::p or self::br or self::u or self::b or self::i) and not(contains(@class,'bloom-cloneToOtherLanguages'))]"))
 			{
 				listToRemove.Add(node);
 			}

--- a/src/BloomTests/Book/TranslationGroupManagerTests.cs
+++ b/src/BloomTests/Book/TranslationGroupManagerTests.cs
@@ -270,6 +270,31 @@ namespace BloomTests.Book
 		}
 
 		[Test]
+		public void UpdateContentLanguageClasses_PrototypeHasUnderlinedText_CopyHasNone()
+		{
+			var contents = @"<div class='bloom-page numberedPage A5Portrait bloom-monolingual'
+							id='f4a22289-1755-4b79-afc1-5d20eaa892fe'>
+<div class='marginBox'>
+  <div class='bloom-translationGroup normal-style'>
+	<div style='' class='bloom-editable bloom-content1' contenteditable='true'
+		lang='en'>The <i>Mother</i> said, <u>Nurse!</u>
+			The Nurse <b>answered</b>.</div>
+</div></div></div>";
+			var dom = new XmlDocument();
+			dom.LoadXml(contents);
+
+			TranslationGroupManager.PrepareElementsInPageOrDocument((XmlElement)dom.SafeSelectNodes("//div[contains(@class,'bloom-page')]")[0], _collectionSettings.Object);
+
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='xyz']", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='fr']", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='es']", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='en' and contains(., 'The Mother')]", 1);
+			AssertThatXmlIn.Dom(dom).HasNoMatchForXpath("//div[@lang='fr']/u");
+			AssertThatXmlIn.Dom(dom).HasNoMatchForXpath("//div[@lang='fr']/b");
+			AssertThatXmlIn.Dom(dom).HasNoMatchForXpath("//div[@lang='fr']/i");
+		}
+
+		[Test]
 		public void UpdateContentLanguageClasses_PrototypeElementHasImageContainer_ImageContainerCopiedToNewSibling()
 		{
 			const string contents = @"<div class='bloom-page'>

--- a/src/BloomTests/XmlHtmlConverterTests.cs
+++ b/src/BloomTests/XmlHtmlConverterTests.cs
@@ -45,6 +45,28 @@ namespace BloomTests
 			}
 		}
 
+		/// <summary>
+		/// I put this test in because (while working on BL-1222) I came across some alleged HTML that contained
+		/// u elements closed in the XML way (closing slash, instead of separate close tag) which is not allowed
+		/// in HTML 5. However, I didn't have to change the code to make it pass; both kinds of empty u/i/b element
+		/// are removed entirely. Still, just in case that changes, this makes sure it doesn't change to something
+		/// invalid.
+		/// </summary>
+		[Test]
+		public void SaveAsHTML_EmptyUbi_DoesNotContract()
+		{
+			var dom = new XmlDocument();
+			dom.LoadXml("<html><body><div data-book='test'/>Text with <u /> and <b /> and <i></i> works</body></html>");
+			using (var temp = new TempFile())
+			{
+				XmlHtmlConverter.SaveDOMAsHtml5(dom, temp.Path);
+				var text = File.ReadAllText(temp.Path);
+				Assert.That(text, Is.Not.StringContaining("<u />"));
+				Assert.That(text, Is.Not.StringContaining("<b />"));
+				Assert.That(text, Is.Not.StringContaining("<i />"));
+			}
+		}
+
 		[Test]
 		public void GetXmlDomFromHtml_HasBrTags_TagsNotDoubled()
 		{


### PR DESCRIPTION
Original code was converting underlined text in prototype
to empty <u> elements which somehow (still not sure) became
<u /> in HTML which messed things up badly.