### PR TITLE
Fix bl-120 by making XMatter receive title data-book elms for all langs

### DIFF
--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.css
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.css
@@ -1,11 +1,10 @@
-﻿.bloom-frontMatter .pageLabel:after,
+.bloom-frontMatter .pageLabel:after,
 .bloom-backMatter .pageLabel:after {
   content: ": Factory Front/Back Matter";
 }
 .A4Portrait.outsideFrontCover .marginBox,
 .A4Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 272mm;
   left: 15mm;
   width: 180mm;
@@ -13,13 +12,11 @@
 .A4Portrait.outsideFrontCover .marginBox IMG,
 .A4Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 180mm;
 }
 .A4Landscape.outsideFrontCover .marginBox,
 .A4Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 185mm;
   left: 15mm;
   width: 267mm;
@@ -27,13 +24,11 @@
 .A4Landscape.outsideFrontCover .marginBox IMG,
 .A4Landscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 267mm;
 }
 .A5Portrait.outsideFrontCover .marginBox,
 .A5Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 185mm;
   left: 15mm;
   width: 118mm;
@@ -41,13 +36,11 @@
 .A5Portrait.outsideFrontCover .marginBox IMG,
 .A5Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 118mm;
 }
 .A5Landscape.outsideFrontCover .marginBox,
 .A5Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 123mm;
   left: 15mm;
   width: 180mm;
@@ -55,13 +48,11 @@
 .A5Landscape.outsideFrontCover .marginBox IMG,
 .A5Landscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 180mm;
 }
 .A6Portrait.outsideFrontCover .marginBox,
 .A6Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 123mm;
   left: 15mm;
   width: 75mm;
@@ -69,13 +60,11 @@
 .A6Portrait.outsideFrontCover .marginBox IMG,
 .A6Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 75mm;
 }
 .A6Landscape.outsideFrontCover .marginBox,
 .A6Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 80mm;
   left: 15mm;
   width: 118mm;
@@ -83,13 +72,11 @@
 .A6Landscape.outsideFrontCover .marginBox IMG,
 .A6Landscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 118mm;
 }
 .B5Portrait.outsideFrontCover .marginBox,
 .B5Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 225mm;
   left: 15mm;
   width: 146mm;
@@ -97,92 +84,79 @@
 .B5Portrait.outsideFrontCover .marginBox IMG,
 .B5Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 146mm;
 }
 .LetterPortrait.outsideFrontCover .marginBox,
 .LetterPortrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 10.015748031496063in;
+  height: 10.01574803in;
   left: 15mm;
-  width: 7.318897637795276in;
+  width: 7.31889764in;
 }
 .LetterPortrait.outsideFrontCover .marginBox IMG,
 .LetterPortrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 7.318897637795276in;
+  max-width: 7.31889764in;
 }
 .LetterLandscape.outsideFrontCover .marginBox,
 .LetterLandscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 7.515748031496063in;
+  height: 7.51574803in;
   left: 15mm;
-  width: 9.818897637795276in;
+  width: 9.81889764in;
 }
 .LetterLandscape.outsideFrontCover .marginBox IMG,
 .LetterLandscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 9.818897637795276in;
+  max-width: 9.81889764in;
 }
 .HalfLetterPortrait.outsideFrontCover .marginBox,
 .HalfLetterPortrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 7.515748031496063in;
+  height: 7.51574803in;
   left: 15mm;
-  width: 4.318897637795276in;
+  width: 4.31889764in;
 }
 .HalfLetterPortrait.outsideFrontCover .marginBox IMG,
 .HalfLetterPortrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 4.318897637795276in;
+  max-width: 4.31889764in;
 }
 .HalfLetterLandscape.outsideFrontCover .marginBox,
 .HalfLetterLandscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 4.515748031496063in;
+  height: 4.51574803in;
   left: 15mm;
-  width: 7.318897637795276in;
+  width: 7.31889764in;
 }
 .HalfLetterLandscape.outsideFrontCover .marginBox IMG,
 .HalfLetterLandscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 7.318897637795276in;
+  max-width: 7.31889764in;
 }
 .QuarterLetterPortrait.outsideFrontCover .marginBox,
 .QuarterLetterPortrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 4.515748031496063in;
+  height: 4.51574803in;
   left: 15mm;
-  width: 3.068897637795276in;
+  width: 3.06889764in;
 }
 .QuarterLetterPortrait.outsideFrontCover .marginBox IMG,
 .QuarterLetterPortrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 3.068897637795276in;
+  max-width: 3.06889764in;
 }
 .QuarterLetterLandscape.outsideFrontCover .marginBox,
 .QuarterLetterLandscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 3.265748031496063in;
+  height: 3.26574803in;
   left: 15mm;
-  width: 4.318897637795276in;
+  width: 4.31889764in;
 }
 .QuarterLetterLandscape.outsideFrontCover .marginBox IMG,
 .QuarterLetterLandscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 4.318897637795276in;
+  max-width: 4.31889764in;
 }
 .insideFrontCover .bloom-content1 {
   display: inherit;
@@ -478,4 +452,3 @@ BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1
 .ISBNContainer .ISBNContainer SPAN {
   vertical-align: top;
 }
-/*# sourceMappingURL=Factory-XMatter.css.map */

--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
@@ -17,7 +17,6 @@
       <div lang="en" class="pageDescription"></div>
       <div class="marginBox">
         <div class="bloom-translationGroup bookTitle">
-          <label class="bubble">Book title in {lang}</label>
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable bloom-nodefaultstylerule Title-On-Cover-style" data-book="bookTitle">
           </div>
         </div>
@@ -72,7 +71,6 @@
       <div lang="en" class="pageDescription"></div>
       <div class="marginBox">
         <div class="bloom-translationGroup" id="titlePageTitleBlock">
-          <label class="bubble">Book title in {lang}</label>
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable Title-On-Title-Page-style" data-book="bookTitle">
           </div>
         </div>

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.css
@@ -1,11 +1,10 @@
-﻿.bloom-frontMatter .pageLabel:after,
+.bloom-frontMatter .pageLabel:after,
 .bloom-backMatter .pageLabel:after {
   content: ": SIL-Cameroon Front/Back Matter";
 }
 .A4Portrait.outsideFrontCover .marginBox,
 .A4Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 272mm;
   left: 15mm;
   width: 180mm;
@@ -13,13 +12,11 @@
 .A4Portrait.outsideFrontCover .marginBox IMG,
 .A4Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 180mm;
 }
 .A4Landscape.outsideFrontCover .marginBox,
 .A4Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 185mm;
   left: 15mm;
   width: 267mm;
@@ -27,13 +24,11 @@
 .A4Landscape.outsideFrontCover .marginBox IMG,
 .A4Landscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 267mm;
 }
 .A5Portrait.outsideFrontCover .marginBox,
 .A5Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 185mm;
   left: 15mm;
   width: 118mm;
@@ -41,13 +36,11 @@
 .A5Portrait.outsideFrontCover .marginBox IMG,
 .A5Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 118mm;
 }
 .A5Landscape.outsideFrontCover .marginBox,
 .A5Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 123mm;
   left: 15mm;
   width: 180mm;
@@ -55,13 +48,11 @@
 .A5Landscape.outsideFrontCover .marginBox IMG,
 .A5Landscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 180mm;
 }
 .A6Portrait.outsideFrontCover .marginBox,
 .A6Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 123mm;
   left: 15mm;
   width: 75mm;
@@ -69,13 +60,11 @@
 .A6Portrait.outsideFrontCover .marginBox IMG,
 .A6Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 75mm;
 }
 .A6Landscape.outsideFrontCover .marginBox,
 .A6Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 80mm;
   left: 15mm;
   width: 118mm;
@@ -83,13 +72,11 @@
 .A6Landscape.outsideFrontCover .marginBox IMG,
 .A6Landscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 118mm;
 }
 .B5Portrait.outsideFrontCover .marginBox,
 .B5Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 225mm;
   left: 15mm;
   width: 146mm;
@@ -97,92 +84,79 @@
 .B5Portrait.outsideFrontCover .marginBox IMG,
 .B5Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 146mm;
 }
 .LetterPortrait.outsideFrontCover .marginBox,
 .LetterPortrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 10.015748031496063in;
+  height: 10.01574803in;
   left: 15mm;
-  width: 7.318897637795276in;
+  width: 7.31889764in;
 }
 .LetterPortrait.outsideFrontCover .marginBox IMG,
 .LetterPortrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 7.318897637795276in;
+  max-width: 7.31889764in;
 }
 .LetterLandscape.outsideFrontCover .marginBox,
 .LetterLandscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 7.515748031496063in;
+  height: 7.51574803in;
   left: 15mm;
-  width: 9.818897637795276in;
+  width: 9.81889764in;
 }
 .LetterLandscape.outsideFrontCover .marginBox IMG,
 .LetterLandscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 9.818897637795276in;
+  max-width: 9.81889764in;
 }
 .HalfLetterPortrait.outsideFrontCover .marginBox,
 .HalfLetterPortrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 7.515748031496063in;
+  height: 7.51574803in;
   left: 15mm;
-  width: 4.318897637795276in;
+  width: 4.31889764in;
 }
 .HalfLetterPortrait.outsideFrontCover .marginBox IMG,
 .HalfLetterPortrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 4.318897637795276in;
+  max-width: 4.31889764in;
 }
 .HalfLetterLandscape.outsideFrontCover .marginBox,
 .HalfLetterLandscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 4.515748031496063in;
+  height: 4.51574803in;
   left: 15mm;
-  width: 7.318897637795276in;
+  width: 7.31889764in;
 }
 .HalfLetterLandscape.outsideFrontCover .marginBox IMG,
 .HalfLetterLandscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 7.318897637795276in;
+  max-width: 7.31889764in;
 }
 .QuarterLetterPortrait.outsideFrontCover .marginBox,
 .QuarterLetterPortrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 4.515748031496063in;
+  height: 4.51574803in;
   left: 15mm;
-  width: 3.068897637795276in;
+  width: 3.06889764in;
 }
 .QuarterLetterPortrait.outsideFrontCover .marginBox IMG,
 .QuarterLetterPortrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 3.068897637795276in;
+  max-width: 3.06889764in;
 }
 .QuarterLetterLandscape.outsideFrontCover .marginBox,
 .QuarterLetterLandscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 3.265748031496063in;
+  height: 3.26574803in;
   left: 15mm;
-  width: 4.318897637795276in;
+  width: 4.31889764in;
 }
 .QuarterLetterLandscape.outsideFrontCover .marginBox IMG,
 .QuarterLetterLandscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 4.318897637795276in;
+  max-width: 4.31889764in;
 }
 .insideFrontCover .bloom-content1 {
   display: inherit;
@@ -478,4 +452,3 @@ BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1
 .ISBNContainer .ISBNContainer SPAN {
   vertical-align: top;
 }
-/*# sourceMappingURL=SIL-Cameroon-XMatter.css.map */

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.htm
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.htm
@@ -17,7 +17,6 @@
       <div lang="en" class="pageDescription"></div>
       <div class="marginBox">
         <div class="bloom-translationGroup bookTitle">
-          <label class="bubble">Book title in {lang}</label>
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable bloom-nodefaultstylerule Title-On-Cover-style" data-book="bookTitle">
           </div>
         </div>
@@ -52,7 +51,6 @@
       <div lang="en" class="pageDescription"></div>
       <div class="marginBox">
         <div class="bloom-translationGroup" id="titlePageTitleBlock">
-          <label class="bubble">Book title in {lang}</label>
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable Title-On-Title-Page-style" data-book="bookTitle">
           </div>
         </div>

--- a/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
+++ b/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.css
@@ -1,11 +1,10 @@
-﻿.bloom-frontMatter .pageLabel:after,
+.bloom-frontMatter .pageLabel:after,
 .bloom-backMatter .pageLabel:after {
   content: ": Traditional Front/Back Matter";
 }
 .A4Portrait.outsideFrontCover .marginBox,
 .A4Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 272mm;
   left: 15mm;
   width: 180mm;
@@ -13,13 +12,11 @@
 .A4Portrait.outsideFrontCover .marginBox IMG,
 .A4Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 180mm;
 }
 .A4Landscape.outsideFrontCover .marginBox,
 .A4Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 185mm;
   left: 15mm;
   width: 267mm;
@@ -27,13 +24,11 @@
 .A4Landscape.outsideFrontCover .marginBox IMG,
 .A4Landscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 267mm;
 }
 .A5Portrait.outsideFrontCover .marginBox,
 .A5Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 185mm;
   left: 15mm;
   width: 118mm;
@@ -41,13 +36,11 @@
 .A5Portrait.outsideFrontCover .marginBox IMG,
 .A5Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 118mm;
 }
 .A5Landscape.outsideFrontCover .marginBox,
 .A5Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 123mm;
   left: 15mm;
   width: 180mm;
@@ -55,13 +48,11 @@
 .A5Landscape.outsideFrontCover .marginBox IMG,
 .A5Landscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 180mm;
 }
 .A6Portrait.outsideFrontCover .marginBox,
 .A6Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 123mm;
   left: 15mm;
   width: 75mm;
@@ -69,13 +60,11 @@
 .A6Portrait.outsideFrontCover .marginBox IMG,
 .A6Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 75mm;
 }
 .A6Landscape.outsideFrontCover .marginBox,
 .A6Landscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 80mm;
   left: 15mm;
   width: 118mm;
@@ -83,13 +72,11 @@
 .A6Landscape.outsideFrontCover .marginBox IMG,
 .A6Landscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 118mm;
 }
 .B5Portrait.outsideFrontCover .marginBox,
 .B5Portrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
   height: 225mm;
   left: 15mm;
   width: 146mm;
@@ -97,92 +84,79 @@
 .B5Portrait.outsideFrontCover .marginBox IMG,
 .B5Portrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
   max-width: 146mm;
 }
 .LetterPortrait.outsideFrontCover .marginBox,
 .LetterPortrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 10.015748031496063in;
+  height: 10.01574803in;
   left: 15mm;
-  width: 7.318897637795276in;
+  width: 7.31889764in;
 }
 .LetterPortrait.outsideFrontCover .marginBox IMG,
 .LetterPortrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 7.318897637795276in;
+  max-width: 7.31889764in;
 }
 .LetterLandscape.outsideFrontCover .marginBox,
 .LetterLandscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 7.515748031496063in;
+  height: 7.51574803in;
   left: 15mm;
-  width: 9.818897637795276in;
+  width: 9.81889764in;
 }
 .LetterLandscape.outsideFrontCover .marginBox IMG,
 .LetterLandscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 9.818897637795276in;
+  max-width: 9.81889764in;
 }
 .HalfLetterPortrait.outsideFrontCover .marginBox,
 .HalfLetterPortrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 7.515748031496063in;
+  height: 7.51574803in;
   left: 15mm;
-  width: 4.318897637795276in;
+  width: 4.31889764in;
 }
 .HalfLetterPortrait.outsideFrontCover .marginBox IMG,
 .HalfLetterPortrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 4.318897637795276in;
+  max-width: 4.31889764in;
 }
 .HalfLetterLandscape.outsideFrontCover .marginBox,
 .HalfLetterLandscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 4.515748031496063in;
+  height: 4.51574803in;
   left: 15mm;
-  width: 7.318897637795276in;
+  width: 7.31889764in;
 }
 .HalfLetterLandscape.outsideFrontCover .marginBox IMG,
 .HalfLetterLandscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 7.318897637795276in;
+  max-width: 7.31889764in;
 }
 .QuarterLetterPortrait.outsideFrontCover .marginBox,
 .QuarterLetterPortrait.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 4.515748031496063in;
+  height: 4.51574803in;
   left: 15mm;
-  width: 3.068897637795276in;
+  width: 3.06889764in;
 }
 .QuarterLetterPortrait.outsideFrontCover .marginBox IMG,
 .QuarterLetterPortrait.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 3.068897637795276in;
+  max-width: 3.06889764in;
 }
 .QuarterLetterLandscape.outsideFrontCover .marginBox,
 .QuarterLetterLandscape.outsideBackCover .marginBox {
   /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
-
-  height: 3.265748031496063in;
+  height: 3.26574803in;
   left: 15mm;
-  width: 4.318897637795276in;
+  width: 4.31889764in;
 }
 .QuarterLetterLandscape.outsideFrontCover .marginBox IMG,
 .QuarterLetterLandscape.outsideBackCover .marginBox IMG {
   /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-
-  max-width: 4.318897637795276in;
+  max-width: 4.31889764in;
 }
 .insideFrontCover .bloom-content1 {
   display: inherit;
@@ -478,4 +452,3 @@ BODY[bookcreationtype="translation"] .titlePage #funding .bloom-contentNational1
 .ISBNContainer .ISBNContainer SPAN {
   vertical-align: top;
 }
-/*# sourceMappingURL=Traditional-XMatter.css.map */

--- a/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.htm
+++ b/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.htm
@@ -17,7 +17,6 @@
       <div lang="en" class="pageDescription"></div>
       <div class="marginBox">
         <div class="bloom-translationGroup bookTitle">
-          <label class="bubble">Book title in {lang}</label>
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable bloom-nodefaultstylerule Title-On-Cover-style" data-book="bookTitle">
           </div>
         </div>
@@ -52,7 +51,6 @@
       <div lang="en" class="pageDescription"></div>
       <div class="marginBox">
         <div class="bloom-translationGroup" id="titlePageTitleBlock">
-          <label class="bubble">Book title in {lang}</label>
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable Title-On-Title-Page-style" data-book="bookTitle">
           </div>
         </div>

--- a/DistFiles/xMatter/bloom-xmatter-mixins.jade
+++ b/DistFiles/xMatter/bloom-xmatter-mixins.jade
@@ -97,9 +97,7 @@ mixin factoryStandard-outsideFrontCover
 		//- light of jade it is overly complicated.
 
 		+field-prototypeDeclaredExplicity.bookTitle
-			label.bubble Book title in {lang}
 			+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style(data-book='bookTitle')
-
 
 		.bloom-imageContainer
 			img(src="placeHolder.png", data-book='coverImage')
@@ -133,7 +131,6 @@ mixin factoryStandard-titlePage
 	// TITLE PAGE
 	+page-xmatter('Title Page').titlePage.bloom-frontMatter(attributes, data-export='front-matter-title-page')#5dcd48df-e9ab-4a07-afd4-6a24d0398381
 		+field-prototypeDeclaredExplicity#titlePageTitleBlock
-			label.bubble Book title in {lang}
 			+editable(kLanguageForPrototypeOnly).Title-On-Title-Page-style(data-book='bookTitle')
 		+field-prototypeDeclaredExplicity#originalContributions
 			label.bubble The contributions made by writers, illustrators, editors, etc., in {lang}

--- a/src/BloomBrowserUI/BloomBrowserUI.csproj
+++ b/src/BloomBrowserUI/BloomBrowserUI.csproj
@@ -98,6 +98,7 @@
     <Content Include="bookEdit\js\bloomEditing.js" />
     <TypeScriptCompile Include="bookEdit\bloomField\bloomFieldSpec.ts" />
     <TypeScriptCompile Include="bookEdit\js\BloomAccordion.ts" />
+    <TypeScriptCompile Include="bookEdit\js\bloomHintBubbles.ts" />
     <TypeScriptCompile Include="bookEdit\js\calledByCSharp.ts" />
     <TypeScriptCompile Include="bookEdit\js\directoryWatcher.ts" />
     <TypeScriptCompile Include="bookEdit\js\getIframeChannel.ts" />

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/bloomSourceBubbles.js
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/bloomSourceBubbles.js
@@ -1,6 +1,6 @@
 /// <reference path="../../lib/jquery.d.ts" />
 /// <reference path="../../lib/localizationManager/localizationManager.ts" />
-/// <reference path="bloomQtipUtils.ts" />
+/// <reference path="../js/bloomQtipUtils.ts" />
 /// <reference path="../StyleEditor/StyleEditor.ts" />
 var bloomSourceBubbles = (function () {
     function bloomSourceBubbles() {

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/bloomSourceBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/bloomSourceBubbles.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../lib/jquery.d.ts" />
 /// <reference path="../../lib/localizationManager/localizationManager.ts" />
-/// <reference path="bloomQtipUtils.ts" />
+/// <reference path="../js/bloomQtipUtils.ts" />
 /// <reference path="../StyleEditor/StyleEditor.ts" />
 
 interface qtipInterface extends JQuery {

--- a/src/BloomBrowserUI/test/specs/SourceBubblesSpec.js
+++ b/src/BloomBrowserUI/test/specs/SourceBubblesSpec.js
@@ -1,4 +1,4 @@
-/// <reference path="../../bookEdit/js/bloomSourceBubbles.ts" />
+/// <reference path="../../bookEdit/sourceBubbles/bloomSourceBubbles.ts" />
 /// <reference path="../../lib/jasmine/jasmine.d.ts"/>
 "use strict";
 describe("bloomSourceBubbles", function () {

--- a/src/BloomBrowserUI/test/specs/SourceBubblesSpec.ts
+++ b/src/BloomBrowserUI/test/specs/SourceBubblesSpec.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../bookEdit/js/bloomSourceBubbles.ts" />
+/// <reference path="../../bookEdit/sourceBubbles/bloomSourceBubbles.ts" />
 /// <reference path="../../lib/jasmine/jasmine.d.ts"/>
 
 "use strict";

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -916,6 +916,9 @@ namespace Bloom.Book
 			layout = Layout.FromDom(bookDOM, layout);
 				//this says, if you can't figure out the page size, use the one we got before we removed the xmatter
 			helper.InjectXMatter(_bookData.GetWritingSystemCodes(), layout);
+
+			var dataBookLangs = bookDOM.GatherDataBookLanguages();
+			TranslationGroupManager.PrepareDataBookTranslationGroups(RawDom, dataBookLangs);
 		}
 
 

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -505,7 +505,7 @@ namespace Bloom.Book
 		}
 
 		/// <summary>
-		/// walk throught the sourceDom, collecting up values from elements that have data-book or data-collection attributes.
+		/// walk through the sourceDom, collecting up values from elements that have data-book or data-collection attributes.
 		/// </summary>
 		private void GatherDataItemsFromXElement(DataSet data,
 			XmlNode sourceElement, // can be the whole sourceDom or just a page

--- a/src/BloomExe/Book/BookStarter.cs
+++ b/src/BloomExe/Book/BookStarter.cs
@@ -293,6 +293,7 @@ namespace Bloom.Book
 				var helper = new XMatterHelper(storage.Dom, xmatterName, _fileLocator);
 				helper.FolderPathForCopyingXMatterFiles = storage.FolderPath;
 				helper.InjectXMatter(data.WritingSystemAliases, sizeAndOrientation);
+				//TranslationGroupManager.PrepareDataBookTranslationGroups(storage.Dom,languages);
 			}
 		}
 

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -736,7 +736,7 @@ namespace Bloom.Book
 			var dataBookElements = RawDom.SafeSelectNodes("//div[@id='bloomDataDiv']/div[@data-book]");
 			return dataBookElements.Cast<XmlElement>()
 				.Select(node => node.GetOptionalStringAttribute("lang", null))
-				.Where(lang => !string.IsNullOrEmpty(lang) && lang!="*")
+				.Where(lang => !string.IsNullOrEmpty(lang) && (lang!="*" || lang!="z"))
 				.Distinct()
 				.ToList();
 		}

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -726,5 +726,19 @@ namespace Bloom.Book
 				node.Attributes["class"].Value = currentValue.Replace("origami-layout-mode", "");
 			}
 		}
+
+		/// <summary>
+		/// Gives all the unique language codes found in datadiv elements that have data-book
+		/// </summary>
+		/// <returns></returns>
+		public List<string> GatherDataBookLanguages()
+		{
+			var dataBookElements = RawDom.SafeSelectNodes("//div[@id='bloomDataDiv']/div[@data-book]");
+			return dataBookElements.Cast<XmlElement>()
+				.Select(node => node.GetOptionalStringAttribute("lang", null))
+				.Where(lang => !string.IsNullOrEmpty(lang) && lang!="*")
+				.Distinct()
+				.ToList();
+		}
 	}
 }

--- a/src/BloomExe/Book/TranslationGroupManager.cs
+++ b/src/BloomExe/Book/TranslationGroupManager.cs
@@ -43,13 +43,11 @@ namespace Bloom.Book
 			{
 				PrepareElementsOnPageOneLanguage(pageOrDocumentNode, collectionSettings.Language3Iso639Code);
 			}
-
-
 		}
 
 		/// <summary>
 		/// Normally, the connection between bloom-translationGroups and the dataDiv is that each bloom-editable child
-		/// (which has an @lang) pulls the corresponding string from the dataDiv. This happens in BooData.
+		/// (which has an @lang) pulls the corresponding string from the dataDiv. This happens in BookData.
 		/// 
 		/// That works except in the case of xmatter which a) start empty and b) only normally get filled with 
 		/// .bloom-editable's for the current languages. Then, when bloom would normally show a source bubble listing

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -746,5 +746,24 @@ namespace BloomTests.Book
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-book='somethingInN2' and @lang='es']", 1);
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-book='somethingInV' and @lang='xyz']", 1);
 		}
+
+		/// <summary>
+		/// This is a regression test for bl-1210, where the translation-group for title would only
+		/// get bloom-editables with the *current* languages. The problem with that is that then the
+		/// source bubble didn't offer up the title in *other* languages.
+		/// </summary>
+		/* At the moment, it doesn't appear that we need BookStarter to deal with this.
+		Keeping this test in case we decide that it does
+		[Test]
+		public void CreateBookOnDiskFromTemplate_FromFactoryVaccinations_CoverHasVariousBookTitles()
+		{
+			var source = FileLocator.GetDirectoryDistributedWithApplication("factoryCollections", "Sample Shells",
+																			"Vaccinations");
+
+			var path = GetPathToHtml(_starter.CreateBookOnDiskFromTemplate(source, _projectFolder.Path));
+
+			AssertThatXmlIn.HtmlFile(path).HasAtLeastOneMatchForXpath("//div[contains(@class,'outsideFrontCover')]//div[@data-book='bookTitle' and @lang='es' and text()]");
+			AssertThatXmlIn.HtmlFile(path).HasAtLeastOneMatchForXpath("//div[contains(@class,'outsideFrontCover')]//div[@data-book='bookTitle' and @lang='tpi' and text()]");
+		}*/
 	}
 }

--- a/src/BloomTests/Book/TranslationGroupManagerTests.cs
+++ b/src/BloomTests/Book/TranslationGroupManagerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml;
+﻿using System.Collections.Generic;
+using System.Xml;
 using Bloom.Book;
 using Bloom.Collection;
 using Moq;
@@ -328,6 +329,27 @@ namespace BloomTests.Book
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='fr']//p[not(contains(@class,'bloom-cloneToOtherLanguages'))]", 0); // get rid of all paragraphs, except for...
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='fr']//p[contains(@class,'bloom-cloneToOtherLanguages')]", 1); // the one with "bloom-cloneToOtherLanguages"
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='fr']/*[contains(text(),'Do copy me')]", 1);
+		}
+
+		[Test]
+		public void PrepareDataBookTranslationGroups_PlaceholdersCreatedAsNeeded()
+		{
+			var contents = @"<div class='bloom-page'>
+								<div class='bloom-translationGroup'>
+										<div class='bloom-editable' data-book='bookTitle' lang='en'>Some English</div>
+								</div>
+						</div>";
+			var dom = new XmlDocument();
+			dom.LoadXml(contents);
+
+			var languages = new string[] {"en","es","fr"};
+			TranslationGroupManager.PrepareDataBookTranslationGroups((XmlElement)dom.SafeSelectNodes("//div[contains(@class,'bloom-page')]")[0], languages);
+
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div/div[contains(@class, 'bloom-editable')]", 3);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='fr']", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='es']", 1);
+			//should touch the existing one
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='en' and text()='Some English']", 1);
 		}
 	}
 }


### PR DESCRIPTION
Previously, xmatter fields only received those data-book values that were in languages that the project actively uses. That meant that other languages were not there in the bloom-translationGroups, and therefore the source bubbles had nothing to show.

With this change, we make placeholders for all langs, then the get filled by pre-existing code.

This is currently limited to "bookTitle" so as to limit side affects elsewhere. We can broaden it in the future if needed.