### PR TITLE
BL-2246, don't upload any variant of thumbs.db

### DIFF
--- a/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
@@ -211,7 +211,7 @@ namespace Bloom.WebLibraryIntegration
 			foreach (string file in filesToUpload)
 			{
 				var fileName = Path.GetFileName(file);
-				if (excludedFileNames.Contains(fileName))
+				if (excludedFileNames.Contains(fileName.ToLowerInvariant()))
 					continue; // BL-2246: skip uploading this one
 
 				var request = new TransferUtilityUploadRequest()


### PR DESCRIPTION
Testing found that Thumbs.db would be uploaded.
Technically they would be different files on Linux,
but I think it's reasonable to exclude
them all on all platforms.