### PR TITLE
Fix BL-2877 Losing cover page image

### DIFF
--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -96,6 +96,22 @@ namespace BloomTests.Book
 			Assert.IsTrue(File.Exists(keepTemp.Path));
 		}
 		[Test]
+		public void CleanupUnusedImageFiles_ImageOnlyReferencedInDataDiv_ImageNotRemoved()
+		{
+			 var storage =
+				GetInitialStorageWithCustomHtml(
+					"<html><body>"+
+					"<div id ='bloomDataDiv'><div data-book='coverImage'>keepme.png</div>"+
+					"<div data-book='coverImage'> keepme.jpg </div></div>" +
+					"<div class='bloom-page'><div class='marginBox'>" +
+					"</div></div></body></html>");
+			var keepTemp = MakeSamplePngImage(Path.Combine(_folder.Path, "keepme.png"));
+			var keepTempJPG = MakeSamplePngImage(Path.Combine(_folder.Path, "keepme.jpg"));
+			storage.CleanupUnusedImageFiles();
+			Assert.IsTrue(File.Exists(keepTemp.Path));
+			Assert.IsTrue(File.Exists(keepTempJPG.Path));
+		}
+		[Test]
 		public void CleanupUnusedImageFiles_ThumbnailsAndPlaceholdersNotRemoved()
 		{
 			var storage =


### PR DESCRIPTION
Previously I didn't expect the cleanup to run at the point where the book didn't yet have its xmatter applied. But I was wrong, and so this fix now also protects from deletion any filename that is mentioned in the datadiv, which is there even when the xmatter is not yet applied and thus not yet referencing the cover image.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/820)
<!-- Reviewable:end -->
