### PR TITLE
Log opening a WebSocketServer (BL-3916)

### DIFF
--- a/src/BloomExe/web/BloomWebSocketServer.cs
+++ b/src/BloomExe/web/BloomWebSocketServer.cs
@@ -29,7 +29,9 @@ namespace Bloom.Api
 		{
 			FleckLog.Level = LogLevel.Warn;
 			_allSockets = new List<IWebSocketConnection>();
-			_server = new WebSocketServer("ws://127.0.0.1:"+ port);
+			var websocketaddr = "ws://127.0.0.1:" + port;
+			Logger.WriteMinorEvent("Attempting to open a WebSocketServer on " + websocketaddr);
+			_server = new WebSocketServer(websocketaddr);
 			
 			try
 			{
@@ -49,6 +51,7 @@ namespace Bloom.Api
 			}
 			catch (SocketException ex)
 			{
+				Logger.WriteEvent("Opening a WebSocketServer on " + websocketaddr + " failed.  Error = " + ex);
 				ErrorReport.NotifyUserOfProblem(ex, "Bloom cannot start properly (cannot set up some internal communications){0}{0}" +
 					"What caused this?{0}" +
 					"Possibly another version of Bloom is running, perhaps not very obviously.{0}{0}" +

--- a/src/BloomExe/web/ServerBase.cs
+++ b/src/BloomExe/web/ServerBase.cs
@@ -177,7 +177,6 @@ namespace Bloom.Api
 				Logger.WriteMinorEvent("Attempting to start http listener on "+ ServerUrlEndingInSlash);
 				_listener = new HttpListener {AuthenticationSchemes = AuthenticationSchemes.Anonymous};
 				_listener.Prefixes.Add(ServerUrlEndingInSlash);
-				_listener.Prefixes.Add(ServerUrlWithBloomPrefixEndingInSlash);
 				_listener.Start();
 				return true;
 			}


### PR DESCRIPTION
This doesn't fix the problem, but provides a few details that are
currently unreported.

Also remove an apparently redundant HttpListener prefix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1275)
<!-- Reviewable:end -->
