### PR TITLE
BL-3144, put longpress popup in front of hint bubbles

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -545,3 +545,5 @@ div.cke_float {
 	span.cke_toolgroup { margin: 0 !important; }
   }
 }
+
+div.long-press-popup {z-index: 15005} // in front of hint bubbles


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/991)

<!-- Reviewable:end -->
