### PR TITLE
Fix BL-3643 error when moving away from Credits Page

### DIFF
--- a/src/BloomExe/Edit/WebThumbNailList.cs
+++ b/src/BloomExe/Edit/WebThumbNailList.cs
@@ -301,8 +301,12 @@ namespace Bloom.Edit
 			{
 				foreach (XmlElement imgNode in imgNodes)
 				{
-					var url = HtmlDom.GetImageElementUrl(imgNode).UrlEncoded + "?thumbnail=1";
-					HtmlDom.SetImageElementUrl(new ElementProxy(imgNode), UrlPathString.CreateFromUrlEncodedString(url));
+					var filename = HtmlDom.GetImageElementUrl(imgNode).UrlEncoded;
+					if(!string.IsNullOrWhiteSpace(filename))
+					{
+						var url = filename + "?thumbnail=1";
+						HtmlDom.SetImageElementUrl(new ElementProxy(imgNode), UrlPathString.CreateFromUrlEncodedString(url));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Thumbnail creator was adding "?thumbnail=1" to src="", giving us an empty image request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1149)
<!-- Reviewable:end -->
