### PR TITLE
Fix BL-3304 by renaming geckofxhtmltopdf.exe to BloomPdfMaker.exe

### DIFF
--- a/DistFiles/IntegrityFailureAdvice-en.md
+++ b/DistFiles/IntegrityFailureAdvice-en.md
@@ -23,3 +23,4 @@ After you submit this report, we will contact you and help you work this out. In
 
 * You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see [this image](https://i.imgur.com/dlRrsSN.png).
 
+###Missing Files

--- a/DistFiles/IntegrityFailureAdvice-en.md
+++ b/DistFiles/IntegrityFailureAdvice-en.md
@@ -10,13 +10,16 @@
 
 After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas:
 
+
 * Run the Bloom installer again, and see if it starts up OK this time.
 
-* If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at **{installFolder}**.
+* If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at **{installFolder}**.
     * AVAST: [Instructions](http://www.getavast.net/support/managing-exceptions).
     * Norton Antivirus: [Instructions from Symantec](https://support.symantec.com/en_US/article.HOWTO80920.html).
     * AVG: [Instructions from AVG](https://support.avg.com/SupportArticleView?l=en_US&urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning).
     * Others: Google for "whitelist directory name-of-your-antivirus"
 
-###Missing Files
+    * Run the Bloom installer again, and see if it starts up OK this time.
+
+* You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see [this image](https://i.imgur.com/dlRrsSN.png).
 

--- a/build/Bloom.proj
+++ b/build/Bloom.proj
@@ -235,7 +235,7 @@
 	<Target Name="SignExesIfPossible">
 		<Exec Command='sign "$(RootDir)\output\$(Configuration)\Bloom.exe"' ContinueOnError="true"></Exec>
 		<!-- These are generated in other TC projects but I think it's OK to sign them here since we control those projects too.-->
-		<Exec Command='sign "$(RootDir)\output\$(Configuration)\GeckofxHtmlToPdf.exe"' ContinueOnError="true"></Exec>
+		<Exec Command='sign "$(RootDir)\output\$(Configuration)\BloomPdfMaker.exe"' ContinueOnError="true"></Exec>
 		<Exec Command='sign "$(RootDir)\output\$(Configuration)\PdfDroplet.exe"' ContinueOnError="true"></Exec>
 		<!-- We don't really need to do this every time since the file is checked in. But this way any updated version
 		is automatically signed, which saves the hassle of coming up with a new signed exe every time we need to check in. -->

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1237,13 +1237,7 @@ copy /Y "$(SolutionDir)\lib\dotnet\Interop.Acrobat.dll" $(OutDir)
   </Target>
   <PropertyGroup>
     <PostBuildEvent>
-"$(DevEnvDir)..\..\VC\bin\editbin.exe" /largeaddressaware "$(TargetPath)"
-copy /Y "$(SolutionDir)\lib\msvcr120.dll" $(OutDir)
-copy /Y "$(SolutionDir)\lib\dotnet\libtidy.dll" $(OutDir)
-copy /Y "$(SolutionDir)\lib\dotnet\Interop.AcroPDFLib.dll" $(OutDir)
-copy /Y "$(SolutionDir)\lib\dotnet\Interop.Acrobat.dll" $(OutDir)
-
-copy /N "$(SolutionDir)lib\dotnet\GeckofxHtmlToPdf.exe" "$(OutDir)BloomPdfMaker.exe" 
-</PostBuildEvent>
+        copy /N "$(SolutionDir)lib\dotnet\GeckofxHtmlToPdf.exe" "$(OutDir)BloomPdfMaker.exe" 
+    </PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1199,7 +1199,6 @@ copy /Y "$(SolutionDir)\lib\dotnet\Interop.Acrobat.dll" $(OutDir)
     <GeckoBrowserAdapter Include="..\..\lib\dotnet\SIL.Windows.Forms.GeckoBrowserAdapter.dll" />
   </ItemGroup>
   <ItemGroup>
-    <GeckofxHtmlToPdf Include="..\..\lib\dotnet\GeckofxHtmlToPdf.exe" />
     <GeckofxHtmlToPdf Include="..\..\lib\dotnet\Args.dll" />
   </ItemGroup>
   <ItemGroup>
@@ -1235,6 +1234,16 @@ copy /Y "$(SolutionDir)\lib\dotnet\Interop.Acrobat.dll" $(OutDir)
     <Copy SourceFiles="@(BasicBookCssFiles)" DestinationFolder="../../DistFiles/factoryCollections/Templates/Leveled Reader" />
     <Copy SourceFiles="@(BasicBookCssFiles)" DestinationFolder="../../DistFiles/factoryCollections/Templates/Decodable Reader" />
     <Copy SourceFiles="@(RemoteDebugFiles)" DestinationFolder="$(OutDir)/remoteDebugging" Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'" />
-    <Copy SourceFiles="@(GeckofxHtmlToPdf)" DestinationFolder="$(OutDir)" />
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>
+"$(DevEnvDir)..\..\VC\bin\editbin.exe" /largeaddressaware "$(TargetPath)"
+copy /Y "$(SolutionDir)\lib\msvcr120.dll" $(OutDir)
+copy /Y "$(SolutionDir)\lib\dotnet\libtidy.dll" $(OutDir)
+copy /Y "$(SolutionDir)\lib\dotnet\Interop.AcroPDFLib.dll" $(OutDir)
+copy /Y "$(SolutionDir)\lib\dotnet\Interop.Acrobat.dll" $(OutDir)
+
+copy /N "$(SolutionDir)lib\dotnet\GeckofxHtmlToPdf.exe" "$(OutDir)BloomPdfMaker.exe" 
+</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/src/BloomExe/MiscUI/BloomIntegrityDialog.cs
+++ b/src/BloomExe/MiscUI/BloomIntegrityDialog.cs
@@ -24,7 +24,7 @@ namespace Bloom.MiscUI
 		public static bool CheckIntegrity()
 		{
 			var errors = new StringBuilder();
-			var files = new[] { "Bloom.chm", "PdfDroplet.exe", "Chorus.exe", "GeckofxHtmlToPdf.exe", "optipng.exe" };
+			var files = new[] { "Bloom.chm", "PdfDroplet.exe", "Chorus.exe", "BloomPdfMaker.exe", "optipng.exe" };
 
 			string[] dirs;
 			if (SIL.PlatformUtilities.Platform.IsWindows)

--- a/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfProgram.cs
+++ b/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfProgram.cs
@@ -18,7 +18,9 @@ using System.Text;
 namespace Bloom.Publish
 {
 	/// <summary>
-	/// This wrapper uses the GeckoFxHtmlToPdf program.  Trying to use the component
+	/// This wrapper uses the GeckoFxHtmlToPdf program, which we rename to
+	/// BloomPdfMaker.exe because AVG likes to quarantine it and we want to
+	/// make it look less scary.  Trying to use the component
 	/// directly leads to obscure bugs, at least on Windows.  Isolating the embedded
 	/// Gecko browser in a separate process appears to at least let us produce the
 	/// desired PDF files.
@@ -96,12 +98,12 @@ namespace Bloom.Publish
 			var loc = Assembly.GetExecutingAssembly().CodeBase.Substring((Platform.IsUnix ? "file://" : "file:///").Length);
 			var execDir = Path.GetDirectoryName(loc);
 			var fromDirectory = String.Empty;
-			var filePath = Path.Combine(execDir, "GeckofxHtmlToPdf.exe");
+			var filePath = Path.Combine(execDir, "BloomPdfMaker.exe");
 			if (!File.Exists(filePath))
 			{
-				var msg = LocalizationManager.GetString("InstallProblem.GeckofxHtmlToPdf",
-					"A component of Bloom, GeckofxHtmlToPdf.exe, seems to be missing. This prevents previews and printing. Antivirus software sometimes does this. You may need technical help to repair the Bloom installation and protect this file from being deleted again.");
-				throw new FileNotFoundException(msg, "GeckofxHtmlToPdf.exe"); // must be this class to trigger the right reporting mechanism.
+				var msg = LocalizationManager.GetString("InstallProblem.BloomPdfMaker",
+					"A component of Bloom, BloomPdfMaker.exe, seems to be missing. This prevents previews and printing. Antivirus software sometimes does this. You may need technical help to repair the Bloom installation and protect this file from being deleted again.");
+				throw new FileNotFoundException(msg, "BloomPdfMaker.exe"); // must be this class to trigger the right reporting mechanism.
 			}
 			if (Platform.IsMono)
 			{
@@ -123,7 +125,7 @@ namespace Bloom.Publish
 				Debug.WriteLine(res.StandardOutput);
 #endif
 				var msg = L10NSharp.LocalizationManager.GetDynamicString(@"Bloom", @"MakePDF.Failed",
-					"Bloom was not able to create the PDF file ({0}).{1}{1}Details: GeckofxHtmlToPdf (command line) did not produce the expected document.",
+					"Bloom was not able to create the PDF file ({0}).{1}{1}Details: BloomPdfMaker (command line) did not produce the expected document.",
 					@"Error message displayed in a message dialog box");
 				var except = new ApplicationException(String.Format(msg, outputPdfPath, Environment.NewLine));
 				// Note that if we're being run by a BackgroundWorker, it will catch the exception.

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -231,7 +231,7 @@ namespace Bloom.Publish
 						//installed, or they had the PDF open in Word, or something like that.
 						ErrorReport.NotifyUserOfProblem(error.Message);
 					}
-					else if (error is FileNotFoundException && ((FileNotFoundException) error).FileName == "GeckofxHtmlToPdf.exe")
+					else if (error is FileNotFoundException && ((FileNotFoundException) error).FileName == "BloomPdfMaker.exe")
 					{
 						ErrorReport.NotifyUserOfProblem(error, error.Message);
 					}


### PR DESCRIPTION
The idea here is just to make it a bit more likely that a user will say "no" when an antivirus asks to quarantine this file, as AVG likes to do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1003)
<!-- Reviewable:end -->
