### PR TITLE
BL-2204 UpdateBook should not change its orientation

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -812,11 +812,11 @@ namespace Bloom.Book
 			foreach (XmlElement templatePageDiv in templateDom.SafeSelectNodes("//body/div"))
 			{
 				if (templatePageDiv.GetOptionalStringAttribute("class", "").Contains("customPage"))
-					return; // we sure don't want to revert this page to its blank custom state
+					continue; // we sure don't want to revert this page to its blank custom state
 
 				var templateId = templatePageDiv.GetStringAttribute("id");
 				if (string.IsNullOrEmpty(templateId))
-					return;
+					continue;
 
 				var templatePageClasses = templatePageDiv.GetAttribute("class");
 				//note, lineage is a series of guids separated by a semicolon


### PR DESCRIPTION
A couple of 'return's were used where 'continue' should have
been to allow necessary cleanup to happen after a loop.