### PR TITLE
BL-3386, prevent resize of DR setup dialog in 3.6

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/decodableReader.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/decodableReader.ts
@@ -122,6 +122,7 @@ function showSetupDialog(showWhat) {
         $(dialogContents).dialog({
             autoOpen: true,
             modal: true,
+            resizable: false, // Do NOT merge into 3.7! There's a problem with resizing (BL-3386) in 3.6 which is already fixed in 3.7
             buttons: (<any>{
                 Help: {
                     // For consistency, I would have made this 'Common.Help', but we already had 'HelpMenu.Help Menu' translated


### PR DESCRIPTION
Please try NOT to merge this into 3.7! Resizing works properly
there and should NOT be disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1047)
<!-- Reviewable:end -->
