### PR TITLE
BL-3077 Make Text Prompt for Inside Front Cover localizable

### DIFF
--- a/DistFiles/localization/Bloom.en.tmx
+++ b/DistFiles/localization/Bloom.en.tmx
@@ -968,7 +968,13 @@
             <seg>If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</seg>
         </tuv>
     </tu>
-    <tu tuid="EditTab.BackMatter.OutsideBackCoverTextPrompt">
+    <tu tuid="EditTab.FrontMatter.InsideFrontCoverTextPrompt">
+        <prop type="x-dynamic">true</prop>
+        <tuv xml:lang="en">
+            <seg>If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.</seg>
+        </tuv>
+     </tu>
+     <tu tuid="EditTab.BackMatter.OutsideBackCoverTextPrompt">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</seg>

--- a/src/BloomExe/Book/RuntimeInformationInjector.cs
+++ b/src/BloomExe/Book/RuntimeInformationInjector.cs
@@ -218,6 +218,9 @@ namespace Bloom.Book
 				"If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.");
 			AddTranslationToDictionaryUsingEnglishAsKey(d, "EditTab.BackMatter.OutsideBackCoverTextPrompt",
 				"If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.");
+			// Used in Traditional Front matter
+			AddTranslationToDictionaryUsingEnglishAsKey(d, "EditTab.FrontMatter.InsideFrontCoverTextPrompt",
+				"If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.");
 
 			AddTranslationToDictionaryUsingKey(d, "EditTab.Image.PasteImage", "Paste Image");
 			AddTranslationToDictionaryUsingKey(d, "EditTab.Image.ChangeImage", "Change Image");


### PR DESCRIPTION
Occurs in Traditional Front Matter

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/990)

<!-- Reviewable:end -->
