### PR TITLE
Fix BL-2847 epub does not show images that have spaces

### DIFF
--- a/src/BloomExe/Publish/EpubMaker.cs
+++ b/src/BloomExe/Publish/EpubMaker.cs
@@ -712,8 +712,8 @@ namespace Bloom.Publish
 				originalFileName = srcPath.Substring(Storage.FolderPath.Length + 1).Replace("\\", "/"); // allows keeping folder structure
 			else
 				originalFileName = Path.GetFileName(srcPath); // probably can't happen, but in case, put at root.
-			string fileName = originalFileName.Replace(" ", "_");
-			var dstPath = Path.Combine(_contentFolder, fileName);
+			string fileName = originalFileName;
+            var dstPath = Path.Combine(_contentFolder, fileName);
 			// We deleted the root directory at the start, so if the file is already
 			// there it is a clash, either multiple sources for files with the same name,
 			// or produced by replacing spaces, or something. Come up with a similar unique name.


### PR DESCRIPTION
It's not clear why the code was previously changing spaces to underscores, but it appeared to be done in the saving of the file, but not in the html, at least in the case reported in BL-2847, which was a cover page and so may have something special going on. As a potential fix for JT to review, I've just removed that conversion as I can't see a reason to do it, it could potentially give us the wrong image (if 2 images differed only by this distinction), and it seems to work fine without it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/813)
<!-- Reviewable:end -->
