### PR TITLE
Produce PDF files one page at a time if desired (BL-3929)

### DIFF
--- a/src/BloomExe/Book/UserPrefs.cs
+++ b/src/BloomExe/Book/UserPrefs.cs
@@ -13,6 +13,7 @@ namespace Bloom.Book
 		private bool _loading = true;
 		private string _filePath;
 		private int _mostRecentPage;
+		private bool _reducePdfMemory;
 
 		private UserPrefs() {}
 
@@ -64,6 +65,17 @@ namespace Bloom.Book
 			set
 			{
 				_mostRecentPage = value;
+				Save();
+			}
+		}
+
+		[JsonProperty("reducePdfMemory")]
+		public bool ReducePdfMemoryUse
+		{
+			get { return _reducePdfMemory; }
+			set
+			{
+				_reducePdfMemory = value;
 				Save();
 			}
 		}

--- a/src/BloomExe/Publish/PdfMaker.cs
+++ b/src/BloomExe/Publish/PdfMaker.cs
@@ -36,21 +36,23 @@ namespace Bloom.Publish
 		/// <param name="inputHtmlPath"></param>
 		/// <param name="outputPdfPath"></param>
 		/// <param name="paperSizeName">A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,B0,B1,B10,B2,B3,B4,B5,B6,B7,B8,B9,C5E,Comm10E,DLE,Executive,Folio,Ledger,Legal,Letter,Tabloid</param>
-		/// <param name="landscape"> </param>
-		/// <param name="layoutPagesForRightToLeft"></param>
-		/// <param name="booketLayoutMethod"> </param>
-		/// <param name="bookletPortion"></param>
+		/// <param name="landscape">true if landscape orientation, false if portrait orientation</param>
+		/// <param name="saveMemoryMode">true if PDF file is to be produced using less memory (but more time)</param>
+		/// <param name="layoutPagesForRightToLeft">true if RTL, false if LTR layout</param>
+		/// <param name="booketLayoutMethod">NoBooklet,SideFold,CutAndStack,Calendar</param>
+		/// <param name="bookletPortion">None,AllPagesNoBooklet,BookletCover,BookletPages,InnerContent</param>
 		/// <param name="worker">If not null, the Background worker which is running this task, and may be queried to determine whether a cancel is being attempted</param>
 		/// <param name="doWorkEventArgs">The event passed to the worker when it was started. If a cancel is successful, it's Cancel property should be set true.</param>
 		/// <param name="owner">A control which can be used to invoke parts of the work which must be done on the ui thread.</param>
-		public void MakePdf(string inputHtmlPath, string outputPdfPath, string paperSizeName, bool landscape, bool layoutPagesForRightToLeft, PublishModel.BookletLayoutMethod booketLayoutMethod, PublishModel.BookletPortions bookletPortion, BackgroundWorker worker, DoWorkEventArgs doWorkEventArgs, Control owner)
+		public void MakePdf(string inputHtmlPath, string outputPdfPath, string paperSizeName, bool landscape, bool saveMemoryMode, bool layoutPagesForRightToLeft,
+			PublishModel.BookletLayoutMethod booketLayoutMethod, PublishModel.BookletPortions bookletPortion, BackgroundWorker worker, DoWorkEventArgs doWorkEventArgs, Control owner)
 		{
 			// Try up to 4 times. This is a last-resort attempt to handle BL-361.
 			// Most likely that was caused by a race condition in MakePdfUsingGeckofxHtmlToPdfComponent.MakePdf,
 			// but as it was an intermittent problem and we're not sure that was the cause, this might help.
 			for (int i = 0; i < 4; i++)
 			{
-				new MakePdfUsingGeckofxHtmlToPdfProgram().MakePdf(inputHtmlPath, outputPdfPath, paperSizeName, landscape,
+				new MakePdfUsingGeckofxHtmlToPdfProgram().MakePdf(inputHtmlPath, outputPdfPath, paperSizeName, landscape, saveMemoryMode,
 					owner, worker, doWorkEventArgs);
 
 				if (doWorkEventArgs.Cancel || (doWorkEventArgs.Result != null && doWorkEventArgs.Result is Exception))

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -127,8 +127,8 @@ namespace Bloom.Publish
 					// Check memory for the benefit of developers.  The user won't see anything.
 					SIL.Windows.Forms.Reporting.MemoryManagement.CheckMemory(true, "about to create PDF file", false);
 					_pdfMaker.MakePdf(tempHtml.Key, PdfFilePath, PageLayout.SizeAndOrientation.PageSizeName,
-						PageLayout.SizeAndOrientation.IsLandScape, LayoutPagesForRightToLeft,
-						layoutMethod, BookletPortion, worker, doWorkEventArgs, View);
+						PageLayout.SizeAndOrientation.IsLandScape, _currentlyLoadedBook.UserPrefs.ReducePdfMemoryUse,
+						LayoutPagesForRightToLeft, layoutMethod, BookletPortion, worker, doWorkEventArgs, View);
 					// Warn the user if we're starting to use too much memory.
 					SIL.Windows.Forms.Reporting.MemoryManagement.CheckMemory(false, "finished creating PDF file", true);
 				}

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -339,6 +339,13 @@ namespace Bloom.Publish
 			}
 			_layoutChoices.Text = LocalizationManager.GetDynamicString("Bloom", "LayoutChoices." + layout, layout.ToString());
 
+			_layoutChoices.DropDownItems.Add(new ToolStripSeparator());
+			var textItem = LocalizationManager.GetDynamicString("Bloom", "lessMemoryPdfMode", "Use less memory (slower)");
+			var menuItem = (ToolStripMenuItem) _layoutChoices.DropDownItems.Add(textItem);
+			menuItem.Checked = _model.BookSelection.CurrentSelection.UserPrefs.ReducePdfMemoryUse;
+			menuItem.CheckOnClick = true;
+			menuItem.CheckedChanged += OnSinglePageModeChanged;
+
 			// "EditTab" because it is the same text.  No sense in having it listed twice.
 			_layoutChoices.ToolTipText = LocalizationManager.GetString("EditTab.PageSizeAndOrientation.Tooltip",
 				"Choose a page size and orientation");
@@ -352,6 +359,12 @@ namespace Bloom.Publish
 			ClearRadioButtons();
 			UpdateDisplay();
 			SetDisplayMode(PublishModel.DisplayModes.WaitForUserToChooseSomething);
+		}
+
+		private void OnSinglePageModeChanged(object sender, EventArgs e)
+		{
+			var item = (ToolStripMenuItem)sender;
+			_model.BookSelection.CurrentSelection.UserPrefs.ReducePdfMemoryUse = item.Checked;
 		}
 
 		public void SetDisplayMode(PublishModel.DisplayModes displayMode)

--- a/src/BloomTests/PdfMakerTests.cs
+++ b/src/BloomTests/PdfMakerTests.cs
@@ -30,7 +30,7 @@ namespace BloomTestsThatAvoidTheSetupFixture
 			{
 				File.WriteAllText(input.Path, "<html><body>Hello</body></html>");
 				File.Delete(output.Path);
-				RunMakePdf(maker, input.Path, output.Path, "a5", false, false,
+				RunMakePdf(maker, input.Path, output.Path, "a5", false, false, false,
 					PublishModel.BookletLayoutMethod.SideFold, PublishModel.BookletPortions.AllPagesNoBooklet);
 				//we don't actually have a way of knowing it did a booklet
 				Assert.IsTrue(File.Exists(output.Path), "Failed to convert trivial HTML file to PDF (AllPagesNoBooklet)");
@@ -50,7 +50,7 @@ namespace BloomTestsThatAvoidTheSetupFixture
 			{
 				File.WriteAllText(input.Path, "<html><body>Hello</body></html>");
 				File.Delete(output.Path);
-				RunMakePdf(maker, input.Path, output.Path, "A5", false, false,
+				RunMakePdf(maker, input.Path, output.Path, "A5", false, false, false,
 					PublishModel.BookletLayoutMethod.SideFold, PublishModel.BookletPortions.BookletPages);
 				//we don't actually have a way of knowing it did a booklet
 				Assert.IsTrue(File.Exists(output.Path), "Failed to convert trivial HTML file to PDF (BookletPages)");
@@ -73,7 +73,7 @@ namespace BloomTestsThatAvoidTheSetupFixture
 			{
 				RobustFile.WriteAllText(input.Path, "<html><body>北京</body></html>");
 				RobustFile.Delete(output.Path);
-				RunMakePdf(maker, input.Path, output.Path, "A5", false, false,
+				RunMakePdf(maker, input.Path, output.Path, "A5", false, false, false,
 					PublishModel.BookletLayoutMethod.SideFold, PublishModel.BookletPortions.BookletPages);
 				//we don't actually have a way of knowing it did a booklet
 				Assert.IsTrue(File.Exists(output.Path), "Failed to convert trivial HTML file to PDF (Chinese filenames and content)");
@@ -93,7 +93,7 @@ namespace BloomTestsThatAvoidTheSetupFixture
 			{
 				File.WriteAllText(input.Path, "<META HTTP-EQUIV=\"content-type\" CONTENT=\"text/html; charset=utf-8\"><html><body>എന്റെ ബുക്ക്</body></html>");
 				File.Delete(output.Path);
-				RunMakePdf(maker, input.Path, output.Path, "A5", false, false,
+				RunMakePdf(maker, input.Path, output.Path, "A5", false, false, false,
 					PublishModel.BookletLayoutMethod.SideFold, PublishModel.BookletPortions.BookletPages);
 				//we don't actually have a way of knowing it did a booklet
 				Assert.IsTrue(File.Exists(output.Path), "Failed to convert trivial HTML file to PDF (Indic script filenames and content)");
@@ -117,14 +117,14 @@ namespace BloomTestsThatAvoidTheSetupFixture
 		/// almost certainly an obscure bug in Mono.  Running the method directly as we do here sidesteps that
 		/// problem.  (See https://jira.sil.org/browse/BL-831.)
 		/// </remarks>
-		void RunMakePdf(PdfMaker maker, string input, string output, string paperSize, bool landscape, bool rightToLeft,
+		void RunMakePdf(PdfMaker maker, string input, string output, string paperSize, bool landscape, bool saveMemoryMode, bool rightToLeft,
 			PublishModel.BookletLayoutMethod layout, PublishModel.BookletPortions portion)
 		{
 			// Passing in a DoWorkEventArgs object prevents a possible exception being thrown.  Which may not
 			// really matter much in the test situation since NUnit would catch the exception.  But I'd rather
 			// have a nice test failure message than an unexpected exception caught message.
 			var eventArgs = new DoWorkEventArgs(null);
-			maker.MakePdf(input, output, paperSize, landscape, rightToLeft, layout, portion, null, eventArgs, null);
+			maker.MakePdf(input, output, paperSize, landscape, saveMemoryMode, rightToLeft, layout, portion, null, eventArgs, null);
 		}
 	}
 }


### PR DESCRIPTION
This allows low-memory machines (at least for Windows) to create
PDF files that otherwise would require too much memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1311)
<!-- Reviewable:end -->
