### PR TITLE
Provide a better message when no printers exist (BL-1237)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -142,12 +142,12 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Printing" Condition="'$(OS)'=='Windows_NT'"/>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
Creating a PDF file through gecko/xul on Windows requires at least
one printer and a default printer being assigned.  The wording of the
messages could certainly be improved, but that has to be done by
someone other than this particular programmer.

I  also fixed the existing message to be localizable.