### PR TITLE
BL-1239, don't depend on decoding filename for downloadUrl

### DIFF
--- a/src/BloomTests/WebLibraryIntegration/BookTransferTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BookTransferTests.cs
@@ -277,7 +277,7 @@ namespace BloomTests.WebLibraryIntegration
 			var dest = _workFolderPath.CombineForPath("output");
 			Directory.CreateDirectory(dest);
 
-			var newBookFolder = _transfer.DownloadFromOrderUrl(_transfer.BookOrderUrl, dest);
+			var newBookFolder = _transfer.DownloadFromOrderUrl(_transfer.BookOrderUrl, dest, "nonsense");
 			Assert.That(Directory.GetFiles(newBookFolder).Length, Is.EqualTo(fileCount + 1)); // book order is added during upload
 		}
 


### PR DESCRIPTION
It was a bad idea to URLEncode the book name in the downloadOrder.
But, turns out it was also a bad idea to actually download
the book order: the url we need is already part of the book order.
So just use it.