### PR TITLE
BL-4191 Catch exception when sending data to JS fails

### DIFF
--- a/src/BloomExe/web/RequestInfo.cs
+++ b/src/BloomExe/web/RequestInfo.cs
@@ -78,8 +78,19 @@ namespace Bloom.Api
 		{
 			response.ContentLength64 += buffer.Length;
 			Stream output = response.OutputStream;
-			output.Write(buffer, 0, buffer.Length);
-			output.Close();
+			try
+			{
+				output.Write(buffer, 0, buffer.Length);
+				output.Close();
+			}
+			catch (HttpListenerException e)
+			{
+				// We may well be unable to write if, while we were gathering the data, the user switched
+				// pages or something similar so that the page that requested the data is gone. This seems
+				// to produce this particular exception type.
+				Logger.WriteEvent("Could not write requested data to JavaScript: " + e.Message + e.StackTrace);
+				Debug.WriteLine(e.Message);
+			}
 			HaveOutput = true;
 		}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1419)
<!-- Reviewable:end -->
