### PR TITLE
Prevent book.userprefs getting all NULs

### DIFF
--- a/src/BloomExe/Book/UserPrefs.cs
+++ b/src/BloomExe/Book/UserPrefs.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Diagnostics;
+using Newtonsoft.Json;
 using System.IO;
 
 namespace Bloom.Book
@@ -47,10 +48,19 @@ namespace Bloom.Book
 
 		private void Save()
 		{
-			// We're checking this because the deserialization routine calls the preoperty setters which triggers a save. We don't
+			// We're checking this because the deserialization routine calls the property setters which triggers a save. We don't
 			// want to save while loading.
-			if (_loading) return;
-			File.WriteAllText(_fileName, JsonConvert.SerializeObject(this));
+			if (_loading)
+				return;
+			var prefs = JsonConvert.SerializeObject(this);
+			Debug.Assert(!string.IsNullOrWhiteSpace(prefs));
+
+			if (!string.IsNullOrWhiteSpace(prefs))
+			{
+				var temp = new SIL.IO.TempFileForSafeWriting(_fileName);
+				File.WriteAllText(temp.TempFilePath, prefs);
+				temp.WriteWasSuccessful();
+			}
 		}
 	}
 


### PR DESCRIPTION
We have several unexplained cases of NULs in userprefs. Looking at the code, if the serialization failed, perhaps it would cause this.

So now we check to see that at least we have a real string. In case the real problem is shutting down while it's being written, we now do a separate safe write and then do a simple "replace" (using a palaso library class) which should be atomic.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/952)
<!-- Reviewable:end -->
