### PR TITLE
Speed up large io calls with Reader Tools

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
@@ -698,7 +698,7 @@ function attachEventHandlers(): void {
   if (typeof ($) === "function") {
 
     $("#open-text-folder").onSafe('click', function() {
-      axios.post('/bloom/api/readers/openTextsFolder');
+      axios.post('/bloom/api/readers/ui/openTextsFolder');
       return false;
     });
 
@@ -754,7 +754,7 @@ function attachEventHandlers(): void {
     });
 
     $('#setup-choose-allowed-words-file').onSafe('click', function() {
-      axios.get<string>('/bloom/api/readers/chooseAllowedWordsListFile').then(result => {
+      axios.get<string>('/bloom/api/readers/ui/chooseAllowedWordsListFile').then(result => {
         var fileName = result.data;
         if (fileName) setAllowedWordsFile(fileName);
 
@@ -829,7 +829,7 @@ function checkAndDeleteAllowedWordsFile(fileName: string): void {
   }
 
   // if you are here, the file name is not in use
-  axios.delete('/bloom/api/readers/allowedWordsList', { params: { 'fileName': fileName } });
+  axios.delete('/bloom/api/readers/io/allowedWordsList', { params: { 'fileName': fileName } });
 }
 
 export function enableSampleWords() {

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools.ts
@@ -171,7 +171,7 @@ function beginLoadSynphonySettings(): JQueryPromise<void> {
     readerToolsInitialized = true;
 
     axios.get<string>('/bloom/api/collection/defaultFont').then(result => setDefaultFont(result.data));
-    axios.get<string>('/bloom/api/readers/readerToolSettings').then(settingsFileContent => {
+    axios.get<string>('/bloom/api/readers/io/readerToolSettings').then(settingsFileContent => {
         initializeSynphony(settingsFileContent.data);
         result.resolve();
     });
@@ -204,7 +204,7 @@ function initializeSynphony(settingsFileContent: string): void {
   }
   else {
     // get the list of sample texts
-    axios.get<string>('/bloom/api/readers/sampleTextsList').then(result =>beginSetTextsList(result.data));
+    axios.get<string>('/bloom/api/readers/ui/sampleTextsList').then(result =>beginSetTextsList(result.data));
   }
 }
 
@@ -264,11 +264,11 @@ function beginRefreshEverything(settings: ReaderSettings) : Promise<void> {
   getTheOneReaderToolsModel().setSynphony(synphony);
 
   // reload the sample texts
-  return <any>axios.get<string>('/bloom/api/readers/sampleTextsList').then(result => beginSetTextsList(result.data));
+  return <any>axios.get<string>('/bloom/api/readers/io/sampleTextsList').then(result => beginSetTextsList(result.data));
 }
 
 export function beginSaveChangedSettings(settings: ReaderSettings, previousMoreWords: string): Promise<void> {
-  return <any>axios.post('/bloom/api/readers/readerToolSettings', settings)
+  return <any>axios.post('/bloom/api/readers/io/readerToolSettings', settings)
     .then(result => {
       // reviewslog: following previous logic that we need to reload files if useAllowedWords
       // is true. Seems we should at least need to do it ALSO if it was PREVIOUSLY true.
@@ -322,7 +322,7 @@ export function makeLetterWordList(): void {
   allWords = _.compact(_.pluck(allWords, 'Name'));
 
   // export the word list
-  var ajaxSettings = {type: 'POST', url: '/bloom/api/readers/makeLetterAndWordList'};
+  var ajaxSettings = {type: 'POST', url: '/bloom/api/readers/ui/makeLetterAndWordList'};
   ajaxSettings['data'] = {
     settings: JSON.stringify(settings),
     allWords: allWords.join('\t')

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -772,7 +772,7 @@ export class ReaderToolsModel {
 //   }
 
   getTextOfWholeBook(): void {
-    axios.get<any[]>('/bloom/api/readers/textOfContentPages').then(result => {
+    axios.get<any[]>('/bloom/api/readers/io/textOfContentPages').then(result => {
       //result.data looks like {'0bbf0bc5-4533-4c26-92d9-bea8fd064525:' : 'Jane saw spot', 'AAbf0bc5-4533-4c26-92d9-bea8fd064525:' : 'words of this page', etc.} 
       this.pageIDToText = result.data;
       this.doMarkup();
@@ -975,7 +975,7 @@ export class ReaderToolsModel {
 
         //note, this endpoint is confusing because it appears that ultimately we only use the word list out of this file (see "sampleTextsList").
         //This ends up being written to a ReaderToolsWords-xyz.json (matching its use, if not it contents).
-        axios.post('/bloom/api/readers/synphonyLanguageData', theOneLanguageDataInstance);
+        axios.post('/bloom/api/readers/io/synphonyLanguageData', theOneLanguageDataInstance);
       }, 200);
     });
   }
@@ -988,7 +988,7 @@ export class ReaderToolsModel {
   beginGetAllSampleFiles(): Promise<void> {
     // The <any> works around a flaw in the declaration of axios.all in axios.d.ts.
     return (<any>axios).all(this.texts.map(fileName => {
-      return axios.get<string>('/bloom/api/readers/sampleFileContents', { params: { fileName: fileName } })
+      return axios.get<string>('/bloom/api/readers/io/sampleFileContents', { params: { fileName: fileName } })
         .then(result => {
           //axios get here is giving us an object even though the c# sends a text/plain.
           //and that would normally be great, but unfortunately the downstream code was written to take a raw
@@ -1160,7 +1160,7 @@ export class ReaderToolsModel {
     stages.forEach(function(stage, index) {
       if (stage.allowedWordsFile) {
           //axios.get<string>('/bloom/api/readers/allowedWordsList?fileName=' + encodeURIComponent(stage.allowedWordsFile))
-          axios.get<string>('/bloom/api/readers/allowedWordsList', { params: { 'fileName': stage.allowedWordsFile } })
+          axios.get<string>('/bloom/api/readers/io/allowedWordsList', { params: { 'fileName': stage.allowedWordsFile } })
               .then(result => this.setAllowedWordsListList(result.data, index));
       }
     });

--- a/src/BloomExe/web/ApiRequest.cs
+++ b/src/BloomExe/web/ApiRequest.cs
@@ -11,6 +11,13 @@ namespace Bloom.Api
 {
 	public delegate void EndpointHandler(ApiRequest request);
 
+	public class EndpointRegistration
+	{
+		public bool HandleOnUIThread = true;
+		public EndpointHandler Handler;
+	}
+
+
 	/// <summary>
 	/// When the Bloom UI makes an API call, a method that has been registered to handle that
 	/// endpoint is called and given one of these. That method uses this class to get information
@@ -93,25 +100,25 @@ namespace Bloom.Api
 			_requestInfo.WriteError(503,text);
 		}
 
-		public static bool Handle(EndpointHandler endpointHandler, IRequestInfo info, CollectionSettings collectionSettings, Book.Book currentBook)
+		public static bool Handle(EndpointRegistration endpointRegistration, IRequestInfo info, CollectionSettings collectionSettings, Book.Book currentBook)
 		{
 			var request = new ApiRequest(info, collectionSettings, currentBook);
 			try
 			{
 				if(Program.RunningUnitTests) 
 				{
-					endpointHandler(request);
+					endpointRegistration.Handler(request);
 				}
 				else
 				{
 					var formForSynchronizing = Application.OpenForms.Cast<Form>().Last();
-					if(formForSynchronizing.InvokeRequired)
+					if (endpointRegistration.HandleOnUIThread && formForSynchronizing.InvokeRequired)
 					{
-						formForSynchronizing.Invoke(endpointHandler, request);
+						formForSynchronizing.Invoke(endpointRegistration.Handler, request);
 					}
 					else
 					{
-						endpointHandler(request);
+						endpointRegistration.Handler(request);
 					}
 				}
 				if(!info.HaveOutput)

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -41,7 +41,7 @@ namespace Bloom.Api
 		private readonly ProjectContext _projectContext;
 
 		// This dictionary ties API endpoints to functions that handle the requests.
-		private Dictionary<string, EndpointHandler> _endpointHandlers = new Dictionary<string, EndpointHandler>();
+		private Dictionary<string, EndpointRegistration> _endpointRegistrations = new Dictionary<string, EndpointRegistration>();
 
 		public CollectionSettings CurrentCollectionSettings { get; set; }
 
@@ -59,9 +59,19 @@ namespace Bloom.Api
 		}
 
 
-		public void RegisterEndpointHandler(string key, EndpointHandler handler)
+		/// <summary>
+		/// Get called when a client (i.e. javascript) does an HTTP api call
+		/// </summary>
+		/// <param name="pattern">Simple string or regex to match APIs that this can handle. This must match what comes after the ".../api/" of the URL</param>
+		/// <param name="handler">The method to call</param>
+		/// <param name="handleOnUiThread">For safety, this defaults to true, but that can kill performance if you don't need it (BL-3452) </param>
+		public void RegisterEndpointHandler(string pattern, EndpointHandler handler, bool handleOnUiThread = true)
 		{
-			_endpointHandlers[key.Trim(new char[] {'/'})] = handler;
+			_endpointRegistrations[pattern.Trim(new char[] {'/'})] = new EndpointRegistration()
+			{
+				Handler = handler,
+				HandleOnUIThread = handleOnUiThread
+			};
 		}
 
 		// We use two different locks to synchronize access to the methods of this class.
@@ -185,7 +195,7 @@ namespace Bloom.Api
 			if (localPath.ToLower().StartsWith("api/"))
 			{
 				var endpoint = localPath.Substring(3).ToLowerInvariant().Trim(new char[] {'/'});
-				foreach (var pair in _endpointHandlers.Where(pair => 
+				foreach (var pair in _endpointRegistrations.Where(pair => 
 						Regex.Match(endpoint,
 							"^" + //must match the beginning
 							pair.Key.ToLower()

--- a/src/BloomExe/web/ReadersApi.cs
+++ b/src/BloomExe/web/ReadersApi.cs
@@ -52,7 +52,8 @@ namespace Bloom.Api
 				request.ReplyWithText(bookFontName);
 			});
 
-			server.RegisterEndpointHandler("readers/.*", HandleRequest);
+			server.RegisterEndpointHandler("readers/ui/.*", HandleRequest, true);
+			server.RegisterEndpointHandler("readers/io/.*", HandleRequest, false);
 
 			//we could do them all like this:
 			//server.RegisterEndpointHandler("readers/loadReaderToolSettings", r=> r.ReplyWithJson(GetDefaultReaderSettings(r.CurrentCollectionSettings)));


### PR DESCRIPTION
BL-3542 was largely caused by trying to do some 1.4mb write on the UI thread. Possibly this is becuase the client is running on the UI thread too, and the size of the payload was large, so the writer couldn't write because it was waiting for the client to consume, but the client couldn't because the thread was blocked waiting to write some more...

Anyhow so I made it possible when registering a handler to say that it doesn't need to be run on the UI thread.

I then split all the READER api calls into either "io" or "ui", and made separate registrations for the two groups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1118)
<!-- Reviewable:end -->
