### PR TITLE
Fix Linux packaging for architecture dependency

### DIFF
--- a/debian/README
+++ b/debian/README
@@ -1,5 +1,5 @@
-The Debian Package bloom-desktop
---------------------------------
+The Debian Package bloom-desktop-beta
+-------------------------------------
 
 This is a native package, because the packaging is maintained by the project
 itself.

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
  icu-devtools | libicu-dev (<< 52)
 
 Package: bloom-desktop-beta
-Architecture: all
+Architecture: any
 Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  mono4-sil, libgdiplus4-sil, gtklp,
  chmsee, libtidy5,
@@ -27,7 +27,8 @@ Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  optipng, libsndfile1,
  wmctrl
 Suggests: art-of-reading
-Replaces: bloom-desktop, bloom-desktop-unstable
+Replaces: bloom-desktop, bloom-desktop-alpha
+Conflicts: bloom-desktop-unstable
 Description: Literacy materials development for language communities
  Bloom Desktop is an application that dramatically "lowers the bar" for
  language communities who want books in their own languages. Bloom delivers

--- a/debian/rules
+++ b/debian/rules
@@ -78,7 +78,7 @@ override_dh_makeclilibs:
 
 # Include mono4-sil in shlib dirs searched
 override_dh_shlibdeps:
-	dh_shlibdeps -l$(MONO_PREFIX)/lib
+	dh_shlibdeps -l$(MONO_PREFIX)/lib --exclude=Firefox
 
 # Include mono4-sil in cli dirs searched
 override_dh_clideps:


### PR DESCRIPTION
This is required by the embedded geckofx45 with firefox binaries.

DO NOT MERGE THESE CHANGES WITH ANY OTHER BRANCH.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1429)
<!-- Reviewable:end -->
