### PR TITLE
BL-1205, improve handling of locked files on download

### DIFF
--- a/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
@@ -4,7 +4,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Text;
+using System.Windows.Forms;
 using Amazon;
 using Amazon.EC2.Model;
 using Amazon.S3;
@@ -292,8 +294,10 @@ namespace Bloom.WebLibraryIntegration
 		/// </summary>
 		/// <param name="sourceDirName"></param>
 		/// <param name="destDirName">Note, this is not the *parent*; this is the actual name you want, e.g. CopyDirectory("c:/foo", "c:/temp/foo") </param>
-		private static void CopyDirectory(string sourceDirName, string destDirName)
+		/// <returns>true if no exception occurred</returns>
+		private static bool CopyDirectory(string sourceDirName, string destDirName)
 		{
+			bool success = true;
 			var sourceDirectory = new DirectoryInfo(sourceDirName);
 
 			if (!sourceDirectory.Exists)
@@ -310,12 +314,50 @@ namespace Bloom.WebLibraryIntegration
 
 			foreach (FileInfo file in sourceDirectory.GetFiles())
 			{
-				file.CopyTo(Path.Combine(destDirName, file.Name), true);
+				var destFileName = Path.Combine(destDirName, file.Name);
+				try
+				{
+					file.CopyTo(destFileName, true);
+				}
+				catch (Exception ex)
+				{
+					if (!(ex is IOException || ex is UnauthorizedAccessException || ex is SecurityException))
+						throw;
+					// Maybe we don't need to write it...it hasn't changed since a previous download?
+					if (!SameFileContent(destFileName, file.FullName))
+						success = false;
+				}
 			}
 
 			foreach (DirectoryInfo subdir in sourceDirectory.GetDirectories())
 			{
-				CopyDirectory(subdir.FullName, Path.Combine(destDirName, subdir.Name));
+				success = CopyDirectory(subdir.FullName, Path.Combine(destDirName, subdir.Name)) && success;
+			}
+			return success;
+		}
+
+		// Return true if both files exist, are readable, and have the same content.
+		static bool SameFileContent(string path1, string path2)
+		{
+			if (!File.Exists(path1))
+				return false;
+			if (!File.Exists(path2))
+				return false;
+			try
+			{
+				var first = File.ReadAllBytes(path1);
+				var second = File.ReadAllBytes(path2);
+				if (first.Length != second.Length)
+					return false;
+				for (int i = 0; i < first.Length; i++)
+					if (first[i] != second[i])
+						return false;
+				return true;
+
+			}
+			catch (IOException)
+			{
+				return false; // can't even read
 			}
 		}
 
@@ -398,21 +440,47 @@ namespace Bloom.WebLibraryIntegration
 				var destinationPath = Path.Combine(pathToDestinationParentDirectory, Path.GetFileName(children[0]));
 
 				//clear out anything exisitng on our target
+				var didDelete = false;
 				if (Directory.Exists(destinationPath))
 				{
-					Directory.Delete(destinationPath, true);
+					try
+					{
+						Directory.Delete(destinationPath, true);
+						didDelete = true;
+					}
+					catch (IOException)
+					{
+						// can't delete it...see if we can copy into it.
+					}
 				}
 
 				//if we're on the same volume, we can just move it. Else copy it.
 				// It's important that books appear as nearly complete as possible, because a file watcher will very soon add the new
 				// book to the list of downloaded books the user can make new ones from, once it appears in the target directory.
-				if (PathUtilities.PathsAreOnSameVolume(pathToDestinationParentDirectory, tempDestination.FolderPath))
+				bool done = false;
+				if (didDelete && PathUtilities.PathsAreOnSameVolume(pathToDestinationParentDirectory, tempDestination.FolderPath))
 				{
-					Directory.Move(children[0], destinationPath);
+					try
+					{
+						Directory.Move(children[0], destinationPath);
+						done = true;
+					}
+					catch (IOException)
+					{
+						// If moving didn't work we'll just try copying
+					}
+					catch (UnauthorizedAccessException)
+					{ }
+
 				}
-				else
+				if (!done)
+					done = CopyDirectory(children[0], destinationPath);
+				if (!done)
 				{
-					CopyDirectory(children[0], destinationPath);
+					var msg = LocalizationManager.GetString("Download.CopyFailed",
+						"Bloom downloaded your book but had problems copying it to the bloom library. Possibly you already have a version of this book and some program is using it. You may need to restart your computer and download it again.");
+					var caption = LocalizationManager.GetString("Download.Incomplete", "Download incomplete");
+					MessageBox.Show(null, msg, caption, MessageBoxButtons.OK, MessageBoxIcon.Warning);
 				}
 				return destinationPath;
 			}

--- a/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
@@ -16,7 +16,9 @@ using BloomTemp;
 using L10NSharp;
 using Palaso.Code;
 using Palaso.Progress;
+using Palaso.Reporting;
 using Palaso.UI.WindowsForms.Progress;
+using Palaso.UI.WindowsForms.Reporting;
 using RestSharp.Contrib;
 using Palaso.IO;
 using System.Net;
@@ -478,9 +480,10 @@ namespace Bloom.WebLibraryIntegration
 				if (!done)
 				{
 					var msg = LocalizationManager.GetString("Download.CopyFailed",
-						"Bloom downloaded your book but had problems copying it to the bloom library. Possibly you already have a version of this book and some program is using it. You may need to restart your computer and download it again.");
-					var caption = LocalizationManager.GetString("Download.Incomplete", "Download incomplete");
-					MessageBox.Show(null, msg, caption, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+						"Bloom downloaded the book but had problems making it available in Bloom. Please restart your computer and try again. If you get this message again, please click the 'Details' button and report the problem to the Bloom developers");
+					// The exception doesn't add much useful information but it triggers a version of the dialog with a Details button
+					// that leads to the yellow box and an easy way to send the report.
+					ErrorReport.NotifyUserOfProblem(new ApplicationException("File Copy problem"), msg);
 				}
 				return destinationPath;
 			}


### PR DESCRIPTION
- If we can't delete destination directory or move otherwise
fails, try copy.
- If we can't copy a particular file, see if it already exists with
the right content, and if so count this as success
- If we really can't make the destination directory correct,
copy all we can, and give a helpful message