### PR TITLE
Fix a regression on handling + signs in url paths (BL-3814)

### DIFF
--- a/src/BloomExe/web/RequestInfo.cs
+++ b/src/BloomExe/web/RequestInfo.cs
@@ -28,7 +28,15 @@ namespace Bloom.Api
 			{
 				var queryStart = RawUrl.IndexOf("?", StringComparison.Ordinal);
 				var urlToDecode = queryStart == -1 ? RawUrl : RawUrl.Substring(0, queryStart);
-				return HttpUtility.UrlDecode(urlToDecode);
+				// this (done in fix for BL-3750) by itself caused us to lose + signs, which according to http://stackoverflow.com/a/1006074/723299 are *not* to be
+				// replaced by space if they are in the "path component" of the url (hence the approach comment out below). In the "query" component,
+				// plus signs do have a special meaning. So if this is correct, UrlDecode appears to be WRONG in its
+				// handling of + signs. They should be treated literally, not turned into spaces.
+				//no:	return HttpUtility.UrlDecode(urlToDecode);
+				
+				// So let's workaround that problem with UrlDecode and still do decoding on the path component:
+				var pathWithoutLiteralPlusSigns = urlToDecode.Replace("+","%2B");
+				return HttpUtility.UrlDecode(pathWithoutLiteralPlusSigns);
 
 				// This uses the wrong encoding to decode the LocalPath. (BL-3750)
 				// See unit test LocalPathWithoutQuery_SpecialCharactersDecodedCorrectly for example.

--- a/src/BloomTests/web/RequestInfoTests.cs
+++ b/src/BloomTests/web/RequestInfoTests.cs
@@ -60,6 +60,7 @@ namespace BloomTests.web
 		[TestCase("bl%23ah", "/bl#ah")]
 		[TestCase("bl?ah", "/bl")]
 		[TestCase("bl%F4%80%80%8Aah", "/bl􀀊ah")] // private use character
+		[TestCase("one + one", "/one + one")] // BL-3814. See http://stackoverflow.com/a/1006074/723299 
 		[RequiresSTA]
 		public void LocalPathWithoutQuery_SpecialCharactersDecodedCorrectly(string urlEnd, string expectedResult)
 		{


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1194)
<!-- Reviewable:end -->
