### PR TITLE
MXB Pamphlet xmatter

### DIFF
--- a/src/BloomBrowserUI/templates/customXMatter/MXBPamphlet-XMatter/MXBPamphlet-XMatter.jade
+++ b/src/BloomBrowserUI/templates/customXMatter/MXBPamphlet-XMatter/MXBPamphlet-XMatter.jade
@@ -1,0 +1,51 @@
+
+include ../../xMatter/bloom-xmatter-mixins.jade
+// The above filepath will need updating if this xmatter ever becomes an official Bloom xmatter pack
+// since it will get moved from customXMatter to xMatter
+
+mixin mxb-nationalSummaryPrinterStatement-insideBackCover
+	// Inside Back Cover
+	+page-xmatter('Inside Back Cover').cover.coverColor.insideBackCover.bloom-backMatter(data-export='back-matter-inside-back-cover')&attributes(attributes)#839e8eee-5e1a-45a7-bb01-2c171b56f8a4
+		+field-mono-meta("N1","insideBackCover").Inside-Back-Cover-style.bloom-copyFromOtherLanguageIfNecessary
+			label.bubble If your publication is not diglot, you can include a national language summary here, which is the inside of the back cover.
+		+field-mono-meta("N1","printerStatement").Printer-Statement-style.bloom-copyFromOtherLanguageIfNecessary
+			label.bubble Printer's Statement goes here.
+
+mixin mxb-combinedTitleCreditsPage-inside-front-cover
+	+page-xmatter('Inside Front Cover').cover.coverColor.titlePage.credits.bloom-frontMatter(data-export='front-matter-title-page')&attributes(attributes)#0d61e568-6814-4836-82ad-81b2bcd106a5
+		+field-prototypeDeclaredExplicity#titlePageTitleBlock
+			label.bubble Book title in {lang}
+			+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Title-Page-style(data-book='bookTitle')
+		#languageInformation.Credits-Page-style('lang'='N1')
+			.languagesOfBook(data-book='languagesOfBook')
+			//- review: can we get rid of these "langName" classes?
+			.langName('data-library'='dialect')
+			.langName(data-library='languageLocation').bloom-writeOnly
+		+field-prototypeDeclaredExplicity#originalContributions
+			label.bubble The contributions made by writers, illustrators, editors, etc., in {lang}
+			+editable(kLanguageForPrototypeOnly).credits.bloom-readOnlyInTranslationMode.bloom-copyFromOtherLanguageIfNecessary.Credits-Page-style(data-book='originalContributions')
+		+field-acknowledgments-localizedVersion
+		+field-acknowledgments-originalVersion
+		+field-prototypeDeclaredExplicity#funding
+			label.bubble Use this to acknowledge any funding agencies.
+			+editable(kLanguageForPrototypeOnly).funding.Credits-Page-style.bloom-copyFromOtherLanguageIfNecessary(data-book='funding')
+		+field-prototypeDeclaredExplicity#printingHistory
+			label.bubble Use this for Printing History (1st Edition, etc.)
+			+editable(kLanguageForPrototypeOnly).PrintingHistory-style.bloom-copyFromOtherLanguageIfNecessary(data-book='printingInfo')
+		+block-licenseAndCopyright
+		+field-ISBN
+		+field-title-page-branding
+
+doctype html
+html
+	head
+		meta(charset='UTF-8')
+		meta(name='BloomFormatVersion', content='2.0')
+		title ILV Mexico Pamphlet Front & Back Matter
+		+stylesheets('MXBPamphlet-XMatter.css')
+	body
+		+factoryStandard-outsideFrontCover
+		+mxb-combinedTitleCreditsPage-inside-front-cover
+		+mxb-nationalSummaryPrinterStatement-insideBackCover
+		+factoryStandard-outsideBackCover
+

--- a/src/BloomBrowserUI/templates/customXMatter/MXBPamphlet-XMatter/MXBPamphlet-XMatter.less
+++ b/src/BloomBrowserUI/templates/customXMatter/MXBPamphlet-XMatter/MXBPamphlet-XMatter.less
@@ -1,0 +1,103 @@
+@import '../../xMatter/bloom-xmatter-common.less';
+
+@XMatterPackName: "MXB Pamphlet";
+
+// moving the license and copyright block to a new place, it needs some top space
+.licenseAndCopyrightBlock {
+    margin-top: 0.5em;
+}
+
+.titlePage {
+    // shrink this down from 3em because we're combining the title and credits pages
+    #titlePageTitleBlock {
+        margin-bottom: 1em;
+    }
+    // shrink things down even more if it's a small paper size
+    &.A6Landscape, &.A6Portrait, &.QuarterLetterLandscape, &.QuarterLetterPortrait {
+        #titlePageTitleBlock {
+            margin-bottom: 0;
+            DIV {
+                margin-bottom: 0;
+            }
+        }
+    }
+}
+
+.insideBackCover {
+    .marginBox {
+        .bloom-editable:only-child {
+            height: 100%;
+            display: inherit;
+        }
+        .bloom-editable:not(:only-child) {
+            flex: auto;
+            display: block;
+            &.Printer-Statement-style {
+                height: auto;
+                padding-bottom: 20px;
+                font-size: 10pt;
+                text-align: center;
+                justify-content: center;
+            }
+        }
+        // set a default style for the new Printer's Statement
+        .Printer-Statement-style {
+            font-size: 10pt;
+            line-height: 1.2;
+        }
+        display: flex;
+        flex-direction: column;
+    }
+}
+
+.credits {
+    #printingHistory .bloom-contentNational1 {
+        display: block;
+    }
+    // default values for the Printing History section
+    .PrintingHistory-style.bloom-contentNational1 {
+    font-size: 10pt;
+    display: block;
+    }
+    // scrunch things down as much as possible
+    .originalAcknowledgments .bloom-contentNational1,.bloom-content1 {
+        margin-bottom: 0.5em;
+    }
+}
+
+// more scrunching
+.titlePage #funding {
+    margin-bottom: 0.5em;
+}
+
+// override .bloom-content1 min-height 3em from bloom-xmatter-common.less
+BODY[bookcreationtype="original"] {
+    .titlePage {
+        #originalContributions {
+            .bloom-content1 {
+                min-height: 1em;
+            }
+        }
+        #funding {
+            .bloom-content1 {
+                min-height: 1em;
+            }
+        }
+    }
+}
+
+// override .bloom-contentNational1 min-height 3em from bloom-xmatter-common.less
+BODY[bookcreationtype="translation"] {
+    .titlePage {
+        #originalContributions {
+            .bloom-contentNational1 {
+                min-height: 1em;
+            }
+        }
+        #funding {
+            .bloom-contentNational1 {
+                min-height: 1em;
+            }
+        }
+    }
+}

--- a/src/BloomBrowserUI/templates/customXMatter/MXBPamphlet-XMatter/description-en.txt
+++ b/src/BloomBrowserUI/templates/customXMatter/MXBPamphlet-XMatter/description-en.txt
@@ -1,0 +1,1 @@
+[V8]Designed for pamphlets, this puts the title and credits page information on the inside of the front cover, and a national language summary and printer's statement on the inside of the back cover.

--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-common.less
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-common.less
@@ -19,7 +19,7 @@
 //a smaller bottom margin, since there is no page number
 .outsideFrontCover .marginBox, .outsideBackCover .marginBox {
     .SetMarginBoxCover(@PageHeight, @PageWidth) {
-        /*There's no page number on the cover, so we might as well have a the bottom stuff closer to the bottom*/
+        /*There's no page number on the cover, so we might as well have the bottom stuff closer to the bottom*/
         height: @PageHeight - (@MarginTop + @BottomMargin-SmallerForCover);
         //Just center the margin box, (for now, we're ignoring the binding)
         left: @MarginOuter;
@@ -326,7 +326,6 @@
         //min-height: 5em;
         line-height: 1.4em; // supports ไปทั่วพื้ ที่นั่ ชื่ ปู ช้ต่างป
     }
-
     .originalAcknowledgments .bloom-contentNational1 {
         display: block !important;
         margin-bottom: @MarginBetweenBlocks;
@@ -338,7 +337,6 @@
     .licenseUrl {
         display: none;
     }
-
     @MarginBetweenBlocks_SmallPaper: .5em;
     &.A6Landscape, &.A6Portrait, &.QuarterLetterLandscape, &.QuarterLetterPortrait {
         .licenseImage {width: 65px};
@@ -350,7 +348,6 @@
         //    .licenseBlock{margin-bottom: 1em;}
         //}
     }
-
    .bottomImageWrapper{
         width: 100%; // this allows the branding to center.
         position: absolute;
@@ -360,7 +357,6 @@
             height: 1in;
         }
     }
-
 }
 
 BODY[bookcreationtype="original"] {
@@ -442,8 +438,7 @@ BODY[bookcreationtype="translation"] {
 
     #languageInformation {
         width: 100%;
-        .languagesOfBook {
-        }
+
         //NB: order would be important here, since in source collections, a block can be both content1 and contentNational1
         .langName.bloom-content1 {
             display: none;
@@ -455,6 +450,7 @@ BODY[bookcreationtype="translation"] {
             display: inherit;
         }
     }
+    
     .bottomImageWrapper{
         width: 100%; // this allows the branding to center.
         position: absolute;
@@ -465,9 +461,9 @@ BODY[bookcreationtype="translation"] {
     }
 }
 
-.insideBackCover .bloom-editable {
-    display: inherit;
-    height: 100%;
+.insideBackCover .bloom-editable { 
+    display: inherit; 
+    height: 100%; 
 }
 
 .outsideBackCover .bloom-editable {

--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.jade
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.jade
@@ -86,8 +86,6 @@ mixin block-licenseAndCopyright
 			.licenseNotes(data-derived="licenseNotes", lang="en").Credits-Page-style
 				| {License Notes}
 
-
-
 //- -------------------------------------------------------------------------------
 //-	Unless every page of your xmatter pack needs to be different than the "factory"
 //-	one that comes with Bloom, use the following mixins to reuse the pages that


### PR DESCRIPTION
* This includes a change to c# code so that
  Credit-Page-style will work on the copyright field
* Add customXMatter folder to templates
* Add jade and less to combine title/credit pages
* Add printer's statement space to inside back cover
* Rearrange some of the parts of the combined page
* Modify a few bits of less, so the rearranged bits fit
* Get Printer's Statement 'bottom aligned'
* Moved both acknowl fields up above funding
* Added Printing Info section just above copyright
* Reduced space below original acknowledgments
   and funding sections
* Reduced min-height to one line for funding and
   original contributions sections
* Get Credit-Page-style to work on all the combined
  title/credits page fields except the titles
* Maintain a separate style for the PrintingInfo
   section

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1272)

<!-- Reviewable:end -->
