### PR TITLE
Stage 1 of BL-2677, Add HalfLetter to size choices

### DIFF
--- a/DistFiles/less/common-mixins.less
+++ b/DistFiles/less/common-mixins.less
@@ -34,6 +34,26 @@
 @B5Portrait-Height: 250mm;
 @B5Portrait-Width: 176mm;
 
+@LetterPortrait-Height: 11in;
+@LetterPortrait-Width: 8.5in;
+@LetterLandscape-Height: @LetterPortrait-Width;
+@LetterLandscape-Width: @LetterPortrait-Height;
+
+@HalfLetterPortrait-Height: 8.5in;
+@HalfLetterPortrait-Width: 5.5in;
+@HalfLetterLandscape-Height: @HalfLetterPortrait-Width;
+@HalfLetterLandscape-Width: @HalfLetterPortrait-Height;
+
+@LegalPortrait-Height: 14in;
+@LegalPortrait-Width: 8.5in;
+@LegalLandscape-Height: @LegalPortrait-Width;
+@LegalLandscape-Width: @LegalPortrait-Height;
+
+@HalfLegalPortrait-Height: 8.5in;
+@HalfLegalPortrait-Width: 7in;
+@HalfLegalLandscape-Height: @HalfLegalPortrait-Width;
+@HalfLegalLandscape-Width: @HalfLegalPortrait-Height;
+
 @MarginTop: 15mm;
 @MarginOuter: 15mm;
 @MarginBottom: 15mm;

--- a/src/BloomBrowserUI/bookLayout/basePage.css
+++ b/src/BloomBrowserUI/bookLayout/basePage.css
@@ -209,6 +209,54 @@ preview.css.
   min-height: 105mm;
   max-height: 105mm;
 }
+.bloom-page.HalfLetterPortrait {
+  min-width: 5.5in;
+  max-width: 5.5in;
+  min-height: 8.5in;
+  max-height: 8.5in;
+}
+.bloom-page.HalfLetterLandscape {
+  min-width: 8.5in;
+  max-width: 8.5in;
+  min-height: 5.5in;
+  max-height: 5.5in;
+}
+.bloom-page.LetterPortrait {
+  min-width: 8.5in;
+  max-width: 8.5in;
+  min-height: 11in;
+  max-height: 11in;
+}
+.bloom-page.LetterLandscape {
+  min-width: 11in;
+  max-width: 11in;
+  min-height: 8.5in;
+  max-height: 8.5in;
+}
+.bloom-page.HalfLegalPortrait {
+  min-width: 7in;
+  max-width: 7in;
+  min-height: 8.5in;
+  max-height: 8.5in;
+}
+.bloom-page.HalfLegalLandscape {
+  min-width: 8.5in;
+  max-width: 8.5in;
+  min-height: 7in;
+  max-height: 7in;
+}
+.bloom-page.LegalPortrait {
+  min-width: 8.5in;
+  max-width: 8.5in;
+  min-height: 14in;
+  max-height: 14in;
+}
+.bloom-page.LegalLandscape {
+  min-width: 14in;
+  max-width: 14in;
+  min-height: 8.5in;
+  max-height: 8.5in;
+}
 /*Margins*/
 .textWholePage .marginBox {
   position: absolute;
@@ -273,6 +321,54 @@ preview.css.
 .B5Portrait .marginBox IMG {
   /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
   max-width: 136mm;
+}
+.HalfLetterPortrait .marginBox {
+  height: 7.31889764in;
+  width: 3.92519685in;
+}
+.HalfLetterPortrait .marginBox IMG {
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
+  max-width: 3.92519685in;
+}
+.LetterPortrait .marginBox {
+  height: 9.81889764in;
+  width: 6.92519685in;
+}
+.LetterPortrait .marginBox IMG {
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
+  max-width: 6.92519685in;
+}
+.LetterLandscape .marginBox {
+  height: 7.31889764in;
+  width: 9.42519685in;
+}
+.LetterLandscape .marginBox IMG {
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
+  max-width: 9.42519685in;
+}
+.HalfLegalPortrait .marginBox {
+  height: 7.31889764in;
+  width: 5.42519685in;
+}
+.HalfLegalPortrait .marginBox IMG {
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
+  max-width: 5.42519685in;
+}
+.LegalPortrait .marginBox {
+  height: 12.81889764in;
+  width: 6.92519685in;
+}
+.LegalPortrait .marginBox IMG {
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
+  max-width: 6.92519685in;
+}
+.LegalLandscape .marginBox {
+  height: 7.31889764in;
+  width: 12.42519685in;
+}
+.LegalLandscape .marginBox IMG {
+  /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
+  max-width: 12.42519685in;
 }
 .publishMode:not(.calendarFold) :not(.outsideFrontCover):not(.outsideBackCover).bloom-page:nth-of-type(odd) .marginBox {
   /* shifted margin */

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -214,6 +214,54 @@ preview.css.
 		min-height: @A6Landscape-Height;
 		max-height: @A6Landscape-Height;
 	}
+	&.HalfLetterPortrait {
+		min-width: @HalfLetterPortrait-Width;
+		max-width: @HalfLetterPortrait-Width;
+		min-height: @HalfLetterPortrait-Height;
+		max-height: @HalfLetterPortrait-Height;
+	}
+	&.HalfLetterLandscape {
+		min-width: @HalfLetterLandscape-Width;
+		max-width: @HalfLetterLandscape-Width;
+		min-height: @HalfLetterLandscape-Height;
+		max-height: @HalfLetterLandscape-Height;
+	}
+	&.LetterPortrait {
+		min-width: @LetterPortrait-Width;
+		max-width: @LetterPortrait-Width;
+		min-height: @LetterPortrait-Height;
+		max-height: @LetterPortrait-Height;
+	}
+	&.LetterLandscape {
+		min-width: @LetterLandscape-Width;
+		max-width: @LetterLandscape-Width;
+		min-height: @LetterLandscape-Height;
+		max-height: @LetterLandscape-Height;
+	}
+	&.HalfLegalPortrait {
+		min-width: @HalfLegalPortrait-Width;
+		max-width: @HalfLegalPortrait-Width;
+		min-height: @HalfLegalPortrait-Height;
+		max-height: @HalfLegalPortrait-Height;
+	}
+	&.HalfLegalLandscape {
+		min-width: @HalfLegalLandscape-Width;
+		max-width: @HalfLegalLandscape-Width;
+		min-height: @HalfLegalLandscape-Height;
+		max-height: @HalfLegalLandscape-Height;
+	}
+	&.LegalPortrait {
+		min-width: @LegalPortrait-Width;
+		max-width: @LegalPortrait-Width;
+		min-height: @LegalPortrait-Height;
+		max-height: @LegalPortrait-Height;
+	}
+	&.LegalLandscape {
+		min-width: @LegalLandscape-Width;
+		max-width: @LegalLandscape-Width;
+		min-height: @LegalLandscape-Height;
+		max-height: @LegalLandscape-Height;
+	}
 }
 /*Margins*/
 .textWholePage .marginBox {
@@ -258,6 +306,26 @@ preview.css.
 	}
 	.B5Portrait & {
 		.SetMarginBox(@B5Portrait-Width, @B5Portrait-Height);
+	}
+
+	.HalfLetterPortrait & {
+		.SetMarginBox(@HalfLetterPortrait-Width, @HalfLetterPortrait-Height);
+	}
+	.LetterPortrait & {
+		.SetMarginBox(@LetterPortrait-Width, @LetterPortrait-Height);
+	}
+	.LetterLandscape & {
+		.SetMarginBox(@LetterLandscape-Width, @LetterLandscape-Height);
+	}
+
+	.HalfLegalPortrait & {
+		.SetMarginBox(@HalfLegalPortrait-Width, @HalfLegalPortrait-Height);
+	}
+	.LegalPortrait & {
+		.SetMarginBox(@LegalPortrait-Width, @LegalPortrait-Height);
+	}
+	.LegalLandscape & {
+		.SetMarginBox(@LegalLandscape-Width, @LegalLandscape-Height);
 	}
 }
 

--- a/src/BloomExe/Book/SizeAndOrientation.cs
+++ b/src/BloomExe/Book/SizeAndOrientation.cs
@@ -104,18 +104,21 @@ namespace Bloom.Book
 						PageSizeName = "A5"
 					};
 			}
-			int startOfAlternativeName=-1;
-			if(nameLower.Contains("landscape"))
-				startOfAlternativeName = startOfOrientationName + "landscape".Length;
-			else
-				startOfAlternativeName = startOfOrientationName + "portrait".Length;
 
 			return new SizeAndOrientation()
 					{
 						IsLandScape = nameLower.Contains("landscape"),
-						PageSizeName = nameLower.Substring(0, startOfOrientationName).ToUpperFirstLetter(),
-						//AlternativeName = name.Substring(startOfAlternativeName, nameLower.Length - startOfAlternativeName)
+						PageSizeName = ExtractPageSizeName(name, startOfOrientationName),
 					};
+		}
+
+		private static string ExtractPageSizeName(string nameLower, int startOfOrientationName)
+		{
+			var name = nameLower.Substring(0, startOfOrientationName).ToUpperFirstLetter();
+			//these are needed so that "HalfLetter" doesn't come out "Halfletter"
+			name = name.Replace("letter", "Letter");
+			name = name.Replace("legal", "Legal");
+			return name;
 		}
 
 		public static void AddClassesForLayout(HtmlDom dom, Layout layout)


### PR DESCRIPTION
In this commit, I added knowledge of the various American page dimensions to the stylesheets. In SizeAndOrientation, I fixed the case-handling so that we see "HalfLetter" instead of "Halfletter". 

Meanwhile Steve has enabled GeckofxHtmlToPDF to handle "halfletter" and "quaterletter" among other American sizs.

So, next we would need to make "HalfLetter" be an option in various templates (e.g. basicBook.less).  And then do all the same for quarterletter.