### PR TITLE
BL-2992 Make Talking Book handle edits

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/decodableReader.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/decodableReader.js
@@ -30,10 +30,6 @@ var DecodableReaderModel = (function () {
         $(container).find('.bloom-editable').focusin(function () {
             model.noteFocus(this); // 'This' is the element that just got focus.
         });
-        // and a slightly different one for keypresses
-        $(container).find('.bloom-editable').keypress(function () {
-            model.doKeypressMarkup();
-        });
         $(container).find('.bloom-editable').keydown(function (e) {
             if ((e.keyCode == 90 || e.keyCode == 89) && e.ctrlKey) {
                 if (model.currentMarkupType !== MarkupType.None) {
@@ -60,6 +56,9 @@ var DecodableReaderModel = (function () {
     };
     DecodableReaderModel.prototype.hideTool = function () {
         model.setMarkupType(0);
+    };
+    DecodableReaderModel.prototype.updateMarkup = function () {
+        model.doMarkup();
     };
     DecodableReaderModel.prototype.name = function () { return 'decodableReaderTool'; };
     return DecodableReaderModel;

--- a/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/decodableReader.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/decodableReader.ts
@@ -30,11 +30,6 @@ class DecodableReaderModel implements ITabModel {
             model.noteFocus(this); // 'This' is the element that just got focus.
         });
 
-        // and a slightly different one for keypresses
-        $(container).find('.bloom-editable').keypress(function() {
-            model.doKeypressMarkup();
-        });
-
         $(container).find('.bloom-editable').keydown(function(e) {
             if ((e.keyCode == 90 || e.keyCode == 89) && e.ctrlKey) { // ctrl-z or ctrl-Y
                 if (model.currentMarkupType !== MarkupType.None) {
@@ -62,6 +57,10 @@ class DecodableReaderModel implements ITabModel {
 
     hideTool() {
         model.setMarkupType(0);
+    }
+
+    updateMarkup() {
+        model.doMarkup();
     }
 
     name() { return 'decodableReaderTool'; }

--- a/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/readerToolsModel.ts
@@ -58,7 +58,6 @@ class ReaderToolsModel {
   setupType: string = '';
   fontName: string = '';
   readableFileExtensions: string[] = [];
-  keypressTimer: any = null;
   directoryWatcher: DirectoryWatcher = null;
   maxAllowedWords: number = 10000;
 
@@ -551,68 +550,6 @@ class ReaderToolsModel {
     return $('.bloom-page', page.contentWindow.document)
       .not('.bloom-frontMatter, .bloom-backMatter')
       .find('.bloom-content1.bloom-editable');
-  }
-
-  doKeypressMarkup(): void {
-
-    // BL-599: "Unresponsive script" while typing in text.
-    // The function setTimeout() returns an integer, not a timer object, and therefore it does not have a member
-    // function called "clearTimeout." Because of this, the jQuery method $.isFunction(this.keypressTimer.clearTimeout)
-    // will always return false (since "this.keypressTimer.clearTimeout" is undefined) and the result is a new 500
-    // millisecond timer being created every time the doKeypress method is called, but none of the pre-existing timers
-    // being cleared. The correct way to clear a timeout is to call clearTimeout(), passing it the integer returned by
-    // the function setTimeout().
-
-    //if (this.keypressTimer && $.isFunction(this.keypressTimer.clearTimeout)) {
-    //  this.keypressTimer.clearTimeout();
-    //}
-    if (model.keypressTimer)
-      clearTimeout(model.keypressTimer);
-
-    model.keypressTimer = setTimeout(function () {
-
-      // This happens 500ms after the user stops typing.
-      var page: HTMLIFrameElement = <HTMLIFrameElement>parent.window.document.getElementById('page');
-      if (!page) return; // unit testing?
-
-      var selection: Selection = page.contentWindow.getSelection();
-      var current: Node = selection.anchorNode;
-      var active = <HTMLDivElement>$(selection.anchorNode).closest('div').get(0);
-      if (!active || selection.rangeCount > 1 || (selection.rangeCount == 1 && !selection.getRangeAt(0).collapsed)) {
-        return; // don't even try to adjust markup while there is some complex selection
-      }
-
-      var myRange: Range = selection.getRangeAt(0).cloneRange();
-      myRange.setStart(active, 0);
-      var offset: number = myRange.toString().length;
-
-      // In case the IP is somewhere like after the last <br> or between <br>s,
-      // its anchorNode is the div itself, or perhaps one of its spans, and we want to try to put it back
-      // in a comparable position. -1 marks a selection that is at a text level.
-      // other values count the <br> elements immediately before the selection.
-      // I am hoping it doesn't happen that there are <br>s at multiple levels.
-      // Note that the newly marked up version will have any <br>s at the top level only (children of the div).
-      var divBrCount: number = -1;
-      if (current.nodeType !== 3) {
-        divBrCount = 0;
-        // endoffset counts the number of childNodes that the selection is after.
-        // We want to know how many <br> nodes are between it and the previous non-empty node.
-        for (var k = myRange.endOffset - 1; k >= 0; k--) {
-          if (current.childNodes[k].localName === 'br') divBrCount++;
-          else if (current.childNodes[k].textContent.length > 0) break;
-        }
-      }
-
-      var atStart: boolean = myRange.endOffset === 0;
-
-      model.doMarkup();
-
-      // Now we try to restore the selection at the specified position.
-      EditableDivUtils.makeSelectionIn(active, offset, divBrCount, atStart);
-
-      // clear this value to prevent unnecessary calls to clearTimeout() for timeouts that have already expired.
-      model.keypressTimer = null;
-    }, 500);
   }
 
   noteFocus(element: HTMLElement): void {

--- a/src/BloomBrowserUI/bookEdit/toolbox/leveledReader/leveledReader.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/leveledReader/leveledReader.js
@@ -21,6 +21,9 @@ var LeveledReaderModel = (function () {
     LeveledReaderModel.prototype.hideTool = function () {
         model.setMarkupType(0);
     };
+    LeveledReaderModel.prototype.updateMarkup = function () {
+        model.doMarkup();
+    };
     LeveledReaderModel.prototype.name = function () { return 'leveledReaderTool'; };
     return LeveledReaderModel;
 })();

--- a/src/BloomBrowserUI/bookEdit/toolbox/leveledReader/leveledReader.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/leveledReader/leveledReader.ts
@@ -22,6 +22,10 @@ class LeveledReaderModel implements ITabModel {
         model.setMarkupType(0);
     }
 
+    updateMarkup() {
+        model.doMarkup();
+    }
+
     name() {return 'leveledReaderTool';}
 }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.js
@@ -615,7 +615,7 @@ var AudioRecording = (function () {
     // special cases); this root method scans down and does it for each such child
     // in a root (possibly the root itself, if it has no children).
     AudioRecording.prototype.makeSentenceSpans = function (root) {
-        var thisClass = this;
+        var _this = this;
         root.each(function (index, e) {
             var children = $(e).children();
             var processedChild = false; // Did we find a significant child?
@@ -625,11 +625,11 @@ var AudioRecording = (function () {
                 // Review: is there a better way to pick out the elements that can occur within content elements?
                 if (name != 'span' && name != 'br' && name != 'i' && name != 'b' && name != 'u' && $(child).attr('id') !== 'formatButton') {
                     processedChild = true;
-                    thisClass.makeSentenceSpans($(child));
+                    _this.makeSentenceSpans($(child));
                 }
             }
             if (!processedChild)
-                thisClass.makeSentenceSpansLeaf($(e));
+                _this.makeSentenceSpansLeaf($(e));
         });
         // Review: is there a need to handle elements that contain both sentence text AND child elements with their own text?
     };

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -654,8 +654,7 @@ class AudioRecording {
     // special cases); this root method scans down and does it for each such child
     // in a root (possibly the root itself, if it has no children).
     private makeSentenceSpans(root: JQuery): void {
-        var thisClass = this;
-        root.each(function(index: number, e: Element) {
+        root.each((index: number, e: Element) => {
             var children = $(e).children();
             var processedChild: boolean = false; // Did we find a significant child?
             for (var i = 0; i < children.length; i++) {
@@ -664,11 +663,11 @@ class AudioRecording {
                 // Review: is there a better way to pick out the elements that can occur within content elements?
                 if (name != 'span' && name != 'br' && name != 'i' && name != 'b' && name != 'u' && $(child).attr('id') !== 'formatButton') {
                     processedChild = true;
-                    thisClass.makeSentenceSpans($(child));
+                    this.makeSentenceSpans($(child));
                 }
             }
             if (!processedChild) // root is a leaf; process its actual content
-                thisClass.makeSentenceSpansLeaf($(e));
+                this.makeSentenceSpansLeaf($(e));
         });
         // Review: is there a need to handle elements that contain both sentence text AND child elements with their own text?
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -285,19 +285,25 @@ class AudioRecording {
     public setupForRecording(): void {
         this.updateInputDeviceDisplay();
         var page = this.getPage();
+        this.hiddenSourceBubbles = page.find('.uibloomSourceTextsBubble');
+        this.hiddenSourceBubbles.hide();
         var editable = <qtipInterface>page.find('div.bloom-editable');
         if (editable.length === 0) {
             // no editable text on this page.
             this.configureForNothingToRecord();
             return;
         }
+        this.updateMarkupAndControlsToCurrentText();
+    }
+
+    public updateMarkupAndControlsToCurrentText() {
+        var page = this.getPage();
+        var editable = <qtipInterface>page.find('div.bloom-editable');
         this.makeSentenceSpans(editable);
         // For displaying the qtip, restrict the editable divs to the ones that have
         // audio sentences.
         editable = <qtipInterface>$(page).find('span.audio-sentence').parents('div.bloom-editable');
         var thisClass = this;
-        this.hiddenSourceBubbles = page.find('.uibloomSourceTextsBubble');
-        this.hiddenSourceBubbles.hide();
 
         thisClass.setStatus('record', Status.Expected);
         thisClass.levelCanvas = $('#audio-meter').get()[0];
@@ -323,7 +329,9 @@ class AudioRecording {
 
     public removeRecordingSetup() {
         this.hiddenSourceBubbles.show();
-        this.getPage().find('.ui-audioCurrent').removeClass('ui-audioCurrent');
+        var page = this.getPage();
+        page.find('.ui-audioCurrent').removeClass('ui-audioCurrent');
+        var editable = <qtipInterface>page.find('div.bloom-editable');
     }
 
     // This gets invoked (via a non-object method of the same name in this file,
@@ -646,19 +654,22 @@ class AudioRecording {
     // special cases); this root method scans down and does it for each such child
     // in a root (possibly the root itself, if it has no children).
     private makeSentenceSpans(root: JQuery): void {
-        var children = root.children();
-        var processedChild: boolean = false; // Did we find a significant child?
-        for (var i = 0; i < children.length; i++) {
-            var child: HTMLElement = children[i];
-            var name = child.nodeName.toLowerCase();
-            // Review: is there a better way to pick out the elements that can occur within content elements?
-            if (name != 'span' && name != 'br' && name != 'i' && name != 'b' && name != 'u') {
-                processedChild = true;
-                this.makeSentenceSpans($(child));
+        var thisClass = this;
+        root.each(function(index: number, e: Element) {
+            var children = $(e).children();
+            var processedChild: boolean = false; // Did we find a significant child?
+            for (var i = 0; i < children.length; i++) {
+                var child: HTMLElement = children[i];
+                var name = child.nodeName.toLowerCase();
+                // Review: is there a better way to pick out the elements that can occur within content elements?
+                if (name != 'span' && name != 'br' && name != 'i' && name != 'b' && name != 'u' && $(child).attr('id') !== 'formatButton') {
+                    processedChild = true;
+                    thisClass.makeSentenceSpans($(child));
+                }
             }
-        }
-        if (!processedChild) // root is a leaf; process its actual content
-            this.makeSentenceSpansLeaf(root);
+            if (!processedChild) // root is a leaf; process its actual content
+                thisClass.makeSentenceSpansLeaf($(e));
+        });
         // Review: is there a need to handle elements that contain both sentence text AND child elements with their own text?
     }
 
@@ -667,6 +678,14 @@ class AudioRecording {
     // Where there aren't exact matches, but there are existing audio-sentence spans, we keep the ids as far as possible,
     // just using the original order, since it is possible we have a match and only spelling or punctuation changed.
     private makeSentenceSpansLeaf(elt: JQuery): void {
+        // When all text is deleted, we get in a temporary state with no paragraph elements, so the root editable div
+        // may be processed...and if this happens during editing the format button may be present. The body of this function
+        // will do weird things with it (wrap it in a sentence span, for example) so the easiest thing is to remove
+        // it at the start and reinstate it at the end. Fortunately its position is predictable. But I wish this
+        // otherwise fairly generic code didn't have to know about it.
+        var formatButton = elt.find('#formatButton');
+        formatButton.remove(); // nothing happens if not found
+
         var markedSentences = elt.find("span.audio-sentence");
         var reuse = []; // an array of id/md5 pairs for any existing sentences marked up for audio in the element.
         markedSentences.each(function(index) {
@@ -723,6 +742,7 @@ class AudioRecording {
 
         // set the html
         elt.html(newHtml);
+        elt.append(formatButton);
     }
 
     private isRecordable(fragment: textFragment): Boolean {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.js
@@ -15,6 +15,9 @@ var TalkingBookModel = (function () {
     TalkingBookModel.prototype.hideTool = function () {
         audioRecorder.removeRecordingSetup();
     };
+    TalkingBookModel.prototype.updateMarkup = function () {
+        audioRecorder.updateMarkupAndControlsToCurrentText();
+    };
     TalkingBookModel.prototype.name = function () { return 'talkingBookTool'; };
     return TalkingBookModel;
 })();

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
@@ -19,6 +19,10 @@ class TalkingBookModel implements ITabModel {
         audioRecorder.removeRecordingSetup();
     }
 
+    updateMarkup() {
+        audioRecorder.updateMarkupAndControlsToCurrentText();
+    }
+
     name() { return 'talkingBookTool'; }
 }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.js
@@ -7,6 +7,7 @@
  */
 var checkMarkString = '&#10004;';
 var showingPanel = false;
+var keypressTimer = null;
 // Class that represents the whole toolbox. Gradually we will move more functionality in here.
 var ToolBox = (function () {
     function ToolBox() {
@@ -15,6 +16,12 @@ var ToolBox = (function () {
     ToolBox.prototype.configureElementsForTools = function (container) {
         for (var i = 0; i < tabModels.length; i++) {
             tabModels[i].configureElements(container);
+            // the toolbox itself handles keypresses in order to manage the process
+            // of giving each tool a chance to update things when the user stops typing
+            // (while maintaining the selection if at all possible).
+            $(container).find('.bloom-editable').keypress(function () {
+                doKeypressMarkup();
+            });
         }
     };
     return ToolBox;
@@ -203,6 +210,60 @@ function requestPanel(checkBoxId, panelId, loadNextCallback, panels, currentPane
                 loadNextCallback(panels, currentPanel);
         });
     }
+}
+function doKeypressMarkup() {
+    // BL-599: "Unresponsive script" while typing in text.
+    // The function setTimeout() returns an integer, not a timer object, and therefore it does not have a member
+    // function called "clearTimeout." Because of this, the jQuery method $.isFunction(keypressTimer.clearTimeout)
+    // will always return false (since "this.keypressTimer.clearTimeout" is undefined) and the result is a new 500
+    // millisecond timer being created every time the doKeypress method is called, but none of the pre-existing timers
+    // being cleared. The correct way to clear a timeout is to call clearTimeout(), passing it the integer returned by
+    // the function setTimeout().
+    //if (this.keypressTimer && $.isFunction(this.keypressTimer.clearTimeout)) {
+    //  this.keypressTimer.clearTimeout();
+    //}
+    if (keypressTimer)
+        clearTimeout(keypressTimer);
+    keypressTimer = setTimeout(function () {
+        // This happens 500ms after the user stops typing.
+        var page = parent.window.document.getElementById('page');
+        if (!page)
+            return; // unit testing?
+        var selection = page.contentWindow.getSelection();
+        var current = selection.anchorNode;
+        var active = $(selection.anchorNode).closest('div').get(0);
+        if (!active || selection.rangeCount > 1 || (selection.rangeCount == 1 && !selection.getRangeAt(0).collapsed)) {
+            return; // don't even try to adjust markup while there is some complex selection
+        }
+        var myRange = selection.getRangeAt(0).cloneRange();
+        myRange.setStart(active, 0);
+        var offset = myRange.toString().length;
+        // In case the IP is somewhere like after the last <br> or between <br>s,
+        // its anchorNode is the div itself, or perhaps one of its spans, and we want to try to put it back
+        // in a comparable position. -1 marks a selection that is at a text level.
+        // other values count the <br> elements immediately before the selection.
+        // I am hoping it doesn't happen that there are <br>s at multiple levels.
+        // Note that the newly marked up version will have any <br>s at the top level only (children of the div).
+        var divBrCount = -1;
+        if (current.nodeType !== 3) {
+            divBrCount = 0;
+            // endoffset counts the number of childNodes that the selection is after.
+            // We want to know how many <br> nodes are between it and the previous non-empty node.
+            for (var k = myRange.endOffset - 1; k >= 0; k--) {
+                if (current.childNodes[k].localName === 'br')
+                    divBrCount++;
+                else if (current.childNodes[k].textContent.length > 0)
+                    break;
+            }
+        }
+        var atStart = myRange.endOffset === 0;
+        if (currentTool)
+            currentTool.updateMarkup();
+        // Now we try to restore the selection at the specified position.
+        EditableDivUtils.makeSelectionIn(active, offset, divBrCount, atStart);
+        // clear this value to prevent unnecessary calls to clearTimeout() for timeouts that have already expired.
+        keypressTimer = null;
+    }, 500);
 }
 var resizeTimer;
 function resizeToolbox() {

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -10,11 +10,15 @@ var checkMarkString = '&#10004;';
 
 var showingPanel = false;
 
+var keypressTimer: any = null;
+
+
 interface ITabModel {
     restoreSettings(settings: string);
     configureElements(container: HTMLElement);
     showTool();
     hideTool();
+    updateMarkup();
     name(): string;
 }
 
@@ -24,7 +28,13 @@ class ToolBox {
     configureElementsForTools(container: HTMLElement) {
         for (var i = 0; i < tabModels.length; i++) {
             tabModels[i].configureElements(container);
-        }
+            // the toolbox itself handles keypresses in order to manage the process
+            // of giving each tool a chance to update things when the user stops typing
+            // (while maintaining the selection if at all possible).
+            $(container).find('.bloom-editable').keypress(function () {
+                doKeypressMarkup();
+            });
+       }
     }
 }
 
@@ -242,6 +252,68 @@ function requestPanel(checkBoxId, panelId, loadNextCallback, panels, currentPane
                     loadNextCallback(panels, currentPanel);
             });
     }
+}
+
+function doKeypressMarkup(): void {
+
+    // BL-599: "Unresponsive script" while typing in text.
+    // The function setTimeout() returns an integer, not a timer object, and therefore it does not have a member
+    // function called "clearTimeout." Because of this, the jQuery method $.isFunction(keypressTimer.clearTimeout)
+    // will always return false (since "this.keypressTimer.clearTimeout" is undefined) and the result is a new 500
+    // millisecond timer being created every time the doKeypress method is called, but none of the pre-existing timers
+    // being cleared. The correct way to clear a timeout is to call clearTimeout(), passing it the integer returned by
+    // the function setTimeout().
+
+    //if (this.keypressTimer && $.isFunction(this.keypressTimer.clearTimeout)) {
+    //  this.keypressTimer.clearTimeout();
+    //}
+    if(keypressTimer)
+      clearTimeout(keypressTimer);
+
+    keypressTimer = setTimeout(function () {
+
+        // This happens 500ms after the user stops typing.
+        var page: HTMLIFrameElement = <HTMLIFrameElement>parent.window.document.getElementById('page');
+        if (!page) return; // unit testing?
+
+        var selection: Selection = page.contentWindow.getSelection();
+        var current: Node = selection.anchorNode;
+        var active = <HTMLDivElement>$(selection.anchorNode).closest('div').get(0);
+        if (!active || selection.rangeCount > 1 || (selection.rangeCount == 1 && !selection.getRangeAt(0).collapsed)) {
+            return; // don't even try to adjust markup while there is some complex selection
+        }
+
+        var myRange: Range = selection.getRangeAt(0).cloneRange();
+        myRange.setStart(active, 0);
+        var offset: number = myRange.toString().length;
+
+        // In case the IP is somewhere like after the last <br> or between <br>s,
+        // its anchorNode is the div itself, or perhaps one of its spans, and we want to try to put it back
+        // in a comparable position. -1 marks a selection that is at a text level.
+        // other values count the <br> elements immediately before the selection.
+        // I am hoping it doesn't happen that there are <br>s at multiple levels.
+        // Note that the newly marked up version will have any <br>s at the top level only (children of the div).
+        var divBrCount: number = -1;
+        if (current.nodeType !== 3) {
+            divBrCount = 0;
+            // endoffset counts the number of childNodes that the selection is after.
+            // We want to know how many <br> nodes are between it and the previous non-empty node.
+            for (var k = myRange.endOffset - 1; k >= 0; k--) {
+                if (current.childNodes[k].localName === 'br') divBrCount++;
+                else if (current.childNodes[k].textContent.length > 0) break;
+            }
+        }
+
+        var atStart: boolean = myRange.endOffset === 0;
+
+        if (currentTool) currentTool.updateMarkup();
+
+        // Now we try to restore the selection at the specified position.
+        EditableDivUtils.makeSelectionIn(active, offset, divBrCount, atStart);
+
+        // clear this value to prevent unnecessary calls to clearTimeout() for timeouts that have already expired.
+        keypressTimer = null;
+    }, 500);
 }
 
 var resizeTimer;


### PR DESCRIPTION
Part of this change moves some code,
mainly doKeypressMarkup(), out of readerToolsModel
into toolbox, so that the logic that initiates updating
tool-related stuff 0.5 seconds after the user stops
typing can be shared by all three tools (with a new
tool method updateMarkup).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/906)

<!-- Reviewable:end -->
