### PR TITLE
Remove unneeded build dependency that can cause packaging failure

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Vcs-Browser: https://github.com/BloomBooks/BloomDesktop
 Standards-Version: 3.9.5
 Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
  wget, unzip, desktop-file-utils,
- libtidy5, optipng,
+ optipng,
  mono-sil, libgdiplus-sil, geckofx29,
  libenchant-dev, libxklavier-dev, libdconf-dev,
  libicu-dev,


### PR DESCRIPTION
If we want to include Linux in beta1, this may need to be part of it.