### PR TITLE
Get image info for filenames with spaces (BL-3749)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -142,25 +142,7 @@ function SetupImageContainer(containerDiv) {
 }
 
 function SetImageTooltip(container, img) {
-    var urlForQuery = GetRawImageUrl(img);
-
-    //Why these three? my thinking is that these are all delimiters in URL query
-    //strings: space, &, and ?. Space is already encoded at this point in my experiments,
-    // and ? isn't allowed in file names so we can ignore that. That leaves the ampersand.
-    urlForQuery = urlForQuery.replace(/\&/g, '%26');
-
-    //See http://stackoverflow.com/questions/2678551/when-to-encode-space-to-plus-or-20.
-    // there, people expect the server to cope with using %20 for space even *in the query portion* of the URL,
-    // but our .net HttpUtility.ParseQueryString does not. See also BL-3235
-
-    //first preserve actual plus signs
-    urlForQuery = urlForQuery.replace(/\+/g, '%2B');
-
-    //then use plus to stand in for space
-    urlForQuery = urlForQuery.replace(/%20/g, '+');
-    
-
- axios.get<string>('/bloom/api/image/info', { params: { image: GetRawImageUrl(img) } }).then(result => {
+    axios.get<string>('/bloom/api/image/info', { params: { image: GetRawImageUrl(img) } }).then(result => {
         var image:any = result.data;
         const kBrowserDpi = 96; // this appears to be constant even on higher dpi screens. See http://www.w3.org/TR/css3-values/#absolute-lengths
         var dpi = Math.round(image.width / ($(img).width() / kBrowserDpi));

--- a/src/BloomExe/web/controllers/ImageApi.cs
+++ b/src/BloomExe/web/controllers/ImageApi.cs
@@ -33,6 +33,13 @@ namespace Bloom.web.controllers
 				var fileName = request.RequiredParam("image");
 				Guard.AgainstNull(_bookSelection.CurrentSelection, "CurrentBook");
 				var path = Path.Combine(_bookSelection.CurrentSelection.FolderPath, fileName);
+				if (!File.Exists(path))
+				{
+					// We can be fed doubly-encoded filenames.  So try to decode a second time and see if that works.
+					// See https://silbloom.myjetbrains.com/youtrack/issue/BL-3749.
+					fileName = System.Web.HttpUtility.UrlDecode(fileName);
+					path = Path.Combine(_bookSelection.CurrentSelection.FolderPath, fileName);
+				}
 				RequireThat.File(path).Exists();
 				var fileInfo = new FileInfo(path);
 				dynamic result = new ExpandoObject();


### PR DESCRIPTION
Also deleted some dead Typescript code related to the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1187)
<!-- Reviewable:end -->
