### PR TITLE
Add appdata file to debian package

### DIFF
--- a/debian/bloom.desktop.appdata.xml
+++ b/debian/bloom.desktop.appdata.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+​<!-- Copyright 2016 SIL International -->
+​<component type="desktop">
+​	<id>bloom.desktop</id>
+	<metadata_license>MIT</metadata_license>
+	<project_license>MIT</project_license>
+	<name>Bloom</name>
+	<summary>Literacy materials development for language communities</summary>
+​
+	<description>
+		<p>
+			Bloom Desktop is an application that dramatically "lowers the bar" for
+			language communities who want books in their own languages. Bloom delivers
+			a low-training, high-output system where mother tongue speakers and their
+			advocates work together to foster both community authorship and access to
+			external material in the vernacular.
+		​</p>
+	</description>
+
+​	<screenshots>
+		<!-- TODO: provide screenshot of the entire app -->
+		<screenshot type="default">
+			<image width="746" height="439">http://bloomlibrary.org/assets/multilingual.png</image>
+			<caption>Multilingual books</caption>
+		</screenshot>
+		<screenshot>
+			<image width="286" height="276">http://bloomlibrary.org/assets/shellbooks.png</image>
+			<caption>Shell books</caption>
+		</screenshot>
+		<screenshot>
+			<image width="292" height="179">http://bloomlibrary.org/assets/templatebooks.png</image>
+			<caption>Template books</caption>
+		</screenshot>
+		​<screenshot>
+			<image width="943" height="507">http://bloomlibrary.org/assets/pdfbooklets.png</image>
+			<caption>Effortless PDF booklets</caption>
+		</screenshot>
+		​​<screenshot>
+			<image width="300" height="282">http://bloomlibrary.org/assets/allbooks.png</image>
+			<caption>All your books, a click away</caption>
+		</screenshot>
+		​​<screenshot>
+			<image width="902" height="452">http://bloomlibrary.org/assets/artofreading.png</image>
+			<caption>Pictures from the Art of Reading Collection</caption>
+		</screenshot>
+	</screenshots> ​
+
+	<url type="homepage">http://bloomlibrary.org/</url>
+	<url type="bugtracker">https://silbloom.myjetbrains.com</url>
+	<url type="help">https://groups.google.com/d/forum/bloom-user</url>
+	<url type="donation">https://www.charity-pay.com/d/donation.asp?CID=82</url>
+
+	<provides>
+		<binary>bloom</binary>
+	</provides>
+	​
+	<releases>
+		<release version="3.6" date="2016-04-19">
+		</release>
+	</releases>
+​</component>

--- a/debian/rules
+++ b/debian/rules
@@ -67,6 +67,11 @@ override_dh_auto_install:
 	# Add bloom-collection mime type
 	install -m 644 debian/bloom-collection.png $(DESTDIR)/usr/share/icons/hicolor/48x48/mimetypes/application-bloom-collection.png
 	install -m 644 debian/bloom-collection.svg $(DESTDIR)/usr/share/icons/hicolor/scalable/mimetypes/application-bloom-collection.svg
+	# Add AppStream metadata file
+	# REVIEW: the specs are not completely clear where the file should go: /usr/share/appdata,
+	# /usr/share/app-info/xmls, or /usr/share/metainfo.
+	install -d $(DESTDIR)/usr/share/appdata
+	install -m 644 debian/bloom.desktop.appdata.xml $(DESTDIR)/usr/share/appdata
 
 # Don't export any assemblies to other packages
 override_dh_makeclilibs:


### PR DESCRIPTION
This is necessary so that Bloom shows up in Gnome Software app
in Xenial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1027)
<!-- Reviewable:end -->
