### PR TITLE
Add a missing comma in a meta.json file

### DIFF
--- a/DistFiles/factoryCollections/Templates/Picture Dictionary/meta.json
+++ b/DistFiles/factoryCollections/Templates/Picture Dictionary/meta.json
@@ -1,6 +1,6 @@
 {
 "bookInstanceId":"7E5B8274-C7BD-4471-B54D-50CF09E4DA17",
 "experimental":"true",
-"suitableForVernacularLibrary":"true"
+"suitableForVernacularLibrary":"true",
 "suitableForMakingShells":"true"
 }


### PR DESCRIPTION
The missing comma was causing an immediate crash trying to run
Bloom on wasta-12.  I would think other systems would be affected
as well.