### PR TITLE
Make ctrl+click do a paste that cleans up linebreaks from pdf

### DIFF
--- a/DistFiles/ReleaseNotes.md
+++ b/DistFiles/ReleaseNotes.md
@@ -10,7 +10,7 @@
 - To get good printing reliability on Windows, install the [Free Adobe Reader](http://get.adobe.com/reader/enterprise/) software. Bloom will automatically use it. If download size is at a premium, you can install [Ghostscript](http://www.softpedia.com/get/System/System-Miscellaneous/GPL-Ghostscript.shtml) instead (13 MB vs. 77 MB). On Linux, we are switching to the system's default way of printing (which is normally GhostScript).
 
 ## 3.1
-
+- CTRL+Click does a paste, and the pasted material is cleaned up, removing the extraneous line breaks that you get when copying out of a PDF.
 - New faster installer with automatic incremental upgrades
 - Page thumbnails now show an "attention" icon if some text on the page is overflow its box
 - Added description texts to Leveled and Decodable Reader templates

--- a/src/BloomBrowserUI/bookEdit/bloomField/bloomField.js
+++ b/src/BloomBrowserUI/bookEdit/bloomField/bloomField.js
@@ -28,6 +28,7 @@ var BloomField = (function () {
             BloomField.ManageWhatHappensIfTheyDeleteEverything(bloomEditableDiv);
             BloomField.PreventArrowingOutIntoField(bloomEditableDiv);
             $(bloomEditableDiv).on('paste', this.ProcessIncomingPaste);
+            
             $(bloomEditableDiv).blur(function () {
                 BloomField.ModifyForParagraphMode(this);
             });
@@ -36,8 +37,37 @@ var BloomField = (function () {
             });
         } else {
             BloomField.PrepareNonParagraphField(bloomEditableDiv);
+            //$(bloomEditableDiv).click(this.ProcessClick);
+            //$(bloomEditableDiv).on('click',this.ProcessClick);
         }
     };
+
+//    BloomField.ProcessClick = function (e) {
+//        // note: currently, the c# code also intercepts the past event and
+//        // makes sure that we just get plain 'ol text on the clipboard.
+//        // That's a bit heavy handed, but the mess you get from pasting
+//        // html from word is formidable.
+//        var txt = e.originalEvent.clipboardData.getData('text/plain');
+//
+//        var html;
+//        alert("click");
+//        if (e.ctrlKey) {
+//            html = txt.replace(/\n\n/g, 'twonewlines');
+//            html = html.replace(/\n/g, ' ');
+//            html = html.replace(/\s+/g, ' ');
+//            html = html.replace(/twonewlines/g, '\n');
+//
+//            //convert remaining newlines to paragraphs. We're already inside a  <p>, so each
+//            //newline finishes that off and starts a new one
+//            html = html.replace(/\n/g, '</p><p>');
+//
+//            document.execCommand("insertHTML", false, html);
+//
+//            //don't do the normal paste
+//            e.stopPropagation();
+//            e.preventDefault();
+//        }
+//    };
 
     BloomField.ProcessIncomingPaste = function (e) {
         // note: currently, the c# code also intercepts the past event and
@@ -46,10 +76,19 @@ var BloomField = (function () {
         // html from word is formidable.
         var txt = e.originalEvent.clipboardData.getData('text/plain');
 
-        //some typists in SHRP indent in MS Word by hitting newline and pressing a bunch of spaces.
-        // We replace any newline followed by 3 or more spaces with just one space. It could
-        // conceivalby hit some false positive, but it would be easy for the user to fix.
-        var html = txt.replace(/\n\s{3,}/g, ' ');
+        var html;
+
+        if (e.ctrlKey) {
+            html = txt.replace(/\n\n/g, 'twonewlines');
+            html = html.replace(/\n/g, ' ');
+            html = html.replace(/\s+/g, ' ');
+            html = html.replace(/twonewlines/g, '\n');
+        } else {
+            //some typists in SHRP indent in MS Word by hitting newline and pressing a bunch of spaces.
+            // We replace any newline followed by 3 or more spaces with just one space. It could
+            // conceivalby hit some false positive, but it would be easy for the user to fix.
+            html = txt.replace(/\n\s{3,}/g, ' ');
+        }
 
         //convert remaining newlines to paragraphs. We're already inside a  <p>, so each
         //newline finishes that off and starts a new one

--- a/src/BloomBrowserUI/bookEdit/bloomField/bloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/bloomField.ts
@@ -29,6 +29,7 @@ class BloomField {
             BloomField.ManageWhatHappensIfTheyDeleteEverything(bloomEditableDiv);
             BloomField.PreventArrowingOutIntoField(bloomEditableDiv);
             $(bloomEditableDiv).on('paste', this.ProcessIncomingPaste);
+            $(bloomEditableDiv).click(function() { this.ProcessClick; });
             $(bloomEditableDiv).blur(function () {
                 BloomField.ModifyForParagraphMode(this);
             });
@@ -41,19 +42,57 @@ class BloomField {
         }
     }
 
-    private static ProcessIncomingPaste(e: any) {
+    private static ProcessClick(e: any) {
+
         // note: currently, the c# code also intercepts the past event and
         // makes sure that we just get plain 'ol text on the clipboard.
         // That's a bit heavy handed, but the mess you get from pasting
         // html from word is formidable.
 
         var txt = e.originalEvent.clipboardData.getData('text/plain');
-        
-        //some typists in SHRP indent in MS Word by hitting newline and pressing a bunch of spaces.
-        // We replace any newline followed by 3 or more spaces with just one space. It could
-        // conceivalby hit some false positive, but it would be easy for the user to fix.
-        var html = txt.replace(/\n\s{3,}/g, ' ');
 
+        var html: string;
+        alert("click");
+        if (e.ctrlKey) {
+            html = txt.replace(/\n\n/g, 'twonewlines');
+            html = html.replace(/\n/g, ' ');
+            html = html.replace(/\s+/g, ' ');
+            html = html.replace(/twonewlines/g, '\n');
+
+            //convert remaining newlines to paragraphs. We're already inside a  <p>, so each 
+            //newline finishes that off and starts a new one
+            html = html.replace(/\n/g, '</p><p>');
+
+            document.execCommand("insertHTML", false, html);
+
+            //don't do the normal paste
+            e.stopPropagation();
+            e.preventDefault();
+        }
+    }
+
+    private static ProcessIncomingPaste(e: any) {
+
+        // note: currently, the c# code also intercepts the past event and
+        // makes sure that we just get plain 'ol text on the clipboard.
+        // That's a bit heavy handed, but the mess you get from pasting
+        // html from word is formidable.
+
+        var txt = e.originalEvent.clipboardData.getData('text/plain');
+
+        var html: string;
+
+        if (e.ctrlKey) {
+            html = txt.replace(/\n\n/g, 'twonewlines');
+            html = html.replace(/\n/g, ' ');
+            html = html.replace(/\s+/g, ' ');
+            html = html.replace(/twonewlines/g, '\n');
+        } else {
+            //some typists in SHRP indent in MS Word by hitting newline and pressing a bunch of spaces.
+            // We replace any newline followed by 3 or more spaces with just one space. It could
+            // conceivalby hit some false positive, but it would be easy for the user to fix.
+            html = txt.replace(/\n\s{3,}/g, ' ');
+        }
         //convert remaining newlines to paragraphs. We're already inside a  <p>, so each 
         //newline finishes that off and starts a new one
         html = html.replace(/\n/g, '</p><p>');


### PR DESCRIPTION
CTRL+Click does a paste, and the pasted material is cleaned up, removing the extraneous line breaks that you get when copying out of a PDF.