### PR TITLE
Remove obsolete commands to installer builder

### DIFF
--- a/build/Bloom.proj
+++ b/build/Bloom.proj
@@ -204,7 +204,7 @@
 		<!-- This is the command that actually runs Squirrel. Usually the exe invoked here is called Squirrel. However, we're building our own
 		version, and it's easiest to go with the exe name that the Squirrel build process actually produces.
 		The relaseDir here is a shared drive for all the build agents (though for now we only use one, because only it has the signing data). -->
-		<Exec Command="$(RootDir)\lib\dotnet\Update --releasify $(RootDir)\build\Bloom$(channel).$(Version).nupkg --releaseDir=$(SquirrelReleaseFolder) -Version $(Version) -i $(RootDir)\src\SquirrelInstaller\BloomSetup.ico -g $(RootDir)\src\SquirrelInstaller\installing.gif -l 'Desktop, StartMenu'"/>
+		<Exec Command="$(RootDir)\lib\dotnet\Update --releasify $(RootDir)\build\Bloom$(channel).$(Version).nupkg --releaseDir=$(SquirrelReleaseFolder) -i $(RootDir)\src\SquirrelInstaller\BloomSetup.ico -g $(RootDir)\src\SquirrelInstaller\installing.gif -l 'Desktop,StartMenu'"/>
 
 		<Copy SourceFiles="$(SquirrelReleaseFolder)\Setup.exe"
 			  DestinationFiles="$(SquirrelReleaseFolder)\$(SquirrelInstallerFileName)"


### PR DESCRIPTION
Some commands we were passing to Update.exe
were unexpected, presumably obsolete. One arg had
an unexpected space.