### PR TITLE
v3.3 BL-2743 Fix AddPage dialog double-click problem

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -15,6 +15,7 @@ using Bloom.ToPalaso.Experimental;
 using Bloom.web;
 using BloomTemp;
 using DesktopAnalytics;
+using Gecko;
 using L10NSharp;
 using Newtonsoft.Json;
 using Palaso.IO;
@@ -22,8 +23,7 @@ using Palaso.Progress;
 using Palaso.Reporting;
 using Palaso.UI.WindowsForms.ClearShare;
 using Palaso.UI.WindowsForms.ImageToolbox;
-using Gecko;
-using Palaso.Xml;
+using Palaso.UI.WindowsForms.Reporting;
 
 namespace Bloom.Edit
 {
@@ -524,7 +524,7 @@ namespace Bloom.Edit
 			Logger.WriteMinorEvent("changing page selection");
 			Analytics.Track("Select Page");//not "edit page" because at the moment we don't have the capability of detecting that.
 			// Trace memory usage in case it may be useful
-			Palaso.UI.WindowsForms.Reporting.MemoryManagement.CheckMemory(false, "switched page in edit", true);
+			MemoryManagement.CheckMemory(false, "switched page in edit", true);
 
 			if (_view != null)
 			{
@@ -623,7 +623,7 @@ namespace Bloom.Edit
 		/// </summary>
 		internal void DocumentCompleted()
 		{
-			System.Windows.Forms.Application.Idle += OnIdleAfterDocumentSupposedlyCompleted;
+			Application.Idle += OnIdleAfterDocumentSupposedlyCompleted;
 		}
 
 		/// <summary>
@@ -636,7 +636,7 @@ namespace Bloom.Edit
 		/// <param name="e"></param>
 		void OnIdleAfterDocumentSupposedlyCompleted(object sender, EventArgs e)
 		{
-			System.Windows.Forms.Application.Idle -= OnIdleAfterDocumentSupposedlyCompleted;
+			Application.Idle -= OnIdleAfterDocumentSupposedlyCompleted;
 
 			//Work-around for BL-422: https://jira.sil.org/browse/BL-422
 			if (_currentlyDisplayedBook == null)
@@ -1131,7 +1131,7 @@ namespace Bloom.Edit
 
 			if (null == FontFamily.Families.FirstOrDefault(f => f.Name.ToLowerInvariant() == name))
 			{
-				var s = L10NSharp.LocalizationManager.GetString("EditTab.FontMissing",
+				var s = LocalizationManager.GetString("EditTab.FontMissing",
 														   "The current selected " +
 														   "font is '{0}', but it is not installed on this computer. Some other font will be used.");
 				return string.Format(s, _collectionSettings.DefaultLanguage1FontName);
@@ -1215,7 +1215,7 @@ namespace Bloom.Edit
 
 		public void ShowAddPageDialog()
 		{
-			this._view.ShowAddPageDialog();
+			_view.ShowAddPageDialog();
 		}
 
 		private const string URL_PREFIX = "/bloom/localhost/";

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1045,9 +1045,6 @@ namespace Bloom.Edit
 
 		public void ShowAddPageDialog()
 		{
-//			if(_view == null || _inProcessOfDeleting || _addPageDialogShowing)
-//				return;
-			//_addPageDialogShowing = true;
 			var jsonTemplates = _model.GetTemplateBookInfo;
 			//if the dialog is already showing, it is up to this method we're calling to detect that and ignore our request
 			RunJavaScript("showAddPageDialog(" + jsonTemplates + ");");

--- a/src/BloomExe/Edit/PageListView.cs
+++ b/src/BloomExe/Edit/PageListView.cs
@@ -15,6 +15,7 @@ namespace Bloom.Edit
 		private readonly EditingModel _model;
 		private bool _dontForwardSelectionEvent;
 		private IPage _pageWeThinkShouldBeSelected;
+		private DateTime _lastButtonClickedTime = DateTime.Now; // initially, instance creation time
 
 		public PageListView(PageSelection pageSelection,  RelocatePageEvent relocatePageEvent, EditingModel model,HtmlThumbNailer thumbnailProvider, NavigationIsolator isolator)
 		{
@@ -142,13 +143,13 @@ namespace Bloom.Edit
 			set { _thumbNailList.Enabled = value; }
 		}
 
-		private DateTime _lastButtonClickedTime = DateTime.Now; // initially, instance creation time
 		private void _addPageButton_Click(object sender, EventArgs e)
 		{
-			var currentTime = DateTime.Now;
-			if (_lastButtonClickedTime > currentTime.AddSeconds(-1))
+			// Turn double-click into a single-click
+			if (_lastButtonClickedTime > DateTime.Now.AddSeconds(-1))
 				return;
-			_lastButtonClickedTime = currentTime;
+			_lastButtonClickedTime = DateTime.Now;
+
 			if (_model.CanAddPages)
 			{
 				_model.ShowAddPageDialog();

--- a/src/BloomExe/Edit/PageListView.cs
+++ b/src/BloomExe/Edit/PageListView.cs
@@ -147,22 +147,28 @@ namespace Bloom.Edit
 		{
 			if (_processingClickHandler)
 				return;
-			_processingClickHandler = true;
-			if (_model.CanAddPages)
+			try
 			{
-				_model.ShowAddPageDialog();
-				// BL-2743 Make sure the dialog is actually showing before we allow another click
-				// (which will then be caught by the js and ignored)
-				Application.DoEvents();
+				_processingClickHandler = true;
+				if (_model.CanAddPages)
+				{
+					_model.ShowAddPageDialog();
+					// BL-2743 Make sure the dialog is actually showing before we allow another click
+					// (which will then be caught by the js and ignored)
+					Application.DoEvents();
+				}
+				else
+				{
+					// TODO: localize buttons
+					string message = "At this time, Bloom does not allow adding pages to a shell book.";
+					message = LocalizationManager.GetDynamicString("Bloom", "EditTab.DisabledAddPageMessage", message);
+					MessageBox.Show(message, "Bloom", MessageBoxButtons.OK, MessageBoxIcon.Information);
+				}
 			}
-			else
+			finally
 			{
-				// TODO: localize buttons
-				string message = "At this time, Bloom does not allow adding pages to a shell book.";
-				message = LocalizationManager.GetDynamicString("Bloom", "EditTab.DisabledAddPageMessage", message);
-				MessageBox.Show(message, "Bloom", MessageBoxButtons.OK, MessageBoxIcon.Information);
+				_processingClickHandler = false;
 			}
-			_processingClickHandler = false;
 		}
 	}
 }

--- a/src/BloomExe/Edit/PageListView.cs
+++ b/src/BloomExe/Edit/PageListView.cs
@@ -142,11 +142,18 @@ namespace Bloom.Edit
 			set { _thumbNailList.Enabled = value; }
 		}
 
+		private bool _processingClickHandler = false;
 		private void _addPageButton_Click(object sender, EventArgs e)
 		{
+			if (_processingClickHandler)
+				return;
+			_processingClickHandler = true;
 			if (_model.CanAddPages)
 			{
 				_model.ShowAddPageDialog();
+				// BL-2743 Make sure the dialog is actually showing before we allow another click
+				// (which will then be caught by the js and ignored)
+				Application.DoEvents();
 			}
 			else
 			{
@@ -155,6 +162,7 @@ namespace Bloom.Edit
 				message = LocalizationManager.GetDynamicString("Bloom", "EditTab.DisabledAddPageMessage", message);
 				MessageBox.Show(message, "Bloom", MessageBoxButtons.OK, MessageBoxIcon.Information);
 			}
+			_processingClickHandler = false;
 		}
 	}
 }


### PR DESCRIPTION
The js needed a chance to run and bring up the dialog window
before we allowed another click to happen. Once the dialog window
is up, the js will catch another attempt to open the dialog while the
first one is up and ignore it.

The important stuff is in PageListView. EditingModel changes are (auto?) refactoring only.