### PR TITLE
[3.7]BL-4160 Make Bloom not complain about backups

### DIFF
--- a/src/BloomExe/Book/BookStarter.cs
+++ b/src/BloomExe/Book/BookStarter.cs
@@ -79,8 +79,10 @@ namespace Bloom.Book
 
 		private string GetPathToHtmlFile(string folder)
 		{
-			var candidates = from x in Directory.GetFiles(folder, "*.htm")
-							 where !(x.ToLowerInvariant().EndsWith("configuration.htm"))
+			// BL-4160: GetFiles here also returns files that end in, for example, ".html.bak"
+			var candidates = from x in Directory.GetFiles(folder, "*.htm", SearchOption.TopDirectoryOnly)
+							 where !x.ToLowerInvariant().EndsWith("configuration.htm") &&
+							 (x.ToLowerInvariant().EndsWith(".htm") || x.ToLowerInvariant().EndsWith(".html"))
 							 select x;
 			if (candidates.Count() == 1)
 				return candidates.First();


### PR DESCRIPTION
* GetFiles finds the search pattern anywhere in the
   filename
* made the search for a single htm file more restrictive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1430)
<!-- Reviewable:end -->
