### PR TITLE
Fixes BL-2349, where six-row months didn't fit in the PDF

### DIFF
--- a/DistFiles/factoryCollections/Templates/Wall Calendar/wallCalendar.css
+++ b/DistFiles/factoryCollections/Templates/Wall Calendar/wallCalendar.css
@@ -29,7 +29,7 @@ DIV.calendarMonthTop DIV.imageHolder {
 }
 .month THEAD TD {
   font-weight: bold;
-  font-size: larger;
+  font-size: 14pt;
 }
 .month THEAD TH {
   width: 3em;
@@ -44,27 +44,39 @@ DIV.calendarMonthTop DIV.imageHolder {
 .calendarMonthBottom TH {
   text-align: center;
   font-weight: bold;
+  display: table-cell;
+  width: 107px;
+}
+.calendarMonthBottom TD {
+  border: 1px solid #000000;
+  padding-left: 3px;
+  padding-right: 3px;
+  position: relative;
+  font-size: inherit;
+  line-height: inherit;
+  display: table-cell;
+  height: 72px;
+  width: 101px;
+  vertical-align: top;
 }
 .calendarMonthBottom TD TEXTAREA {
-  width: 96%;
-  height: 95%;
-  font-size: 65%;
-  position: relative;
-  left: 1px;
-  margin-top: -20px;
+  overflow: hidden;
+  font-size: 9pt;
   line-height: 1.3em;
   text-indent: 2.3em;
-  background: transparent;
+  margin-top: 4px;
+  height: 65px;
 }
 .calendarMonthBottom TD P {
-  position: relative;
   font-style: italic;
-  top: -1px;
   z-index: 5;
+  font-size: 14pt;
+  position: absolute;
+  margin-top: -4px;
 }
 .calendarBottomPageHeader {
   text-align: center;
-  font: 240% sans-serif;
+  font-size: 30pt;
   width: 100%;
   height: 32px;
   margin-bottom: 5mm;
@@ -79,13 +91,6 @@ DIV.calendarMonthTop DIV.imageHolder {
   margin-left: 0;
   width: 20cm;
   height: 13.8cm;
-}
-.calendarMonthBottom TD {
-  width: 2.85714286cm;
-  height: 65px;
-  border: 1px solid #000000;
-  padding: 0 0 0 2px;
-  position: relative;
 }
 /* bilingual */
 .calendarMonthTop.bloom-bilingual .bloom-imageContainer {

--- a/DistFiles/factoryCollections/Templates/Wall Calendar/wallCalendar.less
+++ b/DistFiles/factoryCollections/Templates/Wall Calendar/wallCalendar.less
@@ -39,7 +39,7 @@ DIV.calendarMonthTop DIV.imageHolder
 .month THEAD TD
 {
 	font-weight: bold;
-	font-size: larger;
+	font-size: 14pt;
 }
 .month THEAD TH
 {
@@ -53,35 +53,53 @@ DIV.calendarMonthTop DIV.imageHolder
 .calendarMonthBottom TABLE{
 	border-collapse: collapse;
 }
-.calendarMonthBottom TH
-{
+
+.calendarMonthBottom TH {
 	text-align: center;
 	font-weight: bold;
+	display: table-cell;
+	width: 107px;
 }
 
-.calendarMonthBottom TD TEXTAREA
-{
-	width: 96%;
-	height: 95%;
-	font-size: 65%;
+.calendarMonthBottom TD {
+	border: 1px solid #000000;
+	padding-left: 3px;
+	padding-right: 3px;
 	position: relative;
-	left: 1px;
-	margin-top: -20px;
+	font-size: inherit; //override the (later to be removed) "143%" we get from basePage.css
+	line-height: inherit; //override the (later to be removed) rule we get from basePage.css
+	display: table-cell;
+	height: 72px; // NB: have to allow for up to 6 rows of calendar, not 5!!!!!!!!!!!!
+    width: 101px;//103 is good during editing
+
+	vertical-align: top;
+}
+
+.calendarMonthBottom TD TEXTAREA {
+	overflow: hidden;
+	font-size: 9pt;
 	line-height: 1.3em;
 	text-indent: 2.3em;
-	background: transparent;
+	margin-top: 4px;
+	height: 65px;
 }
-.calendarMonthBottom TD P
-{
-	position: relative;
+
+.calendarMonthBottom TD P {
 	font-style: italic;
-	top: -1px;
 	z-index: 5; // keeps day number in play when textarea overflows
+	font-size: 14pt;
+	position: absolute;
+
+	//top:0;  //<--- NO. For some reason in Bloom 3.1, will put all the numbers at the top (but not in later Firefox, so maybe in the future this will be fine)
+	//so we do this instead
+	margin-top: -4px;
 }
+
+
 .calendarBottomPageHeader
 {
 	text-align: center;
-	font: 240% sans-serif;
+	font-size: 30pt;
 	width: 100%;
 	height: 32px;
 	margin-bottom: 5mm;
@@ -100,14 +118,6 @@ DIV.calendarMonthTop DIV.imageHolder
 	height: @A5PageHeight - (2 * @Border);
 }
 
-.calendarMonthBottom TD
-{
-	width: @DayTableWidth / 7;
-	height: 65px; // NB: have to allow for up to 6 rows of calendar, not 5!!!!!!!!!!!!
-	border: 1px solid #000000;
-	padding: 0 0 0 2px;
-	position: relative;
-}
 
 /* bilingual */
 .calendarMonthTop.bloom-bilingual .bloom-imageContainer

--- a/src/BloomBrowserUI/bookLayout/basePage.css
+++ b/src/BloomBrowserUI/bookLayout/basePage.css
@@ -1,5 +1,4 @@
-﻿/*+init {*/
-
+/*+init {*/
 * {
   position: relative;
   margin: 0;
@@ -69,7 +68,6 @@ To handling the mis-match.*/
   font-size: 10pt;
 }
 /* gridItem means this is a page thumbnail */
-
 .gridItem .pageOverflows {
   background-image: url("/bloom/BloomBrowserUI/images/Attention.svg");
   /* red triangle with exclamation point */
@@ -94,7 +92,19 @@ p {
   min-height: 1em;
 }
 TEXTAREA,
-.bloom-editable,
+.bloom-editable {
+  resize: none;
+  /*don't show those cute little resize controls in Firefox 4 and greater*/
+  overflow: visible;
+  font-size: 143%;
+  line-height: 1.5em;
+  min-height: 1.8em;
+  width: 100%;
+}
+/* The following has been split out from the above rule because it should probably be removed,
+	but at this point we are about to go release candidate with 3.1 so it will have to wait.
+	When we do remove it, the main things it could effect are the Story Primer template and the dozen or so SIL LEAD Uganda SHRP templates.
+*/
 TD {
   resize: none;
   /*don't show those cute little resize controls in Firefox 4 and greater*/
@@ -114,7 +124,7 @@ span.bloom-linebreak {
 DIV.bloom-page {
   display: block;
   page-break-after: auto;
-  background-color: white;
+  background-color: #FFFFFF;
   /*This is a big help with htmltopdf, both for our errors and a legitimate problem, with the "just text" page in which
 the margin-top is calculated to center the text vertically, but htmltopdf then doesn't shrink the box as it should
 so it just heads down off the page, messing things up.*/
@@ -124,7 +134,9 @@ DIV#bloomDataDiv {
   display: none;
 }
 @media screen {
-  
+  DIV.bloom-page {
+    /*[disabled]border:1px solid #000000;*/
+  }
 }
 .centered {
   text-align: center;
@@ -133,13 +145,11 @@ DIV#bloomDataDiv {
   text-align: center;
 }
 /*Unless otherwise positioned and made visible, hide all the language elements in there*/
-
 .bloom-editable {
   display: none;
   height: 100%;
 }
 /*Outside of frontmatter, we assume that if bloom gives it a content tag, then it should be visible*/
-
 .bloom-page:not(.bloom-frontMatter) .bloom-content1,
 .bloom-page:not(.bloom-frontMatter) .bloom-content2,
 .bloom-page:not(.bloom-frontMatter) .bloom-content3 {
@@ -157,7 +167,6 @@ page be the full page, regardless of the contents.
 To compensate, the code asks wkthmlpdf to zoom the page by 9.1%, which an invisble 1px border added by
 preview.css.
 */
-
 .bloom-page.A5Portrait {
   min-width: 148mm;
   max-width: 148mm;
@@ -202,11 +211,9 @@ preview.css.
   max-height: 105mm;
 }
 /*Margins*/
-
 .textWholePage .marginBox {
   position: absolute;
   /* see https://jira.sil.org/browse/BL-390; Without this, the "Just text" page causes the marginBox to drop down to the start of the vertically centered text, and then on PDF, you get an extra page. */
-
 }
 .marginBox {
   position: absolute;
@@ -292,7 +299,6 @@ body:not(.publishMode) .marginBox {
   left: 20mm;
 }
 /*Our javascript (bloomediting.js) uses <label> elements to get help bubbles and placeholders on editable divs.*/
-
 LABEL.bubble,
 LABEL.placeholder {
   display: none;
@@ -308,7 +314,6 @@ H2 {
   font-size: 1.2em;
 }
 /* we will have UI that switches this .box-header-on if th user wants it*/
-
 .box-header-off {
   display: none;
 }

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -81,7 +81,7 @@ DIV.ui-tooltip-content
 p{
   min-height: 1em; //without this, an empty paragraph will be invisible, making blank lines impossible
 }
-TEXTAREA, .bloom-editable, TD
+TEXTAREA, .bloom-editable
 {
 	resize: none;
 	/*don't show those cute little resize controls in Firefox 4 and greater*/
@@ -91,6 +91,21 @@ TEXTAREA, .bloom-editable, TD
 	min-height:  @defaultLineHeight + .3em;
 	width: 100%;
 }
+
+/* The following has been split out from the above rule because it should probably be removed,
+	but at this point we are about to go release candidate with 3.1 so it will have to wait.
+	When we do remove it, the main things it could effect are the Story Primer template and the dozen or so SIL LEAD Uganda SHRP templates.
+*/
+TD {
+	resize: none;
+	/*don't show those cute little resize controls in Firefox 4 and greater*/
+	overflow: visible;
+	font-size: 143%;
+	line-height: @defaultLineHeight;
+	min-height: @defaultLineHeight + .3em;
+	width: 100%;
+}
+
 p{
   min-height: 1em; //without this, an empty paragraph will be invisible, making blank lines impossible
 }


### PR DESCRIPTION
It remains distressing that we don't know why the PDF looks different than the html/css used to make the PDF. It was also hard to fix because the latest FF looks different than the FF in Bloom

On Windows, both the Bloom 3.1 FF, Bloom 3.1 PDF, the latest FF, and IE11 are happy with the current implementation (Chrome makes it too tall).