### PR TITLE
BL-2852 don't add date to window title, since we don't know it now

### DIFF
--- a/src/BloomExe/Shell.cs
+++ b/src/BloomExe/Shell.cs
@@ -130,7 +130,15 @@ namespace Bloom
 
 		public void SetWindowText(string bookName)
 		{
-			string formattedText = string.Format("{0} - Bloom {1} Built on {2}", _workspaceView.Text, GetShortVersionInfo(), GetBuiltOnDate());
+			//string formattedText = string.Format("{0} - Bloom {1} Built on {2}", _workspaceView.Text, GetShortVersionInfo(), GetBuiltOnDate());
+
+			//enhance: above, I have removed the BuildDate portion of the window title. See BL-2852.
+			//With the switch to squirrel/nuget, all the file dates are the installed/updated date, not the build
+			//date. The one file that has the correct date stamp is the .nupkg, but that would take some work to get at...
+			//there may be easier ways to pass this info, e.g. writing out a text file the contains the date during
+			//build. In any case, when we revist this, let's only do it for alpha a beta. It looks odd to have that in 
+			//release builds, and doesn't add much since there are few of them.
+			var formattedText = string.Format("{0} - Bloom {1}", _workspaceView.Text, GetShortVersionInfo());
 			if (bookName != null)
 			{
 				formattedText = string.Format("{0} - {1}", bookName, formattedText);


### PR DESCRIPTION
With the switch to squirrel/nuget, all the file dates are the installed/updated date, not the build date. The one file that has the correct date stamp is the .nupkg, but that would take some work to get at... there may be easier ways to pass this info, e.g. writing out a text file the contains the date during build. In any case, when we revisit this, let's only do it for alpha a beta. It looks odd to have that in release builds, and doesn't add much since there are few of them.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/851)
<!-- Reviewable:end -->
