### PR TITLE
Fix BL-3115, and a number of small probs when html or json is corrupt

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -108,6 +108,10 @@ namespace Bloom.Book
 				OurHtmlDom.AddStyleSheet(@"languageDisplay.css");
 			}
 
+			//if we're showing the user a shell/template book, pick a color for it 
+			//If it is editable, then we don't want to change to the next color, we
+			//want to use the color that we used for the sample shell/template we
+			//showed them previously.
 			if (!info.IsEditable)
 			{
 				Book.SelectNextCoverColor(); // we only increment when showing a template or shell
@@ -480,9 +484,7 @@ namespace Bloom.Book
 			}
 			else
 			{
-				builder.AppendLine("<p>" + LocalizationManager.GetString("Errors.BookProblem",
-					"Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.")
-				                   + "</p>");
+				builder.AppendLine(BookStorage.GenericBookProblemNotice);
 			}
 
 			builder.Append(((StringBuilderProgress) _log).Text);//review: is this ever non-empty?

--- a/src/BloomExe/Book/BookInfo.cs
+++ b/src/BloomExe/Book/BookInfo.cs
@@ -394,7 +394,7 @@ namespace Bloom.Book
 
 	public class ErrorBookInfo : BookInfo
 	{
-		public ErrorBookInfo(string folderPath, Exception exception) //No: our known-bad contents could crash that: base(folderPath,false/*review*/)
+		public ErrorBookInfo(string folderPath, Exception exception) //No: our known-bad contents could crash that: base(folderPath,false)
 		{
 			FolderPath = folderPath;
 			Exception = exception;

--- a/src/BloomExe/Book/BookInfo.cs
+++ b/src/BloomExe/Book/BookInfo.cs
@@ -32,6 +32,11 @@ namespace Bloom.Book
 			get { return _metadata ?? (_metadata = new BookMetaData()); }
 		}
 
+		//for use by ErrorBookInfo
+		protected BookInfo()
+		{
+			
+		}
 		public BookInfo(string folderPath, bool isEditable)
 		{
 			FolderPath = folderPath;
@@ -389,8 +394,9 @@ namespace Bloom.Book
 
 	public class ErrorBookInfo : BookInfo
 	{
-		public ErrorBookInfo(string folderPath, Exception exception) : base(folderPath,false/*review*/)
+		public ErrorBookInfo(string folderPath, Exception exception) //No: our known-bad contents could crash that: base(folderPath,false/*review*/)
 		{
+			FolderPath = folderPath;
 			Exception = exception;
 		}
 
@@ -418,6 +424,10 @@ namespace Bloom.Book
 		public static BookMetaData FromString(string input)
 		{
 			var result = JsonConvert.DeserializeObject<BookMetaData>(input);
+			if(result == null)
+			{
+				throw new ApplicationException("meta.json of this book may be corrupt");
+			}
 			if (result.Tools != null)
 			{
 				foreach (var tool in result.Tools.Where(t => t is UnknownTool).ToArray())

--- a/src/BloomExe/Book/BookServer.cs
+++ b/src/BloomExe/Book/BookServer.cs
@@ -25,7 +25,10 @@ namespace Bloom.Book
 		public Book GetBookFromBookInfo(BookInfo bookInfo)
 		{
 			//Review: Note that this isn't doing any caching yet... worried that caching will just eat up memory, but if anybody is holding onto these, then the memory won't be freed anyhow
-
+			if(bookInfo.GetType()== typeof(ErrorBookInfo))
+			{
+				return new ErrorBook(((ErrorBookInfo)bookInfo).Exception, bookInfo.FolderPath, true );
+			}
 			var book = _bookFactory(bookInfo, _storageFactory(bookInfo.FolderPath));
 			return book;
 		}
@@ -66,7 +69,7 @@ namespace Bloom.Book
 				//Hack: this is a bit of a hack, to handle problems where we make the book with the suggested initial name, but the title is still something else
 				var name = Path.GetFileName(newBookInfo.FolderPath); // this way, we get "my book 1", "my book 2", etc.
 				newBook.SetTitle(name);
-
+				
 				Logger.WriteMinorEvent("Finished CreateFromnewBook({0})", newBook.FolderPath);
 				Logger.WriteEvent("CreateFromSourceBook({0})", newBook.FolderPath);
 				return newBook;

--- a/src/BloomExe/Book/BookServer.cs
+++ b/src/BloomExe/Book/BookServer.cs
@@ -25,7 +25,7 @@ namespace Bloom.Book
 		public Book GetBookFromBookInfo(BookInfo bookInfo)
 		{
 			//Review: Note that this isn't doing any caching yet... worried that caching will just eat up memory, but if anybody is holding onto these, then the memory won't be freed anyhow
-			if(bookInfo.GetType()== typeof(ErrorBookInfo))
+			if(bookInfo is ErrorBookInfo)
 			{
 				return new ErrorBook(((ErrorBookInfo)bookInfo).Exception, bookInfo.FolderPath, true );
 			}

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -1018,11 +1018,19 @@ namespace Bloom.Book
 			string s = "";
 			if (!this._errorAlreadyContainsInstructions)
 			{
-				s = "<p>" + LocalizationManager.GetString("Errors.BookProblem",
-					"Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.")
-				+ "</p>";
+				s = GenericBookProblemNotice;
 			}
 			return s + "<p>" + ErrorMessagesHtml + "</p>";
+		}
+
+		public static string GenericBookProblemNotice
+		{
+			get
+			{
+				return "<p>" + LocalizationManager.GetString("Errors.BookProblem",
+					"Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.")
+				       + "</p>";
+			}
 		}
 	}
 }

--- a/src/BloomExe/Book/ErrorBook.cs
+++ b/src/BloomExe/Book/ErrorBook.cs
@@ -58,11 +58,6 @@ namespace Bloom.Book
 			get { return _canDelete; }
 		}
 
-//		public HtmlDom GetEditableHtmlDomForPage(IPage page)
-//		{
-//			return GetErrorDOM();
-//		}
-
 		public override bool CanUpdate
 		{
 			get { return false; }

--- a/src/BloomExe/Book/ErrorBook.cs
+++ b/src/BloomExe/Book/ErrorBook.cs
@@ -23,6 +23,22 @@ namespace Bloom.Book
 			_folderPath = folderPath;
 			_canDelete = canDelete;
 			Logger.WriteEvent("Created ErrorBook with exception message: " + Exception.Message);
+			BookInfo = new ErrorBookInfo(folderPath,exception);
+		}
+
+
+		public override Layout GetLayout()
+		{
+			return Layout.A5Portrait;
+		}
+
+
+		public override string TitleBestForUserDisplay
+		{
+			get
+			{
+				return Title;
+			}
 		}
 
 		public override string Title
@@ -42,10 +58,10 @@ namespace Bloom.Book
 			get { return _canDelete; }
 		}
 
-		public HtmlDom GetEditableHtmlDomForPage(IPage page)
-		{
-			return GetErrorDOM();
-		}
+//		public HtmlDom GetEditableHtmlDomForPage(IPage page)
+//		{
+//			return GetErrorDOM();
+//		}
 
 		public override bool CanUpdate
 		{
@@ -65,25 +81,26 @@ namespace Bloom.Book
 //            return didDelete;
 //        }
 
-		private HtmlDom GetErrorDOM()
-		{
-			var dom = new XmlDocument();
-			var builder = new StringBuilder();
-			builder.Append("<html><body>");
-			builder.AppendLine("<p>This book (" + FolderPath + ") has errors.");
-			builder.AppendLine(
-				"This doesn't mean your work is lost, but it does mean that something is out of date or has gone wrong, and that someone needs to find and fix the problem (and your book).</p>");
+//		private HtmlDom GetErrorDOM()
+//		{
+//
+//			var dom = new XmlDocument();
+//			var builder = new StringBuilder();
+//			builder.Append("<html><body>");
+//			builder.AppendLine("<p>This book (" + FolderPath + ") has errors.");
+//			builder.AppendLine(
+//				"This doesn't mean your work is lost, but it does mean that something is out of date or has gone wrong, and that someone needs to find and fix the problem (and your book).</p>");
+//
+//			builder.Append(Exception.Message.Replace(Environment.NewLine,"<br/>"));
+//
+//			builder.Append("</body></html>");
+//			return new HtmlDom(builder.ToString());
+//		}
 
-			builder.Append(Exception.Message.Replace(Environment.NewLine,"<br/>"));
-
-			builder.Append("</body></html>");
-			return new HtmlDom(builder.ToString());
-		}
-
-		public override HtmlDom GetPreviewHtmlFileForWholeBook()
-		{
-			return GetErrorDOM();
-		}
+//		public override HtmlDom GetPreviewHtmlFileForWholeBook()
+//		{
+//			return GetErrorDOM();
+//		}
 
 		public override XmlDocument RawDom
 		{

--- a/src/BloomExe/BookThumbNailer.cs
+++ b/src/BloomExe/BookThumbNailer.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Xml;
 using Bloom.Book;

--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -159,14 +159,14 @@ namespace Bloom.Collection
 			_bookInfos.Add(bookInfo);
 		}
 
-		private void AddBookInfo(string path)
+		private void AddBookInfo(string folderPath)
 		{
 			try
 			{
 				//this is handy when windows explorer won't let go of the thumbs.db file, but we want to delete the folder
-				if (Directory.GetFiles(path, "*.htm").Length == 0)
+				if (Directory.GetFiles(folderPath, "*.htm").Length == 0)
 					return;
-				var bookInfo = new BookInfo(path, Type == CollectionType.TheOneEditableCollection);
+				var bookInfo = new BookInfo(folderPath, Type == CollectionType.TheOneEditableCollection);
 
 				_bookInfos.Add(bookInfo);
 			}
@@ -176,8 +176,19 @@ namespace Bloom.Collection
 				{
 					e = e.InnerException;
 				}
+				var jsonPath = Path.Combine(folderPath, BookInfo.MetaDataFileName);
+				Logger.WriteError("Reading "+ jsonPath, e);
+				try
+				{
+					Logger.WriteEvent(jsonPath +" Contents: " +System.Environment.NewLine+ File.ReadAllText(jsonPath));
+				}
+				catch(Exception readError)
+				{
+					Logger.WriteError("Error reading "+ jsonPath, readError);
+				}
+				
 				//_books.Add(new ErrorBook(e, path, Type == CollectionType.TheOneEditableCollection));
-				_bookInfos.Add(new ErrorBookInfo(path, e){});
+				_bookInfos.Add(new ErrorBookInfo(folderPath, e){});
 			}
 		}
 

--- a/src/BloomExe/CollectionTab/LibraryBookView.cs
+++ b/src/BloomExe/CollectionTab/LibraryBookView.cs
@@ -208,13 +208,16 @@ namespace Bloom.CollectionTab
 					try
 					{
 						dlg.Description += Environment.NewLine + Environment.NewLine + Environment.NewLine;
-						dlg.Description+=_bookSelection.CurrentSelection.Storage.ErrorMessagesHtml;
+						if(_bookSelection.CurrentSelection.Storage != null)
+						{
+							dlg.Description += _bookSelection.CurrentSelection.Storage.ErrorMessagesHtml;
+						}
 					}
 					catch (Exception)
 					{
 						//no use chasing errors generated getting error info
 					}
-					
+					dlg.ShowInTaskbar = true;
                     dlg.ShowDialog();
 				}
 			}

--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -241,7 +241,11 @@ namespace Bloom.CollectionTab
 
 		public void UpdateThumbnailAsync(Book.Book book, HtmlThumbNailer.ThumbnailOptions thumbnailOptions, Action<Book.BookInfo, Image> callback, Action<Book.BookInfo, Exception> errorCallback)
 		{
-			_thumbNailer.RebuildThumbNailAsync(book, thumbnailOptions, callback, errorCallback);
+			if (!(book is ErrorBook))
+			{
+				_thumbNailer.RebuildThumbNailAsync(book, thumbnailOptions, callback, errorCallback);
+			}
+			
 		}
 
 		public void MakeBloomPack(string path, bool forReaderTools = false)
@@ -446,7 +450,7 @@ namespace Bloom.CollectionTab
 				i++;
 				var book = _bookServer.GetBookFromBookInfo(bookInfo);
 				//gets overwritten: progress.WriteStatus(book.TitleBestForUserDisplay);
-				progress.WriteMessage("Processing " + book.TitleBestForUserDisplay + " " + i + "/" + TheOneEditableCollection.GetBookInfos().Count());
+				progress.WriteMessage("Processing " + book.TitleBestForUserDisplay+ " " + i + "/" + TheOneEditableCollection.GetBookInfos().Count());
 				book.BringBookUpToDate(progress);
 			}
 		}
@@ -523,7 +527,7 @@ namespace Bloom.CollectionTab
 				var newBook = _bookServer.CreateFromSourceBook(sourceBook, TheOneEditableCollection.PathToDirectory);
 				if (newBook == null)
 					return; //This can happen if there is a configuration dialog and the user clicks Cancel
-
+				
 				TheOneEditableCollection.AddBookInfo(newBook.BookInfo);
 
 				if (_bookSelection != null)

--- a/src/BloomExe/Properties/AssemblyInfo.cs
+++ b/src/BloomExe/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SIL")]
 [assembly: AssemblyProduct("Bloom")]
-[assembly: AssemblyCopyright("© SIL International 2012-2015")]
+[assembly: AssemblyCopyright("© SIL International 2012-2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
The proximate problem was saving the book, in the constructor when it lacked a color and was too corrupt to be saved. We no longer save during construction. While I was in there, I made newly created books have the same cover color as the preview the user was shown.

Corrupt meta.json used to use a very different code path to talking to the user; changed that so that they get the same UI, with a button to send us the book.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/949)
<!-- Reviewable:end -->
