### PR TITLE
Fix BL-3515 bad channel case on update if Bloom launched by url

### DIFF
--- a/src/BloomExe/WebLibraryIntegration/BookDownloadSupport.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookDownloadSupport.cs
@@ -91,7 +91,13 @@ namespace Bloom.WebLibraryIntegration
 
 		private static string CommandToLaunchBloomOnWindows
 		{
-			get { return Application.ExecutablePath.ToLowerInvariant() + " \"%1\""; }
+			get
+			{
+				//Don't do this: Application.ExecutablePath.ToLowerInvariant() 
+				//it cause us to have a wrong idea of the case of channels, which 
+				//leads to urls that AWS S3 rejects when checking for an update. BL-3515
+				return Application.ExecutablePath + " \"%1\"";
+			}
 		}
 	}
 }


### PR DESCRIPTION
When running bloom as result of a download, channel is lower case and so update check fails

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1112)
<!-- Reviewable:end -->
