### PR TITLE
Fix bl-2931 by adding correct $.find().

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -731,7 +731,7 @@ var pageSelectionChanging = function () {
 // think the other is still using.
 var disconnectForGarbageCollection = function () {
     // disconnect all event handlers
-    //find().off();  TODO: This causes a Find dialog box to appear
+    $.find().off();
 
     var page = $('.bloom-page');
     // blow away any img elements to ensure their data disappears.


### PR DESCRIPTION
Originally, this code had ```find().off()```. This ran ```Window.find()``` which... wait for it.... shows a find dialog box.  We just commented that out. Now I've gone back and corrected it to call the jquery find() that was intended.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/855)
<!-- Reviewable:end -->
