### PR TITLE
Don't show regional book title in source bubble (BL-3888)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.ts
@@ -96,6 +96,12 @@ export default class BloomSourceBubbles {
                 $(this).remove();
             }
         });
+        // BL-3888 Don't show regional book title in bubble, since it's already visible on the title page
+        divForBubble.find('*.bloom-contentNational2').each(function () {
+            if ($(this).attr('data-book') === 'bookTitle') {
+                $(this).remove();
+            }
+        });
 
         //in case some formatting didn't get cleaned up
         StyleEditor.CleanupElement(divForBubble);


### PR DESCRIPTION
It's already showing on the title page anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1263)
<!-- Reviewable:end -->
