### PR TITLE
Fix BL-2187

### DIFF
--- a/DistFiles/factoryCollections/Sample Shells/Vaccinations/previewMode.css
+++ b/DistFiles/factoryCollections/Sample Shells/Vaccinations/previewMode.css
@@ -78,7 +78,8 @@ DIV.coverBottomBookTopic DIV.topicN1 {
 body {
   counter-reset: pageNumber;
 }
-DIV.numberedPage {
+.numberedPage,
+.countPageButDoNotShowNumber {
   counter-increment: pageNumber;
 }
 DIV.numberedPage:nth-of-type(odd):after {

--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
@@ -61,8 +61,11 @@
         </div>
       </div>
     </div>
+    <!-- The important thing here, with countPageButDoNotShowNumber,-->
+    <!-- is to get the left pages being even, else the professional publishing folks freak.-->
+    <!-- Beyond that, it's not yet clear what is best, needs some research-->
     <!-- TITLE PAGE-->
-    <div class="A5Portrait bloom-page titlePage bloom-frontMatter" data-page="required singleton" data-export="front-matter-title-page" id="5dcd48df-e9ab-4a07-afd4-6a24d0398381">
+    <div class="A5Portrait bloom-page titlePage bloom-frontMatter countPageButDoNotShowNumber" data-page="required singleton" data-export="front-matter-title-page" id="5dcd48df-e9ab-4a07-afd4-6a24d0398381">
       <div lang="en" class="pageLabel">Title Page</div>
       <div class="marginBox">
         <div class="bloom-translationGroup" id="titlePageTitleBlock">

--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.jade
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.jade
@@ -11,6 +11,9 @@ html
 	body
 		+factoryStandard-outsideFrontCover
 		+factoryStandard-creditsInsideFrontCover
-		+factoryStandard-titlePage
+		// The important thing here, with countPageButDoNotShowNumber,
+		// is to get the left pages being even, else the professional publishing folks freak.
+		// Beyond that, it's not yet clear what is best, needs some research
+		+factoryStandard-titlePage.countPageButDoNotShowNumber
 		+factoryStandard-insideBackCover
 		+factoryStandard-outsideBackCover

--- a/DistFiles/xMatter/bloom-xmatter-mixins.jade
+++ b/DistFiles/xMatter/bloom-xmatter-mixins.jade
@@ -90,7 +90,7 @@ mixin block-licenseAndCopyright
 
 mixin factoryStandard-outsideFrontCover
 	// FRONT COVER
-	+page-cover('Front Cover')(data-export='front-matter-cover').frontCover.outsideFrontCover#74731b2d-18b0-420f-ac96-6de20f659810
+	+page-cover('Front Cover')(attributes, data-export='front-matter-cover').frontCover.outsideFrontCover#74731b2d-18b0-420f-ac96-6de20f659810
 
 		//- enchance: could we 1) adjust stylesheet and 2) preserve bookTitle value to simplify this to
 		//- 	+field-matter('bookTitle').Title-On-Cover-style
@@ -117,12 +117,12 @@ mixin factoryStandard-outsideFrontCover
 
 mixin factoryStandard-creditsInsideFrontCover
 	// Inside Front Cover CREDITS PAGE
-	+page-cover("Credits Page").credits(data-export='front-matter-credits')#B7DB9AC7-5DCC-4D55-86B5-6DD2A5303AA9
+	+page-cover("Credits Page").credits(attributes, data-export='front-matter-credits')#B7DB9AC7-5DCC-4D55-86B5-6DD2A5303AA9
 		+credits-contents
 
 mixin factoryStandard-credits-interiorPage
 	// CREDITS PAGE
-	+page-xmatter("Credits Page").bloom-frontMatter.credits(data-export='front-matter-credits')#2CCC8F26-A797-4A5B-9BA7-E29823D2CB24
+	+page-xmatter("Credits Page").bloom-frontMatter.credits(attributes, data-export='front-matter-credits')#2CCC8F26-A797-4A5B-9BA7-E29823D2CB24
 		+credits-contents
 
 mixin credits-contents
@@ -133,7 +133,7 @@ mixin credits-contents
 
 mixin factoryStandard-titlePage
 	// TITLE PAGE
-	+page-xmatter('Title Page').titlePage.bloom-frontMatter(data-export='front-matter-title-page')#5dcd48df-e9ab-4a07-afd4-6a24d0398381
+	+page-xmatter('Title Page').titlePage.bloom-frontMatter(attributes, data-export='front-matter-title-page')#5dcd48df-e9ab-4a07-afd4-6a24d0398381
 		+field-prototypeDeclaredExplicity#titlePageTitleBlock
 			label.bubble Book title in {lang}
 			+editable(kLanguageForPrototypeOnly).Title-On-Title-Page-style(data-book='bookTitle')

--- a/src/BloomBrowserUI/bookPreview/css/previewMode.css
+++ b/src/BloomBrowserUI/bookPreview/css/previewMode.css
@@ -78,7 +78,8 @@ DIV.coverBottomBookTopic DIV.topicN1 {
 body {
   counter-reset: pageNumber;
 }
-DIV.numberedPage {
+.numberedPage,
+.countPageButDoNotShowNumber {
   counter-increment: pageNumber;
 }
 DIV.numberedPage:nth-of-type(odd):after {

--- a/src/BloomBrowserUI/bookPreview/css/previewMode.less
+++ b/src/BloomBrowserUI/bookPreview/css/previewMode.less
@@ -97,7 +97,7 @@ DIV.coverBottomBookTopic DIV.topicN1
 body {
 	counter-reset: pageNumber;
 }
-DIV.numberedPage
+.numberedPage, .countPageButDoNotShowNumber
 {
 	counter-increment: pageNumber;
 }


### PR DESCRIPTION
We were ignoring countPageButDoNotShowNumber class.

This class was on one of the pages in in the Traditional xmatter, so that the first page was then page 2. This PR adds it to the factory xmatter too.

The jade xmatter mixins were improved to carry classes like this through to the html.