### PR TITLE
Handle encoded spaces in image filenames [3.7] (BL-3835)

### DIFF
--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -487,6 +487,21 @@ namespace Bloom.Api
 					return true;
 				}
 			}
+			// Use '%25' to detect that the % in a Url encoded character (for example space encoded as %20) was encoded as %25.
+			// In this example we would have %2520 in info.RawUrl and %20 in localPath instead of a space.  Note that if an
+			// image has a % in the filename, like 'The other 50%', and it isn't doubly encoded, then this shouldn't be a
+			// problem because we're triggering here only if the file isn't found.
+			if (!File.Exists(localPath) && info.RawUrl.Contains("%25"))
+			{
+				// possibly doubly encoded?  decode one more time and try.  See https://silbloom.myjetbrains.com/youtrack/issue/BL-3835.
+				// Some existing books have somehow acquired Url encoded coverImage data like the following:
+				// <div data-book="coverImage" lang="*">
+				//     The%20Moon%20and%20The%20Cap_Cover.png
+				// </div>
+				// This leads to data being stored doubly encoded in the program's run-time data.  The coverImage data is supposed to be
+				// Html/Xml encoded (using &), not Url encoded (using %).
+				path = System.Web.HttpUtility.UrlDecode(localPath);
+			}
 			if (!File.Exists(path) && IsImageTypeThatCanBeReturned(localPath))
 			{
 				// last resort...maybe we are in the process of renaming a book (BL-3345) and something mysteriously is still using

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -131,6 +131,7 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="Autofac">
       <HintPath>..\..\packages\Autofac.2.6.3.862\lib\NET40\Autofac.dll</HintPath>


### PR DESCRIPTION
For version 3.7, handle spaces (or other characters) that are already
encoded in the HTML file img element src attributes, and then become
encoded a second time when being sent to the Bloom server.  (Note that
this problem was already fixed for 3.8 in BL-3749.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1221)
<!-- Reviewable:end -->
