### PR TITLE
Fix BL-2809 by not allowing booklet option when you choose letter

### DIFF
--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -258,7 +258,11 @@ namespace Bloom.Publish
 
 		public bool ShowBookletOption
 		{
-			get { return BookSelection.CurrentSelection.BookInfo.BookletMakingIsAppropriate; }
+			get
+			{
+				return BookSelection.CurrentSelection.BookInfo.BookletMakingIsAppropriate &&
+				       BookSelection.CurrentSelection.GetLayout().SizeAndOrientation.PageSizeName != "Letter";
+			}
 		}
 
 		public bool ShowCoverOption

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -168,13 +168,18 @@ namespace Bloom.Publish
 			// We choose not to remember the last state this tab might have been in.
 			// Also since we don't know if the pdf is out of date, we assume it is, and don't show the prior pdf.
 			// SetModelFromButtons takes care of both of these things for the model
-			_bookletCoverRadio.Checked = _bookletBodyRadio.Checked = _simpleAllPagesRadio.Checked = _uploadRadio.Checked = false;
+			ClearRadioButtons();
 			SetModelFromButtons();
 			_model.DisplayMode = PublishModel.DisplayModes.WaitForUserToChooseSomething;
 
 			UpdateDisplay();
 
 			_activated = true;
+		}
+
+		private void ClearRadioButtons()
+		{
+			_bookletCoverRadio.Checked = _bookletBodyRadio.Checked = _simpleAllPagesRadio.Checked = _uploadRadio.Checked = false;
 		}
 
 		internal bool IsMakingPdf
@@ -298,7 +303,9 @@ namespace Bloom.Publish
 			var item = (ToolStripMenuItem)sender;
 			_model.PageLayout = ((Layout)item.Tag);
 			_layoutChoices.Text = _model.PageLayout.ToString();
-			ControlsChanged();
+			ClearRadioButtons();
+			UpdateDisplay();
+			SetDisplayMode(PublishModel.DisplayModes.WaitForUserToChooseSomething);
 		}
 
 		public void SetDisplayMode(PublishModel.DisplayModes displayMode)


### PR DESCRIPTION
Fix BL-2809 by not allowing booklet option when you choose letter

Limiting this actually helps shape the user's mental model towards how this really works; if they think "I'm going to print a booklet with my letter paper", then really we need them to choose "half letter" anyhow. Unlike with metric sizes which can be easily doubled/halved, double of "letter size" is... unusual. We can always enable this if there is demand for it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/787)
<!-- Reviewable:end -->
