### PR TITLE
BL-2353 Fix image width on xmatter to use full width

### DIFF
--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.css
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.css
@@ -1,4 +1,4 @@
-﻿.bloom-frontMatter .pageLabel:after,
+.bloom-frontMatter .pageLabel:after,
 .bloom-backMatter .pageLabel:after {
   content: ": Factory Front/Back Matter";
 }
@@ -9,12 +9,20 @@
   left: 15mm;
   width: 180mm;
 }
+.A4Portrait.outsideFrontCover .marginBox IMG,
+.A4Portrait.outsideBackCover .marginBox IMG {
+  max-width: 180mm;
+}
 .A4Landscape.outsideFrontCover .marginBox,
 .A4Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 185mm;
   left: 15mm;
   width: 267mm;
+}
+.A4Landscape.outsideFrontCover .marginBox IMG,
+.A4Landscape.outsideBackCover .marginBox IMG {
+  max-width: 267mm;
 }
 .A5Portrait.outsideFrontCover .marginBox,
 .A5Portrait.outsideBackCover .marginBox {
@@ -23,12 +31,20 @@
   left: 15mm;
   width: 118mm;
 }
+.A5Portrait.outsideFrontCover .marginBox IMG,
+.A5Portrait.outsideBackCover .marginBox IMG {
+  max-width: 118mm;
+}
 .A5Landscape.outsideFrontCover .marginBox,
 .A5Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 123mm;
   left: 15mm;
   width: 180mm;
+}
+.A5Landscape.outsideFrontCover .marginBox IMG,
+.A5Landscape.outsideBackCover .marginBox IMG {
+  max-width: 180mm;
 }
 .A6Portrait.outsideFrontCover .marginBox,
 .A6Portrait.outsideBackCover .marginBox {
@@ -37,6 +53,10 @@
   left: 15mm;
   width: 75mm;
 }
+.A6Portrait.outsideFrontCover .marginBox IMG,
+.A6Portrait.outsideBackCover .marginBox IMG {
+  max-width: 75mm;
+}
 .A6Landscape.outsideFrontCover .marginBox,
 .A6Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
@@ -44,12 +64,20 @@
   left: 15mm;
   width: 118mm;
 }
+.A6Landscape.outsideFrontCover .marginBox IMG,
+.A6Landscape.outsideBackCover .marginBox IMG {
+  max-width: 118mm;
+}
 .B5Portrait.outsideFrontCover .marginBox,
 .B5Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 225mm;
   left: 15mm;
   width: 146mm;
+}
+.B5Portrait.outsideFrontCover .marginBox IMG,
+.B5Portrait.outsideBackCover .marginBox IMG {
+  max-width: 146mm;
 }
 .insideFrontCover .bloom-content1 {
   display: inherit;
@@ -345,4 +373,3 @@ BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1
 .ISBNContainer .ISBNContainer SPAN {
   vertical-align: top;
 }
-/*# sourceMappingURL=Factory-XMatter.css.map */

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
@@ -1,4 +1,4 @@
-﻿.bloom-frontMatter .pageLabel:after,
+.bloom-frontMatter .pageLabel:after,
 .bloom-backMatter .pageLabel:after {
   content: ": SIL-Cameroon Front/Back Matter";
 }
@@ -9,12 +9,20 @@
   left: 15mm;
   width: 180mm;
 }
+.A4Portrait.outsideFrontCover .marginBox IMG,
+.A4Portrait.outsideBackCover .marginBox IMG {
+  max-width: 180mm;
+}
 .A4Landscape.outsideFrontCover .marginBox,
 .A4Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 185mm;
   left: 15mm;
   width: 267mm;
+}
+.A4Landscape.outsideFrontCover .marginBox IMG,
+.A4Landscape.outsideBackCover .marginBox IMG {
+  max-width: 267mm;
 }
 .A5Portrait.outsideFrontCover .marginBox,
 .A5Portrait.outsideBackCover .marginBox {
@@ -23,12 +31,20 @@
   left: 15mm;
   width: 118mm;
 }
+.A5Portrait.outsideFrontCover .marginBox IMG,
+.A5Portrait.outsideBackCover .marginBox IMG {
+  max-width: 118mm;
+}
 .A5Landscape.outsideFrontCover .marginBox,
 .A5Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 123mm;
   left: 15mm;
   width: 180mm;
+}
+.A5Landscape.outsideFrontCover .marginBox IMG,
+.A5Landscape.outsideBackCover .marginBox IMG {
+  max-width: 180mm;
 }
 .A6Portrait.outsideFrontCover .marginBox,
 .A6Portrait.outsideBackCover .marginBox {
@@ -37,6 +53,10 @@
   left: 15mm;
   width: 75mm;
 }
+.A6Portrait.outsideFrontCover .marginBox IMG,
+.A6Portrait.outsideBackCover .marginBox IMG {
+  max-width: 75mm;
+}
 .A6Landscape.outsideFrontCover .marginBox,
 .A6Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
@@ -44,12 +64,20 @@
   left: 15mm;
   width: 118mm;
 }
+.A6Landscape.outsideFrontCover .marginBox IMG,
+.A6Landscape.outsideBackCover .marginBox IMG {
+  max-width: 118mm;
+}
 .B5Portrait.outsideFrontCover .marginBox,
 .B5Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 225mm;
   left: 15mm;
   width: 146mm;
+}
+.B5Portrait.outsideFrontCover .marginBox IMG,
+.B5Portrait.outsideBackCover .marginBox IMG {
+  max-width: 146mm;
 }
 .insideFrontCover .bloom-content1 {
   display: inherit;
@@ -345,4 +373,3 @@ BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1
 .ISBNContainer .ISBNContainer SPAN {
   vertical-align: top;
 }
-/*# sourceMappingURL=SIL-Cameroon-XMatter.css.map */

--- a/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
+++ b/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
@@ -1,4 +1,4 @@
-﻿.bloom-frontMatter .pageLabel:after,
+.bloom-frontMatter .pageLabel:after,
 .bloom-backMatter .pageLabel:after {
   content: ": Traditional Front/Back Matter";
 }
@@ -9,12 +9,20 @@
   left: 15mm;
   width: 180mm;
 }
+.A4Portrait.outsideFrontCover .marginBox IMG,
+.A4Portrait.outsideBackCover .marginBox IMG {
+  max-width: 180mm;
+}
 .A4Landscape.outsideFrontCover .marginBox,
 .A4Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 185mm;
   left: 15mm;
   width: 267mm;
+}
+.A4Landscape.outsideFrontCover .marginBox IMG,
+.A4Landscape.outsideBackCover .marginBox IMG {
+  max-width: 267mm;
 }
 .A5Portrait.outsideFrontCover .marginBox,
 .A5Portrait.outsideBackCover .marginBox {
@@ -23,12 +31,20 @@
   left: 15mm;
   width: 118mm;
 }
+.A5Portrait.outsideFrontCover .marginBox IMG,
+.A5Portrait.outsideBackCover .marginBox IMG {
+  max-width: 118mm;
+}
 .A5Landscape.outsideFrontCover .marginBox,
 .A5Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 123mm;
   left: 15mm;
   width: 180mm;
+}
+.A5Landscape.outsideFrontCover .marginBox IMG,
+.A5Landscape.outsideBackCover .marginBox IMG {
+  max-width: 180mm;
 }
 .A6Portrait.outsideFrontCover .marginBox,
 .A6Portrait.outsideBackCover .marginBox {
@@ -37,6 +53,10 @@
   left: 15mm;
   width: 75mm;
 }
+.A6Portrait.outsideFrontCover .marginBox IMG,
+.A6Portrait.outsideBackCover .marginBox IMG {
+  max-width: 75mm;
+}
 .A6Landscape.outsideFrontCover .marginBox,
 .A6Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
@@ -44,12 +64,20 @@
   left: 15mm;
   width: 118mm;
 }
+.A6Landscape.outsideFrontCover .marginBox IMG,
+.A6Landscape.outsideBackCover .marginBox IMG {
+  max-width: 118mm;
+}
 .B5Portrait.outsideFrontCover .marginBox,
 .B5Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 225mm;
   left: 15mm;
   width: 146mm;
+}
+.B5Portrait.outsideFrontCover .marginBox IMG,
+.B5Portrait.outsideBackCover .marginBox IMG {
+  max-width: 146mm;
 }
 .insideFrontCover .bloom-content1 {
   display: inherit;
@@ -345,4 +373,3 @@ BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1
 .ISBNContainer .ISBNContainer SPAN {
   vertical-align: top;
 }
-/*# sourceMappingURL=Traditional-XMatter.css.map */

--- a/DistFiles/xMatter/bloom-xmatter-common.css
+++ b/DistFiles/xMatter/bloom-xmatter-common.css
@@ -1,4 +1,4 @@
-﻿.bloom-frontMatter .pageLabel:after,
+.bloom-frontMatter .pageLabel:after,
 .bloom-backMatter .pageLabel:after {
   content: ": unknown Front/Back Matter";
 }
@@ -9,12 +9,22 @@
   left: 15mm;
   width: 180mm;
 }
+.A4Portrait.outsideFrontCover .marginBox IMG,
+.A4Portrait.outsideBackCover .marginBox IMG {
+  /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
+  max-width: 180mm;
+}
 .A4Landscape.outsideFrontCover .marginBox,
 .A4Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 185mm;
   left: 15mm;
   width: 267mm;
+}
+.A4Landscape.outsideFrontCover .marginBox IMG,
+.A4Landscape.outsideBackCover .marginBox IMG {
+  /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
+  max-width: 267mm;
 }
 .A5Portrait.outsideFrontCover .marginBox,
 .A5Portrait.outsideBackCover .marginBox {
@@ -23,12 +33,22 @@
   left: 15mm;
   width: 118mm;
 }
+.A5Portrait.outsideFrontCover .marginBox IMG,
+.A5Portrait.outsideBackCover .marginBox IMG {
+  /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
+  max-width: 118mm;
+}
 .A5Landscape.outsideFrontCover .marginBox,
 .A5Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 123mm;
   left: 15mm;
   width: 180mm;
+}
+.A5Landscape.outsideFrontCover .marginBox IMG,
+.A5Landscape.outsideBackCover .marginBox IMG {
+  /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
+  max-width: 180mm;
 }
 .A6Portrait.outsideFrontCover .marginBox,
 .A6Portrait.outsideBackCover .marginBox {
@@ -37,6 +57,11 @@
   left: 15mm;
   width: 75mm;
 }
+.A6Portrait.outsideFrontCover .marginBox IMG,
+.A6Portrait.outsideBackCover .marginBox IMG {
+  /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
+  max-width: 75mm;
+}
 .A6Landscape.outsideFrontCover .marginBox,
 .A6Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
@@ -44,12 +69,22 @@
   left: 15mm;
   width: 118mm;
 }
+.A6Landscape.outsideFrontCover .marginBox IMG,
+.A6Landscape.outsideBackCover .marginBox IMG {
+  /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
+  max-width: 118mm;
+}
 .B5Portrait.outsideFrontCover .marginBox,
 .B5Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
   height: 225mm;
   left: 15mm;
   width: 146mm;
+}
+.B5Portrait.outsideFrontCover .marginBox IMG,
+.B5Portrait.outsideBackCover .marginBox IMG {
+  /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
+  max-width: 146mm;
 }
 .insideFrontCover .bloom-content1 {
   display: inherit;
@@ -345,4 +380,3 @@ BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1
 .ISBNContainer .ISBNContainer SPAN {
   vertical-align: top;
 }
-/*# sourceMappingURL=bloom-xmatter-common.css.map */

--- a/DistFiles/xMatter/bloom-xmatter-common.less
+++ b/DistFiles/xMatter/bloom-xmatter-common.less
@@ -20,6 +20,9 @@
          //Just center the margin box, (for now, we're ignoring the binding) 
           left: @MarginOuter;
           width:  @PageWidth - (2 * @MarginOuter);
+          IMG { /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
+              max-width: @PageWidth - (2 * @MarginOuter);
+          }
       }
       .A4Portrait& {
           .SetMarginBoxCover(@A4Portrait-Height, @A4Portrait-Width);

--- a/src/BloomBrowserUI/bookLayout/basePage.css
+++ b/src/BloomBrowserUI/bookLayout/basePage.css
@@ -224,7 +224,7 @@ preview.css.
   width: 170mm;
 }
 .A4Portrait .marginBox IMG {
-  /* BL-1022 Keeps XMatter thumb images from going too wide */
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
   max-width: 170mm;
 }
 .A4Landscape .marginBox {
@@ -232,7 +232,7 @@ preview.css.
   width: 257mm;
 }
 .A4Landscape .marginBox IMG {
-  /* BL-1022 Keeps XMatter thumb images from going too wide */
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
   max-width: 257mm;
 }
 .A5Portrait .marginBox {
@@ -240,7 +240,7 @@ preview.css.
   width: 108mm;
 }
 .A5Portrait .marginBox IMG {
-  /* BL-1022 Keeps XMatter thumb images from going too wide */
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
   max-width: 108mm;
 }
 .A5Landscape .marginBox {
@@ -248,7 +248,7 @@ preview.css.
   width: 170mm;
 }
 .A5Landscape .marginBox IMG {
-  /* BL-1022 Keeps XMatter thumb images from going too wide */
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
   max-width: 170mm;
 }
 .A6Portrait .marginBox {
@@ -256,7 +256,7 @@ preview.css.
   width: 65mm;
 }
 .A6Portrait .marginBox IMG {
-  /* BL-1022 Keeps XMatter thumb images from going too wide */
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
   max-width: 65mm;
 }
 .A6Landscape .marginBox {
@@ -264,7 +264,7 @@ preview.css.
   width: 108mm;
 }
 .A6Landscape .marginBox IMG {
-  /* BL-1022 Keeps XMatter thumb images from going too wide */
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
   max-width: 108mm;
 }
 .B5Portrait .marginBox {
@@ -272,7 +272,7 @@ preview.css.
   width: 136mm;
 }
 .B5Portrait .marginBox IMG {
-  /* BL-1022 Keeps XMatter thumb images from going too wide */
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
   max-width: 136mm;
 }
 .publishMode:not(.calendarFold) :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd) .marginBox {

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -1,4 +1,4 @@
-@import "../../../distfiles/less/common-mixins.less";
+@import "../../../DistFiles/less/common-mixins.less";
 
 .Browser-Reset() {
 	/*+init {*/
@@ -230,12 +230,12 @@ preview.css.
 }
 
 .marginBox {
-  .SetMarginBox(@PageWidth, @PageHeight) {
+	.SetMarginBox(@PageWidth, @PageHeight) {
 		height: @PageHeight - (@MarginTop + @MarginBottom);
-    width: @PageWidth - ( @MarginOuter + @MarginInner );
-    IMG { /* BL-1022 Keeps XMatter thumb images from going too wide */
-            max-width: @PageWidth - ( @MarginOuter + @MarginInner );
-    }
+		width: @PageWidth - ( @MarginOuter + @MarginInner );
+		IMG { /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
+			max-width: @PageWidth - ( @MarginOuter + @MarginInner );
+		}
 	}
 	
 	.A4Portrait & {


### PR DESCRIPTION
* Fix BL-1022 in basePage.less was overridden by xmatter css
   which have wider relative marginBox margins
* also changed capitalization on @import to match actual
   DistFiles folder name (in case we build less->css on linux
   someday)
* NB: all 'real' changes are to .less files