### PR TITLE
Restore looking for images in template book folder

### DIFF
--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -462,6 +462,13 @@ namespace Bloom.Api
 
 			if (!File.Exists(path) && IsImageTypeThatCanBeReturned(localPath))
 			{
+				// try to find the image in the book that is the template source if we haven't found it yet
+				var templatePath = Path.Combine(_bookSelection.CurrentSelection.FindTemplateBook().FolderPath, Path.GetFileName(localPath));
+				if (File.Exists(templatePath))
+				{
+					info.ReplyWithImage(templatePath);
+					return true;
+				}
 				// last resort...maybe we are in the process of renaming a book (BL-3345) and something mysteriously is still using
 				// the old path. For example, I can't figure out what hangs on to the old path when an image is changed after
 				// altering the main book title.


### PR DESCRIPTION
Without this, pretty yellow dialogs kept popping up when you opened
the Add Pages dialog (at least for some books).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1198)
<!-- Reviewable:end -->
