### PR TITLE
Fix Linux script to quote directory name

### DIFF
--- a/debian/bloom
+++ b/debian/bloom
@@ -6,6 +6,6 @@ SHARE=/usr/share/bloom-desktop-beta
 cd "$SHARE"
 RUNMODE=INSTALLED
 . ./environ
-cd $OLDPWD
+cd "$OLDPWD"
 
 exec mono --debug "$LIB"/Bloom.exe "$@"


### PR DESCRIPTION
This is needed to handle spaces in folder names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1134)
<!-- Reviewable:end -->
