### PR TITLE
Fix BL-2348

### DIFF
--- a/src/BloomBrowserUI/bookLayout/basePage.css
+++ b/src/BloomBrowserUI/bookLayout/basePage.css
@@ -1,5 +1,4 @@
-﻿/*+init {*/
-
+/*+init {*/
 * {
   position: relative;
   margin: 0;
@@ -69,7 +68,6 @@ To handling the mis-match.*/
   font-size: 10pt;
 }
 /* gridItem means this is a page thumbnail */
-
 .gridItem .pageOverflows {
   background-image: url("/bloom/BloomBrowserUI/images/Attention.svg");
   /* red triangle with exclamation point */
@@ -114,7 +112,7 @@ span.bloom-linebreak {
 DIV.bloom-page {
   display: block;
   page-break-after: auto;
-  background-color: white;
+  background-color: #FFFFFF;
   /*This is a big help with htmltopdf, both for our errors and a legitimate problem, with the "just text" page in which
 the margin-top is calculated to center the text vertically, but htmltopdf then doesn't shrink the box as it should
 so it just heads down off the page, messing things up.*/
@@ -124,7 +122,9 @@ DIV#bloomDataDiv {
   display: none;
 }
 @media screen {
-  
+  DIV.bloom-page {
+    /*[disabled]border:1px solid #000000;*/
+  }
 }
 .centered {
   text-align: center;
@@ -133,13 +133,11 @@ DIV#bloomDataDiv {
   text-align: center;
 }
 /*Unless otherwise positioned and made visible, hide all the language elements in there*/
-
 .bloom-editable {
   display: none;
   height: 100%;
 }
 /*Outside of frontmatter, we assume that if bloom gives it a content tag, then it should be visible*/
-
 .bloom-page:not(.bloom-frontMatter) .bloom-content1,
 .bloom-page:not(.bloom-frontMatter) .bloom-content2,
 .bloom-page:not(.bloom-frontMatter) .bloom-content3 {
@@ -157,7 +155,6 @@ page be the full page, regardless of the contents.
 To compensate, the code asks wkthmlpdf to zoom the page by 9.1%, which an invisble 1px border added by
 preview.css.
 */
-
 .bloom-page.A5Portrait {
   min-width: 148mm;
   max-width: 148mm;
@@ -202,11 +199,9 @@ preview.css.
   max-height: 105mm;
 }
 /*Margins*/
-
 .textWholePage .marginBox {
   position: absolute;
   /* see https://jira.sil.org/browse/BL-390; Without this, the "Just text" page causes the marginBox to drop down to the start of the vertically centered text, and then on PDF, you get an extra page. */
-
 }
 .marginBox {
   position: absolute;
@@ -268,31 +263,30 @@ preview.css.
   /* BL-1022 Keeps XMatter thumb images from going too wide */
   max-width: 136mm;
 }
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd) .marginBox {
+.publishMode:not(.calendarFold) :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd) .marginBox {
+  /* shifted margin */
   left: 15mm;
 }
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd).A5Landscape .marginBox,
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd).A4Landscape .marginBox {
-  left: 20mm;
-}
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even) .marginBox {
+.publishMode:not(.calendarFold) :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even) .marginBox {
+  /* shifted margin */
   left: 25mm;
 }
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even).A5Landscape .marginBox,
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even).A4Landscape .marginBox {
+.calendarFold .marginBox {
+  /* balanced margin*/
   left: 20mm;
 }
-.rightToLeft.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd) .marginBox {
+.rightToLeft.publishMode:not(.calendarFold) :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd) .marginBox {
+  /* swap margins on right to left */
   left: 25mm;
 }
-.rightToLeft.publishMode :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even) .marginBox {
+.rightToLeft.publishMode:not(.calendarFold) :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(even) .marginBox {
+  /* swap margins on right to left */
   left: 15mm;
 }
 body:not(.publishMode) .marginBox {
   left: 20mm;
 }
 /*Our javascript (bloomediting.js) uses <label> elements to get help bubbles and placeholders on editable divs.*/
-
 LABEL.bubble,
 LABEL.placeholder {
   display: none;
@@ -308,7 +302,6 @@ H2 {
   font-size: 1.2em;
 }
 /* we will have UI that switches this .box-header-on if th user wants it*/
-
 .box-header-off {
   display: none;
 }

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -250,24 +250,29 @@ preview.css.
 //page looks like page 1 from the view of the css, so showing every page
 //as if it were odd is just confusing for the user.
 //Therefore we only turn on left-vs.right distinctions when when making PDF.
-.publishMode :not(.outsideFrontCover):not(.outsideBackCover){
+.publishMode:not(.calendarFold) :not(.outsideFrontCover):not(.outsideBackCover){
 	&.bloom-page:nth-of-type(odd){
 		.marginBox{
+			/* shifted margin */
 			left: @MarginOuter;
-		}
-		// BL-2310 keep left and right the same for calendar fold
-		&.A5Landscape .marginBox, &.A4Landscape .marginBox{
-			left: @MarginBalanced;
 		}
 	}
 	&.bloom-page:nth-of-type(even){
 		.marginBox{
+			/* shifted margin */
 			left: @MarginInner;
 		}
-		// BL-2310 keep left and right the same for calendar fold
-		&.A5Landscape .marginBox, &.A4Landscape .marginBox{
-			left: @MarginBalanced;
-		}
+	}
+}
+
+// Note: we aren't making any assumption about this or that landscape being calendar fold.
+// The publishModel needs to make that decision (perhaps, in the future, user will be able to control that when
+// making the pdf). From the stylesheet's view, we just need to see this calendarFold class on the Body
+
+.calendarFold{
+	.marginBox {
+		/* balanced margin*/
+		left: @MarginBalanced;
 	}
 }
 
@@ -275,11 +280,14 @@ preview.css.
 //the page order. In doing so, what use to be odd becomes even, and our margins
 //and page numbering logic needs to switch accordingly. Page numbering is
 //not part of the basePage.less.
-.rightToLeft.publishMode :not(.outsideFrontCover):not(.outsideBackCover){
+
+.rightToLeft.publishMode:not(.calendarFold) :not(.outsideFrontCover):not(.outsideBackCover){
   &.bloom-page:nth-of-type(odd) .marginBox  {
+	  /* swap margins on right to left */
 	  left: @MarginInner;
   }
   &.bloom-page:nth-of-type(even) .marginBox  {
+	  /* swap margins on right to left */
 	  left: @MarginOuter;
   }
 }

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -523,6 +523,10 @@ namespace Bloom.Book
 			AddClass((XmlElement)dom.SelectSingleNode("//body"), "hidePlaceHolders");
 		}
 
+		public static void AddCalendarFoldClassToBody(XmlDocument dom)
+		{
+			AddClass((XmlElement)dom.SelectSingleNode("//body"), "calendarFold");
+		}
 		/// <summary>
 		/// The chosen xmatter changes, so we need to clear out any old ones
 		/// </summary>

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -15,6 +15,7 @@ using Bloom.Collection;
 using Bloom.web;
 using DesktopAnalytics;
 using Palaso.IO;
+using PdfDroplet.LayoutMethods;
 
 namespace Bloom.Publish
 {
@@ -159,6 +160,10 @@ namespace Bloom.Publish
 			if (LayoutPagesForRightToLeft)
 				HtmlDom.AddRightToLeftClassToBody(dom);
 			HtmlDom.AddHidePlaceHoldersClassToBody(dom);
+			if (BookSelection.CurrentSelection.GetDefaultBookletLayout() == PublishModel.BookletLayoutMethod.Calendar)
+			{
+				HtmlDom.AddCalendarFoldClassToBody(dom);
+			}
 		}
 
 		private string GetPdfPath(string fname)


### PR DESCRIPTION
The fix here is to have the pdf publisher indicate that it is planning to do a calendar fold. Then the stylesheet keeps the margins left if that class is present.