### PR TITLE
Fix serving of Attention.svg file

### DIFF
--- a/src/BloomBrowserUI/bookLayout/basePage.css
+++ b/src/BloomBrowserUI/bookLayout/basePage.css
@@ -69,7 +69,7 @@ To handling the mis-match.*/
 }
 /* gridItem means this is a page thumbnail */
 .gridItem .pageOverflows {
-  background-image: url("../images/Attention.svg");
+  background-image: url("/bloom/BloomBrowserUI/images/Attention.svg");
   /* red triangle with exclamation point */
   background-position: bottom;
   background-repeat: no-repeat;

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -55,7 +55,7 @@ To handling the mis-match.*/
 /* gridItem means this is a page thumbnail */
 .gridItem {
 	.pageOverflows {
-		background-image: url("../images/Attention.svg"); /* red triangle with exclamation point */
+		background-image: url("/bloom/BloomBrowserUI/images/Attention.svg"); /* red triangle with exclamation point */
         background-position: bottom;
         background-repeat: no-repeat;
         background-size: 70%;

--- a/src/BloomExe/ImageProcessing/ImageServer.cs
+++ b/src/BloomExe/ImageProcessing/ImageServer.cs
@@ -79,7 +79,8 @@ namespace Bloom.ImageProcessing
 			var r = GetLocalPathWithoutQuery(info);
 
 			// only process images
-			if(!IsImageTypeThatCanBeDegraded(r))
+			var isSvg = r.EndsWith(".svg", StringComparison.OrdinalIgnoreCase);
+			if (!IsImageTypeThatCanBeDegraded(r) && !isSvg)
 				return false;
 
 			r = r.Replace("thumbnail", "");
@@ -94,6 +95,12 @@ namespace Bloom.ImageProcessing
 
 			if (!string.IsNullOrEmpty(r))
 			{
+				if (isSvg)
+				{
+					info.ReplyWithImage(r);
+					return true;
+				}
+
 				// thumbnail requests have the thumbnail parameter set in the query string
 				var thumb = info.GetQueryString()["thumbnail"] != null;
 				var pathToFile = _cache.GetPathToResizedImage(r, thumb);

--- a/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
+++ b/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
@@ -96,10 +96,6 @@ namespace Bloom.ImageProcessing
 			if (new[] {"/img/", "placeHolder", "Button"}.Any(s => originalPath.Contains(s)))
 				return originalPath;
 
-			// don't try to resize .svg files
-			if (originalPath.EndsWith(".svg", StringComparison.OrdinalIgnoreCase))
-				return originalPath;
-
 			var cacheFileName = originalPath;
 
 			if (getThumbnail)


### PR DESCRIPTION
There were 2 problems:

1. The image server would not serve svg files.
2. The basePage.css file was refering to Attention.svg on a relative path that is no longer valid.