### PR TITLE
Remove obsolete tooltip

### DIFF
--- a/src/BloomExe/Publish/PublishView.Designer.cs
+++ b/src/BloomExe/Publish/PublishView.Designer.cs
@@ -184,8 +184,6 @@
             this._openinBrowserMenuItem.Name = "_openinBrowserMenuItem";
             this._openinBrowserMenuItem.Size = new System.Drawing.Size(433, 22);
             this._openinBrowserMenuItem.Text = "Open the Html used to make this PDF, in Firefox (must be on path)";
-            this._openinBrowserMenuItem.ToolTipText = "Will show in chrome rather than firefox because it is closest to the html engine " +
-    "the htmltopdf engine uses.";
             this._openinBrowserMenuItem.Click += new System.EventHandler(this._openinBrowserMenuItem_Click);
             // 
             // _menusToolStrip


### PR DESCRIPTION
The tooltip claims we use chrome to produce PDFs, but we use Firefox.