### PR TITLE
Bl 3259 filenames with plus or percent

### DIFF
--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -541,19 +541,18 @@ namespace Bloom.web
 				}
 				else
 				{
-
 					// Surprisingly, this method will return localPath unmodified if it is a fully rooted path
 					// (like C:\... or \\localhost\C$\...) to a file that exists. So this execution path
 					// can return contents of any file that exists if the URL gives its full path...even ones that
 					// are generated temp files most certainly NOT distributed with the application.
-					path = FileLocator.GetFileDistributedWithApplication("BloomBrowserUI", modPath);
+					path = FileLocator.GetFileDistributedWithApplication(true,"BloomBrowserUI", modPath);
 				}
 			}
 			catch (ApplicationException)
 			{
-				// ignore
+				// ignore. Assume this means that this class/method cannot serve that request, but something else may.
 			}
-			if (!File.Exists(path))
+			if (string.IsNullOrEmpty(path) || !File.Exists(path))
 				return false;
 			info.ContentType = GetContentType(Path.GetExtension(modPath));
 			info.ReplyWithFileContent(path);

--- a/src/BloomTests/UrlPathStringTests.cs
+++ b/src/BloomTests/UrlPathStringTests.cs
@@ -44,7 +44,7 @@ namespace BloomTests
 		[Test]
 		public void UnEncoded_withPercent_toUrlEncoded_PercentRetained()
 		{
-			Assert.AreEqual("OneHundred%25", UrlPathString.CreateFromUrlEncodedString("OneHundred%").UrlEncoded);
+			Assert.AreEqual("OneHundred%25", UrlPathString.CreateFromUnencodedString("OneHundred%").UrlEncoded);
 		}
 		[Test]
 		public void UrlEncoded_withPercent_toNotEncoded_PercentRetained()
@@ -52,7 +52,7 @@ namespace BloomTests
 			Assert.AreEqual("OneHundred%", UrlPathString.CreateFromUrlEncodedString("OneHundred%25").NotEncoded);
 		}
 		[Test]
-		public void UrlEncoded_withSpace_toUrlEncoded_SpaceRetained()
+		public void UrlEncoded_withSpace_toUrlEncoded_SpaceEntityRetained()
 		{
 			Assert.AreEqual("test%20me", UrlPathString.CreateFromUrlEncodedString("test%20me").UrlEncoded);
 		}
@@ -119,7 +119,7 @@ namespace BloomTests
 		}
 
 		[Test]
-		public void URLEncodedWithPlus_RoundTripable()
+		public void UnencodedWithPlus_RoundTripable()
 		{
 			Assert.AreEqual("test + me", UrlPathString.CreateFromUnencodedString("test + me").NotEncoded);
 		}

--- a/src/BloomTests/UrlPathStringTests.cs
+++ b/src/BloomTests/UrlPathStringTests.cs
@@ -9,14 +9,50 @@ namespace BloomTests
 	[TestFixture]
 	public class UrlPathStringTests
 	{
+#if NotAnyMore //We changed the behavior for BL-3259
 		[Test]
-		public void UrlEncodedWithPlus_toUrlEncoded_Retained()
+		public void UrlEncodedWithPlusToMeanSpace_toUrlEncoded_Retained()
 		{
 			//sometimes things encode a space a '+' instead of %20
 			Assert.AreEqual("test%20me", UrlPathString.CreateFromUrlEncodedString("test+me").UrlEncoded);
 		}
+#endif
 		[Test]
-		public void UrlEncoded_toUrlEncoded_Retained()
+		public void Unencoded_RoundTripTortureTest()
+		{
+			var fileName = "bread + cinnamon & sugar = 100% yum.JPG";
+			Assert.AreEqual(fileName, UrlPathString.CreateFromUnencodedString(fileName).NotEncoded);
+		}
+		[Test]
+		public void Encoded_RoundTripTortureTest()
+		{
+			var url = "bread%20%2b%20cinnamon%20%26%20sugar%20%3d%20100%25%20yum.jpg";
+			Assert.AreEqual(url, UrlPathString.CreateFromUrlEncodedString(url).UrlEncoded);
+		}
+
+		[Test]
+		public void UrlEncodedWithPlusToMeanPlus_UnEncoded_PlusRetained()
+		{
+			//sometimes things encode a space a '+' instead of %20
+			Assert.AreEqual("one+one = two", UrlPathString.CreateFromUrlEncodedString("one+one%20=%20two").NotEncoded);
+		}
+		[Test]
+		public void UrlEncoded_withPercent_toUrlEncoded_PercentRetained()
+		{
+			Assert.AreEqual("OneHundred%25", UrlPathString.CreateFromUrlEncodedString("OneHundred%25").UrlEncoded);
+		}
+		[Test]
+		public void UnEncoded_withPercent_toUrlEncoded_PercentRetained()
+		{
+			Assert.AreEqual("OneHundred%25", UrlPathString.CreateFromUrlEncodedString("OneHundred%").UrlEncoded);
+		}
+		[Test]
+		public void UrlEncoded_withPercent_toNotEncoded_PercentRetained()
+		{
+			Assert.AreEqual("OneHundred%", UrlPathString.CreateFromUrlEncodedString("OneHundred%25").NotEncoded);
+		}
+		[Test]
+		public void UrlEncoded_withSpace_toUrlEncoded_SpaceRetained()
 		{
 			Assert.AreEqual("test%20me", UrlPathString.CreateFromUrlEncodedString("test%20me").UrlEncoded);
 		}
@@ -80,6 +116,12 @@ namespace BloomTests
 		public void UnencodedWithPlus_roundTripable()
 		{
 			Assert.AreEqual("test+me", UrlPathString.CreateFromUnencodedString("test+me").NotEncoded);
+		}
+
+		[Test]
+		public void URLEncodedWithPlus_RoundTripable()
+		{
+			Assert.AreEqual("test + me", UrlPathString.CreateFromUnencodedString("test + me").NotEncoded);
 		}
 
 		[Test]


### PR DESCRIPTION
Fix BL-3259 Can't set cover to an image with a '+' or '%' in the name

Turned out to be two separate problems.

The '+' one: This did not have a satisfying solution... in part because the rules for encoding are just too conflicting (or perhaps I'm missing something). Of course + can mean SPACE, and indeed we use it that way when sending url query string to the server. Howver our image urls have + as... +. But when UrlPathString.CreateFromUrlEncodedString decoded that, it got rid of the +, changed it to space.

So I made the code defeat that bit of HttpUtility.UrlDecode(), so that '+'s stay as '+'s. Added more unit tests, did a bunch of by-hand tests, and all seems good.

The '%' one: The solution for this is on the URL-encoding side. All explained in UrlPathString.UrlEncoded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/970)
<!-- Reviewable:end -->
