### PR TITLE
Allow a settings.json to define some defaults for a brand (BL-3868)

### DIFF
--- a/DistFiles/branding/GRN-REACH/settings.json
+++ b/DistFiles/branding/GRN-REACH/settings.json
@@ -1,0 +1,5 @@
+{
+    "LicenseUrl":"http://creativecommons.org/licenses/by/3.0/igo/",
+    "LicenseRightsStatement": "Translations—If you create a translation of this work, please add the following disclaimer along with the attribution: This translation was not created by USAID and should not be considered an official USAID translation. USAID shall not be liable for any content or error in this translation.
+        Adaptations—If you create an adaptation of this work, please add the following disclaimer along with the attribution: This is an adaptation of an original work by USAID. Views and opinions expressed in the adaptation are the sole responsibility of the author or authors of the adaptation and are not endorsed by USAID."
+}

--- a/src/BloomExe/BloomFileLocator.cs
+++ b/src/BloomExe/BloomFileLocator.cs
@@ -176,5 +176,25 @@ namespace Bloom
 			var pathInDesiredLanguage = pathToEnglishFile.Replace("-en.", "-" + LocalizationManager.UILanguageId + ".");
 			return File.Exists(pathInDesiredLanguage) ? pathInDesiredLanguage : pathToEnglishFile;
 		}
+
+		/// <summary>
+		/// Gets a file in the specified branding folder
+		/// </summary>
+		/// <param name="brandingNameOrFolderPath"> Normally, the branding is just a name, which we look up in the official branding folder
+		//  but unit tests can instead provide a path to the folder.
+		/// </param>
+		/// <param name="fileName"></param>
+		/// <returns></returns>
+		public static string GetOptionalBrandingFile(string brandingNameOrFolderPath, string fileName)
+		{
+			if(Path.IsPathRooted(brandingNameOrFolderPath)) //if it looks like a path
+			{
+				var path = Path.Combine(brandingNameOrFolderPath, fileName);
+				if(File.Exists(path))
+					return path;
+				return null;
+			}
+			return BloomFileLocator.GetFileDistributedWithApplication(true, "branding", brandingNameOrFolderPath, fileName);
+		}
 	}
 }

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2167,7 +2167,8 @@ namespace Bloom.Book
 		public Metadata GetLicenseMetadata()
 		{
 			//BookCopyrightAndLicense.LogMetdata(OurHtmlDom);
-			var result = BookCopyrightAndLicense.GetMetadata(OurHtmlDom);
+			var result = BookCopyrightAndLicense.GetMetadata(OurHtmlDom, _collectionSettings.BrandingProjectName);
+			
 			//Logger.WriteEvent("After");
 			//BookCopyrightAndLicense.LogMetdata(OurHtmlDom);
 			return result;

--- a/src/BloomExe/web/controllers/BrandingApi.cs
+++ b/src/BloomExe/web/controllers/BrandingApi.cs
@@ -1,4 +1,7 @@
-﻿using Bloom.Collection;
+﻿using System;
+using System.IO;
+using Bloom.Collection;
+using Newtonsoft.Json;
 
 namespace Bloom.Api
 {
@@ -8,7 +11,6 @@ namespace Bloom.Api
 	class BrandingApi
 	{
 		private readonly CollectionSettings _collectionSettings;
-
 
 		public BrandingApi(CollectionSettings collectionSettings)
 		{
@@ -20,16 +22,56 @@ namespace Bloom.Api
 			server.RegisterEndpointHandler("branding/image", request =>
 			{
 				var fileName = request.RequiredFileNameOrPath("id");
-				
-				var path = BloomFileLocator.GetFileDistributedWithApplication(true,"branding", _collectionSettings.BrandingProjectName, fileName.NotEncoded);
+
+				var path = BloomFileLocator.GetOptionalBrandingFile(_collectionSettings.BrandingProjectName, fileName.NotEncoded);
 				if(string.IsNullOrEmpty(path))
 				{
-					request.Failed(""); // the HTML will need to be able to handle this invisibly... see http://stackoverflow.com/questions/22051573/how-to-hide-image-broken-icon-using-only-css-html-without-js
+					request.Failed("");
+					// the HTML will need to be able to handle this invisibly... see http://stackoverflow.com/questions/22051573/how-to-hide-image-broken-icon-using-only-css-html-without-js
 					return;
 				}
 				request.ReplyWithImage(path);
 			});
 
+		}
+
+
+		public class Settings
+		{
+			public string CopyrightNotice;
+			public string LicenseUrl;
+			public string LicenseRightsStatement;
+		}
+
+		/// <summary>
+		/// branding folders can optionally contain a settings.json file which aligns with this Settings class
+		/// </summary>
+		/// <param name="brandingNameOrFolderPath"> Normally, the branding is just a name, which we look up in the official branding folder
+		//but unit tests can instead provide a path to the folder.
+		/// </param>
+		public static Settings GetSettings(string brandingNameOrFolderPath)
+		{
+			try
+			{
+				var settingsPath = BloomFileLocator.GetOptionalBrandingFile(brandingNameOrFolderPath, "settings.json");
+				if(!string.IsNullOrEmpty(settingsPath))
+				{
+					var content = File.ReadAllText(settingsPath);
+					var settings = JsonConvert.DeserializeObject<Settings>(content);
+					if(settings == null)
+					{
+						NonFatalProblem.Report(ModalIf.Beta, PassiveIf.All, "Trouble reading branding settings",
+							"settings.json of the branding " + brandingNameOrFolderPath + " may be corrupt. It had: " + content);
+						return null;
+					}
+					return settings;
+				}
+			}
+			catch(Exception e)
+			{
+				NonFatalProblem.Report(ModalIf.Beta, PassiveIf.All, "Trouble reading branding settings", exception: e);
+			}
+			return null;
 		}
 	}
 }

--- a/src/BloomTests/Book/BookCopyrightAndLicenseTests.cs
+++ b/src/BloomTests/Book/BookCopyrightAndLicenseTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Bloom.Book;
 using Bloom.Collection;
 using L10NSharp;
@@ -16,6 +17,8 @@ namespace BloomTests.Book
 		private CollectionSettings _collectionSettings;
 		private LocalizationManager _localizationManager;
 		private LocalizationManager _palasoLocalizationManager;
+		private static TemporaryFolder _brandingFolder;
+		private string _pathToBrandingSettingJson;
 
 		[SetUp]
 		public void Setup()
@@ -34,6 +37,9 @@ namespace BloomTests.Book
 				null, "", new string[] {});
 			_palasoLocalizationManager = LocalizationManager.Create("fr", "Palaso","Palaso", "1.0.0", localizationDirectory, "SIL/Bloom",
 				null, "", new string[] { });
+
+			_brandingFolder = new TemporaryFolder("unitTestBrandingFolder");
+			_pathToBrandingSettingJson = _brandingFolder.Combine("settings.json");
 		}
 
 		[TearDown]
@@ -41,6 +47,7 @@ namespace BloomTests.Book
 		{
 			_localizationManager.Dispose();
 			_palasoLocalizationManager.Dispose();
+			_brandingFolder.Dispose();
 		}
 
 		[Test]
@@ -106,6 +113,77 @@ namespace BloomTests.Book
 			BookCopyrightAndLicense.SetMetadata(newMetaData, dom,  null, settings);
 			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//div[@data-book='licenseUrl']");
 		}
+
+		// BRANDING-RELATED TESTS
+
+		[Test]
+		public void GetLicenseMetadata_SettingsExistsButIsEmpty_MetadataMatches()
+		{
+			File.WriteAllText(_pathToBrandingSettingJson,@"{}");
+			var dataDivContent = @"";
+			var metadata = GetMetadata(dataDivContent);
+			Assert.AreEqual("http://creativecommons.org/licenses/by/4.0/", metadata.License.Url, "Expected default CC license");
+			Assert.IsNullOrEmpty(metadata.License.RightsStatement);
+			Assert.IsNullOrEmpty(metadata.CopyrightNotice);
+		}
+		[Test]
+		public void GetLicenseMetadata_SettingsExistsButHasBogusJson_MetadataMatches()
+		{
+			File.WriteAllText(_pathToBrandingSettingJson, @"");
+			var dataDivContent = @"{'foo':'bar'}";
+			var metadata = GetMetadata(dataDivContent);
+			Assert.AreEqual("http://creativecommons.org/licenses/by/4.0/", metadata.License.Url, "Expected default CC license");
+			Assert.IsNullOrEmpty(metadata.License.RightsStatement);
+			Assert.IsNullOrEmpty(metadata.CopyrightNotice);
+		}
+		[Test]
+		public void GetLicenseMetadata_BrandingHasLicenseAndNotesButNotCopyright_MetadataMatches()
+		{
+			File.WriteAllText(_pathToBrandingSettingJson,
+				@"{
+					'LicenseUrl':'http://creativecommons.org/licenses/by/3.0/igo/',
+					'LicenseRightsStatement': 'These are custom notes.'
+				}");
+			var dataDivContent = @"";
+			var metadata = GetMetadata(dataDivContent);
+			Assert.AreEqual("http://creativecommons.org/licenses/by/3.0/igo/", metadata.License.Url);
+			Assert.AreEqual("These are custom notes.", metadata.License.RightsStatement);
+			Assert.IsNullOrEmpty(metadata.CopyrightNotice);
+		}
+
+		[Test]
+		public void GetLicenseMetadata_HasCopyrightAndLicenseAndLicenseNotes_MetadataMatches()
+		{
+			File.WriteAllText(_pathToBrandingSettingJson,
+				@"{
+					'CopyrightNotice':'Copyright © 2016',
+					'LicenseUrl':'http://creativecommons.org/licenses/by/3.0/igo/',
+					'LicenseRightsStatement': 'These are custom notes.'
+				}");
+			var dataDivContent = @"";
+			var metadata = GetMetadata(dataDivContent);
+			Assert.AreEqual("http://creativecommons.org/licenses/by/3.0/igo/", metadata.License.Url);
+			Assert.AreEqual("These are custom notes.", metadata.License.RightsStatement);
+			Assert.AreEqual("Copyright © 2016", metadata.CopyrightNotice);
+		}
+
+		// we don't want shell books to get this notice
+		[Test]
+		public void GetLicenseMetadata_HasCopyrightAlready_CustomBrandingStuffIgnored()
+		{
+			File.WriteAllText(_pathToBrandingSettingJson,
+				@"{
+					'CopyrightNotice':'Copyright © 2016',
+					'LicenseUrl':'http://creativecommons.org/licenses/by/3.0/igo/',
+					'LicenseRightsStatement': 'These are custom notes.'
+				}");
+			var dataDivContent = @"<div data-book='copyright' class='bloom-content1'>Copyright © 2012, test</div>";
+			var metadata = GetMetadata(dataDivContent);
+			Assert.IsTrue(metadata.CopyrightNotice.Contains("2012"));
+			Assert.IsTrue(metadata.License is NullLicense);
+			Assert.IsNullOrEmpty(metadata.License.RightsStatement);
+		}
+
 
 		[Test, Ignore("Enable once we have French CC License Localization") /*meanwhile, I have tested on my machine*/]
 		public void SetLicenseMetadata_CCLicenseWithFrenchNationalLanguage_DataDivHasFrenchDescription()
@@ -198,7 +276,11 @@ namespace BloomTests.Book
 		private static Metadata GetMetadata(string dataDivContent)
 		{
 			var dom = MakeDom(dataDivContent);
-			return BookCopyrightAndLicense.GetMetadata(dom);
+			//normally, the branding is just a name, which we look up in the official branding folder
+			//but in order to allow unit tests to test particular contents of it, we also allow
+			//it to be a path to a constructed branding folder.
+			//These unit tests can then write to a temp file and point to that.
+			return BookCopyrightAndLicense.GetMetadata(dom, _brandingFolder.Path);
 		}
 
 		private static HtmlDom MakeDom(string dataDivContent)


### PR DESCRIPTION
Settings.json can contain copyright, license url, and rights statement (license notes)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1233)
<!-- Reviewable:end -->
