### PR TITLE
Make memory check a major logging event when changing pages

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -489,7 +489,8 @@ namespace Bloom.Edit
 		{
 			Logger.WriteMinorEvent("changing page selection");
 			Analytics.Track("Select Page");//not "edit page" because at the moment we don't have the capability of detecting that.
-			Palaso.UI.WindowsForms.Reporting.MemoryManagement.CheckMemory(true, "switched page in edit", true);
+			// Trace memory usage in case it may be useful
+			Palaso.UI.WindowsForms.Reporting.MemoryManagement.CheckMemory(false, "switched page in edit", true);
 
 			if (_view != null)
 			{


### PR DESCRIPTION
This may help determine whether we have memory leaks, and whether
memory use is contributing to crashes that get reported.