### PR TITLE
Update the version number on the master branch to 3.5

### DIFF
--- a/debian/bloom
+++ b/debian/bloom
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-LIB=/usr/lib/bloom-desktop-beta
-SHARE=/usr/share/bloom-desktop-beta
+LIB=/usr/lib/bloom-desktop-unstable
+SHARE=/usr/share/bloom-desktop-unstable
 
 cd "$SHARE"
 RUNMODE=INSTALLED

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
-bloom-desktop-beta (3.4.402) stable; urgency=medium
+bloom-desktop-unstable (3.5.0) stable; urgency=medium
 
-  * Upgrade Version 3.4 to being a beta.
-  * See the source repository log for changes the last three weeks.
+  * Up the version number on the master (unstable) branch to 3.5.
+  * More bug fixes and enhancements: see the source repository log for details.
 
- -- Stephen McConnel <stephen_mcconnel@sil.org>  Tue, 22 Sep 2015 11:43:42 -0500
+ -- Stephen McConnel <stephen_mcconnel@sil.org>  Fri, 25 Sep 2015 10:04:01 -0500
 
 bloom-desktop-unstable (3.4.0) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: bloom-desktop-beta
+Source: bloom-desktop-unstable
 Section: x11
 Priority: extra
 Maintainer: Eberhard Beilharz <eb1@sil.org>
@@ -14,7 +14,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
  libicu-dev,
  icu-devtools | libicu-dev (<< 52)
 
-Package: bloom-desktop-beta
+Package: bloom-desktop-unstable
 Architecture: all
 Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  mono-sil, libgdiplus-sil, geckofx29, gtklp,
@@ -23,8 +23,8 @@ Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  optipng,
  wmctrl
 Suggests: art-of-reading
-Replaces: bloom-desktop, bloom-desktop-unstable
-Conflicts: bloom-desktop, bloom-desktop-unstable
+Replaces: bloom-desktop, bloom-desktop-beta
+Conflicts: bloom-desktop, bloom-desktop-beta
 Description: Literacy materials development for language communities
  Bloom Desktop is an application that dramatically "lowers the bar" for
  language communities who want books in their own languages. Bloom delivers

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,5 +1,5 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: bloom-desktop-beta
+Upstream-Name: bloom-desktop-unstable
 Source: https://github.com/BloomBooks/BloomDesktop
 
 Files: *

--- a/debian/install
+++ b/debian/install
@@ -1,6 +1,6 @@
-lib/dotnet/Chorus.exe.mdb usr/lib/bloom-desktop-beta/
-lib/dotnet/LibChorus.dll.mdb usr/lib/bloom-desktop-beta/
-lib/dotnet/Palaso.Media.dll.mdb usr/lib/bloom-desktop-beta/
-lib/dotnet/PalasoUIWindowsForms.GeckoBrowserAdapter.dll.mdb usr/lib/bloom-desktop-beta/
-lib/dotnet/PalasoUIWindowsForms.dll.mdb usr/lib/bloom-desktop-beta/
-lib/dotnet/SIL.Archiving.dll.mdb usr/lib/bloom-desktop-beta/
+lib/dotnet/Chorus.exe.mdb usr/lib/bloom-desktop-unstable/
+lib/dotnet/LibChorus.dll.mdb usr/lib/bloom-desktop-unstable/
+lib/dotnet/Palaso.Media.dll.mdb usr/lib/bloom-desktop-unstable/
+lib/dotnet/PalasoUIWindowsForms.GeckoBrowserAdapter.dll.mdb usr/lib/bloom-desktop-unstable/
+lib/dotnet/PalasoUIWindowsForms.dll.mdb usr/lib/bloom-desktop-unstable/
+lib/dotnet/SIL.Archiving.dll.mdb usr/lib/bloom-desktop-unstable/

--- a/debian/rules
+++ b/debian/rules
@@ -7,14 +7,14 @@
 export MONO_PREFIX = /opt/mono-sil
 export BUILD = Release
 
-PACKAGE = bloom-desktop-beta
+PACKAGE = bloom-desktop-unstable
 DESTDIR = debian/$(PACKAGE)
 LIB     = usr/lib/$(PACKAGE)
 SHARE   = usr/share/$(PACKAGE)
 
 # NOTE: make the third (and fourth?) number match changelog if you are
 # building the package manually.
-FULL_BUILD_NUMBER ?= 0.0.402.0
+FULL_BUILD_NUMBER ?= 0.0.0.0
 
 %:
 	dh $@ --with=cli --parallel


### PR DESCRIPTION
Also undo a merge from Version3.4 that renamed the package to
bloom-desktop-beta instead of bloom-desktop-unstable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/785)
<!-- Reviewable:end -->
