### PR TITLE
BL-3227 Be calm if for some reason the license is in use momentarily.

### DIFF
--- a/src/BloomExe/Book/BookCopyrightAndLicense.cs
+++ b/src/BloomExe/Book/BookCopyrightAndLicense.cs
@@ -195,7 +195,7 @@ namespace Bloom.Book
 			catch(Exception error)
 			{
 				//BL-3227 Occasionally get The process cannot access the file '...\license.png' because it is being used by another process
-				NonFatalProblem.Report(ModalIf.Alpha, PassiveIf.All, "Could not update license image (BL-3227).", error);
+				NonFatalProblem.Report(ModalIf.Alpha, PassiveIf.All, "Could not update license image (BL-3227).", "Image was at" +imagePath, exception: error);
 			}
 		}
 

--- a/src/BloomExe/Book/UserPrefs.cs
+++ b/src/BloomExe/Book/UserPrefs.cs
@@ -10,7 +10,7 @@ namespace Bloom.Book
 	public class UserPrefs
 	{
 		private bool _loading = true;
-		private string _fileName;
+		private string _filePath;
 		private int _mostRecentPage;
 
 		private UserPrefs() {}
@@ -39,7 +39,7 @@ namespace Bloom.Book
 			}
 			if(userPrefs == null)
 				userPrefs = new UserPrefs();
-			userPrefs._fileName = fileName;
+			userPrefs._filePath = fileName;
 			userPrefs._loading = false;
 			return userPrefs;
 		}
@@ -50,7 +50,7 @@ namespace Bloom.Book
 		/// <param name="newDirectoryName"></param>
 		public void UpdateFileLocation(string newDirectoryName)
 		{
-			_fileName = Path.Combine(newDirectoryName, Path.GetFileName(_fileName));
+			_filePath = Path.Combine(newDirectoryName, Path.GetFileName(_filePath));
 		}
 
 		[JsonProperty("mostRecentPage")]
@@ -81,7 +81,7 @@ namespace Bloom.Book
 			{
 				if(!string.IsNullOrWhiteSpace(prefs))
 				{
-					var temp = new SIL.IO.TempFileForSafeWriting(_fileName);
+					var temp = new SIL.IO.TempFileForSafeWriting(_filePath);
 					File.WriteAllText(temp.TempFilePath, prefs);
 					temp.WriteWasSuccessful();
 				}
@@ -90,7 +90,7 @@ namespace Bloom.Book
 			{
 				//For https://silbloom.myjetbrains.com/youtrack/issue/BL-3222  we did a real fix for 3.6.
 				//But this will cover us for future errors here, which are not worth stopping the user from doing work.
-				NonFatalProblem.Report(ModalIf.Alpha, PassiveIf.All, "Minor book prefs could not be saved to "+_fileName, error);
+				NonFatalProblem.Report(ModalIf.Alpha, PassiveIf.All, "Problem saving book preferences", "book.userprefs could not be saved to " + _filePath, error);
 			}
 		}
 	}

--- a/src/BloomExe/BookThumbNailer.cs
+++ b/src/BloomExe/BookThumbNailer.cs
@@ -190,7 +190,7 @@ namespace Bloom
 			}
 			catch(Exception error)
 			{
-				NonFatalProblem.Report(ModalIf.Alpha, PassiveIf.All, "Problem creating book thumbnail ", error);
+				NonFatalProblem.Report(ModalIf.Alpha, PassiveIf.All, "Problem creating book thumbnail ", exception: error);
 			}
 		}
 	}

--- a/src/BloomExe/MiscUI/ToastNotifier.cs
+++ b/src/BloomExe/MiscUI/ToastNotifier.cs
@@ -71,7 +71,7 @@ namespace Bloom.MiscUI
 			get { return true; }
 		}
 
-		//storing this hear so that we only make one and don't have to worry about disposing of it
+		//storing this here so that we only make one and don't have to worry about disposing of it
 		public static Image WarningBitmap = SystemIcons.Warning.ToBitmap();
 
 		private void PauseTimerTick(object sender, EventArgs e)

--- a/src/BloomExe/MiscUI/ToastNotifier.cs
+++ b/src/BloomExe/MiscUI/ToastNotifier.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace Bloom.MiscUI
@@ -58,6 +59,10 @@ namespace Bloom.MiscUI
 			_pauseTimer.Tick += PauseTimerTick;
 		}
 
+//		public Color BackgroundColor
+//		{
+//			set { this.color}
+//		}
 		/// <summary>
 		/// Stops it stealing focus from the main window even though it will be in front of that window.
 		/// </summary>
@@ -65,6 +70,9 @@ namespace Bloom.MiscUI
 		{
 			get { return true; }
 		}
+
+		//storing this hear so that we only make one and don't have to worry about disposing of it
+		public static Image WarningBitmap = SystemIcons.Warning.ToBitmap();
 
 		private void PauseTimerTick(object sender, EventArgs e)
 		{


### PR DESCRIPTION
The NonFatalProblem.Report problem now uses toast for passive notification.
This will catch the error and put up a toast that the user can click if they want to report it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/964)
<!-- Reviewable:end -->
