### PR TITLE
BL-2334 Find names for some more languages

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -339,6 +339,7 @@
       <DependentUpon>BetterSplitContainer.cs</DependentUpon>
     </Compile>
     <Compile Include="ToPalaso\FontInstaller.cs" />
+    <Compile Include="ToPalaso\LookupIsoCodeModelExtensions.cs" />
     <Compile Include="ToPalaso\MessageLabelProgress.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/src/BloomExe/Book/RuntimeInformationInjector.cs
+++ b/src/BloomExe/Book/RuntimeInformationInjector.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Xml;
 using Bloom.Collection;
 using Bloom.Properties;
+using Bloom.ToPalaso;
 using L10NSharp;
 using Newtonsoft.Json;
 using Palaso.IO;
@@ -96,9 +97,9 @@ namespace Bloom.Book
 				var lookup = new LookupIsoCodeModel(); // < 1ms
 				foreach (var lang in langs) // may include things like empty string, z, *, but this is harmless as they are not language codes.
 				{
-					var match = lookup.GetExactLanguageMatch(lang);
-					if (match != null)
-						mapOriginalToLocalized[lang] = match.Name;
+					var match = lookup.GetBestLanguageName(lang);
+					if (match != lang) // some better name found
+						mapOriginalToLocalized[lang] = match;
 				}
 			}
 		}

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -11,6 +11,7 @@ using System.Xml.Linq;
 using System.Xml.Serialization;
 using Amazon.CloudFront.Model;
 using Bloom.Book;
+using Bloom.ToPalaso;
 using L10NSharp;
 using Palaso.Reporting;
 using Palaso.UI.WindowsForms.WritingSystems;
@@ -205,10 +206,10 @@ namespace Bloom.Collection
 
 		private string GetLanguage1Name_NoCache(string inLanguage)
 		{
-			Iso639LanguageCode exactLanguageMatch = _lookupIsoCode.GetExactLanguageMatch(Language1Iso639Code);
-			if (exactLanguageMatch == null)
+			var exactLanguageMatch = _lookupIsoCode.GetBestLanguageName(Language1Iso639Code);
+			if (exactLanguageMatch == Language1Iso639Code) // no useful name found
 				return "L1-Unknown-" + Language1Iso639Code;
-			return GetLanguageNameInUILangIfPossible(exactLanguageMatch.Name, inLanguage);
+			return GetLanguageNameInUILangIfPossible(exactLanguageMatch, inLanguage);
 		}
 
 		public string GetLanguage2Name(string inLanguage)
@@ -241,11 +242,7 @@ namespace Bloom.Collection
 			//profiling showed we were spending a lot of time looking this up, hence the cache
 			if (!_isoToLangNameDictionary.ContainsKey(code))
 			{
-				var match = _lookupIsoCode.GetExactLanguageMatch(code);
-				if (match == null)
-					_isoToLangNameDictionary[code] = code; // best name we can come up with is the code itself
-				else
-					_isoToLangNameDictionary.Add(code, match.Name);
+				_isoToLangNameDictionary[code] = _lookupIsoCode.GetBestLanguageName(code);
 			}
 
 			return GetLanguageNameInUILangIfPossible(_isoToLangNameDictionary[code], inLanguage);
@@ -654,15 +651,9 @@ namespace Bloom.Collection
 			for (int i = 0; i < isoCodes.Length; i++)
 			{
 				var code = isoCodes[i];
-				var data = _lookupIsoCode.GetExactLanguageMatch(code);
-				string name;
-				if (code == Language1Iso639Code)
-					name = Language1Name;
-				else if (data == null)
-					name = code;
-				else
-					name = data.Name;
+				string name = code == Language1Iso639Code ? Language1Name : _lookupIsoCode.GetBestLanguageName(code);
 				string ethCode;
+				var data = _lookupIsoCode.GetExactLanguageMatch(code);
 				if (data == null)
 					ethCode = code;
 				else

--- a/src/BloomExe/ToPalaso/LookupIsoCodeModelExtensions.cs
+++ b/src/BloomExe/ToPalaso/LookupIsoCodeModelExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Palaso.UI.WindowsForms.WritingSystems;
+
+namespace Bloom.ToPalaso
+{
+	public static class LookupIsoCodeModelExtensions
+	{
+		/// <summary>
+		/// A smarter way to get a name for an iso code. Currently LookupIsoCodeModel.GetExactLanguageMatch() does not find
+		/// a name at all for some languages, typically macro ones. This adds a fall-back which still finds a language
+		/// that has the exact requested language code.
+		/// </summary>
+		/// <returns></returns>
+		public static string GetBestLanguageName(this LookupIsoCodeModel isoModel, string code)
+		{
+			var match = isoModel.GetExactLanguageMatch(code);
+			if (match != null)
+				return match.Name;
+			var lang = isoModel.GetMatchingLanguages(code).FirstOrDefault(x => x.Code == code);
+			if (lang != null)
+				return lang.DesiredName;
+			return code; // best name we can come up with is the code itself
+		}
+	}
+}

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PdfMakerTests.cs" />
     <Compile Include="OpenCreateDialogTests.cs" />
+    <Compile Include="ToPalaso\LookupIsoCodeModelExtensionsTests.cs" />
     <Compile Include="ToPalaso\MostRecentPathsTests.cs" />
     <Compile Include="ToPalaso\ProgresDialogTests.cs" />
     <Compile Include="UpdateVersionTableTests.cs" />

--- a/src/BloomTests/ToPalaso/LookupIsoCodeModelExtensionsTests.cs
+++ b/src/BloomTests/ToPalaso/LookupIsoCodeModelExtensionsTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bloom.ToPalaso;
+using NUnit.Framework;
+using Palaso.UI.WindowsForms.WritingSystems;
+
+namespace BloomTests.ToPalaso
+{
+	[TestFixture]
+	public class LookupIsoCodeModelExtensionsTests
+	{
+		/// <summary>
+		/// This is the one the extension was made for, finds a name that GetExactLanguageMatch misses
+		/// </summary>
+		[Test]
+		public void GetBestLanguageName_ForARA_FindsArabic()
+		{
+			var sut = new LookupIsoCodeModel();
+			Assert.That(sut.GetBestLanguageName("ara"), Is.EqualTo("Arabic"));
+		}
+
+		/// <summary>
+		/// Routine match in GetExactLanguageMatch.
+		/// </summary>
+		[Test]
+		public void GetBestLanguageName_ForFR_FindsFrench()
+		{
+			var sut = new LookupIsoCodeModel();
+			Assert.That(sut.GetBestLanguageName("fr"), Is.EqualTo("French"));
+		}
+
+		/// <summary>
+		/// No match at all.
+		/// </summary>
+		[Test]
+		public void GetBestLanguageName_ForXYZ_FindsXYZ()
+		{
+			var sut = new LookupIsoCodeModel();
+			Assert.That(sut.GetBestLanguageName("xyz"), Is.EqualTo("xyz"));
+		}
+
+		/// <summary>
+		/// In this test, GetMatchingLanguages finds some, but none have the exact right code.
+		/// </summary>
+		[Test]
+		public void GetBestLanguageName_ForArab_FindsArab()
+		{
+			var sut = new LookupIsoCodeModel();
+			Assert.That(sut.GetBestLanguageName("arab"), Is.EqualTo("arab"));
+		}
+	}
+}


### PR DESCRIPTION
Enhances the algorithm for finding default language
names to handle macro languages and possibly other cases
for which the palaso model can find matches but
does not consider it has an 'exact' match.