### PR TITLE
BL-4041 New Collection Wizard error

### DIFF
--- a/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
+++ b/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
@@ -218,12 +218,11 @@ namespace Bloom.CollectionCreating
 			Close();
 		}
 
-
 		private void OnCancel(object sender, EventArgs e)
 		{
 			DialogResult = DialogResult.Cancel;
-			_collectionInfo = null;
 			Close();
+			_collectionInfo = null;
 		}
 
 		protected override bool ProcessCmdKey(ref Message msg, Keys keyData)


### PR DESCRIPTION
This is not a proper Form, or it would have a
settable CancelButton property. Instead we have to
rely on the ProcessCmdKey override. Not ideal.
Moving the nullification of the collection variable after the Close() should
prevent the problem in the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1357)
<!-- Reviewable:end -->
