### PR TITLE
Fix row order of elements in Arithmetic template (BL-4144)

### DIFF
--- a/src/BloomBrowserUI/templates/template books/Arithmetic Template/ArithmeticTemplate.less
+++ b/src/BloomBrowserUI/templates/template books/Arithmetic Template/ArithmeticTemplate.less
@@ -44,6 +44,7 @@
             display: block !important; // so that text-align works
             text-align: center;
             line-height: 1em;
+            order: unset; // to remove the 99 default which misaligns the .equals and .fillInBox elements
         }
         padding-right: 5px;
         & > .bloom-editable {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1407)
<!-- Reviewable:end -->
