### PR TITLE
BL-3572 Fix BigBook template

### DIFF
--- a/src/BloomBrowserUI/templates/template books/Big Book/Big Book.jade
+++ b/src/BloomBrowserUI/templates/template books/Big Book/Big Book.jade
@@ -28,7 +28,7 @@ html
 		//- Eventually, we'll remove Bloom's need for this.
 		meta(name='pageTemplateSource', content='Big Book')
 		title 'Big Book'
-		+stylesheets('BigBook.css')
+		+stylesheets('Big Book.css')
 		style(type="text/css" title="userModifiedStyles")
 			.normal-style { font-size: 65pt !important; }
 	body

--- a/src/BloomBrowserUI/templates/template books/Big Book/Big Book.less
+++ b/src/BloomBrowserUI/templates/template books/Big Book/Big Book.less
@@ -15,8 +15,9 @@ ENDLAYOUTS
 This is a dummy rule used to transmit to javascript what size/orientations this stylesheet can handle.*/
 
 .bigbookInstructions {
-	*{font-size: 12pt !important;}
-	 H1 {
+	font-size: 12pt;
+
+	H1 {
 		text-align: center;
 		color: #000000;
 		font-size: 14pt;
@@ -25,11 +26,12 @@ This is a dummy rule used to transmit to javascript what size/orientations this 
 	.bloom-editable {
 		overflow: visible;
 		font-size: 11pt;
+		line-height: 2.0;
 	}
 
 	P {
 		margin-left: 0px;
-		margin-top: 18px;
+		//margin-top: 18px; // interferes with line-height setting
 	}
 
 	LI{
@@ -71,7 +73,7 @@ height: 786px;
 }
 Text Whole Page
 The key to this text being aligned vertically is the bloom-centerContentVertiaclly on the tranlsation group, which gets picked up in the jscript, which then aligns it*/
-.A4Landscape .bloom-editable
+.bloom-editable
 {
 	font-size: 62pt;
 	overflow: visible;

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -575,7 +575,9 @@ namespace Bloom.Book
 			}
 
 			//ok, so maybe they changed the name of the folder and not the htm. Can we find a *single* html doc?
-			var candidates = new List<string>(Directory.GetFiles(folderPath, "*.htm").Concat(Directory.GetFiles(folderPath, "*.html")));
+			// BL-3572 when the only file in the directory is "BigBook.html", it matches both filters in Windows (tho' not in Linux?)
+			// so Union works better here. (And we'll change the name of the book too.)
+			var candidates = new List<string>(Directory.GetFiles(folderPath, "*.htm").Union(Directory.GetFiles(folderPath, "*.html")));
 			candidates.RemoveAll((name) => name.ToLowerInvariant().Contains("configuration"));
 			if (candidates.Count == 1)
 				return candidates[0];

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -316,6 +316,19 @@ namespace BloomTests.Book
 			Assert.IsTrue(File.Exists(Path.Combine(path, newName + ".htm")));
 		}
 
+		[Test]
+		public void PathToExistingHtml_WorksWithFullHtmlName()
+		{
+			var filenameOnly = "BigBook";
+			var fullFilename = "BigBook.html";
+			var storage = GetInitialStorageWithDifferentFileName(filenameOnly);
+			var oldFullPath = Path.Combine(storage.FolderPath, filenameOnly + ".htm");
+			var newFullPath = Path.Combine(storage.FolderPath, fullFilename);
+			File.Move(oldFullPath, newFullPath); // rename to .html
+			var path = storage.PathToExistingHtml;
+			Assert.AreEqual(fullFilename, Path.GetFileName(path), "If this fails, 'path' will be empty string.");
+		}
+
 		/// <summary>
 		/// This is really testing some Book.cs functionality, but it has to manipulate real files with a real storage,
 		/// so it seems to fit better here.


### PR DESCRIPTION
* fixed algorithm for finding htm/html file if different
   than folder name
* renamed BigBook files (.less and .jade) to match
   Big Book folder name
* also redid solution for BL-3788 (BB Instructions)
   for 3.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1295)
<!-- Reviewable:end -->
