### PR TITLE
BL-2984 Copy images used in template page

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1612,6 +1612,19 @@ namespace Bloom.Book
 			_pageSelection.SelectPage(newPage);
 			//_pageSelection.SelectPage(CreatePageDecriptor(newPageDiv, "should not show", _collectionSettings.Language1Iso639Code));
 
+			// If copied page references images, copy them.
+			foreach (var pathFromBook in BookStorage.GetImagePathsRelativeToBook(newPageDiv))
+			{
+				var path = Path.Combine(FolderPath, pathFromBook);
+				if (!File.Exists(path))
+				{
+					var fileName = Path.GetFileName(path);
+					var sourcePath = Path.Combine(templatePage.Book.FolderPath, fileName);
+					if (File.Exists(sourcePath))
+						File.Copy(sourcePath, path);
+				}
+			}
+
 			Save();
 			if (_pageListChangedEvent != null)
 				_pageListChangedEvent.Raise(null);

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -276,8 +276,8 @@ namespace Bloom.Book
 				imageFiles.Add(Path.GetFileName(GetNormalizedPathForOS(path)));
 			}
 			//Remove from that list each image actually in use
-			var toRemove = (from XmlElement img in HtmlDom.SelectChildImgAndBackgroundImageElements(Dom.RawDom.DocumentElement)
-							select HtmlDom.GetImageElementUrl(img).PathOnly.NotEncoded).Distinct().ToList();
+			var element = Dom.RawDom.DocumentElement;
+			var toRemove = GetImagePathsRelativeToBook(element);
 
 			//also, remove from the doomed list anything referenced in the datadiv that looks like an image
 			//This saves us from deleting, for example, cover page images if this is called before the front-matter
@@ -307,6 +307,17 @@ namespace Bloom.Book
 					//We're not even doing a Debug.Fail because that makes it harder to unit test this condition.
 				}		
 			}
+		}
+
+		/// <summary>
+		/// Return the paths, relative to the book folder, of all the images referred to in the element.
+		/// </summary>
+		/// <param name="element"></param>
+		/// <returns></returns>
+		internal static List<string> GetImagePathsRelativeToBook(XmlElement element)
+		{
+			return (from XmlElement img in HtmlDom.SelectChildImgAndBackgroundImageElements(element)
+				select HtmlDom.GetImageElementUrl(img).PathOnly.NotEncoded).Distinct().ToList();
 		}
 
 		private string GetNormalizedPathForOS(string path)

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -15,6 +15,7 @@ using SIL.Progress;
 using SIL.Windows.Forms.ClearShare;
 using SIL.Xml;
 using System;
+using BloomTemp;
 
 namespace BloomTests.Book
 {
@@ -344,6 +345,23 @@ namespace BloomTests.Book
 			Mock<IPage> templatePage = CreateTemplatePage("<div class='bloom-page'  data-page='extra' >hello</div>");
 			book.InsertPageAfter(existingPage, templatePage.Object);
 			Assert.AreEqual("bloom-page A5Portrait", GetPageFromBookDom(book, 1).GetStringAttribute("class"));
+		}
+
+		[Test]
+		public void InsertPageAfter_TemplateRefsPicture_PictureCopied()
+		{
+			var book = CreateBook();
+			var existingPage = book.GetPages().First();
+			Mock<IPage> templatePage = CreateTemplatePage("<div class='bloom-page'  data-page='extra' >hello<img src='read.png'/></div>");
+			using (var tempFolder = new TemporaryFolder("InsertPageAfter_TemplateRefsPicture_PictureCopied"))
+			{
+				File.WriteAllText(Path.Combine(tempFolder.FolderPath, "read.png"),"This is a test");
+				var mockTemplateBook = new Moq.Mock<Bloom.Book.Book>();
+				mockTemplateBook.Setup(x => x.FolderPath).Returns(tempFolder.FolderPath);
+				templatePage.Setup(x => x.Book).Returns(mockTemplateBook.Object);
+				book.InsertPageAfter(existingPage, templatePage.Object);
+			}
+			Assert.That(File.Exists(Path.Combine(book.FolderPath, "read.png")));
 		}
 
 		[Test]


### PR DESCRIPTION
At some point we made our system smart about
removing any 'unused' images copied from a template
but not used in any current pages. But when we then
insert a template page that uses one of them, we
need it! This makes us copy it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/985)

<!-- Reviewable:end -->
