### PR TITLE
BL-2496 Fix LR rules to stay unselected

### DIFF
--- a/src/BloomBrowserUI/bookEdit/readerSetup/readerSetup.ui.js
+++ b/src/BloomBrowserUI/bookEdit/readerSetup/readerSetup.ui.js
@@ -587,7 +587,7 @@ function attachEventHandlers() {
             var id = this.id.replace(/^use-/, '');
             var txtBox = document.getElementById('max-' + id);
             txtBox.disabled = !this.checked;
-            $('#levels-table').find('tbody tr.selected td.' + id).html(this.checked ? txtBox.value : '');
+            $('#levels-table').find('tbody tr.selected td.' + id).html(this.checked ? txtBox.value : '-');
         });
         levelDetail.find('.level-textbox').onOnce('keyup', function () {
             var id = this.id.replace(/^max-/, '');

--- a/src/BloomBrowserUI/bookEdit/readerSetup/readerSetup.ui.ts
+++ b/src/BloomBrowserUI/bookEdit/readerSetup/readerSetup.ui.ts
@@ -733,7 +733,7 @@ function attachEventHandlers(): void {
       var id = this.id.replace(/^use-/, '');
       var txtBox: HTMLInputElement = <HTMLInputElement>document.getElementById('max-' + id);
       txtBox.disabled = !this.checked;
-      $('#levels-table').find('tbody tr.selected td.' + id).html(this.checked ? txtBox.value : '');
+      $('#levels-table').find('tbody tr.selected td.' + id).html(this.checked ? txtBox.value : '-');
     });
 
     levelDetail.find('.level-textbox').onOnce('keyup', function() {


### PR DESCRIPTION
The text box value that correctly marks a field as having no value is '-', not '' in reader setup.