### PR TITLE
BL-3569 Rename files for clarity

### DIFF
--- a/src/BloomBrowserUI/bookLayout/basePage-sharedRules.less
+++ b/src/BloomBrowserUI/bookLayout/basePage-sharedRules.less
@@ -1,4 +1,6 @@
-﻿body {
+﻿// Styles that are shared by both the regular book css and the more minimalist epub css.
+
+body {
 	line-height: 1.5;
 	font-family: "Andika New Basic", Andika, "Andika Basic", "Gentium Basic", "Gentium Book Basic", "Doulos SIL", Sans-Serif;
 }

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -1,5 +1,5 @@
 @import "../templates/common-mixins.less";
-@import "CommonBasePageEPUB.less";
+@import "basePage-sharedRules.less";
 
 .Browser-Reset() {
 	/*+init {*/

--- a/src/BloomBrowserUI/ePUB/baseEPUB.less
+++ b/src/BloomBrowserUI/ePUB/baseEPUB.less
@@ -3,8 +3,8 @@
 // The remaining rules are things that wound up slightly different from the printed book rules
 // for reasons which I mostly don't remember; unfortunately, the experiments leading to the
 // final epub PR were spread out over a long period.
-@import "../bookLayout/CommonBasePageEPUB.less";
-@import "../templates/xMatter/BloomXMatterEPUBCommon.less";
+@import "../bookLayout/basePage-sharedRules.less";
+@import "../templates/xMatter/bloom-xmatter-sharedRules.less";
 
 .frontCover {
     .bloom-translationGroup.bookTitle {

--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-common.less
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-common.less
@@ -1,5 +1,5 @@
 @import "../common-mixins.less";
-@import "BloomXMatterEPUBCommon.less";
+@import "bloom-xmatter-sharedRules.less";
 
 @XMatterPackName: "unknown";
 

--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-sharedRules.less
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-sharedRules.less
@@ -1,4 +1,4 @@
-﻿// Styles that are used in both regular books front matter and in epubs.
+﻿// Styles that are shared by both the regular book front matter css and the more minimalist epub front matter css.
 
 @MarginBetweenBlocks: 2em;
 


### PR DESCRIPTION
A couple of files were labeled EPUB when actually they
were subsets of rules that were used by regular books
AND Epubs.
* renamed files using *-sharedRules.less
* comments in the files explain why they are in
   separate files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1325)
<!-- Reviewable:end -->
