### PR TITLE
BL-3053 Fix confusion activating proper tab

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/calledByCSharp.ts
+++ b/src/BloomBrowserUI/bookEdit/js/calledByCSharp.ts
@@ -85,11 +85,11 @@ class CalledByCSharp {
       contentWindow['SetCopyrightAndLicense'](contents);
   }
 
-    cleanupAudio() {
-        var contentWindow = this.getPageContent();
-        if (!contentWindow) return;
-        if (typeof contentWindow['cleanupAudio'] === 'function') {
-            contentWindow['cleanupAudio']();
+    removeToolboxMarkup() {
+        var toolboxWindow = this.getToolboxContent();
+        if (!toolboxWindow) return;
+        if (typeof toolboxWindow['removeToolboxMarkup'] === 'function') {
+            toolboxWindow['removeToolboxMarkup']();
         }
     }
 
@@ -100,15 +100,6 @@ class CalledByCSharp {
             toolboxWindow['setPeakLevel'](level);
         }
     }
-
-  removeSynphonyMarkup() {
-    var page = this.getPageContent();
-    if (!page) return;
-    var toolbox = this.getToolboxContent();
-    if ((typeof toolbox['jQuery'] !== 'undefined') && (toolbox['jQuery'].fn.removeSynphonyMarkup)) {
-        toolbox['jQuery'].fn.removeSynphonyMarkup.call(page['jQuery']('.bloom-content1'));
-    }
-  }
 
   invokeToolboxWithOneParameter(functionName: string, value: string) {
 

--- a/src/BloomBrowserUI/bookEdit/test/cSharpDependencyInjector.ts
+++ b/src/BloomBrowserUI/bookEdit/test/cSharpDependencyInjector.ts
@@ -34,8 +34,6 @@ function ForCodeInspection_UnusedFunctions(): void {
   (<InjectorWindow>window).restoreAccordionSettings('');
 
   var x = model.fontName;
-  var calledByCSharpObj = new CalledByCSharp();
-  calledByCSharpObj.removeSynphonyMarkup();
 }
 
 //noinspection JSUnusedGlobalSymbols

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -331,7 +331,6 @@ class AudioRecording {
         this.hiddenSourceBubbles.show();
         var page = this.getPage();
         page.find('.ui-audioCurrent').removeClass('ui-audioCurrent');
-        var editable = <qtipInterface>page.find('div.bloom-editable');
     }
 
     // This gets invoked (via a non-object method of the same name in this file,
@@ -753,11 +752,6 @@ class AudioRecording {
         return !test.match(/^\s*$/);
     }
 
-    // Clean up stuff audio recording leaves around that should not be saved.
-    public cleanupAudio(): void {
-        this.getPage().find('span.ui-audioCurrent').removeClass('ui-audioCurrent');
-    }
-
     private fireCSharpEvent(eventName, eventData): void {
         // Note: other implementations of fireCSharpEvent have 'view':'window', but the TS compiler does
         // not like this. It seems to work fine without it, and I don't know why we had it, so I am just
@@ -776,10 +770,6 @@ function initializeTalkingBookTool() {
     audioRecorder = new AudioRecording();
     libsynphony = new libSynphony();
     audioRecorder.initializeTalkingBookTool();
-}
-
-function cleanupAudio() {
-    audioRecorder.cleanupAudio();
 }
 
 function setPeakLevel(level:string) {

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -146,6 +146,13 @@ function restoreToolboxSettingsWhenCkEditorReady(settings: string) {
     // is done when a tool becomes current.
 }
 
+// Remove any markup the toolbox is inserting (called before saving page)
+function removeToolboxMarkup() {
+    if (currentTool != null) {
+        currentTool.hideTool();
+    }
+}
+
 function getPageFrame(): HTMLIFrameElement {
     return <HTMLIFrameElement>parent.window.document.getElementById('page');
 }
@@ -209,8 +216,10 @@ function setCurrentPanel(currentPanel) {
     var ani = toolbox.accordion('option', 'animate');
     toolbox.accordion('option', 'animate', false);
 
-    // the index must be passed as an int, a string will not work
-    toolbox.accordion('option', 'active', parseInt(idx));
+    // the index must be passed as an int, a string will not work. Also, H3 elements have indexes 1, 3, 5, 7,
+    // since an ID is generated for the intermediate content divs also. We need 0, 1, 2, 3.
+    var toolIndex = Math.floor(parseInt(idx) / 2);
+    toolbox.accordion('option', 'active', toolIndex);
 
     // turn animation back on
     toolbox.accordion('option', 'animate', ani);
@@ -226,7 +235,7 @@ function setCurrentPanel(currentPanel) {
         }
         switchTool(newToolName);
     });
-    //alert('switching to ' + currentPanel);
+    //alert('switching to ' + currentPanel + " which has index " + toolIndex);
     //setTimeout(e => switchTool(currentPanel), 700);
     switchTool(currentPanel);
 }

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -864,7 +864,7 @@ namespace Bloom.Edit
 		/// </summary>
 		public void CleanHtmlAndCopyToPageDom()
 		{
-			RunJavaScript("if (calledByCSharp) { calledByCSharp.removeSynphonyMarkup(); calledByCSharp.cleanupAudio(); }");
+			RunJavaScript("if (calledByCSharp) { calledByCSharp.removeToolboxMarkup(); }");
 			_browser1.ReadEditableAreasNow();
 		}
 


### PR DESCRIPTION
The wrong toolbox tab was being activated while
initialization was done for the right one, leading to all
kinds of confusion.
Also simplifies cleaning up toolbox markup before Save.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/931)

<!-- Reviewable:end -->
