### PR TITLE
Reset the default image license when creating a new book

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryBookView.cs
+++ b/src/BloomExe/CollectionTab/LibraryBookView.cs
@@ -147,6 +147,7 @@ namespace Bloom.CollectionTab
 
 					_createFromSourceBookCommand.Raise(_bookSelection.CurrentSelection);
 					_sendReceiver.CheckInNow(checkinNotice);
+					Palaso.UI.WindowsForms.ClearShare.Metadata.DeleteStoredExemplar(Palaso.UI.WindowsForms.ClearShare.Metadata.FileCategory.Image);
 				}
 				catch(Exception error)
 				{


### PR DESCRIPTION
This addresses BL-2472 "Change Credits Page default license to CC-BY".
The default license is already CC-BY if no information is available.
But the exemplar is set to the most recent license entered if any images
have had a license modified by the user at any time in the past, and that
is used for the next image chosen by the user in any program that uses
the palaso image chooser dialog.