### PR TITLE
Fix sample print settings display for Linux (BL-2213)

### DIFF
--- a/src/BloomExe/Publish/PdfViewer.cs
+++ b/src/BloomExe/Publish/PdfViewer.cs
@@ -31,6 +31,9 @@ namespace Bloom.Publish
 		private const ulong STATE_STOP = 0x00000010;
 		private bool _printing;
 		public event EventHandler<PdfPrintProgressEventArgs> PrintProgress;
+#if __MonoCS__
+		public event EventHandler PrintFinished;
+#endif
 		//private PdfPrintProgressListener _listener;
 		private string _pdfPath;
 
@@ -243,9 +246,21 @@ namespace Bloom.Publish
 					CreateNoWindow = true // don't need a DOS box (does not suppress print dialog)
 				}
 			};
+#if __MonoCS__
+			proc.EnableRaisingEvents = true;
+			proc.Exited += PrintProcessExited;
+#endif
 			proc.Start();
 			return true; // we at least think we printed it (unless the user cancels...anyway, don't try again some other way).
 		}
+
+#if __MonoCS__
+		void PrintProcessExited(object sender, EventArgs e)
+		{
+			if (PrintFinished != null)
+				PrintFinished(sender, e);
+		}
+#endif
 
 		private void PrintAfterPause(object sender, EventArgs e)
 		{


### PR DESCRIPTION
Without the fix, the sample settings disappear on Linux as soon as
the print dialog appears, which is somewhat self defeating.