### PR TITLE
BL-2906 Set Epub phone preview to 400X800px

### DIFF
--- a/src/BloomBrowserUI/Readium/bloomEpubPreview.css
+++ b/src/BloomBrowserUI/Readium/bloomEpubPreview.css
@@ -39,8 +39,8 @@
 }
 #device {
   margin-left: 300px;
-  height: 469px;
-  width: 248px;
+  height: 800px;
+  width: 400px;
   padding-left: 30px;
   padding-top: 72px;
   padding-bottom: 18px;

--- a/src/BloomBrowserUI/epub/bloomEpubPreview.less
+++ b/src/BloomBrowserUI/epub/bloomEpubPreview.less
@@ -39,8 +39,8 @@ body {
 }
 #device {
     margin-left: 300px;
-    height: 469px;
-    width: 248px;
+    height: 800px;
+    width: 400px;
     padding-left: 30px;
     padding-top: 72px;
     padding-bottom: 18px;


### PR DESCRIPTION
Ideally we should maybe display on the preview page what size (in pixels) we were showing and update it when they resized the phone image.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/869)
<!-- Reviewable:end -->
