### PR TITLE
Fix BL-2561 AddPageDialog was sometimes not opening

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/editViewFrame.js
+++ b/src/BloomBrowserUI/bookEdit/js/editViewFrame.js
@@ -153,10 +153,18 @@ function showAddPageDialog(templatesJSON) {
     var theDialog;
     var parentElement = document.getElementById('page').contentWindow;
 
+    // don't show if a dialog already exists
+    if ($(document).find(".ui-dialog").length) {
+        return;
+    }
     parentElement.localizationManager.loadStrings(getAddPageDialogLocalizedStrings(), null, function() {
 
         var title = parentElement.localizationManager.getText('AddPageDialog.Title', 'Add Page...');
-        var dialogContents = CreateAddPageDiv(templatesJSON);
+        var addButtonText = parentElement.localizationManager.getText('AddPageDialog.AddPageButton', 'Add This Page');
+        var descriptionLabel = parentElement.localizationManager.getText('AddPageDialog.DescriptionLabel', 'Description');
+        var blankPreviewMsg = parentElement.localizationManager.getText('AddPageDialog.PreviewMessage',
+            'This will contain a preview of a template page when one is selected.');
+        var dialogContents = CreateAddPageDiv(templatesJSON, descriptionLabel, blankPreviewMsg);
 
         theDialog = $(dialogContents).dialog({
             class: "addPageDialog",

--- a/src/BloomBrowserUI/pageChooser/js/page-chooser.js
+++ b/src/BloomBrowserUI/pageChooser/js/page-chooser.js
@@ -96,7 +96,6 @@ var PageChooser = (function () {
             });
         }
         $("#addPageButton", document).button().click(function () {
-            _this.fireCSharpEvent("setModalStateEvent", "false");
             _this.addPageClickHandler();
         });
         var pageButton = $("#addPageButton", document);

--- a/src/BloomBrowserUI/pageChooser/js/page-chooser.ts
+++ b/src/BloomBrowserUI/pageChooser/js/page-chooser.ts
@@ -111,7 +111,6 @@ class PageChooser {
             });
         }
         $("#addPageButton", document).button().click(() => {
-            this.fireCSharpEvent("setModalStateEvent", "false");
             this.addPageClickHandler();
         });
         var pageButton = $("#addPageButton", document);

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -46,7 +46,6 @@ namespace Bloom.Edit
 		private List<ContentLanguage> _contentLanguages;
 		private IPage _previouslySelectedPage;
 		private bool _inProcessOfDeleting;
-		private bool _addPageDialogShowing;
 		private string _accordionFolder;
 		private EnhancedImageServer _server;
 		private readonly TemplateInsertionCommand _templateInsertionCommand;
@@ -125,7 +124,6 @@ namespace Bloom.Edit
 			_server.CurrentCollectionSettings = _collectionSettings;
 			_server.CurrentBook = CurrentBook;
 			_templateInsertionCommand = templateInsertionCommand;
-			_addPageDialogShowing = false;
 		}
 
 		private Form _oldActiveForm;
@@ -520,15 +518,6 @@ namespace Bloom.Edit
 			}
 		}
 
-		public void ShowAddPageDialog()
-		{
-			if (_view == null || _inProcessOfDeleting || _addPageDialogShowing)
-				return;
-			_addPageDialogShowing = true;
-			var jsonTemplates = GetJsonTemplatePageObject;
-			_view.RunJavaScript("showAddPageDialog(" + jsonTemplates + ");");
-		}
-
 		void OnPageSelectionChanged(object sender, EventArgs e)
 		{
 			Logger.WriteMinorEvent("changing page selection");
@@ -564,7 +553,6 @@ namespace Bloom.Edit
 		public void RefreshDisplayOfCurrentPage()
 		{
 			_view.UpdateSingleDisplayedPage(_pageSelection.CurrentSelection);
-			_addPageDialogShowing = false; // it doesn't get re-created, so if we think it's there we'll never show it again.
 		}
 
 		public void SetupServerWithCurrentPageIframeContents()
@@ -659,7 +647,6 @@ namespace Bloom.Edit
 			}
 			// listen for events raised by javascript
 			_view.AddMessageEventListener("saveAccordionSettingsEvent", SaveAccordionSettings);
-			_view.AddMessageEventListener("setModalStateEvent", SetModalState);
 			_view.AddMessageEventListener("preparePageForEditingAfterOrigamiChangesEvent", RethinkPageAndReloadIt);
 			_view.AddMessageEventListener("finishSavingPage", FinishSavingPage);
 			_view.AddMessageEventListener("handleAddNewPageKeystroke", HandleAddNewPageKeystroke);
@@ -700,7 +687,8 @@ namespace Bloom.Edit
 #endif
 			}
 			//there was some error figuring out a default page, let's just let the user choose what they want
-			ShowAddPageDialog();
+			if(this._view!=null)
+				this._view.ShowAddPageDialog();
 		}
 
 		private Dictionary<string, IPage> GetTemplatePagesForThisBook()
@@ -855,12 +843,6 @@ namespace Bloom.Edit
 			return string.Empty;
 		}
 
-		private void SetModalState(string isModal)
-		{
-			_view.SetModalState(isModal == "true");
-			if (isModal != "true")
-				_addPageDialogShowing = false;
-		}
 
 		private static string CleanUpDataForJavascript(string data)
 		{
@@ -1196,12 +1178,17 @@ namespace Bloom.Edit
 			}
 		}
 
+		/// <summary>
+		/// Returns a json string that gives paths to our current TemplateBook
+		/// </summary>
+		
+		//Enhance: just a json library instead reinventing the wheel
 		private const string URL_PREFIX = "/bloom/localhost/";
 		private const string JSON_START = "[{ ";
 		private const string JSON_DIVIDER = " , ";
 		private const string JSON_END = " }]";
 
-		private string GetJsonTemplatePageObject
+		public string GetTemplateBookInfo
 		{
 			get
 			{
@@ -1215,6 +1202,11 @@ namespace Bloom.Edit
 				var jsonString = JSON_START + jsonBookFolder + JSON_DIVIDER + jsonBook + JSON_DIVIDER + jsonLastPage + JSON_END;
 				return jsonString;
 			}
+		}
+
+		public void ShowAddPageDialog()
+		{
+			this._view.ShowAddPageDialog();;
 		}
 	}
 

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -329,8 +329,11 @@ namespace Bloom.Edit
 
 			Cursor = Cursors.WaitCursor;
 			_model.ViewVisibleNowDoSlowStuff();
+
+			AddMessageEventListener("setModalStateEvent", SetModalState);
 			Cursor = Cursors.Default;
 		}
+
 
 		private void CheckFontAvailablility()
 		{
@@ -1019,9 +1022,9 @@ namespace Bloom.Edit
 		/// Prevent navigation while a dialog box is showing in the browser control
 		/// </summary>
 		/// <param name="isModal"></param>
-		internal void SetModalState(bool isModal)
+		internal void SetModalState(string isModal)
 		{
-			_pageListView.Enabled = !isModal;
+			_pageListView.Enabled = isModal != "true";
 		}
 
 		/// <summary>
@@ -1038,6 +1041,16 @@ namespace Bloom.Edit
 				Cursor = value ? Cursors.WaitCursor : Cursors.Default;
 				_pageListView.Cursor = Cursor;
 			} 
+		}
+
+		public void ShowAddPageDialog()
+		{
+//			if(_view == null || _inProcessOfDeleting || _addPageDialogShowing)
+//				return;
+			//_addPageDialogShowing = true;
+			var jsonTemplates = _model.GetTemplateBookInfo;
+			//if the dialog is already showing, it is up to this method we're calling to detect that and ignore our request
+			RunJavaScript("showAddPageDialog(" + jsonTemplates + ");");
 		}
 	}
 }


### PR DESCRIPTION
Rather than relying on the modalstate flag, we now always ask javascript to open the dialog. But from there, we check for the existence of any jquery dialog and don't open if we find one.

Also moved  a couple things out of the model that belong in the view.