### PR TITLE
Properly decode filenames when getting file info (BL-3749)

### DIFF
--- a/src/BloomExe/web/ApiRequest.cs
+++ b/src/BloomExe/web/ApiRequest.cs
@@ -134,6 +134,12 @@ namespace Bloom.Api
 			return true;
 		}
 
+		public UrlPathString RequiredFileNameOrPath(string name)
+		{
+			if (Parameters.AllKeys.Contains(name))
+				return UrlPathString.CreateFromUnencodedString(Parameters[name]);
+			throw new ApplicationException("The query " + _requestInfo.RawUrl + " should have parameter " + name);
+		}
 
 		public string RequiredParam(string name)
 		{

--- a/src/BloomExe/web/CurrentBookHandler.cs
+++ b/src/BloomExe/web/CurrentBookHandler.cs
@@ -65,13 +65,13 @@ namespace Bloom.Api
 		{
 			try
 			{
-				var fileName = request.RequiredParam("image");
+				var fileName = request.RequiredFileNameOrPath("image");
 				Guard.AgainstNull(_bookSelection.CurrentSelection, "CurrentBook");
-				var path = Path.Combine(_bookSelection.CurrentSelection.FolderPath, fileName);
+				var path = Path.Combine(_bookSelection.CurrentSelection.FolderPath, fileName.NotEncoded);
 				RequireThat.File(path).Exists();
 				var fileInfo = new FileInfo(path);
 				dynamic result = new ExpandoObject();
-				result.name = fileName;
+				result.name = fileName.NotEncoded;
 				result.bytes = fileInfo.Length;
 
 				// Using a stream this way, according to one source,
@@ -114,6 +114,7 @@ namespace Bloom.Api
 				Logger.WriteEvent("Error in server imageInfo/: url was " + request.LocalPath());
 				Logger.WriteEvent("Error in server imageInfo/: exception is " + e.Message);
 				request.Failed(e.Message);
+				NonFatalProblem.Report(ModalIf.None, PassiveIf.Alpha, "Request Error", request.LocalPath(), e);
 			}
 		}
 	}


### PR DESCRIPTION
The imageInfo api wasn't handling encoded characters in file names.
Added a new method on request to encourage handling encoding properly.
Also, it wasn't reporting the error in a way we would notice it, so now we get a toast in alpha for any such api error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1175)
<!-- Reviewable:end -->
