### PR TITLE
Fix BL-2710 Toolbar goes to small mode after minimizing

### DIFF
--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -528,7 +528,10 @@ namespace Bloom.Workspace
 
 		private void WorkspaceView_Resize(object sender, EventArgs e)
 		{
-			AdjustTabStripDisplayForScreenSize();
+			if (this.ParentForm.WindowState != FormWindowState.Minimized)
+			{
+				AdjustTabStripDisplayForScreenSize();
+			}
 		}
 
 		private void WorkspaceView_Load(object sender, EventArgs e)


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/852)
<!-- Reviewable:end -->
