### PR TITLE
Update "Stage X of Y" after reloading wordlists (BL-2464)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/readerToolsModel.js
+++ b/src/BloomBrowserUI/bookEdit/js/readerToolsModel.js
@@ -772,6 +772,7 @@ var ReaderToolsModel = (function () {
             // the JavaScript version of Application.DoEvents().
             setTimeout(function () {
                 model.wordListLoaded = true;
+                model.updateControlContents(); // needed if user deletes all of the stages.
                 model.doMarkup();
                 model.updateWordList();
                 model.processWordListChangedListeners();

--- a/src/BloomBrowserUI/bookEdit/js/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/js/readerToolsModel.ts
@@ -942,6 +942,7 @@ class ReaderToolsModel {
       setTimeout(function() {
 
         model.wordListLoaded = true;
+        model.updateControlContents(); // needed if user deletes all of the stages.
         model.doMarkup();
         model.updateWordList();
         model.processWordListChangedListeners();


### PR DESCRIPTION
This is needed to update that label when the user deletes all of
decodable stage when using word list files to define stages.