### PR TITLE
Fix getDependency scripts for broken wget with queries

### DIFF
--- a/build/getDependencies-Linux.sh
+++ b/build/getDependencies-Linux.sh
@@ -54,10 +54,14 @@ fi
 
 copy_wget() {
 echo "wget: $2 <= $1"
-f=$(basename $2)
-d=$(dirname $2)
-cd $d
+f1=$(basename $1)
+d1=$(dirname $1)
+f2=$(basename $2)
+d2=$(dirname $2)
+cd $d2
 wget -q -L -N $1
+# wget has no true equivalent of curl's -o option.
+if [ "$f1" != "$f2" ]; then mv $f1 $f2; fi
 cd -
 }
 

--- a/build/getDependencies-windows.sh
+++ b/build/getDependencies-windows.sh
@@ -54,10 +54,14 @@ fi
 
 copy_wget() {
 echo "wget: $2 <= $1"
-f=$(basename $2)
-d=$(dirname $2)
-cd $d
+f1=$(basename $1)
+d1=$(dirname $1)
+f2=$(basename $2)
+d2=$(dirname $2)
+cd $d2
 wget -q -L -N $1
+# wget has no true equivalent of curl's -o option.
+if [ "$f1" != "$f2" ]; then mv $f1 $f2; fi
 cd -
 }
 


### PR DESCRIPTION
This is needed for Linux package builds on Jenkins.  (The proper changes
have gone through the BuildUpdate repository pull request process.)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/845)
<!-- Reviewable:end -->
