### PR TITLE
Fix package name for Linux dependency on master

### DIFF
--- a/build/dependencies.config
+++ b/build/dependencies.config
@@ -29,7 +29,7 @@
 
 [common]
 any=optipng libtidy5 mono4-sil libgdiplus4-sil libicu-dev wget unzip \
-fonts-sil-andikanewbasic nodejs
+fonts-sil-andika-new-basic nodejs
 
 [trusty]
 any=icu-devtools


### PR DESCRIPTION
This should get master builds working on TeamCity again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1248)
<!-- Reviewable:end -->
