### PR TITLE
Add missing dependencies for Linux Bloom 3.8 (BL-3592)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
  mono-sil, libgdiplus-sil,
  libenchant-dev, libxklavier-dev, libdconf-dev,
  libicu-dev,
+ libgtk2.0-cil (>= 2.12.10), libgtk2.0-dev (>= 2.14), libasound2-dev,
  icu-devtools | libicu-dev (<< 52)
 
 Package: bloom-desktop-unstable


### PR DESCRIPTION
These were previously supplied indirectly by the dependency on
geckofx29.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1130)
<!-- Reviewable:end -->
