### PR TITLE
BL-1195 Show names for all languages

### DIFF
--- a/src/BloomExe/Book/RuntimeInformationInjector.cs
+++ b/src/BloomExe/Book/RuntimeInformationInjector.cs
@@ -75,12 +75,20 @@ namespace Bloom.Book
 			_collectDynamicStrings = false;
 		}
 
-		internal static void AddLanguagesUsedInPage(XmlDocument xmlDocument, Dictionary<string, string> d)
+		/// <summary>
+		/// Add to the dictionary which maps original to Localized strings an entry for any language code that doesn't already
+		/// have one. We have localizations for a few major languages that map e.g. de->German/Deutsch/etc, so they are functioning
+		/// not just to localize but to expand from a language code to an actual name. For any other languages where we don't
+		/// have localization information, we'd like to at least expand the cryptic code into a name. This method does that.
+		/// </summary>
+		/// <param name="xmlDocument"></param>
+		/// <param name="mapOriginalToLocalized"></param>
+		internal static void AddLanguagesUsedInPage(XmlDocument xmlDocument, Dictionary<string, string> mapOriginalToLocalized)
 		{
 			var langs = xmlDocument.SafeSelectNodes("//*[@lang]").Cast<XmlElement>()
 				.Select(e => e.Attributes["lang"].Value)
 				.Distinct()
-				.Where(lang => !d.ContainsKey(lang))
+				.Where(lang => !mapOriginalToLocalized.ContainsKey(lang))
 				.ToList();
 			if (langs.Any())
 			{
@@ -90,7 +98,7 @@ namespace Bloom.Book
 				{
 					var match = lookup.GetExactLanguageMatch(lang);
 					if (match != null)
-						d[lang] = match.Name;
+						mapOriginalToLocalized[lang] = match.Name;
 				}
 			}
 		}

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Book\BookStorageTests.cs" />
     <Compile Include="Book\BookStarterTests.cs" />
     <Compile Include="Book\BookDataTests.cs" />
+    <Compile Include="Book\RuntimeInformationInjectorTests.cs" />
     <Compile Include="Book\TranslationGroupManagerTests.cs" />
     <Compile Include="Book\LayoutTests.cs" />
     <Compile Include="Book\XMatterHelperTests.cs" />

--- a/src/BloomTests/Book/RuntimeInformationInjectorTests.cs
+++ b/src/BloomTests/Book/RuntimeInformationInjectorTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bloom.Book;
+using NUnit.Framework;
+
+namespace BloomTests.Book
+{
+	public class RuntimeInformationInjectorTests
+	{
+		private HtmlDom _bookDom;
+		private void SetDom(string bodyContents)
+		{
+			_bookDom = new HtmlDom(@"<html ><head></head><body>" + bodyContents + "</body></html>");
+		}
+
+		[Test]
+		public void AddLanguagesUsedInPage_AddsOnlyAppropriateNames()
+		{
+			SetDom(@"<div class='bloom-page' id='guid2'>
+						<p>
+							<textarea lang='en' id='1'>english</textarea>
+							<textarea lang='fub' id='2'>originalVernacular</textarea>
+						</p>
+					</div>
+					<div class='bloom-page' id='guid3'>
+						<p>
+							<div lang='ant' id='4'>more</div>
+							<div  lang='xyz' id='3'>original2</div>
+						</p>
+					</div>
+			");
+			var d = new Dictionary<string, string>();
+			d["en"] = "Anglais";
+
+			RuntimeInformationInjector.AddLanguagesUsedInPage(_bookDom.RawDom, d);
+
+			Assert.That(d["en"], Is.EqualTo("Anglais"), "Should not have replaced an existing key");
+			Assert.That(d["fub"], Is.EqualTo("Adamawa Fulfulde"));
+			Assert.That(d["ant"], Is.EqualTo("Antakarinya"), "Should find in divs as well as textareas");
+			Assert.That(d.Keys, Has.Count.EqualTo(3), "should not have added anything for xyz, since not in db");
+		}
+	}
+}


### PR DESCRIPTION
Anywhere JS is looking for a (localized) language name
it should now find it.
If it's not a major language it won't be localized, but it will be
a name rather than just an ISO code, assuming it's a language
libpalaso knows about.