### PR TITLE
BL-3827 Fix BigBook title page

### DIFF
--- a/DistFiles/factoryCollections/Templates/Big Book/BigBook.css
+++ b/DistFiles/factoryCollections/Templates/Big Book/BigBook.css
@@ -59,6 +59,12 @@ The key to this text being aligned vertically is the bloom-centerContentVertiacl
   font-size: 62pt;
   overflow: visible;
 }
+.titlePage .bloom-editable {
+  font-size: 26pt;
+}
+.titlePage #titlePageTitleBlock .Title-On-Title-Page-style.bloom-content1 {
+  font-size: 30pt;
+}
 .textWholePage .bloom-translationGroup {
   width: 100%;
   max-height: 100%;

--- a/DistFiles/factoryCollections/Templates/Big Book/BigBook.less
+++ b/DistFiles/factoryCollections/Templates/Big Book/BigBook.less
@@ -72,11 +72,24 @@ height: 786px;
 }
 Text Whole Page
 The key to this text being aligned vertically is the bloom-centerContentVertiaclly on the tranlsation group, which gets picked up in the jscript, which then aligns it*/
+
+// Most text on a Big Book should be quite large
 .bloom-editable
 {
 	font-size: 62pt;
 	overflow: visible;
 }
+.titlePage {
+	// ... but not on the title page so much
+	.bloom-editable {
+		font-size: 26pt;
+	}
+	// ... but the vernacular title should be bigger than other fields
+	#titlePageTitleBlock .Title-On-Title-Page-style.bloom-content1 {
+		font-size: 30pt;
+	}
+}
+
 .textWholePage {
 	.bloom-translationGroup {
 		width: 100%;

--- a/src/BloomBrowserUI/xMatter/bloom-xmatter-mixins.jade
+++ b/src/BloomBrowserUI/xMatter/bloom-xmatter-mixins.jade
@@ -129,7 +129,7 @@ mixin factoryStandard-titlePage
 	+page-xmatter('Title Page').titlePage.bloom-frontMatter(data-export='front-matter-title-page')&attributes(attributes)#5dcd48df-e9ab-4a07-afd4-6a24d0398381
 		+field-prototypeDeclaredExplicity#titlePageTitleBlock
 			label.bubble Book title in {lang}
-			+editable(kLanguageForPrototypeOnly).Title-On-Title-Page-style(data-book='bookTitle')
+			+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Title-Page-style(data-book='bookTitle')
 		+field-prototypeDeclaredExplicity#originalContributions
 			label.bubble The contributions made by writers, illustrators, editors, etc., in {lang}
 			+editable(kLanguageForPrototypeOnly).credits.bloom-readOnlyInTranslationMode.bloom-copyFromOtherLanguageIfNecessary.Original-Contributors-On-Title-Page-style(data-book='originalContributions')


### PR DESCRIPTION
* Change default fontsize for title page to 26pt
* Change vernacular title fontsize to 30pt
* Unlink vern and national title style
   (by adding bloom-nodefaultstylerule)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1209)
<!-- Reviewable:end -->
