### PR TITLE
BL-3717 Cut:Don't cleanup unused images

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -967,10 +967,16 @@ namespace Bloom.Edit
 				var editor = new PageEditingModel();
 				editor.ChangePicture(CurrentBook.FolderPath, new ElementProxy(img), imageInfo, progress);
 
-				//we have to save so that when asked by the thumbnailer, the book will give the proper image
+				// We need to save so that when asked by the thumbnailer, the book will give the proper image
 				SaveNow();
-				CurrentBook.Storage.CleanupUnusedImageFiles();
-				//but then, we need the non-cleaned version back there
+
+				// BL-3717: if we cleanup unused image files whenever we change a picture then Cut can lose
+				// all of an image's metadata (because the actual file is missing from the book folder when we go to
+				// paste in the image that was copied onto the clipboard, which doesn't have metadata.)
+				// Let's only do this on ExpensiveIntialization() when loading a book.
+				//CurrentBook.Storage.CleanupUnusedImageFiles();
+
+				// But after saving, we need the non-cleaned version back there
 				_view.UpdateSingleDisplayedPage(_pageSelection.CurrentSelection);
 
 				_view.UpdateThumbnailAsync(_pageSelection.CurrentSelection);


### PR DESCRIPTION
until we load a book (ExpensiveInitialization)
This enables Cut -> Paste to remember the
image metadata.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1320)
<!-- Reviewable:end -->
