### PR TITLE
BL-2155, 2159 etc: use correct file locator

### DIFF
--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -158,6 +158,7 @@ namespace Bloom
 								c.Resolve<EditBookCommand>(), c.Resolve<CreateFromSourceBookCommand>(), c.Resolve<BookServer>(),
 								c.Resolve<CurrentEditableCollectionSelection>())).InstancePerLifetimeScope();
 
+					// Keep in sync with OptimizedFileLocator: it wants to return the object created here.
 					builder.Register<IChangeableFileLocator>(
 						c =>
 							new BloomFileLocator(c.Resolve<CollectionSettings>(), c.Resolve<XMatterPackFinder>(), GetFactoryFileLocations(),
@@ -434,7 +435,7 @@ namespace Bloom
 
 		internal BloomFileLocator OptimizedFileLocator
 		{
-			get { return _scope.Resolve<BloomFileLocator>(); }
+			get { return (BloomFileLocator)_scope.Resolve<IChangeableFileLocator>(); }
 		}
 
 		internal BookServer BookServer


### PR DESCRIPTION
Project Context should be creating just one BloomFileLocator,
but the OptimizedFileLocator property was creating a new one,
not properly initialized, instead of returning it.