### PR TITLE
BL-3166 Remove 'en' license info when setting '*'

### DIFF
--- a/src/BloomExe/Book/BookCopyrightAndLicense.cs
+++ b/src/BloomExe/Book/BookCopyrightAndLicense.cs
@@ -80,6 +80,12 @@ namespace Bloom.Book
 		{
 			dom.SetBookSetting("copyright","*",metadata.CopyrightNotice);
 			dom.SetBookSetting("licenseUrl","*",metadata.License.Url);
+			// This is for backwards compatibility. The book may have  licenseUrl in 'en' created by an earlier version of Bloom.
+			// For backwards compatibiilty, GetMetaData will read that if it doesn't find a '*' license first. So now that we're
+			// setting a licenseUrl for '*', we must make sure the 'en' one is gone, because if we're setting a non-CC license,
+			// the new URL will be empty and the '*' one will go away, possibly exposing the 'en' one to be used by mistake.
+			// See BL-3166.
+			dom.SetBookSetting("licenseUrl", "en", null);
 			string languageUsedForDescription;
 
 			//This part is unfortunate... the license description, which is always localized, doesn't belong in the datadiv; it

--- a/src/BloomTests/Book/BookCopyrightAndLicenseTests.cs
+++ b/src/BloomTests/Book/BookCopyrightAndLicenseTests.cs
@@ -92,6 +92,21 @@ namespace BloomTests.Book
 			Assert.AreEqual("Copyright © 2012, test", GetMetadata(dataDivContent).CopyrightNotice);
 		}
 
+		[Test]
+		public void SetLicenseMetadata_ToNoLicenseUrl_OriginalHasLicenseUrlInEn_ClearsEn()
+		{
+			string dataDivContent = @"<div lang='en' data-book='licenseUrl'>http://creativecommons.org/licenses/by-nc-sa/3.0/</div>";
+			var dom = MakeDom(dataDivContent);
+			var creativeCommonsLicense = (CreativeCommonsLicense)(BookCopyrightAndLicense.GetMetadata(dom).License);
+			Assert.IsTrue(creativeCommonsLicense.AttributionRequired); // yes, we got a CC license from the 'en' licenseUrl
+			var newLicense = new CustomLicense();
+			var newMetaData = new Metadata();
+			newMetaData.License = newLicense;
+			var settings = new CollectionSettings();
+			BookCopyrightAndLicense.SetMetadata(newMetaData, dom,  null, settings);
+			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//div[@data-book='licenseUrl']");
+		}
+
 		[Test, Ignore("Enable once we have French CC License Localization") /*meanwhile, I have tested on my machine*/]
 		public void SetLicenseMetadata_CCLicenseWithFrenchNationalLanguage_DataDivHasFrenchDescription()
 		{
@@ -182,8 +197,13 @@ namespace BloomTests.Book
 
 		private static Metadata GetMetadata(string dataDivContent)
 		{
-			var dom = new HtmlDom(@"<html><head><div id='bloomDataDiv'>" + dataDivContent + "</div></head><body></body></html>");
+			var dom = MakeDom(dataDivContent);
 			return BookCopyrightAndLicense.GetMetadata(dom);
+		}
+
+		private static HtmlDom MakeDom(string dataDivContent)
+		{
+			return new HtmlDom(@"<html><head><div id='bloomDataDiv'>" + dataDivContent + "</div></head><body></body></html>");
 		}
 
 		[Test]


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/955)

<!-- Reviewable:end -->
