### PR TITLE
Stop loading synphony twice if both Decodable and Leveled enabled

### DIFF
--- a/src/BloomBrowserUI/bookEdit/accordion/DecodableRT/DecodableRT.htm
+++ b/src/BloomBrowserUI/bookEdit/accordion/DecodableRT/DecodableRT.htm
@@ -23,6 +23,7 @@
       <div id="make-letter-word-list-div" class="clear"><a id="make-letter-word-list" href="javascript:makeLetterWordList();" data-i18n="DecodableReaderTool.MakeLetterWordReport">Generate a letter and word list report</a></div>
       <script type="text/javascript">
         $(document).ready(function() {
+         // this timeout is different than the LeveledRT timeout to prevent initializing synphony twice
          setTimeout(initializeDecodableRT, 100);
         });
       </script>

--- a/src/BloomBrowserUI/bookEdit/accordion/DecodableRT/DecodableRT.jade
+++ b/src/BloomBrowserUI/bookEdit/accordion/DecodableRT/DecodableRT.jade
@@ -39,5 +39,6 @@ html
 				a#make-letter-word-list(href='javascript:makeLetterWordList();', data-i18n='DecodableReaderTool.MakeLetterWordReport') Generate a letter and word list report
 			script(type='text/javascript').
 				$(document).ready(function() {
+					// this timeout is different than the LeveledRT timeout to prevent initializing synphony twice
 					setTimeout(initializeDecodableRT, 100);
 				});

--- a/src/BloomBrowserUI/bookEdit/accordion/LeveledRT/LeveledRT.htm
+++ b/src/BloomBrowserUI/bookEdit/accordion/LeveledRT/LeveledRT.htm
@@ -68,7 +68,8 @@
       </div>
       <script type="text/javascript">
         $(document).ready(function() {
-         setTimeout(initializeLeveledRT, 100);
+         // this timeout is different than the DecodableRT timeout to prevent initializing synphony twice
+         setTimeout(initializeLeveledRT, 200);
         });
       </script>
     </div>

--- a/src/BloomBrowserUI/bookEdit/accordion/LeveledRT/LeveledRT.jade
+++ b/src/BloomBrowserUI/bookEdit/accordion/LeveledRT/LeveledRT.jade
@@ -70,5 +70,6 @@ html
 						a(href='javascript:loadExternalLink("leveledRTInfo/leveledReaderInfo-en.htm?ChoiceOfTopic")', data-i18n='LeveledReaderTool.ChoiceOfTopic') Choice of Topic
 			script(type='text/javascript').
 				$(document).ready(function() {
-					setTimeout(initializeLeveledRT, 100);
+					// this timeout is different than the DecodableRT timeout to prevent initializing synphony twice
+					setTimeout(initializeLeveledRT, 200);
 				});

--- a/src/BloomBrowserUI/bookEdit/js/readerTools.js
+++ b/src/BloomBrowserUI/bookEdit/js/readerTools.js
@@ -3,6 +3,7 @@
 /// <reference path="../../lib/localizationManager/localizationManager.ts" />
 // listen for messages sent to this page
 window.addEventListener('message', processDLRMessage, false);
+var readerToolsInitialized = false;
 function getSetupDialogWindow() {
     return parent.window.document.getElementById("settings_frame").contentWindow;
 }
@@ -94,11 +95,8 @@ function setupReaderKeyAndFocusHandlers(container, model) {
     });
 }
 function initializeDecodableRT() {
-    // make sure synphony is initialized
-    if (!model.getSynphony().source) {
-        iframeChannel.simpleAjaxGet('/bloom/readers/getDefaultFont', setDefaultFont);
-        iframeChannel.simpleAjaxGet('/bloom/readers/loadReaderToolSettings', initializeSynphony);
-    }
+    // load synphony settings
+    loadSynphonySettings();
     // use the off/on pattern so the event is not added twice if the tool is closed and then reopened
     $('#incStage').onOnce('click.readerTools', function () {
         model.incrementStage();
@@ -124,11 +122,8 @@ function initializeDecodableRT() {
     }, 100);
 }
 function initializeLeveledRT() {
-    // make sure synphony is initialized
-    if (!model.getSynphony().source) {
-        iframeChannel.simpleAjaxGet('/bloom/readers/getDefaultFont', setDefaultFont);
-        iframeChannel.simpleAjaxGet('/bloom/readers/loadReaderToolSettings', initializeSynphony);
-    }
+    // load synphony settings
+    loadSynphonySettings();
     $('#incLevel').onOnce('click.readerTools', function () {
         model.incrementLevel();
     });
@@ -143,6 +138,14 @@ if (typeof ($) === "function") {
         model = new ReaderToolsModel();
         model.setSynphony(new SynphonyApi());
     });
+}
+function loadSynphonySettings() {
+    // make sure synphony is initialized
+    if (!readerToolsInitialized && !model.getSynphony().source) {
+        readerToolsInitialized = true;
+        iframeChannel.simpleAjaxGet('/bloom/readers/getDefaultFont', setDefaultFont);
+        iframeChannel.simpleAjaxGet('/bloom/readers/loadReaderToolSettings', initializeSynphony);
+    }
 }
 /**
  * The function that is called to hook everything up.

--- a/src/BloomBrowserUI/bookEdit/js/readerTools.ts
+++ b/src/BloomBrowserUI/bookEdit/js/readerTools.ts
@@ -16,6 +16,8 @@ interface textMarkup extends JQueryStatic {
 // listen for messages sent to this page
 window.addEventListener('message', processDLRMessage, false);
 
+var readerToolsInitialized: boolean = false;
+
 function getSetupDialogWindow(): Window {
   return (<HTMLIFrameElement>parent.window.document.getElementById("settings_frame")).contentWindow;
 }
@@ -128,11 +130,8 @@ function setupReaderKeyAndFocusHandlers(container: HTMLElement, model: ReaderToo
 
 function initializeDecodableRT(): void {
 
-  // make sure synphony is initialized
-  if (!model.getSynphony().source) {
-    iframeChannel.simpleAjaxGet('/bloom/readers/getDefaultFont', setDefaultFont);
-    iframeChannel.simpleAjaxGet('/bloom/readers/loadReaderToolSettings', initializeSynphony);
-  }
+  // load synphony settings
+  loadSynphonySettings();
 
   // use the off/on pattern so the event is not added twice if the tool is closed and then reopened
   $('#incStage').onOnce('click.readerTools', function() {
@@ -163,11 +162,8 @@ function initializeDecodableRT(): void {
 
 function initializeLeveledRT(): void {
 
-  // make sure synphony is initialized
-  if (!model.getSynphony().source) {
-    iframeChannel.simpleAjaxGet('/bloom/readers/getDefaultFont', setDefaultFont);
-    iframeChannel.simpleAjaxGet('/bloom/readers/loadReaderToolSettings', initializeSynphony);
-  }
+  // load synphony settings
+  loadSynphonySettings();
 
   $('#incLevel').onOnce('click.readerTools', function() {
     model.incrementLevel();
@@ -187,6 +183,16 @@ if (typeof ($) === "function") {
     model = new ReaderToolsModel();
     model.setSynphony(new SynphonyApi());
   });
+}
+
+function loadSynphonySettings(): void {
+
+  // make sure synphony is initialized
+  if (!readerToolsInitialized && !model.getSynphony().source) {
+    readerToolsInitialized = true;
+    iframeChannel.simpleAjaxGet('/bloom/readers/getDefaultFont', setDefaultFont);
+    iframeChannel.simpleAjaxGet('/bloom/readers/loadReaderToolSettings', initializeSynphony);
+  }
 }
 
 /**


### PR DESCRIPTION
The word lists files were being loaded twice if both Decodable and Leveled reader tools were enabled.