### PR TITLE
Fix file/folder problems running Bloom on Linux (BL-3358)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -47,8 +47,8 @@ override_dh_auto_install:
 	rm -rf $(DESTDIR)/$(LIB)/DistFiles/AndikaNewBasic
 	chmod -R a+rX,og-w $(DESTDIR)/$(LIB)/DistFiles
 	# Install browser support files
-	cp -r src/BloomBrowserUI $(DESTDIR)/$(LIB)/
-	chmod -R a+rX,og-w $(DESTDIR)/$(LIB)/BloomBrowserUI
+	cp -r output/browser $(DESTDIR)/$(LIB)
+	chmod -R a+rX,og-w $(DESTDIR)/$(LIB)/browser
 	# Install wrapper script
 	install -d $(DESTDIR)/usr/bin
 	install debian/bloom $(DESTDIR)/usr/bin

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -278,7 +278,7 @@ namespace Bloom
 			yield return FileLocator.GetDirectoryDistributedWithApplication(BloomFileLocator.BrowserRoot);
 
 			//hack to get the distfiles folder itself
-			yield return Path.GetDirectoryName(FileLocator.GetDirectoryDistributedWithApplication("AndikaNewBasic"));
+			yield return Path.GetDirectoryName(FileLocator.GetDirectoryDistributedWithApplication("factoryCollections"));
 
 			yield return FileLocator.GetDirectoryDistributedWithApplication(BloomFileLocator.BrowserRoot);
 			yield return FileLocator.GetDirectoryDistributedWithApplication(Path.Combine(BloomFileLocator.BrowserRoot,"bookEdit/js"));


### PR DESCRIPTION
Looking for a window-specific folder at run-time and installing
the wrong folder each led to problems running the program.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1031)
<!-- Reviewable:end -->
