### PR TITLE
Fix BL-3657 which showed part of cut icon to the right of the button

### DIFF
--- a/src/BloomExe/Edit/EditingView.Designer.cs
+++ b/src/BloomExe/Edit/EditingView.Designer.cs
@@ -322,7 +322,6 @@
 			this._cutButton.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
 			this._cutButton.TextDropShadow = false;
 			this._betterToolTip1.SetToolTip(this._cutButton, "Cut (Ctrl-x)");
-			this._betterToolTip1.SetToolTipWhenDisabled(this._cutButton, "You need to select some text before you can cut it");
 			this._cutButton.UseVisualStyleBackColor = false;
 			this._cutButton.Click += new System.EventHandler(this._cutButton_Click);
 			// 


### PR DESCRIPTION
After hours of messing with this (!) narrowed the problem to some interaction between the BitMapButton and BetterToolTip.SetToolTipWhenDisabled. Removing that call makes the problem go away. For more info, check this bug on youtrack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1163)
<!-- Reviewable:end -->
