### PR TITLE
v3.3 BL-2746 migrate topics that had paragraph markers

### DIFF
--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -199,18 +199,7 @@ namespace Bloom.Book
 			// BL-2746 For awhile in v3.3, after the addition of ckeditor
 			// our topic string was getting wrapped in html paragraph markers
 			// If we find one of those, strip off the markers.
-			var englishString = topicStrings["en"];
-			if (String.IsNullOrEmpty(englishString) || !englishString.StartsWith("<p>"))
-				return;
-			const int LENGTH_TO_STRIP = 7; // length of "<p></p>"
-			if (englishString.Length > LENGTH_TO_STRIP)
-			{
-				topicStrings["en"] = englishString.Substring(3, englishString.Length - LENGTH_TO_STRIP);
-			}
-			else // this branch shouldn't actually be used, included for safety
-			{
-				topicStrings["en"] = String.Empty;
-			}
+			topicStrings["en"] = topicStrings["en"].Replace("<p>", "").Replace("</p>", "");
 			UpdateDomFromDataset(); // push migrated changes to book dom
 		}
 


### PR DESCRIPTION
Two questions:
1) Is there a better way to strip off the paragraph markers?
2) In BookData.SynchronizeDataItemsFromContentsOfElement() the first line creates a DataSet by GatherDataItemsFromCollectionSettings(), but this has already been done and there's a perfectly good (already migrated) BookData._dataSet member variable set up in the ctor of DataSet. Anybody know why we recreate the DataSet here?