### PR TITLE
BL-4026 Allow ISBN font to follow style

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.jade
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.jade
@@ -40,7 +40,7 @@ mixin field-ISBN
 	.ISBNContainer(data-hint="International Standard Book Number. Leave blank if you don't have one of these.")
 		span.bloom-doNotPublishIfParentOtherwiseEmpty.Credits-Page-style
 			| ISBN
-		div.bloom-editable(data-book="ISBN", lang="*").Credits-Page-style.bloom-userCannotModifyStyles
+		div.bloom-editable(data-book="ISBN", lang="*").Credits-Page-style
 
 mixin field-acknowledgments-localizedVersion
 	// readOnlyInAuthorMode: we want to leave this blank for if/when someone takes this doc and is translating it.


### PR DESCRIPTION
Credits-Page-style (language agnostic version)
currently affects both label and number, but this
change makes it so the user can modify that
'non-language' version of the style.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1334)
<!-- Reviewable:end -->
