### PR TITLE
BL-3778 Handle retired xmatter

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -954,6 +954,7 @@ namespace Bloom.Book
 		{
 			//by default, this comes from the collection, but the book can select one, including "null" to select the factory-supplied empty xmatter
 			var nameOfXMatterPack = OurHtmlDom.GetMetaValue("xMatter", _collectionSettings.XMatterPackName);
+			nameOfXMatterPack = Storage.HandleRetiredXMatterPacks(OurHtmlDom, nameOfXMatterPack);
 			var helper = new XMatterHelper(bookDOM, nameOfXMatterPack, _storage.GetFileLocator());
 			//note, we determine this before removing xmatter to fix the situation where there is *only* xmatter, no content, so if
 			//we wait until we've removed the xmatter, we no how no way of knowing what size/orientation they had before the update.

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -938,16 +938,15 @@ namespace Bloom.Book
 				var match = regex.Match(styleRule);
 				if (match.Groups.Count == 2)
 				{
-					return UrlPathString.CreateFromUrlEncodedString(match.Groups[1].Value.Trim(new[] {'\'', '"'}));
+					return UrlPathString.CreateFromUrlEncodedString(match.Groups[1].Value.Trim(new[] { '\'', '"' }));
 				}
 			}
 			//we choose to return this instead of null to reduce errors created by things like 
 			// HtmlDom.GetImageElementUrl(element).UrlEncoded. If we just returned null, that has to be written
 			// as something that checks for null, like:
 			//  var url = HtmlDom.GetImageElementUrl(element). if(url!=null) url.UrlEncoded
-			return UrlPathString.CreateFromUnencodedString("");
+			return UrlPathString.CreateFromUnencodedString(string.Empty);
 		}
-
 
 		/// <summary>
 		/// Sets the url attribute either of an img (the src attribute) 


### PR DESCRIPTION
* books with BigBook xmatter will be switched
   automatically to Factory
* some old Big Books embedded the cover img
   tag inside of the background url; handled both
   getting and setting image element

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1215)
<!-- Reviewable:end -->
