### PR TITLE
BL-3004 Handle Book Settings that are not valid XML

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -788,7 +788,7 @@ namespace Bloom.Book
 			foreach (XmlElement e in RawDom.SafeSelectNodes("//div[@id='bloomDataDiv']/div[@data-book='" + key + "']"))
 			{
 				var lang = e.GetAttribute("lang");
-				result.SetAlternative(lang ?? "", e.InnerXml);
+				result.SetAlternative(lang ?? "", e.InnerText);
 			}
 			return result;
 		}
@@ -821,7 +821,7 @@ namespace Bloom.Book
 				node.SetAttribute("data-book", key);
 				node.SetAttribute("lang", writingSystemId);
 			}
-			node.InnerXml = form;
+			node.InnerText = form; // not InnerXml as it may contain things like SILA & LASI that are not valid XML
 			dataDiv.AppendChild(node);
 		}
 


### PR DESCRIPTION
We were trying to set things like SILA & LASI as the InnerXML
of a DOM element for storing copyright info.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/916)

<!-- Reviewable:end -->
