### PR TITLE
Update the debian package version to 3.3.4 on Version3.3 branch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bloom-desktop-beta (3.3.4) stable; urgency=medium
+
+  * More bug fixes: see the source repository log on the Version3.3 branch.
+
+ -- Stephen McConnel <stephen_mcconnel@sil.org>  Fri, 04 Sep 2015 11:08:17 -0500
+
 bloom-desktop-beta (3.3.3) stable; urgency=medium
 
   * Add comment to rules and adjust FULL_BUILD_NUMBER to match this file.

--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@ SHARE   = usr/share/$(PACKAGE)
 
 # NOTE: make the third (and fourth?) number match changelog if you are
 # building the package manually.
-FULL_BUILD_NUMBER ?= 0.0.3.0
+FULL_BUILD_NUMBER ?= 0.0.4.0
 
 %:
 	dh $@ --with=cli --parallel


### PR DESCRIPTION
This is in preparation for building new beta packages for Linux from the Version3.3 branch.