### PR TITLE
Remove all references to Squirrel on Linux/Mono

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -115,6 +115,17 @@
       <HintPath>..\..\packages\MarkdownDeep.NET.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <!-- On Windows, Squirrel.dll provides the MarkdownSharp class in addition
+	 to all the Squirrel specific classes.  But Linux/Mono cannot handle
+	 referencing Squirrel.dll because it references some Windows specific
+	 assemblies internally.  So for Linux, we have to provide MarkdownSharp
+	 separately by itself.  (Note that trying to reference both Squirrel
+	 and MarkdownSharp on Windows causes fatal confusion in dereferencing.)
+    -->
+    <Reference Include="MarkdownSharp" Condition="'$(OS)'!='Windows_NT'">
+      <HintPath>..\..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NAudio">
       <HintPath>..\..\lib\dotnet\NAudio.dll</HintPath>
@@ -123,7 +134,7 @@
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Squirrel">
+    <Reference Include="NuGet.Squirrel" Condition="'$(OS)'=='Windows_NT'">
       <HintPath>..\..\lib\dotnet\NuGet.Squirrel.dll</HintPath>
     </Reference>
     <Reference Include="PdfDroplet">
@@ -158,7 +169,7 @@
     <Reference Include="Splat">
       <HintPath>..\..\lib\dotnet\Splat.dll</HintPath>
     </Reference>
-    <Reference Include="Squirrel">
+    <Reference Include="Squirrel" Condition="'$(OS)'=='Windows_NT'">
       <HintPath>..\..\lib\dotnet\Squirrel.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/src/BloomExe/InstallerSupport.cs
+++ b/src/BloomExe/InstallerSupport.cs
@@ -18,7 +18,9 @@ using Microsoft.Win32;
 using SIL.IO;
 using SIL.PlatformUtilities;
 using SIL.Reporting;
+#if !__MonoCS__
 using Squirrel;
+#endif
 
 namespace Bloom
 {
@@ -141,10 +143,12 @@ namespace Bloom
 			return Application.ExecutablePath.StartsWith(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86));
 		}
 
+#if !__MonoCS__
 		private static ShortcutLocation StartMenuLocations
 		{
 			get { return ShortcutLocation.Desktop | ShortcutLocation.StartMenuPrograms; }
 		}
+#endif
 
 		static bool IsFirstTimeInstall(string[] programArgs)
 		{

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Analytics" version="2.0.0" targetFramework="net4-client" />
   <package id="Autofac" version="2.6.3.862" targetFramework="net4-client" />
@@ -12,6 +12,7 @@
   <package id="HtmlAgilityPack" version="1.4.3" />
   <package id="ICSharpCode.SharpZipLib.dll" version="0.85.4.369" targetFramework="net4-client" />
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net45" />
+  <package id="MarkdownSharp" version="1.13.0" targetFramework="net45" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />


### PR DESCRIPTION
These more intrusive changes are needed to build packages for Linux.
Linux won't build packages with Squirrel because it can't resolve all
the assemblies it references.  But Squirrel provides MarkdownSharp, so
we have to provide this explicitly for building on Linux with Mono.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1015)
<!-- Reviewable:end -->
