### PR TITLE
Fix BL-2789 removing generic names from source bubble for book titles

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -122,7 +122,8 @@ namespace Bloom.Book
 				}
 			}
 			FixBookIdAndLineageIfNeeded();
-			_storage.Dom.RemoveExtraContentTypesMetas();
+			_storage.Dom.RemoveExtraBookTitles();
+            _storage.Dom.RemoveExtraContentTypesMetas();
 			Guard.Against(OurHtmlDom.RawDom.InnerXml=="","Bloom could not parse the xhtml of this document");
 		}
 

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -433,6 +433,27 @@ namespace Bloom.Book
 			return _dom.SafeSelectNodes("//head/meta[@name='" + name + "']").Count > 0;
 		}
 
+		/// <summary>
+		/// Fix BL-2789, where Tok Pisin and Indonesian would show up in the source bubble for book titles, 
+		/// saying the equivalent of "new book" in each language. BasicBook doesn't have that anymore,
+		/// but this cleans it up in books made from old shells.
+		/// </summary>
+		public void RemoveExtraBookTitles()
+		{ 
+			//NB: here we're just keeping it simple, not even making sure, for example, that 
+			//"Nupela Book" is in a Tok Pisin div. If it was in English, we'd zap it as well.
+			//This xpath will collect up both divs in the data-div, and also copies of this
+			//that may be in a bloom-translationGroup in the cover and title pages.
+			var genericBookNames = new[] { "Basic Book", "Nupela Book", "Buku Dasar" };
+			foreach (XmlElement n in _dom.SafeSelectNodes("//*[@data-book='bookTitle']"))
+			{
+				if (genericBookNames.Contains(n.InnerText.Trim()))
+				{
+					n.ParentNode.RemoveChild(n);
+				}				
+			}
+		}
+
 		public void RemoveExtraContentTypesMetas()
 		{
 			bool first=true;

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -21,6 +21,7 @@ using Palaso.UI.WindowsForms.ImageToolbox;
 using Gecko;
 using TempFile = Palaso.IO.TempFile;
 using Bloom.Workspace;
+using Palaso.Network;
 
 namespace Bloom.Edit
 {
@@ -510,7 +511,8 @@ namespace Bloom.Edit
 			var imageElement = GetImageNode(ge);
 			if (imageElement == null)
 				return;
-			string fileName = imageElement.GetAttribute("src").Replace("%20", " ");
+			var src = imageElement.GetAttribute("src");
+			string fileName = HttpUtilityFromMono.UrlDecode(src);
 
 			var path = Path.Combine(_model.CurrentBook.FolderPath, fileName);
 			using (var imageInfo = PalasoImage.FromFile(path))
@@ -692,7 +694,8 @@ namespace Bloom.Edit
 			var imageElement = GetImageNode(ge);
 			if (imageElement == null)
 				return;
-			string currentPath = imageElement.GetAttribute("src").Replace("%20", " ");
+			var src = imageElement.GetAttribute ("src");
+			string currentPath = HttpUtilityFromMono.UrlDecode(src);
 
 			if (!CheckIfLockedAndWarn(currentPath))
 				return;

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -51,7 +51,7 @@ namespace Bloom.ImageProcessing
 		/// If the image has a filename, replaces any file with the same name.
 		/// </summary>
 		/// <returns>The name of the file, now in the book's folder.</returns>
-		public static string ProcessAndSaveImageIntoFolder(PalasoImage imageInfo, string bookFolderPath)
+		public static string ProcessAndSaveImageIntoFolder(PalasoImage imageInfo, string bookFolderPath, bool isSameFile)
 		{
 			LogMemoryUsage();
 			bool isEncodedAsJpeg = false;
@@ -59,7 +59,11 @@ namespace Bloom.ImageProcessing
 			{
 				isEncodedAsJpeg = AppearsToBeJpeg(imageInfo);
 				var shouldConvertToJpeg = !isEncodedAsJpeg && ShouldChangeFormatToJpeg(imageInfo.Image);
-				var imageFileName = GetFileNameToUseForSavingImage(bookFolderPath, imageInfo, isEncodedAsJpeg || shouldConvertToJpeg);
+				string imageFileName;
+				if (isSameFile)
+					imageFileName = imageInfo.FileName;
+				else
+					imageFileName = GetFileNameToUseForSavingImage(bookFolderPath, imageInfo, isEncodedAsJpeg || shouldConvertToJpeg);
 				var destinationPath = Path.Combine(bookFolderPath, imageFileName);
 				if (shouldConvertToJpeg)
 				{

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -207,5 +207,34 @@ namespace BloomTests.Book
 			HtmlDom.MergeClassesIntoNewPage((XmlElement)sourceDom.SelectSingleNode("div"), targetNode, classesToDrop);
 			return targetNode.GetStringAttribute("class");
 		}
+
+		[Test]
+		public void RemoveExtraBookTitles_BookTitlesThatAreJustGeneric_Removed()
+		{
+			var bookDom = new HtmlDom(@"<html ><head></head><body>
+				<div id='bloomDataDiv'>
+						<div data-book='bookTitle' lang='en'>something unique</div>
+						<div data-book='bookTitle' lang='id'>Buku Dasar</div>
+						<div data-book='bookTitle' lang='tpi'>Nupela Book</div>
+				</div>
+				<div id='somePage'>
+					<div class='bloom-translationGroup bookTitle'>
+						<div class='bloom-editable' data-book='bookTitle' lang='tpi'>
+							<p>Nupela Book<br/></p>
+						</div>
+						<div class='bloom-editable' data-book='bookTitle' lang='id'>
+							<p>Buku Dasar</p>
+						</div>
+						<div class='bloom-editable' data-book='bookTitle'>
+							<p>something unique<br/></p>
+						</div>
+					</div>
+				</div>
+			 </body></html>");
+			bookDom.RemoveExtraBookTitles();
+			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-book='bookTitle' and @lang='en' and text()='something unique']", 1);
+			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-book='bookTitle' and @lang='id']", 0);
+			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-book='bookTitle' and @lang='tpi']", 0);
+		}
 	}
 }

--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -56,7 +56,7 @@ namespace BloomTests.ImageProcessing
 			var image = PalasoImage.FromFile(inputPath);
 			using(var folder = new TemporaryFolder())
 			{
-				var fileName = ImageUtils.ProcessAndSaveImageIntoFolder(image, folder.Path);
+				var fileName = ImageUtils.ProcessAndSaveImageIntoFolder(image, folder.Path, false);
 				Assert.AreEqual(expectedOutputFormat == ImageFormat.Jpeg ? ".jpg" : ".png", Path.GetExtension(fileName));
 				var outputPath = folder.Combine(fileName);
 				using (var img = Image.FromFile(outputPath))


### PR DESCRIPTION
Fix BL-2789, where Tok Pisin and Indonesian would show up in the source bubble for book titles, saying the equivalent of "new book" in each language. BasicBook doesn't have that anymore, but this cleans it up in books made from old shells.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/784)
<!-- Reviewable:end -->
