### PR TITLE
Tweak color of disabled buttons on Linux (BL-3714)

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -87,11 +87,11 @@ namespace Bloom.Edit
 			SetupBrowserContextMenu();
 #if __MonoCS__
 			// The inactive button images look garishly pink on Linux/Mono, but look okay on Windows.
-			// Reduce the red component of the colors for these images to make the inactive images dull blueish
-			// instead of bright pinkish.  (The active form looks okay with or without this fix.)
+			// Merely introducing an "identity color matrix" to the image attributes appears to fix
+			// this problem.  (The active form looks okay with or without this fix.)
 			// See http://issues.bloomlibrary.org/youtrack/issue/BL-3714.
 			float[][] colorMatrixElements = {
-				new float[] {.5F,0,  0,  0,  0},		// red scaling factor of 0.5
+				new float[] {1,  0,  0,  0,  0},		// red scaling factor of 1
 				new float[] {0,  1,  0,  0,  0},		// green scaling factor of 1
 				new float[] {0,  0,  1,  0,  0},		// blue scaling factor of 1
 				new float[] {0,  0,  0,  1,  0},		// alpha scaling factor of 1


### PR DESCRIPTION
With this tweak, the disabled buttons look more like light grey as you would expect, and closely match the color of the associated text.  I have no idea why an identity transformation matrix would have this affect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1387)
<!-- Reviewable:end -->
