### PR TITLE
Fix BL-3477 Fix Longpress (and make a proper API)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -747,16 +747,9 @@ export var disconnectForGarbageCollection = function () {
 };
 
 export function loadLongpressInstructions(jQuerySetOfMatchedElements) {
-    axios.get('/bloom/windows/useLongpress',
-            {headers:{'Accept': 'text/plain',
-            //The default transformResponse of axios eagerly does a JSON.Parse on everything,
-            //so in a debugger, it will choke on 'Yes'. That exception gets swallowed, but
-            //I'm sick of running into it.
-            //So we specify our own identity transformResponse
-            transformResponse:  (data: string) => <string>data }
-        })
+    axios.get<boolean>('/bloom/api/keyboarding/useLongpress')
         .then(response => {
-           if (response.data === 'Yes') {
+           if (response.data) {
                 theOneLocalizationManager.asyncGetText(
                     'BookEditor.CharacterMap.Instructions',
                     'To select, use your mouse wheel or point at what you want, then release the key.')
@@ -766,7 +759,7 @@ export function loadLongpressInstructions(jQuerySetOfMatchedElements) {
                         );
                 });
             };
-        })
+        }).catch(e=>alert("useLongPress query failed:"+e));
 }
 
 

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -529,6 +529,7 @@
     <Compile Include="web\BloomWebSocketServer.cs" />
     <Compile Include="web\CommandAvailabilityPublisher.cs" />
     <Compile Include="web\controllers\AddOrChangePageApi.cs" />
+    <Compile Include="web\controllers\KeybordingConfigApi.cs" />
     <Compile Include="web\controllers\PageTemplatesApi.cs" />
     <Compile Include="web\CurrentBookHandler.cs" />
     <Compile Include="web\SimulatedPageFile.cs" />

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -108,6 +108,7 @@ namespace Bloom
 							typeof(ReadersApi),
 							typeof(PageTemplatesApi),
 							typeof(AddOrChangePageApi),
+							typeof(KeybordingConfigApi),
 							typeof(BloomWebSocketServer)
 						}.Contains(t));
 
@@ -271,6 +272,7 @@ namespace Bloom
 			ToolboxView.RegisterWithServer(server);
 			_scope.Resolve<PageTemplatesApi>().RegisterWithServer(server);
 			_scope.Resolve<AddOrChangePageApi>().RegisterWithServer(server);
+			_scope.Resolve<KeybordingConfigApi>().RegisterWithServer(server);
 			_scope.Resolve<CurrentBookHandler>().RegisterWithServer(server);
 			_scope.Resolve<ReadersApi>().RegisterWithServer(server);
 		}

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -180,6 +180,7 @@ namespace Bloom.Api
 		protected override bool ProcessRequest(IRequestInfo info)
 		{
 			var localPath = GetLocalPathWithoutQuery(info);
+
 			if (localPath.ToLower().StartsWith("api/"))
 			{
 				var endpoint = localPath.Substring(3).ToLowerInvariant().Trim(new char[] {'/'});
@@ -231,25 +232,6 @@ namespace Bloom.Api
 			{
 				if (ProcessI18N(localPath, info))
 					return true;
-			}
-			else if (localPath.StartsWith("windows/useLongpress"))
-			{
-				var usingIP = false;
-
-				if (SIL.PlatformUtilities.Platform.IsWindows)
-				{
-					// In order to detect an input processor, we need to execute this on the main UI thread.
-					var frm = Application.OpenForms.Cast<Form>().FirstOrDefault(f => f is Shell);
-					if (frm != null)
-					{
-						usingIP = SIL.Windows.Forms.Keyboarding.KeyboardController.IsFormUsingInputProcessor(frm);
-					}
-				}
-
-				// Send to browser
-				info.ContentType = "text/plain";
-				info.WriteCompleteOutput(usingIP ? "No" : "Yes");
-				return true;
 			}
 			else if (localPath.StartsWith("directoryWatcher/", StringComparison.InvariantCulture))
 				return ProcessDirectoryWatcher(info);

--- a/src/BloomExe/web/controllers/KeybordingConfigAPI.cs
+++ b/src/BloomExe/web/controllers/KeybordingConfigAPI.cs
@@ -1,0 +1,19 @@
+﻿using System.Linq;
+using System.Windows.Forms;
+using Bloom.Api;
+
+namespace Bloom.web.controllers
+{
+	class KeybordingConfigApi
+	{
+		public void RegisterWithServer(EnhancedImageServer server)
+		{
+			server.RegisterEndpointHandler("keyboarding/useLongPress", (ApiRequest request) => 
+			{
+				//detect if some keyboarding system is active, e.g. KeyMan. If it is, don't enable LongPress
+				var form = Application.OpenForms.Cast<Form>().Last();
+				request.ReplyWithText(SIL.Windows.Forms.Keyboarding.KeyboardController.IsFormUsingInputProcessor(form)?"false":"true");
+			});
+		}
+	}
+}


### PR DESCRIPTION
This was working in Chrome, but not FF or Bloom. While trying to figure it out, I just went ahead and refactored into a proper api handler. The problem was somehow related to handling the string result. Changing from "yes/no" to better true/false did the trick.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1095)
<!-- Reviewable:end -->
