### PR TITLE
Bl 2165 just text cog

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.js
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.js
@@ -61,23 +61,11 @@ var OverflowChecker = (function () {
         // In fact, the focused grey border causes the same problem in detecting the bottom of a marginBox
         // so we'll apply the same 'fudge' factor to both comparisons.
         var focusedBorderFudgeFactor = 2;
-        //The "basic book" template has a "Just Text" page which does some weird things to get vertically-centered
-        //text. I don't know why, but this makes the clientHeight 2 pixels larger than the scrollHeight once it
-        //is beyond its minimum height. We can detect that we're using this because it has this "firefoxHeight" data
-        //element. This problem also shows up (and is detectable the same way) in Big Book. Except it turns out the
-        //number of pixels to fudge is related to the point size. I think at base it's a preferred line spacing issue.
-        var growFromCenterVerticalFudgeFactor = 0;
-        if ($(element).data('firefoxheight')) {
-            var fontSizeRemnant = new StyleEditor("/bloom/bookEdit").GetCalculatedFontSizeInPoints(element) - 22;
-            if (fontSizeRemnant > 0) {
-                growFromCenterVerticalFudgeFactor = (fontSizeRemnant / 5) + 1;
-            }
-        }
         //In the Picture Dictionary template, all words have a scrollHeight that is 3 greater than the client height.
         //In the Headers of the Term Intro of the SHRP C1 P3 Pupil's book, scrollHeight = clientHeight + 6!!! Sigh.
         // the focussedBorderFudgeFactor takes care of 2 pixels, this adds one more.
         var shortBoxFudgeFactor = 4;
-        return element.scrollHeight > element.clientHeight + focusedBorderFudgeFactor + growFromCenterVerticalFudgeFactor + shortBoxFudgeFactor || element.scrollWidth > element.clientWidth + focusedBorderFudgeFactor;
+        return element.scrollHeight > element.clientHeight + focusedBorderFudgeFactor + shortBoxFudgeFactor || element.scrollWidth > element.clientWidth + focusedBorderFudgeFactor;
     };
     // Actual testable determination of Type II overflow or not
     // 'public' for testing (2 types of overflow are defined in MarkOverflowInternal below)

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -75,25 +75,12 @@ class OverflowChecker {
         // so we'll apply the same 'fudge' factor to both comparisons.
         var focusedBorderFudgeFactor = 2;
 
-        //The "basic book" template has a "Just Text" page which does some weird things to get vertically-centered
-        //text. I don't know why, but this makes the clientHeight 2 pixels larger than the scrollHeight once it
-        //is beyond its minimum height. We can detect that we're using this because it has this "firefoxHeight" data
-        //element. This problem also shows up (and is detectable the same way) in Big Book. Except it turns out the
-        //number of pixels to fudge is related to the point size. I think at base it's a preferred line spacing issue.
-        var growFromCenterVerticalFudgeFactor = 0;
-        if ($(element).data('firefoxheight')) {
-            var fontSizeRemnant = new StyleEditor("/bloom/bookEdit").GetCalculatedFontSizeInPoints(element) - 22;
-            if (fontSizeRemnant > 0) {
-                growFromCenterVerticalFudgeFactor = (fontSizeRemnant / 5) + 1;
-            }
-        }
-
         //In the Picture Dictionary template, all words have a scrollHeight that is 3 greater than the client height.
         //In the Headers of the Term Intro of the SHRP C1 P3 Pupil's book, scrollHeight = clientHeight + 6!!! Sigh.
         // the focussedBorderFudgeFactor takes care of 2 pixels, this adds one more.
         var shortBoxFudgeFactor = 4;
 
-        return element.scrollHeight > element.clientHeight + focusedBorderFudgeFactor + growFromCenterVerticalFudgeFactor + shortBoxFudgeFactor ||
+        return element.scrollHeight > element.clientHeight + focusedBorderFudgeFactor + shortBoxFudgeFactor ||
             element.scrollWidth > element.clientWidth + focusedBorderFudgeFactor
     }
 

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
@@ -455,6 +455,15 @@ var StyleEditor = (function () {
         var $target = $(targetBox);
         return typeof ($target.closest('.bloom-frontMatter')[0]) !== 'undefined' || typeof ($target.closest('.bloom-backMatter')[0]) !== 'undefined';
     };
+    StyleEditor.prototype.AdjustFormatButton = function (jqueryNode) {
+        var newBottom = -1 * GetDifferenceBetweenHeightAndParentHeight(jqueryNode.parent());
+        if (newBottom < 0) {
+            newBottom = 0;
+        }
+        $("#formatButton").css({
+            bottom: newBottom
+        });
+    };
     StyleEditor.prototype.AttachToBox = function (targetBox) {
         var styleName = StyleEditor.GetStyleNameForElement(targetBox);
         if (!styleName)
@@ -478,12 +487,9 @@ var StyleEditor = (function () {
         // the user won't see resize and drag controls when they click on it
         $(targetBox).append('<div id="formatButton" contenteditable="false" class="bloom-ui"><img  contenteditable="false" src="' + editor._supportFilesRoot + '/img/cogGrey.svg"></div>');
         //make the button stay at the bottom if we overflow and thus scroll
-        $(targetBox).on("scroll", function () {
-            var newBottom = -1 * $(this).scrollTop();
-            $("#formatButton").css({
-                bottom: newBottom
-            });
-        });
+        $(targetBox).on("scroll", this.AdjustFormatButton);
+        // And in case we are starting out on a centerVertically page we might need to adjust it now
+        this.AdjustFormatButton($(targetBox));
         var formatButton = $('#formatButton');
         /* we removed this for BL-799, plus it was always getting in the way, once the format popup was opened
         var txt = localizationManager.getText('EditTab.FormatDialogTip', 'Adjust formatting for style');

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -16,6 +16,8 @@ interface qtipInterface extends JQuery {
     qtipSecondary(options: any): JQuery;
 }
 
+declare function GetDifferenceBetweenHeightAndParentHeight(JQuery):number;
+
 class StyleEditor {
 
     private _previousBox: Element;
@@ -501,6 +503,16 @@ class StyleEditor {
         return typeof ($target.closest('.bloom-frontMatter')[0]) !== 'undefined' || typeof ($target.closest('.bloom-backMatter')[0]) !== 'undefined';
     }
 
+    AdjustFormatButton(jqueryNode: JQuery):void {
+        var newBottom = -1 * GetDifferenceBetweenHeightAndParentHeight(jqueryNode.parent());
+        if (newBottom < 0) {
+            newBottom = 0;
+        }
+        $("#formatButton").css({
+            bottom: newBottom
+        });
+    }
+
     AttachToBox(targetBox: HTMLElement) {
         var styleName = StyleEditor.GetStyleNameForElement(targetBox);
         if (!styleName)
@@ -528,12 +540,10 @@ class StyleEditor {
         $(targetBox).append('<div id="formatButton" contenteditable="false" class="bloom-ui"><img  contenteditable="false" src="' + editor._supportFilesRoot + '/img/cogGrey.svg"></div>');
 
         //make the button stay at the bottom if we overflow and thus scroll
-        $(targetBox).on("scroll", function () {
-            var newBottom = -1 * $(this).scrollTop();
-            $("#formatButton").css({
-                bottom: newBottom
-            });
-        });
+        $(targetBox).on("scroll", this.AdjustFormatButton);
+
+        // And in case we are starting out on a centerVertically page we might need to adjust it now
+        this.AdjustFormatButton($(targetBox));
 
         var formatButton = $('#formatButton');
         /* we removed this for BL-799, plus it was always getting in the way, once the format popup was opened

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -51,14 +51,6 @@ $.fn.CenterVerticallyInParent = function() {
         var ph = $(this).parent().height();
         var mh = Math.ceil((ph - ah) / 2);
         $(this).css('margin-top', mh);
-
-        ///There is a bug in wkhtmltopdf where it determines the height of these incorrectly, causing, in a multlingual situation, the 1st text box to hog up all the room and
-        //push the other guys off the page. So the hack solution of the moment is to remember the correct height here, in gecko-land, and use it over there to set the max-height.
-        //See bloomPreview.SetMaxHeightForHtmlToPDFBug()
-        $(this).children().each(function(){
-            var h= $(this).height();
-            $(this).attr('data-firefoxHeight', h);
-        });
     });
 };
 

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -47,13 +47,26 @@ function fireCSharpEditEvent(eventName, eventData) {
 
 $.fn.CenterVerticallyInParent = function() {
     return this.each(function(i) {
-        var ah = $(this).height();
-        var ph = $(this).parent().height();
-        var mh = Math.ceil((ph - ah) / 2);
+        var $this = $(this);
+        $this.css('margin-top', 0); // reset before calculating in case of previously messed up page
+        var diff = GetDifferenceBetweenHeightAndParentHeight($this);
+        if (diff < 0) {
+            // we're too big, do nothing to margin-top
+            // but the formatButton may need adjusting, in StyleEditor
+            return;
+        }
+        var mh = Math.ceil(diff / 2);
         $(this).css('margin-top', mh);
     });
 };
 
+function GetDifferenceBetweenHeightAndParentHeight(jqueryNode) {
+    // function also declared and used in StyleEditor
+    if (!jqueryNode) {
+        return 0;
+    }
+    return jqueryNode.parent().height() - jqueryNode.height();
+}
 
 function isBrOrWhitespace(node) {
     return node && ( (node.nodeType == 1 && node.nodeName.toLowerCase() == "br") ||
@@ -1050,6 +1063,10 @@ function SetupElements(container) {
             //so we actually attach twice. That's ok, the editor handles that, but I don't know why we're passing the if, and it could be improved.
             if ($(this).closest('.bloom-userCannotModifyStyles').length == 0)
                 editor.AttachToBox(this);
+        }
+        else {
+            // already have a format cog, better make sure it's in the right place
+            editor.AdjustFormatButton($(this));
         }
     });
 

--- a/src/BloomBrowserUI/bookPreview/js/bloomPreview.js
+++ b/src/BloomBrowserUI/bookPreview/js/bloomPreview.js
@@ -6,32 +6,10 @@ $.fn.CenterVerticallyInParent = function () {
         var ph = $(this).parent().height();
         var mh = Math.ceil((ph - ah) / 2);
         $(this).css('margin-top', mh);
-
-        ///There is a bug in wkhtmltopdf where it determines the height of these incorrectly, causing, in a multlingual situation, the 1st text box to hog up all the room and
-        //push the other guys off the page. So the hack solution of the moment is to remember the correct height here, in gecko-land, and use it over there to set the max-height.
-        //See bloomPreview.SetMaxHeightForHtmlToPDFBug()
-        $(this).children().each(function () {
-            var h = $(this).height();
-            $(this).attr('data-firefoxHeight', h);
-        });
     });
 };
 
  //Do the little bit of jscript needed even when we're just displaying the document
-
-function SetMaxHeightForHtmlToPDFBug(element)
-{
-        //this comes from trying tying to find a way to work-around a bug in htmltopdf, which, when the margin-top grows, just pushes the box down & off the page.
-        //we were able to make it work for one lang by doing an overflow:hidden, but for multilingual, the first div just pushes then next into oblivion.
-        //I started trying to dynamically set the max-height of each div. Problem: we don't actually have a way of knowing how high they *should* be, because
-        // here in wkhtmltopdf, we get the wrong value (that's what got us in this fix in the first place).
-        //The hack for now is to, over in the editing javascript, remember the proper height while we're still in firefox, then use it here in wkhtmltopdf
-        $(element).children().each(function(){
-          if($(this).attr('data-firefoxHeight') != undefined){
-                $(this).css('max-height', $(this).attr('data-firefoxHeight'));
-          };
-        });
-}
 
 jQuery(document).ready(function () {
 
@@ -70,7 +48,5 @@ jQuery(document).ready(function () {
     //Like I say, it doesn't work yet anyhow...
 
     $(".bloom-centerVertically").CenterVerticallyInParent();
-
-    $(".bloom-centerVertically").each(function () { SetMaxHeightForHtmlToPDFBug($(this)) });
 
 });


### PR DESCRIPTION
* removed workaround for wkhtmltopdf for centerVertically
* make cog stay in frame on centerVertically when moving
  in and out of overflow state and cutting and pasting