### PR TITLE
Bl2782 migration dropping size and orientation

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -763,12 +763,16 @@ namespace Bloom.Book
 			GuidAndPath updateTo;
 			if (!PageMigrations.TryGetValue(originalTemplateGuid, out updateTo))
 				return; // Not one we want to migrate. Possibly already done, or one we don't want to convert, or created in the field...
+			var layoutOfThisBook = GetLayout();
 			var rootFolder = FileLocator.GetDirectoryDistributedWithApplication("factoryCollections/Templates");
 			var bookPath = Path.Combine(rootFolder, updateTo.Path);
 			var templateDoc = XmlHtmlConverter.GetXmlDomFromHtmlFile(bookPath, false);
 			var newChild = (XmlElement)templateDoc.SafeSelectNodes("//div[@id='" + updateTo.Guid + "']")[0];
 			var newPage = (XmlElement)page.OwnerDocument.ImportNode(newChild, true);
 			page.ParentNode.ReplaceChild(newPage, page);
+			var classesToDrop = new[] { "imageWholePage","imageOnTop","imageInMiddle","imageOnBottom","textWholePage","pictureAndWordPage" };
+            HtmlDom.MergeClassesIntoNewPage(page, newPage, classesToDrop);
+			SizeAndOrientation.UpdatePageSizeAndOrientationClasses(newPage, layoutOfThisBook);
 			newPage.SetAttribute("id", page.Attributes["id"].Value);
 			newPage.SetAttribute("data-pagelineage", lineage.Replace(originalTemplateGuid, updateTo.Guid));
 			// migrate text

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -601,5 +601,28 @@ namespace Bloom.Book
 				node.Attributes["class"].Value = currentValue.Replace("origami-layout-mode", "");
 			}
 		}
+
+		/// <summary>
+		/// Blindly merge the classes from the source into the target.
+		/// </summary>
+		/// <param name="sourcePage"></param>
+		/// <param name="targetPage"></param>
+		/// <param name="classesToDrop"></param>
+		public static void MergeClassesIntoNewPage(XmlElement sourcePage, XmlElement targetPage, string[] classesToDrop)
+		{
+			foreach (var c in GetClasses(sourcePage))
+			{
+				if(!classesToDrop.Contains(c))
+					AddClassIfMissing(targetPage, c);
+			}
+		}
+
+		private static IEnumerable<string> GetClasses(XmlElement element)
+		{
+			var classes = element.GetAttribute("class");
+			if (String.IsNullOrEmpty(classes))
+				return new string[] {};
+			return classes.SplitTrimmed(' ');
+		}
 	}
 }

--- a/src/BloomExe/MiscUI/BloomIntegrityDialog.cs
+++ b/src/BloomExe/MiscUI/BloomIntegrityDialog.cs
@@ -24,7 +24,7 @@ namespace Bloom.MiscUI
 		public static bool CheckIntegrity()
 		{
 			var errors = new StringBuilder();
-			var files = new[] { "Bloom.chm", "PdfDroplet.exe", "Chorus.exe", "GeckofxHtmlToPdf.exe", "BloomBookUploader.exe", "optipng.exe" };
+			var files = new[] { "Bloom.chm", "PdfDroplet.exe", "Chorus.exe", "GeckofxHtmlToPdf.exe", "optipng.exe" };
 
 			var dirs = new[] { "AndikaNewBasic", "factoryCollections", "localization", "xMatter", "xslts" };
 

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -163,30 +163,30 @@ namespace BloomTests.Book
 		[Test]
 		public void MergeClassesIntoNewPage_BothEmtpy()
 		{
-			AssertHasClases("", MergeClasses("","", new[] { "dropMe" }));
+			AssertHasClasses("", MergeClasses("","", new[] { "dropMe" }));
 		}
 		[Test]
 		public void MergeClassesIntoNewPage_TargetEmpty()
 		{
-			AssertHasClases("one two", MergeClasses("one two", "", new[] {"dropMe"}));
+			AssertHasClasses("one two", MergeClasses("one two", "", new[] {"dropMe"}));
 		}
 		[Test]
 		public void MergeClassesIntoNewPage_SourceEmpty()
 		{
-			AssertHasClases("one two", MergeClasses("", "one two", new[] { "dropMe" }));
+			AssertHasClasses("one two", MergeClasses("", "one two", new[] { "dropMe" }));
 		}
 		[Test]
 		public void MergeClassesIntoNewPage_SourceAllDroppable()
 		{
-			AssertHasClases("one two", MergeClasses("dropMe dropMe dropMe ", "one two", new[] { "dropMe" }));
+			AssertHasClasses("one two", MergeClasses("dropMe dropMe dropMe ", "one two", new[] { "dropMe" }));
 		}
 		[Test]
 		public void MergeClassesIntoNewPage_MergesAndDropsItemsInDropList()
 		{
-			AssertHasClases("one two three", MergeClasses("one drop two delete", "three", new[] { "drop","delete" }));
+			AssertHasClasses("one two three", MergeClasses("one drop two delete", "three", new[] { "drop","delete" }));
 		}
 
-		private void AssertHasClases(string expectedString, string actualString)
+		private void AssertHasClasses(string expectedString, string actualString)
 		{
 			var expected = expectedString.Split(new[] { ' ' });
 			var actual = actualString.Split(new[] {' '});

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -6,6 +6,7 @@ using System.Xml;
 using NUnit.Framework;
 using Bloom.Book;
 using Palaso.TestUtilities;
+using Palaso.Xml;
 
 namespace BloomTests.Book
 {
@@ -156,6 +157,55 @@ namespace BloomTests.Book
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//head/link[9][@href='../settingsCollectionStyles.css']", 1);
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//head/link[10][@href='../customCollectionStyles.css']", 1);
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//head/link[11][@href='customBookStyles.css']", 1);
+		}
+
+
+		[Test]
+		public void MergeClassesIntoNewPage_BothEmtpy()
+		{
+			AssertHasClases("", MergeClasses("","", new[] { "dropMe" }));
+		}
+		[Test]
+		public void MergeClassesIntoNewPage_TargetEmpty()
+		{
+			AssertHasClases("one two", MergeClasses("one two", "", new[] {"dropMe"}));
+		}
+		[Test]
+		public void MergeClassesIntoNewPage_SourceEmpty()
+		{
+			AssertHasClases("one two", MergeClasses("", "one two", new[] { "dropMe" }));
+		}
+		[Test]
+		public void MergeClassesIntoNewPage_SourceAllDroppable()
+		{
+			AssertHasClases("one two", MergeClasses("dropMe dropMe dropMe ", "one two", new[] { "dropMe" }));
+		}
+		[Test]
+		public void MergeClassesIntoNewPage_MergesAndDropsItemsInDropList()
+		{
+			AssertHasClases("one two three", MergeClasses("one drop two delete", "three", new[] { "drop","delete" }));
+		}
+
+		private void AssertHasClases(string expectedString, string actualString)
+		{
+			var expected = expectedString.Split(new[] { ' ' });
+			var actual = actualString.Split(new[] {' '});
+			Assert.AreEqual(expected.Length, actual.Length);
+			foreach (var e in expected)
+			{
+				Assert.IsTrue(actual.Contains(e));
+			}
+		}
+
+		private string MergeClasses(string sourceClasses, string targetClasses, string[] classesToDrop)
+		{
+			var sourceDom = new XmlDocument();
+			sourceDom.LoadXml(string.Format("<div class='{0}'/>", sourceClasses));
+			var targetDom = new XmlDocument();
+			targetDom.LoadXml(string.Format("<div class='{0}'/>", targetClasses));
+			var targetNode = (XmlElement)targetDom.SelectSingleNode("div");
+			HtmlDom.MergeClassesIntoNewPage((XmlElement)sourceDom.SelectSingleNode("div"), targetNode, classesToDrop);
+			return targetNode.GetStringAttribute("class");
 		}
 	}
 }


### PR DESCRIPTION
Fix BL-2782 Migration to custom pages was dropping the size & layout

I added a couple tests for this and a related future problem, which is that of dropping other classes that are on the page. now, it merges the two classes, but drops the now irrelevant classes like "imageOnTop".