### PR TITLE
BL-3230 allow overwrite of ReaderToolsSettings

### DIFF
--- a/src/BloomExe/Edit/DecodableReaderTool.cs
+++ b/src/BloomExe/Edit/DecodableReaderTool.cs
@@ -67,7 +67,7 @@ namespace Bloom.Edit
 				return;
 			if (File.Exists(readerToolsPath) && File.GetLastWriteTime(readerToolsPath) > File.GetLastWriteTime(newReaderTools))
 				return; // don't overwrite newer existing settings?
-			File.Copy(newReaderTools, readerToolsPath);
+			File.Copy(newReaderTools, readerToolsPath, true);
 		}
 
 		public const string kReaderToolsWordsFileNameFormat = "ReaderToolsWords-{0}.json";


### PR DESCRIPTION
In rare situations we want to update reader tools settings
not modified by the user but inherited from a previous Bloom.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/974)

<!-- Reviewable:end -->
