### PR TITLE
Fix BL-1226: Credits lost in PDF

### DIFF
--- a/DistFiles/UnusedTemplates/Template Maker/Factory-XMatter.css
+++ b/DistFiles/UnusedTemplates/Template Maker/Factory-XMatter.css
@@ -246,19 +246,19 @@
 .verso .licenseUrl {
   display: none;
 }
-BODY[editmode="original"] .titlePage #originalContributions .bloom-content1 {
+BODY[bookcreationtype="original"] .titlePage #originalContributions .bloom-content1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="original"] .titlePage #funding .bloom-content1 {
+BODY[bookcreationtype="original"] .titlePage #funding .bloom-content1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="translation"] .titlePage #originalContributions .bloom-contentNational1 {
+BODY[bookcreationtype="translation"] .titlePage #originalContributions .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="translation"] .titlePage #funding .bloom-contentNational1 {
+BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
 }

--- a/DistFiles/xMatter/BigBook-XMatter/editMode.css
+++ b/DistFiles/xMatter/BigBook-XMatter/editMode.css
@@ -29,7 +29,6 @@ DIV.bloom-imageContainer
 {
 	border: thin solid rgba(1, 1, 1, 0.2);
 }
-/*There are 2 sub-modes of editing, each with their own stylesheets: originalEditMode and translationEditMode.*/
 BODY
 {
 	background-color: #363333;

--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.css
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.css
@@ -246,19 +246,19 @@
 .verso .licenseUrl {
   display: none;
 }
-BODY[editmode="original"] .titlePage #originalContributions .bloom-content1 {
+BODY[bookcreationtype="original"] .titlePage #originalContributions .bloom-content1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="original"] .titlePage #funding .bloom-content1 {
+BODY[bookcreationtype="original"] .titlePage #funding .bloom-content1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="translation"] .titlePage #originalContributions .bloom-contentNational1 {
+BODY[bookcreationtype="translation"] .titlePage #originalContributions .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="translation"] .titlePage #funding .bloom-contentNational1 {
+BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
 }

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
@@ -246,19 +246,19 @@
 .verso .licenseUrl {
   display: none;
 }
-BODY[editmode="original"] .titlePage #originalContributions .bloom-content1 {
+BODY[bookcreationtype="original"] .titlePage #originalContributions .bloom-content1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="original"] .titlePage #funding .bloom-content1 {
+BODY[bookcreationtype="original"] .titlePage #funding .bloom-content1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="translation"] .titlePage #originalContributions .bloom-contentNational1 {
+BODY[bookcreationtype="translation"] .titlePage #originalContributions .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="translation"] .titlePage #funding .bloom-contentNational1 {
+BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
 }

--- a/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
+++ b/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
@@ -246,19 +246,19 @@
 .verso .licenseUrl {
   display: none;
 }
-BODY[editmode="original"] .titlePage #originalContributions .bloom-content1 {
+BODY[bookcreationtype="original"] .titlePage #originalContributions .bloom-content1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="original"] .titlePage #funding .bloom-content1 {
+BODY[bookcreationtype="original"] .titlePage #funding .bloom-content1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="translation"] .titlePage #originalContributions .bloom-contentNational1 {
+BODY[bookcreationtype="translation"] .titlePage #originalContributions .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="translation"] .titlePage #funding .bloom-contentNational1 {
+BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
 }

--- a/DistFiles/xMatter/bloom-xmatter-common.css
+++ b/DistFiles/xMatter/bloom-xmatter-common.css
@@ -246,19 +246,19 @@
 .verso .licenseUrl {
   display: none;
 }
-BODY[editmode="original"] .titlePage #originalContributions .bloom-content1 {
+BODY[bookcreationtype="original"] .titlePage #originalContributions .bloom-content1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="original"] .titlePage #funding .bloom-content1 {
+BODY[bookcreationtype="original"] .titlePage #funding .bloom-content1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="translation"] .titlePage #originalContributions .bloom-contentNational1 {
+BODY[bookcreationtype="translation"] .titlePage #originalContributions .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
 }
-BODY[editmode="translation"] .titlePage #funding .bloom-contentNational1 {
+BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1 {
   display: inherit;
   min-height: 3em;
 }

--- a/DistFiles/xMatter/bloom-xmatter-common.less
+++ b/DistFiles/xMatter/bloom-xmatter-common.less
@@ -319,7 +319,7 @@
     }
 }
 
-BODY[editmode="original"] {
+BODY[bookcreationtype="original"] {
     .titlePage {
         #originalContributions {
             .bloom-content1 {
@@ -336,7 +336,7 @@ BODY[editmode="original"] {
     }
 }
 
-BODY[editmode="translation"] {
+BODY[bookcreationtype="translation"] {
     .titlePage {
         #originalContributions {
             .bloom-contentNational1 {

--- a/src/BloomBrowserUI/bookEdit/css/editPaneGlobal.css
+++ b/src/BloomBrowserUI/bookEdit/css/editPaneGlobal.css
@@ -95,29 +95,25 @@ DIV.ui-tooltip-title
 	border-radius: 3pt;
 }
 
-/* There are 2 sub-modes of editing, each with their own stylesheets: originalEditMode and translationEditMode.
-	Parts of each of these files has been moved to this global file because their targets are not within the scoped css.
-	Book.GetEditableHtmlDomForPage() now adds an 'editMode' attribute to the BODY element to distinguish the rules.
-
-	Moved from editOriginalMode.css */
-BODY[editMode="original"] DIV.ui-sourceTextsForBubble TEXTAREA, BODY[editMode="original"] DIV.ui-sourceTextsForBubble DIV
+/* 	Book.GetEditableHtmlDomForPage() now adds an 'bookcreationtype' attribute to the BODY element to distinguish the rules. */
+BODY[bookcreationtype="original"] DIV.ui-sourceTextsForBubble TEXTAREA, BODY[bookcreationtype="original"] DIV.ui-sourceTextsForBubble DIV
 {
 	background-color: transparent;
 	border: none;
 	max-height: 236px;
 	overflow: auto;
 }
-/* Moved from editTranslationMode.css */
-BODY[editMode="translation"] DIV.ui-sourceTextsForBubble
+
+BODY[bookcreationtype="translation"] DIV.ui-sourceTextsForBubble
 {
 	width: 203px;
 	margin-top: 10px;
 }
-BODY[editMode="translation"] DIV.uibloomSourceTextsBubble DIV.ui-tooltip-content
+BODY[bookcreationtype="translation"] DIV.uibloomSourceTextsBubble DIV.ui-tooltip-content
 {
 	width: 210px;
 }
-BODY[editMode="translation"] DIV DIV.ui-sourceTextsForBubble TEXTAREA
+BODY[bookcreationtype="translation"] DIV DIV.ui-sourceTextsForBubble TEXTAREA
 {
 	height: 304px;
 	background: transparent;
@@ -126,13 +122,13 @@ BODY[editMode="translation"] DIV DIV.ui-sourceTextsForBubble TEXTAREA
 	width: 320px;
 	margin: 11px 0 0;
 }
-BODY[editMode="translation"] .ui-tooltip .qtip .uibloomSourceTextsBubble
+BODY[bookcreationtype="translation"] .ui-tooltip .qtip .uibloomSourceTextsBubble
 {
 	width: 293px !important;
 	height: 138px;
 	max-width: 1009px !important;
 }
-BODY[editMode="translation"] DIV.ui-sourceTextsForBubble UL
+BODY[bookcreationtype="translation"] DIV.ui-sourceTextsForBubble UL
 {
 	background: none;
 }

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -288,13 +288,14 @@ namespace Bloom.Book
 			if(LockedDown)
 			{
 				pageDom.AddStyleSheet(_storage.GetFileLocator().LocateFileWithThrow(@"editTranslationMode.css").ToLocalhost());
-				pageDom.AddEditMode("translation");
 			}
 			else
 			{
 				pageDom.AddStyleSheet(_storage.GetFileLocator().LocateFileWithThrow(@"editOriginalMode.css").ToLocalhost());
-				pageDom.AddEditMode("original");
 			}
+
+			AddCreationTypeAttribute(pageDom);
+
 			pageDom.AddStyleSheet(_storage.GetFileLocator().LocateFileWithThrow(@"editPaneGlobal.css").ToLocalhost());
 			pageDom.SortStyleSheetLinks();
 			AddJavaScriptForEditing(pageDom);
@@ -605,6 +606,7 @@ namespace Bloom.Book
 				return GetPageListingErrorsWithBook(_storage.GetValidateErrors());
 			}
 			var previewDom= GetBookDomWithStyleSheets("previewMode.css", "origami.css");
+			AddCreationTypeAttribute(previewDom);
 
 			//We may have just run into an error for the first time
 			if (HasFatalError)
@@ -624,6 +626,11 @@ namespace Bloom.Book
 			AddPreviewJScript(previewDom);
 			previewDom.AddPublishClassToBody();
 			return previewDom;
+		}
+
+		private void AddCreationTypeAttribute(HtmlDom htmlDom)
+		{
+			htmlDom.AddCreationType(LockedDown ? "translation" : "original");
 		}
 
 		public void BringBookUpToDate(IProgress progress)
@@ -1615,7 +1622,7 @@ namespace Bloom.Book
 		public HtmlDom GetDomForPrinting(PublishModel.BookletPortions bookletPortion, BookCollection currentBookCollection, BookServer bookServer)
 		{
 			var printingDom = GetBookDomWithStyleSheets("previewMode.css", "origami.css");
-			//dom.LoadXml(OurHtmlDom.OuterXml);
+			AddCreationTypeAttribute(printingDom);
 
 			if (IsFolio)
 			{

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -189,10 +189,15 @@ namespace Bloom.Book
 			Body.AppendChild(MakeJavascriptElement(pathToJavascript));
 		}
 
-		public void AddEditMode(string mode)
+		/// <summary>
+		/// The Creation Type is either "translation" or "original". This is used to protect fields that should
+		/// normally not be editable in one or the other.
+		/// This is a bad name, and we know it!
+		/// </summary>
+		public void AddCreationType(string mode)
 		{
 			// RemoveModeStyleSheets() should have already removed any editMode attribute on the body element
-			Body.SetAttribute("editMode", mode);
+			Body.SetAttribute("bookcreationtype", mode);
 		}
 
 		public void RemoveModeStyleSheets()


### PR DESCRIPTION
The problem was that we have stylesheets looking for this attribute to decide which language it was supposed to show, but the attribute wasn't being set when we make a PDF.

1) Changee "editMode" to "bookcreationtype" (which no more descriptive, but at least it is differentiated from "editMode.css", which is has nothing to do with this attribute).
2) Set this attribute when getting the preview/pdf html, instead of just the html for editing.