### PR TITLE
Fix remnant of BL-2598, can no longer type in read-only fields

### DIFF
--- a/DistFiles/factoryCollections/Sample Shells/Vaccinations/Vaccinations.htm
+++ b/DistFiles/factoryCollections/Sample Shells/Vaccinations/Vaccinations.htm
@@ -205,9 +205,9 @@
         <div data-book="ISBN" class="bloom-editable" contenteditable="true" lang="*">
           9980-0-1858-5
         </div>
-      </div><!-- readOnlyInEditMode: we want to leave this blank for if/when someone takes this doc and is translating it.-->
+      </div><!-- ReadOnlyInAuthorMode: we want to leave this blank for if/when someone takes this doc and is translating it.-->
 
-      <div class="bloom-content1 bloom-editable versionAcknowledgments inside-cover-version-acknowledgments-style bloom-readOnlyInEditMode" data-book="versionAcknowledgments" data-hint="Acknowledgments for translated version, in {lang}" contenteditable="true" lang="tpi"></div>
+      <div class="bloom-content1 bloom-editable versionAcknowledgments inside-cover-version-acknowledgments-style bloom-ReadOnlyInAuthorMode" data-book="versionAcknowledgments" data-hint="Acknowledgments for translated version, in {lang}" contenteditable="true" lang="tpi"></div>
     </div>
   </div>
 

--- a/DistFiles/localization/Bloom.en.tmx
+++ b/DistFiles/localization/Bloom.en.tmx
@@ -1350,7 +1350,7 @@
         <seg>Position</seg>
       </tuv>
     </tu>
-    <tu tuid="EditTab.ReadOnlyInEditMode">
+    <tu tuid="EditTab.ReadOnlyInAuthorMode">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>You cannot put anything in there while making an original book.</seg>

--- a/DistFiles/localization/Bloom.es.tmx
+++ b/DistFiles/localization/Bloom.es.tmx
@@ -1849,7 +1849,7 @@
         <seg>Posición</seg>
       </tuv>
     </tu>
-    <tu tuid="EditTab.ReadOnlyInEditMode">
+    <tu tuid="EditTab.ReadOnlyInAuthorMode">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>You cannot put anything in there while making an original book.</seg>

--- a/DistFiles/localization/Bloom.fr.tmx
+++ b/DistFiles/localization/Bloom.fr.tmx
@@ -2157,7 +2157,7 @@
         <seg>Position</seg>
       </tuv>
     </tu>
-    <tu tuid="EditTab.ReadOnlyInEditMode">
+    <tu tuid="EditTab.ReadOnlyInAuthorMode">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>You cannot put anything in there while making an original book.</seg>

--- a/DistFiles/xMatter/BigBook-XMatter/BigBook-XMatter.htm
+++ b/DistFiles/xMatter/BigBook-XMatter/BigBook-XMatter.htm
@@ -54,7 +54,7 @@
         </div>
         <div class="bloom-translationGroup">
           <label class="bubble">When you make a book from a shell, use this box to tell who did the translation.</label>
-          <div lang="N1" contenteditable="true" class="bloom-content1 bloom-editable versionAcknowledgments bloom-readOnlyInEditMode" data-book="versionAcknowledgments">
+          <div lang="N1" contenteditable="true" class="bloom-content1 bloom-editable versionAcknowledgments bloom-ReadOnlyInAuthorMode" data-book="versionAcknowledgments">
           </div>
         </div>
         <div class="bloom-translationGroup" id="funding">

--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
@@ -58,8 +58,8 @@
           <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary Credits-Page-style" data-book="originalAcknowledgments">{Original Acknowledgments}
           </div>
         </div>
-        <!-- readOnlyInEditMode: we want to leave this blank for if/when someone takes this doc and is translating it.-->
-        <div lang="N1" contenteditable="true" class="bloom-content1 bloom-editable versionAcknowledgments Credits-Page-style bloom-readOnlyInEditMode" data-book="versionAcknowledgments" data-hint="Name of Translator, in {lang}">
+        <!-- readOnlyInAuthorMode: we want to leave this blank for if/when someone takes this doc and is translating it.-->
+        <div lang="N1" contenteditable="true" class="bloom-content1 bloom-editable versionAcknowledgments Credits-Page-style bloom-readOnlyInAuthorMode" data-book="versionAcknowledgments" data-hint="Name of Translator, in {lang}">
         </div>
       </div>
     </div>

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.htm
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.htm
@@ -100,8 +100,8 @@
           <!-- TODO we need this to be localizable, so we can have "ISO 639-3 Language Code" or "Code langue ISO 639-3"-->ISO 639 Language Code:
           <DIV data-collection="iso639Code"></DIV>
         </div>
-        <!-- readOnlyInEditMode: we want to leave this blank for if/when someone takes this doc and is translating it.-->
-        <div lang="N1" contenteditable="true" class="bloom-content1 bloom-editable versionAcknowledgments Credits-Page-style bloom-readOnlyInEditMode" data-book="versionAcknowledgments" data-hint="Name of Translator, in {lang}">
+        <!-- readOnlyInAuthorMode: we want to leave this blank for if/when someone takes this doc and is translating it.-->
+        <div lang="N1" contenteditable="true" class="bloom-content1 bloom-editable versionAcknowledgments Credits-Page-style bloom-readOnlyInAuthorMode" data-book="versionAcknowledgments" data-hint="Name of Translator, in {lang}">
         </div>
       </div>
     </div>

--- a/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.htm
+++ b/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.htm
@@ -93,8 +93,8 @@
         <div data-hint="International Standard Book Number. Leave blank if you don't have one of these." class="ISBNContainer"><span class="bloom-doNotPublishIfParentOtherwiseEmpty Credits-Page-style">ISBN</span>
           <div data-book="ISBN" lang="*" class="bloom-editable Credits-Page-style bloom-userCannotModifyStyles"></div>
         </div>
-        <!-- readOnlyInEditMode: we want to leave this blank for if/when someone takes this doc and is translating it.-->
-        <div lang="N1" contenteditable="true" class="bloom-content1 bloom-editable versionAcknowledgments Credits-Page-style bloom-readOnlyInEditMode" data-book="versionAcknowledgments" data-hint="Name of Translator, in {lang}">
+        <!-- readOnlyInAuthorMode: we want to leave this blank for if/when someone takes this doc and is translating it.-->
+        <div lang="N1" contenteditable="true" class="bloom-content1 bloom-editable versionAcknowledgments Credits-Page-style bloom-readOnlyInAuthorMode" data-book="versionAcknowledgments" data-hint="Name of Translator, in {lang}">
         </div>
       </div>
     </div>

--- a/DistFiles/xMatter/bloom-xmatter-mixins.jade
+++ b/DistFiles/xMatter/bloom-xmatter-mixins.jade
@@ -46,11 +46,11 @@ mixin field-ISBN
 		div.bloom-editable(data-book="ISBN", lang="*").Credits-Page-style.bloom-userCannotModifyStyles
 
 mixin field-acknowledgments-localizedVersion
-	// readOnlyInEditMode: we want to leave this blank for if/when someone takes this doc and is translating it.
+	// readOnlyInAuthorMode: we want to leave this blank for if/when someone takes this doc and is translating it.
 	//- Why both versionAcknowledgments && inside-cover-version-Credits-Page-style?
 	//-   versionAcknowledgments governs placement on the page, inside-cover-version-Credits-Page-style is a
 	//-   holding place for user style adjustments (like font-size)
-	+editable("N1").versionAcknowledgments.Credits-Page-style.bloom-readOnlyInEditMode(data-book="versionAcknowledgments", data-hint="Name of Translator, in {lang}")
+	+editable("N1").versionAcknowledgments.Credits-Page-style.bloom-readOnlyInAuthorMode(data-book="versionAcknowledgments", data-hint="Name of Translator, in {lang}")
 
 // TODO: this is a mess
 mixin field-acknowledgments-originalVersion

--- a/src/BloomBrowserUI/bookEdit/css/editOriginalMode.css
+++ b/src/BloomBrowserUI/bookEdit/css/editOriginalMode.css
@@ -4,7 +4,7 @@ OL#topics
 	list-style: none;
 }
 /*this is used for the "versionAcknowledgments" textarea, which we don't want shell-makers to be filling in*/
-.bloom-readOnlyInEditMode
+.bloom-readOnlyInAuthorMode
 {
 	/*we have javascript function which notices this setting and makes it read-only
 (which isn't a style, so we can't set it ourselves*/

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -211,7 +211,7 @@ function AddLanguageTags(container) {
         if (isTranslationMode && $this.hasClass('bloom-readOnlyInTranslationMode')) {
             return;
         }
-        if (!isTranslationMode && $this.hasClass('bloom-readOnlyInEditMode')) {
+        if (!isTranslationMode && $this.hasClass('bloom-readOnlyInAuthorMode')) {
             return;
         }
 
@@ -665,6 +665,10 @@ $(document).ready(function() {
 
         if ($(this).hasClass('bloom-userCannotModifyStyles'))
             return; // equivalent to 'continue'
+
+        if ($(this).css('cursor') == 'not-allowed')
+            return;
+
         var ckedit = CKEDITOR.inline(this);
 
         // Record the div of the edit box for use later in positioning the format bar.

--- a/src/BloomBrowserUI/bookEdit/js/bloomNotices.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomNotices.ts
@@ -29,12 +29,12 @@ class bloomNotices {
     public static addEditingNotAllowedMessages(container: HTMLElement): void {
         var notAllowed = localizationManager.getText('EditTab.EditNotAllowed',
             'You cannot change these because this is not the original copy.');
-        var readOnly = localizationManager.getText('EditTab.ReadOnlyInEditMode',
+        var readOnly = localizationManager.getText('EditTab.ReadOnlyInAuthorMode',
             'You cannot put anything in there while making an original book.');
         $(container).find('*[data-hint]').each(function () {
             if ($(this).css('cursor') == 'not-allowed') {
                 var whyDisabled = notAllowed;
-                if ($(this).hasClass('bloom-readOnlyInEditMode')) {
+                if ($(this).hasClass('bloom-ReadOnlyInAuthorMode')) {
                     whyDisabled = readOnly;
                 }
 


### PR DESCRIPTION
While I was at it, I changed "ReadOnlyInEditMode", which meant nothing to me (or suggested edit vs. publish, which is incorrect), to "ReadOnlyInAuthorMode".

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/846)
<!-- Reviewable:end -->
