### PR TITLE
BL-2221 Save origami before leaving page

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -655,4 +655,14 @@ $(document).ready(function() {
 //        var commandStatus = JSON.parse(event.data);
 //        alert("DeleteCurrentPage Command "+ (commandStatus.deleteCurrentPage.enabled == true ? "Enabled" : "Disabled")) ;
 //    }
+
+    // This is invoked from C# when we are about to change pages. It is mainly for origami,
+    // but preparePageForEditingAfterOrigamiChangesEvent currently has the (very important)
+    // side effect of saving the changes to the current page.
+    var pageSelectionChanging = function () {
+        var marginBox = $('.marginBox');
+        marginBox.removeClass('origami-layout-mode');
+        marginBox.find('.bloom-translationGroup .textBox-identifier').remove();
+        fireCSharpEditEvent('preparePageForEditingAfterOrigamiChangesEvent', '');
+    }
 }); // end document ready function

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -655,14 +655,14 @@ $(document).ready(function() {
 //        var commandStatus = JSON.parse(event.data);
 //        alert("DeleteCurrentPage Command "+ (commandStatus.deleteCurrentPage.enabled == true ? "Enabled" : "Disabled")) ;
 //    }
-
-    // This is invoked from C# when we are about to change pages. It is mainly for origami,
-    // but preparePageForEditingAfterOrigamiChangesEvent currently has the (very important)
-    // side effect of saving the changes to the current page.
-    var pageSelectionChanging = function () {
-        var marginBox = $('.marginBox');
-        marginBox.removeClass('origami-layout-mode');
-        marginBox.find('.bloom-translationGroup .textBox-identifier').remove();
-        fireCSharpEditEvent('preparePageForEditingAfterOrigamiChangesEvent', '');
-    }
 }); // end document ready function
+
+// This is invoked from C# when we are about to change pages. It is mainly for origami,
+// but preparePageForEditingAfterOrigamiChangesEvent currently has the (very important)
+// side effect of saving the changes to the current page.
+var pageSelectionChanging = function () {
+    var marginBox = $('.marginBox');
+    marginBox.removeClass('origami-layout-mode');
+    marginBox.find('.bloom-translationGroup .textBox-identifier').remove();
+    fireCSharpEditEvent('finishSavingPage', '');
+}

--- a/src/BloomBrowserUI/bookEdit/js/calledByCSharp.js
+++ b/src/BloomBrowserUI/bookEdit/js/calledByCSharp.js
@@ -1,4 +1,4 @@
-/// <reference path="readerToolsModel.ts" />
+﻿/// <reference path="readerToolsModel.ts" />
 var CalledByCSharp = (function () {
     function CalledByCSharp() {
     }
@@ -16,6 +16,11 @@ var CalledByCSharp = (function () {
         if (!contentWindow || !contentWindow.model || !contentWindow.model.shouldHandleUndo())
             return 'fail';
         return contentWindow.model.canUndo();
+    };
+
+    CalledByCSharp.prototype.pageSelectionChanging = function () {
+        var contentWindow = this.getPageContent();
+        contentWindow['pageSelectionChanging']();
     };
 
     CalledByCSharp.prototype.loadReaderToolSettings = function (settings, bookFontName) {

--- a/src/BloomBrowserUI/bookEdit/js/calledByCSharp.ts
+++ b/src/BloomBrowserUI/bookEdit/js/calledByCSharp.ts
@@ -18,6 +18,11 @@ class CalledByCSharp {
     return contentWindow.model.canUndo();
   }
 
+    pageSelectionChanging() {
+        var contentWindow = this.getPageContent();
+        contentWindow['pageSelectionChanging']();
+    }
+
   loadReaderToolSettings(settings: string, bookFontName: string) {
 
     var contentWindow = this.getAccordionContent();

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -489,6 +489,14 @@ namespace Bloom.Edit
 		// Invoked by an event handler just before we change pages. Unless we are in the process of deleting the
 		// current page, we need to save changes to it. Currently this is a side effect of calling the JS
 		// pageSelectionChanging(), which calls back to our 'FinishSavingPage()'
+		// Note that this is fully synchronous event handling, all in the current thread:
+		// PageSelection.SelectPage [CS] raises PageSelectionChanging
+		//		OnPageSelectionChanging() [CS, here] responds to this event
+		//			it calls pageSelectionChanging() [in JS]
+		//				pageSelectionChanging raises HTML event finishSavingPage
+		//					this class is listening for finishSavingPage, and handles it by calling FinishSavingPage() [CS]
+		//		all those calls return
+		//		SelectPage continues with actually changing the current page, and then calls PageChanged.
 		private void OnPageSelectionChanging(object sender, EventArgs eventArgs)
 		{
 			if (_view != null && !_inProcessOfDeleting)

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -497,6 +497,15 @@ namespace Bloom.Edit
 		//					this class is listening for finishSavingPage, and handles it by calling FinishSavingPage() [CS]
 		//		all those calls return
 		//		SelectPage continues with actually changing the current page, and then calls PageChanged.
+		// I am confident that RunJavaScript does not return until it has finished executing the JavaScript function,
+		// because the wrapper code in Browser.cs is capable of returning a result from the JS function.
+		// I am confident that fireCSharpEditEvent (in bloomEditing.js) does not return until all the event handlers
+		// (in this case, our C# FinishSavingPage() method) have completed, because it is implemented using
+		// document.dispatchEvent(), and this returns a result determined by the handlers, specifically whether
+		// one of them canceled the event.
+		// Thus, the whole sequence of steps above behaves like a series of nested function calls,
+		// and SelectPage does not proceed with actually changing the current page until after FinishSavingPage has
+		// completed saving it.
 		private void OnPageSelectionChanging(object sender, EventArgs eventArgs)
 		{
 			if (_view != null && !_inProcessOfDeleting)

--- a/src/BloomExe/Edit/PageSelection.cs
+++ b/src/BloomExe/Edit/PageSelection.cs
@@ -6,12 +6,13 @@ namespace Bloom.Edit
 	public class PageSelection
 	{
 		private IPage _currentSelection;
-		public event EventHandler SelectionChanged;
+		public event EventHandler SelectionChanging; // before it changes
+		public event EventHandler SelectionChanged; // after it changed
 
 		public bool SelectPage(IPage page)
 		{
-			//enhance... send out cancellable pre-change event
-
+			//enhance... make pre-change event cancellable
+			InvokeSelectionChanging();
 			_currentSelection = page;
 
 			InvokeSelectionChanged();
@@ -21,6 +22,15 @@ namespace Bloom.Edit
 		public IPage CurrentSelection
 		{
 			get { return _currentSelection; }
+		}
+
+		private void InvokeSelectionChanging()
+		{
+			EventHandler handler = SelectionChanging;
+			if (handler != null)
+			{
+				handler(this, null);
+			}
 		}
 
 		private void InvokeSelectionChanged()


### PR DESCRIPTION
Moves the responsibility for saving the page into a new
SelectionChanging event handler, so it all clearly
happens before we change the current page.