### PR TITLE
Handle decimal.TryParse deterministically

### DIFF
--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -509,7 +509,10 @@ namespace Bloom.Collection
 		{
 			var s = GetValue(library, id, defaultValue.ToString(CultureInfo.InvariantCulture));
 			decimal d;
-			decimal.TryParse(s, out d);
+			// REVIEW: if we localize the display of decimal values in the line-height combo box, then this
+			// needs to handle the localized version of the number.  (This happens automatically by removing
+			// the middle two arguments.)
+			decimal.TryParse(s, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out d);
 			return d;
 		}
 


### PR DESCRIPTION
This works properly with the current way decimal values for line heights
are displayed in CollectionSettingsDialog and stored in the settings file.
If that display should be localized, some adjustment would be needed to
ensure compatible storage and decoding of these decimal values.

Without this fix, line height setting would be forgotten for any locale that
does not use . for "decimal points".  (This fix is a follow-on to BL-4040.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1343)
<!-- Reviewable:end -->
