### PR TITLE
Handle URL encoded cover image filenames in more places (BL-3901)

### DIFF
--- a/src/BloomExe/Book/ImageUpdater.cs
+++ b/src/BloomExe/Book/ImageUpdater.cs
@@ -86,8 +86,9 @@ namespace Bloom.Book
 
 			if (metadata == null)
 			{
+				// The fileName might be URL encoded.  See https://silbloom.myjetbrains.com/youtrack/issue/BL-3901.
+				var path = UrlPathString.GetFullyDecodedPath(folderPath, ref fileName);
 				progress.WriteStatus("Reading metadata from " + fileName);
-				var path = folderPath.CombineForPath(fileName);
 				if (!RobustFile.Exists(path)) // they have bigger problems, which aren't appropriate to deal with here.
 				{
 					imgElement.RemoveAttribute("data-copyright");

--- a/src/BloomExe/UrlPathString.cs
+++ b/src/BloomExe/UrlPathString.cs
@@ -144,6 +144,30 @@ namespace Bloom
 			return (_notEncoded != null ? _notEncoded.GetHashCode() : 0);
 		}
 
-
+		/// <summary>
+		/// Some library books have been uploaded with the cover image filename URL encoded in the file instead of HTML/XML encoded.
+		/// So if the file doesn't exist, try one more level of decoding to see if that may be the problem, but preserve the original
+		/// path in case an error message is still needed.
+		/// </summary>
+		/// <param name="directory">path of the containing folder</param>
+		/// <param name="filename">base filename to be combined with directory.  This may be modified by HttpUtility.UrlDecode().</param>
+		/// <remarks>
+		/// See https://silbloom.myjetbrains.com/youtrack/issue/BL-3901.
+		/// </remarks>
+		public static string GetFullyDecodedPath(string directory, ref string filename)
+		{
+			var path = System.IO.Path.Combine(directory, filename);
+			if (!SIL.IO.RobustFile.Exists(path) && filename.Contains("%"))
+			{
+				var filename1 = System.Web.HttpUtility.UrlDecode(filename);
+				var path1 = System.IO.Path.Combine(directory, filename1);
+				if (SIL.IO.RobustFile.Exists(path1))
+				{
+					filename = filename1;
+					return path1;
+				}
+			}
+			return path;
+		}
 	}
 }

--- a/src/BloomExe/web/CurrentBookHandler.cs
+++ b/src/BloomExe/web/CurrentBookHandler.cs
@@ -68,11 +68,13 @@ namespace Bloom.Api
 			{
 				var fileName = request.RequiredFileNameOrPath("image");
 				Guard.AgainstNull(_bookSelection.CurrentSelection, "CurrentBook");
-				var path = Path.Combine(_bookSelection.CurrentSelection.FolderPath, fileName.NotEncoded);
+				var plainfilename = fileName.NotEncoded;
+				// The fileName might be URL encoded.  See https://silbloom.myjetbrains.com/youtrack/issue/BL-3901.
+				var path = UrlPathString.GetFullyDecodedPath(_bookSelection.CurrentSelection.FolderPath, ref plainfilename);
 				RequireThat.File(path).Exists();
 				var fileInfo = new FileInfo(path);
 				dynamic result = new ExpandoObject();
-				result.name = fileName.NotEncoded;
+				result.name = plainfilename;
 				result.bytes = fileInfo.Length;
 
 				// Using a stream this way, according to one source,


### PR DESCRIPTION
I've tested this fix on both Linux (Wasta 14) and Windows 10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1251)
<!-- Reviewable:end -->
