### PR TITLE
BL-2980 remove spurious ref to notify-custom.js

### DIFF
--- a/src/BloomBrowserUI/pageChooser/page-chooser-main.htm
+++ b/src/BloomBrowserUI/pageChooser/page-chooser-main.htm
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="../bookEdit/css/bloomDialog.css" type="text/css">
     <script type="text/javascript" src="../lib/jquery.js"></script>
     <script type="text/javascript" src="../lib/jquery-ui.js"></script>
-    <script type="text/javascript" src="../lib/notify-custom.js"></script>
     <script type="text/javascript" src="js/page-chooser.js"></script>
     <script type="text/javascript" src="../lib/localizationManager/localizationManager.js"></script>
     <script type="text/javascript" src="../bookEdit/js/getIframeChannel.js"></script>

--- a/src/BloomBrowserUI/pageChooser/page-chooser-main.jade
+++ b/src/BloomBrowserUI/pageChooser/page-chooser-main.jade
@@ -11,7 +11,6 @@ html
 		+stylesheet('../bookEdit/css/bloomDialog.css')
 		+script('../lib/jquery.js')
 		+script('../lib/jquery-ui.js')
-		+script('../lib/notify-custom.js')
 		+script('js/page-chooser.js')
 		+script('../lib/localizationManager/localizationManager.js')
 		+script('../bookEdit/js/getIframeChannel.js')


### PR DESCRIPTION
This reference was added in commit
96e373863596ca056fd201fac7fdada0824b1027
on August 17 2015, apparently to support a single .notify
call that was added to page-chooser.ts for debugging
and accidentally not removed. The .notify call was commented
out two days later and sometime later removed completely.
The notify-custom.js file is also gone. I think we can
safely remove the code that tries (and fails) to load it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/900)

<!-- Reviewable:end -->
