### PR TITLE
Fix BL-3015 where saving a Bloompack inside its own collection failed

### DIFF
--- a/src/BloomExe/Collection/BloomPack/BloomPackInstallDialog.cs
+++ b/src/BloomExe/Collection/BloomPack/BloomPackInstallDialog.cs
@@ -47,7 +47,13 @@ namespace Bloom.Collection.BloomPack
 				ErrorReport.NotifyUserOfProblem(msg, _path);
 				return;
 			}
+
+			//For BL-3061 at the moment, I'm just trying to log more information.
+			Logger.WriteEvent("BloomPackInstallDialog.BeginInstall. _path is " + _path);
+
 			_folderName = GetRootFolderName();
+
+			Logger.WriteEvent("BloomPackInstallDialog.BeginInstall. _folderName is " + _folderName);
 			if (_folderName == null)
 				return;
 			string destinationFolder = Path.Combine(ProjectContext.GetInstalledCollectionsDirectory(), _folderName);

--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -254,7 +254,7 @@ namespace Bloom.CollectionTab
 					File.Delete(path);
 				}
 
-				Logger.WriteEvent("Making BloomPack");
+				Logger.WriteEvent("Making BloomPack at "+path+" forReaderTools="+forReaderTools.ToString());
 
 				using (var pleaseWait = new SimpleMessageDialog("Creating BloomPack...", "Bloom"))
 				{
@@ -272,6 +272,7 @@ namespace Bloom.CollectionTab
 
 						var dirNameOffest = dir.Length - rootName.Length;
 
+						Logger.WriteEvent("BloomPack path will be " + path + ", made from " + dir + " with rootName " + rootName);
 						using (var fsOut = File.Create(path))
 						{
 							using (ZipOutputStream zipStream = new ZipOutputStream(fsOut))
@@ -304,7 +305,7 @@ namespace Bloom.CollectionTab
 		}
 
 		// these files (if encountered) won't be compressed into a BloomPack
-		private static readonly string[] excludedFileExtensions = { ".db", ".pdf" };
+		private static readonly string[] excludedFileExtensions = { ".db", ".pdf", ".BloomPack" };
 
 		/// <summary>
 		/// Adds a directory, along with all files and subdirectories, to the ZipStream.

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -147,6 +147,7 @@ namespace Bloom
 						using (_applicationContainer = new ApplicationContainer())
 						{
 							SetUpLocalization();
+							Logger.Init();
 							var path = args[0];
 							// This allows local links to bloom packs.
 							if (path.ToLowerInvariant().StartsWith("bloom://"))


### PR DESCRIPTION
The fix is to filter out *.BloomPack from the compression process. Also added logging.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/927)
<!-- Reviewable:end -->
