### PR TITLE
Find Palaso named strings in proper SIL namespace (BL-2923)

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -808,7 +808,7 @@ namespace Bloom
 										   "Palaso", "Palaso", /*review: this is just bloom's version*/Application.ProductVersion,
 										   installedStringFileFolder,
 											"SIL/Bloom",
-											Resources.Bloom, "issues@bloomlibrary.org", "Palaso.UI");
+											Resources.Bloom, "issues@bloomlibrary.org", "SIL");
 
 				Settings.Default.UserInterfaceLanguage = LocalizationManager.UILanguageId;
 			}

--- a/src/BloomExe/Properties/AssemblyInfo.cs
+++ b/src/BloomExe/Properties/AssemblyInfo.cs
@@ -36,6 +36,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("0.9.999.0")]
 [assembly: AssemblyVersion("3.5.000.0")]
 [assembly: AssemblyFileVersion("3.5.000.0")]
-[assembly: AssemblyInformationalVersion("3.1.000.0")]
+[assembly: AssemblyInformationalVersion("3.5.000.0")]
 [assembly: InternalsVisibleTo("BloomTests")]
 [assembly: AssemblyMetadata("SquirrelAwareVersion", "1")]


### PR DESCRIPTION
Also fixed AssemblyInformationalVersion to be the same as
AssemblyVersion and AssemblyFileVersion.  This allowed the bug to
happen on developer machines as well as user machines.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/857)
<!-- Reviewable:end -->
