### PR TITLE
Prevent endless thumbnails for inaccessible books (BL-3841)

### DIFF
--- a/src/BloomExe/BookThumbNailer.cs
+++ b/src/BloomExe/BookThumbNailer.cs
@@ -43,6 +43,7 @@ namespace Bloom
 				if (book.HasFatalError) //NB: we might not know yet... we don't fully load every book just to show its thumbnail
 				{
 					callback(Resources.Error70x70);
+					return;
 				}
 				Image thumb;
 				if (book.Storage.TryGetPremadeThumbnail(thumbnailOptions.FileName, out thumb))


### PR DESCRIPTION
The fix is almost embarrassingly simple.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1226)
<!-- Reviewable:end -->
