### PR TITLE
In folios, rewrite the img src attrs so that the image is found

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Web;
 using System.Xml;
 using Bloom.Collection;
 using Bloom.Edit;
@@ -1696,7 +1697,13 @@ namespace Bloom.Book
 					currentLastContentPage.ParentNode.InsertAfter(importedPage, currentLastContentPage);
 					currentLastContentPage = importedPage;
 
-					ImageUpdater.MakeImagePathsOfImportedPagePointToOriginalLocations(importedPage, bookInfo.FolderPath);
+					foreach(XmlElement img in importedPage.SafeSelectNodes("descendant::img"))
+					{
+						var bookFolderName = Path.GetFileName(bookInfo.FolderPath);
+						var pathRelativeToFolioFolder = ".../" + bookFolderName + "/" + img.GetAttribute("src");
+						var fullPathInLinkFormat = HttpUtility.UrlEncode(pathRelativeToFolioFolder);
+						img.SetAttribute("src", fullPathInLinkFormat);
+					}
 				}
 			}
 		}

--- a/src/BloomExe/Book/ImageUpdater.cs
+++ b/src/BloomExe/Book/ImageUpdater.cs
@@ -18,14 +18,6 @@ namespace Bloom.Book
 {
 	public class ImageUpdater
 	{
-		public static void MakeImagePathsOfImportedPagePointToOriginalLocations(XmlElement pageDiv, string folderPath)
-		{
-			foreach (XmlElement img in pageDiv.SafeSelectNodes("descendant::img"))
-			{
-				img.SetAttribute("src", "file://"+ Path.Combine(folderPath, img.GetAttribute("src")));
-			}
-		}
-
 		public static void CopyImageMetadataToWholeBook(string folderPath, HtmlDom dom, Metadata metadata, IProgress progress)
 		{
 			progress.WriteStatus("Starting...");

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -486,11 +486,24 @@ namespace Bloom.web
 				modPath = tempPath;
 			try
 			{
-				// Surprisingly, this method will return localPath unmodified if it is a fully rooted path
-				// (like C:\... or \\localhost\C$\...) to a file that exists. So this execution path
-				// can return contents of any file that exists if the URL gives its full path...even ones that
-				// are generated temp files most certainly NOT distributed with the application.
-				path = FileLocator.GetFileDistributedWithApplication("BloomBrowserUI", modPath);
+				// Is this request the full path to an image file? For most images, we just have the filename. However, in at
+				// least one use case, the image we want isn't in the folder of the PDF we're looking at. That case is when 
+				// we are looking at a "folio", a book that gathers up other books into one big PDF. In that case, we want
+				// to find the image in the correct book folder.  See AddChildBookContentsToFolio();
+				var possibleFullImagePath = HttpUtility.UrlDecode(localPath);
+				if(File.Exists(possibleFullImagePath) && Path.IsPathRooted(possibleFullImagePath))
+				{
+					path = possibleFullImagePath;
+				}
+				else
+				{
+
+					// Surprisingly, this method will return localPath unmodified if it is a fully rooted path
+					// (like C:\... or \\localhost\C$\...) to a file that exists. So this execution path
+					// can return contents of any file that exists if the URL gives its full path...even ones that
+					// are generated temp files most certainly NOT distributed with the application.
+					path = FileLocator.GetFileDistributedWithApplication("BloomBrowserUI", modPath);
+				}
 			}
 			catch (ApplicationException)
 			{


### PR DESCRIPTION
We recently switched from file-path to URL-based PDF creation. That worked fine for most books, because for those images are just a file name. However for folios, where many books are combined, we need a relative path to the folder where the image resides. So now when a folio is being assembled for running through the PDF engine, an img src attribute might be changed from "lion.png" to "../animals/lion.jpg", which then gets url encoded.