### PR TITLE
Don't crash if no body element (BL-3988)

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -963,7 +963,12 @@ namespace Bloom.Edit
 				return null;
 			// The following line looks like it should work, but it doesn't (at least not reliably in Geckofx45).
 			// return frame.ContentDocument.Body;
-			return frame.ContentWindow.Document.GetElementsByTagName("body").First();
+			// On a fast shutdown of Bloom, while it is redisplaying, we can get an empty enumeration.
+			// See http://issues.bloomlibrary.org/youtrack/issue/BL-3988.
+			var elements = frame.ContentWindow.Document.GetElementsByTagName("body");
+			if (elements.Length == 0)
+				return null;
+			return elements.First();
 		}
 
 		/// <summary>


### PR DESCRIPTION
With this fix, I haven't been to provoke  a problematic shutdown on my (fast) Windows 10 machine.  On Linux, I can still provoke shutdowns where the program hangs during shutdown and has to be manually killed one way or another.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1377)
<!-- Reviewable:end -->
