### PR TITLE
Fix BL-2535, give helpful error if error accessing default printer

### DIFF
--- a/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfProgram.cs
+++ b/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfProgram.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Printing;
 using System.Reflection;
 using System.Threading;
 using System.Windows.Forms;
@@ -55,7 +54,7 @@ namespace Bloom.Publish
 				}
 				else
 				{
-					PrintQueue defaultPrinter;
+					System.Printing.PrintQueue defaultPrinter;
 					// BL-2535 it's possible get past the above printQueues.Any() but then get 
 					// a System.Printing.PrintQueueException exception with "Access Denied" error here, if
 					// the default printer for some reason is no longer "allowed".

--- a/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfProgram.cs
+++ b/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfProgram.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Printing;
 using System.Reflection;
 using System.Threading;
 using System.Windows.Forms;
@@ -47,25 +48,44 @@ namespace Bloom.Publish
 				// Gecko on Windows requires a default printer for any print operation, even one
 				// to a file.  See https://jira.sil.org/browse/BL-1237.
 				var printServer = new System.Printing.LocalPrintServer();
-				var printQueues = printServer.GetPrintQueues();
-				bool fOkay = printQueues.Any();
-				if (fOkay)
+				string errorMessage = null;
+				if (!printServer.GetPrintQueues().Any())
 				{
-					var defaultPrinter = System.Printing.LocalPrintServer.GetDefaultPrintQueue();
-					fOkay = defaultPrinter != null && !String.IsNullOrEmpty(defaultPrinter.FullName);
+					errorMessage = GetNoDefaultPrinterErrorMessage();
 				}
-				if (!fOkay)
+				else
 				{
-					var msg = L10NSharp.LocalizationManager.GetDynamicString(@"Bloom", @"MakePDF.NoPrinter",
-						"Bloom needs you to have a printer selected on this computer before it can make a PDF, even though you are not printing.  It appears that you do not have a printer selected.  Please go to Devices and Printers and add a printer.",
-						@"Error message displayed in a message dialog box");
-					var except = new ApplicationException(msg);
+					PrintQueue defaultPrinter;
+					// BL-2535 it's possible get past the above printQueues.Any() but then get 
+					// a System.Printing.PrintQueueException exception with "Access Denied" error here, if
+					// the default printer for some reason is no longer "allowed".
+					try
+					{
+						defaultPrinter = System.Printing.LocalPrintServer.GetDefaultPrintQueue();
+
+						if(defaultPrinter == null || String.IsNullOrEmpty(defaultPrinter.FullName))
+						{
+							errorMessage = GetNoDefaultPrinterErrorMessage();
+						}
+					}
+					catch(Exception error) // System.Printing.PrintQueueException isn't in our System.Printing assembly, so... using Exception
+					{
+						defaultPrinter = null;
+						errorMessage = L10NSharp.LocalizationManager.GetDynamicString(@"Bloom", @"MakePDF.PrinterError",
+							"Bloom requires access to a printer in order to make a PDF, even though you are not printing.  Windows gave this error when Bloom tried to access the default printer: {0}",
+							@"Error message displayed in a message dialog box");
+						errorMessage = string.Format(errorMessage, error.Message);
+					}
+				}
+				if (errorMessage !=null)
+				{
+					var exception = new ApplicationException(errorMessage);
 					// Note that if we're being run by a BackgroundWorker, it will catch the exception.
 					// If not, but the caller provides a DoWorkEventArgs, pass the exception through
 					// that object rather than throwing it.
 					if (worker != null || doWorkEventArgs == null)
-						throw except;
-					doWorkEventArgs.Result = except;
+						throw exception;
+					doWorkEventArgs.Result = exception;
 					return;
 				}
 			}
@@ -115,6 +135,13 @@ namespace Bloom.Publish
 				else
 					doWorkEventArgs.Result = except;
 			}
+		}
+
+		private static string GetNoDefaultPrinterErrorMessage()
+		{
+			return L10NSharp.LocalizationManager.GetDynamicString(@"Bloom", @"MakePDF.NoPrinter",
+				"Bloom needs you to have a printer selected on this computer before it can make a PDF, even though you are not printing.  It appears that you might not have a printer set as the default.  Please go to Devices and Printers and select a printer as a default. If you don't have a real printer attached, just select the Microsoft XPS or PDF printers.",
+				@"Error message displayed in a message dialog box");
 		}
 
 		//BottomMarginInMillimeters = 0,


### PR DESCRIPTION
This is in addition to the previous error handling, which handled the case where there was no default printer at all.

This is to merged into 3.2