### PR TITLE
BL-4027/9 and 4036 TextBox Properties dialog

### DIFF
--- a/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.ts
+++ b/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.ts
@@ -1,0 +1,148 @@
+import theOneLocalizationManager from '../../lib/localizationManager/localizationManager';
+import { EditableDivUtils } from "../js/editableDivUtils";
+
+declare function WebFxTabPane(element: HTMLElement, useCookie: boolean, callback: any): any; // from tabpane, from a <script> tag
+
+export default class TextBoxProperties {
+
+    private _previousBox: Element;
+    private boxBeingEdited: HTMLElement;
+    private _supportFilesRoot: string;
+    private ignoreControlChanges: boolean;
+    private authorMode: boolean; // true if authoring (rather than translating)
+
+    constructor(supportFilesRoot: string) {
+        this._supportFilesRoot = supportFilesRoot;
+    }
+
+    // This method is called when the origami panel gets focus.
+    AttachToBox(targetBox: HTMLElement) {
+        var propDlg = this;
+        this._previousBox = targetBox;
+
+        // put the format button in the text box itself, so that it's always in the right place.
+        $(targetBox).append('<div id="formatButton" contenteditable="false" class="bloom-ui"><img  contenteditable="false" src="' + propDlg._supportFilesRoot + '/img/cogGrey.svg"></div>');
+
+        var formatButton = $('#formatButton');
+
+        // BL-2476: Readers made from BloomPacks should have formatting dialogs disabled
+        var suppress = $(document).find('meta[name="lockFormatting"]');
+        var noFormatChange = suppress.length > 0 && suppress.attr('content').toLowerCase() === 'true';
+
+        // Why do we use .off and .on? See comment in a nearly identical location in StyleEditor.ts
+        $(targetBox).off('click.formatButton');
+        $(targetBox).on('click.formatButton', '#formatButton', function () {
+            propDlg.boxBeingEdited = targetBox;
+
+            // If this text box has had properties set already, get them so we can setup the dialog contents
+            // if not already set, this will return 'Auto'
+            var languageGroup = propDlg.getTextBoxLanguage(targetBox);
+
+            var html = '<div id="text-properties-dialog" class="bloom-ui bloomDialogContainer">'
+                + '<div data-i18n="EditTab.TextBoxProperties.Title" class="bloomDialogTitleBar">Text Box Properties</div>';
+            if (noFormatChange) {
+                // Review gjm: Is this true for this dialog?
+                var translation = theOneLocalizationManager.getText('BookEditor.FormattingDisabled', 'Sorry, Reader Templates do not allow changes to formatting.');
+                html += '<div class="bloomDialogMainPage"><p>' + translation + '</p></div>';
+            }
+            else {
+                html += '<div class="tab-pane" id="tabRoot">';
+                html += '<div class="tab-page">'
+                    + '<h2 class="tab" data-i18n="EditTab.TextBoxProperties.LanguageTab">Language</h2>'
+                    + '<div style="width: 420px; font-size: 8pt; margin-top: 10px;" data-i18n="EditTab.TextBoxProperties.NormalLabel">'
+                    + '"Normal" will show local language, and potentially regional or national, depending on the bilingual settings of the book. Use this for most content.'
+                    + '</div>'
+                    + '<div id="language-group">'
+                    + '<input type="radio" style="margin-left: 5px;" name="languageRadioGroup" value="Auto"'
+                    + propDlg.getCheckedValue(languageGroup, "Auto") + '> Normal</input><br/>'
+                    + '<div style="width: 420px; font-size: 8pt; margin-top: 10px;" data-i18n="EditTab.TextBoxProperties.OtherLanguagesLabel">'
+                    + 'Use one of these for simple text boxes that are always in only one language.'
+                    + '</div>'
+                    + '<input type="radio" style="margin-left: 5px;" name="languageRadioGroup" value="N1"'
+                    + propDlg.getCheckedValue(languageGroup, "N1") + '> National Language</input><br/>'
+                    + '<input type="radio" style="margin-left: 5px;" name="languageRadioGroup" value="N2"'
+                    + propDlg.getCheckedValue(languageGroup, "N2") + '> Regional Language</input><br/>'
+                    + '<input type="radio" style="margin-left: 5px;" name="languageRadioGroup" value="V"'
+                    + propDlg.getCheckedValue(languageGroup, "V") + '> Local Language</input><br/>'
+                    + '</div>' // end of #language-group div
+                    + '</div>'; // end of Language tab-page div
+                // Here follows a skeleton implementation of tabs 2 and 3
+                // html += '<div class="tab-page" id="bordersPage"><h2 class="tab" data-i18n="EditTab.TextBoxProperties.BordersTab">Borders</h2>'
+                //     // + propDlg.makeBordersContent(currentBorder)
+                //     + '</div>' // end of tab-page div for borders tab
+                //     + '<div class="tab-page" id="bubblesPage"><h2 class="tab" data-i18n="EditTab.TextBoxProperties.BubblesTab">Hint Bubbles</h2>'
+                //     // + propDlg.makeBubblesContent(currentBubbles)
+                //     + '</div>' // end of tab-page div for hint bubbles tab
+                html += '</div>'; // end of tab-pane div
+            }
+            html += '</div>'; // end of text-properties-dialog div
+            $('#text-properties-dialog').remove(); // in case there's still one somewhere else
+            $('body').append(html);
+
+            var dialogElement = $('#text-properties-dialog');
+            dialogElement.find('*[data-i18n]').localize();
+            dialogElement.draggable({ distance: 10, scroll: false, containment: $('html') });
+            dialogElement.draggable("disable"); // until after we make sure it's in the Viewport
+            dialogElement.css('opacity', 1.0);
+            if (!noFormatChange) {
+                // Hook up change event handlers
+                $('#language-group').change(function () { propDlg.changeLanguageGroup(); });
+                new WebFXTabPane($('#tabRoot').get(0), false, null);
+            }
+            // Give the browser time to get the dialog into the DOM first, before doing this stuff
+            // It just needs to delay one 'cycle'.
+            // http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
+            setTimeout(function () {
+                var offset = $('#formatButton').offset();
+                dialogElement.offset({ left: offset.left + 30, top: offset.top - 30 });
+                EditableDivUtils.positionInViewport(dialogElement);
+                dialogElement.draggable("enable");
+
+                $('html').off('click.dialogElement');
+                $('html').on("click.dialogElement", function (event) {
+                    if (event.target !== dialogElement.get(0) &&
+                        dialogElement.has(event.target).length === 0 &&
+                        $(event.target).parent() !== dialogElement &&
+                        dialogElement.has(event.target).length === 0 &&
+                        dialogElement.is(":visible")) {
+                        dialogElement.remove();
+                        event.stopPropagation();
+                        event.preventDefault();
+                    }
+                });
+                dialogElement.on("click.dialogElement", function (event) {
+                    // this stops an event inside the dialog from propagating to the html element, which would close the dialog
+                    event.stopPropagation();
+                });
+            }, 0); // just push this to the end of the event queue
+        })
+    }
+
+    changeLanguageGroup() {
+        // get radio button value and set 'data-default-languages' attribute
+        var radioValue = $('input[name="languageRadioGroup"]:checked').val();
+        var targetGroup = $(this.getAffectedTranslationGroup(this.boxBeingEdited));
+        // currently 'radioValue' should be one of: 'Auto', 'N1', 'N2', or 'V'
+        if (targetGroup)
+            targetGroup.attr('data-default-languages', radioValue);
+    }
+
+    getTextBoxLanguage(targetBox: HTMLElement): string {
+        var targetGroup = $(this.getAffectedTranslationGroup(targetBox));
+        if (!targetGroup || !targetGroup.hasAttr('data-default-languages')) return "Auto";
+        var result = targetGroup.attr('data-default-languages');
+        const acceptable = ['Auto', 'N1', 'N2', 'V'];
+        return acceptable.indexOf(result) > -1 ? result : 'Auto';
+    }
+
+    getAffectedTranslationGroup(targetBox: HTMLElement): HTMLElement {
+        var container = $(targetBox).parent();
+        // I'm not sure (gjm) how often another translationGroup with box-header-off shows up,
+        // but I found at least one instance, so make sure that's not the one we grab.
+        return container.find('.bloom-translationGroup:not(.box-header-off)')[0];
+    }
+
+    getCheckedValue(value: string, compareTo: string): string {
+        return (value == compareTo) ? ' checked="true"' : '';
+    }
+}

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -92,4 +92,44 @@ export class EditableDivUtils {
     // an equivalent place in an adjacent node).
     return false;
   }
+
+  static WaitForCKEditorReady(window: Window, targetBox: any, callback: (target: any) => any) {
+    var editorInstances = (<any>window).CKEDITOR.instances;
+    for (var i = 1; ; i++) {
+      var instance = editorInstances['editor' + i];
+      if (instance == null) {
+        break; // if we get here all instances are ready
+      }
+      if (!instance.instanceReady) {
+        instance.on('instanceReady', e => callback(targetBox));
+        return;
+      }
+    }
+  }
+
+  // Positions the dialog box so that it is completely visible, so that it does not extend below the
+  // current viewport.
+  // @param dialogBox
+  static positionInViewport(dialogBox: JQuery): void {
+
+    // get the current size and position of the dialogBox
+    var elem: HTMLElement = dialogBox[0];
+    var top = elem.offsetTop;
+    var height = elem.offsetHeight;
+
+    // get the top of the dialogBox in relation to the top of its containing elements
+    while (elem.offsetParent) {
+      elem = <HTMLElement>elem.offsetParent;
+      top += elem.offsetTop;
+    }
+
+    // diff is the portion of the dialogBox that is below the viewport
+    var diff = (top + height) - (window.pageYOffset + window.innerHeight);
+    if (diff > 0) {
+      var offset = dialogBox.offset();
+
+      // the extra 30 pixels is for padding
+      dialogBox.offset({ left: offset.left, top: offset.top - diff - 30 });
+    }
+  }
 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -5,7 +5,7 @@ import 'jquery-ui/jquery-ui-1.10.3.custom.min.js';
 import '../../lib/jquery.i18n.custom';
 import "../../lib/jquery.onSafe";
 import axios = require('axios');
-import {EditableDivUtils} from '../js/editableDivUtils';
+import { EditableDivUtils } from '../js/editableDivUtils';
 
 /**
  * The html code for a check mark character
@@ -105,8 +105,8 @@ export class ToolBox {
      */
     static fireCSharpToolboxEvent(eventName: string, eventData: string) {
 
-    var event = new MessageEvent(eventName, {'bubbles' : true, 'cancelable' : true, 'data' : eventData});
-    top.document.dispatchEvent(event);
+        var event = new MessageEvent(eventName, { 'bubbles': true, 'cancelable': true, 'data': eventData });
+        top.document.dispatchEvent(event);
     }
 
     static getTabModels() { return tabModels; }
@@ -177,28 +177,7 @@ function restoreToolboxSettingsWhenPageReady(settings: string) {
 
 function restoreToolboxSettingsWhenCkEditorReady(settings: string) {
     if ((<any>getPageFrame().contentWindow).CKEDITOR) {
-        var editorInstances = (<any>getPageFrame().contentWindow).CKEDITOR.instances;
-        // Somewhere in the process of initializing ckeditor, it resets content to what it was initially.
-        // This wipes out (at least) our page initialization.
-        // To prevent this we hold our initialization until CKEditor has done initializing.
-        // If any instance on the page (e.g., one per div) is not ready, wait until all are.
-        // (The instances property leads to an object in which a field editorN is defined for each
-        // editor, so we just loop until some value of N which doesn't yield an editor instance.)
-        for (var i = 1; ; i++) {
-            var instance = editorInstances['editor' + i];
-            if (instance == null) {
-                if (i === 0) {
-                    // no instance at all...if one is later created, get us invoked.
-                    (<any>this.getPageFrame().contentWindow).CKEDITOR.on('instanceReady', e => restoreToolboxSettingsWhenCkEditorReady(settings));
-                    return;
-                }
-                break; // if we get here all instances are ready
-            }
-            if (!instance.instanceReady) {
-                instance.on('instanceReady', e => restoreToolboxSettingsWhenCkEditorReady(settings));
-                return;
-            }
-        }
+        EditableDivUtils.WaitForCKEditorReady(<any>getPageFrame().contentWindow, settings, restoreToolboxSettingsWhenCkEditorReady);
     }
     // OK, CKEditor is done (or page doesn't use it), we can finally do the real initialization.
     var opts = settings;


### PR DESCRIPTION
* hook up dialog
* factor out common code to editableDivUtils from
   StyleEditor, toolbox and TextBoxProperties
* put basic Language tab UI in place
* get dialog to install data-default-languages attribute
   in appropriate translationGroup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1359)
<!-- Reviewable:end -->
