### PR TITLE
Fix an annoying exception that gets swallowed later

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -530,7 +530,7 @@ namespace Bloom.CollectionTab
 				book.CheckBook(dialog.Progress, pathToFolderOfReplacementImages);
 				dialog.ProgressString.WriteMessage("");
 			}
-			dialog.ProgressBar.Value++;
+			dialog.Progress.ProgressIndicator.PercentCompleted = 100;
 		}
 
 


### PR DESCRIPTION
See the comment about 9 lines above when looking at the diff!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1103)
<!-- Reviewable:end -->
