### PR TITLE
Title Page Display editbox should not be "flex" BL-3766

### DIFF
--- a/src/BloomBrowserUI/xMatter/bloom-xmatter-common.less
+++ b/src/BloomBrowserUI/xMatter/bloom-xmatter-common.less
@@ -371,19 +371,19 @@ BODY[bookcreationtype="translation"] {
             line-height: 1.4em; // supports ไปทั่วพื้ ที่นั่ ชื่ ปู ช้ต่างป
         }
         .bloom-content1 {
-            display: inherit;
+            display: block;
             //margin-bottom: @MarginBetweenMinorItems; messes up BL-1200
         }
         //NB: we show the national language even if this is a monolingual book
         .bloom-contentNational1 {
-            display: inherit;
+            display: block;
             //margin-bottom: @MarginBetweenMinorItems; messes up BL-1200
         }
         //...but we show the regional language only if the book is tri-lingual,
         //   which we can tell because Bloom will stick a "bloom-content3" on the appropriate element
         //NOPE: .bloom-contentNational2 {
         .bloom-content3 {
-            display: inherit;
+            display: block;
         }
         margin-bottom: @MarginBetweenTitleAndFunding;
     }


### PR DESCRIPTION
Prevent multi-paragraph titles from showing in columns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1181)
<!-- Reviewable:end -->
