### PR TITLE
BL-3293 Duplicate page does not copy audio markup

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1655,6 +1655,17 @@ namespace Bloom.Book
 			if (currentPageIndex < 0)
 				return;
 
+			foreach (var span in newpageDiv.SafeSelectNodes(".//span[@class='audio-sentence']").Cast<XmlElement>().ToList())
+			{
+				XmlNode after = span;
+				foreach (XmlNode child in span.ChildNodes)
+				{
+					span.ParentNode.InsertAfter(child, after);
+					after = child;
+				}
+				span.ParentNode.RemoveChild(span);
+			}
+
 			body.InsertAfter(newpageDiv, pages[currentPageIndex]);
 
 			ClearPagesCache();

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1655,16 +1655,13 @@ namespace Bloom.Book
 			if (currentPageIndex < 0)
 				return;
 
-			foreach (var span in newpageDiv.SafeSelectNodes(".//span[@class='audio-sentence']").Cast<XmlElement>().ToList())
-			{
-				XmlNode after = span;
-				foreach (XmlNode child in span.ChildNodes)
-				{
-					span.ParentNode.InsertAfter(child, after);
-					after = child;
-				}
-				span.ParentNode.RemoveChild(span);
-			}
+			// If we copy audio markup, the new page will be linked to the SAME audio files,
+			// and the pages might well continue to share markup even when text on one of them
+			// is changed. If we WANT to copy the audio links, we need to do something like
+			// assigning a new guid each time a new recording is made, or at least if we
+			// find another sentence in the book sharing the same recording and with different
+			// text.
+			RemoveAudioMarkup(newpageDiv);
 
 			body.InsertAfter(newpageDiv, pages[currentPageIndex]);
 
@@ -1678,6 +1675,20 @@ namespace Bloom.Book
 			if (_pagesCache == null)
 				BuildPageCache();
 			_pageSelection.SelectPage(_pagesCache[currentPageIndex + 1]);
+		}
+
+		private static void RemoveAudioMarkup(XmlElement newpageDiv)
+		{
+			foreach (var span in newpageDiv.SafeSelectNodes(".//span[contains(@class,'audio-sentence')]").Cast<XmlElement>().ToList())
+			{
+				XmlNode after = span;
+				foreach (XmlNode child in span.ChildNodes)
+				{
+					span.ParentNode.InsertAfter(child, after);
+					after = child;
+				}
+				span.ParentNode.RemoveChild(span);
+			}
 		}
 
 		public void DeletePage(IPage page)


### PR DESCRIPTION
This prevents the duplicate page from sharing audio
recordings with the original, possibly even after one
or the other has been edited.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/995)

<!-- Reviewable:end -->
