### PR TITLE
BL-2998 Remove knowledge of DR from main server

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/leveledReader/leveledReader.htm
+++ b/src/BloomBrowserUI/bookEdit/toolbox/leveledReader/leveledReader.htm
@@ -61,11 +61,11 @@
       </div>
       <div style="margin-left: 8px;" class="section"><span data-i18n="EditTab.Toolbox.LeveledReaderTool.KeepInMind">Keep in mind</span>
         <ul>
-          <li><a href="javascript:loadExternalLink(&quot;leveledRTInfo/leveledReaderInfo-en.htm?Vocabulary&quot;)" data-i18n="EditTab.Toolbox.LeveledReaderTool.Vocabulary">Vocabulary</a></li>
-          <li><a href="javascript:loadExternalLink(&quot;leveledRTInfo/leveledReaderInfo-en.htm?Formatting&quot;)" data-i18n="EditTab.Toolbox.LeveledReaderTool.Formatting">Formatting</a></li>
-          <li><a href="javascript:loadExternalLink(&quot;leveledRTInfo/leveledReaderInfo-en.htm?Predictability&quot;)" data-i18n="EditTab.Toolbox.LeveledReaderTool.Predictability">Predictability</a></li>
-          <li><a href="javascript:loadExternalLink(&quot;leveledRTInfo/leveledReaderInfo-en.htm?IllustrationSupport&quot;)" data-i18n="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport">Illustration Support</a></li>
-          <li><a href="javascript:loadExternalLink(&quot;leveledRTInfo/leveledReaderInfo-en.htm?ChoiceOfTopic&quot;)" data-i18n="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic">Choice of Topic</a></li>
+          <li><a href="javascript:loadExternalLink(&quot;openFileInBrowser/leveledRTInfo/leveledReaderInfo-en.htm?Vocabulary&quot;)" data-i18n="EditTab.Toolbox.LeveledReaderTool.Vocabulary">Vocabulary</a></li>
+          <li><a href="javascript:loadExternalLink(&quot;openFileInBrowser/leveledRTInfo/leveledReaderInfo-en.htm?Formatting&quot;)" data-i18n="EditTab.Toolbox.LeveledReaderTool.Formatting">Formatting</a></li>
+          <li><a href="javascript:loadExternalLink(&quot;openFileInBrowser/leveledRTInfo/leveledReaderInfo-en.htm?Predictability&quot;)" data-i18n="EditTab.Toolbox.LeveledReaderTool.Predictability">Predictability</a></li>
+          <li><a href="javascript:loadExternalLink(&quot;openFileInBrowser/leveledRTInfo/leveledReaderInfo-en.htm?IllustrationSupport&quot;)" data-i18n="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport">Illustration Support</a></li>
+          <li><a href="javascript:loadExternalLink(&quot;openFileInBrowser/leveledRTInfo/leveledReaderInfo-en.htm?ChoiceOfTopic&quot;)" data-i18n="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic">Choice of Topic</a></li>
         </ul>
       </div>
       <script type="text/javascript">

--- a/src/BloomBrowserUI/bookEdit/toolbox/leveledReader/leveledReader.jade
+++ b/src/BloomBrowserUI/bookEdit/toolbox/leveledReader/leveledReader.jade
@@ -61,15 +61,15 @@ html
 				span(data-i18n='EditTab.Toolbox.LeveledReaderTool.KeepInMind') Keep in mind
 				ul
 					li
-						a(href='javascript:loadExternalLink("leveledRTInfo/leveledReaderInfo-en.htm?Vocabulary")', data-i18n='EditTab.Toolbox.LeveledReaderTool.Vocabulary') Vocabulary
+						a(href='javascript:loadExternalLink("openFileInBrowser/leveledRTInfo/leveledReaderInfo-en.htm?Vocabulary")', data-i18n='EditTab.Toolbox.LeveledReaderTool.Vocabulary') Vocabulary
 					li
-						a(href='javascript:loadExternalLink("leveledRTInfo/leveledReaderInfo-en.htm?Formatting")', data-i18n='EditTab.Toolbox.LeveledReaderTool.Formatting') Formatting
+						a(href='javascript:loadExternalLink("openFileInBrowser/leveledRTInfo/leveledReaderInfo-en.htm?Formatting")', data-i18n='EditTab.Toolbox.LeveledReaderTool.Formatting') Formatting
 					li
-						a(href='javascript:loadExternalLink("leveledRTInfo/leveledReaderInfo-en.htm?Predictability")', data-i18n='EditTab.Toolbox.LeveledReaderTool.Predictability') Predictability
+						a(href='javascript:loadExternalLink("openFileInBrowser/leveledRTInfo/leveledReaderInfo-en.htm?Predictability")', data-i18n='EditTab.Toolbox.LeveledReaderTool.Predictability') Predictability
 					li
-						a(href='javascript:loadExternalLink("leveledRTInfo/leveledReaderInfo-en.htm?IllustrationSupport")', data-i18n='EditTab.Toolbox.LeveledReaderTool.IllustrationSupport') Illustration Support
+						a(href='javascript:loadExternalLink("openFileInBrowser/leveledRTInfo/leveledReaderInfo-en.htm?IllustrationSupport")', data-i18n='EditTab.Toolbox.LeveledReaderTool.IllustrationSupport') Illustration Support
 					li
-						a(href='javascript:loadExternalLink("leveledRTInfo/leveledReaderInfo-en.htm?ChoiceOfTopic")', data-i18n='EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic') Choice of Topic
+						a(href='javascript:loadExternalLink("openFileInBrowser/leveledRTInfo/leveledReaderInfo-en.htm?ChoiceOfTopic")', data-i18n='EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic') Choice of Topic
 			script(type='text/javascript').
 				$(document).ready(function() {
 					// this timeout is different than the decodableReader timeout to prevent initializing synphony twice

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -222,6 +222,7 @@ namespace Bloom
 //				else
 //				{
 					_httpServer = new EnhancedImageServer(new RuntimeImageProcessor(bookRenameEvent), parentContainer.Resolve<BookThumbNailer>());
+					ReadersHandler.Init(_httpServer);
 //				}
 					builder.Register((c => _httpServer)).AsSelf().SingleInstance();
 

--- a/src/BloomExe/web/ReadersHandler.cs
+++ b/src/BloomExe/web/ReadersHandler.cs
@@ -41,7 +41,6 @@ namespace Bloom.web
 		{
 			Server = server;
 			server.RegisterRequestHandler("readers/", HandleRequest);
-			server.RegisterRequestHandler("leveledRTInfo/", ProcessLeveldRtInfo);
 		}
 
 		// The current book we are editing. Currently this is needed so we can return all the text, to enable JavaScript to update
@@ -462,90 +461,6 @@ namespace Bloom.web
 			public int GetHashCode(string obj)
 			{
 				return obj.ToLowerInvariant().GetHashCode();
-			}
-		}
-
-		/// <summary>
-		/// Handle server queries starting with "leveledRTInfo/". Currently these are requests to see
-		/// one of the additional suggestions for a particular level.
-		/// </summary>
-		/// <param name="localPath"></param>
-		/// <param name="info"></param>
-		/// <param name="dummy"></param>
-		/// <returns></returns>
-		public static bool ProcessLeveldRtInfo(string localPath, IRequestInfo info, CollectionSettings dummy)
-		{
-			var queryPart = String.Empty;
-			if (info.RawUrl.Contains("?"))
-				queryPart = "#" + info.RawUrl.Split('?')[1];
-			var langCode = LocalizationManager.UILanguageId;
-			var completeEnglishPath = FileLocator.GetFileDistributedWithApplication(localPath);
-			var completeUiLangPath = GetUiLanguageFileVersion(completeEnglishPath, langCode);
-			string url;
-			if (langCode != "en" && File.Exists(completeUiLangPath))
-				url = completeUiLangPath;
-			else
-				url = completeEnglishPath;
-			var cleanUrl = url.Replace("\\", "/"); // allows jump to file to work
-
-			string browser = String.Empty;
-			if (Platform.IsLinux)
-			{
-				// REVIEW: This opens HTML files in the browser. Do we have any non-html
-				// files that this code needs to open in the browser? Currently they get
-				// opened in whatever application the user has selected for that file type
-				// which might well be an editor.
-				browser = "xdg-open";
-			}
-			else
-			{
-				// If we don't provide the path of the browser, i.e. Process.Start(url + queryPart), we get file not found exception.
-				// If we prepend "file:///", the anchor part of the link (#xxx) is not sent unless we provide the browser path too.
-				// This is the same behavior when simply typing a url into the Run command on Windows.
-				// If we fail to get the browser path for some reason, we still load the page, just without navigating to the anchor.
-				string defaultBrowserPath;
-				if (TryGetDefaultBrowserPath(out defaultBrowserPath))
-				{
-					browser = defaultBrowserPath;
-				}
-			}
-
-			if (!String.IsNullOrEmpty(browser))
-			{
-				try
-				{
-					Process.Start(browser, "\"file:///" + cleanUrl + queryPart + "\"");
-					return false;
-				}
-				catch (Exception)
-				{
-					Debug.Fail("Jumping to browser with anchor failed.");
-					// Don't crash Bloom because we can't open an external file.
-				}
-			}
-			// If the above failed, either for lack of default browser or exception, try this:
-			Process.Start("\"" + cleanUrl + "\"");
-			return false;
-		}
-
-		private static string GetUiLanguageFileVersion(string englishFileName, string langCode)
-		{
-			return englishFileName.Replace("-en.htm", "-" + langCode + ".htm");
-		}
-
-		private static bool TryGetDefaultBrowserPath(out string defaultBrowserPath)
-		{
-			try
-			{
-				string key = @"HTTP\shell\open\command";
-				using (RegistryKey registrykey = Registry.ClassesRoot.OpenSubKey(key, false))
-					defaultBrowserPath = ((string)registrykey.GetValue(null, null)).Split('"')[1];
-				return true;
-			}
-			catch
-			{
-				defaultBrowserPath = null;
-				return false;
 			}
 		}
 	}


### PR DESCRIPTION
Adds a mechanism to inject request handlers into the
main server, and uses it for handlers for the
Decodable and Leveled reader requests.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/907)

<!-- Reviewable:end -->
