### PR TITLE
BL-3788 userModifiedStyles

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -1107,12 +1107,14 @@ export default class StyleEditor {
 
     changeLineheight() {
         if (this.ignoreControlChanges) return;
+
+        var units = 'em'; // Mozilla says unitless line-height is preferred, but it doesn't work for some reason!
         var lineHeight = $('#line-height-select').val();
         var rule = this.getStyleRule(false);
-        rule.style.setProperty("line-height", lineHeight, "important");
+        rule.style.setProperty("line-height", lineHeight + units, "important");
         if (this.shouldSetDefaultRule()) {
             rule = this.getStyleRule(true);
-            rule.style.setProperty("line-height", lineHeight, "important");
+            rule.style.setProperty("line-height", lineHeight + units, "important");
         }
        this.cleanupAfterStyleChange();
     }


### PR DESCRIPTION
* Big Book Introduction style in
  the userModified Styles section
  breaks font-size editing when
  line-height is unitless
* This is contrary to the preference
  for unitless line-height mentioned
  several places on the web
* It oughta work!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1199)
<!-- Reviewable:end -->
