### PR TITLE
BL-2339 handle case of no pages

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -534,10 +534,12 @@ namespace Bloom.Book
 		}
 
 
-
+		/// <summary>
+		/// First page in the book (or null if there are none)
+		/// </summary>
 		public IPage FirstPage
 		{
-			get { return GetPages().First(); }
+			get { return GetPages().FirstOrDefault(); }
 		}
 
 		public IPage GetPageByIndex(int pageIndex)


### PR DESCRIPTION
The fix for selecting a page at startup has
generated crashes when there are no pages.
I don't know how it's possible to get a book
into such a state, since we don't allow deleting
XMatter.