### PR TITLE
Fix BL-2918 (probably) by skipping refresh if the control isn't ready

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Book\DataSet.cs" />
     <Compile Include="Book\StyleSheetLinkSorter.cs" />
     <Compile Include="Book\TranslationGroupManager.cs" />
+    <Compile Include="ToPalaso\SafeInvoke.cs" />
     <Compile Include="UrlPathString.cs" />
     <Compile Include="Book\UserPrefs.cs" />
     <Compile Include="Book\XMatterHelper.cs" />

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -488,7 +488,7 @@ namespace Bloom.CollectionTab
 		/// <param name="eventArgs"></param>
 		private void DownLoadedBooksChanged(object sender, ProjectChangedEventArgs eventArgs)
 		{
-			SafeInvoke.InvokeIfPosssible("LibraryListView update downloaded books",this,true,(Action) (() =>
+			SafeInvoke.InvokeIfPossible("LibraryListView update downloaded books",this,true,(Action) (() =>
 			{
 				// We may notice a change to the downloaded books directory before the other Bloom instance has finished
 				// copying the new book there. Finishing should not take long, because the download is done...at worst

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -12,6 +12,7 @@ using System.Windows.Forms;
 using Bloom.Book;
 using Bloom.Collection;
 using Bloom.Properties;
+using Bloom.ToPalaso;
 using Bloom.WebLibraryIntegration;
 using Bloom.Workspace;
 using DesktopAnalytics;
@@ -487,7 +488,7 @@ namespace Bloom.CollectionTab
 		/// <param name="eventArgs"></param>
 		private void DownLoadedBooksChanged(object sender, ProjectChangedEventArgs eventArgs)
 		{
-			Invoke((Action) (() =>
+			SafeInvoke.InvokeIfPosssible("LibraryListView update downloaded books",this,true,(Action) (() =>
 			{
 				// We may notice a change to the downloaded books directory before the other Bloom instance has finished
 				// copying the new book there. Finishing should not take long, because the download is done...at worst

--- a/src/BloomExe/ToPalaso/SafeInvoke.cs
+++ b/src/BloomExe/ToPalaso/SafeInvoke.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Diagnostics;
+using System.Windows.Forms;
+using SIL.Code;
+
+namespace Bloom.ToPalaso
+{
+	class SafeInvoke
+	{
+		/// <summary>
+		/// Invoke and action safely even if called from the background thread.
+		/// </summary>
+		/// <remarks>
+		/// Invoking on the ui thread from background threads works *most* of the time, with occasional crash.
+		/// Stackoverflow has a good collection of people trying to deal with these corner cases, where
+		/// InvokeRequired(), for example, is unreliable (it doesn't tell you if the control hasn't even
+		/// got a handle yet).
+		/// SIL.Core (lipalaso) has a SafeInvoke on its LogBox control, which sees heavy background/foreground interaction
+		/// and seems to work well over the course of years.
+		/// I think I (JH) wrote that, but it relies on a couple of odd things:
+		/// 1) it calls IsHandleCreated() (which can reportedly create the handle on the wrong thread?)
+		/// and 2) uses SynchronizationContext which works for that single control case but I'm not seeing how
+		/// to generalize that.
+		/// So now I'm trying something more mainstream here, from a highly voted SO answer.
+		/// </remarks>
+		public static void Invoke(string nameForErrorReporting, Control control, bool forceSynchronous, bool throwIfAnythingGoesWrong, Action action)
+		{
+			Guard.AgainstNull(control, nameForErrorReporting); // throw this one regardless of the throwIfAnythingGoesWrong
+
+			//mostly following http://stackoverflow.com/a/809186/723299
+			try
+			{
+				if (control.IsDisposed)
+				{
+					throw new ObjectDisposedException("Control is already disposed. (" + nameForErrorReporting + ")");
+				}
+				if (control.InvokeRequired)
+				{
+					var delgate = (Action)delegate { Invoke(nameForErrorReporting, control, forceSynchronous, throwIfAnythingGoesWrong, action); };
+					if (forceSynchronous)
+					{
+						control.Invoke(delgate);
+					}
+					else
+					{
+						control.BeginInvoke(delgate);
+					}
+				}
+				else
+				{
+					// InvokeRequired will return false if the control isn't set up yet
+					if (!control.IsHandleCreated)
+					{
+						//This situation happened in BL-2918, prompting the introduction of this safeinvoke
+						throw new ApplicationException("SafeInvoke.Invoke apparently called before control created ("+ nameForErrorReporting+")");
+
+						//note, resist the temptation to work around this by just making the handle be created with something like
+						//var unused = control.Handle
+						//I've read a rumour that this can create the handle "on the wrong thread".
+						//At a minimum, we would need to investigate the truth of that before using it here.
+					}
+					action();
+				}
+			}
+			catch (Exception error)
+			{
+				if (throwIfAnythingGoesWrong)
+					throw;
+				else
+				{
+					Debug.Fail("This error would be swallowed in release version: " + error.Message);
+					SIL.Reporting.Logger.WriteEvent("**** "+error.Message);
+				}
+			}
+		}
+
+		/// <summary>
+		/// This version just makes it clear that the call is permissive, won't bother the user
+		/// if something goes wrong, which is appropriate for 
+		/// many background-->foreground ui tasks, like refreshing.
+		/// </summary>
+		public static void InvokeIfPosssible(string nameForErrorReporting, Control control, bool forceSynchronous, Action action)
+		{
+			Invoke(nameForErrorReporting, control, forceSynchronous, false, action);
+		}
+	}
+}

--- a/src/BloomExe/ToPalaso/SafeInvoke.cs
+++ b/src/BloomExe/ToPalaso/SafeInvoke.cs
@@ -79,7 +79,7 @@ namespace Bloom.ToPalaso
 		/// if something goes wrong, which is appropriate for 
 		/// many background-->foreground ui tasks, like refreshing.
 		/// </summary>
-		public static void InvokeIfPosssible(string nameForErrorReporting, Control control, bool forceSynchronous, Action action)
+		public static void InvokeIfPossible(string nameForErrorReporting, Control control, bool forceSynchronous, Action action)
 		{
 			Invoke(nameForErrorReporting, control, forceSynchronous, false, action);
 		}


### PR DESCRIPTION
This is a timing thing that we can't reproduce, so this is speculative.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/844)
<!-- Reviewable:end -->
