### PR TITLE
BL-2399 Repair 'Report a Problem'

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -75,6 +75,9 @@
     <Reference Include="Chorus">
       <HintPath>..\..\lib\dotnet\Chorus.exe</HintPath>
     </Reference>
+    <Reference Include="EasyHttp">
+      <HintPath>..\..\packages\EasyHttp.1.6.29.0\lib\net40\EasyHttp.dll</HintPath>
+    </Reference>
     <Reference Include="Fleck">
       <HintPath>..\..\packages\Fleck.0.12.0.39\lib\net40\Fleck.dll</HintPath>
     </Reference>

--- a/src/BloomExe/MiscUI/ProblemReporterDialog.Designer.cs
+++ b/src/BloomExe/MiscUI/ProblemReporterDialog.Designer.cs
@@ -158,7 +158,7 @@
 			this._L10NSharpExtender.SetLocalizingId(this._screenshotHolder, "pictureBox1");
 			this._screenshotHolder.Location = new System.Drawing.Point(21, 247);
 			this._screenshotHolder.Name = "_screenshotHolder";
-			this._screenshotHolder.Size = new System.Drawing.Size(437, 156);
+			this._screenshotHolder.Size = new System.Drawing.Size(437, 141);
 			this._screenshotHolder.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
 			this._screenshotHolder.TabIndex = 8;
 			this._screenshotHolder.TabStop = false;
@@ -237,10 +237,10 @@
 			this._L10NSharpExtender.SetLocalizableToolTip(this._status, null);
 			this._L10NSharpExtender.SetLocalizationComment(this._status, null);
 			this._L10NSharpExtender.SetLocalizingId(this._status, "ReportProblemDialog.HtmlLabel");
-			this._status.Location = new System.Drawing.Point(21, 406);
+			this._status.Location = new System.Drawing.Point(21, 391);
 			this._status.Margin = new System.Windows.Forms.Padding(0);
 			this._status.Name = "_status";
-			this._status.Size = new System.Drawing.Size(337, 84);
+			this._status.Size = new System.Drawing.Size(437, 84);
 			this._status.TabIndex = 28;
 			// 
 			// _submitMsg
@@ -260,6 +260,7 @@
 			// 
 			// _privacyLabel
 			// 
+			this._privacyLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
 			this._privacyLabel.AutoSize = true;
 			this._privacyLabel.LinkColor = System.Drawing.Color.Black;
 			this._L10NSharpExtender.SetLocalizableToolTip(this._privacyLabel, null);


### PR DESCRIPTION
YouTrackSharp depends on EasyHttp.dll. The compiler
should realize this and 'copy local' both of them, but
doesn't, possibly because EasyHttp.dll is not at the
expected relative location. Adding a direct reference
makes the DLL available when needed.

The other change tweaks control sizes and positions
so the status messages can be fully read.