### PR TITLE
Handle capitalized sight words in decodable readers (BL-2550)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/readerToolsModel.js
+++ b/src/BloomBrowserUI/bookEdit/js/readerToolsModel.js
@@ -592,7 +592,8 @@ var ReaderToolsModel = (function () {
                 editableElements.checkDecodableReader({
                     focusWords: cumulativeWords,
                     previousWords: cumulativeWords,
-                    sightWords: sightWords,
+                    // libsynphony lowercases the text, so we must do the same with sight words.  (BL-2550)
+                    sightWords: sightWords.join(' ').toLowerCase().split(' '),
                     knownGraphemes: this.stageGraphemes
                 });
                 break;

--- a/src/BloomBrowserUI/bookEdit/js/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/js/readerToolsModel.ts
@@ -721,7 +721,8 @@ class ReaderToolsModel {
         editableElements.checkDecodableReader({
           focusWords: cumulativeWords,
           previousWords: cumulativeWords,
-          sightWords: sightWords,
+          // libsynphony lowercases the text, so we must do the same with sight words.  (BL-2550)
+          sightWords: sightWords.join(' ').toLowerCase().split(' '),
           knownGraphemes: this.stageGraphemes
         });
 


### PR DESCRIPTION
The solution isn't perfect, but the best we can do without modifying
libsynphony to be much more complicated in dealing with capitalized
words.