### PR TITLE
BL-2205 Improve error reporting when cannot set up socket

### DIFF
--- a/src/BloomExe/web/CommandAvailabilityPublisher.cs
+++ b/src/BloomExe/web/CommandAvailabilityPublisher.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net.Sockets;
 using Fleck;
+using Palaso.Reporting;
 
 namespace Bloom.web
 {
@@ -26,19 +28,31 @@ namespace Bloom.web
 			FleckLog.Level = LogLevel.Warn;
 			_allSockets = new List<IWebSocketConnection>();
 			_server = new WebSocketServer("ws://127.0.0.1:8189");
-			_server.Start(socket =>
+			try
 			{
-				socket.OnOpen = () =>
+				_server.Start(socket =>
 				{
-					Debug.WriteLine("Backend received an request to open a CommandAvailabilityPublisher socket");
-					_allSockets.Add(socket);
-				};
-				socket.OnClose = () =>
-				{
-					Debug.WriteLine("Backend received an request to close  CommandAvailabilityPublisher socket");
-					_allSockets.Remove(socket);
-				};
-			});
+					socket.OnOpen = () =>
+					{
+						Debug.WriteLine("Backend received an request to open a CommandAvailabilityPublisher socket");
+						_allSockets.Add(socket);
+					};
+					socket.OnClose = () =>
+					{
+						Debug.WriteLine("Backend received an request to close  CommandAvailabilityPublisher socket");
+						_allSockets.Remove(socket);
+					};
+				});
+			}
+			catch (SocketException ex)
+			{
+				ErrorReport.NotifyUserOfProblem(ex, "Bloom cannot start properly (cannot set up some internal communications){0}{0}" +
+					"What caused this?{0}" +
+					"Possibly another version of Bloom is running, perhaps not very obviously.{0}{0}" +
+					"What can you do?{0}" +
+					"Click OK, then exit Bloom and restart your computer.{0}" +
+					"If the problem keeps happening, click 'Details' and report the problem to the developers.", Environment.NewLine);
+			}
 		}
 
 		void command_EnabledChanged(object sender, EventArgs e)


### PR DESCRIPTION
The report indicates a failure to set up the web socket we
use to publish command availability to the embedded browser.
Probably because of another instance running.