### PR TITLE
BL-1260: disable overflow checks on some pages

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -6,7 +6,7 @@
 	"jade": "0.35",
 	"less": "1.7.x",
 	"clean-css": "2.2.x",
-	"typescript": "1.0.x"
+	"typescript": "1.4.x"
   },
   "engine": "node >= 1.0.0"
 }

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.js
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.js
@@ -1,48 +1,39 @@
-﻿
 var OverflowChecker = (function () {
     function OverflowChecker() {
     }
     OverflowChecker.prototype.AddOverflowHandlers = function (container) {
         var queryElementsThatCanOverflow = ".bloom-editable, textarea";
         var editablePageElements = $(container).find(queryElementsThatCanOverflow);
-
+        if (editablePageElements.length > 30)
+            return;
         editablePageElements.each(function () {
             OverflowChecker.CheckOnMinHeight(this);
         });
-
         editablePageElements.on("keyup paste", function (e) {
             var target = e.target;
-
             setTimeout(function () {
                 OverflowChecker.MarkOverflowInternal(target);
-
                 $(queryElementsThatCanOverflow).qtip('reposition');
             }, 100);
             e.stopPropagation();
         });
-
         $(container).find(".split-pane-component-inner").bind('_splitpaneparentresize', function () {
             var $this = $(this);
             $this.find(queryElementsThatCanOverflow).each(function () {
                 OverflowChecker.MarkOverflowInternal(this);
             });
         });
-
         editablePageElements.each(function () {
             OverflowChecker.MarkOverflowInternal(this);
         });
     };
-
     OverflowChecker.IsOverflowingSelf = function (element) {
         if (element.hasAttribute('data-book') && element.getAttribute('data-book') == "topic") {
             return false;
         }
-
         if ($(element).css('display') === 'none' || $(element).css('display') === 'inline')
             return false;
-
         var focusedBorderFudgeFactor = 2;
-
         var growFromCenterVerticalFudgeFactor = 0;
         if ($(element).data('firefoxheight')) {
             var fontSizeRemnant = new StyleEditor("/bloom/bookEdit").GetCalculatedFontSizeInPoints(element) - 22;
@@ -50,17 +41,13 @@ var OverflowChecker = (function () {
                 growFromCenterVerticalFudgeFactor = (fontSizeRemnant / 5) + 1;
             }
         }
-
         var shortBoxFudgeFactor = 4;
-
         return element.scrollHeight > element.clientHeight + focusedBorderFudgeFactor + growFromCenterVerticalFudgeFactor + shortBoxFudgeFactor || element.scrollWidth > element.clientWidth + focusedBorderFudgeFactor;
     };
-
     OverflowChecker.IsOverflowingMargins = function (element) {
         if (element.hasAttribute('data-book') && element.getAttribute('data-book') == "topic") {
             return false;
         }
-
         var marginBoxParent = $(element).parents('.marginBox');
         var parentBottom;
         if (marginBoxParent && marginBoxParent.length > 0)
@@ -69,12 +56,9 @@ var OverflowChecker = (function () {
             parentBottom = 999999;
         var elemTop = $(element).offset().top;
         var elemBottom = elemTop + $(element).outerHeight(false);
-
         var focusedBorderFudgeFactor = 2;
-
         return elemBottom > parentBottom + focusedBorderFudgeFactor;
     };
-
     OverflowChecker.MarkOverflowInternal = function (box) {
         var $box = $(box);
         $box.removeClass('overflow');
@@ -82,17 +66,15 @@ var OverflowChecker = (function () {
         if (OverflowChecker.IsOverflowingSelf(box) || OverflowChecker.HasImmediateSplitParentThatOverflows($box)) {
             $box.addClass('overflow');
         }
-
         var container = $box.closest('.marginBox');
-
         var queryElementsThatCanOverflow = ".bloom-editable, textarea";
         var editablePageElements = $(container).find(queryElementsThatCanOverflow);
-
         editablePageElements.each(function () {
             var $this = $(this);
             if (OverflowChecker.IsOverflowingMargins($this[0])) {
                 $this.addClass('marginOverflow');
-            } else {
+            }
+            else {
                 if (!OverflowChecker.IsOverflowingSelf($this[0]) && !OverflowChecker.HasImmediateSplitParentThatOverflows($this)) {
                     $this.removeClass('overflow');
                     $this.removeClass('marginOverflow');
@@ -101,7 +83,6 @@ var OverflowChecker = (function () {
         });
         OverflowChecker.UpdatePageOverflow(container.closest('.bloom-page'));
     };
-
     OverflowChecker.HasImmediateSplitParentThatOverflows = function (jQueryBox) {
         var splitterParents = jQueryBox.parents('.split-pane-component-inner');
         if (splitterParents.length == 0) {
@@ -109,7 +90,6 @@ var OverflowChecker = (function () {
         }
         return OverflowChecker.IsOverflowingSelf(splitterParents[0]);
     };
-
     OverflowChecker.UpdatePageOverflow = function (page) {
         var $page = $(page);
         if (!($page.find('.overflow').length) && !($page.find('.marginOverflow').length))
@@ -117,23 +97,22 @@ var OverflowChecker = (function () {
         else
             $page.addClass('pageOverflows');
     };
-
     OverflowChecker.CheckOnMinHeight = function (box) {
         var $box = $(box);
         var overflowy = $box.css("overflow-y");
         if (overflowy == 'hidden') {
             $box.css("min-height", $box.css("line-height"));
-        } else {
+        }
+        else {
             $box.css('min-height', '');
             var lineHeight = parseFloat($box.css("line-height"));
             var minHeight = parseFloat($box.css("min-height"));
-
             if (minHeight < lineHeight) {
                 $box.css("min-height", lineHeight + 0.01);
             }
         }
-
         $box.removeClass('Layout-Problem-Detected');
     };
     return OverflowChecker;
 })();
+//# sourceMappingURL=OverflowChecker.js.map

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -13,6 +13,9 @@ class OverflowChecker {
         var queryElementsThatCanOverflow = ".bloom-editable, textarea";
         var editablePageElements = $(container).find(queryElementsThatCanOverflow);
 
+        // BL-1260: disable overflow checking for pages with too many elements
+        if (editablePageElements.length > 30) return;
+
         //first, check to see if the stylesheet is going to give us overflow even for a single character:
         editablePageElements.each(function () {
             OverflowChecker.CheckOnMinHeight(this);


### PR DESCRIPTION
Bloom 3.1 beta 2.
On pages with many editable controls, the overflow checking causes the program to freeze. This is especially true in the word search page of a story primer which has almost 500 editable controls.