### PR TITLE
BL-4163 Don't update if running on Vista

### DIFF
--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -48,6 +48,18 @@ namespace Bloom
 		internal static async void CheckForASquirrelUpdate(BloomUpdateMessageVerbosity verbosity, Action<string> restartBloom, bool autoUpdate)
 		{
 #if !__MonoCS__
+			// Warning: Environment.OSVERsion.Version is potentially flaky. It won't return a higher version than 6.2 (Win8) unless
+			// Bloom's manifest says it knows about that version. Currently that gives good values up to 10.0 for Windows 10 (or above).
+			if (Environment.OSVersion.Version < Version.Parse("6.2"))
+			{
+				// Running Vista or before. Can't update to 3.8+. This logic is only in the last 3.7, which is the last ever
+				// version for Vista, so we just don't update.
+				var osNotifier = new ToastNotifier();
+				osNotifier.Image.Image = Resources.BloomIcon.ToBitmap();
+				string message = LocalizationManager.GetString("CollectionTab.UpdateRequiresLaterOS", "Bloom cannot be updated on this version of Windows");
+				osNotifier.Show(message, "", 5);
+				return;
+			}
 			if (OkToInitiateUpdateManager)
 			{
 				string updateUrl;


### PR DESCRIPTION
This change is intended to be put only in a final 3.7 which we will release
for the purpose of preventing Vista updating to later (3.8) versions
since they require an incompatible version of .NET.

Do NOT merge into master or any later branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1411)
<!-- Reviewable:end -->
