### PR TITLE
BL-3117 release our audio connection on exit

### DIFF
--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -50,6 +50,14 @@ namespace Bloom.Edit
 						_recorder = new AudioRecorder(1);
 						_recorder.PeakLevelChanged += ((s, e) => SetPeakLevel(e));
 						BeginMonitoring(); // will call this recursively; make sure _recorder has been set by now!
+						Application.ApplicationExit += (sender, args) =>
+						{
+							if (_recorder != null)
+							{
+								_recorder.Dispose();
+								_recorder = null;
+							}
+						};
 					}));
 				}
 				return _recorder;

--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -54,8 +54,18 @@ namespace Bloom.Edit
 						{
 							if (_recorder != null)
 							{
-								_recorder.Dispose();
+								var temp = _recorder;
 								_recorder = null;
+								try
+								{
+									temp.Dispose();
+								}
+								catch (Exception)
+								{
+									// Not sure how this can fail, but we don't need to crash if
+									// something goes wrong trying to free the audio object.
+									Debug.Fail("Something went wrong disposing of AudioRecorder");
+								}
 							}
 						};
 					}));


### PR DESCRIPTION
It would be nicer to (also) release it whenever not doing audio,
but that calls for more refactoring than I want to do
while WebpackToolbox is in progress. This is simple enough
to cherry-pick into 3.5.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/938)

<!-- Reviewable:end -->
