### PR TITLE
BL-2678 restrict book cmds

### DIFF
--- a/DistFiles/localization/Bloom.en.tmx
+++ b/DistFiles/localization/Bloom.en.tmx
@@ -3444,6 +3444,12 @@
         <seg>Wall Calendar</seg>
       </tuv>
     </tu>
+    <tu tuid="TemplateBooks.BookName.Vaccinations">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Vaccinations</seg>
+      </tuv>
+    </tu>
     <tu tuid="Topics.Agriculture">
       <note>shows in the topics chooser in the edit tab</note>
       <prop type="x-dynamic">true</prop>

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -581,10 +581,16 @@ namespace Bloom.Book
 			return new HtmlDom(builder.ToString());
 		}
 
+		private bool IsDownloaded
+		{
+			get { return FolderPath.Contains(BookCollection.DownloadedBooksCollectionNameInEnglish); }
+		}
 
 		public virtual bool CanDelete
 		{
-			get { return IsEditable; }
+			// BL-2678: we want the user to be able to delete troublesome/no longer needed books
+			// downloaded from BloomLibrary.org
+			get { return IsEditable || IsDownloaded; }
 		}
 
 		public bool CanPublish

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -15,6 +15,7 @@ using Bloom.Edit;
 using Bloom.ImageProcessing;
 using Bloom.Properties;
 using Bloom.Publish;
+using Bloom.WebLibraryIntegration;
 using L10NSharp;
 using MarkdownSharp;
 using Palaso.Code;
@@ -583,7 +584,7 @@ namespace Bloom.Book
 
 		private bool IsDownloaded
 		{
-			get { return FolderPath.Contains(BookCollection.DownloadedBooksCollectionNameInEnglish); }
+			get { return FolderPath.StartsWith(BookTransfer.DownloadFolder); }
 		}
 
 		public virtual bool CanDelete

--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -24,6 +24,7 @@ namespace Bloom.Collection
 
 		private readonly string _path;
 		private List<BookInfo> _bookInfos;
+		private string _factoryDir;
 
 		private readonly BookSelection _bookSelection;
 
@@ -191,13 +192,29 @@ namespace Bloom.Collection
 
 		public bool IsDownloaded { get { return Name == DownloadedBooksCollectionNameInEnglish; } }
 
-		public bool IsFactoryTemplates
+		private string FactoryDir
 		{
 			get
 			{
-				return String.Equals(Name, InstalledTemplatesCollectionNameInEnglish, StringComparison.InvariantCultureIgnoreCase);
+				if (String.IsNullOrEmpty(_factoryDir))
+				{
+					var basicBookDir = Path.GetDirectoryName(BloomFileLocator.GetFileDistributedWithApplication(
+						"factoryCollections",
+						InstalledTemplatesCollectionNameInEnglish,
+						"Basic Book",
+						"Basic Book.htm"));
+					if (String.IsNullOrEmpty(basicBookDir))
+						throw new ApplicationException("Basic Book template cannot be found!");
+					_factoryDir = basicBookDir.Substring(0, basicBookDir.IndexOf(InstalledTemplatesCollectionNameInEnglish));
+				}
+				return _factoryDir;
 			}
 		}
+
+		/// <summary>
+		/// This includes everything in "factoryCollections" (i.e. Templates folder AND Sample Shells:Vaccinations folder)
+		/// </summary>
+		public bool IsFactoryTemplates { get { return PathToDirectory.Contains(FactoryDir); } }
 
 		private FileSystemWatcher _watcher;
 		/// <summary>

--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -77,7 +77,7 @@ namespace Bloom.Collection
 				return;
 
 			Logger.WriteEvent("After BookStorage.DeleteBook({0})", bookInfo.FolderPath);
-			Debug.Assert(_bookInfos.Contains(bookInfo));
+			//Debug.Assert(_bookInfos.Contains(bookInfo)); this will occur if we delete a book from the BloomLibrary section
 			_bookInfos.Remove(bookInfo);
 
 			if (CollectionChanged != null)

--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -5,9 +5,6 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using Bloom.Book;
-#if !__MonoCS__
-using IWshRuntimeLibrary;
-#endif
 using Palaso.Reporting;
 using Palaso.UI.WindowsForms.FileSystem;
 using File = System.IO.File;
@@ -189,7 +186,18 @@ namespace Bloom.Collection
 			set { throw new NotImplementedException(); }
 		}
 
-		public static string DownloadedBooksCollectionNameInEnglish = "Books From BloomLibrary.org";
+		public const string DownloadedBooksCollectionNameInEnglish = "Books From BloomLibrary.org";
+		private const string InstalledTemplatesCollectionNameInEnglish = "Templates";
+
+		public bool IsDownloaded { get { return Name == DownloadedBooksCollectionNameInEnglish; } }
+
+		public bool IsFactoryTemplates
+		{
+			get
+			{
+				return String.Equals(Name, InstalledTemplatesCollectionNameInEnglish, StringComparison.InvariantCultureIgnoreCase);
+			}
+		}
 
 		private FileSystemWatcher _watcher;
 		/// <summary>

--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -188,33 +188,13 @@ namespace Bloom.Collection
 		}
 
 		public const string DownloadedBooksCollectionNameInEnglish = "Books From BloomLibrary.org";
-		private const string InstalledTemplatesCollectionNameInEnglish = "Templates";
 
-		public bool IsDownloaded { get { return Name == DownloadedBooksCollectionNameInEnglish; } }
-
-		private string FactoryDir
-		{
-			get
-			{
-				if (String.IsNullOrEmpty(_factoryDir))
-				{
-					var basicBookDir = Path.GetDirectoryName(BloomFileLocator.GetFileDistributedWithApplication(
-						"factoryCollections",
-						InstalledTemplatesCollectionNameInEnglish,
-						"Basic Book",
-						"Basic Book.htm"));
-					if (String.IsNullOrEmpty(basicBookDir))
-						throw new ApplicationException("Basic Book template cannot be found!");
-					_factoryDir = basicBookDir.Substring(0, basicBookDir.IndexOf(InstalledTemplatesCollectionNameInEnglish));
-				}
-				return _factoryDir;
-			}
-		}
+		public bool ContainsDownloadedBooks { get { return Name == DownloadedBooksCollectionNameInEnglish; } }
 
 		/// <summary>
 		/// This includes everything in "factoryCollections" (i.e. Templates folder AND Sample Shells:Vaccinations folder)
 		/// </summary>
-		public bool IsFactoryTemplates { get { return PathToDirectory.Contains(FactoryDir); } }
+		public bool IsFactoryInstalled { get { return PathToDirectory.Contains(ProjectContext.FactoryCollectionsDirectory); } }
 
 		private FileSystemWatcher _watcher;
 		/// <summary>

--- a/src/BloomExe/CollectionCreating/CollectionNameControl.cs
+++ b/src/BloomExe/CollectionCreating/CollectionNameControl.cs
@@ -75,9 +75,7 @@ namespace Bloom.CollectionCreating
 				}
 
 				_collectionInfo.PathToSettingsFile = CollectionSettings.GetPathForNewSettings(_destinationDirectory, _collectionNameControl.Text);
-				if (DestinationAlreadyExists)
-					return false;
-				return true;
+				return !DestinationAlreadyExists && _collectionNameControl.Text.ToLowerInvariant() != "templates";
 		}
 
 		private bool DestinationAlreadyExists

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -723,9 +723,11 @@ namespace Bloom.CollectionTab
 		{
 			foreach (var btn in AllBookButtons())
 			{
-				if ((btn.Tag as BookButtonInfo).BookInfo == bookInfo)
+				var bookButtonInfo = btn.Tag as BookButtonInfo;
+				if (bookButtonInfo.BookInfo == bookInfo)
 				{
-					btn.Paint += btn_Paint;
+					// BL-2678 don't display menu triangle if there's no menu to display
+					if(!bookButtonInfo.IsFactoryTemplate) btn.Paint += btn_Paint;
 					btn.FlatAppearance.BorderColor = Palette.TextAgainstDarkBackground;
 				}
 				else
@@ -953,10 +955,15 @@ namespace Bloom.CollectionTab
 			var button = FindBookButton(SelectedBook.BookInfo);
 			if (_model.DeleteBook(SelectedBook))
 			{
-				Debug.Assert(button != null && _primaryCollectionFlow.Controls.Contains(button));
-				if (button != null && _primaryCollectionFlow.Controls.Contains(button))
+				Debug.Assert(button != null);
+				if (button != null)
 				{
-					_primaryCollectionFlow.Controls.Remove(button);
+					// BL-2678 it must be in one or the other, but now it could be
+					// a book downloaded from BloomLibrary.org
+					if (_primaryCollectionFlow.Controls.Contains(button))
+						_primaryCollectionFlow.Controls.Remove(button);
+					else
+						_sourceBooksFlow.Controls.Remove(button);
 				}
 			}
 		}

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -397,22 +397,22 @@ namespace Bloom.CollectionTab
 		{
 			collection.CollectionChanged += OnCollectionChanged;
 			bool loadedAtLeastOneBook = false;
-			foreach (Book.BookInfo bookInfo in collection.GetBookInfos())
+			foreach (var bookInfo in collection.GetBookInfos())
 			{
 				try
 				{
 					if (!bookInfo.IsExperimental || Settings.Default.ShowExperimentalBooks)
 					{
 						loadedAtLeastOneBook = true;
-						AddOneBook(bookInfo, flowLayoutPanel, collection.Name.ToLowerInvariant() == "templates");
+						AddOneBook(bookInfo, flowLayoutPanel, collection.IsFactoryTemplates, collection.IsDownloaded);
 					}
 				}
 				catch (Exception error)
 				{
-					Palaso.Reporting.ErrorReport.NotifyUserOfProblem(error, "Could not load the book at " + bookInfo.FolderPath);
+					ErrorReport.NotifyUserOfProblem(error, "Could not load the book at " + bookInfo.FolderPath);
 				}
 			}
-			if (collection.Name == BookCollection.DownloadedBooksCollectionNameInEnglish)
+			if (collection.IsDownloaded)
 			{
 				_downloadedBookCollection = collection;
 				collection.FolderContentChanged += DownLoadedBooksChanged;
@@ -503,10 +503,10 @@ namespace Bloom.CollectionTab
 			get { return Parent.Parent.Parent.Parent != null; }
 		}
 
-		private void AddOneBook(BookInfo bookInfo, FlowLayoutPanel flowLayoutPanel, bool localizeTitle)
+		private void AddOneBook(BookInfo bookInfo, FlowLayoutPanel flowLayoutPanel, bool isFactoryTemplatesCollection, bool isFromBloomLibrary)
 		{
 			string title = bookInfo.QuickTitleUserDisplay;
-			if (localizeTitle)
+			if (isFactoryTemplatesCollection)
 				title = LocalizationManager.GetDynamicString("Bloom", "TemplateBooks.BookName." + title, title);
 
 			var button = new Button
@@ -519,7 +519,7 @@ namespace Bloom.CollectionTab
 				FlatStyle = FlatStyle.Flat,
 				ForeColor = Palette.TextAgainstDarkBackground,
 				UseMnemonic = false, //otherwise, it tries to interpret '&' as a shortcut
-				ContextMenuStrip = _bookContextMenu,
+				ContextMenuStrip = isFactoryTemplatesCollection ? null : (isFromBloomLibrary ? _bloomLibraryContextMenu : _bookContextMenu),
 				AutoSize = false,
 
 				Tag = bookInfo
@@ -1150,7 +1150,7 @@ namespace Bloom.CollectionTab
 			}
 
 			// directory for the new book
-			var newBookName = GetAvaialableDirectory(collectionDir, baseName, copyNum);
+			var newBookName = GetAvailableDirectory(collectionDir, baseName, copyNum);
 			var newBookDir = Path.Combine(collectionDir, newBookName);
 			Directory.CreateDirectory(newBookDir);
 
@@ -1182,7 +1182,7 @@ namespace Bloom.CollectionTab
 		/// <param name="baseName"></param>
 		/// <param name="copyNum"></param>
 		/// <returns></returns>
-		private static string GetAvaialableDirectory(string collectionDir, string baseName, int copyNum)
+		private static string GetAvailableDirectory(string collectionDir, string baseName, int copyNum)
 		{
 			string newName;
 			if (copyNum == 1)

--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -91,7 +91,7 @@ namespace Bloom.CollectionTab
 				_bookCollections = new List<BookCollection>(GetBookCollectionsOnce());
 
 				//we want the templates to be second (after the vernacular collection) regardless of alphabetical sorting
-				var templates = _bookCollections.First(c => c.IsFactoryTemplates);
+				var templates = _bookCollections.First(c => c.Name.ToLowerInvariant() == "templates");
 				_bookCollections.Remove(templates);
 				_bookCollections.Insert(1,templates);
 			}
@@ -112,7 +112,7 @@ namespace Bloom.CollectionTab
 			get { return TheOneEditableCollection.GetBookInfos().Select(book => book.Title); }
 		}
 
-		private BookCollection TheOneEditableCollection
+		internal BookCollection TheOneEditableCollection
 		{
 			get { return GetBookCollections().First(c => c.Type == BookCollection.CollectionType.TheOneEditableCollection); }
 		}

--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -91,7 +91,7 @@ namespace Bloom.CollectionTab
 				_bookCollections = new List<BookCollection>(GetBookCollectionsOnce());
 
 				//we want the templates to be second (after the vernacular collection) regardless of alphabetical sorting
-				var templates = _bookCollections.First(c => c.Name.ToLowerInvariant() == "templates");
+				var templates = _bookCollections.First(c => c.IsFactoryTemplates);
 				_bookCollections.Remove(templates);
 				_bookCollections.Insert(1,templates);
 			}

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -390,7 +390,11 @@ namespace Bloom
 				}
 			}
 		}
-		private static string FactoryCollectionsDirectory
+
+		/// <summary>
+		/// Directory that contains both Templates and Sample Shells factory installed with Bloom
+		/// </summary>
+		public static string FactoryCollectionsDirectory
 		{
 			get { return FileLocator.GetDirectoryDistributedWithApplication("factoryCollections"); }
 		}


### PR DESCRIPTION
Eliminates context menu for books distributed with Bloom. Allows deletion of books downloaded from BloomLibrary.org. Limits context menu in ways set out in BL-2678.

Also disallows using 'templates' or some case variant as a new collection name.