### PR TITLE
[v3.4]Revert "Cherry-pick image metadata work to 3.4"

### DIFF
--- a/src/BloomExe/Book/ImageUpdater.cs
+++ b/src/BloomExe/Book/ImageUpdater.cs
@@ -30,7 +30,11 @@ namespace Bloom.Book
 			{
 				progress.ProgressIndicator.PercentCompleted = (int)(100.0 * (float)completed / imgElements.Count());
 				progress.WriteStatus("Copying to " + Path.GetFileName(path));
-				metadata.Write(path);
+				using (var image = PalasoImage.FromFile(path))
+				{
+					image.Metadata = metadata;
+					image.SaveUpdatedMetadataIfItMakesSense();
+				}
 				++completed;
 			}
 
@@ -91,7 +95,10 @@ namespace Bloom.Book
 					//Debug.Fail(" (Debug only) Image " + path + " is missing");
 					return;
 				}
-				metadata = Metadata.FromFile(path);
+				using (var image = PalasoImage.FromFile(path))
+				{
+					metadata = image.Metadata;
+				}
 			}
 
 			progress.WriteStatus("Writing metadata to HTML for " + fileName);

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -514,9 +514,6 @@ namespace Bloom.Edit
 			var src = imageElement.GetAttribute("src");
 			string fileName = HttpUtilityFromMono.UrlDecode(src);
 
-			//enhance: this all could be done without loading the image into memory
-			//could just deal with the metadata
-			//e.g., var metadata = Metadata.FromFile(path)
 			var path = Path.Combine(_model.CurrentBook.FolderPath, fileName);
 			using (var imageInfo = PalasoImage.FromFile(path))
 			{


### PR DESCRIPTION
This reverts commit ae1e25746f9595a42d62c1ec99f609cd5ba01a7d.
This was actually BL-2871, not BL-2887!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/870)
<!-- Reviewable:end -->
