### PR TITLE
Fix BL-3238 where imageinfo failed if the name had an "&".

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.js
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.js
@@ -125,7 +125,25 @@ function SetupImageContainer(containerDiv) {
 }
 
 function SetImageTooltip(container, img) {
-  getIframeChannel().simpleAjaxGet('/bloom/imageInfo?image=' + GetRawImageUrl(img), function (response) {
+    var urlForQuery = GetRawImageUrl(img);
+
+    //Why these three? my thinking is that these are all delimiters in URL query
+    //strings: space, &, and ?. Space is already encoded at this point in my experiments,
+    // and ? isn't allowed in file names so we can ignore that. That leaves the ampersand.
+    urlForQuery = urlForQuery.replace(/\&/g, '%26');
+
+    //See http://stackoverflow.com/questions/2678551/when-to-encode-space-to-plus-or-20.
+    // there, people expect the server to cope with using %20 for space even *in the query portion* of the URL,
+    // but our .net HttpUtility.ParseQueryString does not. See also BL-3235
+
+    //first preserve actual plus signs
+    urlForQuery = urlForQuery.replace(/\+/g, '%2B');
+
+    //then use plus to stand in for space
+    urlForQuery = urlForQuery.replace(/%20/g, '+');
+    
+
+    getIframeChannel().simpleAjaxGet('/bloom/imageInfo?image=' + urlForQuery, function (response) {
         const kBrowserDpi = 96; // this appears to be constant even on higher dpi screens. See http://www.w3.org/TR/css3-values/#absolute-lengths
         var dpi = Math.round(response.width / ($(img).width() / kBrowserDpi));
       var info = response.name + "\n"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/967)
<!-- Reviewable:end -->
