### PR TITLE
Fix Version3.6 for xenial package dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Architecture: all
 Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  mono-sil, libgdiplus-sil, geckofx29, gtklp,
  chmsee, libtidy5,
- fonts-sil-andika-new-basic,
+ fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,
  optipng, libsndfile1,
  wmctrl
 Suggests: art-of-reading


### PR DESCRIPTION
fonts-sil-andika-new-basic was renamed on xenial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1037)
<!-- Reviewable:end -->
