### PR TITLE
Fix BL-3383 making anchors to help work again, now simplified

### DIFF
--- a/src/BloomBrowserUI/bookEdit/editViewFrame.ts
+++ b/src/BloomBrowserUI/bookEdit/editViewFrame.ts
@@ -9,7 +9,6 @@ import {getToolboxFrameExports} from './js/bloomFrames';
 export {getToolboxFrameExports};
 import {getPageFrameExports} from './js/bloomFrames';
 export {getPageFrameExports};
-export {default as BloomHelp} from '../BloomHelp';
 import {showAddPageDialog} from '../pageChooser/page-chooser';
 export {showAddPageDialog};
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/readerSetup/ReaderSetup.jade
+++ b/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/readerSetup/ReaderSetup.jade
@@ -70,7 +70,7 @@ html
 								a#open-text-folder.blue-link(href='', data-i18n='ReaderSetup.Words.SampleTextFolder') Sample Texts Folder
 							#dls_word_lists.disableable.flex-column-expanding-row
 							#how_to_export(style="display: none")
-								a(href="", onclick="return FrameExports.getToolboxFrameExports().BloomHelp.show('/bloom/help/Tasks/Edit_tasks/Decodable_Reader_Tool/Language_tab.htm');", data-i18n='ReaderSetup.HowToExport') Help exporting and converting files to use as sample texts
+								a(href="/bloom/api/help/Tasks/Edit_tasks/Decodable_Reader_Tool/Language_tab.htm", data-i18n='ReaderSetup.HowToExport') Help exporting and converting files to use as sample texts
 			#dlstabs-2.reader-setup-tab
 				.floating(style='width: 100%; box-sizing: border-box; margin-bottom: 8px;')
 					table

--- a/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/readerSetup/readerSetup.ui.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/readerSetup/readerSetup.ui.ts
@@ -4,7 +4,6 @@ import theOneLocalizationManager from '../../../../lib/localizationManager/local
 import '../../../../lib/jquery.onSafe.ts';
 import {saveChangedSettings, cleanSpaceDelimitedList, toolboxWindow, setPreviousMoreWords, getPreviousMoreWords} from './readerSetup.io';
 import {DataWord} from '../libSynphony/bloom_lib';
-import BloomHelp from '../../../../BloomHelp.ts';
 import axios = require('axios');
 //import {ReaderToolsModel} from '../readerToolsModel';
 import * as _ from 'underscore';
@@ -118,7 +117,7 @@ function process_UI_Message(event: MessageEvent): void {
         default:
       }
       if (helpFile)
-        BloomHelp.show(helpFile);
+        axios.get("/bloom/api/help/"+helpFile);
       return;
 
     default:

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -54,8 +54,6 @@ span.ui-audioCurrent {
         background-position: center
    }
 
-    #audio-help-wrapper {margin-top:10px;}
-
     .disabled{
         opacity: 0.4;
     }    
@@ -113,7 +111,11 @@ span.ui-audioCurrent {
         top:12px;
         width:80px;
     }
-    a.audio-help {
+    
+    
+    a {
+        display: block; //start on a new line
+        margin-top:10px;
         text-decoration:underline;
         cursor:pointer
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.jade
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.jade
@@ -32,5 +32,4 @@ html
 				+buttonGroup('clear', 'enabled', 'Clear', 'Clear')
 				+buttonGroup('listen', 'disabled', 'Listen to the whole page', 'Listen')
 				div.audio-about(data-i18n='EditTab.Toolbox.TalkingBookTool.ToolPurpose') Make an e-book that can play recordings while highlighting sentences.
-				div#audio-help-wrapper
-					a.audio-help(onclick="return window['top'].FrameExports.BloomHelp.show('/Tasks/Edit_tasks/Record_Audio/Record_Audio_overview.htm');", data-i18n='Common.Help') Help
+				a(href='/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Record_Audio_overview.htm', data-i18n='Common.Help') Help

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolboxBootstrap.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolboxBootstrap.ts
@@ -13,7 +13,6 @@ export {removeToolboxMarkup};
 export {showSetupDialog, initializeReaderSetupDialog, closeSetupDialog} from './decodableReader/decodableReader'
 export {addWordListChangedListener} from './decodableReader/readerTools';
 export {loadLongpressInstructions} from '../js/bloomEditing';
-export {default as BloomHelp} from '../../BloomHelp';
 export {TalkingBookModel}; // one function is called by CSharp; also, exporting something from it gets it included in the bundle.
 export {LeveledReaderModel}; // just to make sure it gets included in the bundle (and adds an instance of itself to the collection in toolbox.ts)
 export {handleBookSettingCheckboxClick}; // called by click handler in jade; also, exporting something from it gets it included in the bundle.

--- a/src/BloomBrowserUI/ePUB/bloomEpubPreview.jade
+++ b/src/BloomBrowserUI/ePUB/bloomEpubPreview.jade
@@ -6,7 +6,6 @@ html
     link(rel='stylesheet', href='/bloom/lib/jquery-ui.css')
     script(src='/bloom/node_modules/jquery/dist/jquery.js')
     script(src='/bloom/lib/jquery-ui/jquery-ui.min.js')
-    script(src='/bloom/bloomHelp.js')
     script.
       $(function () { $('#device').resizable({ minHeight: 300, minWidth: 200, handles: { 'se': '#BottomRightHandle' } }); });
   //_AudioSituationClass_ is replaced at runtime
@@ -34,13 +33,13 @@ html
       h3 Recommended Reader
       p Our testing has shown
         a(href='https://play.google.com/store/apps/details?id=com.gitden.epub.reader.app') Gitden Reader
-        |  to be a good choice for Android and IOS (IPhone & IPad) devices.
+        |  to be a good choice for Android and IOS (IPhone &amp; IPad) devices.
       p.showForTalkingBooks
         | To listen to this Talking Book using Gitden on a phone or tablet, you will need to disable Gitden's "Text To Speech" feature. Then it will show you the audio controls.
       h3.showWhenNoAudio Make it Talk
       p.showWhenNoAudio
-        | If you want to make a "Talking Book" that new readers can read-along with, use Bloom's
-        a(href='javascript:void(0)', onclick="return window['top'].FrameExports.BloomHelp.show('/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm');") Talking Book tool
+        | If you want to make a "Talking Book" that new readers can read-along with, use Bloom's&nbsp;
+        a(href='/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm') Talking Book Tool
         |  to add voice recordings.
       h3 Write to us!
       p Are you interested in distributing Bloom books for use on phones and other ebook readers? Is there something you would need us to do before it is useful for you? Please use the Help:Report A Problem command to send us feedback. Thanks!

--- a/src/BloomExe/HelpLauncher.cs
+++ b/src/BloomExe/HelpLauncher.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using Bloom.Api;
 using SIL.IO;
 
 namespace Bloom
@@ -21,6 +22,16 @@ namespace Bloom
 		public static void Show(Control parent, string helpFileName, string topic)
 		{
 			Help.ShowHelp(parent, FileLocator.GetFileDistributedWithApplication(helpFileName), topic);
+		}
+
+		public static void RegisterWithServer(EnhancedImageServer server)
+		{
+			server.RegisterEndpointHandler("help/.*", (request) =>
+			{
+				var topic = request.LocalPath().ToLowerInvariant().Replace("api/help","");
+				Show(Application.OpenForms.Cast<Form>().Last(), topic);
+				request.Cancel();
+			});
 		}
 	}
 }

--- a/src/BloomExe/HelpLauncher.cs
+++ b/src/BloomExe/HelpLauncher.cs
@@ -30,7 +30,8 @@ namespace Bloom
 			{
 				var topic = request.LocalPath().ToLowerInvariant().Replace("api/help","");
 				Show(Application.OpenForms.Cast<Form>().Last(), topic);
-				request.Cancel();
+				//if this is called from a simple html anchor, we don't want the browser to do anything
+				request.SucceededDoNotNavigate();
 			});
 		}
 	}

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -260,8 +260,10 @@ namespace Bloom
 			_httpServer.StartListening();	// as a side-effect, sets port number needed by RegisterWithServer (BL-3337)
 			var server = _scope.Resolve<EnhancedImageServer>();
 			_scope.Resolve<AudioRecording>().RegisterWithServer(server);
+			HelpLauncher.RegisterWithServer(server);
 			ToolboxView.RegisterWithServer(server);
 		}
+
 
 		internal static BloomS3Client CreateBloomS3Client()
 		{

--- a/src/BloomExe/web/ApiRequest.cs
+++ b/src/BloomExe/web/ApiRequest.cs
@@ -54,10 +54,18 @@ namespace Bloom.Api
 
 		public void Succeeded()
 		{
-			//review: not sure what is proper if we have nothing to say. This will work.
 			_requestInfo.ContentType = "text/plain";
 			_requestInfo.WriteCompleteOutput("OK");
 		}
+
+		//Used when an anchor has given us info, but we don't actually want the browser to navigate
+		//For example, anchors that lead to help lead to an api handler that opens help but then
+		//calls this so that the browser just stays where it was.
+		public void SucceededDoNotNavigate()
+		{
+			_requestInfo.SucceededDoNotNavigate();
+		}
+
 		public void ReplyWithText(string text)
 		{
 			//Debug.WriteLine(this.Requestinfo.LocalPathWithoutQuery + ": " + text);

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -2,31 +2,23 @@
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Drawing;
-using System.Drawing.Imaging;
-using System.Dynamic;
-using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
 using Bloom.Book;
 using System.IO;
 using System.Net;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using Bloom.ImageProcessing;
 using BloomTemp;
 using L10NSharp;
 using Microsoft.Win32;
-using SIL.Code;
 using SIL.IO;
 using Bloom.Collection;
-using Bloom.Edit;
 using Newtonsoft.Json;
 using SIL.Reporting;
 using SIL.Extensions;
-using RestSharp.Contrib;
 
 namespace Bloom.Api
 {
@@ -448,12 +440,6 @@ namespace Bloom.Api
 					return true;
 				case "topics":
 					return GetTopicList(info);
-				case "help":
-					var post = info.GetPostDataWhenFormEncoded();
-					// Help launches a separate process so it doesn't matter that we don't call
-					// it on the UI thread
-					HelpLauncher.Show(null, post["data"]);
-					return true;
 			}
 			return ProcessAnyFileContent(info, localPath);
 		}

--- a/src/BloomExe/web/IRequestInfo.cs
+++ b/src/BloomExe/web/IRequestInfo.cs
@@ -27,5 +27,6 @@ namespace Bloom.Api
 		string GetPostJson();
 		string GetPostString();
 		HttpMethods HttpMethod { get; }
+		void SucceededDoNotNavigate();
 	}
 }

--- a/src/BloomExe/web/RequestInfo.cs
+++ b/src/BloomExe/web/RequestInfo.cs
@@ -52,6 +52,14 @@ namespace Bloom.Api
 			_actualContext = actualContext;
 		}
 
+		//used when an anchor has given us info, but we don't actually want the browser to navigate
+		public void SucceededDoNotNavigate()
+		{
+			_actualContext.Response.StatusCode = 202; //Accepted. Request accepted but not completed yet, it will continue asynchronously.
+			HaveOutput = true;
+			return;
+		}
+
 		public void WriteCompleteOutput(string s)
 		{
 			WriteOutput(Encoding.UTF8.GetBytes(s), _actualContext.Response);

--- a/src/BloomTests/PretendRequestInfo.cs
+++ b/src/BloomTests/PretendRequestInfo.cs
@@ -9,6 +9,7 @@ namespace Bloom.Api
 	public class PretendRequestInfo : IRequestInfo
 	{
 		public HttpMethods HttpMethod { get; set; }
+
 		public string ReplyContents;
 		public string ReplyImagePath;
 		//public HttpListenerContext Context; //todo: could we mock a context and then all but do away with this pretend class by subclassing the real one?
@@ -98,6 +99,8 @@ namespace Bloom.Api
 		{
 			return "";
 		}
+		public void SucceededDoNotNavigate(){}
+
 		public string RawUrl { get; private set; }
 	}
 }


### PR DESCRIPTION
Got rid of BloomHelp altogether; you can now lanch help just by setting the href of an anchor to "/bloom/api/help/.... topic".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1039)
<!-- Reviewable:end -->
