### PR TITLE
Ignore missing branding images files (BL-3891)

### DIFF
--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -521,18 +521,7 @@ namespace Bloom.Api
 				{
 					path = "(was null)";
 				}
-				var stuffToIgnore = new[] {
-					//browser/debugger stuff
-					"favicon.ico", ".map",
-					// Audio files may well be missing because we look for them as soon
-					// as we define an audio ID, but they wont' exist until we record something.
-					"/audio/",					
-					// This is readium stuff that we don't ship with, because they are needed by the original reader to support display and implementation 
-					// of controls we hide for things like adding books to collection, displaying the collection, playing audio (that last we might want back one day).
-					EpubMaker.kEPUBExportFolder.ToLowerInvariant()
-				};
-
-				if(stuffToIgnore.Any(s => (localPath.ToLowerInvariant().Contains(s))))
+				if (IgnoreFileIfMissing(localPath))
 					return false;
 
 				// we have any number of incidences where something asks for a page after we've navigated from it. E.g. BL-3715, BL-3769.


### PR DESCRIPTION
The fix may also more quietly ignore some other unimportant files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1256)
<!-- Reviewable:end -->
