### PR TITLE
Reverse package name changes accidently merged to master

### DIFF
--- a/debian/bloom
+++ b/debian/bloom
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-LIB=/usr/lib/bloom-desktop-beta
-SHARE=/usr/share/bloom-desktop-beta
+LIB=/usr/lib/bloom-desktop-unstable
+SHARE=/usr/share/bloom-desktop-unstable
 
 cd "$SHARE"
 RUNMODE=INSTALLED

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
-bloom-desktop-beta (3.3.2) stable; urgency=medium
+bloom-desktop-unstable (3.4.0) stable; urgency=medium
 
-  * Rename package to bloom-desktop-beta for public consumption.
+  * Update to version 3.4 on the master (unstable) branch.
   * More bug fixes: see the source repository log for details.
 
- -- Stephen McConnel <stephen_mcconnel@sil.org>  Wed, 26 Aug 2015 14:13:06 -0500
+ -- Stephen McConnel <stephen_mcconnel@sil.org>  Mon, 31 Aug 2015 10:57:13 -0500
 
 bloom-desktop-unstable (3.3.1) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: bloom-desktop-beta
+Source: bloom-desktop-unstable
 Section: x11
 Priority: extra
 Maintainer: Eberhard Beilharz <eb1@sil.org>
@@ -14,7 +14,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
  libicu-dev,
  icu-devtools | libicu-dev (<< 52)
 
-Package: bloom-desktop-beta
+Package: bloom-desktop-unstable
 Architecture: all
 Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  mono-sil, libgdiplus-sil, geckofx29, gtklp,

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,5 +1,5 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: bloom-desktop-beta
+Upstream-Name: bloom-desktop-unstable
 Source: https://github.com/BloomBooks/BloomDesktop
 
 Files: *

--- a/debian/install
+++ b/debian/install
@@ -1,6 +1,6 @@
-lib/dotnet/Chorus.exe.mdb usr/lib/bloom-desktop-beta/
-lib/dotnet/LibChorus.dll.mdb usr/lib/bloom-desktop-beta/
-lib/dotnet/Palaso.Media.dll.mdb usr/lib/bloom-desktop-beta/
-lib/dotnet/PalasoUIWindowsForms.GeckoBrowserAdapter.dll.mdb usr/lib/bloom-desktop-beta/
-lib/dotnet/PalasoUIWindowsForms.dll.mdb usr/lib/bloom-desktop-beta/
-lib/dotnet/SIL.Archiving.dll.mdb usr/lib/bloom-desktop-beta/
+lib/dotnet/Chorus.exe.mdb usr/lib/bloom-desktop-unstable/
+lib/dotnet/LibChorus.dll.mdb usr/lib/bloom-desktop-unstable/
+lib/dotnet/Palaso.Media.dll.mdb usr/lib/bloom-desktop-unstable/
+lib/dotnet/PalasoUIWindowsForms.GeckoBrowserAdapter.dll.mdb usr/lib/bloom-desktop-unstable/
+lib/dotnet/PalasoUIWindowsForms.dll.mdb usr/lib/bloom-desktop-unstable/
+lib/dotnet/SIL.Archiving.dll.mdb usr/lib/bloom-desktop-unstable/

--- a/debian/rules
+++ b/debian/rules
@@ -7,14 +7,14 @@
 export MONO_PREFIX = /opt/mono-sil
 export BUILD = Release
 
-PACKAGE = bloom-desktop-beta
+PACKAGE = bloom-desktop-unstable
 DESTDIR = debian/$(PACKAGE)
 LIB     = usr/lib/$(PACKAGE)
 SHARE   = usr/share/$(PACKAGE)
 
 # NOTE: make the third (and fourth?) number match changelog if you are
 # building the package manually.
-FULL_BUILD_NUMBER ?= 0.0.2.0
+FULL_BUILD_NUMBER ?= 0.0.1.0
 
 %:
 	dh $@ --with=cli --parallel


### PR DESCRIPTION
Linux/debian packages on the master branch should be named with an
unstable suffix.  (debian files should never be merged across branches!)