### PR TITLE
BL-2629 Generate thumbnails for Add Page dialog

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/editViewFrame.js
+++ b/src/BloomBrowserUI/bookEdit/js/editViewFrame.js
@@ -133,7 +133,8 @@ function CreateAddPageDiv(templatesJSON) {
 
     var dialogContents = $('<div id="addPageConfig"/>').appendTo($('body'));
 
-    var html = "<iframe id=\"addPage_frame\" src=\"/bloom/pageChooser/page-chooser-main.htm\" scrolling=\"no\" style=\"width: 100%; height: 100%; border: none; margin: 0\"></iframe>";
+    // For some reason when the height is 100% we get an unwanted scroll bar on the far right.
+    var html = "<iframe id=\"addPage_frame\" src=\"/bloom/pageChooser/page-chooser-main.htm\" scrolling=\"no\" style=\"width: 100%; height: 99%; border: none; margin: 0\"></iframe>";
 
     dialogContents.append(html);
 

--- a/src/BloomBrowserUI/pageChooser/js/page-chooser.js
+++ b/src/BloomBrowserUI/pageChooser/js/page-chooser.js
@@ -194,8 +194,8 @@ var PageChooser = (function () {
             // any changes to how we tweak the page label to get a file name
             // must also be made in EnhancedImageServer.FindOrGenerateImage().
             pageLabel = pageLabel.replace("&", "+"); //ampersands don't work in the svg file names, so we use "+" instead
-            // gensvg is a 'magic' extension which the Bloom fileserver understands. See EnhancedImageServer.FindOrGenerateImage.
-            $("img", currentGridItemHtml).attr("src", pageFolderUrl + "/template" + "/" + pageLabel + ".gensvg");
+            // May actually retrieve a png (possibly after generating it). See EnhancedImageServer.FindOrGenerateImage.
+            $("img", currentGridItemHtml).attr("src", pageFolderUrl + "/template" + "/" + pageLabel + ".svg?generateThumbnaiIfNecessary=true");
             $(".innerCollectionContainer", currentCollection).append(currentGridItemHtml);
         }); // each
         // once the template pages are installed, attach click handler to them.

--- a/src/BloomBrowserUI/pageChooser/js/page-chooser.js
+++ b/src/BloomBrowserUI/pageChooser/js/page-chooser.js
@@ -11,14 +11,25 @@ function process_EditFrame_Message(event) {
         default:
     }
 }
-// this version of the test string may be useful later testing more than one template collection
-//var JSONTestString = "[{ \"templateBookUrl\": \"../../../DistFiles/factoryCollections/Templates/Basic Book/Basic Book.htm\" }, { \"templateBookUrl\": \"../../../DistFiles/factoryCollections/Templates/Basic Book/Basic Book.htm\" }]";
-// no longer using test string, but let's keep it around as documentation of what PageChooser's ctor is expecting
-//var JSONTestString = "[{ \"templateBookUrl\": \"bloom/localhost/C$/BloomDesktop/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.htm\" }]";
+// latest version of the expected JSON initialization string (from EditingModel.GetTemplateBookInfo)
+// "{\"lastPageAdded\":\"(guid of template page)\",
+//   \"orientation\":\"landscape\",
+//   \"collections\":[{\"templateBookFolderUrl\":\"/bloom/localhost/C$/BloomDesktop/DistFiles/factoryCollections/Templates/Basic Book\",
+//                     \"templateBookUrl\":\"/bloom/localhost/C$/BloomDesktop/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.htm\"}]}"
 var PageChooser = (function () {
-    function PageChooser(templateBookUrls) {
-        if (templateBookUrls) {
-            this._templateBookUrls = templateBookUrls;
+    function PageChooser(initializationJsonString) {
+        var initializationObject;
+        if (initializationJsonString) {
+            try {
+                initializationObject = $.parseJSON(initializationJsonString);
+            }
+            catch (e) {
+                console.log("Received bad JSON string: " + e);
+                return;
+            }
+            this._templateBookUrls = initializationObject["collections"];
+            this._lastPageAdded = initializationObject["lastPageAdded"];
+            this._orientation = initializationObject["orientation"];
         }
         else {
             console.log("Expected url in PageChooser ctor!");
@@ -122,22 +133,12 @@ var PageChooser = (function () {
         var collectionHtml = $(".collection", document).first().clone();
         // there should only be the one default 'gridItem' at this point
         var gridItemHtml = $(".gridItem", collectionHtml).first().clone();
-        var collectionUrls;
-        try {
-            collectionUrls = $.parseJSON(this._templateBookUrls);
-        }
-        catch (e) {
-            console.log("Received bad template url: " + e);
-            return;
-        }
-        var pageChooser = this;
-        if ($(collectionUrls).length > 0) {
+        if ($(this._templateBookUrls).length > 0) {
             // Remove original stub section
             $(".outerCollectionContainer", document).empty();
-            $.each(collectionUrls, function (index) {
+            $.each(this._templateBookUrls, function (index, item) {
                 //console.log('  ' + (index + 1) + ' loading... ' + this['templateBookUrl'] );
-                var collectionLastPageAdded = this["lastPageAdded"];
-                pageChooser.loadCollection(this["templateBookFolderUrl"], this["templateBookUrl"], collectionHtml, gridItemHtml, collectionLastPageAdded);
+                _this.loadCollection(item["templateBookFolderUrl"], item["templateBookUrl"], collectionHtml, gridItemHtml, _this._lastPageAdded);
             });
         }
         $("#addPageButton", document).button().click(function () {
@@ -148,6 +149,9 @@ var PageChooser = (function () {
             .done(function (translation) {
             pageButton.attr('value', translation);
         });
+        if (this._orientation === 'landscape') {
+            $("#mainContainer").addClass("landscape");
+        }
     }; // LoadInstalledCollections
     PageChooser.prototype.loadCollection = function (pageFolderUrl, pageUrl, collectionHTML, gridItemHTML, lastPageAdded) {
         var _this = this;
@@ -191,11 +195,7 @@ var PageChooser = (function () {
             $(".pageDescription", currentGridItemHtml).first().text(pageDescription);
             var pageLabel = $(".pageLabel", div).first().text().trim();
             $(".gridItemCaption", currentGridItemHtml).first().text(pageLabel);
-            // any changes to how we tweak the page label to get a file name
-            // must also be made in EnhancedImageServer.FindOrGenerateImage().
-            pageLabel = pageLabel.replace("&", "+"); //ampersands don't work in the svg file names, so we use "+" instead
-            // May actually retrieve a png (possibly after generating it). See EnhancedImageServer.FindOrGenerateImage.
-            $("img", currentGridItemHtml).attr("src", pageFolderUrl + "/template" + "/" + pageLabel + ".svg?generateThumbnaiIfNecessary=true");
+            $("img", currentGridItemHtml).attr("src", _this.buildThumbSrcFilename(pageFolderUrl, pageLabel));
             $(".innerCollectionContainer", currentCollection).append(currentGridItemHtml);
         }); // each
         // once the template pages are installed, attach click handler to them.
@@ -209,6 +209,14 @@ var PageChooser = (function () {
         }); // each
         return indexToSelect;
     }; // LoadPagesFromCollection
+    // any changes to how we tweak the page label to get a file name
+    // must also be made in EnhancedImageServer.FindOrGenerateImage().
+    PageChooser.prototype.buildThumbSrcFilename = function (pageFolderUrl, pageLabel) {
+        var label = pageLabel.replace('&', '+'); //ampersands don't work in the svg file names, so we use "+" instead
+        // ?generateThumbnaiIfNecessary=true triggers logic in EnhancedImageServer.FindOrGenerateImage.
+        // The result may actually be a png file or an svg, and there may be some delay while the png is generated.
+        return pageFolderUrl + '/template/' + label + (this._orientation === 'landscape' ? '-landscape' : '') + '.svg?generateThumbnaiIfNecessary=true';
+    };
     /**
      * Fires an event for C# to handle
      * @param {String} eventName

--- a/src/BloomBrowserUI/pageChooser/js/page-chooser.ts
+++ b/src/BloomBrowserUI/pageChooser/js/page-chooser.ts
@@ -170,6 +170,10 @@ class PageChooser {
             .done(translation => {
                 pageButton.attr('value', translation);
             });
+
+        if (this._orientation === 'landscape') {
+            $("#mainContainer").addClass("landscape");
+        }
     } // LoadInstalledCollections
 
     loadCollection(pageFolderUrl, pageUrl, collectionHTML, gridItemHTML, lastPageAdded:string): void {
@@ -241,7 +245,9 @@ class PageChooser {
     // must also be made in EnhancedImageServer.FindOrGenerateImage().
     buildThumbSrcFilename(pageFolderUrl: string, pageLabel: string): string {
         var label = pageLabel.replace('&', '+'); //ampersands don't work in the svg file names, so we use "+" instead
-        return pageFolderUrl + '/template/' + label + (this._orientation === 'landscape' ? '-landscape' : '') + '.svg';
+        // ?generateThumbnaiIfNecessary=true triggers logic in EnhancedImageServer.FindOrGenerateImage.
+        // The result may actually be a png file or an svg, and there may be some delay while the png is generated.
+        return pageFolderUrl + '/template/' + label + (this._orientation === 'landscape' ? '-landscape' : '') + '.svg?generateThumbnaiIfNecessary=true';
     }
 
     /**

--- a/src/BloomBrowserUI/pageChooser/js/page-chooser.ts
+++ b/src/BloomBrowserUI/pageChooser/js/page-chooser.ts
@@ -218,7 +218,7 @@ class PageChooser {
             var pageDescription = $(".pageDescription", div).first().text();
             $(".pageDescription", currentGridItemHtml).first().text(pageDescription);
 
-            var pageLabel = $(".pageLabel", div).first().text();
+            var pageLabel = $(".pageLabel", div).first().text().trim();
             $(".gridItemCaption", currentGridItemHtml).first().text(pageLabel);
 
             $("img", currentGridItemHtml).attr("src", this.buildThumbSrcFilename(pageFolderUrl, pageLabel));
@@ -237,6 +237,8 @@ class PageChooser {
         return indexToSelect;
     } // LoadPagesFromCollection
 
+    // any changes to how we tweak the page label to get a file name
+    // must also be made in EnhancedImageServer.FindOrGenerateImage().
     buildThumbSrcFilename(pageFolderUrl: string, pageLabel: string): string {
         var label = pageLabel.replace('&', '+'); //ampersands don't work in the svg file names, so we use "+" instead
         return pageFolderUrl + '/template/' + label + (this._orientation === 'landscape' ? '-landscape' : '') + '.svg';

--- a/src/BloomBrowserUI/pageChooser/page-chooser-main.htm
+++ b/src/BloomBrowserUI/pageChooser/page-chooser-main.htm
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <!-- PageChooserMain - .jade file is the primary source; .html file is generated from .jade file-->
 <html>
   <head>
@@ -23,7 +23,7 @@
             <div class="innerCollectionContainer">
               <div class="gridItem">
                 <!-- this was used when we were using iframes to prevent messing with the underlying page items, could come back conceivably for pages that lack svg thumbnails-->
-                <div class="invisibleThumbCover"></div><img src="" class="thumbnail">
+                <div class="invisibleThumbCover"></div><div class="selectionOverlay"></div><img src="" class="thumbnail">
                 <div class="gridItemCaption">Page Title</div>
                 <div class="pageDescription"></div>
               </div>

--- a/src/BloomBrowserUI/pageChooser/page-chooser-main.jade
+++ b/src/BloomBrowserUI/pageChooser/page-chooser-main.jade
@@ -29,6 +29,7 @@ html
 							.gridItem
 								// this was used when we were using iframes to prevent messing with the underlying page items, could come back conceivably for pages that lack svg thumbnails
 								.invisibleThumbCover
+								.selectionOverlay
 								img(src='').thumbnail
 								.gridItemCaption Page Title
 								.pageDescription

--- a/src/BloomBrowserUI/pageChooser/page-chooser.css
+++ b/src/BloomBrowserUI/pageChooser/page-chooser.css
@@ -1,4 +1,4 @@
-BODY {
+﻿BODY {
   margin: 4px;
 }
 #mainContainer {
@@ -23,6 +23,7 @@ BODY {
   order: 2;
   height: auto;
   min-width: 320px;
+  max-width: 370px;
   padding-left: 15px;
 }
 #singlePagePreview img {
@@ -48,8 +49,6 @@ BODY {
   margin-left: 15px;
 }
 .outerCollectionContainer {
-  flex: 1;
-  display: flex;
   flex-direction: column;
 }
 .collection {
@@ -71,11 +70,11 @@ BODY {
   width: 104px;
   display: inline-block;
 }
-.gridItem:hover {
-  background: #b0dee4;
+.gridItem:hover .selectionOverlay {
+  background: rgba(122, 199, 210, 0.45);
 }
-.gridItem.ui-selected {
-  background: #b0dee4;
+.gridItem.ui-selected .selectionOverlay {
+  background: rgba(122, 199, 210, 0.45);
 }
 .thumbnail {
   overflow: hidden;
@@ -102,6 +101,13 @@ BODY {
   z-index: 5;
   position: absolute;
   height: 130px;
+  width: 100px;
+  background: url(transparent.gif);
+}
+.selectionOverlay {
+  z-index: 3;
+  position: absolute;
+  height: 100px;
   width: 100px;
   background: url(transparent.gif);
 }
@@ -160,3 +166,4 @@ BODY {
   border: 5px solid #b0dee4;
   font-weight: bold;
 }
+/*# sourceMappingURL=page-chooser.css.map */

--- a/src/BloomBrowserUI/pageChooser/page-chooser.css
+++ b/src/BloomBrowserUI/pageChooser/page-chooser.css
@@ -35,6 +35,10 @@
 #preview {
   width: 200px;
 }
+.landscape #preview {
+  width: unset;
+  height: 200px;
+}
 #previewCaption {
   font-weight: bold;
   text-align: center;
@@ -85,6 +89,11 @@
   width: 60px;
   margin-left: 20px;
 }
+.landscape .thumbnail {
+  width: unset;
+  height: 60px;
+  margin-left: 6px;
+}
 .gridItem .gridItemCaption {
   display: none;
   text-align: center;
@@ -110,6 +119,9 @@
   height: 100px;
   width: 100px;
   background: url(transparent.gif);
+}
+.landscape .selectionOverlay {
+  height: 70px;
 }
 #mainContainer div.ui-dialog div.ui-dialog-buttonset button.ui-button {
   background: #e1e1e1 !important;

--- a/src/BloomBrowserUI/pageChooser/page-chooser.css
+++ b/src/BloomBrowserUI/pageChooser/page-chooser.css
@@ -118,7 +118,6 @@
   position: absolute;
   height: 100px;
   width: 100px;
-  background: url(transparent.gif);
 }
 .landscape .selectionOverlay {
   height: 70px;

--- a/src/BloomBrowserUI/pageChooser/page-chooser.less
+++ b/src/BloomBrowserUI/pageChooser/page-chooser.less
@@ -175,7 +175,6 @@ BODY {
 	position: absolute;
 	height: 100px;
 	width: 100px;
-	background: url(transparent.gif);
 }
 
 .landscape {

--- a/src/BloomBrowserUI/pageChooser/page-chooser.less
+++ b/src/BloomBrowserUI/pageChooser/page-chooser.less
@@ -51,6 +51,13 @@ BODY {
 #preview {
 	width: 200px;
 }
+
+.landscape {
+    #preview {
+        width: unset;
+        height: 200px;
+    }
+}
 #previewCaption {
 	font-weight: bold;
 	text-align: center;
@@ -135,6 +142,14 @@ BODY {
 	//take the height proportionally, from the width
 	margin-left: 20px;//centers the thumbnail in the enclosing grid item
 }
+
+.landscape {
+    .thumbnail {
+        width:unset;
+        height: 60px;
+        margin-left: 6px;
+    }
+}
 .gridItem {
 	.gridItemCaption {
 		display: none; // The captions aren't really helping the user, just adding complexity
@@ -161,6 +176,12 @@ BODY {
 	height: 100px;
 	width: 100px;
 	background: url(transparent.gif);
+}
+
+.landscape {
+    .selectionOverlay {
+        height: 70px;
+    }
 }
 
 #mainContainer div.ui-dialog div.ui-dialog-buttonset button.ui-button{

--- a/src/BloomBrowserUI/pageChooser/page-chooser.less
+++ b/src/BloomBrowserUI/pageChooser/page-chooser.less
@@ -7,6 +7,10 @@
 @WindowsButton-BackgroundColor-Hover: #B0DEE4;
 @WindowsButton-Border: #ADADAD;
 @HighlightColor: rgba(176, 222, 228, 1);
+ // partly transparent to go on TOP of the page image but still let it show through.
+ // Intended to be similar to HighlightColor when over the default dialog background, but I haven't
+ // tried to figure out exactly what would achieve that.
+@TransparentHiglightColor: hsla(186.9, 49.1%, 65%, 0.45);
 
 BODY {
 	margin: 4px;
@@ -33,6 +37,7 @@ BODY {
 	order: 2;
 	height: auto;
 	min-width: 320px;
+    max-width: 370px; // in the standard dialog width, allows the other pane to be wide enough for 3 columns with scroll bar
 	padding-left: @PreviewPaneLeftPadding;
 
 	img{
@@ -85,8 +90,6 @@ BODY {
 //    flex-wrap: nowrap;
 //}
 .outerCollectionContainer {
-	flex: 1;
-	display: flex;
 	flex-direction: column;
 }
 .collection {
@@ -111,14 +114,14 @@ BODY {
 }
 
 .gridItem:hover {
-	background: @HighlightColor;
+    .selectionOverlay {
+        background: @TransparentHiglightColor;
+    }
 }
 .gridItem.ui-selected {
-	background: @HighlightColor;
-
-	.invisibleThumbCover {
-		//background: @HighlightColor;
-	}
+    .selectionOverlay {
+        background: @TransparentHiglightColor;
+    }
 }
 .thumbnail {
 	overflow: hidden;
@@ -149,6 +152,13 @@ BODY {
 	z-index: 5;
 	position: absolute;
 	height: 130px;
+	width: 100px;
+	background: url(transparent.gif);
+}
+.selectionOverlay {
+	z-index: 3;
+	position: absolute;
+	height: 100px;
 	width: 100px;
 	background: url(transparent.gif);
 }

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -377,6 +377,8 @@ namespace Bloom.Book
 		/// an enlarged version of the page, we generate these at a higher resolution than usual.
 		/// Also, to make more realistic views of template pages we insert fake text wherever
 		/// there is an empty edit block.
+		///
+		/// The result is cached for possible future use so the caller should not dispose of it.
 		/// </summary>
 		/// <param name="page"></param>
 		/// <returns></returns>
@@ -385,12 +387,25 @@ namespace Bloom.Book
 			var pageDom = GetThumbnailXmlDocumentForPage(page);
 			var thumbnailOptions = new HtmlThumbNailer.ThumbnailOptions()
 			{
-				BackgroundColor = Palette.TextAgainstDarkBackground,
-				BorderStyle = HtmlThumbNailer.ThumbnailOptions.BorderStyles.Solid,
-				CenterImageUsingTransparentPadding = true,
-				Width = 200,
-				Height = 200
+				BackgroundColor = Color.White,// matches the hand-made previews.
+				BorderStyle = HtmlThumbNailer.ThumbnailOptions.BorderStyles.None, // allows the HTML to add its preferred border in the larger preview
+				CenterImageUsingTransparentPadding = true
 			};
+			// The actual page size is rather arbitrary, but we want the right ratio for A4.
+			// Using the actual A4 sizes in mm makes a big enough image to look good in the larger
+			// preview box on the right as well as giving exactly the ratio we want.
+			// We need to make the image the right shape to avoid some sort of shadow/box effects
+			// that I can't otherwise find a way to get rid of.
+			if (GetLayout().SizeAndOrientation.IsLandScape)
+			{
+				thumbnailOptions.Width = 297;
+				thumbnailOptions.Height = 210;
+			}
+			else
+			{
+				thumbnailOptions.Width = 210;
+				thumbnailOptions.Height = 297;
+			}
 			return _thumbnailProvider.GetThumbnail(page.Id, pageDom, thumbnailOptions);
 		}
 

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -371,18 +371,19 @@ namespace Bloom.Book
 			return _storage.MakeDomRelocatable(inputDom, _log);
 		}
 
-		/// <summary>
-		/// Currently used by the image server
-		/// to get thumbnails that are used in the add page dialog. Since this dialog can show
-		/// an enlarged version of the page, we generate these at a higher resolution than usual.
-		/// Also, to make more realistic views of template pages we insert fake text wherever
-		/// there is an empty edit block.
+		///  <summary>
+		///  Currently used by the image server
+		///  to get thumbnails that are used in the add page dialog. Since this dialog can show
+		///  an enlarged version of the page, we generate these at a higher resolution than usual.
+		///  Also, to make more realistic views of template pages we insert fake text wherever
+		///  there is an empty edit block.
 		///
-		/// The result is cached for possible future use so the caller should not dispose of it.
-		/// </summary>
-		/// <param name="page"></param>
+		///  The result is cached for possible future use so the caller should not dispose of it.
+		///  </summary>
+		///  <param name="page"></param>
+		/// <param name="isLandscape"></param>
 		/// <returns></returns>
-		public Image GetThumbnailForPage(IPage page)
+		public Image GetThumbnailForPage(IPage page, bool isLandscape)
 		{
 			var pageDom = GetThumbnailXmlDocumentForPage(page);
 			var thumbnailOptions = new HtmlThumbNailer.ThumbnailOptions()
@@ -391,22 +392,28 @@ namespace Bloom.Book
 				BorderStyle = HtmlThumbNailer.ThumbnailOptions.BorderStyles.None, // allows the HTML to add its preferred border in the larger preview
 				CenterImageUsingTransparentPadding = true
 			};
+			var pageDiv = pageDom.RawDom.SafeSelectNodes("descendant-or-self::div[contains(@class,'bloom-page')]").Cast<XmlElement>().FirstOrDefault();
 			// The actual page size is rather arbitrary, but we want the right ratio for A4.
 			// Using the actual A4 sizes in mm makes a big enough image to look good in the larger
 			// preview box on the right as well as giving exactly the ratio we want.
 			// We need to make the image the right shape to avoid some sort of shadow/box effects
 			// that I can't otherwise find a way to get rid of.
-			if (GetLayout().SizeAndOrientation.IsLandScape)
+			if (isLandscape)
 			{
 				thumbnailOptions.Width = 297;
 				thumbnailOptions.Height = 210;
+				pageDiv.SetAttribute("class", pageDiv.Attributes["class"].Value.Replace("Portrait", "Landscape"));
 			}
 			else
 			{
 				thumbnailOptions.Width = 210;
 				thumbnailOptions.Height = 297;
+				// On the offchance someone makes a template with by-default-landscape pages...
+				pageDiv.SetAttribute("class", pageDiv.Attributes["class"].Value.Replace("Landscape", "Portrait"));
 			}
-			return _thumbnailProvider.GetThumbnail(page.Id, pageDom, thumbnailOptions);
+			// In different books (or even the same one) in the same session we may have portrait and landscape
+			// versions of the same template page. So we must use different IDs.
+			return _thumbnailProvider.GetThumbnail(page.Id + (isLandscape ? "L" : ""), pageDom, thumbnailOptions);
 		}
 
 		public HtmlDom GetPreviewXmlDocumentForPage(IPage page)

--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -135,6 +135,15 @@ namespace Bloom
 			GeckoPreferences.User["browser.sessionhistory.max_entries"] = 1;
 			GeckoPreferences.User["browser.sessionhistory.max_total_viewers"] = 0;
 			GeckoPreferences.User["browser.cache.memory.enable"] = false;
+			// These settings prevent a problem where the gecko instance running the add page dialog
+			// would request several images at once, but we were not able to generate the image
+			// because we could not make additional requests of the localhost server, since some limit
+			// had been reached. I'm not sure all of them are needed, but since in this program we
+			// only talk to our own local server, there is no reason to limit any requests to the server,
+			// so increasing all the ones that look at all relevant seems like a good idea.
+			GeckoPreferences.User["network.http.max-persistent-connections-per-server"] = 200;
+			GeckoPreferences.User["network.http.pipelining.maxrequests"] = 200;
+			GeckoPreferences.User["network.http.pipelining.max-optimistic-requests"] = 200;
 
 			Application.ApplicationExit += OnApplicationExit;
 		}

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -534,7 +534,7 @@ namespace Bloom.web
 				// but it has nothing to do with the actual file location.
 				if (localPath.StartsWith("OriginalImages/"))
 					possibleFullImagePath = localPath.Substring(15);
-				if (localPath.EndsWith(".gensvg"))
+				if (info.GetQueryString()["generateThumbnaiIfNecessary"] == "true")
 					return FindOrGenerateImage(info, localPath);
 				if(File.Exists(possibleFullImagePath) && Path.IsPathRooted(possibleFullImagePath))
 				{
@@ -562,18 +562,18 @@ namespace Bloom.web
 		}
 
 		/// <summary>
-		/// Requests for .gensvg files are potentially recursive in that we may have to navigate
+		/// Requests with ?generateThumbnaiIfNecessary=true are potentially recursive in that we may have to navigate
 		/// a browser to the template page in order to construct the thumbnail.
 		/// </summary>
 		/// <param name="context"></param>
 		/// <returns></returns>
 		protected override bool IsRecursiveRequestContext(HttpListenerContext context)
 		{
-			return base.IsRecursiveRequestContext(context) || context.Request.RawUrl.EndsWith(".gensvg");
+			return base.IsRecursiveRequestContext(context) || context.Request.QueryString["generateThumbnaiIfNecessary"] == "true";
 		}
 
 		/// <summary>
-		/// Currently used in the Add Page dialog, a path ending in .gensvg indicates a thumbnail for
+		/// Currently used in the Add Page dialog, a path with ?generateThumbnaiIfNecessary=true indicates a thumbnail for
 		/// a template page. Usually we expect that a file at the same path but with extension .svg will
 		/// be found and returned. Failing this we try for one ending in .png. If this still fails we
 		/// start a process to generate an image from the template page content.

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Windows.Forms;
 using Bloom.Book;
 using System.IO;
+using System.Net;
 using Bloom.ImageProcessing;
 using BloomTemp;
 using L10NSharp;
@@ -255,23 +256,39 @@ namespace Bloom.web
 				return ProcessLevedRTInfo(info, localPath);
 			else if (localPath.StartsWith("localhost/", StringComparison.InvariantCulture))
 			{
-#if __MonoCS__
-				// The JSON format may use a string like this to reference a local path.
-				// Try it without the leading marker.
-				var temp = localPath.Substring(10);
+				var temp = LocalHostPathToFilePath(localPath);
 				if (File.Exists(temp))
 					localPath = temp;
-#else
-				// project on network mapped drive like localhost\C$.
-				// URL was something like /bloom///localhost/C$/, but info.LocalPathWithoutQuery uses Uri.LocalPath
-				// which for some reason drops the needed leading slashes.
-				var temp = "//" + localPath;
-				if (File.Exists(temp))
-					localPath = temp;
-#endif
 			}
 
 			return ProcessContent(info, localPath);
+		}
+
+		/// <summary>
+		/// Adjust the 'localPath' obtained from a request in a platform-dependent way to a path
+		/// that can actually be used to retrieve a file (or test for its existence).
+		/// </summary>
+		/// <param name="localPath"></param>
+		/// <returns></returns>
+		private static string LocalHostPathToFilePath(string localPath)
+		{
+#if __MonoCS__
+			// The JSON format may use a string like this to reference a local path.
+			// Try it without the leading marker.
+			return localPath.Substring(10);
+#else
+			// project on network mapped drive like localhost\C$.
+			// URL was something like /bloom///localhost/C$/, but info.LocalPathWithoutQuery uses Uri.LocalPath
+			// which for some reason drops the needed leading slashes.
+			return "//" + localPath;
+#endif
+		}
+
+		private static string AdjustPossibleLocalHostPathToFilePath(string path)
+		{
+			if (!path.StartsWith("localhost/", StringComparison.InvariantCulture))
+				return path;
+			return LocalHostPathToFilePath(path);
 		}
 
 		/// <summary>
@@ -497,7 +514,7 @@ namespace Bloom.web
 			return true;
 		}
 
-		private static bool ProcessAnyFileContent(IRequestInfo info, string localPath)
+		private bool ProcessAnyFileContent(IRequestInfo info, string localPath)
 		{
 			string modPath = localPath;
 			string path = null;
@@ -517,6 +534,8 @@ namespace Bloom.web
 				// but it has nothing to do with the actual file location.
 				if (localPath.StartsWith("OriginalImages/"))
 					possibleFullImagePath = localPath.Substring(15);
+				if (localPath.EndsWith(".gensvg"))
+					return FindOrGenerateImage(info, localPath);
 				if(File.Exists(possibleFullImagePath) && Path.IsPathRooted(possibleFullImagePath))
 				{
 					path = possibleFullImagePath;
@@ -540,6 +559,84 @@ namespace Bloom.web
 			info.ContentType = GetContentType(Path.GetExtension(modPath));
 			info.ReplyWithFileContent(path);
 			return true;
+		}
+
+		/// <summary>
+		/// Requests for .gensvg files are potentially recursive in that we may have to navigate
+		/// a browser to the template page in order to construct the thumbnail.
+		/// </summary>
+		/// <param name="context"></param>
+		/// <returns></returns>
+		protected override bool IsRecursiveRequestContext(HttpListenerContext context)
+		{
+			return base.IsRecursiveRequestContext(context) || context.Request.RawUrl.EndsWith(".gensvg");
+		}
+
+		/// <summary>
+		/// Currently used in the Add Page dialog, a path ending in .gensvg indicates a thumbnail for
+		/// a template page. Usually we expect that a file at the same path but with extension .svg will
+		/// be found and returned. Failing this we try for one ending in .png. If this still fails we
+		/// start a process to generate an image from the template page content.
+		/// </summary>
+		/// <param name="path"></param>
+		/// <returns>Should always return true, unless we really can't come up with an image at all.</returns>
+		private bool FindOrGenerateImage(IRequestInfo info, string path)
+		{
+			var localPath = AdjustPossibleLocalHostPathToFilePath(path);
+			var svgpath = Path.ChangeExtension(localPath, "svg");
+			if (File.Exists(svgpath))
+			{
+				ReplyWithFileContentAndType(info, svgpath);
+				return true;
+			}
+			var pngpath = Path.ChangeExtension(localPath, "png");
+			if (File.Exists(pngpath))
+			{
+				ReplyWithFileContentAndType(info, pngpath);
+				return true;
+			}
+			// We don't have an image; try to make one.
+			if (CurrentBook == null)
+				return false; // paranoia
+			var template = CurrentBook.FindTemplateBook();
+			if (template == null)
+				return false; // paranoia
+			var caption = Path.GetFileNameWithoutExtension(path).Trim();
+			int dummy = 0;
+			// The Replace of & with + corresponds to a replacement made in page-chooser.ts method loadPagesFromCollection.
+			var templatePage = template.GetPages().FirstOrDefault(page => page.Caption.Replace("&", "+") == caption);
+			if (templatePage == null)
+				templatePage = template.GetPages().FirstOrDefault(); // may get something useful?? or throw??
+
+			Image image = template.GetThumbnailForPage(templatePage);
+
+			// The clone here is an attempt to prevent an unexplained exception complaining that the source image for the bitmap is in use elsewhere.
+			using (Bitmap b = new Bitmap((Image)image.Clone()))
+			{
+				try
+				{
+					{
+						Directory.CreateDirectory(Path.GetDirectoryName(pngpath));
+						b.Save(pngpath);
+					}
+					ReplyWithFileContentAndType(info, pngpath);
+				}
+				catch (Exception)
+				{
+					using (var file = new TempFile())
+					{
+						b.Save(file.Path);
+						ReplyWithFileContentAndType(info, file.Path);
+					}
+				}
+			}
+			return true; // We came up with some reply
+		}
+
+		private static void ReplyWithFileContentAndType(IRequestInfo info, string path)
+		{
+			info.ContentType = GetContentType(Path.GetExtension(path));
+			info.ReplyWithFileContent(path);
 		}
 
 		private bool ProcessCssFile(IRequestInfo info, string localPath)

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -602,13 +602,16 @@ namespace Bloom.web
 			if (template == null)
 				return false; // paranoia
 			var caption = Path.GetFileNameWithoutExtension(path).Trim();
+			var isLandscape = caption.EndsWith("-landscape"); // matches string in page-chooser.ts
+			if (isLandscape)
+				caption = caption.Substring(0, caption.Length - "-landscape".Length);
 			int dummy = 0;
 			// The Replace of & with + corresponds to a replacement made in page-chooser.ts method loadPagesFromCollection.
 			var templatePage = template.GetPages().FirstOrDefault(page => page.Caption.Replace("&", "+") == caption);
 			if (templatePage == null)
 				templatePage = template.GetPages().FirstOrDefault(); // may get something useful?? or throw??
 
-			Image image = template.GetThumbnailForPage(templatePage);
+			Image image = template.GetThumbnailForPage(templatePage, isLandscape);
 
 			// The clone here is an attempt to prevent an unexplained exception complaining that the source image for the bitmap is in use elsewhere.
 			using (Bitmap b = new Bitmap((Image)image.Clone()))


### PR DESCRIPTION
The template folder may now contain a Caption.png file,
which will be used if Caption.svg is not found. If neither is
found, the system will generate a thumbnail on the fly.
Achieving this involved some tricky changes to our fileserver
so requests for multiple thumbnails don't lock out the server
requests needed to generate a thumbnail.