### PR TITLE
Fix failing unit tests to use Image.FromFile again

### DIFF
--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -59,7 +59,7 @@ namespace BloomTests.ImageProcessing
 				var fileName = ImageUtils.ProcessAndSaveImageIntoFolder(image, folder.Path);
 				Assert.AreEqual(expectedOutputFormat == ImageFormat.Jpeg ? ".jpg" : ".png", Path.GetExtension(fileName));
 				var outputPath = folder.Combine(fileName);
-				using (var img = ImageUtils.GetImageFromFile(outputPath))
+				using (var img = Image.FromFile(outputPath))
 				{
 					Assert.AreEqual(expectedOutputFormat, img.RawFormat);
 				}

--- a/src/BloomTests/PageEditingModelTests.cs
+++ b/src/BloomTests/PageEditingModelTests.cs
@@ -106,7 +106,7 @@ namespace BloomTests
 				model.ChangePicture(dest.Path, dom, "two", original);
 				Assert.IsTrue(File.Exists(dest.Combine("new.png")));
 				AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath(@"//img[@id='two' and @src='new.png']", 1);
-				using (var converted = ImageUtils.GetImageFromFile(dest.Combine("new.png")))
+				using (var converted = Image.FromFile(dest.Combine("new.png")))
 				{
 					Assert.AreEqual(ImageFormat.Png.Guid, converted.RawFormat.Guid);
 				}
@@ -126,7 +126,7 @@ namespace BloomTests
 				model.ChangePicture(dest.Path, dom, "two", original);
 				Assert.IsTrue(File.Exists(dest.Combine("new.jpg")));
 				AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath(@"//img[@id='two' and @src='new.jpg']", 1);
-				using (var converted = ImageUtils.GetImageFromFile(dest.Combine("new.jpg")))
+				using (var converted = Image.FromFile(dest.Combine("new.jpg")))
 				{
 					Assert.AreEqual(ImageFormat.Jpeg.Guid, converted.RawFormat.Guid);
 				}


### PR DESCRIPTION
This reverts some changes made earlier today.  It turns out that copying
a Bitmap doesn't preserve all of the characteristics of the original
Bitmap.