### PR TITLE
Provide system specific BloomExe packages.config files

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -25,8 +25,8 @@
 
 	<PropertyGroup>
 		<NuGetToolsPath>$(MSBuildThisFileDirectory)</NuGetToolsPath>
-		<PackagesConfig Condition="'$(OS)'=='Windows_NT'">$(ProjectDir)packages.config</PackagesConfig>
-		<PackagesConfig Condition="'$(OS)'!='Windows_NT'">$(ProjectDir)/packages.config</PackagesConfig>
+		<PackagesConfig Condition="'$(PackagesConfig)'=='' AND '$(OS)'=='Windows_NT'">$(ProjectDir)packages.config</PackagesConfig>
+		<PackagesConfig Condition="'$(PackagesConfig)'=='' AND '$(OS)'!='Windows_NT'">$(ProjectDir)/packages.config</PackagesConfig>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -8,6 +8,8 @@
     </TargetFrameworkProfile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <PackagesConfig Condition="'$(OS)'=='Windows_NT'">$(MSBuildProjectDirectory)\packages.config</PackagesConfig>
+    <PackagesConfig Condition="'$(OS)'!='Windows_NT'">$(MSBuildProjectDirectory)/Linux/packages.config</PackagesConfig>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>8.0.30703</ProductVersion>

--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -22,6 +22,8 @@
   <package id="RestSharp" version="105.0.1" targetFramework="net4-client" requireReinstallation="true" />
   <package id="SourceMapDotNet" version="1.0.5478.26629" targetFramework="net45" />
   <package id="TechTalk.JiraRestClient.RestSharp105" version="2.3.0.1" targetFramework="net4-client" />
-  <!-- Windows specific packages.  Changes above this line must be copied to ./Linux/packages.config -->
-  <package id="Geckofx45" version="45.0.19.0" targetFramework="net45" />
+  <!-- Linux specific packages.  Changes above this line must be copied to ../packages.config -->
+  <package id="Geckofx45.32.Linux" version="45.0.21.0" targetFramework="net45" />
+  <package id="Geckofx45.64.Linux" version="45.0.21.0" targetFramework="net45" />
+  <package id="SharpFont" version="3.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Unfortunately, the file MUST be named packages.config, but its exact
location doesn't matter.

I've tested this on both Windows and Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1216)
<!-- Reviewable:end -->
