### PR TITLE
Smarter reminder about adding dynamic string to english tmx

### DIFF
--- a/src/BloomBrowserUI/lib/localizationManager/localizationManager.ts
+++ b/src/BloomBrowserUI/lib/localizationManager/localizationManager.ts
@@ -223,7 +223,7 @@ export class LocalizationManager {
 
     localizeThenSetElementText(element: HTMLElement, stringId:string, englishText:string): void {
         this.asyncGetText(stringId, englishText).then( (translation) => {
-            element.outerHTML = translation;
+            element.innerText = translation;
         });
     }
 

--- a/src/BloomBrowserUI/lib/localizationManager/localizationManager.ts
+++ b/src/BloomBrowserUI/lib/localizationManager/localizationManager.ts
@@ -100,11 +100,11 @@ export class LocalizationManager {
     public getText(stringId: string, englishText?: string, ...args): string {
         if(typeof stringId === 'undefined')
         {
-            try { 
+            try {
                 throw new Error('localizationManager.getText() stringid was undefined');
             }
-            catch (e) { 
-                    throw(e.message+e.stack); 
+            catch (e) {
+                    throw(e.message+e.stack);
             }
         }
         if ((!this.inlineDictionaryLoaded) && (typeof GetInlineDictionary === 'function')) {
@@ -219,6 +219,12 @@ export class LocalizationManager {
             }
         });
         return deferred.promise();
+    }
+
+    localizeThenSetElementText(element: HTMLElement, stringId:string, englishText:string): void {
+        this.asyncGetText(stringId, englishText).then( (translation) => {
+            element.outerHTML = translation;
+        });
     }
 
 /**

--- a/src/BloomExe/web/I18NHandler.cs
+++ b/src/BloomExe/web/I18NHandler.cs
@@ -83,12 +83,23 @@ namespace Bloom.Api
 					}
 					else
 					{
-						//ok, so we don't have it translated yet. Make sure it's at least listed in the things that can be translated.
-						// And return the English string, which is what we would do the next time anyway.  (BL-3374)
-						LocalizationManager.GetDynamicString("Bloom", id, englishText);
-						var modal = ApplicationUpdateSupport.ChannelName.StartsWith("Developer/") ? ModalIf.All : ModalIf.None;
-						var longMsg = String.Format("**I18NHandler: Added missing translatable string (\"{0}\")", englishText);
-						NonFatalProblem.Report(modal, PassiveIf.Alpha, "adding translatable string", longMsg);
+						// it's ok if we don't have a translation, but if the string isn't even in the list of things that need translating,
+						// then we want to remind the developer to add it to the english tmx file.
+						if(!LocalizationManager.GetIsStringAvailableForLangId(id, "en"))
+						{
+							var modal = ApplicationUpdateSupport.ChannelName.StartsWith("Developer/") ? ModalIf.All : ModalIf.None;
+							var longMsg =
+								String.Format(
+									"Dear Developer: Please add this dynamic string to the english.tmx file: Id=\"{0}\" English =\"{1}\"", id,
+									englishText);
+							NonFatalProblem.Report(modal, PassiveIf.Alpha, longMsg);
+						}
+						else // we *could* do this even if the above error is detected, but it just masks the problem then. So let's not.
+						{
+							//ok, so we don't have it translated yet. Make sure it's at least listed in the things that can be translated.
+							// And return the English string, which is what we would do the next time anyway.  (BL-3374)
+							LocalizationManager.GetDynamicString("Bloom", id, englishText);
+						}
 						info.ContentType = "text/plain";
 						info.WriteCompleteOutput(englishText);
 						return true;


### PR DESCRIPTION
This fixes a couple problems in the old code:
1) Tells you exactly what it is you're supposed to do
2) Doesn't throw a false alarm just because the string isn't translated in your current UI language
3) Doesn't mask the problem by adding it to your *local* tmx file if it's not in the *distribution* en.tmx.

For free, this commit includes a small function I ended up not being able to use but which would normally be a good way to safely set HTML to a localized string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1166)
<!-- Reviewable:end -->
