### PR TITLE
UrlPathString now handles names with non-encoded plus signs

### DIFF
--- a/src/BloomExe/UrlPathString.cs
+++ b/src/BloomExe/UrlPathString.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Web;
 
@@ -25,8 +26,15 @@ namespace Bloom
 			// essentially didn't trust that the string was already decoded.
 			// Assuming that was done for a good reason, that behavior is
 			// formalized here. It would seem to be a small risk (makes it
-			// impossible to have, say "%20" in your actual file name)
-			unencoded = HttpUtility.UrlDecode(unencoded);
+			// impossible to have, say "%20" in your actual file name).
+			// However, a '+' in the name is much more likely, and so blindly
+			// re-encoding is a problem. Not clear what's best, so at the moment
+			// I'm going with detecting %20 an only encoding if we see that.
+			
+			// space % !	#	$	&	'	(	)	*	+	,	/	:	;	=	?	@	[	]
+			if ("%20 %21 %23 %24 %25 %26 %27 %28 %29 %2A %2B %2C %2F %3A %3B %3D %3F %40 %5B %5D".Split(' ')
+				.Any(s=>unencoded.Contains(s)))
+					unencoded = HttpUtility.UrlDecode(unencoded);
 			return new UrlPathString(unencoded);
 		}
 
@@ -47,7 +55,7 @@ namespace Bloom
 		{
 			get
 			{
-				return CreateFromUrlEncodedString(_notEncoded.Split('?')[0]);
+				return CreateFromUnencodedString(_notEncoded.Split('?')[0]);
 			}
 		}
 

--- a/src/BloomExe/UrlPathString.cs
+++ b/src/BloomExe/UrlPathString.cs
@@ -32,7 +32,7 @@ namespace Bloom
 			// re-encoding is a problem. So the algorithm is that if the
 			// symbol is ambiguous (like '+'), assume it is unencoded (because that's
 			// the name of the method) but if it's obviously encoded, then
-			// encode it.
+			// decode it.
 			
 			if(!strictlyTreatAsEncoded && Regex.IsMatch(unencoded,"%[A-Fa-f0-9]{2}"))
 					unencoded = HttpUtility.UrlDecode(unencoded);

--- a/src/BloomTests/UrlPathStringTests.cs
+++ b/src/BloomTests/UrlPathStringTests.cs
@@ -10,6 +10,12 @@ namespace BloomTests
 	public class UrlPathStringTests
 	{
 		[Test]
+		public void UrlEncodedWithPlus_toUrlEncoded_Retained()
+		{
+			//sometimes things encode a space a '+' instead of %20
+			Assert.AreEqual("test%20me", UrlPathString.CreateFromUrlEncodedString("test+me").UrlEncoded);
+		}
+		[Test]
 		public void UrlEncoded_toUrlEncoded_Retained()
 		{
 			Assert.AreEqual("test%20me", UrlPathString.CreateFromUrlEncodedString("test%20me").UrlEncoded);
@@ -24,6 +30,7 @@ namespace BloomTests
 		{
 			Assert.AreEqual("test%20me", UrlPathString.CreateFromUrlEncodedString("test me").UrlEncoded);
 		}
+
 		[Test]
 		public void Unencoded_toUnencoded_Correct()
 		{ 
@@ -41,12 +48,30 @@ namespace BloomTests
 		{
 			Assert.AreEqual("test me", UrlPathString.CreateFromUnencodedString("test%20me").PathOnly.NotEncoded);
 		}
+
+		[Test]
+		public void PathOnly_AmbiguousInput_RoundTrips()
+		{
+			Assert.AreEqual("test+me", UrlPathString.CreateFromUnencodedString("test+me").PathOnly.NotEncoded);
+		}
+
 		//make sure we don't double-encode
 		[Test]
-		public void CreateFromUnencodedString_StringWasAlreadyEncode_Adapts()
+		public void CreateFromUnencodedString_ObviousStringWasAlreadyEncoded_Adapts()
 		{
 			Assert.AreEqual("test me", UrlPathString.CreateFromUnencodedString("test%20me").NotEncoded);
+			Assert.AreEqual("test%me", UrlPathString.CreateFromUnencodedString("test%25me").NotEncoded);
+			Assert.AreEqual("John&John", UrlPathString.CreateFromUnencodedString("John%26John").NotEncoded);
 		}
+
+		//note however that a + sign is really ambiguous, and we've decided that since the method name
+		//says that the input is unencoded, we should then assume it is really a plus sign.
+		[Test]
+		public void UnencodedWithPlus_roundTripable()
+		{
+			Assert.AreEqual("test+me", UrlPathString.CreateFromUnencodedString("test+me").NotEncoded);
+		}
+
 		[Test]
 		public void Equals_AreEqual_True()
 		{

--- a/src/BloomTests/UrlPathStringTests.cs
+++ b/src/BloomTests/UrlPathStringTests.cs
@@ -54,7 +54,17 @@ namespace BloomTests
 		{
 			Assert.AreEqual("test+me", UrlPathString.CreateFromUnencodedString("test+me").PathOnly.NotEncoded);
 		}
-
+		[Test]
+		public void PathOnly_LooksEncodedButSetStrictlyTreatAsEncodedTrue_RoundTrips()
+		{
+			//this checks that PathOnly doesn't do processing in ambiguous mode, undoing the information we gave it to be strict
+			Assert.AreEqual("test%20me", UrlPathString.CreateFromUnencodedString("test%20me", true).PathOnly.NotEncoded);
+		}
+		[Test]
+		public void CreateFromUnencodedString_LooksEncodedButSetStrictlyTreatAsEncodedTrue_RoundTrips()
+		{
+			Assert.AreEqual("test%20me", UrlPathString.CreateFromUnencodedString("test%20me", true).NotEncoded);
+		}
 		//make sure we don't double-encode
 		[Test]
 		public void CreateFromUnencodedString_ObviousStringWasAlreadyEncoded_Adapts()


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/882)
<!-- Reviewable:end -->
