### PR TITLE
BL-2626 Prevent opening invalid collection

### DIFF
--- a/src/BloomExe/CollectionChoosing/MostRecentPathsList.cs
+++ b/src/BloomExe/CollectionChoosing/MostRecentPathsList.cs
@@ -92,5 +92,10 @@ namespace Bloom.CollectionChoosing
 			_paths.Insert(0, path);
 			return true;
 		}
+
+		public void RemovePath(string path)
+		{
+			_paths.Remove(path);
+		}
 	}
 }

--- a/src/BloomExe/CollectionChoosing/OpenCreateCloneControl.cs
+++ b/src/BloomExe/CollectionChoosing/OpenCreateCloneControl.cs
@@ -210,22 +210,29 @@ namespace Bloom.CollectionChoosing
 			SelectedPath = path;
 			if (!string.IsNullOrEmpty(path))
 			{
-				if (IsInASourceCollectionFolder(path))
-				{
-					var msg = L10NSharp.LocalizationManager.GetString("OpenCreateCloneControl.InSourceCollectionMessage",
-						"This collection is part of your 'Sources for new books' which you can see in the bottom left of the Collections tab. It cannot be opened for editing.");
-					MessageBox.Show(msg);
-					return;
-				}
+				if (ReportIfInvalidCollectionToEdit(path)) return;
 				CheckForBeingInDropboxFolder(path);
 				_mruList.AddNewPath(path);
 				Invoke(DoneChoosingOrCreatingLibrary);
 			}
 		}
 
-		private bool IsInASourceCollectionFolder(string path)
+		public static bool ReportIfInvalidCollectionToEdit(string path)
 		{
-			return path.StartsWith(ProjectContext.GetInstalledCollectionsDirectory());
+			if (IsInvalidCollectionToEdit(path))
+			{
+				var msg = L10NSharp.LocalizationManager.GetString("OpenCreateCloneControl.InSourceCollectionMessage",
+					"This collection is part of your 'Sources for new books' which you can see in the bottom left of the Collections tab. It cannot be opened for editing.");
+				MessageBox.Show(msg);
+				return true;
+			}
+			return false;
+		}
+
+		public static bool IsInvalidCollectionToEdit(string path)
+		{
+			return path.StartsWith(ProjectContext.GetInstalledCollectionsDirectory())
+				|| path.StartsWith(ProjectContext.FactoryCollectionsDirectory);
 		}
 
 		/// <summary>

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -236,6 +236,8 @@ namespace Bloom
 						if (args.Length == 1 && !IsInstallerLaunch(args))
 						{
 							Debug.Assert(args[0].ToLowerInvariant().EndsWith(".bloomcollection")); // Anything else handled above.
+							if (CollectionChoosing.OpenCreateCloneControl.ReportIfInvalidCollectionToEdit(args[0]))
+								return;
 							Settings.Default.MruProjects.AddNewPath(args[0]);
 						}
 
@@ -531,6 +533,12 @@ namespace Bloom
 			if (!string.IsNullOrEmpty(path))
 			{
 				CollectionChoosing.OpenCreateCloneControl.CheckForBeingInDropboxFolder(path);
+				while (CollectionChoosing.OpenCreateCloneControl.IsInvalidCollectionToEdit(path))
+				{
+					// Somehow...from a previous version?...we have an invalid file in our MRU list.
+					Settings.Default.MruProjects.RemovePath(path);
+					path = Settings.Default.MruProjects.Latest;
+				}
 			}
 
 			if (path == null || !OpenProjectWindow(path))


### PR DESCRIPTION
Try 2: identifies more invalid collections and
prevents more ways of opening them. Hopefully
all of them now!