### PR TITLE
Remove Chorus from Linux packaging

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,5 +1,3 @@
-lib/dotnet/Chorus.exe.mdb usr/lib/bloom-desktop-unstable/
-lib/dotnet/LibChorus.dll.mdb usr/lib/bloom-desktop-unstable/
 lib/dotnet/SIL.Archiving.dll.mdb usr/lib/bloom-desktop-unstable/
 lib/dotnet/SIL.Core.dll.mdb usr/lib/bloom-desktop-unstable/
 lib/dotnet/SIL.Media.dll.mdb usr/lib/bloom-desktop-unstable/


### PR DESCRIPTION
It's been removed everywhere else already, and packages aren't
building on jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1344)
<!-- Reviewable:end -->
