### PR TITLE
BL-2654 Fix IsConnectivityError

### DIFF
--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -68,12 +68,10 @@ namespace Bloom
 						// but if they did, try and give them a hint about what went wrong
 						if (result.IsConnectivityError)
 						{
-
 							var failMsg = LocalizationManager.GetString("CollectionTab.UnableToCheckForUpdate",
 								"Could not connect to the server to check for an update. Are you connected to the internet?",
 								"Shown when Bloom tries to check for an update but can't, for example becuase it can't connect to the internet, or a problems with our server, etc.");
 							ShowFailureNotification(failMsg);
-
 						}
 						else if (result.Error == null)
 						{

--- a/src/BloomExe/UpdateVersionTable.cs
+++ b/src/BloomExe/UpdateVersionTable.cs
@@ -33,7 +33,7 @@ namespace Bloom
 				get
 				{
 					return Error != null &&
-					       Error.Status == WebExceptionStatus.Timeout || Error.Status == WebExceptionStatus.NameResolutionFailure;
+						(Error.Status == WebExceptionStatus.Timeout || Error.Status == WebExceptionStatus.NameResolutionFailure);
 				}
 			}
 		}

--- a/src/BloomTests/UpdateVersionTableTests.cs
+++ b/src/BloomTests/UpdateVersionTableTests.cs
@@ -25,6 +25,16 @@ namespace BloomTests
 		}
 
 		[Test]
+		public void UpgradeTableError_NoCrash()
+		{
+			var t = new UpdateVersionTable();
+			t.TextContentsOfTable = @"0.0.0,3.1.99999, http://first.com/first";
+			t.RunningVersion = Version.Parse("3.2.0");
+			var url = t.LookupURLOfUpdate();
+			Assert.IsFalse(url.IsConnectivityError);
+		}
+
+		[Test]
 		public void ServerAddressIsBogus_ErrorIsCorrect()
 		{
 			var t = new UpdateVersionTable {URLOfTable = "http://notthere7blah/foo.txt"};

--- a/src/BloomTests/UpdateVersionTableTests.cs
+++ b/src/BloomTests/UpdateVersionTableTests.cs
@@ -32,33 +32,41 @@ namespace BloomTests
 			t.RunningVersion = Version.Parse("3.2.0");
 			var lookupResult = t.LookupURLOfUpdate();
 			Assert.IsFalse(lookupResult.IsConnectivityError);
+			Assert.IsNullOrEmpty(lookupResult.Error.Message);
 			Assert.IsNullOrEmpty(lookupResult.URL);
 		}
 
 		[Test]
-		public void UpgradeTableParsingError_NoCrash()
+		public void LookupURLOfUpdate_TooManyCommas_LogsErrorGivesNoURL()
 		{
 			var t = new UpdateVersionTable();
 			t.TextContentsOfTable = @"0.0.0,3,1,99999, http://first.com/first"; // too many commas
 			t.RunningVersion = Version.Parse("3.2.0");
 			var lookupResult = t.LookupURLOfUpdate();
 			Assert.IsNullOrEmpty(lookupResult.URL);
-
-			t = new UpdateVersionTable();
-			t.TextContentsOfTable = @"0.0.0,, http://first.com/first"; // too few commas
-			t.RunningVersion = Version.Parse("3.2.0");
-			lookupResult = t.LookupURLOfUpdate();
-			Assert.IsNullOrEmpty(lookupResult.URL);
+			Assert.IsTrue(lookupResult.Error.Message.StartsWith("Could not parse a line of the UpdateVersionTable"));
 		}
 
 		[Test]
-		public void UpgradeTableVersionParsingError_NoCrash()
+		public void LookupURLOfUpdate_TooFewCommas_LogsErrorGivesNoURL()
+		{
+			var t = new UpdateVersionTable();
+			t.TextContentsOfTable = @"0.0.0, http://first.com/first"; // too few commas
+			t.RunningVersion = Version.Parse("3.2.0");
+			var lookupResult = t.LookupURLOfUpdate();
+			Assert.IsNullOrEmpty(lookupResult.URL);
+			Assert.IsTrue(lookupResult.Error.Message.StartsWith("Could not parse a line of the UpdateVersionTable"));
+		}
+
+		[Test]
+		public void LookupURLOfUpdate_BadVersionNumber_LogsErrorGivesNoURL()
 		{
 			var t = new UpdateVersionTable();
 			t.TextContentsOfTable = @"random,3.1.99999, http://first.com/first"; // bad version number
 			t.RunningVersion = Version.Parse("3.2.0");
 			var lookupResult = t.LookupURLOfUpdate();
 			Assert.IsNullOrEmpty(lookupResult.URL);
+			Assert.IsTrue(lookupResult.Error.Message.StartsWith("Could not parse a version number in the UpdateVersionTable"));
 		}
 
 		[Test]

--- a/src/BloomTests/UpdateVersionTableTests.cs
+++ b/src/BloomTests/UpdateVersionTableTests.cs
@@ -32,6 +32,33 @@ namespace BloomTests
 			t.RunningVersion = Version.Parse("3.2.0");
 			var url = t.LookupURLOfUpdate();
 			Assert.IsFalse(url.IsConnectivityError);
+			Assert.IsNullOrEmpty(url.URL);
+		}
+
+		[Test]
+		public void UpgradeTableParsingError_NoCrash()
+		{
+			var t = new UpdateVersionTable();
+			t.TextContentsOfTable = @"0.0.0,3,1,99999, http://first.com/first"; // too many commas
+			t.RunningVersion = Version.Parse("3.2.0");
+			var url = t.LookupURLOfUpdate();
+			Assert.IsNullOrEmpty(url.URL);
+
+			t = new UpdateVersionTable();
+			t.TextContentsOfTable = @"0.0.0,, http://first.com/first"; // too few commas
+			t.RunningVersion = Version.Parse("3.2.0");
+			url = t.LookupURLOfUpdate();
+			Assert.IsNullOrEmpty(url.URL);
+		}
+
+		[Test]
+		public void UpgradeTableVersionParsingError_NoCrash()
+		{
+			var t = new UpdateVersionTable();
+			t.TextContentsOfTable = @"random,3.1.99999, http://first.com/first"; // bad version number
+			t.RunningVersion = Version.Parse("3.2.0");
+			var url = t.LookupURLOfUpdate();
+			Assert.IsNullOrEmpty(url.URL);
 		}
 
 		[Test]

--- a/src/BloomTests/UpdateVersionTableTests.cs
+++ b/src/BloomTests/UpdateVersionTableTests.cs
@@ -25,14 +25,14 @@ namespace BloomTests
 		}
 
 		[Test]
-		public void UpgradeTableError_NoCrash()
+		public void LookupURLOfUpdate_AllWell_ReportsNoConnectivityError()
 		{
 			var t = new UpdateVersionTable();
 			t.TextContentsOfTable = @"0.0.0,3.1.99999, http://first.com/first";
 			t.RunningVersion = Version.Parse("3.2.0");
-			var url = t.LookupURLOfUpdate();
-			Assert.IsFalse(url.IsConnectivityError);
-			Assert.IsNullOrEmpty(url.URL);
+			var lookupResult = t.LookupURLOfUpdate();
+			Assert.IsFalse(lookupResult.IsConnectivityError);
+			Assert.IsNullOrEmpty(lookupResult.URL);
 		}
 
 		[Test]
@@ -41,14 +41,14 @@ namespace BloomTests
 			var t = new UpdateVersionTable();
 			t.TextContentsOfTable = @"0.0.0,3,1,99999, http://first.com/first"; // too many commas
 			t.RunningVersion = Version.Parse("3.2.0");
-			var url = t.LookupURLOfUpdate();
-			Assert.IsNullOrEmpty(url.URL);
+			var lookupResult = t.LookupURLOfUpdate();
+			Assert.IsNullOrEmpty(lookupResult.URL);
 
 			t = new UpdateVersionTable();
 			t.TextContentsOfTable = @"0.0.0,, http://first.com/first"; // too few commas
 			t.RunningVersion = Version.Parse("3.2.0");
-			url = t.LookupURLOfUpdate();
-			Assert.IsNullOrEmpty(url.URL);
+			lookupResult = t.LookupURLOfUpdate();
+			Assert.IsNullOrEmpty(lookupResult.URL);
 		}
 
 		[Test]
@@ -57,8 +57,8 @@ namespace BloomTests
 			var t = new UpdateVersionTable();
 			t.TextContentsOfTable = @"random,3.1.99999, http://first.com/first"; // bad version number
 			t.RunningVersion = Version.Parse("3.2.0");
-			var url = t.LookupURLOfUpdate();
-			Assert.IsNullOrEmpty(url.URL);
+			var lookupResult = t.LookupURLOfUpdate();
+			Assert.IsNullOrEmpty(lookupResult.URL);
 		}
 
 		[Test]


### PR DESCRIPTION
IsConnectivityError was failing because of an && || precedence problem. Adding parentheses fixed it.