### PR TITLE
BL-3305, handle installation in Program files

### DIFF
--- a/build/Bloom.proj
+++ b/build/Bloom.proj
@@ -223,7 +223,7 @@
 		<!-- This is the command that actually runs Squirrel. Usually the exe invoked here is called Squirrel. However, we're building our own
 		version, and it's easiest to go with the exe name that the Squirrel build process actually produces.
 		The relaseDir here is a shared drive for all the build agents (though for now we only use one, because only it has the signing data). -->
-		<Exec Command="$(RootDir)\lib\dotnet\Update --releasify $(RootDir)\build\Bloom$(channel).$(Version).nupkg --releaseDir=$(SquirrelReleaseFolder) -i $(RootDir)\src\SquirrelInstaller\BloomSetup.ico -g $(RootDir)\src\SquirrelInstaller\installing.gif -l 'Desktop,StartMenu'"/>
+		<Exec Command="$(RootDir)\lib\dotnet\Update --releasify $(RootDir)\build\Bloom$(channel).$(Version).nupkg --releaseDir=$(SquirrelReleaseFolder) --no-msi -i $(RootDir)\src\SquirrelInstaller\BloomSetup.ico -g $(RootDir)\src\SquirrelInstaller\installing.gif -l 'Desktop,StartMenu'"/>
 
 		<Copy SourceFiles="$(SquirrelReleaseFolder)\Setup.exe"
 			  DestinationFiles="$(SquirrelReleaseFolder)\$(SquirrelInstallerFileName)"

--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -229,10 +229,12 @@ namespace Bloom
 		/// True if it is currently possible to start checking for or getting updates.
 		/// This approach is only relevant for Windows.
 		/// If some bloom update activity is already in progress we must not start another one...that crashes.
+		/// If we were installed in Program Files (using the --allUsers installer command-line argument
+		/// in administrator mode), we don't attempt updates.
 		/// </summary>
 		internal static bool OkToInitiateUpdateManager
 		{
-			get { return Platform.IsWindows && _bloomUpdateManager == null; }
+			get { return Platform.IsWindows && _bloomUpdateManager == null && !InstallerSupport.SharedByAllUsers(); }
 		}
 
 		internal static bool NoUpdatesAvailable(UpdateInfo info)
@@ -274,7 +276,7 @@ namespace Bloom
 				var version = updateInfo.FutureReleaseEntry.Version;
 				var releasesToDownload = updateInfo.ReleasesToApply;
 				var size = releasesToDownload.Sum(x => x.Filesize)/1024;
-				var updatingMsg = String.Format(LocalizationManager.GetString("CollectionTab.Updating", "Downloading update to {0} ({1}K)"), version, size);
+				var updatingMsg = String.Format(LocalizationManager.GetString("CollectionTab.Updating", "Downloading update to {0} ({1}K)"), version.ToString(), size);
 				SIL.Reporting.Logger.WriteEvent("Squirrel: "+updatingMsg);
 				updatingNotifier.Show(updatingMsg, "", -1);
 

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -124,6 +124,9 @@
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NuGet.Squirrel">
+      <HintPath>..\..\lib\dotnet\NuGet.Squirrel.dll</HintPath>
+    </Reference>
     <Reference Include="PdfDroplet">
       <HintPath>..\..\lib\dotnet\PdfDroplet.exe</HintPath>
     </Reference>

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -188,7 +188,8 @@ namespace Bloom
 						using (_applicationContainer = new ApplicationContainer())
 						{
 							SetUpLocalization();
-							InstallerSupport.MakeBloomRegistryEntries();
+							InstallerSupport.MakeBloomRegistryEntries(args);
+							BookDownloadSupport.EnsureDownloadFolderExists();
 							Browser.SetUpXulRunner();
 							Browser.XulRunnerShutdown += OnXulRunnerShutdown;
 							LocalizationManager.SetUILanguage(Settings.Default.UserInterfaceLanguage, false);
@@ -243,7 +244,8 @@ namespace Bloom
 							return;
 						}
 
-						InstallerSupport.MakeBloomRegistryEntries();
+						InstallerSupport.MakeBloomRegistryEntries(args);
+						BookDownloadSupport.EnsureDownloadFolderExists();
 
 						SetUpLocalization();
 


### PR DESCRIPTION
When the installer is run with the new --allUsers command
line argument, it will install Bloom in Program Files (x86).
These changes mean that in this situation Bloom will make
all its registry entries in LocalMachine instead of CurrentUser.
Also, in this (typically classroom) situation we assume an admin
is managing updates, and Bloom will not be able to do its own in
Program Files, so we don't attempt automatic updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1009)
<!-- Reviewable:end -->
