### PR TITLE
Maybe help with BL-3774 by filtering titles for null

### DIFF
--- a/src/BloomExe/CollectionTab/MakeReaderTemplateBloomPackDlg.cs
+++ b/src/BloomExe/CollectionTab/MakeReaderTemplateBloomPackDlg.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using L10NSharp;
+using SIL.Code;
 
 namespace Bloom.CollectionTab
 {
@@ -28,7 +29,10 @@ namespace Bloom.CollectionTab
 		{
 			_bookList.SuspendLayout();
 			_bookList.Items.Clear();
-			_bookList.Items.AddRange(files.ToArray());
+			var titles = files.Where(f => f !=null); //added to bandaid overBL-3774 since we could not reproduce
+			if(titles.Count() < files.Count())
+				NonFatalProblem.Report(ModalIf.Beta, PassiveIf.All, "Please Report problem with one or more titles (BL-3774)");
+			_bookList.Items.AddRange(titles.ToArray());
 			_bookList.ResumeLayout();
 		}
 	}


### PR DESCRIPTION
I could not reproduce the problem. So this is a bandaid.  Possibly, the error would next show up somewhere else down the line? But this is something.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1182)
<!-- Reviewable:end -->
