### PR TITLE
Reduce number of (expensive) BookStorage objects created (BL-3782)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -589,6 +589,10 @@ namespace Bloom.Book
 			return pages[pageIndex];
 		}
 
+		// Reduce repetitive reloading of books when looking up the related "TemplateBook".
+		string _cachedTemplateKey;
+		Book _cachedTemplateBook;
+
 		public Book FindTemplateBook()
 		{
 				Guard.AgainstNull(_templateFinder, "_templateFinder");
@@ -601,7 +605,14 @@ namespace Bloom.Book
 				{
 					if (templateKey.ToLowerInvariant() == "basicbook")//catch this pre-beta spelling with no space
 						templateKey = "Basic Book";
+					// We can assume that a book's "TemplateBook" does not change over time.  To be even safer,
+					// we'll add a check for the same "TemplateKey" to allow reusing a cached "TemplateBook".
+					// See https://silbloom.myjetbrains.com/youtrack/issue/BL-3782.
+					if (templateKey == _cachedTemplateKey && _cachedTemplateBook != null)
+						return _cachedTemplateBook;
 					book = _templateFinder.FindTemplateBook(templateKey);
+					_cachedTemplateBook = book;
+					_cachedTemplateKey = templateKey;
 					if(book==null)
 					{
 						ErrorReport.NotifyUserOfProblem("Bloom could not find the source of template pages named {0} (as in {0}.htm).\r\nThis comes from the <meta name='pageTemplateSource' content='{0}'/>.\r\nCheck that name matches the html exactly.",templateKey);


### PR DESCRIPTION
This is done by caching the value of Book.FindTemplateBook() when
possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1192)
<!-- Reviewable:end -->
