### PR TITLE
BL-2357 smart order lgs (v3.3?)

### DIFF
--- a/src/BloomBrowserUI/BloomBrowserUI.csproj
+++ b/src/BloomBrowserUI/BloomBrowserUI.csproj
@@ -181,6 +181,8 @@
     <TypeScriptCompile Include="bookEdit\js\readerTools.ts" />
     <TypeScriptCompile Include="bookEdit\js\readerToolsModel.ts" />
     <TypeScriptCompile Include="bookEdit\js\synphonyApi.ts" />
+    <TypeScriptCompile Include="bookEdit\test\SourceBubblesSpec.ts" />
+    <TypeScriptCompile Include="bookEdit\test\StyleEditorSpec.ts" />
     <TypeScriptCompile Include="bookEdit\TopicChooser\TopicChooser.ts" />
     <TypeScriptCompile Include="bookEdit\readerSetup\readerSetup.io.ts" />
     <TypeScriptCompile Include="bookEdit\readerSetup\readerSetup.ui.ts" />

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -548,7 +548,9 @@ function SetupElements(container) {
     if ($(container).find(".bloom-preventSourceBubbles").length == 0) {
         $(container).find("*.bloom-translationGroup").not(".bloom-readOnlyInTranslationMode").each(function() {
             if ($(this).find("textarea, div").length > 1) {
-                bloomSourceBubbles.MakeSourceTextDivForGroup(this);
+                var divForBubble = bloomSourceBubbles.MakeSourceTextDivForGroup(this);
+                if(divForBubble != null)
+                    bloomSourceBubbles.TurnDivIntoTabbedBubbleWithToolTips(this, divForBubble);
             }
         });
     }

--- a/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.js
@@ -105,7 +105,8 @@ var bloomSourceBubbles = (function () {
         return items;
     };
     bloomSourceBubbles.DoSafeReplaceInList = function (items, langCode, position) {
-        // if items contains a div with langCode, then try to put it at the position specified in the list.
+        // if items contains a div with langCode, then try to put it at the position specified in the list
+        // (unless it already occurs at an earlier position).
         var moveFrom = 0;
         var objToMove;
         var itemArray = items.toArray();

--- a/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.js
@@ -48,7 +48,7 @@ var bloomSourceBubbles = (function () {
         StyleEditor.CleanupElement(divForBubble);
         //if there are no languages to show in the bubble, bail out now
         if ($(divForBubble).find("textarea, div").length == 0)
-            return;
+            return null;
         var vernacularLang = localizationManager.getVernacularLang();
         //make the li's for the source text elements in this new div, which will later move to a tabbed bubble
         // divForBubble is a single cloned bloom-translationGroup, so no need for .each() here
@@ -87,7 +87,7 @@ var bloomSourceBubbles = (function () {
                 }
             }
         });
-        bloomSourceBubbles.TurnDivIntoTabbedBubbleWithToolTips(group, divForBubble);
+        return divForBubble;
     }; // end MakeSourceTextDivForGroup()
     bloomSourceBubbles.SmartOrderSourceTabs = function (items) {
         // BL-2357 Do some smart ordering of source language tabs
@@ -129,6 +129,7 @@ var bloomSourceBubbles = (function () {
     // N.B.: Sorting the last used source language first means we no longer need to specify which tab is selected.
     // Then turns that bundle into a qtip bubble attached to 'group'.
     // Then makes sure the tooltips are setup correctly.
+    // Made this public in order to test what feeds into it.
     bloomSourceBubbles.TurnDivIntoTabbedBubbleWithToolTips = function (group, divForBubble) {
         var $group = $(group);
         //now turn that new div into a set of tabs

--- a/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.ts
@@ -85,18 +85,12 @@ class bloomSourceBubbles {
         if ($(divForBubble).find("textarea, div").length == 0)
             return;
 
-        /* removed june 12 2013 was dying with new jquery as this was Window and that had no OwnerDocument
-           $(this).after(divForBubble);
-         */
-
-        var selectorOfDefaultTab="li:first-child";
-
         var vernacularLang = localizationManager.getVernacularLang();
 
         //make the li's for the source text elements in this new div, which will later move to a tabbed bubble
         // divForBubble is a single cloned bloom-translationGroup, so no need for .each() here
         var $this = $(divForBubble[0]);
-        $this.prepend('<nav><ul class="editTimeOnly bloom-ui"></ul></nav>');
+        $this.prepend('<nav><ul class="editTimeOnly bloom-ui"></ul></nav>'); // build the tabs here
         var list = $this.find('ul');
         //nb: Jan 2012: we modified "jquery.easytabs.js" to target @lang attributes, rather than ids.  If that change gets lost,
         //it's just a one-line change.
@@ -114,6 +108,8 @@ class bloomSourceBubbles {
                 return 1;
             return 0;
         });
+
+        var selectorOfDefaultTab="li:first-child";
         var shellEditingMode = false;
         items.each(function() {
             var iso = $(this).attr('lang');
@@ -134,16 +130,25 @@ class bloomSourceBubbles {
             }
         });
 
+        bloomSourceBubbles.TurnDivIntoTabbedBubbleWithToolTips(group, divForBubble, selectorOfDefaultTab);
+    } // end MakeSourceTextDivForGroup()
+
+    // Turns the cloned div 'divForBubble' into a tabbed bundle with tab corresponding to 'selectorOfDefaultTab'
+    // selected.
+    // Then turns that bundle into a qtip bubble attached to 'group'.
+    // Then makes sure the tooltips are setup correctly.
+    private static TurnDivIntoTabbedBubbleWithToolTips(group: HTMLElement, divForBubble: JQuery, selectorOfDefaultTab: string): void {
+        var $group = $(group);
         //now turn that new div into a set of tabs
-        if ($(divForBubble).find("li").length > 0) {
-            (<easytabsInterface>$(divForBubble)).easytabs({
+        if (divForBubble.find("li").length > 0) {
+            (<easytabsInterface>divForBubble).easytabs({
                 animate: false,
                 defaultTab: selectorOfDefaultTab,
                 tabs: "> nav > ul > li"
             });
         }
         else {
-            $(divForBubble).remove();//no tabs, so hide the bubble
+            divForBubble.remove();//no tabs, so hide the bubble
             return;
         }
 
@@ -153,7 +158,7 @@ class bloomSourceBubbles {
         var hideEventsStr;
         var shouldShowAlways = true;
 
-        if(bloomQtipUtils.mightCauseHorizontallyOverlappingBubbles($(group))) {
+        if(bloomQtipUtils.mightCauseHorizontallyOverlappingBubbles($group)) {
             showEvents = true;
             showEventsStr = 'focusin';
             hideEvents = true;
@@ -162,7 +167,7 @@ class bloomSourceBubbles {
         }
 
         // turn that tab thing into a bubble, and attach it to the original div ("group")
-        $(group).each(function () {
+        $group.each(function () {
             // var targetHeight = Math.max(55, $(this).height()); // This ensures we get at least one line of the source text!
 
             var $this: qtipInterface = <qtipInterface>$(this);
@@ -176,7 +181,7 @@ class bloomSourceBubbles {
                         y: 0
                     }
                 },
-                content: $(divForBubble),
+                content: divForBubble,
 
                 show: {
                     event: (showEvents ? showEventsStr : showEvents),
@@ -218,32 +223,34 @@ class bloomSourceBubbles {
                 }
             });
 
-            // BL-878: show the full-size tool tip when the text area has focus
-            $this.find('.bloom-editable').focus(function(event) {
+            bloomSourceBubbles.SetupTooltips($this);
+        });
+    }
 
-                // reset tool tips that may be expanded
-                var $body = $('body');
-                $body.find('.qtip[data-max-height]').each(function(idx, obj) {
-                    var $thisTip = $(obj);
-                    $thisTip.css('max-height', parseInt($thisTip.attr('data-max-height')));
-                    $thisTip.css('z-index', 15001);
-                    $thisTip.addClass('passive-bubble');
-                });
+    private static SetupTooltips(editableDiv: JQuery): void
+    {
+        // BL-878: show the full-size tool tip when the text area has focus
+        editableDiv.find('.bloom-editable').focus(function(event) {
 
-                // show the full tip, if needed
-                var tipId = event.target.parentNode.getAttribute('aria-describedby');
-                var $tip = $body.find('#' + tipId);
-                var maxHeight = $tip.attr('data-max-height');
-
-                if (maxHeight) {
-                    $tip.css('max-height', '');
-                    $tip.css('z-index', 15002);
-                    $tip.removeClass('passive-bubble');
-                }
-
-                //event.stopPropagation();
-                //event.preventDefault();
+            // reset tool tips that may be expanded
+            var $body = $('body');
+            $body.find('.qtip[data-max-height]').each(function(idx, obj) {
+                var $thisTip = $(obj);
+                $thisTip.css('max-height', parseInt($thisTip.attr('data-max-height')));
+                $thisTip.css('z-index', 15001);
+                $thisTip.addClass('passive-bubble');
             });
+
+            // show the full tip, if needed
+            var tipId = event.target.parentNode.getAttribute('aria-describedby');
+            var $tip = $body.find('#' + tipId);
+            var maxHeight = $tip.attr('data-max-height');
+
+            if (maxHeight) {
+                $tip.css('max-height', '');
+                $tip.css('z-index', 15002);
+                $tip.removeClass('passive-bubble');
+            }
         });
     }
 }

--- a/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.ts
@@ -28,19 +28,6 @@ class bloomSourceBubbles {
         return $.trim($(obj).text()).length == 0;
     }
 
-    // Call this after source bubble is displayed to scroll the current tab into view
-    private static ShowCurrentTab(): void {
-        var activeTabs = $("body").find(".ui-sourceTextsForBubble li.active");
-        if (activeTabs.length) {
-            activeTabs.each(function() {
-                // GJM 6/22/15: This scrolling does put the active tab in view (horizontal scrolling)
-                // However, it also scrolls the whole page up in Bloom by about 2mm. I haven't
-                // discovered yet how to avoid this.
-                this.scrollIntoView();
-            });
-        }
-    }
-
     //Sets up the (currently yellow) qtip bubbles that give you the contents of the box in the source languages
     // param 'group' is a .bloom-translationGroup DIV
     public static MakeSourceTextDivForGroup(group: HTMLElement): void {
@@ -91,11 +78,12 @@ class bloomSourceBubbles {
         // divForBubble is a single cloned bloom-translationGroup, so no need for .each() here
         var $this = $(divForBubble[0]);
         $this.prepend('<nav><ul class="editTimeOnly bloom-ui"></ul></nav>'); // build the tabs here
-        var list = $this.find('ul');
-        //nb: Jan 2012: we modified "jquery.easytabs.js" to target @lang attributes, rather than ids.  If that change gets lost,
-        //it's just a one-line change.
+
+        // First, sort the divs (and/or textareas) alphabetically by language code
         var items = $this.find("textarea, div");
         (<arraySort>items).sort(function(a, b) {
+            //nb: Jan 2012: we modified "jquery.easytabs.js" to target @lang attributes, rather than ids.  If that change gets lost,
+            //it's just a one-line change.
             var keyA = $(a).attr('lang');
             var keyB = $(b).attr('lang');
             if (keyA === vernacularLang)
@@ -109,8 +97,10 @@ class bloomSourceBubbles {
             return 0;
         });
 
-        var selectorOfDefaultTab="li:first-child";
+        items = bloomSourceBubbles.SmartOrderSourceTabs(items); // BL-2357
+
         var shellEditingMode = false;
+        var list = $this.find('ul');
         items.each(function() {
             var iso = $(this).attr('lang');
             if (iso) {
@@ -121,29 +111,61 @@ class bloomSourceBubbles {
 
                 // in translation mode, don't include the vernacular in the tabs, because the tabs are being moved to the bubble
                 if (iso !== "z" && (shellEditingMode || !shouldShowOnPage)) {
-
                     $(list).append('<li id="' + iso + '"><a class="sourceTextTab" href="#' + iso + '">' + languageName + '</a></li>');
-                    if (iso === GetSettings().defaultSourceLanguage) {
-                        selectorOfDefaultTab = "li#" + iso; //selectorOfDefaultTab="li:#"+iso; this worked in jquery 1.4
-                    }
                 }
             }
         });
 
-        bloomSourceBubbles.TurnDivIntoTabbedBubbleWithToolTips(group, divForBubble, selectorOfDefaultTab);
+        bloomSourceBubbles.TurnDivIntoTabbedBubbleWithToolTips(group, divForBubble);
     } // end MakeSourceTextDivForGroup()
 
-    // Turns the cloned div 'divForBubble' into a tabbed bundle with tab corresponding to 'selectorOfDefaultTab'
-    // selected.
+    private static SmartOrderSourceTabs(items):JQuery {
+        // BL-2357 Do some smart ordering of source language tabs
+        var settingsObject = GetSettings();
+        var defaultSrcLang = settingsObject.defaultSourceLanguage;
+        items = bloomSourceBubbles.DoSafeReplaceInList(items, defaultSrcLang, 0);
+        var language2 = settingsObject.currentCollectionLanguage2;
+        var language3 = settingsObject.currentCollectionLanguage3;
+        if (language2 && language2 != defaultSrcLang) {
+            items = bloomSourceBubbles.DoSafeReplaceInList(items, language2, 1);
+        }
+        if (language3 && language3 != defaultSrcLang) {
+            items = bloomSourceBubbles.DoSafeReplaceInList(items, language3, 2);
+        }
+        return items;
+    }
+
+    private static DoSafeReplaceInList(items:JQuery, langCode:String, position:number):JQuery {
+        // if items contains a div with langCode, then try to put it at the position specified in the list.
+        var moveFrom = 0;
+        var objToMove;
+        var itemArray = items.toArray();
+        items.each(function(idx, obj) {
+            var iso = $(this).attr('lang');
+            if(iso == langCode && position < idx) {
+                moveFrom = idx;
+                objToMove = obj;
+            }
+        });
+        if(moveFrom > 0) {
+            itemArray.splice(moveFrom, 1); // removes the objToMove from the array
+            itemArray.splice(position, 0, objToMove); // puts objToMove back in at position
+            items = $(itemArray);
+        }
+        return items;
+    }
+
+    // Turns the cloned div 'divForBubble' into a tabbed bundle with the first tab, corresponding to
+    // defaultSourceLanguage, selected.
+    // N.B.: Sorting the last used source language first means we no longer need to specify which tab is selected.
     // Then turns that bundle into a qtip bubble attached to 'group'.
     // Then makes sure the tooltips are setup correctly.
-    private static TurnDivIntoTabbedBubbleWithToolTips(group: HTMLElement, divForBubble: JQuery, selectorOfDefaultTab: string): void {
+    private static TurnDivIntoTabbedBubbleWithToolTips(group: HTMLElement, divForBubble: JQuery): void {
         var $group = $(group);
         //now turn that new div into a set of tabs
         if (divForBubble.find("li").length > 0) {
             (<easytabsInterface>divForBubble).easytabs({
                 animate: false,
-                defaultTab: selectorOfDefaultTab,
                 tabs: "> nav > ul > li"
             });
         }
@@ -216,10 +238,6 @@ class bloomSourceBubbles {
                             $tip.attr('data-max-height', maxHeight)
                         }
                     },
-                    visible: function(event, api) {
-                        // After the qtip becomes visible, show the current tab
-                        bloomSourceBubbles.ShowCurrentTab();
-                    }
                 }
             });
 

--- a/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.ts
@@ -30,7 +30,7 @@ class bloomSourceBubbles {
 
     //Sets up the (currently yellow) qtip bubbles that give you the contents of the box in the source languages
     // param 'group' is a .bloom-translationGroup DIV
-    public static MakeSourceTextDivForGroup(group: HTMLElement): void {
+    public static MakeSourceTextDivForGroup(group: HTMLElement): JQuery {
         // Copy source texts out to their own div, where we can make a bubble with tabs out of them
         // We do this because if we made a bubble out of the div, that would suck up the vernacular editable area, too,
         var divForBubble = $(group).clone();
@@ -70,7 +70,7 @@ class bloomSourceBubbles {
 
         //if there are no languages to show in the bubble, bail out now
         if ($(divForBubble).find("textarea, div").length == 0)
-            return;
+            return null;
 
         var vernacularLang = localizationManager.getVernacularLang();
 
@@ -116,7 +116,7 @@ class bloomSourceBubbles {
             }
         });
 
-        bloomSourceBubbles.TurnDivIntoTabbedBubbleWithToolTips(group, divForBubble);
+        return divForBubble;
     } // end MakeSourceTextDivForGroup()
 
     private static SmartOrderSourceTabs(items):JQuery {
@@ -161,7 +161,8 @@ class bloomSourceBubbles {
     // N.B.: Sorting the last used source language first means we no longer need to specify which tab is selected.
     // Then turns that bundle into a qtip bubble attached to 'group'.
     // Then makes sure the tooltips are setup correctly.
-    private static TurnDivIntoTabbedBubbleWithToolTips(group: HTMLElement, divForBubble: JQuery): void {
+    // Made this public in order to test what feeds into it.
+    public static TurnDivIntoTabbedBubbleWithToolTips(group: HTMLElement, divForBubble: JQuery): void {
         var $group = $(group);
         //now turn that new div into a set of tabs
         if (divForBubble.find("li").length > 0) {
@@ -223,7 +224,8 @@ class bloomSourceBubbles {
                     show: function(event, api) {
                         // don't need to do this if there is only one editable area
                         var $body: JQuery = $('body');
-                        if ($body.find("*.bloom-translationGroup").not(".bloom-readOnlyInTranslationMode").length < 2) return;
+                        if ($body.find("*.bloom-translationGroup").not(".bloom-readOnlyInTranslationMode").length < 2)
+                            return;
 
                         // BL-878: set the tool tips to not be larger than the text area so they don't overlap each other
                         var $tip = api.elements.tooltip;

--- a/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomSourceBubbles.ts
@@ -136,7 +136,8 @@ class bloomSourceBubbles {
     }
 
     private static DoSafeReplaceInList(items:JQuery, langCode:String, position:number):JQuery {
-        // if items contains a div with langCode, then try to put it at the position specified in the list.
+        // if items contains a div with langCode, then try to put it at the position specified in the list
+        // (unless it already occurs at an earlier position).
         var moveFrom = 0;
         var objToMove;
         var itemArray = items.toArray();

--- a/src/BloomBrowserUI/bookEdit/js/collectionSettings.d.ts
+++ b/src/BloomBrowserUI/bookEdit/js/collectionSettings.d.ts
@@ -7,6 +7,8 @@ interface settingsObject {
   isSourceCollection: boolean;
   languageForNewTextBoxes: string;
   defaultSourceLanguage: string;
+  currentCollectionLanguage2: string;
+  currentCollectionLanguage3: string;
   bloomBrowserUIFolder: string;
   topics: string[];
 }

--- a/src/BloomBrowserUI/bookEdit/test/cSharpDependencyInjector.js
+++ b/src/BloomBrowserUI/bookEdit/test/cSharpDependencyInjector.js
@@ -1,40 +1,38 @@
-﻿/// <reference path="../js/calledByCSharp.ts" />
-
+/// <reference path="../js/calledByCSharp.ts" />
 /**
-* Test substitute for RuntimeInformationInjector.cs AddUISettingsToDom()
-* @returns {Object}
-*/
+ * Test substitute for RuntimeInformationInjector.cs AddUISettingsToDom()
+ * @returns {Object}
+ */
 function GetSettings() {
     var v = {};
     v.defaultSourceLanguage = 'en';
+    v.currentCollectionLanguage2 = 'tpi';
+    v.currentCollectionLanguage3 = 'fr';
     v.languageForNewTextBoxes = 'en';
     v.isSourceCollection = 'false';
     v.bloomBrowserUIFolder = '';
+    v.topics = ['Agriculture', 'Animal Stories', 'Business', 'Culture', 'Community Living', 'Dictionary', 'Environment', 'Fiction', 'Health', 'How To', 'Math', 'Non Fiction', 'Spiritual', 'Personal Development', 'Primer', 'Science', 'Tradition'];
     return v;
 }
-
 //noinspection JSUnusedGlobalSymbols
 /**
-* These functions are called by C#, so the WebStorm code inspection thinks they are unused.
-*/
+ * These functions are called by C#, so the WebStorm code inspection thinks they are unused.
+ */
 function ForCodeInspection_UnusedFunctions() {
     // don't actually do anything
     if (1 === 1)
         return;
-
     window.restoreAccordionSettings('');
-
     var x = model.fontName;
     var calledByCSharpObj = new CalledByCSharp();
     calledByCSharpObj.removeSynphonyMarkup();
 }
-
 //noinspection JSUnusedGlobalSymbols
 /**
-* Test substitute for RuntimeInformationInjector.cs AddUIDictionaryToDom()
-* @returns {Object}
-*/
+ * Test substitute for RuntimeInformationInjector.cs AddUIDictionaryToDom()
+ * @returns {Object}
+ */
 function GetInlineDictionary() {
-    return { "en": "English", "vernacularLang": "en", "{V}": "English", "{N1}": "English", "{N2}": "", "ar": "العربية/عربي‎","id": "Bahasa Indonesia", "ha": "Hausa", "hi": "हिन्दी", "es": "español", "fr": "français", "pt": "português", "swa": "Swahili", "th": "ภาษาไทย", "tpi": "Tok Pisin", "EditTab.ThumbnailCaptions.Front Cover": "Front Cover", "*You may use this space for author/illustrator, or anything else.": "*You may use this space for author/illustrator, or anything else.", "Click to choose topic": "Click to choose topic", "BookEditor.FontSizeTip": "Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\\nCurrent size is {2}pt.", "FrontMatter.Factory.Book title in {lang}": "Book title in {lang}", "FrontMatter.Factory.Click to choose topic": "Click to choose topic", "FrontMatter.Factory.International Standard Book Number. Leave blank if you don't have one of these.": "International Standard Book Number. Leave blank if you don't have one of these.", "FrontMatter.Factory.Acknowledgments for translated version, in {lang}": "Acknowledgments for translated version, in {lang}", "FrontMatter.Factory.Use this to acknowledge any funding agencies.": "Use this to acknowledge any funding agencies.", "BackMatter.Factory.If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.": "If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.", "BackMatter.Factory.If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.": "If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover." };
+    return { "en": "English", "vernacularLang": "en", "{V}": "English", "{N1}": "English", "{N2}": "", "ar": "العربية/عربي‎", "id": "Bahasa Indonesia", "ha": "Hausa", "hi": "हिन्दी", "es": "español", "fr": "français", "pt": "português", "swa": "Swahili", "th": "ภาษาไทย", "tpi": "Tok Pisin", "EditTab.ThumbnailCaptions.Front Cover": "Front Cover", "*You may use this space for author/illustrator, or anything else.": "*You may use this space for author/illustrator, or anything else.", "Click to choose topic": "Click to choose topic", "BookEditor.FontSizeTip": "Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\\nCurrent size is {2}pt.", "FrontMatter.Factory.Book title in {lang}": "Book title in {lang}", "FrontMatter.Factory.Click to choose topic": "Click to choose topic", "FrontMatter.Factory.International Standard Book Number. Leave blank if you don't have one of these.": "International Standard Book Number. Leave blank if you don't have one of these.", "FrontMatter.Factory.Acknowledgments for translated version, in {lang}": "Acknowledgments for translated version, in {lang}", "FrontMatter.Factory.Use this to acknowledge any funding agencies.": "Use this to acknowledge any funding agencies.", "BackMatter.Factory.If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.": "If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.", "BackMatter.Factory.If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.": "If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover." };
 }
 //# sourceMappingURL=cSharpDependencyInjector.js.map

--- a/src/BloomBrowserUI/bookEdit/test/cSharpDependencyInjector.ts
+++ b/src/BloomBrowserUI/bookEdit/test/cSharpDependencyInjector.ts
@@ -13,6 +13,8 @@ interface InjectorWindow extends Window {
 function GetSettings(): any {
   var v: any = {};
   v.defaultSourceLanguage = 'en';
+  v.currentCollectionLanguage2 = 'tpi';
+  v.currentCollectionLanguage3 = 'fr';
   v.languageForNewTextBoxes = 'en';
   v.isSourceCollection = 'false';
   v.bloomBrowserUIFolder = '';

--- a/src/BloomBrowserUI/karma.conf.js
+++ b/src/BloomBrowserUI/karma.conf.js
@@ -39,6 +39,7 @@ module.exports = function (config) {
             '**/js/bloomEditing.js',
             '**/StyleEditor/StyleEditor.js',
             '**/OverflowChecker/OverflowChecker.js',
+            '**/js/bloomSourceBubbles.js',
             // as long as the test filename is in the test/specs folder, it will be included in the test run
             'test/specs/**/*.js',
 

--- a/src/BloomBrowserUI/test/specs/SourceBubblesSpec.js
+++ b/src/BloomBrowserUI/test/specs/SourceBubblesSpec.js
@@ -1,0 +1,35 @@
+/// <reference path="../../bookEdit/js/bloomSourceBubbles.ts" />
+/// <reference path="../../lib/jasmine/jasmine.d.ts"/>
+"use strict";
+describe("bloomSourceBubbles", function () {
+    // reset fixture
+    beforeEach(function () {
+        $('body').html('');
+    });
+    it("Run MakeSourceTextDivForGroup with pre-defined settings", function () {
+        // TODO: Testing is a bit hampered by not being able (currently) to put test values
+        // into the cSharpDependencyInjector version of GetSettings(). Someday it might
+        // be worth modifying that file so that tests can setup their own values for:
+        // defaultSourceLanguage ('en' in tests; also marked vernacular)
+        // currentCollectionLanguage2 ('tpi' in tests)
+        // currentCollectionLanguage3 ('fr' in tests)
+        var testHtml = $([
+            "<div id='testTarget' class='bloom-translationGroup'>",
+            "   <div class='bloom-editable' lang='es'>Spanish text</div>",
+            "   <div class='bloom-editable' lang='en'>English text</div>",
+            "   <div class='bloom-editable' lang='fr'>French text</div>",
+            "   <div class='bloom-editable' lang='tpi'>Tok Pisin text</div>",
+            "</div>"
+        ].join("\n"));
+        $('body').append(testHtml);
+        var result = bloomSourceBubbles.MakeSourceTextDivForGroup($('body').find('#testTarget')[0]);
+        var listItems = result.find('nav ul li');
+        expect(listItems.length).toBe(3); // English in test is vernacular, so no tab for it
+        // Tok Pisin tab gets moved to first place, since it is currentCollectionLanguage2
+        expect(listItems.first().html()).toBe("<a class=\"sourceTextTab\" href=\"#tpi\">Tok Pisin</a>");
+        expect(listItems.last().html()).toBe("<a class=\"sourceTextTab\" href=\"#es\">español</a>");
+        expect(result.find('li#fr').html()).toBe("<a class=\"sourceTextTab\" href=\"#fr\">français</a>");
+        expect(result.find('div').length).toBe(4); // including English
+    });
+});
+//# sourceMappingURL=SourceBubblesSpec.js.map

--- a/src/BloomBrowserUI/test/specs/SourceBubblesSpec.ts
+++ b/src/BloomBrowserUI/test/specs/SourceBubblesSpec.ts
@@ -1,0 +1,38 @@
+/// <reference path="../../bookEdit/js/bloomSourceBubbles.ts" />
+/// <reference path="../../lib/jasmine/jasmine.d.ts"/>
+
+"use strict";
+
+describe("bloomSourceBubbles", function () {
+  // reset fixture
+  beforeEach(function () {
+    $('body').html('');
+  });
+
+  it("Run MakeSourceTextDivForGroup with pre-defined settings", function () {
+    // TODO: Testing is a bit hampered by not being able (currently) to put test values
+    // into the cSharpDependencyInjector version of GetSettings(). Someday it might
+    // be worth modifying that file so that tests can setup their own values for:
+    // defaultSourceLanguage ('en' in tests; also marked vernacular)
+    // currentCollectionLanguage2 ('tpi' in tests)
+    // currentCollectionLanguage3 ('fr' in tests)
+
+    var testHtml = $([
+      "<div id='testTarget' class='bloom-translationGroup'>",
+      "   <div class='bloom-editable' lang='es'>Spanish text</div>",
+      "   <div class='bloom-editable' lang='en'>English text</div>",
+      "   <div class='bloom-editable' lang='fr'>French text</div>",
+      "   <div class='bloom-editable' lang='tpi'>Tok Pisin text</div>",
+      "</div>"
+    ].join("\n"));
+    $('body').append(testHtml);
+    var result = bloomSourceBubbles.MakeSourceTextDivForGroup($('body').find('#testTarget')[0]);
+    var listItems = result.find('nav ul li');
+    expect(listItems.length).toBe(3); // English in test is vernacular, so no tab for it
+    // Tok Pisin tab gets moved to first place, since it is currentCollectionLanguage2
+    expect(listItems.first().html()).toBe("<a class=\"sourceTextTab\" href=\"#tpi\">Tok Pisin</a>");
+    expect(listItems.last().html()).toBe("<a class=\"sourceTextTab\" href=\"#es\">español</a>");
+    expect(result.find('li#fr').html()).toBe("<a class=\"sourceTextTab\" href=\"#fr\">français</a>");
+    expect(result.find('div').length).toBe(4); // including English
+  });
+});

--- a/src/BloomExe/Book/RuntimeInformationInjector.cs
+++ b/src/BloomExe/Book/RuntimeInformationInjector.cs
@@ -284,6 +284,16 @@ namespace Bloom.Book
 			d.Add("languageForNewTextBoxes", collectionSettings.Language1Iso639Code);
 			d.Add("isSourceCollection", collectionSettings.IsSourceCollection.ToString());
 
+			// BL-2357 To aid in smart ordering of source languages in source bubble
+			if (!String.IsNullOrEmpty(collectionSettings.Language2Iso639Code))
+			{
+				d.Add("currentCollectionLanguage2", collectionSettings.Language2Iso639Code);
+			}
+			if (!String.IsNullOrEmpty(collectionSettings.Language3Iso639Code))
+			{
+				d.Add("currentCollectionLanguage3", collectionSettings.Language3Iso639Code);
+			}
+
 			d.Add("bloomBrowserUIFolder", FileLocator.GetDirectoryDistributedWithApplication("BloomBrowserUI").ToLocalhost());
 
 	


### PR DESCRIPTION
* puts LastViewedSource language first in the list of tabs (if there's translatable material for that language)
* puts the 2nd and 3rd language (from Settings dialog) in 2nd and 3rd position (with above caveat)
* due to the first change, we no longer need to specify which tab is selected or scroll to the selected tab, since the default first tab is always what we want selected.