### PR TITLE
Fix BL-2575 by drastically reducing the amount of dir listing text

### DIFF
--- a/src/BloomExe/MiscUI/BloomIntegrityDialog.Designer.cs
+++ b/src/BloomExe/MiscUI/BloomIntegrityDialog.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Bloom
+﻿namespace Bloom.MiscUI
 {
 	partial class BloomIntegrityDialog
 	{

--- a/src/BloomExe/MiscUI/BloomIntegrityDialog.cs
+++ b/src/BloomExe/MiscUI/BloomIntegrityDialog.cs
@@ -1,20 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Diagnostics;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using Bloom.MiscUI;
-using Bloom.Publish;
-using Palaso.IO;
 using Palaso.Extensions;
+using Palaso.IO;
+using Palaso.PlatformUtilities;
 
-namespace Bloom
+namespace Bloom.MiscUI
 {
 	public partial class BloomIntegrityDialog : Form
 	{
@@ -31,46 +24,46 @@ namespace Bloom
 		public static bool CheckIntegrity()
 		{
 			var errors = new StringBuilder();
-			var files = new[] { "Bloom.chm","PdfDroplet.exe", "Chorus.exe", "GeckofxHtmlToPdf.exe", "BloomBookUploader.exe", "optipng.exe" };
-			
-			var dirs = new[] {"AndikaNewBasic","factoryCollections","localization","xMatter","xslts"};
-			
+			var files = new[] { "Bloom.chm", "PdfDroplet.exe", "Chorus.exe", "GeckofxHtmlToPdf.exe", "BloomBookUploader.exe", "optipng.exe" };
+
+			var dirs = new[] { "AndikaNewBasic", "factoryCollections", "localization", "xMatter", "xslts" };
+
 			foreach(var fileName in files)
 			{
-				if (!Palaso.PlatformUtilities.Platform.IsWindows && fileName == "optipng.exe")
+				if(!Platform.IsWindows && fileName == "optipng.exe")
 				{
 					// optipng is provided by a package dependency, will be found as /usr/bin/optipng (no .exe)
 					continue;
 				}
-				if(Palaso.IO.FileLocator.GetFileDistributedWithApplication(true, fileName) == null)
+				if(FileLocator.GetFileDistributedWithApplication(true, fileName) == null)
 				{
 					//In a code directory, the FileLocator considers the solution the root, so it can't find files in output\debug
-					if(!File.Exists(Path.Combine(FileLocator.DirectoryOfTheApplicationExecutable,fileName)))
+					if(!File.Exists(Path.Combine(FileLocator.DirectoryOfTheApplicationExecutable, fileName)))
 					{
 						//maybe it's an exe in distfiles?
 						if(fileName.EndsWith(".exe") && File.Exists(Path.Combine(FileLocator.DirectoryOfApplicationOrSolution, "DistFiles")))
 						{
 							continue;
-						}							
+						}
 						errors.AppendFormat("Missing File: {0}{1}{1}", fileName, Environment.NewLine);
 					}
 				}
 			}
 			foreach(var directory in dirs)
 			{
-				if(Palaso.IO.FileLocator.GetDirectoryDistributedWithApplication(true, directory) == null)
+				if(FileLocator.GetDirectoryDistributedWithApplication(true, directory) == null)
 				{
 					errors.AppendFormat("Missing Directory: {0}{1}{1}", directory, Environment.NewLine);
 				}
 			}
-			if (errors.Length == 0)
+			if(errors.Length == 0)
 				return true;
 
-			using (var dlg = new BloomIntegrityDialog())
+			using(var dlg = new BloomIntegrityDialog())
 			{
 				var messagePath = FileLocator.GetFileDistributedWithApplication("IntegrityFailureAdvice-en.md");
 				string message;
-				if (messagePath == null) // maybe we can't even get at this file we need for a good description of the problem
+				if(messagePath == null) // maybe we can't even get at this file we need for a good description of the problem
 				{
 					message = "Bloom cannot find some of its own files, and cannot continue. After you submit this report, we will contact you and help you work this out. In the meantime, you can run the Bloom installer again.";
 				}
@@ -80,33 +73,33 @@ namespace Bloom
 							.CombineForPath(Application.ProductName);
 					message = File.ReadAllText(messagePath).Replace("{installFolder}", installFolder);
 				}
-				
-                message = message + Environment.NewLine+ Environment.NewLine + errors.ToString();
+
+				message = message + Environment.NewLine + Environment.NewLine + errors.ToString();
 				dlg.markDownTextBox1.MarkDownText = message;
 				dlg.ShowDialog();
 			}
-			using (var dlg = new ProblemReporterDialog(null, null))
+			using(var dlg = new ProblemReporterDialog(null, null))
 			{
 				dlg.Summary = "Bloom Integrity Check Failed: {0}";
 				dlg.Description = "Please answer any of these questions that you understand:"
-				                  + Environment.NewLine + Environment.NewLine
-				                  + "Did you install Bloom just now, or maybe allow it to update?"
-				                  + Environment.NewLine + Environment.NewLine
-				                  + "Is your computer locked down against installing new software?"
-				                  + Environment.NewLine + Environment.NewLine
-				                  + "What antivirus program do you use?"
-				                  + Environment.NewLine + Environment.NewLine
+								  + Environment.NewLine + Environment.NewLine
+								  + "Did you install Bloom just now, or maybe allow it to update?"
+								  + Environment.NewLine + Environment.NewLine
+								  + "Is your computer locked down against installing new software?"
+								  + Environment.NewLine + Environment.NewLine
+								  + "What antivirus program do you use?"
+								  + Environment.NewLine + Environment.NewLine
 								  + "--------------------------------------------"
-								  + Environment.NewLine + Environment.NewLine 
+								  + Environment.NewLine + Environment.NewLine
 								  + "The following information is for Bloom developers to see just what is and isn't missing:"
-				                  + Environment.NewLine + Environment.NewLine
-				                  + errors.ToString()
-				                  + Environment.NewLine + Environment.NewLine
-				                  + GetDirectoryListing(Palaso.IO.FileLocator.DirectoryOfTheApplicationExecutable)
-				                  + "Detected Antivirus Program(s): " + InstalledAntivirusPrograms();
+								  + Environment.NewLine + Environment.NewLine
+								  + errors.ToString()
+								  + Environment.NewLine + Environment.NewLine
+								  + GetDirectoryListing(FileLocator.DirectoryOfTheApplicationExecutable)
+								  + "Detected Antivirus Program(s): " + InstalledAntivirusPrograms();
 
 #if !__MonoCS__
-				
+
 				try
 				{
 					var logPath =
@@ -114,23 +107,23 @@ namespace Bloom
 							.CombineForPath(Application.ProductName, "SquirrelSetup.log");
 					dlg.Description += "=Squirrel Log=" + Environment.NewLine;
 					dlg.Description += logPath + Environment.NewLine;
-                    if (File.Exists(logPath))
+					if(File.Exists(logPath))
 					{
 						dlg.Description += File.ReadAllText(logPath);
 					}
 					else
 					{
-						dlg.Description += logPath+ "not found";
+						dlg.Description += logPath + "not found";
 					}
 				}
-				catch (Exception error)
+				catch(Exception error)
 				{
 					dlg.Description += error.Message;
 				}
 #endif
 				dlg.ShowDialog();
 			}
-			
+
 			return false; //Force termination of the current process.
 		}
 
@@ -141,18 +134,19 @@ namespace Bloom
 
 		static string GetDirectoryListing(string directory)
 		{
-			var builder  = new StringBuilder();
-			GetDirectoryListing(directory,builder);
+			var builder = new StringBuilder();
+			builder.AppendLine("The following are under " + directory);
+			GetDirectoryListing(directory.Length, directory, builder);
 			return builder.ToString();
 		}
 
-		static void GetDirectoryListing(string directory, StringBuilder builder )
+		static void GetDirectoryListing(int rootDirectoryLength, string directory, StringBuilder builder)
 		{
 			try
 			{
-				foreach (var f in Directory.GetFiles(directory))
+				foreach(var f in Directory.GetFiles(directory))
 				{
-					builder.AppendLine(f);
+					builder.AppendLine(f.Substring(rootDirectoryLength, f.Length - rootDirectoryLength));
 				}
 			}
 			catch(Exception error)
@@ -161,14 +155,23 @@ namespace Bloom
 			}
 			try
 			{
+				//If we let this box get to full, the user can't type into it (BL-2575). So we clip the tree on some big directories:
+				string[] bigDirectoriesToSkip = new string[] { "pdf", "Mercurial", "BloomBrowserUI" };
 				foreach(var d in Directory.GetDirectories(directory))
 				{
-					GetDirectoryListing(d, builder);
+					if(bigDirectoriesToSkip.Contains(Path.GetFileName(d)))
+					{
+						builder.AppendLine(d.Substring(rootDirectoryLength, d.Length - rootDirectoryLength) + " (will not list contents)");
+					}
+					else
+					{
+						GetDirectoryListing(rootDirectoryLength, d, builder);
+					}
 				}
 			}
 			catch(Exception error)
 			{
-				builder.AppendLine("**** "+error.Message);
+				builder.AppendLine("**** " + error.Message);
 			}
 		}
 
@@ -182,12 +185,12 @@ namespace Bloom
 				var searcher = new System.Management.ManagementObjectSearcher(wmipathstr, "SELECT * FROM AntivirusProduct");
 				var instances = searcher.Get();
 
-				foreach (var instance in instances)
+				foreach(var instance in instances)
 				{
-					result += instance.GetText(System.Management.TextFormat.Mof).ToString() + System.Environment.NewLine;
+					result += instance.GetText(System.Management.TextFormat.Mof).ToString() + Environment.NewLine;
 				}
 			}
-			catch (Exception error)
+			catch(Exception error)
 			{
 				return error.Message;
 			}

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -21,6 +21,7 @@ using Palaso.UI.WindowsForms.Registration;
 using Palaso.UI.WindowsForms.Reporting;
 using Palaso.UI.WindowsForms.UniqueToken;
 using System.Linq;
+using Bloom.MiscUI;
 
 namespace Bloom
 {


### PR DESCRIPTION
The content of the report was so full of file listings that the edit box wouldn't let the user type in it. I changed it so that
1) it doesn't repeat the root directory for every listing
2) it has a list of directories that it should not go down into

Was 126k characters on my machine, now is 15k.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/662)
<!-- Reviewable:end -->
