### PR TITLE
Further fix for BL-3235 with ampersands in image name on cover

### DIFF
--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -629,6 +629,10 @@ namespace Bloom.Book
 					else
 					{
 						value = node.InnerXml.Trim(); //may contain formatting
+						if(KeysOfVariablesThatAreUrlEncoded.Contains(key))
+						{
+							value = UrlPathString.CreateFromHtmlXmlEncodedString(value).UrlEncoded;
+						}
 					}
 
 					string lang = node.GetOptionalStringAttribute("lang", "*");
@@ -672,6 +676,12 @@ namespace Bloom.Book
 							t.SetAlternative(lang, value);
 						}
 					}
+
+					if (KeysOfVariablesThatAreUrlEncoded.Contains(key))
+					{
+						Debug.Assert(!value.Contains("&amp;"), "In memory, all image urls should be encoded such that & is just &.");
+					}
+
 				}
 			}
 			catch (Exception error)
@@ -736,6 +746,10 @@ namespace Bloom.Book
 							//Ideally, we have this string, in this desired language.
 							var s = data.TextVariables[key].TextAlternatives.GetBestAlternativeString(new[] {lang, "*"});
 
+							if(KeysOfVariablesThatAreUrlEncoded.Contains(key))
+							{
+								Debug.Assert(!s.Contains("&amp;"),"In memory, all image urls should be encoded such that & is just &.");
+							}
 							//But if not, maybe we should copy one in from another national language
 							if (string.IsNullOrEmpty(s))
 								s = PossiblyCopyFromAnotherLanguage(node, lang, data, key);

--- a/src/BloomExe/UrlPathString.cs
+++ b/src/BloomExe/UrlPathString.cs
@@ -49,6 +49,14 @@ namespace Bloom
 			return new UrlPathString(unencoded);
 		}
 
+		/// <summary>
+		/// In these strings, "&" would be &amp;  space would just be " "
+		/// </summary>
+		public static UrlPathString CreateFromHtmlXmlEncodedString(string encoded)
+		{
+			return new UrlPathString(HttpUtility.HtmlDecode(encoded));
+		}
+
 		public string UrlEncoded
 		{
 			get
@@ -64,6 +72,11 @@ namespace Bloom
 				//now do our own encoding for the protected space
 				return x.Replace(standInForSpace,"%20");
 			}
+		}
+
+		public string HtmlXmlEncoded
+		{
+			get { return HttpUtility.HtmlEncode(_notEncoded); }
 		}
 
 		public string NotEncoded
@@ -130,5 +143,7 @@ namespace Bloom
 		{
 			return (_notEncoded != null ? _notEncoded.GetHashCode() : 0);
 		}
+
+
 	}
 }

--- a/src/BloomTests/UrlPathStringTests.cs
+++ b/src/BloomTests/UrlPathStringTests.cs
@@ -157,5 +157,18 @@ namespace BloomTests
 		{
 			Assert.IsFalse(UrlPathString.CreateFromUrlEncodedString("test me") == null);
 		}
+
+		[Test]
+		public void HtmlEncodedWithAmpersand_RoundTripable()
+		{
+			var s = "one&amp;two";
+			Assert.AreEqual(s, UrlPathString.CreateFromHtmlXmlEncodedString(s).HtmlXmlEncoded);
+		}
+
+		[Test]
+		public void CreateFromHtmlXmlEncodedString_WithAmpersand_UnencodedAsExpected()
+		{
+			Assert.AreEqual("one&two", UrlPathString.CreateFromHtmlXmlEncodedString("one&amp;two").NotEncoded);
+		}
 	}
 }


### PR DESCRIPTION
The thing here is that when we re-visit the book and read in the cover image file name, it will be encoded there as HTML; we immediately re-encode as it is the @src attributes, so that it is the same as when we are pulling from the @src.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/986)
<!-- Reviewable:end -->
