### PR TITLE
Fix crash during epub creation caused by missing wav files (BL-3666)

### DIFF
--- a/src/BloomExe/Publish/EpubMaker.cs
+++ b/src/BloomExe/Publish/EpubMaker.cs
@@ -396,8 +396,7 @@ namespace Bloom.Publish
 					else
 					{
 						NonFatalProblem.Report(ModalIf.All, PassiveIf.All,
-							string.Format(
-								"Bloom could not find one of the expected audio files for this book, {0}, nor a precomputed duration. Bloom can only make a very rough estimate of the length of the mp3 file."));
+							"Bloom could not find one of the expected audio files for this book, nor a precomputed duration. Bloom can only make a very rough estimate of the length of the mp3 file.");
 						// Crude estimate. In one sample, a 61K mp3 is 7s long.
 						// So, multiply by 7 and divide by 61K to get seconds.
 						// Then, to make a TimeSpan we need ticks, which are 0.1 microseconds,


### PR DESCRIPTION
There was a missing format element in a NonFatalProblem string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1150)
<!-- Reviewable:end -->
