### PR TITLE
BL-2411 Improve FormatDialog dragging

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.js
@@ -530,7 +530,8 @@ var StyleEditor = (function () {
                 $('body').after(html);
                 var toolbar = $('#format-toolbar');
                 toolbar.find('*[data-i18n]').localize();
-                toolbar.draggable();
+                toolbar.draggable({ distance: 10, scroll: false, containment: $('html') });
+                toolbar.draggable("disable"); // until after we make sure it's in the Viewport
                 toolbar.css('opacity', 1.0);
                 editor.getCharTabDescription();
                 editor.getMoreTabDescription();
@@ -585,6 +586,7 @@ var StyleEditor = (function () {
                 var offset = $('#formatButton').offset();
                 toolbar.offset({ left: offset.left + 30, top: offset.top - 30 });
                 StyleEditor.positionInViewport(toolbar);
+                toolbar.draggable("enable");
                 $('html').off('click.toolbar');
                 $('html').on("click.toolbar", function (event) {
                     if (event.target != toolbar && toolbar.has(event.target).length === 0 && $(event.target.parent) != toolbar && toolbar.has(event.target).length === 0 && toolbar.is(":visible")) {

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -636,7 +636,8 @@ class StyleEditor {
                 $('body').after(html);
                 var toolbar = $('#format-toolbar');
                 toolbar.find('*[data-i18n]').localize();
-                toolbar.draggable();
+                toolbar.draggable({distance: 10, scroll: false, containment: $('html')});
+                toolbar.draggable("disable"); // until after we make sure it's in the Viewport
                 toolbar.css('opacity', 1.0);
                 editor.getCharTabDescription();
                 editor.getMoreTabDescription();
@@ -674,6 +675,7 @@ class StyleEditor {
                 var offset = $('#formatButton').offset();
                 toolbar.offset({ left: offset.left + 30, top: offset.top - 30 });
                 StyleEditor.positionInViewport(toolbar);
+                toolbar.draggable("enable");
 
                 $('html').off('click.toolbar');
                 $('html').on("click.toolbar", function (event) {

--- a/src/BloomBrowserUI/bookEdit/css/bloomDialog.css
+++ b/src/BloomBrowserUI/bookEdit/css/bloomDialog.css
@@ -77,7 +77,7 @@
 .bloomDialogContainer {
   background-color: white;
   opacity: 1;
-  z-index: 1010;
+  z-index: 16010;
   position: absolute;
   line-height: 1.8;
   font-family: Segoe UI, Open Sans, Arial, sans-serif;
@@ -95,6 +95,6 @@
 .bloomDialogContainer .bloomDialogMainPage {
   background: #ffffff;
   margin-left: 1em;
-  font: Segoe UI, Open Sans, Arial, sans-serif;
+  font-family: Segoe UI, Open Sans, Arial, sans-serif;
   font-size: 10pt;
 }

--- a/src/BloomBrowserUI/bookEdit/css/bloomDialog.less
+++ b/src/BloomBrowserUI/bookEdit/css/bloomDialog.less
@@ -80,7 +80,7 @@
 .bloomDialogContainer {
 	background-color: white;
 	opacity: 1;
-	z-index: 1010;
+	z-index: 16010;
 	position: absolute;
 	line-height: 1.8;
 	font-family: Segoe UI, Open Sans, Arial, sans-serif;
@@ -98,6 +98,6 @@
 .bloomDialogContainer .bloomDialogMainPage {
 	background: #ffffff;
 	margin-left: 1em;
-	font: Segoe UI, Open Sans, Arial, sans-serif;
+	font-family: Segoe UI, Open Sans, Arial, sans-serif;
 	font-size: 10pt;
 }


### PR DESCRIPTION
* dialog covers source bubbles, not vice versa
* dragging cursor has to move 10 pixels to activate
* dragging is limited to space available in iframe so dragging
   the dialog to the side doesn't cause scrolling