### PR TITLE
Add program/system information to analytics exception reports (BL-2418)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -174,7 +174,7 @@
     </Reference>
     <Reference Include="DesktopAnalytics">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\DesktopAnalytics.1.1.3\lib\net40\DesktopAnalytics.dll</HintPath>
+      <HintPath>..\..\packages\DesktopAnalytics.1.1.7\lib\net40\DesktopAnalytics.dll</HintPath>
     </Reference>
     <Reference Include="YouTrackSharp, Version=2.0.30.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/BloomExe/Collection/BloomPack/BloomPackInstallDialog.cs
+++ b/src/BloomExe/Collection/BloomPack/BloomPackInstallDialog.cs
@@ -242,7 +242,7 @@ namespace Bloom.Collection.BloomPack
 				}
 				_errorImage.Visible = true;
 				_okButton.Text = L10NSharp.LocalizationManager.GetString("Common.CancelButton","&Cancel");
-				DesktopAnalytics.Analytics.ReportException(e.Error);
+				DesktopAnalytics.Analytics.ReportException(e.Error, Program.GetProgramProperties());
 				ErrorReport.NotifyUserOfProblem(e.Error, _message.Text);
 				return;
 			}

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -150,7 +150,7 @@ namespace Bloom.CollectionTab
 					catch (Exception error)
 					{
 						Palaso.Reporting.ErrorReport.NotifyUserOfProblem(error, "Could not export the book to XML");
-						Analytics.ReportException(error);
+						Analytics.ReportException(error, Program.GetProgramProperties());
 					}
 				}
 			}
@@ -1070,12 +1070,12 @@ namespace Bloom.CollectionTab
 			catch (IOException error)
 			{
 				Palaso.Reporting.ErrorReport.NotifyUserOfProblem(error.Message, "Could not export the book");
-				Analytics.ReportException(error);
+				Analytics.ReportException(error, Program.GetProgramProperties());
 			}
 			catch (Exception error)
 			{
 				Palaso.Reporting.ErrorReport.NotifyUserOfProblem(error, "Could not export the book");
-				Analytics.ReportException(error);
+				Analytics.ReportException(error, Program.GetProgramProperties());
 			}
 		}
 

--- a/src/BloomExe/HtmlThumbNailer.cs
+++ b/src/BloomExe/HtmlThumbNailer.cs
@@ -203,7 +203,7 @@ namespace Bloom
 				//Debug.Fail("Reproduction of BL-524: Crash making thumbnail?");
 				//otherwise, don't tell the user, just log and send exception if they're online
 				Logger.WriteEvent("***Error making thumbnail, possible bl-524 reproduction, swallowed. "+ e.Message);
-				Analytics.ReportException(e);
+				Analytics.ReportException(e, Program.GetProgramProperties());
 				return new Size(0,0); // this tells the caller we failed
 			}
 

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Windows.Forms;
+using System.Collections.Generic;
 using Bloom.Collection;
 using Bloom.Collection.BloomPack;
 using Bloom.Properties;
@@ -827,7 +828,7 @@ Anyone looking specifically at our issue tracking system can read what you sent 
 			Palaso.Reporting.ErrorReport.AddStandardProperties();
 			Palaso.Reporting.ExceptionHandler.Init();
 
-			ExceptionHandler.AddDelegate((w,e) => DesktopAnalytics.Analytics.ReportException(e.Exception));
+			ExceptionHandler.AddDelegate((w,e) => DesktopAnalytics.Analytics.ReportException(e.Exception, Program.GetProgramProperties()));
 		}
 
 
@@ -1002,6 +1003,24 @@ Anyone looking specifically at our issue tracking system can read what you sent 
 		public static BloomFileLocator OptimizedFileLocator
 		{
 			get { return _projectContext.OptimizedFileLocator; }
+		}
+
+		/// <summary>
+		/// Get the standard program properties for analytics crash reporting.
+		/// </summary>
+		public static Dictionary<string, string> GetProgramProperties()
+		{
+			var props = ErrorReport.GetStandardProperties();
+			// Sanitize user and specific machine information.  These aren't really needed
+			// for debugging analysis.
+			// (username can probably be derived from the CommandLine and CurrentDirectory,
+			// but why make it blatant to snoopers?)
+			props.Remove("MachineName");
+			props.Remove("UserName");
+			props.Remove("UserDomainName");
+			// Bloom specific information.
+			props.Add("Channel", ApplicationUpdateSupport.ChannelName);
+			return props;
 		}
 	}
 }

--- a/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
@@ -118,7 +118,7 @@ namespace Bloom.WebLibraryIntegration
 					// more goes wrong, ignore it.
 					Analytics.Track("DownloadedBook-Failure",
 						new Dictionary<string, string>() { { "url", url }, { "title", title } });
-					Analytics.ReportException(e);
+					Analytics.ReportException(e, Program.GetProgramProperties());
 				}
 				catch (Exception)
 				{

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Analytics" version="2.0.0" targetFramework="net40-Client" />
   <package id="Autofac" version="2.6.3.862" targetFramework="net40-Client" />
   <package id="AWSSDK.xplatform" version="2.3.6.0" targetFramework="net40-Client" requireReinstallation="True" />
   <package id="DeltaCompressionDotNet" version="1.0.0" targetFramework="net45" />
-  <package id="DesktopAnalytics" version="1.1.3" targetFramework="net40-Client" />
+  <package id="DesktopAnalytics" version="1.1.7" targetFramework="net40-Client" />
   <package id="EasyHttp" version="1.6.29.0" targetFramework="net45" />
   <package id="Fleck" version="0.12.0.39" targetFramework="net40-Client" />
   <package id="HtmlAgilityPack" version="1.4.3" />

--- a/src/BloomExe/web/ServerBase.cs
+++ b/src/BloomExe/web/ServerBase.cs
@@ -397,8 +397,8 @@ namespace Bloom.web
 					//prompted by the mysterious BL 273, Crash while closing down the imageserver
 #if DEBUG
 					throw;
-#else				//just quitely report this
-					DesktopAnalytics.Analytics.ReportException(e);
+#else				//just quietly report this
+					DesktopAnalytics.Analytics.ReportException(e, Program.GetProgramProperties());
 #endif
 				}
 			}


### PR DESCRIPTION
See Palaso/Reporting/ErrorReport.cs for the list of properties.  The machine name and user name
properties are removed to reduce sensitivity concerns.