### PR TITLE
BL-4037 Further Text Box Properties dialog changes

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -532,8 +532,24 @@ export default class StyleEditor {
         // config.allowedContent, and data-cke-survive did not work.
         // The only solution we have found is to postpone adding the gear icon until CkEditor has done
         // its nefarious work. The following block achieves this.
-        // gjm: Refactored it into EditableDivUtils.
-        EditableDivUtils.WaitForCKEditorReady(window, targetBox, this.AttachToBox);
+        // Enhance: this logic is roughly duplicated in toolbox.ts restoreToolboxSettingsWhenCkEditorReady.
+        // There may be some way to refactor it into a common place, but I don't know where.
+        var editorInstances = (<any>window).CKEDITOR.instances;
+        for (var i = 1; ; i++) {
+            var instance = editorInstances['editor' + i];
+            if (instance == null) {
+                if (i === 0) {
+                    // no instance at all...if one is later created, get us invoked.
+                    (<any>window).CKEDITOR.on('instanceReady', e => this.AttachToBox(targetBox));
+                    return;
+                }
+                break; // if we get here all instances are ready
+            }
+            if (!instance.instanceReady) {
+                instance.on('instanceReady', e => this.AttachToBox(targetBox));
+                return;
+            }
+        }
 
         var styleName = StyleEditor.GetStyleNameForElement(targetBox);
         if (!styleName)

--- a/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.ts
+++ b/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.ts
@@ -152,7 +152,7 @@ export default class TextBoxProperties {
 
     // The z-index puts the formatButton above the origami-ui stuff so a click will find it.
     getDialogActivationButton(): string {
-        return '<div style="z-index: 60000; position: absolute; left:0; bottom: 0;" contenteditable="false" class="bloom-ui formatButton">'
+        return '<div contenteditable="false" class="bloom-ui formatButton">'
             + '<img  contenteditable="false" src="' + this._supportFilesRoot + '/img/cogGrey.svg"></div>';
     }
 }

--- a/src/BloomBrowserUI/bookEdit/css/origami.less
+++ b/src/BloomBrowserUI/bookEdit/css/origami.less
@@ -224,7 +224,7 @@
 .origami-layout-mode .split-pane-component-inner .textBox-identifier {
     /*content: "Text Box";*/
     color: @inactiveColor;
-    white-space: nowrap;
+    white-space: normal;
     transition-property: font-size;
     transition-duration: 0.5s;
     text-align: center;
@@ -232,6 +232,11 @@
     position: absolute;
     top: 45%;
     z-index: 50000;
+    .formatButton {
+        z-index: 60000;
+        padding-left: 10px;
+        display: inline-flex;
+    }
 }
 .container-selector-links {
 	display: none;

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -93,20 +93,6 @@ export class EditableDivUtils {
         return false;
     }
 
-    static WaitForCKEditorReady(window: Window, targetBox: any, callback: (target: any) => any) {
-        var editorInstances = (<any>window).CKEDITOR.instances;
-        for (var i = 1; ; i++) {
-            var instance = editorInstances['editor' + i];
-            if (instance == null) {
-                break; // if we get here all instances are ready
-            }
-            if (!instance.instanceReady) {
-                instance.on('instanceReady', e => callback(targetBox));
-                return;
-            }
-        }
-    }
-
     // Positions the dialog box so that it is completely visible, so that it does not extend below the
     // current viewport.
     // @param dialogBox

--- a/src/BloomBrowserUI/bookEdit/js/origami.ts
+++ b/src/BloomBrowserUI/bookEdit/js/origami.ts
@@ -58,15 +58,16 @@ function setupLayoutMode() {
             // split-panes represent an area that has already been split. A reasonable repair is
             // to remove the split-pane-component-inner, leaving its contents.
             $this.find('.split-pane').unwrap();
-            return true; // continue
+            return true; // continue .each()
         }
         if (!$this.find('.bloom-imageContainer, .bloom-translationGroup:not(.box-header-off)').length)
             $this.append(getTypeSelectors());
 
         $this.append(getButtons());
         var contents = $this.find('.bloom-translationGroup:not(.box-header-off) > .bloom-editable');
-        if ($this.find('.bloom-imageContainer').length)
-            return true; // don't put text box identifier in image container!
+        // don't put text box identifier in image container or where we just put the "Picture or Text"" selector links
+        if ($this.find('.bloom-imageContainer, .selector-links').length)
+            return true; // continue .each()
         $this.append(getTextBoxIdentifier());
     });
     // Text should not be editable in layout mode
@@ -83,7 +84,8 @@ function setupLayoutMode() {
         }
     });
 
-    (<any>window).ElementQueries.init();//have  css-element-queries notice the new elements and track them, adding classes that let rules trigger depending on size
+    //have  css-element-queries notice the new elements and track them, adding classes that let rules trigger depending on size
+    (<any>window).ElementQueries.init();
 }
 
 function layoutToggleClickHandler() {


### PR DESCRIPTION
* un-refactor looking for 'ready' CKEditor instances
* fix overlapping "Picture or Text" links and "Text Box"
* reposition gear to end of "Text Box" identifier
   (and put the gear styles in origami.less)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1385)
<!-- Reviewable:end -->
