### PR TITLE
Catch "Out of memory" viewing "Rescue Missing Images" log

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -506,7 +506,15 @@ namespace Bloom.CollectionTab
 
 				var path = Path.GetTempFileName() + ".txt";
 				File.WriteAllText(path, dlg.ProgressString.Text);
-				PathUtilities.OpenFileInApplication(path);
+				try
+				{
+					PathUtilities.OpenFileInApplication(path);
+				}
+				catch (System.OutOfMemoryException)
+				{
+					// This has happened at least once.  See https://silbloom.myjetbrains.com/youtrack/issue/BL-3431.
+					MessageBox.Show("Bloom ran out of memory trying to open the log.  You should quit and restart the program.  (Your books should all be okay.)");
+				}
 			}
 
 		}


### PR DESCRIPTION
Warning the user to quit and restart is better than crashing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1108)
<!-- Reviewable:end -->
