### PR TITLE
Fix Linux problem of selecting pages too fast (BL-3586)

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1140,5 +1140,23 @@ namespace Bloom.Edit
 			CurrentBook.SetMetadata(metadata);
 			RefreshDisplayOfCurrentPage(); //the cleanup() that is part of Save removes qtips, so let's redraw everything
 		}
+
+#if __MonoCS__
+		/// <summary>
+		/// Flag that a page selection is currently under way.
+		/// </summary>
+		internal void PageSelectionStarted()
+		{
+			_pageSelection.StartChangingPage();
+		}
+
+		/// <summary>
+		/// Flag that the current (former) page selection has finished, so it's safe to select another page.
+		/// </summary>
+		internal void PageSelectionFinished()
+		{
+			_pageSelection.ChangingPageFinished();
+		}
+#endif
 	}
 }

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -364,9 +364,30 @@ namespace Bloom.Edit
 				// never happens.
 				_browser1.WebBrowser.DocumentCompleted += WebBrowser_ReadyStateChanged;
 				_browser1.WebBrowser.ReadyStateChange += WebBrowser_ReadyStateChanged;
+#if __MonoCS__
+				// On Linux/Mono, the user can click between pages too fast in Edit mode, resulting
+				// in a warning dialog popping up.  I've never seen this happen on Windows, but it's
+				// happening fairly often on Linux when I just try to move around a book.  The fix
+				// here is to set a flag that page selection is still processing and block any
+				// further page selecting until the current page has finished loading.
+				_model.PageSelectionStarted();
+				_browser1.WebBrowser.DocumentCompleted += WebBrowser_DocumentCompleted;
+#endif
 			}
 			UpdateDisplay();
 		}
+
+#if __MonoCS__
+		/// <summary>
+		/// Flag the PageSelection object that the current (former?) page selection has completed,
+		/// so it's safe to select another page now.
+		/// </summary>
+		void WebBrowser_DocumentCompleted(object sender, EventArgs e)
+		{
+			_model.PageSelectionFinished();
+			_browser1.WebBrowser.DocumentCompleted -= WebBrowser_DocumentCompleted;
+		}
+#endif
 
 		void WebBrowser_ReadyStateChanged(object sender, EventArgs e)
 		{

--- a/src/BloomExe/Edit/PageSelection.cs
+++ b/src/BloomExe/Edit/PageSelection.cs
@@ -5,12 +5,21 @@ namespace Bloom.Edit
 {
 	public class PageSelection
 	{
+#if __MonoCS__
+		private bool _stillChanging = false;	// whether in the process of changing the displayed page
+#endif
 		private IPage _currentSelection;
 		public event EventHandler SelectionChanging; // before it changes
 		public event EventHandler SelectionChanged; // after it changed
 
 		public bool SelectPage(IPage page)
 		{
+#if __MonoCS__
+			// If we haven't finished displaying the previously selected page, we can't select another page yet.
+			// See https://silbloom.myjetbrains.com/youtrack/issue/BL-3586.
+			if (_stillChanging)
+				return false;
+#endif
 			//enhance... make pre-change event cancellable
 			InvokeSelectionChanging();
 			_currentSelection = page;
@@ -41,5 +50,23 @@ namespace Bloom.Edit
 				handler(this, null);
 			}
 		}
+
+#if __MonoCS__
+		/// <summary>
+		/// Flag that a page selection is currently under way.
+		/// </summary>
+		internal void StartChangingPage()
+		{
+			_stillChanging = true;
+		}
+
+		/// <summary>
+		/// Flag that the current (former) page selection has finished, so it's safe to select another page.
+		/// </summary>
+		internal void ChangingPageFinished()
+		{
+			_stillChanging = false;
+		}
+#endif
 	}
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1185)
<!-- Reviewable:end -->
