### PR TITLE
BL-3438 Show toast when saving page

### DIFF
--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
@@ -1,9 +1,12 @@
 // C# used to replace this with the desired background color,
 // but the switch to a separate less/css file defeated that mechanism.
 
+@import (less) '../../node_modules/toastr/toastr.less';
+
 @bloomYellow : #FEBF00;
 @highlightColor: @bloomYellow;//#96668f;
 @DarkGray:#404040;
+@BloomDarkestGray: #363333;
 
 BODY {
     background-color: @DarkGray;
@@ -139,3 +142,22 @@ BODY {
     bottom:6px;
     right: 0;
 }
+
+//for "Saved" toast
+.toast-info {
+	background-color: @BloomDarkestGray;
+	width: 100% !important;
+    padding: 0px 0px 0px 0px;
+}
+
+ #toast-container {
+   font-family: "Segoe UI","sans-serif";
+   font-size: 9pt;
+ }
+ 
+ #toast-container > .toast{
+     //opacity: 1.0 !important;
+     box-shadow: none !important;
+     background-image: none !important;
+     padding-left:5px;//don't leave room for the icon
+ }

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.ts
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.ts
@@ -1,5 +1,11 @@
 /// <reference path="../../typings/jquery/jquery.d.ts" />
 /// <reference path="../../typings/jquery.gridly.d.ts" />
+///<reference path="../../typings/toastr/toastr.d.ts"/>
+/// <reference path="../../lib/localizationManager/localizationManager.ts" />
+
+import theOneLocalizationManager from '../../lib/localizationManager/localizationManager';
+
+import * as toastr from 'toastr';
 import * as $ from 'jquery';
 import '../../modified_libraries/gridly/jquery.gridly.js';
 import {SetImageElementUrl} from '../js/bloomImages';
@@ -32,6 +38,32 @@ $(window).ready(function(){
         event.stopPropagation();
         fireCSharpEvent("menuClicked", $(this).parent().parent().attr('id'));
     });
+    
+    const websocketPort = parseInt(window.location.port) + 1;
+    
+    //NB: testing shows that our webSocketServer does receive a close notification when this window goes away
+    window["webSocket"] = new WebSocket("ws://127.0.0.1:"+websocketPort.toString());
+
+theOneLocalizationManager.asyncGetText("EditTab.SavingNotification","Saving...").done(savingNotification =>
+    window["webSocket"] .onmessage = event => {
+        var e = JSON.parse(event.data);
+        if(e.id == "saving"){
+            toastr.info(savingNotification,"",{
+                positionClass: "toast-top-left",
+                preventDuplicates: true,
+                showDuration: 300,
+                hideDuration: 300,
+                timeOut: 1000,
+                extendedTimeOut: 1000,
+                showEasing: "swing",
+                showMethod: "fadeIn",
+                hideEasing: "linear",
+                hideMethod: "fadeOut",
+                messageClass:"toast-for-saved-message",
+                iconClass:""
+            });
+        }
+    })
 });
 
 function fireCSharpEvent(eventName, eventData) {

--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -566,11 +566,6 @@ namespace Bloom.Edit
 						_recorder = null;
 					}
 #endif
-					if (_webSocketServer != null)
-					{
-						_webSocketServer.Dispose();
-						_webSocketServer = null;
-					}
 				}
 
 				// shared (dispose and finalizable) cleanup logic

--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -36,7 +36,7 @@ namespace Bloom.Edit
 #if !__MonoCS__
 		private AudioRecorder _recorder;
 #endif
-		BloomWebSocketServer _peakLevelWebSocketServer;
+		BloomWebSocketServer _webSocketServer;
 		
 		/// <summary>
 		/// The file we want to record to
@@ -69,7 +69,7 @@ namespace Bloom.Edit
 		// call directly since it is static.
 		private static AudioRecording CurrentRecording { get; set; }
 
-		public AudioRecording(BookSelection bookSelection)
+		public AudioRecording(BookSelection bookSelection, BloomWebSocketServer bloomWebSocketServer)
 		{
 			_bookSelection = bookSelection;
 			_startRecordingTimer = new Timer();
@@ -77,6 +77,7 @@ namespace Bloom.Edit
 			_startRecordingTimer.Tick += OnStartRecordingTimer_Elapsed;
 			_backupPath = System.IO.Path.GetTempFileName();
 			CurrentRecording = this;
+			_webSocketServer = bloomWebSocketServer;
 		}
 
 		public void RegisterWithServer(EnhancedImageServer server)
@@ -90,7 +91,6 @@ namespace Bloom.Edit
 			server.RegisterEndpointHandler("audio/devices", HandleAudioDevices);
 
 			Debug.Assert(ServerBase.portForHttp > 0,"Need the server to be listening before this can be registered (BL-3337).");
-			_peakLevelWebSocketServer = new BloomWebSocketServer((ServerBase.portForHttp+1).ToString(CultureInfo.InvariantCulture));//review: we have no dispose (on us or our parent) so this is never disposed
 		}
 
 		// does this page have any audio at all? Used enable the Listen page.
@@ -160,7 +160,7 @@ namespace Bloom.Edit
 			if(level != _previousLevel)
 			{
 				_previousLevel = level;
-				_peakLevelWebSocketServer.Send(level.ToString(CultureInfo.InvariantCulture));
+				_webSocketServer.Send("peakAudioLevel", level.ToString(CultureInfo.InvariantCulture));
 			}
 		}
 #endif
@@ -566,10 +566,10 @@ namespace Bloom.Edit
 						_recorder = null;
 					}
 #endif
-					if (_peakLevelWebSocketServer != null)
+					if (_webSocketServer != null)
 					{
-						_peakLevelWebSocketServer.Dispose();
-						_peakLevelWebSocketServer = null;
+						_webSocketServer.Dispose();
+						_webSocketServer = null;
 					}
 				}
 

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Dynamic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -50,6 +51,7 @@ namespace Bloom.Edit
 		private bool _inProcessOfDeleting;
 		private string _toolboxFolder;
 		private EnhancedImageServer _server;
+		private readonly BloomWebSocketServer _webSocketServer;
 		private readonly TemplateInsertionCommand _templateInsertionCommand;
 		private Dictionary<string, IPage> _templatePagesDict;
 		private string _lastPageAdded;
@@ -80,7 +82,8 @@ namespace Bloom.Edit
 			LocalizationChangedEvent localizationChangedEvent,
 			CollectionSettings collectionSettings,
 			SendReceiver sendReceiver,
-			EnhancedImageServer server)
+			EnhancedImageServer server,
+			BloomWebSocketServer webSocketServer)
 		{
 			_bookSelection = bookSelection;
 			_pageSelection = pageSelection;
@@ -90,6 +93,7 @@ namespace Bloom.Edit
 			_collectionSettings = collectionSettings;
 			_sendReceiver = sendReceiver;
 			_server = server;
+			_webSocketServer = webSocketServer;
 			_templatePagesDict = null;
 			_lastPageAdded = String.Empty;
 
@@ -865,6 +869,8 @@ namespace Bloom.Edit
 			{
 				try
 				{
+					_webSocketServer.Send("saving", "");
+
 					// CleanHtml already requires that we are on UI thread. But it's worth asserting here too in case that changes.
 					// If we weren't sure of that we would need locking for access to _tasksToDoAfterSaving and _inProcessOfSaving,
 					// and would need to be careful about whether any delayed tasks needed to be on the UI thread.

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -103,7 +104,8 @@ namespace Bloom
 							typeof (EditingModel),
 							typeof (AudioRecording),
 							typeof(CurrentBookHandler),
-							typeof(ReadersApi)
+							typeof(ReadersApi),
+							typeof(BloomWebSocketServer)
 						}.Contains(t));
 
 					builder.RegisterAssemblyTypes(Assembly.GetExecutingAssembly())
@@ -260,6 +262,8 @@ namespace Bloom
 			var server = _scope.Resolve<EnhancedImageServer>();
 			server.StartListening();
 			_scope.Resolve<AudioRecording>().RegisterWithServer(server);
+
+			_scope.Resolve<BloomWebSocketServer>().Init((ServerBase.portForHttp + 1).ToString(CultureInfo.InvariantCulture));
 			HelpLauncher.RegisterWithServer(server);
 			ExternalLinkController.RegisterWithServer(server);
 			ToolboxView.RegisterWithServer(server);

--- a/src/BloomExe/web/BloomWebSocketServer.cs
+++ b/src/BloomExe/web/BloomWebSocketServer.cs
@@ -17,7 +17,7 @@ namespace Bloom.Api
 	/// Alternatively, you could have multiple instances of this class, each with its own "port" parameter, and intended for use by a single, simple end point.
 	/// That is the case as this is introduced in Bloom 3.6, for getting the peak level of the audio coming from a microphone.
 	/// </summary>
-	class BloomWebSocketServer : IDisposable
+	public class BloomWebSocketServer : IDisposable
 	{
 		//Note, in normal web apps, you'd have any number of clients opening sockets to this single server. It would be 1 to n. In Bloom, where there is
 		//only a single client, we think more in terms of 1 to 1.  However there's nothing preventing multiple parts of the Bloom client from opening their
@@ -25,7 +25,7 @@ namespace Bloom.Api
 		private WebSocketServer _server;
 		private List<IWebSocketConnection> _allSockets;
 
-		public BloomWebSocketServer(string port)
+		public void Init(string port)
 		{
 			FleckLog.Level = LogLevel.Warn;
 			_allSockets = new List<IWebSocketConnection>();
@@ -58,13 +58,17 @@ namespace Bloom.Api
 			}
 		}
 
-		public void Send(string message)
+		public void Send(string eventId, string eventData)
 		{
+			dynamic e = new DynamicJson();
+			e.id = eventId;
+			e.payload = eventData;
+
 			//note, if there is no open socket, this isn't going to do anything, and
 			//that's (currently) fine.
 			foreach (var socket in _allSockets)
 			{
-				socket.Send(message);
+				socket.Send(e.ToString());
 			}
 		}
 


### PR DESCRIPTION
Previously, the websocket was only used by the audio system. This changes it to be more general, and then makes the page list view show a localized notification when pages are being saved. You won't see the message if it's be saved while leaving this tab or quiting the program, that's ok.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1084)
<!-- Reviewable:end -->
