### PR TITLE
Stop saving twice with each page change BL-3772

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1743,12 +1743,16 @@ namespace Bloom.Book
 			Debug.Assert(IsEditable);
 			try
 			{
-				//replace the corresponding page contents in our DOM with what is in this PageDom
-				XmlElement divElement = editedPageDom.SelectSingleNodeHonoringDefaultNS("//div[contains(@class, 'bloom-page')]");
-				string pageDivId = divElement.GetAttribute("id");
-				var page = GetPageFromStorage(pageDivId);
+				// This is needed if the user did some ChangeLayout (origami) manipulation. This will populate new
+				// translationGroups with .bloom-editables and set the proper classes on those editables to match the current multilingual settings. 
+				UpdateEditableAreasOfElement(editedPageDom);
 
-				HtmlDom.ProcessPageAfterEditing(page, divElement);
+				//replace the corresponding page contents in our DOM with what is in this PageDom
+				XmlElement pageFromEditedDom = editedPageDom.SelectSingleNodeHonoringDefaultNS("//div[contains(@class, 'bloom-page')]");
+				string pageId = pageFromEditedDom.GetAttribute("id");
+				var pageFromStorage = GetPageFromStorage(pageId);
+
+				HtmlDom.ProcessPageAfterEditing(pageFromStorage, pageFromEditedDom);
 
 				_bookData.SuckInDataFromEditedDom(editedPageDom); //this will do an updatetitle
 				// When the user edits the styles on a page, the new or modified rules show up in a <style/> element with title "userModifiedStyles". Here we copy that over to the book DOM.
@@ -1756,7 +1760,7 @@ namespace Bloom.Book
 				if (userModifiedStyles != null)
 				{
 					GetOrCreateUserModifiedStyleElementFromStorage().InnerXml = userModifiedStyles.InnerXml;
-					Debug.WriteLine("Incoming User Modified Styles:   " + userModifiedStyles.OuterXml);
+					//Debug.WriteLine("Incoming User Modified Styles:   " + userModifiedStyles.OuterXml);
 				}
 				Save();
 

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -735,7 +735,7 @@ namespace Bloom.Book
 		}
 		*/
 
-		public static void ProcessPageAfterEditing(XmlElement page, XmlElement divElement)
+		public static void ProcessPageAfterEditing(XmlElement destinationPageDiv, XmlElement edittedPageDiv)
 		{
 			// strip out any elements that are part of bloom's UI; we don't want to save them in the document or show them in thumbnails etc.
 			// Thanks to http://stackoverflow.com/questions/1390568/how-to-match-attributes-that-contain-a-certain-string for the xpath.
@@ -745,23 +745,23 @@ namespace Bloom.Book
 			// However, we need to do this in the edited page before copying to the storage page, since we are about to suck
 			// info from the edited page into the dataDiv and we don't want the bloom-ui elements in there either!
 			foreach (
-				var node in divElement.SafeSelectNodes("//*[contains(concat(' ', @class, ' '), ' bloom-ui ')]").Cast<XmlNode>().ToArray())
+				var node in edittedPageDiv.SafeSelectNodes("//*[contains(concat(' ', @class, ' '), ' bloom-ui ')]").Cast<XmlNode>().ToArray())
 				node.ParentNode.RemoveChild(node);
 
-			page.InnerXml = divElement.InnerXml;
+			destinationPageDiv.InnerXml = edittedPageDiv.InnerXml;
 
 			//Enhance: maybe we should just copy over all attributes?
-			page.SetAttribute("class", divElement.GetAttribute("class"));
+			destinationPageDiv.SetAttribute("class", edittedPageDiv.GetAttribute("class"));
 			//The SIL LEAD SHRP templates rely on "lang" on some ancestor to trigger the correct rules in labels.css.
 			//Those get set by putting data-metalanguage on Page, which then leads to a lang='xyz'. Let's save that
 			//back to the html in keeping with our goal of having the page look right if you were to just open the
 			//html file in Firefox.
-			page.SetAttribute("lang", divElement.GetAttribute("lang"));
+			destinationPageDiv.SetAttribute("lang", edittedPageDiv.GetAttribute("lang"));
 
 			// Upon save, make sure we are not in layout mode.  Otherwise we show the sliders.
 			foreach(
 				var node in
-					page.SafeSelectNodes(".//*[contains(concat(' ', @class, ' '), ' origami-layout-mode ')]").Cast<XmlNode>().ToArray())
+					destinationPageDiv.SafeSelectNodes(".//*[contains(concat(' ', @class, ' '), ' origami-layout-mode ')]").Cast<XmlNode>().ToArray())
 			{
 				string currentValue = node.Attributes["class"].Value;
 				node.Attributes["class"].Value = currentValue.Replace("origami-layout-mode", "");

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -830,21 +830,10 @@ namespace Bloom.Edit
 			if (CannotSavePage())
 				return;
 
+			var stopwatch = Stopwatch.StartNew();
 			SaveNow();
-
-			// "Origami" is the javascript system that lets the user introduce new elements to the page.
-			// It can insert .bloom-translationGroup's, but it can't populate them with .bloom-editables
-			// or set the proper classes on those editables to match the current multilingual settings.
-			// So after a change, this eventually gets called. We then ask the page's book to fix things
-			// up so that those boxes are ready to edit
-			_domForCurrentPage = CurrentBook.GetEditableHtmlDomForPage(_pageSelection.CurrentSelection);
-			CheckForBL2364("reset dom in finish save");
-			_currentlyDisplayedBook.UpdateEditableAreasOfElement(_domForCurrentPage);
-			CheckForBL2364("updated editable areas");
-
-			//Enhance: Probably we could avoid having two saves, by determing what it is that they entail that is required.
-			//But at the moment both of them are required
-			SaveNow();
+			stopwatch.Stop();
+			Debug.WriteLine("Save Now Elapsed Time: {0} ms", stopwatch.ElapsedMilliseconds);
 		}
 
 		private bool CannotSavePage()


### PR DESCRIPTION
Moved the call to UpdateEditableAreasOfELement() out of EditModel into Book.SavePage() method, so that SaveNow() doesn't have to be called twice as before. Result: changing pages is about 50% faster.

HtmlDom: Just clearer names

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1180)
<!-- Reviewable:end -->
