### PR TITLE
Remove bogus "build dates" BL-4095

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -936,6 +936,9 @@ Anyone looking specifically at our issue tracking system can read what you sent 
 ", issueTrackingUrl);
 			SIL.Reporting.ErrorReport.EmailAddress = "issues@bloomlibrary.org";
 			SIL.Reporting.ErrorReport.AddStandardProperties();
+			// with squirrel, the file's dates only reflect when they were installed, so we override this version thing which
+			// normally would include a bogus "Apparently Built On" date:
+			ErrorReport.Properties["Version"] = ErrorReport.VersionNumberString + " " + ApplicationUpdateSupport.ChannelName;
 			SIL.Reporting.ExceptionHandler.Init();
 
 			ExceptionHandler.AddDelegate((w,e) => DesktopAnalytics.Analytics.ReportException(e.Exception));

--- a/src/BloomExe/Shell.cs
+++ b/src/BloomExe/Shell.cs
@@ -149,18 +149,6 @@ namespace Bloom
 			Text = formattedText;
 		}
 
-		public static string GetBuiltOnDate()
-		{
-			var asm = Assembly.GetExecutingAssembly();
-			var ver = asm.GetName().Version;
-			var file = asm.CodeBase.Replace("file://", string.Empty);
-			if (SIL.PlatformUtilities.Platform.IsWindows)
-				file = file.TrimStart('/');
-			var fi = new FileInfo(file);
-
-			return string.Format("{0}",fi.CreationTimeUtc.ToString("dd-MMM-yyyy"));
-		}
-
 		public static string GetShortVersionInfo()
 		{
 			var asm = Assembly.GetExecutingAssembly();

--- a/src/BloomExe/SplashScreen.cs
+++ b/src/BloomExe/SplashScreen.cs
@@ -36,7 +36,7 @@ namespace Bloom
 		{
 			InitializeComponent();
 			_shortVersionLabel.Text = Shell.GetShortVersionInfo();
-			_longVersionInfo.Text = Shell.GetBuiltOnDate();
+			_longVersionInfo.Text = "";
 			_feedbackStatusLabel.Visible = !DesktopAnalytics.Analytics.AllowTracking;
 		}
 


### PR DESCRIPTION
We could probably fish out the appropriate nupkg and get its date, but that doesn't feel worth it at the moment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1380)
<!-- Reviewable:end -->
