### PR TITLE
BL-3368 remove obsolete license notes in lang other than '*'

### DIFF
--- a/src/BloomExe/Book/BookCopyrightAndLicense.cs
+++ b/src/BloomExe/Book/BookCopyrightAndLicense.cs
@@ -95,6 +95,9 @@ namespace Bloom.Book
 			var description = metadata.License.GetDescription(collectionSettings.LicenseDescriptionLanguagePriorities, out languageUsedForDescription);
 			dom.SetBookSetting("licenseDescription", languageUsedForDescription, description);
 
+			// Book may have old licenseNotes, typically in 'en'. This can certainly show up again if licenseNotes in '*' is removed,
+			// and maybe anyway. Safest to remove it altogether if we are setting it using the new scheme.
+			dom.RemoveBookSetting("licenseNotes");
 			dom.SetBookSetting("licenseNotes", "*", metadata.License.RightsStatement);
 
 			// we could do away with licenseImage in the bloomDataDiv, since the name is always the same, but we keep it for backward compatibility


### PR DESCRIPTION
(when saving new ones in proper lang, or deliberately
removing them)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1122)

<!-- Reviewable:end -->
