### PR TITLE
Replace Image.FromFile with method that doesn't lock (BL-2214)

### DIFF
--- a/src/BloomExe/Book/BookInfo.cs
+++ b/src/BloomExe/Book/BookInfo.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
+using Bloom.ImageProcessing;
 using Bloom.ToPalaso;
 using L10NSharp;
 using Newtonsoft.Json;
@@ -223,11 +224,7 @@ namespace Bloom.Book
 			string path = Path.Combine(FolderPath, "thumbnail.png");
 			if (File.Exists(path))
 			{
-				//this FromFile thing locks the file until the image is disposed of. Therefore, we copy the image and dispose of the original.
-				using (var tempImage = Image.FromFile(path))
-				{
-					image = new Bitmap(tempImage);
-				}
+				image = ImageUtils.GetImageFromFile(path);
 				return true;
 			}
 			image = null;

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -162,11 +162,7 @@ namespace Bloom.Book
 			string path = Path.Combine(_folderPath, fileName);
 			if (File.Exists(path))
 			{
-				//this FromFile thing locks the file until the image is disposed of. Therefore, we copy the image and dispose of the original.
-				using (var tempImage = Image.FromFile(path))
-				{
-					image = new Bitmap(tempImage);
-				}
+				image = ImageUtils.GetImageFromFile(path);
 				return true;
 			}
 			image = null;

--- a/src/BloomExe/CollectionTab/LibraryBookView.cs
+++ b/src/BloomExe/CollectionTab/LibraryBookView.cs
@@ -78,7 +78,9 @@ namespace Bloom.CollectionTab
 			}
 			catch (Exception error)
 			{
-				Palaso.Reporting.ErrorReport.NotifyUserOfProblem(error,"Problem selecting book");
+				var msg = L10NSharp.LocalizationManager.GetString("Bloom", "Errors.ErrorSelecting",
+					"There was a problem selecting the book.  Restarting Bloom may fix the problem.  If not, please click the 'Details' button and report the problem to the Bloom Developers.");
+				Palaso.Reporting.ErrorReport.NotifyUserOfProblem(error, msg);
 			}
 		}
 

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -858,7 +858,16 @@ namespace Bloom.CollectionTab
 
 		private void OnBringBookUpToDate_Click(object sender, EventArgs e)
 		{
-			_model.BringBookUpToDate();
+			try
+			{
+				_model.BringBookUpToDate();
+			}
+			catch (Exception error)
+			{
+				var msg = LocalizationManager.GetDynamicString("Bloom", "Errors.ErrorUpdating",
+					"There was a problem updating the book.  Restarting Bloom may fix the problem.  If not, please click the 'Details' button and report the problem to the Bloom Developers.");
+				ErrorReport.NotifyUserOfProblem(error, msg);
+			}
 		}
 
 		private void _openFolderOnDisk_Click(object sender, EventArgs e)

--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -22,14 +22,14 @@ namespace BloomTests.ImageProcessing
 		public void ShouldChangeFormatToJpeg_Photo_True()
 		{
 			var path = Palaso.IO.FileLocator.GetFileDistributedWithApplication(_pathToTestImages, "man.jpg");
-			Assert.IsTrue(ImageUtils.ShouldChangeFormatToJpeg(Image.FromFile(path)));
+			Assert.IsTrue(ImageUtils.ShouldChangeFormatToJpeg(ImageUtils.GetImageFromFile(path)));
 		}
 
 		[Test]
 		public void ShouldChangeFormatToJpeg_OneColor_False()
 		{
 			var path = Palaso.IO.FileLocator.GetFileDistributedWithApplication(_pathToTestImages, "bird.png");
-			Assert.IsFalse(ImageUtils.ShouldChangeFormatToJpeg(Image.FromFile(path)));
+			Assert.IsFalse(ImageUtils.ShouldChangeFormatToJpeg(ImageUtils.GetImageFromFile(path)));
 		}
 
 		[Test]
@@ -59,7 +59,7 @@ namespace BloomTests.ImageProcessing
 				var fileName = ImageUtils.ProcessAndSaveImageIntoFolder(image, folder.Path);
 				Assert.AreEqual(expectedOutputFormat == ImageFormat.Jpeg ? ".jpg" : ".png", Path.GetExtension(fileName));
 				var outputPath = folder.Combine(fileName);
-				using(var img = Image.FromFile(outputPath))
+				using (var img = ImageUtils.GetImageFromFile(outputPath))
 				{
 					Assert.AreEqual(expectedOutputFormat, img.RawFormat);
 				}

--- a/src/BloomTests/ImageProcessing/RuntimeImageProcessingTests.cs
+++ b/src/BloomTests/ImageProcessing/RuntimeImageProcessingTests.cs
@@ -20,7 +20,7 @@ namespace BloomTests.RuntimeImageProcessing
 			using (var cache = new RuntimeImageProcessor(new BookRenamedEvent()) { TargetDimension = 100 })
 			using (var file = MakeTempPNGImage(200,80))
 			{
-				using(var img = Image.FromFile(cache.GetPathToResizedImage(file.Path)))
+				using(var img = ImageUtils.GetImageFromFile(cache.GetPathToResizedImage(file.Path)))
 				{
 					Assert.AreEqual(100, img.Width);
 					Assert.AreEqual(40, img.Height);
@@ -36,7 +36,7 @@ namespace BloomTests.RuntimeImageProcessing
 			using (var file = MakeTempJPGImage(200, 80))
 			{
 				var pathToResizedImage = cache.GetPathToResizedImage(file.Path);
-				using (var img = Image.FromFile(pathToResizedImage))
+				using (var img = ImageUtils.GetImageFromFile(pathToResizedImage))
 				{
 					Assert.AreEqual(".jpg", Path.GetExtension(pathToResizedImage));
 
@@ -56,7 +56,7 @@ namespace BloomTests.RuntimeImageProcessing
 			using (var cache = new RuntimeImageProcessor(new BookRenamedEvent()) { TargetDimension = 100 })
 			using (var file = MakeTempPNGImage(10,10))
 			{
-				using (var img = Image.FromFile(cache.GetPathToResizedImage(file.Path)))
+				using (var img = ImageUtils.GetImageFromFile(cache.GetPathToResizedImage(file.Path)))
 				{
 					Assert.AreEqual(10, img.Width);
 				}

--- a/src/BloomTests/PageEditingModelTests.cs
+++ b/src/BloomTests/PageEditingModelTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 using Bloom.Edit;
+using Bloom.ImageProcessing;
 using NUnit.Framework;
 using Palaso.TestUtilities;
 using Palaso.UI.WindowsForms.ImageToolbox;
@@ -60,7 +61,7 @@ namespace BloomTests
 					var destDogImagePath = dest.Combine("dog.png");
 					File.WriteAllText(destDogImagePath, "old dog");
 					model.ChangePicture(dest.Path, dom, "two", original);
-					Assert.IsTrue(Image.FromFile(destDogImagePath).Width == kSampleImageDimension);
+					Assert.IsTrue(ImageUtils.GetImageFromFile(destDogImagePath).Width == kSampleImageDimension);
 				}
 			}
 		}
@@ -105,7 +106,7 @@ namespace BloomTests
 				model.ChangePicture(dest.Path, dom, "two", original);
 				Assert.IsTrue(File.Exists(dest.Combine("new.png")));
 				AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath(@"//img[@id='two' and @src='new.png']", 1);
-				using (var converted = Image.FromFile(dest.Combine("new.png")))
+				using (var converted = ImageUtils.GetImageFromFile(dest.Combine("new.png")))
 				{
 					Assert.AreEqual(ImageFormat.Png.Guid, converted.RawFormat.Guid);
 				}
@@ -125,7 +126,7 @@ namespace BloomTests
 				model.ChangePicture(dest.Path, dom, "two", original);
 				Assert.IsTrue(File.Exists(dest.Combine("new.jpg")));
 				AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath(@"//img[@id='two' and @src='new.jpg']", 1);
-				using (var converted = Image.FromFile(dest.Combine("new.jpg")))
+				using (var converted = ImageUtils.GetImageFromFile(dest.Combine("new.jpg")))
 				{
 					Assert.AreEqual(ImageFormat.Jpeg.Guid, converted.RawFormat.Guid);
 				}


### PR DESCRIPTION
Also catch exception thrown while updating books and report it to the
user, with a suggestion to restart the program.  Such exceptions are
usually due to running out of memory somehow, probably by fragmenting
the C level heap and then trying to load a very large image.