### PR TITLE
Add SharpFont.dll.config that works for packaging

### DIFF
--- a/lib/dotnet/SharpFont.dll.config
+++ b/lib/dotnet/SharpFont.dll.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- The SharpFont.dll.config file distributed with via nuget SharpFont does not work with debian packaging. -->
+<!-- (It appears to work at runtime, but not when checking with dh_clideps during packaging.) -->
+<configuration>
+	<dllmap dll="freetype6.dll" os="linux" target="libfreetype.so.6" />
+	<dllmap dll="freetype6.dll" os="osx" target="/Library/Frameworks/Mono.framework/Libraries/libfreetype.6.dylib" />
+</configuration>

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1212,7 +1212,6 @@ cp -p "$(SolutionDir)lib/dotnet/GeckofxHtmlToPdf.exe.config" "$(OutDir)BloomPdfM
   </ItemGroup>
   <ItemGroup>
     <SourceFiles Include="..\..\lib\dotnet\*.config" />
-    <SourceFiles Include="..\..\packages\SharpFont.3.1.0\config\SharpFont.dll.config" Condition="'$(OS)'!='Windows_NT'" />
   </ItemGroup>
   <ItemGroup>
     <RemoteDebugFiles Include="..\..\remoteDebugging\**" />


### PR DESCRIPTION
The distributed version causes debian packaging to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1080)
<!-- Reviewable:end -->
