### PR TITLE
Don't alarm user with missing i18n strings (BL-3374)

### DIFF
--- a/DistFiles/localization/Bloom.en.tmx
+++ b/DistFiles/localization/Bloom.en.tmx
@@ -1529,6 +1529,13 @@
         <seg>1</seg>
       </tuv>
     </tu>
+    <tu tuid="TemplateBooks.PageLabel.1 Problem">
+      <note>This label indicates a page with one arithemetic problem on it.</note>
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>1 Problem</seg>
+      </tuv>
+    </tu>
     <tu tuid="TemplateBooks.PageLabel.10">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1595,6 +1602,13 @@
         <seg>2</seg>
       </tuv>
     </tu>
+    <tu tuid="TemplateBooks.PageLabel.2 Problems">
+      <note>This label indicates a page with two arithemetic problems on it.</note>
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>2 Problems</seg>
+      </tuv>
+    </tu>
     <tu tuid="TemplateBooks.PageLabel.20">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1613,10 +1627,24 @@
         <seg>3</seg>
       </tuv>
     </tu>
+    <tu tuid="TemplateBooks.PageLabel.3 Problems">
+      <note>This label indicates a page with three arithemetic problems on it.</note>
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>3 Problems</seg>
+      </tuv>
+    </tu>
     <tu tuid="TemplateBooks.PageLabel.4">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>4</seg>
+      </tuv>
+    </tu>
+    <tu tuid="TemplateBooks.PageLabel.4 Problems">
+      <note>This label indicates a page with four arithemetic problems on it.</note>
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>4 Problems</seg>
       </tuv>
     </tu>
     <tu tuid="TemplateBooks.PageLabel.5">

--- a/src/BloomExe/NonFatalProblem.cs
+++ b/src/BloomExe/NonFatalProblem.cs
@@ -35,6 +35,10 @@ namespace Bloom
 			string moreDetails = null,
 			Exception exception = null)
 		{
+			// Simplify some checks below by tweaking the channel name on Linux.
+			var channel = ApplicationUpdateSupport.ChannelName.ToLowerInvariant();
+			if (channel.EndsWith("-unstable"))
+				channel = channel.Replace("unstable", "alpha");
 			try
 			{
 				shortUserLevelMessage = shortUserLevelMessage == null ? "" : shortUserLevelMessage;
@@ -79,8 +83,6 @@ namespace Bloom
 					shortUserLevelMessage = "[Alpha]: " + shortUserLevelMessage;
 				}
 
-				var channel = ApplicationUpdateSupport.ChannelName.ToLower();
-
 				if(Matches(modalThreshold).Any(s => channel.Contains(s)))
 				{
 					try
@@ -107,7 +109,7 @@ namespace Bloom
 			catch(Exception errorWhileReporting)
 			{
 				Debug.Fail("error in nonfatalError reporting");
-				if(ApplicationUpdateSupport.ChannelName.ToLower().Contains("alpha"))
+				if (channel.Contains("alpha"))
 					ErrorReport.NotifyUserOfProblem(errorWhileReporting,"Error while reporting non fatal error");
 			}
 		}

--- a/src/BloomExe/web/I18NHandler.cs
+++ b/src/BloomExe/web/I18NHandler.cs
@@ -84,8 +84,14 @@ namespace Bloom.Api
 					else
 					{
 						//ok, so we don't have it translated yet. Make sure it's at least listed in the things that can be translated.
+						// And return the English string, which is what we would do the next time anyway.  (BL-3374)
 						LocalizationManager.GetDynamicString("Bloom", id, englishText);
-						return false;
+						var modal = ApplicationUpdateSupport.ChannelName.StartsWith("Developer/") ? ModalIf.All : ModalIf.None;
+						var longMsg = String.Format("**I18NHandler: Added missing translatable string (\"{0}\")", englishText);
+						NonFatalProblem.Report(modal, PassiveIf.Beta, "adding translatable string", longMsg);
+						info.ContentType = "text/plain";
+						info.WriteCompleteOutput(englishText);
+						return true;
 					}
 					break;
 			}


### PR DESCRIPTION
I added the (known) missing strings to the base Bloom.en.tmx file
and changed the handling of missing strings to work more quietly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1036)
<!-- Reviewable:end -->
