### PR TITLE
BL-2324 BookSettings sensitive to if in shellbook or not

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettings.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettings.ts
@@ -1,28 +1,23 @@
-﻿import axios = require('axios');
-if (typeof ($) === "function") { // have jquery
-    $(document).ready(() => {
-        // request our model and set the controls
-        axios.get<any>('/bloom/api/bookSettings').then(result => {
-            var settings = result.data;
-            // enhance: this is just dirt-poor binding of 1 checkbox for now
-            $("input[name='unlockShellBook']").prop("checked", settings.unlockShellBook);
-        });
+﻿///<reference path="../../../typings/axios/axios.d.ts"/>
+import axios = require('axios');
+
+$(document).ready(() => {
+    // request our model and set the controls
+    axios.get<any>('/bloom/api/bookSettings').then(result => {
+        var settings = result.data;
+        // enhance: this is just dirt-poor binding of 1 checkbox for now
+        $("input[name='unlockShellBook']").prop("checked", settings.unlockShellBook);
     });
-}
+});
 
 export function handleBookSettingCheckboxClick(clickedButton: any) {
     // read our controls and send the model back to c#
     // enhance: this is just dirt-poor serialization of checkboxes for now
     var inputs = $(".bookSettings :input");
-    var settings = $.map(inputs, function (input, i) {
+    var settings = $.map(inputs, (input, i) => {
         var o = {};
         o[input.name] = $(input).prop("checked");
         return o;
     })[0];
-    bookSettingsFireCSharpEvent("setBookSettings", JSON.stringify(settings));
-}
-
-function bookSettingsFireCSharpEvent(eventName, eventData): void {
-    var event = new MessageEvent(eventName, { 'bubbles': true, 'cancelable': true, 'data': eventData });
-    document.dispatchEvent(event);
+    axios.post("/bloom/api/bookSettings", settings);
 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettings.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettings.ts
@@ -5,8 +5,15 @@ $(document).ready(() => {
     // request our model and set the controls
     axios.get<any>('/bloom/api/bookSettings').then(result => {
         var settings = result.data;
-        // enhance: this is just dirt-poor binding of 1 checkbox for now
-        $("input[name='unlockShellBook']").prop("checked", settings.unlockShellBook);
+
+        // Only show this if we are editing a shell book. Otherwise, it's already not locked.
+        if(!settings.isRecordedAsLockedDown){
+            $(".showOnlyWhenBookWouldNormallyBeLocked").css("display","none");
+        }
+        else{
+            // enhance: this is just dirt-poor binding of 1 checkbox for now
+            $("input[name='unlockShellBook']").prop("checked", settings.unlockShellBook);
+        }
     });
 });
 

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -552,7 +552,6 @@
     <Compile Include="Workspace\FeedbackDialog.Designer.cs">
       <DependentUpon>FeedbackDialog.cs</DependentUpon>
     </Compile>
-    <Compile Include="web\BloomServer.cs" />
     <Compile Include="web\WebLibraryView.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1200,14 +1200,14 @@ namespace Bloom.Book
 		/// </summary>
 		public bool RecordedAsLockedDown
 		{
-			get { return IsLockedDown(OurHtmlDom); }
+			get { return HtmlHasLockedDownFlag(OurHtmlDom); }
 			set
 			{
 				RecordAsLockedDown(OurHtmlDom, value);
 			}
 		}
 
-		public static bool IsLockedDown(HtmlDom dom)
+		public static bool HtmlHasLockedDownFlag(HtmlDom dom)
 		{
 			var node = dom.SafeSelectNodes(String.Format("//meta[@name='lockedDownAsShell' and @content='true']"));
 			return node.Count > 0;

--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -89,6 +89,7 @@ namespace Bloom.Edit
 			server.RegisterEndpointHandler("audio/checkForSegment", HandleCheckForSegment);
 			server.RegisterEndpointHandler("audio/devices", HandleAudioDevices);
 
+			Debug.Assert(ServerBase.portForHttp > 0,"Need the server to be listening before this can be registered (BL-3337).");
 			_peakLevelWebSocketServer = new BloomWebSocketServer((ServerBase.portForHttp+1).ToString(CultureInfo.InvariantCulture));//review: we have no dispose (on us or our parent) so this is never disposed
 		}
 

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -131,7 +131,6 @@ namespace Bloom.Edit
 			});
 			_contentLanguages = new List<ContentLanguage>();
 			_server.CurrentCollectionSettings = _collectionSettings;
-			CurrentBookHandler.CurrentBook = CurrentBook;
 			_templateInsertionCommand = templateInsertionCommand;
 		}
 
@@ -181,7 +180,6 @@ namespace Bloom.Edit
 			var wasNull = _domForCurrentPage == null;
 			_domForCurrentPage = null;
 			_currentlyDisplayedBook = null;
-			CurrentBookHandler.CurrentBook = CurrentBook;
 			_templatePagesDict = null;
 			if (Visible)
 			{
@@ -591,7 +589,6 @@ namespace Bloom.Edit
 			//else
 			//	_server.ToolboxContent = "<html><head><meta charset=\"UTF-8\"/></head><body></body></html>";
 
-			CurrentBookHandler.CurrentBook = _currentlyDisplayedBook;
 			_server.AuthorMode = CanAddPages;
 		}
 
@@ -686,7 +683,6 @@ namespace Bloom.Edit
 			AddMessageEventListener("saveToolboxSettingsEvent", SaveToolboxSettings);
 			AddMessageEventListener("preparePageForEditingAfterOrigamiChangesEvent", RethinkPageAndReloadIt);
 			AddMessageEventListener("setTopic", SetTopic);
-			AddMessageEventListener("setBookSettings", SetBookSettings);
 			AddMessageEventListener("finishSavingPage", FinishSavingPage);
 			AddMessageEventListener("handleAddNewPageKeystroke", HandleAddNewPageKeystroke);
 			AddMessageEventListener("addPage", (id) => AddNewPageBasedOnTemplate(id));
@@ -696,17 +692,6 @@ namespace Bloom.Edit
 		private void SaveToolboxSettings(string data)
 		{
 			ToolboxView.SaveToolboxSettings(_currentlyDisplayedBook,data);
-		}
-
-		private void SetBookSettings(string json)
-		{
-			//note: since we only have this one value, it's not clear yet whether the panel involved here will be more of a
-			//and "edit settings", or a "book settings", or a combination of them.
-			//enhance: if this gets much beyond single value, we should create a BookEditSettingsModel (or whatever name fits)
-			//and move all handling there
-			dynamic settings = DynamicJson.Parse(json);
-			_currentlyDisplayedBook.TemporarilyUnlocked = settings.unlockShellBook;
-			RefreshDisplayOfCurrentPage();
 		}
 
 		private void AddMessageEventListener(string name, Action<string> listener)

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -100,7 +100,8 @@ namespace Bloom
 							typeof (LocalizationChangedEvent),
 							typeof (ControlKeyEvent),
 							typeof (EditingModel),
-							typeof (AudioRecording)
+							typeof (AudioRecording),
+							typeof(ReadersApi)
 						}.Contains(t));
 
 					builder.RegisterAssemblyTypes(Assembly.GetExecutingAssembly())
@@ -259,6 +260,7 @@ namespace Bloom
 			_scope.Resolve<AudioRecording>().RegisterWithServer(server);
 			HelpLauncher.RegisterWithServer(server);
 			ToolboxView.RegisterWithServer(server);
+			_scope.Resolve<ReadersApi>().RegisterWithServer(server);
 		}
 
 

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -29,7 +29,6 @@ namespace Bloom
 		/// </summary>
 		private ILifetimeScope _scope;
 
-		private EnhancedImageServer _httpServer;
 //		private CommandAvailabilityPublisher _commandAvailabilityPublisher;
 		public Form ProjectWindow { get; private set; }
 
@@ -221,11 +220,9 @@ namespace Bloom
 //				}
 //				else
 //				{
-					_httpServer = new EnhancedImageServer(new RuntimeImageProcessor(bookRenameEvent), parentContainer.Resolve<BookThumbNailer>());
-					ReadersApi.Init(_httpServer);
-					CurrentBookHandler.Init(_httpServer);
-//				}
-					builder.Register((c => _httpServer)).AsSelf().SingleInstance();
+					builder.Register<EnhancedImageServer>(
+						c =>
+							new EnhancedImageServer(new RuntimeImageProcessor(bookRenameEvent), c.Resolve<BookThumbNailer>(), c.Resolve<BookSelection>() )).SingleInstance();
 
 					builder.Register<Func<WorkspaceView>>(c => () =>
 					{
@@ -257,8 +254,8 @@ namespace Bloom
 				Application.Exit();
 			}
 
-			_httpServer.StartListening();	// as a side-effect, sets port number needed by RegisterWithServer (BL-3337)
 			var server = _scope.Resolve<EnhancedImageServer>();
+			server.StartListening();
 			_scope.Resolve<AudioRecording>().RegisterWithServer(server);
 			HelpLauncher.RegisterWithServer(server);
 			ToolboxView.RegisterWithServer(server);

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -257,13 +257,14 @@ namespace Bloom
 			}
 
 			var server = _scope.Resolve<EnhancedImageServer>();
-			server.StartListening();
+			
 			_scope.Resolve<AudioRecording>().RegisterWithServer(server);
 
 			HelpLauncher.RegisterWithServer(server);
 			ToolboxView.RegisterWithServer(server);
 			_scope.Resolve<CurrentBookHandler>().RegisterWithServer(server);
 			_scope.Resolve<ReadersApi>().RegisterWithServer(server);
+			server.StartListening();
 		}
 
 

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -101,6 +101,7 @@ namespace Bloom
 							typeof (ControlKeyEvent),
 							typeof (EditingModel),
 							typeof (AudioRecording),
+							typeof(CurrentBookHandler),
 							typeof(ReadersApi)
 						}.Contains(t));
 
@@ -258,8 +259,10 @@ namespace Bloom
 			var server = _scope.Resolve<EnhancedImageServer>();
 			server.StartListening();
 			_scope.Resolve<AudioRecording>().RegisterWithServer(server);
+
 			HelpLauncher.RegisterWithServer(server);
 			ToolboxView.RegisterWithServer(server);
+			_scope.Resolve<CurrentBookHandler>().RegisterWithServer(server);
 			_scope.Resolve<ReadersApi>().RegisterWithServer(server);
 		}
 

--- a/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
@@ -324,7 +324,7 @@ namespace Bloom.WebLibraryIntegration
 			{
 				var xmlDomFromHtmlFile = XmlHtmlConverter.GetXmlDomFromHtmlFile(htmlFile, false);
 				domForLocking = new HtmlDom(xmlDomFromHtmlFile);
-				wasLocked = Book.Book.IsLockedDown(domForLocking);
+				wasLocked = Book.Book.HtmlHasLockedDownFlag(domForLocking);
 				allowLocking = !metadata.IsSuitableForMakingShells;
 				if (allowLocking && !wasLocked)
 				{

--- a/src/BloomExe/web/CurrentBookHandler.cs
+++ b/src/BloomExe/web/CurrentBookHandler.cs
@@ -4,6 +4,7 @@ using System.Drawing.Imaging;
 using System.Dynamic;
 using System.Globalization;
 using System.IO;
+using Bloom.Book;
 using SIL.Code;
 using SIL.Reporting;
 
@@ -14,11 +15,18 @@ namespace Bloom.Api
 	/// An exception is some reader tools requests, which have their own handler, though most of them depend
 	/// on knowing the current book. This class provides that information to the ReadersHandler.
 	/// </summary>
-	public static class CurrentBookHandler
+	public class CurrentBookHandler
 	{
-		public static Book.Book CurrentBook { set; get; }
+		private readonly BookSelection _bookSelection;
+		private readonly PageRefreshEvent _pageRefreshEvent;
 
-		public static void Init(EnhancedImageServer server)
+		public CurrentBookHandler(BookSelection bookSelection, PageRefreshEvent pageRefreshEvent)
+		{
+			_bookSelection = bookSelection;
+			_pageRefreshEvent = pageRefreshEvent;
+		}
+
+		public void RegisterWithServer(EnhancedImageServer server)
 		{
 			server.RegisterEndpointHandler("bookSettings", HandleGetBookSettings);
 			server.RegisterEndpointHandler("imageInfo", HandleGetImageInfo);
@@ -27,24 +35,39 @@ namespace Bloom.Api
 		/// <summary>
 		/// Get a json of the book's settings.
 		/// </summary>
-		private static void HandleGetBookSettings(ApiRequest request)
+		private  void HandleGetBookSettings(ApiRequest request)
 		{
-			dynamic settings = new ExpandoObject();
-			settings.unlockShellBook = CurrentBook.TemporarilyUnlocked;
-			settings.currentToolBoxTool = CurrentBook.BookInfo.CurrentTool;
-			request.ReplyWithJson((object) settings);
+			switch (request.HttpMethod)
+			{
+				case HttpMethods.Get:
+					dynamic settings = new ExpandoObject();
+					settings.unlockShellBook = _bookSelection.CurrentSelection.TemporarilyUnlocked;
+					settings.currentToolBoxTool = _bookSelection.CurrentSelection.BookInfo.CurrentTool;
+					request.ReplyWithJson((object)settings);
+					break;
+				case HttpMethods.Post:
+					//note: since we only have this one value, it's not clear yet whether the panel involved here will be more of a
+					//an "edit settings", or a "book settings", or a combination of them.
+					settings = DynamicJson.Parse(request.RequiredPostJson());
+					_bookSelection.CurrentSelection.TemporarilyUnlocked = settings["unlockShellBook"];
+					_pageRefreshEvent.Raise(null);
+					request.Succeeded();
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
 		}
 
 		/// <summary>
 		/// Get a json of stats about the image. It is used to populate a tooltip when you hover over an image container
 		/// </summary>
-		private static void HandleGetImageInfo(ApiRequest request)
+		private void HandleGetImageInfo(ApiRequest request)
 		{
 			try
-			{		
+			{
 				var fileName = request.RequiredParam("image");
-				Guard.AgainstNull(CurrentBook, "CurrentBook");
-				var path = Path.Combine(CurrentBook.FolderPath, fileName);
+				Guard.AgainstNull(_bookSelection.CurrentSelection, "CurrentBook");
+				var path = Path.Combine(_bookSelection.CurrentSelection.FolderPath, fileName);
 				RequireThat.File(path).Exists();
 				var fileInfo = new FileInfo(path);
 				dynamic result = new ExpandoObject();
@@ -54,12 +77,12 @@ namespace Bloom.Api
 				// Using a stream this way, according to one source,
 				// http://stackoverflow.com/questions/552467/how-do-i-reliably-get-an-image-dimensions-in-net-without-loading-the-image,
 				// supposedly avoids loading the image into memory when we only want its dimensions
-				using (var stream = File.OpenRead(path))
-				using (var img = Image.FromStream(stream, false, false))
+				using(var stream = File.OpenRead(path))
+				using(var img = Image.FromStream(stream, false, false))
 				{
 					result.width = img.Width;
 					result.height = img.Height;
-					switch (img.PixelFormat)
+					switch(img.PixelFormat)
 					{
 						case PixelFormat.Format32bppArgb:
 						case PixelFormat.Format32bppRgb:
@@ -86,7 +109,7 @@ namespace Bloom.Api
 				}
 				request.ReplyWithJson((object) result);
 			}
-			catch (Exception e)
+			catch(Exception e)
 			{
 				Logger.WriteEvent("Error in server imageInfo/: url was " + request.LocalPath());
 				Logger.WriteEvent("Error in server imageInfo/: exception is " + e.Message);

--- a/src/BloomExe/web/CurrentBookHandler.cs
+++ b/src/BloomExe/web/CurrentBookHandler.cs
@@ -2,7 +2,6 @@
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Dynamic;
-using System.Globalization;
 using System.IO;
 using Bloom.Book;
 using SIL.Code;
@@ -13,7 +12,7 @@ namespace Bloom.Api
 	/// <summary>
 	/// This class is responsible for handling Server requests that depend on knowledge of the current book.
 	/// An exception is some reader tools requests, which have their own handler, though most of them depend
-	/// on knowing the current book. This class provides that information to the ReadersHandler.
+	/// on knowing the current book.
 	/// </summary>
 	public class CurrentBookHandler
 	{
@@ -28,14 +27,14 @@ namespace Bloom.Api
 
 		public void RegisterWithServer(EnhancedImageServer server)
 		{
-			server.RegisterEndpointHandler("bookSettings", HandleGetBookSettings);
-			server.RegisterEndpointHandler("imageInfo", HandleGetImageInfo);
+			server.RegisterEndpointHandler("bookSettings", HandleBookSettings);
+			server.RegisterEndpointHandler("imageInfo", HandleImageInfo);
 		}
 
 		/// <summary>
 		/// Get a json of the book's settings.
 		/// </summary>
-		private  void HandleGetBookSettings(ApiRequest request)
+		private  void HandleBookSettings(ApiRequest request)
 		{
 			switch (request.HttpMethod)
 			{
@@ -62,7 +61,7 @@ namespace Bloom.Api
 		/// <summary>
 		/// Get a json of stats about the image. It is used to populate a tooltip when you hover over an image container
 		/// </summary>
-		private void HandleGetImageInfo(ApiRequest request)
+		private void HandleImageInfo(ApiRequest request)
 		{
 			try
 			{

--- a/src/BloomExe/web/CurrentBookHandler.cs
+++ b/src/BloomExe/web/CurrentBookHandler.cs
@@ -41,6 +41,7 @@ namespace Bloom.Api
 			{
 				case HttpMethods.Get:
 					dynamic settings = new ExpandoObject();
+					settings.isRecordedAsLockedDown = _bookSelection.CurrentSelection.RecordedAsLockedDown;
 					settings.unlockShellBook = _bookSelection.CurrentSelection.TemporarilyUnlocked;
 					settings.currentToolBoxTool = _bookSelection.CurrentSelection.BookInfo.CurrentTool;
 					request.ReplyWithJson((object)settings);

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -36,6 +36,7 @@ namespace Bloom.Api
 		static Dictionary<string, string> _urlToSimulatedPageContent = new Dictionary<string, string>(); // see comment on MakeSimulatedPageFileInBookFolder
 		private BloomFileLocator _fileLocator;
 		private readonly BookThumbNailer _thumbNailer;
+		private readonly BookSelection _bookSelection;
 		private readonly ProjectContext _projectContext;
 
 		// This dictionary ties API endpoints to functions that handle the requests.
@@ -46,12 +47,13 @@ namespace Bloom.Api
 		/// <summary>
 		/// This is only used in a few special cases where we need one to pass as an argument but it won't be fully used.
 		/// </summary>
-		internal EnhancedImageServer() : this( new RuntimeImageProcessor(new BookRenamedEvent()), null, null)
+		internal EnhancedImageServer(BookSelection bookSelection) : this( new RuntimeImageProcessor(new BookRenamedEvent()), null, bookSelection)
 		{ }
 
-		public EnhancedImageServer(RuntimeImageProcessor cache, BookThumbNailer thumbNailer,  BloomFileLocator fileLocator = null) : base(cache)
+		public EnhancedImageServer(RuntimeImageProcessor cache, BookThumbNailer thumbNailer, BookSelection bookSelection,  BloomFileLocator fileLocator = null) : base(cache)
 		{
 			_thumbNailer = thumbNailer;
+			_bookSelection = bookSelection;
 			_fileLocator = fileLocator;
 			// Storing this in the ReadersHandler means there can only be one instance of EIS, since ReadersHandler is static. But for
 			// now that's true anyway because we use a fixed port. If we need to change this we could just make an instance here.

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -215,7 +215,6 @@
     <Compile Include="WebLibraryIntegration\BookTransferTests.cs" />
     <Compile Include="web\ReadersApiTests.cs" />
     <Compile Include="web\ApiTest.cs" />
-    <Compile Include="web\BloomServerTests.cs" />
     <Compile Include="ImageProcessing\ImageServerTests.cs" />
     <Compile Include="web\EndpointHandlerTests.cs" />
     <Compile Include="web\RequestInfoTests.cs" />

--- a/src/BloomTests/web/EndpointHandlerTests.cs
+++ b/src/BloomTests/web/EndpointHandlerTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Bloom.Api;
+using Bloom.Book;
 using NUnit.Framework;
 
 namespace BloomTests.web
@@ -22,7 +23,7 @@ namespace BloomTests.web
 			// as long as we're only using one, fixed port number, we need to prevent unit test runner
 			// from running these tests in parallel.
 			Monitor.Enter(_portMonitor);
-			_server = new EnhancedImageServer();
+			_server = new EnhancedImageServer(new BookSelection());
 		}
 
 		[TearDown]

--- a/src/BloomTests/web/EnhancedImageServerTests.cs
+++ b/src/BloomTests/web/EnhancedImageServerTests.cs
@@ -150,7 +150,9 @@ namespace BloomTests.web
 
 		private EnhancedImageServer CreateImageServer()
 		{
-			return new EnhancedImageServer(new RuntimeImageProcessor(new BookRenamedEvent()), _fileLocator);
+			var bookSelection = new BookSelection();
+			bookSelection.SelectBook(new Bloom.Book.Book());
+			return new EnhancedImageServer(new RuntimeImageProcessor(new BookRenamedEvent()), null, bookSelection, _fileLocator);
 		}
 
 		private TempFile MakeTempImage()

--- a/src/BloomTests/web/ReadersApiTests.cs
+++ b/src/BloomTests/web/ReadersApiTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Bloom.Edit;
 using Bloom.Api;
+using Bloom.Book;
 using Bloom.Collection;
 using NUnit.Framework;
 
@@ -18,12 +19,13 @@ namespace BloomTests.web
 		[SetUp]
 		public void Setup()
 		{
-			_server = new EnhancedImageServer();
+			var bookSelection = new BookSelection();
+			bookSelection.SelectBook(new Bloom.Book.Book());
+			_server = new EnhancedImageServer(bookSelection);
 			//needed to avoid a check in the server
 			_server.CurrentCollectionSettings = new CollectionSettings();
-			CurrentBookHandler.CurrentBook = new Bloom.Book.Book();
-
-			ReadersApi.Init(_server); //this won't get us far, as there is no project context setup
+			var controller = new ReadersApi(bookSelection);
+			controller.RegisterWithServer(_server);
 		}
 
 		[TearDown]
@@ -34,9 +36,8 @@ namespace BloomTests.web
 		}
 
 		[Test]
-		public void Get_Test_Works()
+		public void IsReceivingApiCalls()
 		{
-
 			var result = ApiTest.GetString(_server,"readers/test");
 			Assert.That(result, Is.EqualTo("OK"));
 		}


### PR DESCRIPTION
Although the intended improvement here was just a few lines, I found several things that offered themselves for clean up. Somewhat after-the-fact, I split these into separate commits in case that helps with review.

The biggest thing was removing the dependency of various things on the CurrentBookHandler, which wanted to become a nice independent api controller.

In doing this, I broke the ReadersApi, which was a bunch of statics. That is now, also a normal class that is created by the Project Context and given its dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1056)
<!-- Reviewable:end -->
