### PR TITLE
Fix BL-3719 Prefer letter list over word list

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readerTools.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readerTools.less
@@ -40,7 +40,11 @@ div.word { margin: 0 2px 2px; width: auto; }
 div.sight-word {
 	color: #87CEFA;
 }
-div#lettersTable {max-height: 100px;}
+
+#lettersTable {
+	max-height: ~"calc(100% - 200px)"; //prefer the letters list over the word list. It's a real drag to have to scroll the letters.
+	min-height: 100px;
+}
 
 div.section ul { padding-left: 16px; margin-top: 4px; }
 div.section ul li { color: #fff; }
@@ -53,7 +57,7 @@ div.section ul li { color: #fff; }
   	padding: 8px 4px;
 	background-color: #333;
 	box-sizing: border-box;
-	width: calc(100% - 3px);
+	width: ~"calc(100% - 3px)";
 }
 #make-letter-word-list {
   font-size: 10px;


### PR DESCRIPTION
The first change makes the lettersTable be more assertive.

The second change here is just a bug I noticed. The original "calc(100% - 3px)" was being converted to "calc(97%)". This actually fixes a small visual bug that we had not noticed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1164)
<!-- Reviewable:end -->
