### PR TITLE
BL-3035 and 3053 cleanup

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.js
@@ -273,8 +273,13 @@ function getToolbox() {
     var toolbox = parent.window.document.getElementById("toolbox");
 
     // toolbox will be undefined during unit testing
-    if (toolbox)
-        return toolbox.contentWindow['toolbox'];
+    if (toolbox) {
+        var result = toolbox.contentWindow['toolbox'];
+        // This is a way of checking that it really is our instance of Toolbox.
+        // Somehow at some point an HTML element can get assigned to that variable.
+        if (result && result.toolboxIsShowing) {return result;}
+    }
+    return null;
 }
 
 // Originally, all this code was in document.load and the selectors were acting

--- a/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/decodableReader.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/decodableReader.ts
@@ -69,7 +69,9 @@ class DecodableReaderModel implements ITabModel {
         model.doMarkup();
     }
 
-    name() { return 'decodableReaderTool'; }
+    name() { return 'decodableReader'; }
+
+    hasRestoredSettings: boolean;
 }
 
 tabModels.push(new DecodableReaderModel());

--- a/src/BloomBrowserUI/bookEdit/toolbox/leveledReader/leveledReader.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/leveledReader/leveledReader.ts
@@ -28,7 +28,9 @@ class LeveledReaderModel implements ITabModel {
         model.doMarkup();
     }
 
-    name() {return 'leveledReaderTool';}
+    name() {return 'leveledReader';}
+
+    hasRestoredSettings: boolean;
 }
 
 tabModels.push(new LeveledReaderModel());

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
@@ -16,7 +16,9 @@
         audioRecorder.updateMarkupAndControlsToCurrentText();
     }
 
-    name() { return 'talkingBookTool'; }
+    name() { return 'talkingBook'; }
+
+    hasRestoredSettings: boolean;
 }
 
 tabModels.push(new TalkingBookModel());


### PR DESCRIPTION
Another attempt at fixing the various problems related
to initializing the each tool properly when needed.
Also:
- replaced two strategies for determining whether toolbox is visible
  with the simpler and more reliable one
- cleanup up some ambiguous uses of the name 'toolbox'
  (sometimes our Toolbox object, sometimes $('#toolbox')

Will need careful merging into WebPackToolbox because
it messes with some of the globals which that changes

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/936)

<!-- Reviewable:end -->
