### PR TITLE
BL-3558 Fix resizing images when box dividers moved

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -20,6 +20,7 @@ import 'jquery.qtip.js'
 import 'jquery.qtipSecondary.js'
 import 'long-press/jquery.longpress.js'
 import 'jquery.hotkeys'; //makes the on(keydown work with keynames)
+import '../../lib/jquery.resize'; // makes jquery resize work on all elements
 import {getToolboxFrameExports} from './bloomFrames';
 
 

--- a/src/BloomBrowserUI/lib/jquery.resize.js
+++ b/src/BloomBrowserUI/lib/jquery.resize.js
@@ -253,4 +253,4 @@ function ResetRememberedSize(element) {
 
   };
 
-})(jQuery,this);
+})(jQuery, window); // JohnT mod: in module context, 'this' is not defined.


### PR DESCRIPTION
May fix other problems too.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1123)

<!-- Reviewable:end -->
