### PR TITLE
Stop double-escaping line feeds (bl-3969 and bl-3970)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -1018,11 +1018,7 @@ export class ReaderToolsModel {
     return (<any>axios).all(this.texts.map(fileName => {
       return axios.get<string>('/bloom/api/readers/io/sampleFileContents', { params: { fileName: fileName } })
         .then(result => {
-          //axios get here is giving us an object even though the c# sends a text/plain.
-          //and that would normally be great, but unfortunately the downstream code was written to take a raw
-          //string (which happpens to be JSON). So for now, we just make it a string.
-          var resultAsString = JSON.stringify(result.data);
-          this.setSampleFileContents(resultAsString);
+          this.setSampleFileContents(result.data);
         });
     }));
   }

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools_libSynphonySpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools_libSynphonySpec.ts
@@ -88,26 +88,34 @@ describe("readerTools-libSynphony tests", function() {
         expect(getTheOneReaderToolsModel().allWords).toEqual({the: 4, cat: 2, sat: 2, on: 2, mat: 1, rat: 1});
     });
 
+    it("addWordsFromFile properly handles paragraphs", function () {
+        getTheOneReaderToolsModel().clearForTest();
+        var fileContents = 'one\r\ntwo\nthree four five.\r\n six. seven';
 
-/* skipping See BL-3554
-    it("addWordsToSynphony", function() {
-
-        generateTestData();
-        var synphony = getTheOneReaderToolsModel().synphony;
-
-        expect(synphony.stages.length).toBe(3);
-        getTheOneReaderToolsModel().setStageNumber(1);
-        expect(_.pluck(getTheOneReaderToolsModel().getStageWords(), 'Name').sort()).toEqual(['cat', 'mat', 'rat']);
-        getTheOneReaderToolsModel().setStageNumber(2);
-        expect(_.pluck(getTheOneReaderToolsModel().getStageWords(), 'Name').sort()).toEqual(['cat', 'mat', 'rat', 'sat']);
-        getTheOneReaderToolsModel().setStageNumber(3);
-        expect(_.pluck(getTheOneReaderToolsModel().getStageWords(), 'Name').sort()).toEqual(['cat', 'mat', 'on', 'one', 'rat', 'sat', 'the', 'three']);
-
-        expect(synphony.stages[0].sightWords).toEqual('canine feline');
-        expect(synphony.stages[1].sightWords).toEqual('carnivore omnivore');
-        expect(synphony.stages[2].sightWords).toEqual('rodent');
+        getTheOneReaderToolsModel().addWordsFromFile(fileContents);
+        expect(getTheOneReaderToolsModel().allWords).toEqual({ one: 1, two: 1, three: 1, four: 1, five: 1, six: 1, seven: 1 });
     });
-*/
+
+
+    /* skipping See BL-3554
+        it("addWordsToSynphony", function() {
+
+            generateTestData();
+            var synphony = getTheOneReaderToolsModel().synphony;
+
+            expect(synphony.stages.length).toBe(3);
+            getTheOneReaderToolsModel().setStageNumber(1);
+            expect(_.pluck(getTheOneReaderToolsModel().getStageWords(), 'Name').sort()).toEqual(['cat', 'mat', 'rat']);
+            getTheOneReaderToolsModel().setStageNumber(2);
+            expect(_.pluck(getTheOneReaderToolsModel().getStageWords(), 'Name').sort()).toEqual(['cat', 'mat', 'rat', 'sat']);
+            getTheOneReaderToolsModel().setStageNumber(3);
+            expect(_.pluck(getTheOneReaderToolsModel().getStageWords(), 'Name').sort()).toEqual(['cat', 'mat', 'on', 'one', 'rat', 'sat', 'the', 'three']);
+
+            expect(synphony.stages[0].sightWords).toEqual('canine feline');
+            expect(synphony.stages[1].sightWords).toEqual('carnivore omnivore');
+            expect(synphony.stages[2].sightWords).toEqual('rodent');
+        });
+    */
 
     /**
      * Test for BL-223, div displaying markup if there is no text


### PR DESCRIPTION
We had a workaround in JS which, when the c# was fixed, actually became a bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1304)
<!-- Reviewable:end -->
