### PR TITLE
Disable CanSubmitToSILJiraAutomatedTestProject test on Linux

### DIFF
--- a/src/BloomTests/ProblemReporterDialogTests.cs
+++ b/src/BloomTests/ProblemReporterDialogTests.cs
@@ -49,6 +49,7 @@ namespace BloomTests
 		/// It sends reports to https://jira.sil.org/browse/AUT
 		/// </summary>
 		[Test]
+		[Platform(Exclude = "Linux", Reason = "YouTrackSharp is too Windows-centric")]
 		public void CanSubmitToSILJiraAutomatedTestProject()
 		{
 			using (var dlg = new ProblemReporterDialogDouble())


### PR DESCRIPTION
This doesn't begin to work since we changed over to YouTrack.