### PR TITLE
Fix the check for a simulated file url (BL-3574)

### DIFF
--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -563,7 +563,7 @@ namespace Bloom.Api
 		protected bool IsSimulatedFileUrl(string localPath)
 		{
 			var extension = Path.GetExtension(localPath);
-			if(extension != null && !extension.StartsWith("htm"))
+			if (extension != null && !extension.StartsWith(".htm"))
 				return false;
 
 			// a good improvement might be to make these urls more obviously cache requests. But for now, let's just see if they are filename guids


### PR DESCRIPTION
It still complains to alpha users with a better message, and hints to
beta users about a problem with a toast.

This fix is only on the master (3.8) branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1288)
<!-- Reviewable:end -->
