### PR TITLE
Fix memory leak, try browser optimization, and more checks (BL-1234)

### DIFF
--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -122,6 +122,19 @@ namespace Bloom
 			GeckoPreferences.User["network.proxy.http"] = string.Empty;
 			GeckoPreferences.User["network.proxy.http_port"] = 80;
 			GeckoPreferences.User["network.proxy.type"] = 1; // 0 = direct (uses system settings on Windows), 1 = manual configuration
+			// Try some settings to reduce memory consumption by the mozilla browser engine.
+			// Testing on Linux showed eventual substantial savings after several cycles of viewing
+			// all the pages and then going to the publish tab and producing PDF files for several
+			// books with embedded jpeg files.  (physical memory 1,153,864K, managed heap 37,789K
+			// instead of physical memory 1,952,380K, managed heap 37,723K for stepping through the
+			// same operations on the same books in the same order.  I don't know why managed heap
+			// changed although it didn't change much.)
+			// See http://kb.mozillazine.org/About:config_entries, http://www.davidtan.org/tips-reduce-firefox-memory-cache-usage
+			// and http://forums.macrumors.com/showthread.php?t=1838393.
+			GeckoPreferences.User["memory.free_dirty_pages"] = true;
+			GeckoPreferences.User["browser.sessionhistory.max_entries"] = 1;
+			GeckoPreferences.User["browser.sessionhistory.max_total_viewers"] = 0;
+			GeckoPreferences.User["browser.cache.memory.enable"] = false;
 
 			Application.ApplicationExit += OnApplicationExit;
 		}

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -713,6 +713,8 @@ namespace Bloom.Edit
 				}
 			}
 			Logger.WriteEvent("Showing ImageToolboxDialog Editor Dialog");
+			// Check memory for the benefit of developers.  The user won't see anything.
+			Palaso.UI.WindowsForms.Reporting.MemoryManagement.CheckMemory(true, "about to choose picture", false);
 			// Deep in the ImageToolboxDialog, when the user asks to see images from the ArtOfReading,
 			// We need to use the Gecko version of the thumbnail viewer, since the original ListView
 			// one has a sticky scroll bar in applications that are using Gecko.  On Linux, we also
@@ -727,15 +729,20 @@ namespace Bloom.Edit
 			}
 			using (var dlg = new ImageToolboxDialog(imageInfo, null))
 			{
-				if (DialogResult.OK == dlg.ShowDialog())
+				var result = dlg.ShowDialog();
+				// Check memory for the benefit of developers.  The user won't see anything.
+				Palaso.UI.WindowsForms.Reporting.MemoryManagement.CheckMemory(true, "picture chosen or canceled", false);
+				if (DialogResult.OK == result)
 				{
-
 					// var path = MakePngOrJpgTempFileForImage(dlg.ImageInfo.Image);
 					SaveChangedImage(imageElement, dlg.ImageInfo, "Bloom had a problem including that image");
+					// Warn the user if we're starting to use too much memory.
+					Palaso.UI.WindowsForms.Reporting.MemoryManagement.CheckMemory(true, "picture chosen and saved", true);
 				}
 			}
 			Logger.WriteMinorEvent("Emerged from ImageToolboxDialog Editor Dialog");
 			Cursor = Cursors.Default;
+			imageInfo.Dispose();	// ensure memory doesn't leak
 		}
 
 		void SaveChangedImage(GeckoHtmlElement imageElement, PalasoImage imageInfo, string exceptionMsg)

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -269,6 +269,8 @@ namespace Bloom
 			}
 			finally
 			{
+				// Check memory one final time for the benefit of developers.  The user won't see anything.
+				Palaso.UI.WindowsForms.Reporting.MemoryManagement.CheckMemory(true, "Bloom finished and exiting", false);
 				if (!skipReleaseToken)
 					UniqueToken.ReleaseToken();
 			}

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -111,9 +111,13 @@ namespace Bloom.Publish
 					else
 						layoutMethod = BookSelection.CurrentSelection.GetDefaultBookletLayout();
 
+					// Check memory for the benefit of developers.  The user won't see anything.
+					Palaso.UI.WindowsForms.Reporting.MemoryManagement.CheckMemory(true, "about to create PDF file", false);
 					_pdfMaker.MakePdf(tempHtml.Key, PdfFilePath, PageLayout.SizeAndOrientation.PageSizeName,
 						PageLayout.SizeAndOrientation.IsLandScape, LayoutPagesForRightToLeft,
 						layoutMethod, BookletPortion, worker, doWorkEventArgs, View);
+					// Warn the user if we're starting to use too much memory.
+					Palaso.UI.WindowsForms.Reporting.MemoryManagement.CheckMemory(false, "finished creating PDF file", true);
 				}
 			}
 			catch (Exception e)

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -379,7 +379,8 @@ namespace Bloom.Workspace
 		private void SelectPage(Control view)
 		{
 			CurrentTabView = view as IBloomTabArea;
-			Palaso.UI.WindowsForms.Reporting.MemoryManagement.CheckMemory(true, "switched page in workspace", true);
+			// Warn the user if we're starting to use too much memory.
+			Palaso.UI.WindowsForms.Reporting.MemoryManagement.CheckMemory(false, "switched page in workspace", true);
 
 			if(_previouslySelectedControl !=null)
 				_containerPanel.Controls.Remove(_previouslySelectedControl);


### PR DESCRIPTION
The memory leak is in the area of choosing images.  The browser
optimization may not do much, but I figure every little bit helps.
The additional checking gives a bit more information about where
memory is being consumed, and may catch growing memory a bit sooner.