### PR TITLE
Fix Linux packages.config to match revised Windows file

### DIFF
--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -10,7 +10,6 @@
   <package id="EasyHttp" version="1.6.86.0" targetFramework="net461" />
   <package id="Fleck" version="0.14.0.59" targetFramework="net461" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net461" />
-  <package id="ICSharpCode.SharpZipLib.dll" version="0.85.4.369" targetFramework="net461" />
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net461" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net461" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net461" />
@@ -18,6 +17,7 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NuGet.Core" version="2.12.0" targetFramework="net461" />
   <package id="RestSharp" version="105.2.3" targetFramework="net461" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net461" />
   <package id="SourceMapDotNet" version="1.0.5478.26629" targetFramework="net461" />
   <package id="TechTalk.JiraRestClient.RestSharp105" version="2.3.0.1" targetFramework="net461" />
   <!-- Linux specific packages.  Changes above this line must be copied to ../packages.config -->

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <!-- If you edit this file, don't forget to also edit ./Linux/packages.config appropriately! -->
   <package id="Analytics" version="2.0.2" targetFramework="net461" />
   <package id="Autofac" version="4.1.1" targetFramework="net461" />
   <package id="AWSSDK.Core" version="3.3.2.1" targetFramework="net461" />


### PR DESCRIPTION
Bloom won't build on Linux without this fix.  Well, at least the first file of the fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1382)
<!-- Reviewable:end -->
