### PR TITLE
Fix data for counting words in leveled readers (BL-3498)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -1191,7 +1191,9 @@ export class ReaderToolsModel {
           axios.get<string>('/bloom/api/readers/io/allowedWordsList', { params: { 'fileName': stage.allowedWordsFile } })
               .then(result => this.setAllowedWordsListList(result.data, index));
       }
-    });
+    // During Linux testing of BL-3498, the this (_this in the TS converted to JS), in the axios.get callback was
+    // undefined without this bind().  This .bind() is also the fix for BL-3496.
+    }.bind(this));
   }
 
   setAllowedWordsListList(fileContents: string, stageIndex: number): void {

--- a/src/BloomExe/web/ReadersApi.cs
+++ b/src/BloomExe/web/ReadersApi.cs
@@ -195,8 +195,11 @@ namespace Bloom.Api
 		{
 			// As http://stackoverflow.com/questions/42068/how-do-i-handle-newlines-in-json attempts to explain,
 			// it takes TWO backslashes before r or n in JSON to get an actual embedded newline into the string.
-			// (And of course FOUR here in the C# source to produce two in the literal passed to Replace.)
-			return value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", "\\\\r").Replace("\n", "\\\\n");
+			// That's from the perspective of seeing it in C# or the debugger.  It's only one real backslash.
+			// See also https://silbloom.myjetbrains.com/youtrack/issue/BL-3498.  If we put two real backslashes
+			// in the string, represented by four backslashes here, before the r or n, then javascript receives
+			// two real backslashes followed by r or n, not a carriage return or linefeed character.
+			return value.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", "\\r").Replace("\n", "\\n");
 		}
 
 		private string GetSampleTextsList(string settingsFilePath)


### PR DESCRIPTION
I've tested the updated fix on both Linux and Windows.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1279)
<!-- Reviewable:end -->
