### PR TITLE
Fix Linux crash due to writing license.png (BL-3284)

### DIFF
--- a/src/BloomExe/Book/BookCopyrightAndLicense.cs
+++ b/src/BloomExe/Book/BookCopyrightAndLicense.cs
@@ -177,6 +177,9 @@ namespace Bloom.Book
 		{
 			var licenseImage = metadata.License.GetImage();
 			var imagePath = bookFolderPath.CombineForPath("license.png");
+			// Don't try to overwrite the license image for a template book.  (See BL-3284.)
+			if (File.Exists(imagePath) && IsInstalledFile(imagePath))
+				return;
 			try
 			{
 				if(licenseImage != null)
@@ -197,6 +200,14 @@ namespace Bloom.Book
 				//BL-3227 Occasionally get The process cannot access the file '...\license.png' because it is being used by another process
 				NonFatalProblem.Report(ModalIf.Alpha, PassiveIf.All, "Could not update license image (BL-3227).", "Image was at" +imagePath, exception: error);
 			}
+		}
+
+		/// <summary>
+		/// Check whether this file was installed with Bloom (and likely to be read-only on Linux).
+		/// </summary>
+		private static bool IsInstalledFile(string filepath)
+		{
+			return filepath.Contains(ProjectContext.FactoryCollectionsDirectory);
 		}
 
 		private static bool ShouldSetToDefaultLicense(HtmlDom dom)


### PR DESCRIPTION
The templates installed with Bloom are stored in a read-only
location on Linux.  Updating the license image for a template
book seems rather pointless in any case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/982)
<!-- Reviewable:end -->
