### PR TITLE
BL-2989 stop always displaying reader tools

### DIFF
--- a/src/BloomExe/Edit/BookSettingsTool.cs
+++ b/src/BloomExe/Edit/BookSettingsTool.cs
@@ -12,5 +12,9 @@
 				return;
 		}
 
+		public override bool AlwaysEnabled
+		{
+			get { return true; }
+		}
 	}
 }

--- a/src/BloomExe/Edit/TalkingBookTool.cs
+++ b/src/BloomExe/Edit/TalkingBookTool.cs
@@ -4,5 +4,10 @@
 	{
 		public const string StaticToolId = "talkingBook";  // Avoid changing value; see ToolboxTool.JsonToolId
 		public override string ToolId { get { return StaticToolId; } }
+
+		public override bool AlwaysEnabled
+		{
+			get { return true; }
+		}
 	}
 }

--- a/src/BloomExe/Edit/ToolboxTool.cs
+++ b/src/BloomExe/Edit/ToolboxTool.cs
@@ -42,6 +42,15 @@ namespace Bloom.Edit
 		public bool Enabled { get; set; }
 
 		/// <summary>
+		/// Override in tools that don't have an Enabled checkbox but are always enabled.
+		/// </summary>
+		[JsonIgnore]
+		public virtual bool AlwaysEnabled
+		{
+			get { return false; }
+		}
+
+		/// <summary>
 		/// Different tools may use this arbitrarily. Currently decodable and leveled readers use it to store
 		/// the stage or level a book belongs to (at least the one last active when editing it).
 		/// </summary>

--- a/src/BloomExe/Edit/ToolboxView.cs
+++ b/src/BloomExe/Edit/ToolboxView.cs
@@ -92,7 +92,7 @@ namespace Bloom.Edit
 			toolsToDisplay.AddRange(
 				idsOfToolsThisVersionKnowsAbout.Except(
 					toolsThatHaveDataInBookInfo.Select(t => t.ToolId)).Select(ToolboxTool.CreateFromToolId));
-			return toolsToDisplay;
+			return toolsToDisplay.Where(t => t.Enabled || t.AlwaysEnabled).ToList();
 		}
 
 		private static void EmbedSettings(Book.Book book, IEnumerable<ToolboxTool> enabledTools, HtmlDom domForToolbox)


### PR DESCRIPTION
A recent bug made these tools always displayed

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/915)

<!-- Reviewable:end -->
