### PR TITLE
BL-3406 make synphony handle &nbsp; as white space

### DIFF
--- a/src/BloomBrowserUI/bookEdit/test/libsynphony/split_sentences.test.js
+++ b/src/BloomBrowserUI/bookEdit/test/libsynphony/split_sentences.test.js
@@ -1,5 +1,10 @@
 /**
- * Unit tests for various sentence-related code
+ * split_sentences.test.js
+ *
+ * Trying out the unit tests for javascript
+ *
+ * Created Apr 22, 2014 by Phil Hopper
+ *
  */
 
 describe("Splitting text into sentences", function() {
@@ -76,6 +81,16 @@ describe("Splitting text into sentences", function() {
         expect(fragments[4].text).toBe('This is sentence 3.');
     });
 
+    it("Nbsp between sentences extra space", function () {
+        var inputText = "This is sentence 1.&nbsp; This is sentence 2.";
+        var fragments = libsynphony.stringToSentences(inputText);
+
+        expect(fragments.length).toBe(3);
+        expect(fragments[0].text).toBe('This is sentence 1.');
+        expect(fragments[1].text).toBe('&nbsp; ');
+        expect(fragments[2].text).toBe('This is sentence 2.');
+    });
+
     it("Empty tag between sentences", function() {
         var inputText = "This is sentence 1.<span class=\"test\"></span>This is sentence 2. This is sentence 3.";
         var fragments = libsynphony.stringToSentences(inputText);
@@ -134,3 +149,5 @@ describe("Splitting text into sentences", function() {
     });
 
 });
+
+

--- a/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/libsynphony/bloom_lib.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/libsynphony/bloom_lib.js
@@ -94,6 +94,7 @@ libSynphony.prototype.stringToSentences = function(textHTML) {
     var tagHolderClose = String.fromCharCode(5);   // u0005 is a replacement character for all other closing html tags
     var tagHolderSelf = String.fromCharCode(6);    // u0006 is a replacement character for all other self-closing html tags
     var tagHolderEmpty = String.fromCharCode(7);   // u0007 is a replacement character for empty html tags
+    var nbsp = String.fromCharCode(8);             // u0008 is a replacement character for &nbsp;
     if (textHTML === null) textHTML = '';
 
     // look for html break tags, replace them with the htmlLineBreak place holder
@@ -120,6 +121,9 @@ libSynphony.prototype.stringToSentences = function(textHTML) {
     var emptyTags = textHTML.match(/\u0004\u0005/g);
     textHTML = textHTML.replace(/\u0004\u0005/g, tagHolderEmpty);
 
+    // replace &nbsp; with nbsp
+    textHTML = textHTML.replace(/&nbsp;/g, nbsp);
+
     // look for paragraph ending sequences
     regex = XRegExp(
         '[^\\p{PEP}]*[\\p{PEP}]+' // break on all paragraph ending punctuation (PEP)
@@ -134,7 +138,7 @@ libSynphony.prototype.stringToSentences = function(textHTML) {
         '([\\p{SEP}]+'                      // sentence ending punctuation (SEP)
         + '[\'"\\p{Pf}\\p{Pe}\\u0005]*)'    // characters that can follow the SEP
         + '([\\u0004]*)'                    // opening tag between sentences
-        + '([\\s\\p{PEP}\\u0006\\u0007]+)'  // inter-sentence space
+        + '([\\s\\p{PEP}\\u0006\\u0007\\u0008]+)'  // inter-sentence space
         + '([\\u0005]*)'                    // closing tag between sentences
         + '(?![^\\p{L}]*'                   // may be followed by non-letter chars
         + '[\\p{Ll}\\p{SCP}]+)',            // first letter following is not lower case
@@ -171,6 +175,9 @@ libSynphony.prototype.stringToSentences = function(textHTML) {
             // put the self-closing html tags back in
             while (fragment.indexOf('\u0006') > - 1)
                 fragment = fragment.replace(/\u0006/, selfTags.shift());
+
+            // put nbsp back in
+            fragment = fragment.replace(/\u0008/g, "&nbsp;");
 
             // check to avoid blank segments at the end
             if ((j < (fragments.length - 1)) || (fragment.length > 0)) {

--- a/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/libsynphony/jquery.text-markup.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/decodableReader/libsynphony/jquery.text-markup.js
@@ -73,6 +73,11 @@
                 }
             }
 
+            // If this element represents a paragraph, then the overall page text needs a paragraph break here.
+            if (leaf.tagName === "P") {
+                allWords += "\r\n";
+            }
+
             // set the html
             $(leaf).html(newHtml);
             restoreNonTextUIElementsInEditBox(leaf);

--- a/src/BloomExe/web/ReadersHandler.cs
+++ b/src/BloomExe/web/ReadersHandler.cs
@@ -170,7 +170,10 @@ namespace Bloom.web
 
 		private static string EscapeJsonValue(string value)
 		{
-			return value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", "\\r").Replace("\n", "\\n");
+			// As http://stackoverflow.com/questions/42068/how-do-i-handle-newlines-in-json attempts to explain,
+			// it takes TWO backslashes before r or n in JSON to get an actual embedded newline into the string.
+			// (And of course FOUR here in the C# source to produce two in the literal passed to Replace.)
+			return value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", "\\\\r").Replace("\n", "\\\\n");
 		}
 
 		private static string GetSampleTextsList(string settingsFilePath)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1058)
<!-- Reviewable:end -->
