### PR TITLE
Ensure web source files treated as text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,12 +6,12 @@
 *.idh   diff=cpp
 
 # Different settings for javascript, typescript, html, tmx, less and css files
-*.js   whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2
-*.ts   whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2
-*.htm* whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2
-*.tmx  whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2
-*.css -whitespace
-*.less -whitespace
+*.js   whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2 text
+*.ts   whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2 text
+*.htm* whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2 text
+*.tmx  whitespace=-indent-with-non-tab,tab-in-indent,trailing-space,tabwidth=2 text
+*.css -whitespace text
+*.less -whitespace text
 
 # Don't check (nor fix) whitespace for generated files
 *.csproj -whitespace


### PR DESCRIPTION
A git problem earlier today was probably due to a "new" .less file
being considered a binary file on check-in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/997)
<!-- Reviewable:end -->
