### PR TITLE
Fix-bl2826 Give helpful message when Bloom is locked out of user files

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryBookView.Designer.cs
+++ b/src/BloomExe/CollectionTab/LibraryBookView.Designer.cs
@@ -113,6 +113,8 @@
 			// _previewBrowser
 			// 
 			this._previewBrowser.BackColor = System.Drawing.Color.DarkGray;
+			this._previewBrowser.ContextMenuProvider = null;
+			this._previewBrowser.ControlKeyEvent = null;
 			this._previewBrowser.Dock = System.Windows.Forms.DockStyle.Fill;
 			this._previewBrowser.Isolator = null;
 			this._L10NSharpExtender.SetLocalizableToolTip(this._previewBrowser, null);
@@ -124,10 +126,13 @@
 			this._previewBrowser.Size = new System.Drawing.Size(900, 338);
 			this._previewBrowser.TabIndex = 2;
 			this._previewBrowser.VerticalScrollDistance = 0;
+			this._previewBrowser.OnBrowserClick += new System.EventHandler(this._previewBrowser_OnBrowserClick);
 			// 
 			// _readmeBrowser
 			// 
 			this._readmeBrowser.BackColor = System.Drawing.Color.DarkGray;
+			this._readmeBrowser.ContextMenuProvider = null;
+			this._readmeBrowser.ControlKeyEvent = null;
 			this._readmeBrowser.Dock = System.Windows.Forms.DockStyle.Fill;
 			this._readmeBrowser.Isolator = null;
 			this._L10NSharpExtender.SetLocalizableToolTip(this._readmeBrowser, null);

--- a/src/BloomExe/CollectionTab/LibraryBookView.cs
+++ b/src/BloomExe/CollectionTab/LibraryBookView.cs
@@ -3,9 +3,11 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;
 using Bloom.Book;
+using Bloom.MiscUI;
 using Bloom.SendReceive;
 using Bloom.web;
 using Gecko;
+using Gecko.DOM;
 
 namespace Bloom.CollectionTab
 {
@@ -182,11 +184,47 @@ namespace Bloom.CollectionTab
 			var ge = e as DomEventArgs;
 			var target = (GeckoHtmlElement)ge.Target.CastToGeckoElement();
 			var anchor = target as Gecko.DOM.GeckoAnchorElement;
-			if (anchor != null && anchor.Href != "" && anchor.Href != "#")
+			if (GetAnchorHref(e) != "" && GetAnchorHref(e) != "#")
 			{
 				_readmeBrowser.HandleLinkClick(anchor, ge, _bookSelection.CurrentSelection.FolderPath);
 			}
 		}
 
+		/// <summary>
+		/// Support the "Report a Problem" button when it shows up in the preview window as part of
+		/// a page reporting that we can't open the book for some reason.
+		/// </summary>
+		private void _previewBrowser_OnBrowserClick(object sender, EventArgs e)
+		{
+			if (GetAnchorHref(e).EndsWith("ReportProblem"))
+			{
+				using (var dlg = new ProblemReporterDialog(null,_bookSelection))
+				{
+					dlg.SetDefaultIncludeBookSetting(true);
+					dlg.Description =
+						"This book had a problem. Please tell us anything that might be helpful in diagnosing the problem here:" +
+						Environment.NewLine;
+                   
+					try
+					{
+						dlg.Description += Environment.NewLine + Environment.NewLine + Environment.NewLine;
+						dlg.Description+=_bookSelection.CurrentSelection.Storage.ErrorMessagesHtml;
+					}
+					catch (Exception)
+					{
+						//no use chasing errors generated getting error info
+					}
+					
+                    dlg.ShowDialog();
+				}
+			}
+		}
+
+		private static string GetAnchorHref(EventArgs e)
+		{
+			var element = (GeckoHtmlElement) (e as DomEventArgs).Target.CastToGeckoElement();
+			//nb: it might not be an actual anchor; could be an input-button that we've stuck href on
+			return element == null ? "" : element.GetAttribute("href");
+		}
 	}
 }

--- a/src/BloomExe/MiscUI/BloomIntegrityDialog.cs
+++ b/src/BloomExe/MiscUI/BloomIntegrityDialog.cs
@@ -78,7 +78,7 @@ namespace Bloom.MiscUI
 				dlg.markDownTextBox1.MarkDownText = message;
 				dlg.ShowDialog();
 			}
-			using(var dlg = new ProblemReporterDialog(null, null))
+			using(var dlg = new ProblemReporterDialog())
 			{
 				dlg.Summary = "Bloom Integrity Check Failed: {0}";
 				dlg.Description = "Please answer any of these questions that you understand:"

--- a/src/BloomExe/XmlHtmlConverter.cs
+++ b/src/BloomExe/XmlHtmlConverter.cs
@@ -72,7 +72,7 @@ namespace Bloom
 					var errors = tidy.CleanAndRepair();
 					if (!string.IsNullOrEmpty(errors))
 					{
-						throw new ApplicationException(string.Format("{0}{2}{2}{1}", errors, content, Environment.NewLine));
+						throw new ApplicationException(errors);
 					}
 					var newContents = tidy.Save();
 					try

--- a/src/BloomTests/ProblemReporterDialogTests.cs
+++ b/src/BloomTests/ProblemReporterDialogTests.cs
@@ -13,7 +13,7 @@ namespace BloomTests
 	{
 		class ProblemReporterDialogDouble: ProblemReporterDialog
 		{
-			public ProblemReporterDialogDouble(): base(null, null)
+			public ProblemReporterDialogDouble()
 			{
 				Success = true;
 				_youTrackProjectKey = "AUT";


### PR DESCRIPTION
Ended up overhauling a good chunk of the error reporting stuff so that we don't get a bunch of dialogs, just the preview page, which now sports a button the user can click to send us the problem book via the Report A Problem dialog.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/816)
<!-- Reviewable:end -->
