### PR TITLE
Fix installer/updater code to not compile on Linux

### DIFF
--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -259,6 +259,10 @@ namespace Bloom
 		// Adapted from Squirrel's EasyModeMixin.UpdateApp, but this version yields the new directory.
 		internal static async Task<UpdateResult> UpdateApp(IUpdateManager manager)
 		{
+#if __MonoCS__
+			Debug.Fail("UpdateApp should not run on Linux!");	// and the code below doesn't compile on Linux
+			return null;
+#else
 			bool ignoreDeltaUpdates = false;
 
 			retry:
@@ -339,6 +343,7 @@ namespace Bloom
 				NewInstallDirectory = newInstallDirectory,
 				Outcome = newInstallDirectory == null ? UpdateOutcome.AlreadyUpToDate : UpdateOutcome.GotNewVersion
 			};
+#endif
 		}
 
 		private static void UpdateProgress(ToastNotifier updatingNotifier, string updatingMsg, string progressMsg, int x)

--- a/src/BloomExe/InstallerSupport.cs
+++ b/src/BloomExe/InstallerSupport.cs
@@ -71,6 +71,10 @@ namespace Bloom
 
 		internal static void HandleSquirrelInstallEvent(string[] args)
 		{
+#if __MonoCS__
+			Debug.Fail("HandleSquirrelInstallEvent should not run on Linux!");	// and the code below doesn't compile on Linux
+			return;
+#else
 			bool firstTime = false;
 			var updateUrlResult = LookupUrlOfSquirrelUpdate();
 			// Should only be null if we're not online. Not sure how squirrel will handle that,
@@ -122,6 +126,7 @@ namespace Bloom
 					}
 					break;
 			}
+#endif
 		}
 
 		/// <summary>


### PR DESCRIPTION
A couple of pieces don't compile on Linux, but aren't needed or
wanted there anyway.  We could just omit the two files from
compiling altogether on Linux, but that would require bigger
changes elsewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1013)
<!-- Reviewable:end -->
