### PR TITLE
BL-2174 and BL-2173 File Watcher problem

### DIFF
--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -79,7 +79,6 @@ namespace Bloom.Collection
 				return;
 
 			Logger.WriteEvent("After BookStorage.DeleteBook({0})", bookInfo.FolderPath);
-			//ListOfBooksIsOutOfDate();
 			Debug.Assert(_bookInfos.Contains(bookInfo));
 			_bookInfos.Remove(bookInfo);
 

--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -102,17 +102,13 @@ namespace Bloom.Collection
 
 		}
 
-
-		private void ListOfBooksIsOutOfDate()
-		{
-			_bookInfos = null;
-		}
-
 		public virtual IEnumerable<Book.BookInfo> GetBookInfos()
 		{
 			if (_bookInfos == null)
 			{
+				_watcherIsDisabled = true;
 				LoadBooks();
+				_watcherIsDisabled = false;
 			}
 
 			return _bookInfos;
@@ -227,12 +223,15 @@ namespace Bloom.Collection
 		}
 
 		public event EventHandler<ProjectChangedEventArgs> FolderContentChanged;
+		private bool _watcherIsDisabled = false;
 
 		private void WatcherOnChange(object sender, FileSystemEventArgs fileSystemEventArgs)
 		{
+			if (_watcherIsDisabled)
+				return;
 			_bookInfos = null; // Possibly obsolete; next request will update it.
 			if (FolderContentChanged != null)
-				FolderContentChanged(this, new ProjectChangedEventArgs() {Path = fileSystemEventArgs.FullPath});
+				FolderContentChanged(this, new ProjectChangedEventArgs() { Path = fileSystemEventArgs.FullPath });
 		}
 	}
 


### PR DESCRIPTION
Sometimes when a downloaded book had triggered GetBookInfos() (which builds the collection _bookInfos), the file system watcher would discover a file had been added (the downloaded book) and trigger the watcher code which started off by setting _bookInfos = null. Solved the thread crashing by disabling the watcher while in GetBookInfos() and verified that the Watcher does get called again after.

The "sometimes" above, seems to be when the download process coughs up a non-fatal Bloom Problem dialog...