### PR TITLE
Hide the Talking Book Tool on Linux (BL-3430)

### DIFF
--- a/src/BloomExe/Edit/ToolboxView.cs
+++ b/src/BloomExe/Edit/ToolboxView.cs
@@ -102,6 +102,10 @@ namespace Bloom.Edit
 			toolsToDisplay.AddRange(
 				idsOfToolsThisVersionKnowsAbout.Except(
 					toolsThatHaveDataInBookInfo.Select(t => t.ToolId)).Select(ToolboxTool.CreateFromToolId));
+#if __MonoCS__
+			// Until we get sound working on Linux, there's no point in showing a nonfunctional tool!
+			toolsToDisplay = toolsToDisplay.Where(t => t.ToolId != TalkingBookTool.StaticToolId).ToList();
+#endif
 			return toolsToDisplay.Where(t => t.Enabled || t.AlwaysEnabled).ToList();
 		}
 


### PR DESCRIPTION
This is what we all agreed was the best thing to do for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1069)
<!-- Reviewable:end -->
