### PR TITLE
v3.3 Added 3 entries to AddPageDialog localization

### DIFF
--- a/DistFiles/localization/Bloom.en.tmx
+++ b/DistFiles/localization/Bloom.en.tmx
@@ -885,6 +885,25 @@
         <seg>There was a problem downloading your book.</seg>
       </tuv>
     </tu>
+    <tu tuid="EditTab.AddPageDialog.AddPageButton">
+      <note>This is for the button that LAUNCHES the dialog, not the "Add this page" button that is IN the dialog.</note>
+      <tuv xml:lang="en">
+        <seg>Add Page</seg>
+      </tuv>
+    </tu>
+    <tu tuid="EditTab.AddPageDialog.AddThisPageButton">
+      <note>This is for the button inside the dialog</note>
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Add This Page</seg>
+      </tuv>
+    </tu>
+    <tu tuid="EditTab.AddPageDialog.Title">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Add Page...</seg>
+      </tuv>
+    </tu>
     <tu tuid="EditTab.BackMatter.InsideBackCoverTextPrompt">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">

--- a/DistFiles/localization/Bloom.fr.tmx
+++ b/DistFiles/localization/Bloom.fr.tmx
@@ -1524,6 +1524,34 @@
         <seg>Il y avait un problème de téléchargement du livre : quelque chose a pris trop de temps. Vous pouvez réessayer plus tard ou nous écrire à issues@bloomlibrary.org si vous ne pouvez pas le télécharger à partir de votre endroit.</seg>
       </tuv>
     </tu>
+    <tu tuid="EditTab.AddPageDialog.AddPageButton">
+      <note>This is for the button that LAUNCHES the dialog, not the "Add this page" button that is IN the dialog.</note>
+      <tuv xml:lang="en">
+        <seg>Add Page</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ajouter une page</seg>
+      </tuv>
+    </tu>
+    <tu tuid="EditTab.AddPageDialog.AddThisPageButton">
+      <note>This is for the button inside the dialog</note>
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Add This Page</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ajouter cette page</seg>
+      </tuv>
+    </tu>
+    <tu tuid="EditTab.AddPageDialog.Title">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Add Page...</seg>
+      </tuv>
+      <tuv xml:lang="fr">
+        <seg>Ajouter des pages...</seg>
+      </tuv>
+    </tu>
     <tu tuid="EditTab.BackMatter.InsideBackCoverTextPrompt">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">

--- a/src/BloomBrowserUI/bookEdit/js/editViewFrame.js
+++ b/src/BloomBrowserUI/bookEdit/js/editViewFrame.js
@@ -159,7 +159,7 @@ function showAddPageDialog(templatesJSON) {
     }
     parentElement.localizationManager.loadStrings(getAddPageDialogLocalizedStrings(), null, function() {
 
-        var title = parentElement.localizationManager.getText('AddPageDialog.Title', 'Add Page...');
+        var title = parentElement.localizationManager.getText('EditTab.AddPageDialog.Title', 'Add Page...');
         var dialogContents = CreateAddPageDiv(templatesJSON);
 
         theDialog = $(dialogContents).dialog({
@@ -196,7 +196,7 @@ function showAddPageDialog(templatesJSON) {
 function getAddPageDialogLocalizedStrings() {
     // Without preloading these, they are not available when the dialog is created
     var pairs = {};
-    pairs['AddPageDialog.Title'] = 'Add Page...';
+    pairs['EditTab.AddPageDialog.Title'] = 'Add Page...';
     return pairs;
 }
 

--- a/src/BloomBrowserUI/pageChooser/js/page-chooser.js
+++ b/src/BloomBrowserUI/pageChooser/js/page-chooser.js
@@ -100,7 +100,7 @@ var PageChooser = (function () {
             _this.addPageClickHandler();
         });
         var pageButton = $("#addPageButton", document);
-        localizationManager.asyncGetText('AddPageDialog.AddPageButton', 'Add This Page').done(function (translation) {
+        localizationManager.asyncGetText('EditTab.AddPageDialog.AddThisPageButton', 'Add This Page').done(function (translation) {
             pageButton.attr('value', translation);
         });
     }; // LoadInstalledCollections

--- a/src/BloomBrowserUI/pageChooser/js/page-chooser.ts
+++ b/src/BloomBrowserUI/pageChooser/js/page-chooser.ts
@@ -117,7 +117,7 @@ class PageChooser {
             this.addPageClickHandler();
         });
         var pageButton = $("#addPageButton", document);
-        localizationManager.asyncGetText('AddPageDialog.AddPageButton', 'Add This Page')
+        localizationManager.asyncGetText('EditTab.AddPageDialog.AddThisPageButton', 'Add This Page')
             .done(translation => {
                 pageButton.attr('value', translation);
             });


### PR DESCRIPTION
* moved 2 AddPageDialog entries under EditTab
* added French localization for all 3 entries

I hope we don't have to leave the old entries in and say no longer used when we're moving them to a new place in the tree structure...
[Later: actually I see there's a commit from JT that did all this and also accounts for the missing BL-2700 fix that JH just put back. It's 81ce85be133c7 on 1 Sept; but that's on master]