### PR TITLE
Fix BL-2921 by choosing which language to use for topics.

### DIFF
--- a/DistFiles/factoryCollections/Sample Shells/Vaccinations/Vaccinations.htm
+++ b/DistFiles/factoryCollections/Sample Shells/Vaccinations/Vaccinations.htm
@@ -47,14 +47,6 @@
       Health
     </div>
 
-    <div data-book="topic" lang="id">
-      Kesehatan
-    </div>
-
-    <div data-book="topic" lang="es">
-      Salud
-    </div>
-
     <div data-book="originalAcknowledgments" lang="*">
       The material in this booklet was borrowed with permission from the book "Yu Tu i Ken Daunim Sik Long Ples",
       originally published by Liklik Buk Information Centre, Free Mail Bag, Unitech, LAE. Illustrations adapted by Anis Ka'abu.

--- a/DistFiles/factoryCollections/Templates/Arithmetic/Arithmetic.htm
+++ b/DistFiles/factoryCollections/Templates/Arithmetic/Arithmetic.htm
@@ -23,6 +23,7 @@
   <body>
     <div id="bloomDataDiv">
       <div data-book="bookTitle" lang="en">Arithmetic</div>
+	  <div data-book="topic" lang="en">Math</div>
     </div>
     <div class="A5Portrait bloom-page numberedPage oneProblem" data-page="extra" id="aaa72b3e-c874-4e56-9120-5a241468e6aa">
       <div lang="en" class="pageLabel">1 Problem</div>

--- a/DistFiles/factoryCollections/Templates/Picture Dictionary/Picture Dictionary.htm
+++ b/DistFiles/factoryCollections/Templates/Picture Dictionary/Picture Dictionary.htm
@@ -23,10 +23,6 @@
       <div data-book="bookTitle" lang="tpi">Piksa Diksionari</div>
       <div data-book="bookTitle" lang="id">Kamus Bergambar</div>
       <div data-book="topic" lang="en">Dictionary</div>
-      <div data-book="topic" lang="fr">Dictionnaire</div>
-      <div data-book="topic" lang="id">Kamus</div>
-      <div data-book="topic" lang="th">พจนานุกรม</div>
-      <div data-book="topic" lang="es">Diccionario</div>
     </div>
     <div id="7E5B8274-C7BD-4471-B54D-50CF09E4D899" class="bloom-page numberedPage images6 A5Portrait pictureDictionaryPage">
       <div class="pageLabel">Picture Dictionary Page</div>

--- a/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
+++ b/DistFiles/xMatter/Factory-XMatter/Factory-XMatter.htm
@@ -31,9 +31,7 @@
         </div>
         <div class="bottomBlock">
           <div data-book="languagesOfBook" class="coverBottomLangName Cover-Default-style"></div>
-          <div data-functionOnHintClick="ShowTopicChooser()" data-hint="Click to choose topic" class="bloom-translationGroup coverBottomBookTopic bloom-readOnlyInTranslationMode bloom-alwaysShowBubble">
-            <div data-book="topic" class="bloom-readOnlyInTranslationMode bloom-editable bloom-userCannotModifyStyles Cover-Default-style"></div>
-          </div>
+          <div data-derived="topic" data-functionOnHintClick="ShowTopicChooser()" data-hint="Click to choose topic" class="coverBottomBookTopic bloom-readOnlyInTranslationMode bloom-userCannotModifyStyles bloom-alwaysShowBubble Cover-Default-style"></div>
         </div>
       </div>
     </div>

--- a/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.htm
+++ b/DistFiles/xMatter/SIL-Cameroon-XMatter/SIL-Cameroon-XMatter.htm
@@ -31,9 +31,7 @@
         </div>
         <div class="bottomBlock">
           <div data-book="languagesOfBook" class="coverBottomLangName Cover-Default-style"></div>
-          <div data-functionOnHintClick="ShowTopicChooser()" data-hint="Click to choose topic" class="bloom-translationGroup coverBottomBookTopic bloom-readOnlyInTranslationMode bloom-alwaysShowBubble">
-            <div data-book="topic" class="bloom-readOnlyInTranslationMode bloom-editable bloom-userCannotModifyStyles Cover-Default-style"></div>
-          </div>
+          <div data-derived="topic" data-functionOnHintClick="ShowTopicChooser()" data-hint="Click to choose topic" class="coverBottomBookTopic bloom-readOnlyInTranslationMode bloom-userCannotModifyStyles bloom-alwaysShowBubble Cover-Default-style"></div>
         </div>
       </div>
     </div>

--- a/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.htm
+++ b/DistFiles/xMatter/Traditional-XMatter/Traditional-XMatter.htm
@@ -31,9 +31,7 @@
         </div>
         <div class="bottomBlock">
           <div data-book="languagesOfBook" class="coverBottomLangName Cover-Default-style"></div>
-          <div data-functionOnHintClick="ShowTopicChooser()" data-hint="Click to choose topic" class="bloom-translationGroup coverBottomBookTopic bloom-readOnlyInTranslationMode bloom-alwaysShowBubble">
-            <div data-book="topic" class="bloom-readOnlyInTranslationMode bloom-editable bloom-userCannotModifyStyles Cover-Default-style"></div>
-          </div>
+          <div data-derived="topic" data-functionOnHintClick="ShowTopicChooser()" data-hint="Click to choose topic" class="coverBottomBookTopic bloom-readOnlyInTranslationMode bloom-userCannotModifyStyles bloom-alwaysShowBubble Cover-Default-style"></div>
         </div>
       </div>
     </div>

--- a/DistFiles/xMatter/bloom-xmatter-mixins.jade
+++ b/DistFiles/xMatter/bloom-xmatter-mixins.jade
@@ -36,8 +36,7 @@ mixin page-cover(label)
 
 mixin chooser-topic
 	//- TODO: Somehow the data-functionOnHintClick doesn't interact well with the new label.bubble method.
-	.bloom-translationGroup.coverBottomBookTopic.bloom-readOnlyInTranslationMode.bloom-alwaysShowBubble(data-functionOnHintClick="ShowTopicChooser()", data-hint="Click to choose topic")
-		.bloom-readOnlyInTranslationMode.bloom-editable.bloom-userCannotModifyStyles.Cover-Default-style(data-book="topic")
+	.coverBottomBookTopic.bloom-readOnlyInTranslationMode.bloom-userCannotModifyStyles.bloom-alwaysShowBubble.Cover-Default-style(data-derived="topic", data-functionOnHintClick="ShowTopicChooser()", data-hint = "Click to choose topic")
 
 mixin field-ISBN
 	.ISBNContainer(data-hint="International Standard Book Number. Leave blank if you don't have one of these.")

--- a/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooser.js
+++ b/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooser.js
@@ -28,7 +28,7 @@ var TopicChooser = (function () {
                     width: 100,
                     click: function () {
                         var t = $("ol#topicList li.ui-selected");
-                        //set or clear the topic variable in our 
+                        //Ask the Model to set or clear the topic variable
                         if (t.length) {
                             var key = t[0].dataset['key'];
                             //notice here that we are not changing the topic on the page.

--- a/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooser.js
+++ b/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooser.js
@@ -28,30 +28,16 @@ var TopicChooser = (function () {
                     width: 100,
                     click: function () {
                         var t = $("ol#topicList li.ui-selected");
-                        //set or clear the topic variable in our data-div
+                        //set or clear the topic variable in our 
                         if (t.length) {
                             var key = t[0].dataset['key'];
-                            var translationGroup = $("div[data-book='topic']").parent();
-                            var englishDiv = translationGroup.find("[lang='en']")[0];
-                            if (!englishDiv) {
-                                englishDiv = translationGroup.find("div[data-book='topic']")[0];
-                                $(englishDiv).clone().attr("lang", "en");
-                                $(englishDiv).appendTo($(translationGroup));
-                            }
-                            //for translation convenience, we use "NoTopic" as the key during UI. But when storing, it's cleaner to just save empty string if we don't have a topic
-                            if (key == "NoTopic") {
-                                //this will clear all of them, for everylanguage
-                                $("div[data-book='topic']").text("");
-                            }
-                            else {
-                                $(englishDiv).text(key);
-                                //NB: when the nationalLanguage1 is also English, this won't do anything, but that's ok because we set the element to the key which is the same as its
-                                //English, at least today. If that changes in the future, we'd need to put the "key" somewhere other than in the text of the English element
-                                localizationManager.asyncGetTextInLang("Topics." + key, key, "N1")
-                                    .done(function (topicInNatLang1) {
-                                    $("div[data-book='topic']").filter(".bloom-contentNational1").text(topicInNatLang1);
-                                });
-                            }
+                            //notice here that we are not changing the topic on the page.
+                            //Doing so here would mean duplicating the logic we have to have
+                            //in c# anyhow. Instead, we are doing more of a react-style
+                            //thing here where the UI raises an event requesting a change
+                            //to the model, and then let that propagate back down to the
+                            //ui (that is, the html on the page).
+                            TopicChooser.fireCSharpEvent('setTopic', key);
                         }
                         $(this).dialog("close");
                     }
@@ -63,6 +49,10 @@ var TopicChooser = (function () {
             var x = dlg.dialog("option", "buttons");
             x['OK'].apply(dlg);
         });
+    };
+    TopicChooser.fireCSharpEvent = function (eventName, eventData) {
+        var event = new MessageEvent(eventName, { 'bubbles': true, 'cancelable': true, 'data': eventData });
+        document.dispatchEvent(event);
     };
     TopicChooser.createTopicDialogDiv = function (currentTopicKey) {
         // if it's already there, remove it

--- a/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooser.ts
+++ b/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooser.ts
@@ -31,7 +31,7 @@ class TopicChooser {
                     width: 100,
                     click() {
                         var t = $("ol#topicList li.ui-selected");
-                        //set or clear the topic variable in our 
+                        //Ask the Model to set or clear the topic variable
                         if (t.length) {
                             var key = t[0].dataset['key'];
                             //notice here that we are not changing the topic on the page.

--- a/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooser.ts
+++ b/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooser.ts
@@ -29,33 +29,18 @@ class TopicChooser {
                     id: "OKButton",
                     text: "OK",
                     width: 100,
-                    click: function() {
+                    click() {
                         var t = $("ol#topicList li.ui-selected");
-                        //set or clear the topic variable in our data-div
+                        //set or clear the topic variable in our 
                         if (t.length) {
                             var key = t[0].dataset['key'];
-                            var translationGroup = $("div[data-book='topic']").parent();
-                            var englishDiv = translationGroup.find("[lang='en']")[0];
-                            if (!englishDiv) {
-                                englishDiv = translationGroup.find("div[data-book='topic']")[0];
-                                $(englishDiv).clone().attr("lang", "en");
-                                $(englishDiv).appendTo($(translationGroup));
-                            }
-
-                            //for translation convenience, we use "NoTopic" as the key during UI. But when storing, it's cleaner to just save empty string if we don't have a topic
-                            if (key == "NoTopic") {
-                                //this will clear all of them, for everylanguage
-                                $("div[data-book='topic']").text("");
-                            } else {
-                                $(englishDiv).text(key);
-
-                                //NB: when the nationalLanguage1 is also English, this won't do anything, but that's ok because we set the element to the key which is the same as its
-                                //English, at least today. If that changes in the future, we'd need to put the "key" somewhere other than in the text of the English element
-                                localizationManager.asyncGetTextInLang("Topics." + key, key, "N1")
-                                    .done(topicInNatLang1 => {
-                                        $("div[data-book='topic']").filter(".bloom-contentNational1").text(topicInNatLang1);
-                                    });
-                            }
+                            //notice here that we are not changing the topic on the page.
+                            //Doing so here would mean duplicating the logic we have to have
+                            //in c# anyhow. Instead, we are doing more of a react-style
+                            //thing here where the UI raises an event requesting a change
+                            //to the model, and then let that propagate back down to the
+                            //ui (that is, the html on the page).
+                            TopicChooser.fireCSharpEvent('setTopic', key);
                         }
                         $(this).dialog("close");
                     }
@@ -68,6 +53,11 @@ class TopicChooser {
             var x = dlg.dialog("option", "buttons");
             x['OK'].apply(dlg);
         });
+    }
+
+    static fireCSharpEvent(eventName, eventData): void {
+        var event = new MessageEvent(eventName, { 'bubbles': true, 'cancelable': true, 'data': eventData });
+        document.dispatchEvent(event);
     }
 
     static createTopicDialogDiv(currentTopicKey: string) {

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2053,17 +2053,6 @@ namespace Bloom.Book
 			XmlHtmlConverter.GetXmlDomFromHtmlFile(_storage.PathToExistingHtml,true).Save(path);
 		}
 
-		/// <summary>
-		/// public for use in external scripts that set up pre-packaged books/collections
-		/// </summary>
-		/// <param name="key"></param>
-		/// <param name="value"></param>
-		/// <param name="libaryValue"></param>
-		public void SetDataItem(string key, string value, string languageCode)
-		{
-			_bookData.Set(key, value,languageCode);
-		}
-
 		public void Save()
 		{
 			Guard.Against(Type != Book.BookType.Publication, "Tried to save a non-editable book.");
@@ -2095,5 +2084,15 @@ namespace Bloom.Book
 		}
 
 		internal IBookStorage Storage {get { return _storage; }}
+
+		/// <summary>
+		/// This gets called as a result of a UI action. It sets the new topic in our data, 
+		/// but doesn't do anything related to how it is displayed on the page.
+		/// The way to think about this is that we're aiming for a more react™-style flow.
+		/// </summary>
+		public void SetTopic(string englishTopicAsKey)
+		{
+			_bookData.Set("topic",englishTopicAsKey,"en");
+		}
 	}
 }

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -194,6 +194,14 @@ namespace Bloom.Book
 				topicStrings.RemoveLanguageForm(topicStrings.Find("tpi"));
 			}
 
+			// BL-2746 For awhile during the v3.3 beta period, after the addition of ckeditor
+			// our topic string was getting wrapped in html paragraph markers. There were a good
+			// number of beta testers, so we need to clean up that mess.
+			topicStrings.Forms
+				.ForEach(
+					languageForm =>
+						topicStrings[languageForm.WritingSystemId] = languageForm.Form.Replace("<p>", "").Replace("</p>", ""));
+
 			if (!string.IsNullOrEmpty(topicStrings["en"]))
 			{
 				//starting with 3.5, we only store the English key in the datadiv.
@@ -204,14 +212,6 @@ namespace Bloom.Book
 				_dom.SafeSelectNodes("//div[@id='bloomDataDiv']/div[@data-book='topic' and not(@lang='en')]")
 					.Cast<XmlElement>()
 					.ForEach(e => e.ParentNode.RemoveChild(e));
-
-				// BL-2746 For awhile during the v3.3 beta period, after the addition of ckeditor
-				// our topic string was getting wrapped in html paragraph markers. There were a good
-				// number of beta testers, so we need to clean up that mess.
-				topicStrings.Forms
-					.ForEach(
-						languageForm =>
-							topicStrings[languageForm.WritingSystemId] = languageForm.Form.Replace("<p>", "").Replace("</p>", ""));
 			}
 		}
 
@@ -259,7 +259,8 @@ namespace Bloom.Book
 			topicPageElement.InnerText = "";
 
 			NamedMutliLingualValue topicData;
-			//if we have no topic element in the data-div, clear it out from the page
+			//if we have no topic element in the data-div, just leave now, 
+			//leaving the field in the page with an empty text.
 			if (!data.TextVariables.TryGetValue("topic", out topicData))
 				return;
 

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Xml;
@@ -9,6 +10,8 @@ using System.Xml.Linq;
 using Bloom.Collection;
 using L10NSharp;
 using SIL.Code;
+using SIL.Extensions;
+using SIL.Linq;
 using SIL.Text;
 using SIL.Windows.Forms.ClearShare;
 using SIL.Xml;
@@ -171,7 +174,6 @@ namespace Bloom.Book
 
 			UpdateTitle(info);//this may change our "bookTitle" variable if the title is based on a template that reads other variables (e.g. "Primer Term2-Week3")
 			UpdateIsbn(info);
-			UpdateTags(info);
 			UpdateCredits(info);
 		}
 
@@ -192,12 +194,24 @@ namespace Bloom.Book
 				topicStrings.RemoveLanguageForm(topicStrings.Find("tpi"));
 			}
 
-			// BL-2746 For awhile during th v3.3 beta period, after the addition of ckeditor
-			// our topic string was getting wrapped in html paragraph markers. There were a good
-			// number of beta testers, so we need to clean up that mess.
-			foreach (var languageForm in topicStrings.Forms)
+			if (!string.IsNullOrEmpty(topicStrings["en"]))
 			{
-				topicStrings[languageForm.WritingSystemId] = languageForm.Form.Replace("<p>", "").Replace("</p>", "");
+				//starting with 3.5, we only store the English key in the datadiv.
+				topicStrings.Forms
+					.Where(lf => lf.WritingSystemId != "en")
+					.ForEach(lf => topicStrings.RemoveLanguageForm(lf));
+
+				_dom.SafeSelectNodes("//div[@id='bloomDataDiv']/div[@data-book='topic' and not(@lang='en')]")
+					.Cast<XmlElement>()
+					.ForEach(e => e.ParentNode.RemoveChild(e));
+
+				// BL-2746 For awhile during the v3.3 beta period, after the addition of ckeditor
+				// our topic string was getting wrapped in html paragraph markers. There were a good
+				// number of beta testers, so we need to clean up that mess.
+				topicStrings.Forms
+					.ForEach(
+						languageForm =>
+							topicStrings[languageForm.WritingSystemId] = languageForm.Form.Replace("<p>", "").Replace("</p>", ""));
 			}
 		}
 
@@ -216,30 +230,76 @@ namespace Bloom.Book
 		}
 
 		/// <summary>
-		/// grabs the english (which serves as the 'key') from the datadiv and then adds or updates
-		/// the equivalent for the current cover language
+		/// Topics are uni-directional value, react™-style. The UI tells the book to change the topic
+		/// key, and then eventually the page/book is re-evaluated and the appropriate topic is displayed
+		/// on the page.
+		/// To differentiate from fields with @data-book, which are two-way, the topic on the page instead
+		/// has a @data-derived attribute (in the data-div, it is still a data-book... perhaps that too could
+		/// change to something like data-book-source, but it's not clear to me yet, so.. not yet). 
+		/// When the topic is changed, the javascript sends c# a message with the new English Key for the topic is set in the data-div,
+		/// and then the page is re-computed. That leads to this method, which grabs the 
+		/// english topic (which serves as the 'key') from the datadiv. It then finds the placeholder
+		/// for the topic and fills it with the best translation it can find.
 		/// </summary>
-		/// <param name="data"></param>
-		private void UpdateTopicInLanguageOfCover(DataSet data)
+		private void SetUpDisplayOfTopicInBook(DataSet data)
 		{
-			NamedMutliLingualValue topicData;
-			if(data.TextVariables.TryGetValue("topic", out topicData))
+			var topicPageElement = this._dom.SelectSingleNode("//div[@data-derived='topic']");
+			if (topicPageElement == null)
 			{
-				//we use English as the "key" for topics.
-				var englishTopic = topicData.TextAlternatives.GetExactAlternative("en");
-				if (string.IsNullOrEmpty(englishTopic))
+				//old-style. here we don't have the data-derived, so we need to avoid picking from the datadiv
+				topicPageElement = this._dom.SelectSingleNode("//div[not(id='bloomDataDiv')]//div[@data-book='topic']");
+				if (topicPageElement == null)
+				{
+					//most unit tests do not have complete books, so this not surprising. It just means we don't have anything to do
 					return;
-				string langOfTopicToShowOnCover = _collectionSettings.Language2Iso639Code;
-				var id = "Topics." + englishTopic;
-
-				string s = "";
-				
-				var bestTranslation = LocalizationManager.GetDynamicStringOrEnglish("Bloom", id, englishTopic, "this is a book topic", langOfTopicToShowOnCover);;
-				//NB: in a unit test environment, GetDynamicStringOrEnglish is going to give us the id back, which is annoying.
-				if (bestTranslation == id)
-					bestTranslation = englishTopic;
-				data.AddLanguageString("topic", bestTranslation, langOfTopicToShowOnCover, false);
+				}
 			}
+			//clear it out what's there now
+			topicPageElement.RemoveAttribute("lang");
+			topicPageElement.InnerText = "";
+
+			NamedMutliLingualValue topicData;
+			//if we have no topic element in the data-div, clear it out from the page
+			if (!data.TextVariables.TryGetValue("topic", out topicData))
+				return;
+
+			//we use English as the "key" for topics.
+			var englishTopic = topicData.TextAlternatives.GetExactAlternative("en");
+
+			//if we have no topic, just clear it out from the page
+			if (string.IsNullOrEmpty(englishTopic) || englishTopic == "NoTopic")
+				return;
+
+			var stringId = "Topics." + englishTopic;
+
+			//get the topic in the most prominent language for which we have a translation
+			var langOfTopicToShowOnCover = _collectionSettings.Language1Iso639Code;
+			if (LocalizationManager.GetIsStringAvailableForLangId(stringId, _collectionSettings.Language1Iso639Code))
+			{
+				langOfTopicToShowOnCover = _collectionSettings.Language1Iso639Code;
+			}
+			else if (LocalizationManager.GetIsStringAvailableForLangId(stringId, _collectionSettings.Language2Iso639Code))
+			{
+				langOfTopicToShowOnCover = _collectionSettings.Language2Iso639Code;
+			}
+			else if (LocalizationManager.GetIsStringAvailableForLangId(stringId, _collectionSettings.Language3Iso639Code))
+			{
+				langOfTopicToShowOnCover = _collectionSettings.Language3Iso639Code;
+			}
+			else 
+			{
+				langOfTopicToShowOnCover = "en";
+			}
+
+			var bestTranslation = LocalizationManager.GetDynamicStringOrEnglish("Bloom", stringId, englishTopic,
+				"this is a book topic", langOfTopicToShowOnCover);
+			
+			//NB: in a unit test environment, GetDynamicStringOrEnglish is going to give us the id back, which is annoying.
+			if (bestTranslation == stringId)
+				bestTranslation = englishTopic;
+
+			topicPageElement.SetAttribute("lang", langOfTopicToShowOnCover);
+			topicPageElement.InnerText = bestTranslation;
 		}
 
 		private void UpdateIsbn(BookInfo info)
@@ -255,38 +315,6 @@ namespace Bloom.Book
 			}
 			info.Isbn = isbn ?? "";
 		}
-
-		// For now, when there is no UI for multiple tags, we make Tags a single item, the book topic.
-		// It's not clear what we will want to do when the topic changes and there is a UI for (possibly multiple) tags.
-		// Very likely we still want to add the new topic (if it is not already present).
-		// Should we still remove the old one?
-		private void UpdateTags(BookInfo info)
-		{
-			if (info == null)
-				return;
-
-			NamedMutliLingualValue tagData;
-			string tag = null;
-			if (_dataset.TextVariables.TryGetValue("topic", out tagData))
-			{
-				tag = tagData.TextAlternatives.GetBestAlternativeString(WritingSystemIdsToTry);
-			}
-
-			if (tag == null)
-				return;
-
-			// In case we're running localized, for now we'd like to record in the metadata the original English tag.
-			// This allows the book to be found by this tag in the current, non-localized version of bloom library.
-			// Eventually it will make it easier, we think, to implement localization of bloom library.
-			string originalTag;
-			if (RuntimeInformationInjector.TopicReversal == null ||
-				!RuntimeInformationInjector.TopicReversal.TryGetValue(tag, out originalTag))
-			{
-				originalTag = tag; // just use it unmodified if we don't have anything
-			}
-			info.TagsList = originalTag;
-		}
-
 
 		/// <summary>
 		///
@@ -439,7 +467,7 @@ namespace Bloom.Book
 			//REVIEW: the other methods here are, for some reason, acting on a local DataSet, "data". 
 			//But then this one is acting on the member variable. First Q: why is the rest of this method acting on a local variable dataset?
 			UpdateTitle();
-
+			SetUpDisplayOfTopicInBook(_dataset);
 			return data;
 		}
 
@@ -621,7 +649,6 @@ namespace Bloom.Book
 		/// </summary>
 		private void UpdateDomFromDataSet(DataSet data, string elementName,XmlDocument targetDom, HashSet<Tuple<string, string>> itemsToDelete)
 		{
-			UpdateTopicInLanguageOfCover(data);
 			try
 			{
 				var query = String.Format("//{0}[(@data-book or @data-collection or @data-library)]", elementName);

--- a/src/BloomExe/Book/XMatterHelper.cs
+++ b/src/BloomExe/Book/XMatterHelper.cs
@@ -29,7 +29,7 @@ namespace Bloom.Book
 		/// we leave it to the supplied fileLocator to find it.
 		/// </summary>
 		/// <param name="nameOfXMatterPack">e.g. "Factory", "SILIndonesia"</param>
-		/// <param name="fileLocator">The locator needs to be able tell use the path to an xmater html file, given its name</param>
+		/// <param name="fileLocator">The locator needs to be able tell us the path to an xmater html file, given its name</param>
 		public XMatterHelper(HtmlDom bookDom, string nameOfXMatterPack, IFileLocator fileLocator)
 		{		
 			_bookDom = bookDom;

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -676,6 +676,7 @@ namespace Bloom.Edit
 		{
 			AddMessageEventListener("saveAccordionSettingsEvent", SaveAccordionSettings);
 			AddMessageEventListener("preparePageForEditingAfterOrigamiChangesEvent", RethinkPageAndReloadIt);
+			AddMessageEventListener("setTopic", SetTopic);
 			AddMessageEventListener("finishSavingPage", FinishSavingPage);
 			AddMessageEventListener("handleAddNewPageKeystroke", HandleAddNewPageKeystroke);
 			AddMessageEventListener("addPage", (id) => AddNewPageBasedOnTemplate(id));
@@ -812,6 +813,15 @@ namespace Bloom.Edit
 		private void ChangeRecordingDevice(string deviceName)
 		{
 			_audioRecording.ChangeRecordingDevice(deviceName);
+		}
+
+		//invoked from TopicChooser.ts
+		private void SetTopic(string englishTopicAsKey)
+		{
+			//make the change in the data div
+			_currentlyDisplayedBook.SetTopic(englishTopicAsKey);
+			//reflect that change on this page
+			RethinkPageAndReloadIt(null);
 		}
 
 		private void RethinkPageAndReloadIt(string obj)

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -5,8 +5,10 @@ using System.Linq;
 using System.Xml;
 using Bloom.Book;
 using Bloom.Collection;
+using L10NSharp;
 using NUnit.Framework;
 using SIL.Extensions;
+using SIL.IO;
 using SIL.Reporting;
 using SIL.TestUtilities;
 using SIL.Windows.Forms.ClearShare;
@@ -17,14 +19,29 @@ namespace BloomTests.Book
 	public sealed class BookDataTests
 	{
 		private CollectionSettings _collectionSettings;
+		private LocalizationManager _localizationManager;
 
 		[SetUp]
 		public void Setup()
 		{
-			_collectionSettings = new CollectionSettings(new NewCollectionSettings() {
+			_collectionSettings = new CollectionSettings(new NewCollectionSettings()
+			{
 				PathToSettingsFile = CollectionSettings.GetPathForNewSettings(new TemporaryFolder("BookDataTests").Path, "test"),
-				Language1Iso639Code = "xyz", Language2Iso639Code = "en", Language3Iso639Code = "fr" });
+				Language1Iso639Code = "xyz",
+				Language2Iso639Code = "en",
+				Language3Iso639Code = "fr"
+			});
 			ErrorReport.IsOkToInteractWithUser = false;
+
+			var localizationDirectory = FileLocator.GetDirectoryDistributedWithApplication("localization");
+			_localizationManager = LocalizationManager.Create("fr", "Bloom", "Bloom", "1.0.0", localizationDirectory, "SIL/Bloom",
+				null, "", new string[] {});
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			_localizationManager.Dispose();
 		}
 
 		[Test]
@@ -590,25 +607,87 @@ namespace BloomTests.Book
 			Assert.AreEqual("health", data.GetVariableOrNull("topic", "en"));
 			Assert.IsNull(data.GetVariableOrNull("topic", "tpi"));
 		}
+
 		[Test]
-		public void SynchronizeDataItemsThroughoutDOM_TopicHasParagraphElement_Removed()
+		public void SynchronizeDataItemsThroughoutDOM_VariousTopicScenarios()
 		{
-			var bookDom = new HtmlDom(@"<html ><head></head><body>
+			TestTopicHandling("Health", "fr", "Santé", "fr", "en", null, "Should use lang1");
+			TestTopicHandling("Health", "fr", "Santé", "x", "fr", null, "Should use lang2");
+			TestTopicHandling("Health", "fr", "Santé", "x", "y", "fr", "Should use lang2");
+			TestTopicHandling("Health", "en", "Health", "x", "y", "z", "Should use English");
+			TestTopicHandling("Health", "en", "Health", "en", "fr", "es", "Should use lang1");
+			TestTopicHandling("NoTopic", "", "", "en", "fr", "es", "'No Topic' should give no @lang and no text");
+			TestTopicHandling("Bogus", "en", "Bogus", "z", "fr", "es", "Unrecognized topic should give topic in English");
+		}
+		private void TestTopicHandling(string topicKey, string expectedLanguage, string expectedTranslation, string lang1, string lang2, string lang3, string description)
+		{
+			_collectionSettings.Language1Iso639Code = lang1;
+			_collectionSettings.Language2Iso639Code = lang2;
+			_collectionSettings.Language3Iso639Code = lang3;
+
+			var bookDom = new HtmlDom(@"<html><body>
 				<div id='bloomDataDiv'>
-						<div data-book='topic' lang='en'><p>health</p></div>
-						<div data-book='topic' lang='fr'><p>santé</p></div>
+						<div data-book='topic' lang='en'>"+topicKey+@"</div>
 				</div>
 				<div id='somePage'>
-                    <div data-book='topic' lang='fr'>
-                       <p>santé</p>
+                    <div id='test' data-derived='topic'>
 					</div>
                 </div>
 			 </body></html>");
 			var data = new BookData(bookDom, _collectionSettings, null);
 			data.SynchronizeDataItemsThroughoutDOM();
-			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-book='topic' and @lang='en']/p", 0);
-			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-book='topic' and @lang='en' and text()='health']", 1);
-			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-book='topic' and @lang='fr' and text()='santé']", 2);
+			try
+			{
+				if (string.IsNullOrEmpty(expectedLanguage))
+				{
+					AssertThatXmlIn.Dom(bookDom.RawDom)
+						.HasSpecifiedNumberOfMatchesForXpath(
+							"//div[@id='test' and @data-derived='topic' and not(@lang) and text()='" + expectedTranslation + "']", 1);
+				}
+				else
+				{
+					AssertThatXmlIn.Dom(bookDom.RawDom)
+						.HasSpecifiedNumberOfMatchesForXpath(
+							"//div[@id='test' and @data-derived='topic' and @lang='" + expectedLanguage + "' and text()='" +
+							expectedTranslation + "']", 1);
+				}
+			}
+			catch (Exception)
+			{
+				Assert.Fail(description);
+			}
+			
+		}
+
+		/// <summary>
+		/// we use English as the one and only "key" language for topics in the datadiv
+		/// </summary>
+		[Test]
+		public void SynchronizeDataItemsThroughoutDOM_HasMultipleTopicItems_RemovesAllButEnglish()
+		{
+			var bookDom = new HtmlDom(@"<html><body>
+				<div id='bloomDataDiv'>
+						<div data-book='topic' lang='en'>Health</div>
+						<div data-book='topic' lang='fr'>Santé</div>
+				</div>
+			 </body></html>");
+			var data = new BookData(bookDom, _collectionSettings, null);
+			data.SynchronizeDataItemsThroughoutDOM();
+			AssertThatXmlIn.Dom(bookDom.RawDom).HasNoMatchForXpath("//div[@id='bloomDataDiv']/div[@data-book='topic' and @lang='fr']");
+		}
+
+		[Test]
+		public void SynchronizeDataItemsThroughoutDOM_TopicHasParagraphElement_Removed()
+		{
+			var bookDom = new HtmlDom(@"<html><body>
+				<div id='bloomDataDiv'>
+						<div data-book='topic' lang='en'><p>Health</p></div>
+				</div>
+			 </body></html>");
+			var data = new BookData(bookDom, _collectionSettings, null);
+			data.SynchronizeDataItemsThroughoutDOM();
+			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-derived='topic' and @lang='en']/p", 0);
+			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='topic' and @lang='en' and text()='Health']", 1);
 		}
 		private bool AndikaNewBasicIsInstalled()
 		{

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -613,7 +613,7 @@ namespace BloomTests.Book
 		{
 			TestTopicHandling("Health", "fr", "Santé", "fr", "en", null, "Should use lang1");
 			TestTopicHandling("Health", "fr", "Santé", "x", "fr", null, "Should use lang2");
-			TestTopicHandling("Health", "fr", "Santé", "x", "y", "fr", "Should use lang2");
+			TestTopicHandling("Health", "fr", "Santé", "x", "y", "fr", "Should use lang3");
 			TestTopicHandling("Health", "en", "Health", "x", "y", "z", "Should use English");
 			TestTopicHandling("Health", "en", "Health", "en", "fr", "es", "Should use lang1");
 			TestTopicHandling("NoTopic", "", "", "en", "fr", "es", "'No Topic' should give no @lang and no text");

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -203,7 +203,7 @@ namespace BloomTests.Book
 		public void CreateBookOnDiskFromTemplate_FromFactoryVaccinations_HasCorrectTopicOnCover()
 		{
 			AssertThatXmlIn.HtmlFile(GetNewVaccinationsBookPath()).HasSpecifiedNumberOfMatchesForXpath(
-				"//div[contains(@class,'cover')]//*[@data-book='topic' and text()='Health']", 1);
+				"//div[contains(@class,'cover')]//*[@data-derived='topic' and text()='Health']", 1);
 		}
 
 

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -956,7 +956,7 @@ namespace BloomTests.Book
 				</head>
 				<body>
 					<div class='bloom-page' id='guid3'>
-						<div lang='en' data-book='topic'>original</div>
+						<div lang='en' data-derived='topic'>original</div>
 					</div>
 				</body></html>");
 


### PR DESCRIPTION
The new algorithm for choosing the language of the topic is Vernacular > National Lang 1 > National Lang 2 > English.

This commit simplifies topic handling.
1) only the english key is now stored in the datadiv, ever.
2) only one html element holds the topic on the page. Its @lang and text are determined only by some c#, no more javascript. By moving to a single html element for which code can select the language, we simplify life by not having the static stylesheets try to impose what language will be shown (and then in many cases not know how to translate the topic into that language).
3) The typescript TopicChooser now does not touch the html. React-style, it instead sends up an event which changes the mode (the bloomDataDiv) and then the UI (the html at the bottom of the cover page) gets recomputed.
4) The element holding the topic on the page has a new attribute, "data-derived" to indicate that this value is the result of some computation, it's not part of the model any more (in the old system, it was both, leading to unneeded complexity).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/868)
<!-- Reviewable:end -->
