### PR TITLE
BL-3549 Make Calendar default to reasonable year

### DIFF
--- a/src/BloomBrowserUI/templates/template books/Wall Calendar/configuration.jade
+++ b/src/BloomBrowserUI/templates/template books/Wall Calendar/configuration.jade
@@ -5,10 +5,11 @@ html
 		title Set Up Calendar
 		link(rel="stylesheet" href="configuration.css" type="text/css")
 		script(type="text/javascript" src="jquery-1.10.1.js")
-	body
+		script(type="text/javascript" src="configure.js")
+	body(onload="getYear()")
 		form#form
 			label.year Year
-			input.year(name="calendar.year" type="number" value="2015")
+			input.year(name="calendar.year" type="number" value="2015")#dateInput
 			#dayNames
 				h1 Day Names
 				label Sunday

--- a/src/BloomBrowserUI/templates/template books/Wall Calendar/configure.js
+++ b/src/BloomBrowserUI/templates/template books/Wall Calendar/configure.js
@@ -1,7 +1,19 @@
 //
-// Typescript configuration file for Bloom Wall Calendar
+// Javascript configuration file for Bloom Wall Calendar
 //
-// Creates calendar pages for a Bloom book.
+// This function is input to the configuration dialog (run by "onload").
+// Get a default year for the Calendar configuration dialog
+// If after May use next year, otherwise use the current year.
+function getYear() {
+    var d = new Date();
+    var month = d.getMonth() + 1;
+    var year = d.getFullYear();
+
+    var x = document.getElementById("dateInput");
+    x.value = month > 5 ? year + 1 : year;
+}
+
+// The rest of this file takes the configuration dialog input and creates calendar pages for a Bloom book.
 //
 //   This script is fed a configuration object as a JSON string with the following elements:
 //       configuration.calendar.year
@@ -13,8 +25,6 @@
 //   This script relies on the 2 pages that should be in the DOM it operates on:
 //       One with classes 'calendarMonthTop'
 //       One with classes 'calendarMonthBottom'
-//
-/// <reference path="jquery.d.ts" />
 //
 // This is the main public entry point called by Configurator.ConfigureBookInternal()
 // in a context where the current dom is the book.


### PR DESCRIPTION
* If after the month of May, use next year
* Otherwise use the current year

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1338)
<!-- Reviewable:end -->
