### PR TITLE
Fix BL-3160  audio backup file occasionally locks stopping recording

### DIFF
--- a/src/BloomExe/web/ServerBase.cs
+++ b/src/BloomExe/web/ServerBase.cs
@@ -272,7 +272,8 @@ namespace Bloom.web
 						Logger.WriteEvent("At ServerBase: ListenerCallback(): stack=");
 						Logger.WriteEvent(error.StackTrace);
 #if DEBUG
-						throw;
+						//NB: "throw" here makes it impossible for even the programmer to continue and try to see how it happens
+						Debug.Fail("(Debug Only) "+error.Message);
 #endif
 					}
 				}


### PR DESCRIPTION
This fix detects that and makes a new backup. I was tempted to try a simpler approach which would be to record to a randomly named temp file, then copy that to our destination only if we are satisfied. The current approach instead always makes this backup that we can revert to. I left it because if we add undo, this will be useful.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/947)
<!-- Reviewable:end -->
