### PR TITLE
Prevent bogus message about missing page (BL-3715)

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -213,7 +213,9 @@ namespace Bloom.Edit
 				SaveNow(); //ensure current page is saved first
 				_domForCurrentPage = null; //prevent us trying to save it later, as the page selection changes
 				_currentlyDisplayedBook.DuplicatePage(page);
-				_view.UpdatePageList(false);
+				// Book.DuplicatePage() updates the page list so we don't need to do it here.
+				// (See http://issues.bloomlibrary.org/youtrack/issue/BL-3715.)
+				//_view.UpdatePageList(false);
 				Logger.WriteEvent("Duplicate Page");
 				Analytics.Track("Duplicate Page");
 			}


### PR DESCRIPTION
This is prevented by not duplicating calls to Browser.Navigate by not
duplicating calls to EditingView.UpdatePageList.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1339)
<!-- Reviewable:end -->
