### PR TITLE
Fix BL-3280 thumbnail failures will not send analytics, but show toast

### DIFF
--- a/src/BloomExe/HtmlThumbNailer.cs
+++ b/src/BloomExe/HtmlThumbNailer.cs
@@ -250,10 +250,7 @@ namespace Bloom
 			}
 			catch (Exception e)
 			{
-				//Debug.Fail("Reproduction of BL-524: Crash making thumbnail?");
-				//otherwise, don't tell the user, just log and send exception if they're online
-				Logger.WriteEvent("***Error making thumbnail, possible bl-524 reproduction, swallowed. "+ e.Message);
-				Analytics.ReportException(e);
+				NonFatalProblem.Report(ModalIf.None, PassiveIf.Alpha, "Could not make thumbnail","Ref bl-524", e);
 				return new Size(0,0); // this tells the caller we failed
 			}
 

--- a/src/BloomExe/MiscUI/ToastNotifier.cs
+++ b/src/BloomExe/MiscUI/ToastNotifier.cs
@@ -26,6 +26,7 @@ namespace Bloom.MiscUI
 		private int startPosX;
 		private int startPosY;
 		private bool _stayUp;
+		private static string _currentMessage;
 
 		/// <summary>
 		/// The user clicked on the toast popup
@@ -121,6 +122,8 @@ namespace Bloom.MiscUI
 				//If the client app starts with a "show dialog" open (e.g., selecting a file to open), this Close() actually closes *that* dialog, which is, um, bad.
 				//So I'm just going to not do the close, figuring that it only runs once per run of the application anyhow
 				//Close();
+
+				_currentMessage = null;
 			}
 			else
 				SetDesktopLocation(startPosX, startPosY);
@@ -143,6 +146,10 @@ namespace Bloom.MiscUI
 		/// <param name="seconds">How long to show before it goes back down</param>
 		public void Show(string message, string callToAction, int seconds)
 		{
+			//avoid showing a blizzard of the same message
+			if(message == _currentMessage)
+				return;
+			_currentMessage = message;
 			_message.Text = message;
 			_callToAction.Text = callToAction;
 			if (seconds < 0)

--- a/src/BloomExe/NonFatalProblem.cs
+++ b/src/BloomExe/NonFatalProblem.cs
@@ -14,8 +14,8 @@ using SIL.Reporting;
 namespace Bloom
 {
 	// NB: these must have the exactly the same symbols
-	public enum ModalIf { Alpha, Beta, All }
-	public enum PassiveIf { Alpha, Beta, All }
+	public enum ModalIf { None, Alpha, Beta, All }
+	public enum PassiveIf { None, Alpha, Beta, All }
 
 	/// <summary>
 	/// Provides a way to note a problem in the log and, depending on channel, notify the user.
@@ -52,7 +52,12 @@ namespace Bloom
 						exception = errorToGetStackTrace;
 					}
 				}
-				Analytics.ReportException(exception);
+				//if this isn't going modal even for devs, it's just background noise and we don't want the 
+				//thousands of exceptions we were getting as with BL-3280
+				if(modalThreshold != ModalIf.None)
+				{
+					Analytics.ReportException(exception);
+				}
 
 				Logger.WriteError("NonFatalProblem: " + fullDetailedMessage, exception);
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/980)
<!-- Reviewable:end -->
