### PR TITLE
BL-2966 copy only ClearShare metadata to all images

### DIFF
--- a/src/BloomExe/Book/ImageUpdater.cs
+++ b/src/BloomExe/Book/ImageUpdater.cs
@@ -30,7 +30,7 @@ namespace Bloom.Book
 			{
 				progress.ProgressIndicator.PercentCompleted = (int)(100.0 * (float)completed / imgElements.Count());
 				progress.WriteStatus("Copying to " + Path.GetFileName(path));
-				metadata.WriteLicenseOnly(path);
+				metadata.WriteIntellectualPropertyOnly(path);
 				++completed;
 			}
 

--- a/src/BloomExe/Book/ImageUpdater.cs
+++ b/src/BloomExe/Book/ImageUpdater.cs
@@ -30,7 +30,7 @@ namespace Bloom.Book
 			{
 				progress.ProgressIndicator.PercentCompleted = (int)(100.0 * (float)completed / imgElements.Count());
 				progress.WriteStatus("Copying to " + Path.GetFileName(path));
-				metadata.Write(path);
+				metadata.WriteLicenseOnly(path);
 				++completed;
 			}
 


### PR DESCRIPTION
in collection
LibPalaso is changing so that the default is to write everything.
This PR should be merged as soon as possible after it so we don't
copy irrelevant metadata from one image to another.
Do NOT merge BEFORE https://github.com/sillsdev/libpalaso/pull/340

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/926)

<!-- Reviewable:end -->
