### PR TITLE
Enable ckeditor in National language text boxes (BL-2515)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -662,7 +662,7 @@ $(document).ready(function() {
 
     // attach ckeditor to the contenteditable="true" class="bloom-content1"
     // also to contenteditable="true" and class="bloom-content2" or class="bloom-content3"
-    $('div.bloom-page').find('.bloom-content1[contenteditable="true"],.bloom-content2[contenteditable="true"],.bloom-content3[contenteditable="true"]').each(function() {
+    $('div.bloom-page').find('.bloom-content1[contenteditable="true"],.bloom-content2[contenteditable="true"],.bloom-content3[contenteditable="true"],.bloom-contentNational1[contenteditable="true"]').each(function() {
 
         var ckedit = CKEDITOR.inline(this);
 


### PR DESCRIPTION
This adds the proper behavior for single language books where the
national language differs from the book's language.