### PR TITLE
Split words on ZERO WIDTH SPACE (BL-3933)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.js
@@ -369,15 +369,16 @@ LibSynphony.prototype.getWordsFromHtmlString = function(textHTML, letters) {
      **************************************************************************/
     regex = XRegExp(
         '(^' + punct + '+)'                             // punctuation at the beginning of a string
-        + '|(' + punct + '+[\\s\\p{Z}]+' + punct + '+)' // punctuation within a sentence, between 2 words (word" "word)
-        + '|([\\s\\p{Z}]+' + punct + '+)'               // punctuation within a sentence, before a word
-        + '|(' + punct + '+[\\s\\p{Z}]+)'               // punctuation within a sentence, after a word
+        + '|(' + punct + '+[\\s\\p{Z}\\p{C}]]+' + punct + '+)' // punctuation within a sentence, between 2 words (word" "word)
+        + '|([\\s\\p{Z}\\p{C}]+' + punct + '+)'               // punctuation within a sentence, before a word
+        + '|(' + punct + '+[\\s\\p{Z}\\p{C}]+)'               // punctuation within a sentence, after a word
         + '|(' + punct + '+$)',                         // punctuation at the end of a string
         'g');
     s = XRegExp.replace(s, regex, ' ');
 
-    // split into words using space characters
-    regex = XRegExp('[\\p{Z}]+', 'xg');
+    // split into words using Separator and Control characters
+    // (ZERO WIDTH SPACE is a Control charactor.  See http://issues.bloomlibrary.org/youtrack/issue/BL-3933.)
+    regex = XRegExp('[\\p{Z}\\p{C}]+', 'xg');
     return XRegExp.split(s.trim(), regex);
 };
 


### PR DESCRIPTION
Actually, we now split words on all Control characters (ZERO WIDTH SPACE
is a Control character) as well as all Separator characters.

This is on the master (3.8) branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1287)
<!-- Reviewable:end -->
