### PR TITLE
Prevent Bloom trying to install fonts in allUsers mode

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -293,7 +293,9 @@ namespace Bloom
 						LocalizationManager.SetUILanguage(Settings.Default.UserInterfaceLanguage, false);
 
 						// BL-1258: sometimes the newly installed fonts are not available until after Bloom restarts
-						if (FontInstaller.InstallFont("AndikaNewBasic")) 
+						// We don't even want to try to install fonts if we are installed by an admin for all users;
+						// leave it to the admin to install the font if wanted.
+						if ((!InstallerSupport.SharedByAllUsers()) && FontInstaller.InstallFont("AndikaNewBasic"))
 							return;
 
 						Run();


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1017)
<!-- Reviewable:end -->
