### PR TITLE
Fix crash clicking 'This is a template book' checkbox (BL-3872)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettings.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettings.ts
@@ -23,8 +23,8 @@ export function handleBookSettingCheckboxClick(clickedButton: any) {
     // read our controls and send the model back to c#
     // enhance: this is just dirt-poor serialization of checkboxes for now
     var inputs = $(".bookSettings :input");
+    var o = {}; // declaring this inside the method results in only the first item being returned: see BL-3872
     var settings = $.map(inputs, (input, i) => {
-        var o = {};
         o[input.name] = $(input).prop("checked");
         return o;
     })[0];


### PR DESCRIPTION
I also tweaked a couple of statements to make debugging easier.  (I don't know why some people have a phobia of temporary variables.)  The critical bugfix to avoid the yellow crash dialog was in the TypeScript file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1301)
<!-- Reviewable:end -->
