### PR TITLE
Fix BL-3860 Super Paper Saver showing extra lang field for original acks

### DIFF
--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -149,15 +149,14 @@ div#bloomDataDiv
 	display: none;
 	height: 100%;
 }
-/*Outside of frontmatter, we assume that if bloom gives it a content tag, then it should be visible*/
-.bloom-page:not(.bloom-frontMatter) .bloom-content1, .bloom-page:not(.bloom-frontMatter) .bloom-content2, .bloom-page:not(.bloom-frontMatter) .bloom-content3
-{
-	display: inherit;
+
+/*Outside of xmatter, we assume that if bloom gives it a content tag, then it should be visible*/
+.bloom-page:not(.bloom-frontMatter):not(.bloom-backMatter) {
+  .bloom-content1, .bloom-content2, .bloom-content3 {
+    display:inherit;
+  }
 }
-.bloom-page:not(.bloom-frontMatter) .bloom-content2
-{
-	display: inherit;
-}
+
 /*Notes on wkhtmltopdf and page sizes: Set the border color of Div.Page in preview.css so you can see what the pdf is doing
 these should be 14.8, but wkhtmltopdf shinks it
 The folowing are the values which work with a 1px border.  With 0px border, I could not get the pages to come out

--- a/src/BloomBrowserUI/xMatter/Factory-XMatter/Factory-XMatter.less
+++ b/src/BloomBrowserUI/xMatter/Factory-XMatter/Factory-XMatter.less
@@ -1,4 +1,4 @@
 @import '../bloom-xmatter-common.less';
 
-@XMatterPackName: "Factory";
+@XMatterPackName: "Paper Saver";
 

--- a/src/BloomBrowserUI/xMatter/bloom-xmatter-common.less
+++ b/src/BloomBrowserUI/xMatter/bloom-xmatter-common.less
@@ -466,10 +466,12 @@ BODY[bookcreationtype="translation"] {
 }
 
 .insideBackCover .bloom-editable {
+    display: inherit;
     height: 100%;
 }
 
 .outsideBackCover .bloom-editable {
+    display: inherit;
     height: inherit; // let this shrink to make room for branding at bottom, if present
     text-align: center;
 }


### PR DESCRIPTION
There was a rule that assumed that only the front matter had multilingual fields. I  generalized that to include back matter also.  that, in turn, required specifying the display for the two back matter pages in other xmatter packs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1257)
<!-- Reviewable:end -->
