### PR TITLE
Fix BL-2887 migration code should not mess with data-page attribute

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -613,6 +613,18 @@ namespace Bloom.Book
 			var oldLineageAttr = page.Attributes["data-pagelineage"];
 			var oldLineage = oldLineageAttr == null ? "" : oldLineageAttr.Value;
 			newPage.SetAttribute("data-pagelineage", lineage);
+
+			//preserve the data-page attribute of the old page, which will normally be empty or missing
+			var dataPageValue = page.GetAttribute("data-page");
+			if (string.IsNullOrEmpty(dataPageValue))
+			{
+				newPage.RemoveAttribute("data-page");
+			}
+			else
+			{
+				newPage.SetAttribute("data-page", dataPageValue); //the template has these as 
+			}
+
 			// migrate text
 			MigrateChildren(page, "bloom-translationGroup", newPage);
 			// migrate images

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -622,7 +622,7 @@ namespace Bloom.Book
 			}
 			else
 			{
-				newPage.SetAttribute("data-page", dataPageValue); //the template has these as 
+				newPage.SetAttribute("data-page", dataPageValue); //the template has these as data-page='extra'
 			}
 
 			// migrate text

--- a/src/BloomTests/Book/PageMigrationTests.cs
+++ b/src/BloomTests/Book/PageMigrationTests.cs
@@ -327,6 +327,52 @@ namespace BloomTests.Book
 			Assert.IsFalse(updatedPage.OuterXml.Contains("imageOnTop"), "imageOnTop refers to the old fixed-stylesheet way of showing pages");
 		}
 
+		
+		/// <summary>
+		/// this is a regression test, from BL-2887
+		/// </summary>
+		[Test]
+		public void BringPageUpToDateWithMigration_SourceHasNoDataPage_DoesNotAcquireDataPageFromTemplate()
+		{
+			//the  data-pagelineage='FD115DFF-0415-4444-8E76-3D2A18DBBD27' here tells us we came from
+			//an old template page and triggers migration to its current equivalent
+			SetDom(@"<div class='imageOnTop'  data-pagelineage='FD115DFF-0415-4444-8E76-3D2A18DBBD27' id='thePage'>
+			   <div class='marginBox'>
+					<div class='bloom-imageContainer bloom-leadingElement'><img src='erjwx3bl.q3c.png'></img></div>
+				</div>
+			</div>
+			");
+			var book = CreateBook();
+			var dom = book.RawDom;
+			var page = (XmlElement)dom.SafeSelectNodes("//div[@id='thePage']")[0];
+			book.BringPageUpToDate(page);
+			//The source template page has data-page='extra', but the migrated page *must not* have this.
+			AssertThatXmlIn.Dom(dom).HasNoMatchForXpath("//div[@id='thePage' and @data-page='extra']");
+			AssertThatXmlIn.Dom(dom).HasNoMatchForXpath("//div[@id='thePage' and @data-page]");
+		}
+
+		/// <summary>
+		/// this is a regression test, from BL-2887
+		/// </summary>
+		[Test]
+		public void BringPageUpToDateWithMigration_SourceHasEmptyDataPage_DoesNotAcquireDataPageFromTemplate()
+		{
+			//the  data-pagelineage='FD115DFF-0415-4444-8E76-3D2A18DBBD27' here tells us we came from
+			//an old template page and triggers migration to its current equivalent
+			SetDom(@"<div class='imageOnTop'  data-page='' data-pagelineage='FD115DFF-0415-4444-8E76-3D2A18DBBD27' id='thePage'>
+			   <div class='marginBox'>
+					<div class='bloom-imageContainer bloom-leadingElement'><img src='erjwx3bl.q3c.png'></img></div>
+				</div>
+			</div>
+			");
+			var book = CreateBook();
+			var dom = book.RawDom;
+			var page = (XmlElement)dom.SafeSelectNodes("//div[@id='thePage']")[0];
+			book.BringPageUpToDate(page);
+			//The source template page has data-page='extra', but the migrated page *must not* have this.
+			AssertThatXmlIn.Dom(dom).HasNoMatchForXpath("//div[@id='thePage' and @data-page='extra']");
+			AssertThatXmlIn.Dom(dom).HasNoMatchForXpath("//div[@id='thePage' and @data-page]");
+		}
 		// Common code for tests of adding needed styles. The main difference between the tests is the state of the stylesheet
 		// (if any) inserted by the modifyHead action.
 		private XmlDocument CreateAndMigrateBigWordsPage(Action<XmlElement> modifyHead)


### PR DESCRIPTION
Since September, every non-xmatter page was migrated and the data-page attribute was set to 'extra'. When any such book is used then as a shell those pages disappear forever.

This PR stops it from doing that, but we will require a followup commit to heal all the books that have been broken by this.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/858)
<!-- Reviewable:end -->
