### PR TITLE
Fix links in ProblemReporterDialog

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -23,6 +23,7 @@ using Palaso.UI.WindowsForms.Reporting;
 using Palaso.UI.WindowsForms.UniqueToken;
 using System.Linq;
 using Bloom.MiscUI;
+using Palaso.UI.WindowsForms.HtmlBrowser;
 
 namespace Bloom
 {
@@ -64,6 +65,8 @@ namespace Bloom
 			{
 				Application.EnableVisualStyles();
 				Application.SetCompatibleTextRenderingDefault(false);
+
+				XWebBrowser.DefaultBrowserType = XWebBrowser.BrowserType.GeckoFx;
 
 				var args = args1;
 


### PR DESCRIPTION
For the links to work properly in ProblemReporterDialog we have to
use GeckoFx. This change sets the default browser type for Palaso's
XWebBrowser class so that the links in ProblemReporterDialog open
in an external browser window.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/815)
<!-- Reviewable:end -->
