### PR TITLE
Tell what the failed license URL was when we can't parse it. BL-4108

### DIFF
--- a/src/BloomExe/Book/BookCopyrightAndLicense.cs
+++ b/src/BloomExe/Book/BookCopyrightAndLicense.cs
@@ -60,8 +60,14 @@ namespace Bloom.Book
 			}
 			else // there is a licenseUrl, which means it is a CC license
 			{
-				metadata.License = CreativeCommonsLicense.FromLicenseUrl(licenseUrl);
-
+				try
+				{
+					metadata.License = CreativeCommonsLicense.FromLicenseUrl(licenseUrl);
+				}
+				catch (Exception e)
+				{
+					throw new ApplicationException("Bloom had trouble parsing this license url: '" + licenseUrl + "'. (ref BL-4108)", e);
+				}
 				//are there notes that go along with that?
 				var licenseNotes = dom.GetBookSetting("licenseNotes");
 				if(!licenseNotes.Empty)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1391)
<!-- Reviewable:end -->
