### PR TITLE
Fix BL-3493 DR Setup doesn't find words

### DIFF
--- a/src/BloomBrowserUI/.vscode/launch.json
+++ b/src/BloomBrowserUI/.vscode/launch.json
@@ -5,18 +5,17 @@
     // Chrome: CTRL+P: "ext install Debugger for Chrome"
     // 1) Run Bloom, go to a page.
     // 2) Here in VSCODE, run Debug (F5, once you've done it once)
-
+    //
     // This should open the page in Firefox or Chrome. Breakpoints should point to the typescript.
-
-
+    //
     // Firefox Troubleshooting tips
     // Note: as of Sept 20 2016, I haven't gotten Firefox breakpoints to work, for TS or JS. So this is pretty worthless.
-
+    //
     // Chrome Troubleshooting tips
     // Note: you cannot (yet?) have the chrome inspector open at the same time (!!!) https://github.com/Microsoft/vscode-chrome-debug/issues/83,
     //       https://github.com/Microsoft/vscode-chrome-debug/issues/95, https://bugs.chromium.org/p/chromium/issues/detail?id=129539#.
     // Workaround: open a different tab with the same URL, you can Inspect that one.
-    // * If Chrome cannot get the page, check that your Bloom is really listening on 8091 as listed in the "url" below? Bloom has
+    // * If Chrome cannot get the page, check that your Bloom is really listening on 8089 as listed in the "url" below? Bloom has
     //   the ability to change ports if the default isn't available.
     // If the debugger says it cannot connect to Chrome:
     // * Uncomment the diagnosticLogging line below
@@ -25,14 +24,13 @@
     //     "c:/Program Files (x86)/Google/Chrome/Application/chrome.exe" --remote-debugging-port=9222 --no-first-run --incognito --disable-extensions
     // * Try restarting your computer (clears out the bazillion chromes around), which somehow interfer.
     // * Try avoiding using chrome for other things while doing this (e.g. use FF).
-
     "version": "0.2.0",
     "configurations": [
         {
             "name": "Launch in Firefox",
             "type": "firefox",
             "request": "launch",
-            "url": "http://localhost:8091/bloom/CURRENTPAGE.htm",
+            "url": "http://localhost:8089/bloom/CURRENTPAGE.htm",
             "webRoot": "${workspaceRoot}",
             "log": {
                 "consoleLevel": {
@@ -49,8 +47,7 @@
             "runtimeExecutable": "c:/Program Files (x86)/Google/Chrome/Application/chrome.exe",
             // these args don't appear to work... trying to get it to not offer to restore previous pages
             //"runtimeArgs": [ "--no-first-run --kiosk --disable-session-crashed-bubble --disable-infobars --incognito --disable-extensions"],
-
-            "url": "http://localhost:8091/bloom/CURRENTPAGE.htm",
+            "url": "http://localhost:8089/bloom/CURRENTPAGE.htm",
             "webRoot": "${workspaceRoot}",
             "sourceMaps": true,
             "userDataDir": "${workspaceRoot}/output/chrome"
@@ -68,7 +65,7 @@
             "userDataDir": "${workspaceRoot}/output/chrome"
             //,"diagnosticLogging": true
         },
-        {   // Note: you have to launch the test runner separately (karma start --browsers Chrome)
+        { // Note: you have to launch the test runner separately (karma start --browsers Chrome)
             // and you may have to do a browser REFRESH before breakpoints are caught
             // Enhance: could we get it to attach to the chrome that karma starts? Maybe need to have kara start one with the debug port open?
             "name": "Debug Unit Tests",

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
@@ -473,17 +473,20 @@ function tabBeforeActivate(ui): void {
     }
 
     // update more words
-    if ((<HTMLInputElement>document.getElementById('dls_more_words')).value !== getPreviousMoreWords()) {
-      // remember the new list of more words
-      setPreviousMoreWords((<HTMLInputElement>document.getElementById('dls_more_words')).value);
-
+    const moreWords = (<HTMLInputElement>document.getElementById('dls_more_words')).value;
+    if (moreWords !== getPreviousMoreWords()) {
       // save the changes and update lists
       var toolbox = toolboxWindow();
       // Note, this means that changes to sample words (and any other changes we already made) will persist,
       // even if the user eventually cancels the dialog. Not sure if this is desirable. However, if we
       // want updated matching words in the other tab, it will be difficult to achieve without doing this.
       // We'd probably need our own copy of theOneLanguageDataInstance.
-      beginSaveChangedSettings().then(() => requestWordsForSelectedStage());
+      beginSaveChangedSettings().then(() => {
+        // remember the new list of more words, but don't do it before we save changed settings because
+        // that uses the old value of 'more words' to know to reset Synphony's data.
+        setPreviousMoreWords(moreWords);
+        requestWordsForSelectedStage()
+      });
     }
   }
 }


### PR DESCRIPTION
* changing tabs from Sample Words to Decodable
   Stages was not remembering the words in a way
   that allowed Synphony to update its data
* since we fixed that pre-registered url issue on our
   dev machines I changed the ports in launch.json

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1283)
<!-- Reviewable:end -->
