### PR TITLE
BL-2310 Make equal left/right margins for calendar fold

### DIFF
--- a/DistFiles/factoryCollections/Templates/Wall Calendar/wallCalendar.css
+++ b/DistFiles/factoryCollections/Templates/Wall Calendar/wallCalendar.css
@@ -69,10 +69,13 @@ DIV.calendarMonthTop DIV.imageHolder {
   height: 32px;
   margin-bottom: 5mm;
 }
-/*Since this is calendar-fold, we want to defeat the left page vs. right page margin shifting */
+/*Since this is calendar-fold, we want to defeat the left page vs. right page margin shifting
+	BL-2310 does this in basePage.css, but we need a smaller margin for this particular page
+	which makes the 'left' rule here need the '!important' tag (since it is less 'specific';
+	we want it to apply to Edit mode too.) */
 .A5Landscape.calendarMonthBottom .marginBox {
   top: 5mm;
-  left: 5mm;
+  left: 5mm !important;
   margin-left: 0;
   width: 20cm;
   height: 13.8cm;

--- a/DistFiles/factoryCollections/Templates/Wall Calendar/wallCalendar.less
+++ b/DistFiles/factoryCollections/Templates/Wall Calendar/wallCalendar.less
@@ -88,10 +88,13 @@ DIV.calendarMonthTop DIV.imageHolder
 }
 @Border: 5mm;
 @DayTableWidth: @A5PageWidth - (2 * @Border);
-/*Since this is calendar-fold, we want to defeat the left page vs. right page margin shifting */
+/*Since this is calendar-fold, we want to defeat the left page vs. right page margin shifting
+	BL-2310 does this in basePage.css, but we need a smaller margin for this particular page
+	which makes the 'left' rule here need the '!important' tag (since it is less 'specific';
+	we want it to apply to Edit mode too.) */
 .A5Landscape.calendarMonthBottom .marginBox {
 	top: @Border;
-	left: @Border;
+	left: @Border !important;
 	margin-left: 0;
 	width: @DayTableWidth;
 	height: @A5PageHeight - (2 * @Border);

--- a/DistFiles/less/common-mixins.less
+++ b/DistFiles/less/common-mixins.less
@@ -39,4 +39,4 @@
 @MarginBottom: 15mm;
 @ExtraSpaceForBinding: 10mm;
 @MarginInner: @MarginOuter + @ExtraSpaceForBinding;
-@MarginEven: (@MarginOuter + @MarginInner) / 2.0; // for when we want the same left and right margins
+@MarginBalanced: (@MarginOuter + @MarginInner) / 2.0; // for when we want the same left and right margins

--- a/DistFiles/less/common-mixins.less
+++ b/DistFiles/less/common-mixins.less
@@ -39,3 +39,4 @@
 @MarginBottom: 15mm;
 @ExtraSpaceForBinding: 10mm;
 @MarginInner: @MarginOuter + @ExtraSpaceForBinding;
+@MarginEven: (@MarginOuter + @MarginInner) / 2.0; // for when we want the same left and right margins

--- a/src/BloomBrowserUI/bookLayout/basePage.css
+++ b/src/BloomBrowserUI/bookLayout/basePage.css
@@ -1,4 +1,4 @@
-﻿/*+init {*/
+/*+init {*/
 * {
   position: relative;
   margin: 0;
@@ -263,11 +263,19 @@ preview.css.
   /* BL-1022 Keeps XMatter thumb images from going too wide */
   max-width: 136mm;
 }
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd) .marginBox {
+.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd):not(.A5Landscape):not(.A4Landscape) .marginBox {
   left: 15mm;
 }
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even) .marginBox {
+.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd).A5Landscape .marginBox,
+.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd).A4Landscape .marginBox {
+  left: 20mm;
+}
+.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even):not(.A5Landscape):not(.A4Landscape) .marginBox {
   left: 25mm;
+}
+.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even).A5Landscape:not(.calendarMonthBottom) .marginBox,
+.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even).A4Landscape .marginBox {
+  left: 20mm;
 }
 body:not(.publishMode) .marginBox {
   left: 20mm;
@@ -311,4 +319,3 @@ H2 {
   height: 99%;
   width: 99%;
 }
-/*# sourceMappingURL=basePage.css.map */

--- a/src/BloomBrowserUI/bookLayout/basePage.css
+++ b/src/BloomBrowserUI/bookLayout/basePage.css
@@ -263,17 +263,17 @@ preview.css.
   /* BL-1022 Keeps XMatter thumb images from going too wide */
   max-width: 136mm;
 }
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd):not(.A5Landscape):not(.A4Landscape) .marginBox {
+.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd) .marginBox {
   left: 15mm;
 }
 .publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd).A5Landscape .marginBox,
 .publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd).A4Landscape .marginBox {
   left: 20mm;
 }
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even):not(.A5Landscape):not(.A4Landscape) .marginBox {
+.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even) .marginBox {
   left: 25mm;
 }
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even).A5Landscape:not(.calendarMonthBottom) .marginBox,
+.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even).A5Landscape .marginBox,
 .publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even).A4Landscape .marginBox {
   left: 20mm;
 }

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -262,7 +262,7 @@ preview.css.
 			left: @MarginOuter;
 		}
 		&.A5Landscape .marginBox, &.A4Landscape .marginBox{
-			left: @MarginEven; // BL-2310 keep left and right the same for calendar fold
+			left: @MarginBalanced; // BL-2310 keep left and right the same for calendar fold
 		}
 	}
 	&.bloom-page:nth-of-type(even){
@@ -270,14 +270,14 @@ preview.css.
 			left: @MarginInner;
 		}
 		&.A5Landscape:not(.calendarMonthBottom) .marginBox, &.A4Landscape .marginBox{
-			left: @MarginEven; // BL-2310 keep left and right the same for calendar fold
+			left: @MarginBalanced; // BL-2310 keep left and right the same for calendar fold
 		}
 	}
 }
 
 //in edit mode, just split the difference, centering the margin box
 body:not(.publishMode) .marginBox{
-  left: @MarginEven;
+  left: @MarginBalanced;
 }
 
 /*Our javascript (bloomediting.js) uses <label> elements to get help bubbles and placeholders on editable divs.*/

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -258,19 +258,21 @@ preview.css.
 //so we only turn them on when making PDF
 .publishMode :not(.outsideFrontCover):not(.outsideBackCover){
 	&.bloom-page:nth-of-type(odd){
-		&:not(.A5Landscape):not(.A4Landscape) .marginBox{
+		.marginBox{
 			left: @MarginOuter;
 		}
+		// BL-2310 keep left and right the same for calendar fold
 		&.A5Landscape .marginBox, &.A4Landscape .marginBox{
-			left: @MarginBalanced; // BL-2310 keep left and right the same for calendar fold
+			left: @MarginBalanced;
 		}
 	}
 	&.bloom-page:nth-of-type(even){
-		&:not(.A5Landscape):not(.A4Landscape) .marginBox{
+		.marginBox{
 			left: @MarginInner;
 		}
-		&.A5Landscape:not(.calendarMonthBottom) .marginBox, &.A4Landscape .marginBox{
-			left: @MarginBalanced; // BL-2310 keep left and right the same for calendar fold
+		// BL-2310 keep left and right the same for calendar fold
+		&.A5Landscape .marginBox, &.A4Landscape .marginBox{
+			left: @MarginBalanced;
 		}
 	}
 }

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -257,17 +257,27 @@ preview.css.
 //currently, in edit mode every page looks like page 1 to css, so left-vs-right margins are just confusing
 //so we only turn them on when making PDF
 .publishMode :not(.outsideFrontCover):not(.outsideBackCover){
-  &.bloom-page:nth-of-type(odd) .marginBox  {
-	  left: @MarginOuter;
-  }
-  &.bloom-page:nth-of-type(even) .marginBox  {
-	  left: @MarginInner;
-  }
+	&.bloom-page:nth-of-type(odd){
+		&:not(.A5Landscape):not(.A4Landscape) .marginBox{
+			left: @MarginOuter;
+		}
+		&.A5Landscape .marginBox, &.A4Landscape .marginBox{
+			left: @MarginEven; // BL-2310 keep left and right the same for calendar fold
+		}
+	}
+	&.bloom-page:nth-of-type(even){
+		&:not(.A5Landscape):not(.A4Landscape) .marginBox{
+			left: @MarginInner;
+		}
+		&.A5Landscape:not(.calendarMonthBottom) .marginBox, &.A4Landscape .marginBox{
+			left: @MarginEven; // BL-2310 keep left and right the same for calendar fold
+		}
+	}
 }
 
 //in edit mode, just split the difference, centering the margin box
 body:not(.publishMode) .marginBox{
-  left: @MarginOuter + ( (@MarginInner - @MarginOuter) / 2)
+  left: @MarginEven;
 }
 
 /*Our javascript (bloomediting.js) uses <label> elements to get help bubbles and placeholders on editable divs.*/


### PR DESCRIPTION
* only applies to: a)  A4Landscape (on A3 paper)
   and b) A5Landscape (on A4 paper)
* the latter only being found (so far) in Wall Calendar,
   the calendar bottom page needed an extra tweak.