### PR TITLE
Fix Linux packages.config to match Windows

### DIFF
--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -6,7 +6,7 @@
   <package id="AWSSDK.S3" version="3.3.1" targetFramework="net461" />
   <package id="CommandLineParser" version="2.0.275-beta" targetFramework="net461" />
   <package id="DeltaCompressionDotNet" version="1.1.0" targetFramework="net461" />
-  <package id="DesktopAnalytics" version="1.2.3" targetFramework="net461" />
+  <package id="DesktopAnalytics" version="1.2.4.1" targetFramework="net461" />
   <package id="EasyHttp" version="1.6.86.0" targetFramework="net461" />
   <package id="Fleck" version="0.14.0.59" targetFramework="net461" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net461" />


### PR DESCRIPTION
Without this fix, Bloom won't even build on Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1351)
<!-- Reviewable:end -->
