### PR TITLE
Create temporary files in book folder if needed (BL-3954)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2060,7 +2060,11 @@ namespace Bloom.Book
 			var template = RobustFile.ReadAllText(_storage.GetFileLocator().LocateFileWithThrow("languageDisplayTemplate.css"));
 			var path = _storage.FolderPath.CombineForPath("languageDisplay.css");
 
-			using (var temp = TempFile.WithExtension(".css"))
+			// Use a temporary file pathname in the current book's folder.  This is needed to ensure proper permissions are granted
+			// to the resulting file later after FileUtils.ReplaceFileWithUserInteractionIfNeeded is called.  That method may call
+			// File.Replace which replaces both the file content and the file metadata (permissions).  The result of that if we use
+			// the user's temp directory is described in http://issues.bloomlibrary.org/youtrack/issue/BL-3954.
+			using (var temp = TempFile.InFolderOf(path))	// We don't need a .css extension for the temporary file.
 			{
 				RobustFile.WriteAllText(temp.Path,
 					template.Replace("VERNACULAR", _collectionSettings.Language1Iso639Code)

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -284,16 +284,20 @@ namespace Bloom.ImageProcessing
 
 			//nb: there are cases (notably http://jira.palaso.org/issues/browse/WS-34711, after cropping a jpeg) where we get out of memory if we are not operating on a copy
 
-			using (var tempPath = new TempFile())
+			// Use a temporary file pathname in the destination folder.  This is needed to ensure proper permissions are granted
+			// to the resulting file later after FileUtils.ReplaceFileWithUserInteractionIfNeeded is called.  That method may call
+			// File.Replace which replaces both the file content and the file metadata (permissions).  The result of that if we use
+			// the user's temp directory is described in http://issues.bloomlibrary.org/youtrack/issue/BL-3954.
+			using (var temp = TempFile.InFolderOf(destinationPath))
 			using (var safetyImage = new Bitmap(image))
 			{
 				using(var parameters = new EncoderParameters(1))
 				{
 					//0 = max compression, 100 = least
 					parameters.Param[0] = new EncoderParameter(encoder, 100L);
-					SIL.IO.RobustIO.SaveImage(safetyImage, tempPath.Path, jpgEncoder, parameters);
+					SIL.IO.RobustIO.SaveImage(safetyImage, temp.Path, jpgEncoder, parameters);
 				}
-				SIL.IO.FileUtils.ReplaceFileWithUserInteractionIfNeeded(tempPath.Path, destinationPath, null);
+				SIL.IO.FileUtils.ReplaceFileWithUserInteractionIfNeeded(temp.Path, destinationPath, null);
 			}
 		}
 


### PR DESCRIPTION
This preserves the proper permissions for access over a network
file share.

This is an alternative to https://github.com/BloomBooks/BloomDesktop/pull/1322.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1327)
<!-- Reviewable:end -->
