### PR TITLE
BL-3305, handle installation in Program files (for 3.6)

### DIFF
--- a/Bloom.sln
+++ b/Bloom.sln
@@ -27,7 +27,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		WebEssentials2015-Settings.json = WebEssentials2015-Settings.json
 	EndProjectSection
 EndProject
-Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "BloomBrowserUI", "src\BloomBrowserUI\", "{38519496-4C3D-46FA-951D-C64C32D5D026}"
+Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "BloomBrowserUI(3)", "src\BloomBrowserUI\", "{38519496-4C3D-46FA-951D-C64C32D5D026}"
 	ProjectSection(WebsiteProperties) = preProject
 		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
 		Debug.AspNetCompiler.VirtualPath = "/localhost_50301"
@@ -97,15 +97,11 @@ Global
 		{38519496-4C3D-46FA-951D-C64C32D5D026}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{38519496-4C3D-46FA-951D-C64C32D5D026}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{38519496-4C3D-46FA-951D-C64C32D5D026}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{38519496-4C3D-46FA-951D-C64C32D5D026}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{38519496-4C3D-46FA-951D-C64C32D5D026}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{38519496-4C3D-46FA-951D-C64C32D5D026}.Debug|x86.Build.0 = Debug|Any CPU
 		{38519496-4C3D-46FA-951D-C64C32D5D026}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{38519496-4C3D-46FA-951D-C64C32D5D026}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{38519496-4C3D-46FA-951D-C64C32D5D026}.Release|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{38519496-4C3D-46FA-951D-C64C32D5D026}.Release|Mixed Platforms.Build.0 = Debug|Any CPU
 		{38519496-4C3D-46FA-951D-C64C32D5D026}.Release|x86.ActiveCfg = Debug|Any CPU
-		{38519496-4C3D-46FA-951D-C64C32D5D026}.Release|x86.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -229,10 +229,12 @@ namespace Bloom
 		/// True if it is currently possible to start checking for or getting updates.
 		/// This approach is only relevant for Windows.
 		/// If some bloom update activity is already in progress we must not start another one...that crashes.
+		/// If we were installed in Program Files (using the --allUsers installer command-line argument
+		/// in administrator mode), we don't attempt updates.
 		/// </summary>
 		internal static bool OkToInitiateUpdateManager
 		{
-			get { return Platform.IsWindows && _bloomUpdateManager == null; }
+			get { return Platform.IsWindows && _bloomUpdateManager == null && !InstallerSupport.SharedByAllUsers(); }
 		}
 
 		internal static bool NoUpdatesAvailable(UpdateInfo info)

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -188,7 +188,8 @@ namespace Bloom
 						using (_applicationContainer = new ApplicationContainer())
 						{
 							SetUpLocalization();
-							InstallerSupport.MakeBloomRegistryEntries();
+							InstallerSupport.MakeBloomRegistryEntries(args);
+							BookDownloadSupport.EnsureDownloadFolderExists();
 							Browser.SetUpXulRunner();
 							Browser.XulRunnerShutdown += OnXulRunnerShutdown;
 							LocalizationManager.SetUILanguage(Settings.Default.UserInterfaceLanguage, false);
@@ -243,7 +244,8 @@ namespace Bloom
 							return;
 						}
 
-						InstallerSupport.MakeBloomRegistryEntries();
+						InstallerSupport.MakeBloomRegistryEntries(args);
+						BookDownloadSupport.EnsureDownloadFolderExists();
 
 						SetUpLocalization();
 


### PR DESCRIPTION
Depends on branch allUsersForBloom3.6 of Squirrel, so before merging this, we want to get that branch into our fork and make a TC build of it and make 3.6 use artifacts from that build.
When the installer is run with the new --allUsers command
line argument, it will install Bloom in Program Files (x86).
These changes mean that in this situation Bloom will make
all its registry entries in LocalMachine instead of CurrentUser.
Also, in this (typically classroom) situation we assume an admin
is managing updates, and Bloom will not be able to do its own in
Program Files, so we don't attempt automatic updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1008)
<!-- Reviewable:end -->
