### PR TITLE
Add audio recording for Linux (BL-3935)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -327,7 +327,7 @@ export default class AudioRecording {
                         if (data.devices.length == 2) {
                                 // Just toggle between them
                                 var device = (data.devices[0] == data.productName) ? data.devices[1] : data.devices[0];
-                                axios.post("/bloom/api/audio/currentRecordingDevice", device)
+                                axios.post("/bloom/api/audio/currentRecordingDevice", device, {headers:{'Content-Type':'text/plain'}})
                                         .then(result=>{
                                                  this.updateInputDeviceDisplay();
                                         })
@@ -343,7 +343,7 @@ export default class AudioRecording {
                         }
                         (<any>devList).one("click", function(event) {
                                         devList.hide();
-                                        axios.post("/bloom/api/audio/currentRecordingDevice", $(event.target).text())
+                                        axios.post("/bloom/api/audio/currentRecordingDevice", $(event.target).text(), {headers:{'Content-Type':'text/plain'}})
                                          .then(result=>{
                                                  this.updateInputDeviceDisplay();
                                         }).catch(error=>{
@@ -370,10 +370,10 @@ export default class AudioRecording {
 
                         // This seems a reasonable default to suggest what needs to be connected
                         // if nothing is. It's also the default if we don't recognize anything significant in the name.
-                        var imageName = 'Microphone.svg';
+                        var imageName = 'microphone.svg';
                         if (genericName !== null) {
                                 if (genericName.indexOf('Internal') >= 0 || genericName.indexOf('Array') >= 0) imageName = 'Computer.png';
-                                else if (genericName.indexOf('USB Audio Device') >= 0 || genericName.indexOf('Headse') >= 0) imageName = 'HeadSet.png';
+                                else if (genericName.indexOf('USB Audio') >= 0 || genericName.indexOf('Headse') >= 0) imageName = 'HeadSet.png';
 
                                 if (deviceName.indexOf('ZOOM') >= 0) imageName = 'Recorder.png';
                                 else if (deviceName.indexOf('Plantronics') >= 0 || deviceName.indexOf('Andrea') >= 0 || deviceName.indexOf('Microphone (VXi X200') >= 0) imageName = 'HeadSet.png';

--- a/src/BloomExe/Edit/LameEncoder.cs
+++ b/src/BloomExe/Edit/LameEncoder.cs
@@ -64,7 +64,10 @@ namespace Bloom.Edit
 		/// <returns>the path, if found, else null</returns>
 		static private string LocateLAME()
 		{
-#if !MONO
+#if __MonoCS__
+			if (File.Exists("/usr/bin/lame"))
+				return "/usr/bin/lame";
+#else
 			//nb: this is sensitive to whether we are compiled against win32 or not,
 			//not just the host OS, as you might guess.
 			var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
@@ -83,8 +86,8 @@ namespace Bloom.Edit
 				if (RobustFile.Exists(exePath))
 					return exePath;
 			}
-			return string.Empty;
 #endif
+			return string.Empty;
 		}
 	}
 }

--- a/src/BloomExe/Edit/ToolboxView.cs
+++ b/src/BloomExe/Edit/ToolboxView.cs
@@ -102,10 +102,6 @@ namespace Bloom.Edit
 			toolsToDisplay.AddRange(
 				idsOfToolsThisVersionKnowsAbout.Except(
 					toolsThatHaveDataInBookInfo.Select(t => t.ToolId)).Select(ToolboxTool.CreateFromToolId));
-#if __MonoCS__
-			// Until we get sound working on Linux, there's no point in showing a nonfunctional tool!
-			toolsToDisplay = toolsToDisplay.Where(t => t.ToolId != TalkingBookTool.StaticToolId).ToList();
-#endif
 			return toolsToDisplay.Where(t => t.Enabled || t.AlwaysEnabled).ToList();
 		}
 


### PR DESCRIPTION
This uses the work I did for Linux FieldWorks sound recording,
implementing Bloom tailored forms of SIL.Media.NAudio.AudioRecorder
and related classes.  (without any use of NAudio, of course)

I think this implements everything except trimming the wav file and showing
(and adjusting?) the recording levels.  It even allows switching input devices
inside the program, and detecting when devices are added or removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1397)
<!-- Reviewable:end -->
