### PR TITLE
Fix BL-3150 Empty book.userPrefs kill Bloom.

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -77,7 +77,7 @@ namespace Bloom.Book
 			BookRefreshEvent bookRefreshEvent)
 		{
 			BookInfo = info;
-			UserPrefs = UserPrefs.Load(Path.Combine(info.FolderPath, "book.userPrefs"));
+			UserPrefs = UserPrefs.LoadOrMakeNew(Path.Combine(info.FolderPath, "book.userPrefs"));
 
 			Guard.AgainstNull(storage,"storage");
 

--- a/src/BloomExe/Book/UserPrefs.cs
+++ b/src/BloomExe/Book/UserPrefs.cs
@@ -1,5 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using System.Diagnostics;
+using Newtonsoft.Json;
 using System.IO;
+using SIL.Reporting;
+
 
 namespace Bloom.Book
 {
@@ -11,12 +15,30 @@ namespace Bloom.Book
 
 		private UserPrefs() {}
 
-		public static UserPrefs Load(string fileName)
+		public static UserPrefs LoadOrMakeNew(string fileName)
 		{
 			if (string.IsNullOrEmpty(fileName))
 				return null;
 
-			var userPrefs = File.Exists(fileName) ? JsonConvert.DeserializeObject<UserPrefs>(File.ReadAllText(fileName)) : new UserPrefs();
+			UserPrefs userPrefs = null;
+			if(File.Exists(fileName))
+			{
+				try
+				{
+					userPrefs = JsonConvert.DeserializeObject<UserPrefs>(File.ReadAllText(fileName));
+					if (userPrefs == null)
+						throw new ApplicationException("JsonConvert.DeserializeObject() returned null");
+				}
+				catch (Exception e)
+				{
+					Logger.WriteEvent("error reading UserPrefs at "+fileName+"  "+e.Message);
+					//otherwise, just give them a new user prefs
+					userPrefs = null;
+				}
+				
+			}
+			if(userPrefs == null)
+				userPrefs = new UserPrefs();
 			userPrefs._fileName = fileName;
 			userPrefs._loading = false;
 			return userPrefs;

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Book\BookCollectionTests.cs" />
     <Compile Include="Book\BookCopyrightAndLicenseTests.cs" />
     <Compile Include="Book\BookInfoTests.cs" />
+    <Compile Include="Book\UserPrefsTests.cs" />
     <Compile Include="Book\BookTestsBase.cs" />
     <Compile Include="Publish\ExportEpubTests.cs" />
     <Compile Include="Book\HtmlDomTests.cs" />

--- a/src/BloomTests/Book/UserPrefsTests.cs
+++ b/src/BloomTests/Book/UserPrefsTests.cs
@@ -1,0 +1,38 @@
+﻿using Bloom.Book;
+using NUnit.Framework;
+using SIL.IO;
+
+namespace BloomTests.Book
+{
+	[TestFixture]
+	public class UserPrefsTests
+	{
+		[Test]
+		public void LoadOrMakeNew_EmptyFile_GivesNewPrefs()
+		{
+			using (var t = new TempFile(""))
+			{
+				var up = UserPrefs.LoadOrMakeNew(t.Path);
+				Assert.That(up.MostRecentPage == 0);
+			}
+		}
+		[Test]
+		public void LoadOrMakeNew_CorrupFile_GivesNewPrefs()
+		{
+			using (var t = new TempFile("hellow world"))
+			{
+				var up = UserPrefs.LoadOrMakeNew(t.Path);
+				Assert.That(up.MostRecentPage == 0);
+			}
+		}
+		[Test]
+		public void LoadOrMakeNew_MostRecentPage_ReadsCorrectly()
+		{
+			using (var t = new TempFile("{\"mostRecentPage\":3}"))
+			{
+				var up = UserPrefs.LoadOrMakeNew(t.Path);
+				Assert.That(up.MostRecentPage == 3);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added unit test for this case and corrupted file case, and fixed both.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/943)
<!-- Reviewable:end -->
