### PR TITLE
Correct typo in Doulos SIL font name (BL-3609)

### DIFF
--- a/DistFiles/UnusedTemplates/Template Maker/basePage.css
+++ b/DistFiles/UnusedTemplates/Template Maker/basePage.css
@@ -58,7 +58,7 @@ A IMG {
 }
 BODY {
   line-height: 1.5;
-  font-family: Andika, "Andika Basic", "Gentium Basic", "Gentium Book Basic", "Doulous SIL", Sans-Serif;
+  font-family: Andika, "Andika Basic", "Gentium Basic", "Gentium Book Basic", "Doulos SIL", Sans-Serif;
   /*Most text in the document should be % changes from this value. Collection.css can then change it to make all the text  bigger.
 Note: the webkit browsers (wkhtml which bloom uses for pdf, and google chrome)
 Need about 2% more space to draw the same text on a ine (can't tell if the font is bigger or the box is smaller)

--- a/DistFiles/infoPages/HtmlSamples/Horizontal Centering With Prefix Image/basePage.css
+++ b/DistFiles/infoPages/HtmlSamples/Horizontal Centering With Prefix Image/basePage.css
@@ -46,7 +46,7 @@ BODY
 /*+}*/
 BODY
 {
-	font-family: Andika, "Andika Basic", "Gentium Basic", "Gentium Book Basic", "Doulous SIL", Sans-Serif;
+	font-family: Andika, "Andika Basic", "Gentium Basic", "Gentium Book Basic", "Doulos SIL", Sans-Serif;
 /*Most text in the document should be % changes from this value. Collection.css can then change it to make all the text  bigger.
 Note: the webkit browsers (wkhtml which bloom uses for pdf, and google chrome)
 Need about 2% more space to draw the same text on a ine (can't tell if the font is bigger or the box is smaller)

--- a/src/BloomBrowserUI/bookLayout/CommonBasePageEPUB.less
+++ b/src/BloomBrowserUI/bookLayout/CommonBasePageEPUB.less
@@ -1,6 +1,6 @@
 ﻿body {
 	line-height: 1.5;
-	font-family: "Andika New Basic", Andika, "Andika Basic", "Gentium Basic", "Gentium Book Basic", "Doulous SIL", Sans-Serif;
+	font-family: "Andika New Basic", Andika, "Andika Basic", "Gentium Basic", "Gentium Book Basic", "Doulos SIL", Sans-Serif;
 }
 
 .bloom-backgroundImage{


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1152)
<!-- Reviewable:end -->
