### PR TITLE
BL-4148 Fix lost image metadata

### DIFF
--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -203,20 +203,21 @@ namespace Bloom.ImageProcessing
 				{
 					if (!AppearsToBeJpeg(pi))
 					{
-						RemoveTransparency(pi.Image, path, progress);
+						RemoveTransparency(pi, path, progress);
 					}
 				}
 				completed++;
 			}
 		}
 
-		private static void RemoveTransparency(Image original, string path, IProgress progress)
+		private static void RemoveTransparency(PalasoImage original, string path, IProgress progress)
 		{
 			progress.WriteStatus("RemovingTransparency from image: " + Path.GetFileName(path));
-			using (var b = new Bitmap(original.Width, original.Height))
+			using (var b = new Bitmap(original.Image.Width, original.Image.Height))
 			{
-				DrawImageWithWhiteBackground(original, b);
-				SIL.IO.RobustIO.SaveImage(b, path, ImageFormat.Png);
+				DrawImageWithWhiteBackground(original.Image, b);
+				original.Image = b;
+				RobustIO.SavePalasoImage(original, path); // BL-4148: this method preserves existing metadata
 			}
 		}
 


### PR DESCRIPTION
Our process for removing transparency was stripping out metadata too.
(cherry picked from commit b2f78a5b02f9b0b2e014504c1d6daf0396885c1e)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1420)
<!-- Reviewable:end -->
