### PR TITLE
BL-2854 Remove improper split-pane-component-inner layer

### DIFF
--- a/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.htm
+++ b/DistFiles/factoryCollections/Templates/Basic Book/Basic Book.htm
@@ -61,26 +61,24 @@
           <div style="bottom: 76%" class="split-pane-divider horizontal-divider"></div>
           <!--NB: this split percent has to be the same as that used for upper!!!!!!-->
           <div style="height: 76%" class="split-pane-component position-bottom">
-            <div class="split-pane-component-inner">
-              <div class="split-pane horizontal-percent">
-                <div style="bottom: 30%" class="split-pane-component position-top">
-                  <div class="split-pane-component-inner">
-                    <div class="bloom-imageContainer bloom-leadingElement"><img src="placeHolder.png" alt="Could not load the picture"/>
-                    </div>
-                  </div>
+            <div class="split-pane horizontal-percent">
+            <div style="bottom: 30%" class="split-pane-component position-top">
+                <div class="split-pane-component-inner">
+                <div class="bloom-imageContainer bloom-leadingElement"><img src="placeHolder.png" alt="Could not load the picture"/>
                 </div>
-                <div style="bottom: 30%" class="split-pane-divider horizontal-divider"></div>
-                <!--NB: this split percent has to be the same as that used for upper!!!!!!-->
-                <div style="height: 30%" class="split-pane-component position-bottom">
-                  <div class="split-pane-component-inner">
-                    <div class="bloom-translationGroup bloom-trailingElement normal-style">
-                      <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable">
-                      </div>
-                    </div>
-                  </div>
                 </div>
-                <div class="split-pane-resize-shim"></div>
-              </div>
+            </div>
+            <div style="bottom: 30%" class="split-pane-divider horizontal-divider"></div>
+            <!--NB: this split percent has to be the same as that used for upper!!!!!!-->
+            <div style="height: 30%" class="split-pane-component position-bottom">
+                <div class="split-pane-component-inner">
+                <div class="bloom-translationGroup bloom-trailingElement normal-style">
+                    <div lang="z" contenteditable="true" class="bloom-content1 bloom-editable">
+                    </div>
+                </div>
+                </div>
+            </div>
+            <div class="split-pane-resize-shim"></div>
             </div>
           </div>
           <div class="split-pane-resize-shim"></div>

--- a/src/BloomBrowserUI/bookEdit/js/origami.js
+++ b/src/BloomBrowserUI/bookEdit/js/origami.js
@@ -25,6 +25,15 @@ function isEmpty(el) {
 function setupLayoutMode() {
     $('.split-pane-component-inner').each(function () {
         var $this = $(this);
+        if ($this.find('.split-pane').length) {
+            // This is an unexpected situation, probably caused by using a broken version of the
+            // origami-based picture-in-middle. split-pane-component-inner's are not meant to be
+            // wrapped around split-panes; they indicate leaves that can be further split, while
+            // split-panes represent an area that has already been split. A reasonable repair is
+            // to remove the split-pane-component-inner, leaving its contents.
+            $this.find('.split-pane').unwrap();
+            return true; // continue
+        }
         if (!$this.find('.bloom-imageContainer, .bloom-translationGroup:not(.box-header-off)').length)
             $this.append(getTypeSelectors());
 


### PR DESCRIPTION
Note that the change to Basic book, though it looks messy in github, really just removes one layer of div around its entire content. Apart from indent changes, only two lines are deleted. Try in reviewable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/856)
<!-- Reviewable:end -->
