### PR TITLE
Fix BL-3497 missing file error in epub preview

### DIFF
--- a/src/BloomExe/Publish/EpubMaker.cs
+++ b/src/BloomExe/Publish/EpubMaker.cs
@@ -28,6 +28,8 @@ namespace Bloom.Publish
 	/// </summary>
 	public class EpubMaker : IDisposable
 	{
+		public const string kEPUBExportFolder = "ePUB export";
+
 		public Book.Book Book
 		{
 			get
@@ -110,11 +112,11 @@ namespace Bloom.Publish
 		{
 			_publishWithoutAudio = publishWithoutAudio;
 			Debug.Assert(_stagingFolder == null, "EpubMaker should only be used once");
-			var epubExport = "ePUB export";
+			
 			//I (JH) kept having trouble making epubs because this kept getting locked.
-			SIL.IO.DirectoryUtilities.DeleteDirectoryRobust(Path.Combine(Path.GetTempPath(), epubExport));
+			SIL.IO.DirectoryUtilities.DeleteDirectoryRobust(Path.Combine(Path.GetTempPath(), kEPUBExportFolder));
 
-			_stagingFolder = new TemporaryFolder(epubExport);
+			_stagingFolder = new TemporaryFolder(kEPUBExportFolder);
 			// The readium control remembers the current page for each book.
 			// So it is useful to have a unique name for each one.
 			// However, it needs to be something we can put in a URL without complications,

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -16,6 +16,7 @@ using L10NSharp;
 using Microsoft.Win32;
 using SIL.IO;
 using Bloom.Collection;
+using Bloom.Publish;
 using Newtonsoft.Json;
 using SIL.Reporting;
 using SIL.Extensions;
@@ -241,7 +242,11 @@ namespace Bloom.Api
 				if (File.Exists(temp))
 					localPath = temp;
 			}
-
+			// this is used only by the readium viewer
+			else if (localPath.StartsWith("node_modules/jquery/dist/jquery.js"))
+			{
+				localPath = BloomFileLocator.GetBrowserFile("jquery.min.js");
+			}
 			//Firefox debugger, looking for a source map, was prefixing in this unexpected 
 			//way.
 			localPath = localPath.Replace("output/browser/", "");
@@ -468,13 +473,18 @@ namespace Bloom.Api
 					return true;
 				}
 			}
+			
 			if (!File.Exists(path))
 			{
 				if(path == null)
 				{
 					path = "(was null)";
 				}
-				var stuffToIgnore = new[] { "favicon.ico", ".map" };
+				var stuffToIgnore = new[] {
+					//browser/debugger stuff
+					"favicon.ico", ".map",
+					// readium stuff that we don't ship with (though I don't know why)
+					EpubMaker.kEPUBExportFolder.ToLowerInvariant() };
 				if(stuffToIgnore.Any(s => (localPath.ToLowerInvariant().Contains(s))))
 					return false;
 				NonFatalProblem.Report(ModalIf.Beta, PassiveIf.All, "Server could not find the file "+path,"LocalPath was "+localPath);


### PR DESCRIPTION
We ship a subset of readium, and were getting file not found errors on the bits we don't ship. Also, I redirected a request for jquery to where it is (probably could have just swallowed that, too).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1104)
<!-- Reviewable:end -->
