### PR TITLE
Check for null ProgressDialog object (fix related to BL-2312)

### DIFF
--- a/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
@@ -400,7 +400,8 @@ namespace Bloom.WebLibraryIntegration
 			using (var tempDestination = new TemporaryFolder("BDS_" + Guid.NewGuid()))
 			{
 				var tempDirectory = Path.Combine(tempDestination.FolderPath, bookFolderName);
-				downloadProgress.Invoke((Action)(() => { downloadProgress.ProgressRangeMaximum = totalItems; }));
+				if (downloadProgress != null)
+					downloadProgress.Invoke((Action)(() => { downloadProgress.ProgressRangeMaximum = totalItems; }));
 				int booksDownloaded = 0;
 				for (int i = 0; i < matching.S3Objects.Count; ++i)
 				{
@@ -419,7 +420,8 @@ namespace Bloom.WebLibraryIntegration
 					};
 					_transferUtility.Download(req);
 					++booksDownloaded;
-					downloadProgress.Invoke((Action)(() => { downloadProgress.Progress = booksDownloaded; }));
+					if (downloadProgress != null)
+						downloadProgress.Invoke((Action)(() => { downloadProgress.Progress = booksDownloaded; }));
 				}
 				var destinationPath = Path.Combine(pathToDestinationParentDirectory, bookFolderName);
 


### PR DESCRIPTION
This should fix some failing tests.  It appears that MonoDevelop doesn't run the failing tests since they don't fail on my build machine, but do fail on the Linux build on TeamCity (as well as the Windows build).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/778)
<!-- Reviewable:end -->
