### PR TITLE
Fix problems with epub embedded fonts (BL-4146)

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -24,6 +24,7 @@ namespace Bloom.Book
 	public class HtmlDom
 	{
 		public const string RelativePathAttrName = "data-base";
+		private static readonly Regex s_regexBangImportant = new Regex("\\s*!\\s*important\\s*", RegexOptions.Compiled);
 		private XmlDocument _dom;
 
 		public HtmlDom()
@@ -904,7 +905,13 @@ namespace Bloom.Book
 			return attr.Value;
 		}
 
-		public static void FindFontsUsedInCss(string cssContent, HashSet<string> result)
+		/// <summary>
+		/// Finds a list of fonts used in the given css
+		/// </summary>
+		/// <param name="cssContent"></param>
+		/// <param name="result"></param>
+		/// <param name="includeFallbackFonts">true to include fallback fonts, false to include only the first font in each font family</param>
+		public static void FindFontsUsedInCss(string cssContent, HashSet<string> result, bool includeFallbackFonts)
 		{
 			var findFF = new Regex("font-family:\\s*([^;}]*)[;}]");
 			foreach (Match match in findFF.Matches(cssContent))
@@ -915,7 +922,11 @@ namespace Bloom.Book
 					// Strip matched quotes
 					if (name[0] == '\'' || name[0] == '"' && name[0] == name[name.Length - 1])
 						name = name.Substring(1, name.Length - 2);
-					result.Add(name);
+					name = s_regexBangImportant.Replace(name, "");
+					if (name.ToLowerInvariant() != "inherit" && name.ToLowerInvariant() != "segoe ui")
+						result.Add(name);
+					if (!includeFallbackFonts)
+						break;
 				}
 			}
 		}

--- a/src/BloomExe/Publish/EpubMaker.cs
+++ b/src/BloomExe/Publish/EpubMaker.cs
@@ -564,7 +564,11 @@ namespace Bloom.Publish
 		/// </summary>
 		private void EmbedFonts()
 		{
-			var fontsWanted = GetFontsUsed();
+			// The 'false' here says to ignore all but the first font face in CSS's ordered lists of desired font faces.
+			// If someone is publishing an Epub, they should have that font showing. For one thing, this makes it easier
+			// for us to not embed fonts we don't want/ need.For another, it makes it less likely that an epub will look
+			// different or have glyph errors when shown on a machine that does have that primary font.
+			var fontsWanted = GetFontsUsed(Book.FolderPath, false);
 			var fontFileFinder = new FontFileFinder();
 			var filesToEmbed = fontsWanted.SelectMany(fontFileFinder.GetFilesForFont).ToArray();
 			foreach (var file in filesToEmbed)
@@ -602,14 +606,17 @@ namespace Bloom.Publish
 		/// bit of text what actual font and face it is using.
 		/// For now we examine the stylesheets and collect the font families they mention.
 		/// </summary>
+		/// <param name="bookPath"></param>
+		/// <param name="includeFallbackFonts"></param>
 		/// <returns></returns>
-		private IEnumerable<string> GetFontsUsed()
+		private IEnumerable<string> GetFontsUsed(string bookPath, bool includeFallbackFonts)
 		{
 			var result = new HashSet<string>();
-			foreach (var ss in Directory.GetFiles(Book.FolderPath, "*.css"))
+			// Css for styles are contained in the actual html
+			foreach (var ss in Directory.EnumerateFiles(bookPath, "*.*").Where(f => f.EndsWith(".css") || f.EndsWith(".htm") || f.EndsWith(".html")))
 			{
 				var root = RobustFile.ReadAllText(ss, Encoding.UTF8);
-				HtmlDom.FindFontsUsedInCss(root, result);
+				HtmlDom.FindFontsUsedInCss(root, result, includeFallbackFonts);
 			}
 			return result;
 		}

--- a/src/BloomTests/Publish/ExportEpubTests.cs
+++ b/src/BloomTests/Publish/ExportEpubTests.cs
@@ -586,7 +586,7 @@ namespace BloomTests.Publish
 		public void FindFontsUsedInCss_FindsSimpleFontFamily()
 		{
 			var results = new HashSet<string>();
-			HtmlDom.FindFontsUsedInCss("body {font-family:Arial}", results);
+			HtmlDom.FindFontsUsedInCss("body {font-family:Arial}", results, true);
 			Assert.That(results, Has.Count.EqualTo(1));
 			Assert.That(results.Contains("Arial"));
 		}
@@ -595,21 +595,73 @@ namespace BloomTests.Publish
 		public void FindFontsUsedInCss_FindsQuotedFontFamily()
 		{
 			var results = new HashSet<string>();
-			HtmlDom.FindFontsUsedInCss("body {font-family:'Times New Roman'}", results);
-			HtmlDom.FindFontsUsedInCss("body {font-family:\"Andika New Basic\"}", results);
+			HtmlDom.FindFontsUsedInCss("body {font-family:'Times New Roman'}", results, true);
+			HtmlDom.FindFontsUsedInCss("body {font-family:\"Andika New Basic\"}", results, true);
 			Assert.That(results, Has.Count.EqualTo(2));
 			Assert.That(results.Contains("Times New Roman"));
 			Assert.That(results.Contains("Andika New Basic"));
 		}
 
 		[Test]
-		public void FindFontsUsedInCss_FindsMultipleFontFamilies()
+		public void FindFontsUsedInCss_IncludeFallbackFontsTrue_FindsMultipleFontFamilies()
 		{
 			var results = new HashSet<string>();
-			HtmlDom.FindFontsUsedInCss("body {font-family: 'Times New Roman', Arial,\"Andika New Basic\";}", results);
+			HtmlDom.FindFontsUsedInCss("body {font-family: 'Times New Roman', Arial,\"Andika New Basic\";}", results, true);
 			Assert.That(results, Has.Count.EqualTo(3));
 			Assert.That(results.Contains("Times New Roman"));
 			Assert.That(results.Contains("Andika New Basic"));
+			Assert.That(results.Contains("Arial"));
+		}
+
+		[Test]
+		public void FindFontsUsedInCss_IncludeFallbackFontsFalse_FindsFirstFontInEachList()
+		{
+			var results = new HashSet<string>();
+			HtmlDom.FindFontsUsedInCss("body {font-family: 'Times New Roman', Arial,\"Andika New Basic\";} " +
+			                           "div {font-family: Font1, \"Font2\";} " +
+			                           "p {font-family: \"Font3\";}", results, false);
+			Assert.That(results, Has.Count.EqualTo(3));
+			Assert.That(results.Contains("Times New Roman"));
+			Assert.That(results.Contains("Font1"));
+			Assert.That(results.Contains("Font3"));
+		}
+
+		[TestCase("Arial !important")]
+		[TestCase("Arial ! important")]
+		[TestCase("Arial ! important ")]
+		[TestCase("Arial  ! important , Times New Roman")]
+		public void FindFontsUsedInCss_RemovesBangImportant(string fontFamily)
+		{
+			var results = new HashSet<string>();
+			HtmlDom.FindFontsUsedInCss("body {font-family:" + fontFamily + "}", results, false);
+			Assert.That(results, Has.Count.EqualTo(1));
+			Assert.That(results.Contains("Arial"));
+		}
+
+		[Test]
+		public void FindFontsUsedInCss_IgnoresInherit()
+		{
+			var results = new HashSet<string>();
+			HtmlDom.FindFontsUsedInCss("body {font-family:inherit}", results, false);
+			Assert.That(results, Has.Count.EqualTo(0));
+		}
+
+		[TestCase("Segoe UI", true)]
+		[TestCase("Segoe UI", false)]
+		[TestCase("segoe ui,Arial", false)]
+		public void FindFontsUsedInCss_IgnoresSegoeUi(string fontFamily, bool includeFallbackFonts)
+		{
+			var results = new HashSet<string>();
+			HtmlDom.FindFontsUsedInCss("body {font-family:" + fontFamily + "}", results, includeFallbackFonts);
+			Assert.That(results, Has.Count.EqualTo(0));
+		}
+
+		[TestCase("segoe ui,Arial")]
+		public void FindFontsUsedInCss_IgnoresSegoeUi(string fontFamily)
+		{
+			var results = new HashSet<string>();
+			HtmlDom.FindFontsUsedInCss("body {font-family:" + fontFamily + "}", results, true);
+			Assert.That(results, Has.Count.EqualTo(1));
 			Assert.That(results.Contains("Arial"));
 		}
 


### PR DESCRIPTION
We weren't including fonts for styles
We were embedding extra fonts

This was cherry-picked from 3.8 but then changed to implement the includeFallbackFonts flag.

(cherry picked from commit d6ae7e9c6f993187cc2fcdbff3dd392411738702)

Conflicts:
-	src/BloomExe/Book/HtmlDom.cs
-	src/BloomExe/CLI/GetUsedFontsCommand.cs
-	src/BloomExe/Publish/EpubMaker.cs
-	src/BloomTests/Publish/ExportEpubTests.cs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1428)
<!-- Reviewable:end -->
