### PR TITLE
Fix Linux packaging to build with Bloom.sln

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -25,12 +25,12 @@ override_dh_auto_build:
 	build/getDependencies-Linux.sh
 	. ./environ && \
 		xbuild /t:SetAssemblyVersion /p:RootDir=$(shell pwd) /p:BUILD_NUMBER=$(FULL_BUILD_NUMBER) build/Bloom.proj && \
-		xbuild /p:Configuration=$(BUILD) "BloomLinux.sln"
+		xbuild /p:Configuration=$(BUILD) "Bloom.sln"
 
 override_dh_auto_test:
 
 override_dh_auto_clean:
-	. ./environ && xbuild /p:Configuration=$(BUILD) "BloomLinux.sln" /t:Clean
+	. ./environ && xbuild /p:Configuration=$(BUILD) "Bloom.sln" /t:Clean
 	dh_clean
 
 override_dh_auto_install:


### PR DESCRIPTION
This should have been part of my earlier removal of BloomLinux.sln.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1317)
<!-- Reviewable:end -->
