### PR TITLE
BL-2283 Give tooltip explaining overflow

### DIFF
--- a/DistFiles/localization/Bloom.en.tmx
+++ b/DistFiles/localization/Bloom.en.tmx
@@ -1985,6 +1985,18 @@
         <seg>There are no other layout options for this template.</seg>
       </tuv>
     </tu>
+    <tu tuid="EditTab.Overflow">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>This box has more text than will fit</seg>
+      </tuv>
+    </tu>
+    <tu tuid="EditTab.OverflowContainer">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>A container on this page is overflowing</seg>
+      </tuv>
+    </tu>
     <tu tuid="EditTab.TitleOfCopyIPToWholeBooksDialog">
       <tuv xml:lang="en">
         <seg>Picture Intellectual Property Information</seg>


### PR DESCRIPTION
(includes BL-2284)

When a block is overflowed (text red),
mouse-over produces a tooltip below it.

When a container is overflowed (red bottom border),
hovering over the red border brings up a tooltip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1086)
<!-- Reviewable:end -->
