### PR TITLE
BL-2258 Put Split Across Pages back in Basic Book css

### DIFF
--- a/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.css
+++ b/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.css
@@ -62,51 +62,76 @@ generic*/
 .imageOnTop .bloom-editable {
   left: 0;
 }
-.imageOnTop:not(.layout-style-SideBySide) .bloom-imageContainer {
+.imageOnTop:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) .bloom-imageContainer {
   height: calc(45% - 10px);
   width: 100%;
   position: absolute;
   left: 0;
   top: 0;
 }
-.bloom-monolingual.imageOnTop:not(.layout-style-SideBySide) .bloom-translationGroup {
+.bloom-monolingual.imageOnTop:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) .bloom-translationGroup {
   top: 50%;
   height: 50%;
 }
-.bloom-monolingual.imageOnTop:not(.layout-style-SideBySide) .bloom-editable {
+.bloom-monolingual.imageOnTop:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) .bloom-editable {
   position: absolute;
   bottom: 0;
 }
-.bloom-bilingual.imageOnTop:not(.layout-style-SideBySide) .bloom-imageContainer {
+.bloom-bilingual.imageOnTop:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) .bloom-imageContainer {
   top: 33%;
   height: 32%;
   margin-top: 5px;
 }
-.bloom-bilingual.imageOnTop:not(.layout-style-SideBySide) .bloom-editable {
+.bloom-bilingual.imageOnTop:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) .bloom-editable {
   height: 32%;
 }
-.bloom-bilingual.imageOnTop:not(.layout-style-SideBySide) .bloom-content2 {
+.bloom-bilingual.imageOnTop:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) .bloom-content2 {
   position: absolute;
   bottom: 0;
 }
-.bloom-bilingual.imageOnTop:not(.layout-style-SideBySide) .bloom-content3 {
+.bloom-bilingual.imageOnTop:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) .bloom-content3 {
   position: absolute;
   bottom: 0;
 }
-.bloom-trilingual.imageOnTop:not(.layout-style-SideBySide) .bloom-imageContainer {
+.bloom-trilingual.imageOnTop:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) .bloom-imageContainer {
   top: calc(13px + 24%);
   height: 24%;
 }
-.bloom-trilingual.imageOnTop:not(.layout-style-SideBySide) .bloom-editable {
+.bloom-trilingual.imageOnTop:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) .bloom-editable {
   height: 24%;
 }
-.bloom-trilingual.imageOnTop:not(.layout-style-SideBySide) .bloom-content2 {
+.bloom-trilingual.imageOnTop:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) .bloom-content2 {
   position: absolute;
   top: calc(1.3% + 24% +  24%);
 }
-.bloom-trilingual.imageOnTop:not(.layout-style-SideBySide) .bloom-content3 {
+.bloom-trilingual.imageOnTop:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) .bloom-content3 {
   position: absolute;
   bottom: 0;
+}
+.imageOnTop.layout-style-SplitAcrossPages .bloom-imageContainer {
+  width: 100%;
+  height: 100%;
+  top: 0;
+}
+.imageOnTop.layout-style-SplitAcrossPages.bloom-bilingual .bloom-editable {
+  height: calc(50% - 10px);
+}
+.imageOnTop.layout-style-SplitAcrossPages.bloom-trilingual .bloom-editable {
+  height: calc(33% - 10px);
+}
+.imageOnTop.layout-style-SplitAcrossPages .bloom-translationGroup {
+  height: 100%;
+  width: 100%;
+  /*Note, this is supposed to respond to bloom-centerVertically, but it doesn't. The jscript for CenterVerticallyInParent() always things the block is as big as the marginbox, so it doesn't center it*/
+  /*[disabled]position:relative;*/
+  /*So instead, we're settling for starting the text part of the way down*/
+  display: block !important;
+  position: relative;
+  left: 0;
+  top: 0;
+}
+.imageOnTop.layout-style-SplitAcrossPages .bloom-translationGroup .bloom-editable {
+  font-size: 300%;
 }
 .imageOnTop.layout-style-SideBySide .bloom-imageContainer {
   width: 48%;
@@ -175,7 +200,7 @@ generic*/
   top: 35%;
 }
 .imageInMiddle .bloom-translationGroup {
-  height: 33% !important;
+  height: 33%;
   width: 100%;
   position: absolute;
 }
@@ -192,6 +217,33 @@ generic*/
 }
 .imageInMiddle .bloom-translationGroup:nth-of-type(3) .bloom-editable {
   margin-top: 10px;
+}
+.imageInMiddle.layout-style-SplitAcrossPages .bloom-imageContainer {
+  width: 100%;
+  height: 100%;
+  top: 0;
+}
+.imageInMiddle.layout-style-SplitAcrossPages .bloom-translationGroup {
+  height: calc(50% - 10px);
+}
+.imageInMiddle.layout-style-SplitAcrossPages.bloom-bilingual .bloom-translationGroup .bloom-editable {
+  height: calc(50% - 10px);
+}
+.imageInMiddle.layout-style-SplitAcrossPages.bloom-trilingual .bloom-translationGroup .bloom-editable {
+  height: calc(33% - 10px);
+}
+.imageInMiddle.layout-style-SplitAcrossPages .bloom-translationGroup {
+  width: 100%;
+  /*Note, this is supposed to respond to bloom-centerVertically, but it doesn't. The jscript for CenterVerticallyInParent() always things the block is as big as the marginbox, so it doesn't center it*/
+  /*[disabled]position:relative;*/
+  /*So instead, we're settling for starting the text part of the way down*/
+  display: block !important;
+  position: relative;
+  left: 0;
+  top: 0;
+}
+.imageInMiddle.layout-style-SplitAcrossPages .bloom-translationGroup .bloom-editable {
+  font-size: 300%;
 }
 .imageInMiddle .bloom-editable {
   width: 100%;
@@ -243,6 +295,25 @@ generic*/
   position: absolute;
   left: 0;
   top: 0;
+}
+.imageOnBottom.layout-style-SplitAcrossPages .bloom-imageContainer {
+  width: 100%;
+  height: 100%;
+  top: 0;
+}
+.imageOnBottom.layout-style-SplitAcrossPages .bloom-translationGroup {
+  width: 100%;
+  height: 100%;
+  /*Note, this is supposed to respond to bloom-centerVertically, but it doesn't. The jscript for CenterVerticallyInParent() always things the block is as big as the marginbox, so it doesn't center it*/
+  /*[disabled]position:relative;*/
+  /*So instead, we're settling for starting the text part of the way down*/
+  display: block !important;
+  position: relative;
+  left: 0;
+  top: 0;
+}
+.imageOnBottom.layout-style-SplitAcrossPages .bloom-translationGroup .bloom-editable {
+  font-size: 300%;
 }
 .imageWholePage .bloom-imageContainer {
   width: 100%;

--- a/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.less
+++ b/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.less
@@ -72,7 +72,7 @@ generic*/
 	.bloom-editable {
 		left: 0;
 	}
-	&:not(.layout-style-SideBySide) {
+	&:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) {
 		.bloom-imageContainer {
 			.SetHeightWithPercentMinusConstant(45%, @StandardMultilingualEditBoxSeparation);
 			width: 100%;
@@ -130,7 +130,34 @@ generic*/
 		}
 	}
 
-
+	&.layout-style-SplitAcrossPages {
+		.bloom-imageContainer {
+			width: 100%;
+			height: 100%;
+			top: 0;
+		}
+		&.bloom-bilingual .bloom-editable{
+			.SetHeightWithPercentMinusConstant(50%, @StandardMultilingualEditBoxSeparation);
+		}
+		&.bloom-trilingual .bloom-editable{
+			.SetHeightWithPercentMinusConstant(33%, @StandardMultilingualEditBoxSeparation);
+		}
+		.bloom-translationGroup {
+			height: 100%;
+			width: 100%;
+			/*Note, this is supposed to respond to bloom-centerVertically, but it doesn't. The jscript for CenterVerticallyInParent() always things the block is as big as the marginbox, so it doesn't center it*/
+			/*[disabled]position:relative;*/
+			/*So instead, we're settling for starting the text part of the way down*/
+			//position: relative !important;
+			display: block !important;
+			position: relative;
+			left: 0;
+			top: 0;
+			.bloom-editable {
+				font-size: 300%;
+			}
+		}
+	}
 	&.layout-style-SideBySide {
 		.bloom-imageContainer {
 			width: 48%;
@@ -201,9 +228,6 @@ generic*/
 	}
 }
 
-
-
-
 .imageInMiddle {
 	//we place the edit boxes in different places depending on the multilingual settings,
 	//so we don't want the default margin-top's for the 2nd and 3rd ones.
@@ -217,7 +241,7 @@ generic*/
 	}
 	// ----- GROUP ------
 	.bloom-translationGroup {
-		height: 33% !important;
+		height: 33%; // !important messes up other layout-style-xxx
 		width: 100%;
 		position: absolute;
 	}
@@ -238,6 +262,37 @@ generic*/
 		bottom: 0;
 		.bloom-editable {
 			margin-top: @SpaceBetweenMultilingualAlternatives;
+		}
+	}
+
+	&.layout-style-SplitAcrossPages {
+		.bloom-imageContainer {
+			width: 100%;
+			height: 100%;
+			top: 0;
+		}
+		.bloom-translationGroup {
+			.SetHeightWithPercentMinusConstant(50%, @StandardMultilingualEditBoxSeparation);
+		}
+		&.bloom-bilingual .bloom-translationGroup .bloom-editable {
+			.SetHeightWithPercentMinusConstant(50%, @StandardMultilingualEditBoxSeparation);
+		}
+		&.bloom-trilingual .bloom-translationGroup .bloom-editable {
+			.SetHeightWithPercentMinusConstant(33%, @StandardMultilingualEditBoxSeparation);
+		}
+		.bloom-translationGroup {
+			width: 100%;
+			/*Note, this is supposed to respond to bloom-centerVertically, but it doesn't. The jscript for CenterVerticallyInParent() always things the block is as big as the marginbox, so it doesn't center it*/
+			/*[disabled]position:relative;*/
+			/*So instead, we're settling for starting the text part of the way down*/
+			//position: relative !important;
+			display: block !important;
+			position: relative;
+			left: 0;
+			top: 0;
+			.bloom-editable {
+				font-size: 300%;
+			}
 		}
 	}
 	// ----- Text Boxes ------
@@ -277,7 +332,7 @@ generic*/
 	}
 	&.bloom-bilingual {
 		.bloom-translationGroup .bloom-editable {
-		.SetHeightWithPercentMinusConstant(50%, @StandardMultilingualEditBoxSeparation);
+			.SetHeightWithPercentMinusConstant(50%, @StandardMultilingualEditBoxSeparation);
 		}
 	}
 	&.bloom-trilingual .bloom-translationGroup .bloom-editable {
@@ -296,6 +351,28 @@ generic*/
 		position: absolute;
 		left: 0;
 		top: 0;
+	}
+	&.layout-style-SplitAcrossPages {
+		.bloom-imageContainer {
+			width: 100%;
+			height: 100%;
+			top: 0;
+		}
+		.bloom-translationGroup {
+			width: 100%;
+			height: 100%;
+			/*Note, this is supposed to respond to bloom-centerVertically, but it doesn't. The jscript for CenterVerticallyInParent() always things the block is as big as the marginbox, so it doesn't center it*/
+			/*[disabled]position:relative;*/
+			/*So instead, we're settling for starting the text part of the way down*/
+			//position: relative !important;
+			display: block !important;
+			position: relative;
+			left: 0;
+			top: 0;
+			.bloom-editable {
+				font-size: 300%;
+			}
+		}
 	}
 }
 .imageWholePage {


### PR DESCRIPTION
The switch from plain .css to .less lost the SplitAcrossPages layout.

Conceivably the users will eventually request that the text side of "SplitAcrossPages" should be centered vertically... That will not be easy, especially in the case of Image in Middle where there are two .bloom-translationGroups to center as a group.