### PR TITLE
Fix BL-3739 Error if you move a page and then try to duplicate it

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1846,7 +1846,7 @@ namespace Bloom.Book
 			{
 				body.InsertAfter(pageDiv, pages[indexOfItemAfterRelocation-1]);
 			}
-
+			BuildPageCache();
 			Save();
 			InvokeContentsChanged(null);
 			return true;


### PR DESCRIPTION
The move operation cleared the page cache, but then didn't rebuild it after the move.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1173)
<!-- Reviewable:end -->
