### PR TITLE
Fix epub tests

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -152,9 +152,9 @@ namespace Bloom.Book
 		internal bool UseOriginalImages { get; set; }
 
 
-		public void AddStyleSheet(string locateFile)
+		public void AddStyleSheet(string path)
 		{
-			RawDom.AddStyleSheet(locateFile);
+			RawDom.AddStyleSheet(path);
 		}
 
 		public XmlNodeList SafeSelectNodes(string xpath)

--- a/src/BloomExe/Publish/EpubMaker.cs
+++ b/src/BloomExe/Publish/EpubMaker.cs
@@ -463,6 +463,12 @@ namespace Bloom.Publish
 		private HtmlDom MakePageFile(XmlElement pageElement, int pageIndex, int firstContentPageIndex)
 		{
 			var pageDom = GetEpubFriendlyHtmlDomForPage(pageElement);
+
+			// Note, the following stylsheet stuff can be quite bewildering...
+			// Testing shows that these stylesheets are not actually used
+			// in RemoveUnwantedContent(), which falls back to the stylsheets in place for the book, which in turn,
+			// in unit tests, is backed by a simple mocked BookStorage which doesn't have the stylesheet smarts. Sigh.
+
 			pageDom.RemoveModeStyleSheets();
 			if (Unpaginated)
 			{
@@ -477,11 +483,11 @@ namespace Bloom.Publish
 				pageDom.AddStyleSheet(Storage.GetFileLocator().LocateFileWithThrow(@"basePage.css").ToLocalhost());
 				pageDom.AddStyleSheet(Storage.GetFileLocator().LocateFileWithThrow(@"previewMode.css"));
 				pageDom.AddStyleSheet(Storage.GetFileLocator().LocateFileWithThrow(@"origami.css"));
-				pageDom.AddStyleSheet(Storage.GetFileLocator().LocateFileWithThrow(@"languageDisplay.css"));
 			}
 
 			RemoveUnwantedContent(pageDom);
 
+			pageDom.AddStyleSheet("languageDisplay.css");
 			pageDom.SortStyleSheetLinks();
 			pageDom.AddPublishClassToBody();
 

--- a/src/BloomTests/Publish/ExportEpubTests.cs
+++ b/src/BloomTests/Publish/ExportEpubTests.cs
@@ -514,7 +514,7 @@ namespace BloomTests.Publish
 						@"<div class='bloom-editable' lang='xyz'><label class='bubble'>Book title in {lang} should be removed</label>vernacular text (content1) should always display</div>
 								<div class='bloom-editable' lang='fr'>French text (second national language) should not display</div>
 								<div class='bloom-editable' lang='de'>German should never display in this collection</div>",
-					extraStyleSheet: "<link rel='stylesheet' href='basePage.css' type='text/css'></link><link rel='stylesheet' href='Factory-XMatter/Factory-XMatter.css' type='text/css'></link>",
+					extraStyleSheet: "<link rel='stylesheet' href='languageDisplay.css' type='text/css'/><link rel='stylesheet' href='basePage.css' type='text/css'></link><link rel='stylesheet' href='Factory-XMatter/Factory-XMatter.css' type='text/css'></link>",
 					extraEditGroupClasses: "bookTitle",
 					defaultLanguages: "V,N1");
 
@@ -566,7 +566,7 @@ namespace BloomTests.Publish
 								<div class='bloom-editable' lang='fr'>National 2 should not be displayed</div>
 								<div class='bloom-editable' lang='de'>German should never display in this collection</div>",
 					extraStyleSheet:
-						"<link rel='stylesheet' href='basePage.css' type='text/css'></link><link rel='stylesheet' href='Factory-XMatter/Factory-XMatter.css' type='text/css'></link>",
+						"<link rel='stylesheet' href='languageDisplay.css' type='text/css'/> <link rel='stylesheet' href='basePage.css' type='text/css'></link><link rel='stylesheet' href='Factory-XMatter/Factory-XMatter.css' type='text/css'></link>",
 					extraEditGroupClasses: "originalAcknowledgments",
 					defaultLanguages: "N1");
 


### PR DESCRIPTION
Added languagedisplay.css to tests. Had to hold my nose while doing this, it feels like a hack. Every unit test should not have to be updted to whatever the current stylesheet system is; but the system of detecting which fields are visible actually *goes around* the stylesheets of the actual page, so that the only stylesheets it sees are what have been added to the unit test. Very frustrating, but not worth more time now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1371)
<!-- Reviewable:end -->
