### PR TITLE
Fix BL-3214 Bloom changes PNG-->JPG without changing extension

### DIFF
--- a/src/BloomExe/Edit/PageEditingModel.cs
+++ b/src/BloomExe/Edit/PageEditingModel.cs
@@ -20,7 +20,7 @@ namespace Bloom.Edit
 		public void ChangePicture(string bookFolderPath, ElementProxy imgOrDivWithBackgroundImage, PalasoImage imageInfo,
 			IProgress progress)
 		{
-			var isSameFile = IsSameFilePath(bookFolderPath, HtmlDom.GetImageElementUrl(imgOrDivWithBackgroundImage).UrlEncoded, imageInfo);
+			var isSameFile = IsSameFilePath(bookFolderPath, HtmlDom.GetImageElementUrl(imgOrDivWithBackgroundImage), imageInfo);
 			var imageFileName = ImageUtils.ProcessAndSaveImageIntoFolder(imageInfo, bookFolderPath, isSameFile);
 			HtmlDom.SetImageElementUrl(imgOrDivWithBackgroundImage,
 				UrlPathString.CreateFromUnencodedString(imageFileName));
@@ -39,11 +39,11 @@ namespace Bloom.Edit
 		/// revised name.  We still need a tool to remove unused picture files from a
 		/// book's folder.  (ie, BL-2351)
 		/// </remarks>
-		private bool IsSameFilePath(string bookFolderPath, string src, PalasoImage imageInfo)
+		private bool IsSameFilePath(string bookFolderPath, UrlPathString src, PalasoImage imageInfo)
 		{
-			if (!String.IsNullOrEmpty(src))
+			if (src!=null)
 			{
-				var path = Path.Combine(bookFolderPath, HttpUtilityFromMono.UrlDecode(src));
+				var path = Path.Combine(bookFolderPath, src.NotEncoded);
 				if (path == imageInfo.OriginalFilePath)
 					return true;
 			}

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -60,7 +60,7 @@ namespace Bloom.ImageProcessing
 				isEncodedAsJpeg = AppearsToBeJpeg(imageInfo);
 				var shouldConvertToJpeg = !isEncodedAsJpeg && ShouldChangeFormatToJpeg(imageInfo.Image);
 				string imageFileName;
-				if (isSameFile)
+				if (!shouldConvertToJpeg && isSameFile)
 					imageFileName = imageInfo.FileName;
 				else
 					imageFileName = GetFileNameToUseForSavingImage(bookFolderPath, imageInfo, isEncodedAsJpeg || shouldConvertToJpeg);
@@ -69,10 +69,8 @@ namespace Bloom.ImageProcessing
 				{
 					SaveAsTopQualityJpeg(imageInfo.Image, destinationPath);
 				}
-				else
-				{
-					imageInfo.Save(destinationPath);
-				}
+				imageInfo.Save(destinationPath);
+
 				return imageFileName;
 
 				/* I (Hatton) have decided to stop compressing images until we have a suite of
@@ -147,7 +145,7 @@ namespace Bloom.ImageProcessing
 			else
 			{
 				// Even pictures that aren't obviously unnamed or temporary may have the same name.
-				// See https://silbloom.myjetbrains.com/youtrack/issue/BL-2627 ("Wierd Image Problem").
+				// See https://silbloom.myjetbrains.com/youtrack/issue/BL-2627 ("Weird Image Problem").
 				basename = Path.GetFileNameWithoutExtension(imageInfo.FileName);
 			}
 			var i = 0;


### PR DESCRIPTION
...leading to error when trying to read metadata. Once fixed, I then discovered that it failed to save the metadata if the format changed, so I fixed that too (removing the else ).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/979)
<!-- Reviewable:end -->
