### PR TITLE
Gitden Reader link navigates to help rather than Play Store (BL-3628)

### DIFF
--- a/src/BloomBrowserUI/ePUB/bloomEpubPreview.jade
+++ b/src/BloomBrowserUI/ePUB/bloomEpubPreview.jade
@@ -26,7 +26,7 @@ html
       p A handy way to get books to your phone is to set up Dropbox or similar service on both your computer and your phone/tablet.  Just click Save ePUB and then choose your Dropbox folder. On your phone, open the Dropbox app and select your book. If you are using a laptop, you can also try the free #[a(href='http://shareit.lenovo.com/') ShareIt] program to send files from your laptop to a phone or tablet.
       h3 Recommended Reader
       :marked
-        Our testing has shown [Gitden Reader](https://play.google.com/store/apps/details?id=com.gitden.epub.reader.app)
+        Our testing has shown [Gitden Reader](/bloom/api/help/Concepts/Gitden_Reader.htm)
         to be a good choice for Android and IOS (IPhone &amp; IPad) devices.
       p.showForTalkingBooks
         | To listen to this Talking Book using Gitden on a phone or tablet, you will need to disable Gitden's "Text To Speech" feature. Then it will show you the audio controls.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1153)
<!-- Reviewable:end -->
