### PR TITLE
Fix 10mm extra margin in PDF

### DIFF
--- a/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfProgram.cs
+++ b/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfProgram.cs
@@ -130,7 +130,7 @@ namespace Bloom.Publish
 			string paperSizeName, bool landscape)
 		{
 			bldr.AppendFormat("\"{0}\" \"{1}\"", inputHtmlPath, outputPdfPath);
-			bldr.AppendFormat(" -B0 -T0 -L0 -R0 -s {0}", paperSizeName);
+			bldr.AppendFormat(" -B 0 -T 0 -L 0 -R 0 -s {0}", paperSizeName);
 			bldr.Append(" --graphite");
 			if (landscape)
 				bldr.Append(" -Landscape");


### PR DESCRIPTION
Problem was that bloom was giving geckofxhtmltopdf a command line that it couldn't make sense of, e.g. "-R0 -T0 -B0 -L0" instead of "-R 0 -T 0 -B 0 -L 0", so it was using defaults, which are 10mm all around.