### PR TITLE
Fix Bl-3319 with mixed up dialog title names for addpagedialog

### DIFF
--- a/src/BloomBrowserUI/bookEdit/editViewFrame.ts
+++ b/src/BloomBrowserUI/bookEdit/editViewFrame.ts
@@ -93,9 +93,6 @@ export function showAddPageDialog(templatesJSON) {
     var english = 'Add Page...';
 
     if (forChooseLayout) {
-        var title = theOneLocalizationManager.getText('EditTab.AddPageDialog.ChooseLayoutTitle', 'Choose Different Layout...');
-
-    } else {
         key = 'EditTab.AddPageDialog.ChooseLayoutTitle';
         english = 'Choose Different Layout...';
     }


### PR DESCRIPTION
Kinda looks like there was a merger bug here

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1012)
<!-- Reviewable:end -->
