### PR TITLE
DO NOT MERGE BEYOND 3.7 -- Move fixed DeleteDirectoryRobust from libpalaso to Bloom (BL-4141)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -285,6 +285,7 @@
     <Compile Include="Book\DataSet.cs" />
     <Compile Include="Book\StyleSheetLinkSorter.cs" />
     <Compile Include="Book\TranslationGroupManager.cs" />
+    <Compile Include="ToPalaso\DirectoryUtilities.cs" />
     <Compile Include="ToPalaso\SafeInvoke.cs" />
     <Compile Include="UrlPathString.cs" />
     <Compile Include="Book\UserPrefs.cs" />

--- a/src/BloomExe/Publish/EpubMaker.cs
+++ b/src/BloomExe/Publish/EpubMaker.cs
@@ -119,7 +119,9 @@ namespace Bloom.Publish
 			Debug.Assert(_stagingFolder == null, "EpubMaker should only be used once");
 			
 			//I (JH) kept having trouble making epubs because this kept getting locked.
-			SIL.IO.DirectoryUtilities.DeleteDirectoryRobust(Path.Combine(Path.GetTempPath(), kEPUBExportFolder));
+			// Ideally, this would be SIL.IO.DirectoryUtilities.DeleteDirectoryRobust or RobustIO.DeleteDirectory.
+			// See comment on Bloom.ToPalaso.DirectoryUtilities.DeleteDirectoryRobust.
+			Bloom.ToPalaso.DirectoryUtilities.DeleteDirectoryRobust(Path.Combine(Path.GetTempPath(), kEPUBExportFolder));
 
 			_stagingFolder = new TemporaryFolder(kEPUBExportFolder);
 			// The readium control remembers the current page for each book.

--- a/src/BloomExe/TempFiles.cs
+++ b/src/BloomExe/TempFiles.cs
@@ -246,7 +246,9 @@ namespace BloomTemp
 			{
 				try
 				{
-					RobustIO.DeleteDirectory(folder, true);
+					// Ideally, would be RobustIO.DeleteDirectory(folder, true);
+					// See comment on Bloom.ToPalaso.DirectoryUtilities.DeleteDirectoryRobust
+					Bloom.ToPalaso.DirectoryUtilities.DeleteDirectoryRobust(folder);
 				}
 				catch (Exception e)
 				{
@@ -267,7 +269,9 @@ namespace BloomTemp
 						}
 						//sleep and try again (in case some other thread will  let go of them)
 						Thread.Sleep(1000);
-						RobustIO.DeleteDirectory(folder, true);
+						// Ideally, whould be RobustIO.DeleteDirectory(folder, true);
+						// See comment on Bloom.ToPalaso.DirectoryUtilities.DeleteDirectoryRobust
+						Bloom.ToPalaso.DirectoryUtilities.DeleteDirectoryRobust(folder);
 					}
 					catch (Exception)
 					{

--- a/src/BloomExe/ToPalaso/DirectoryUtilities.cs
+++ b/src/BloomExe/ToPalaso/DirectoryUtilities.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+
+namespace Bloom.ToPalaso
+{
+	class DirectoryUtilities
+	{
+		/// <summary>
+		/// There are various things which can prevent a simple directory deletion, mostly timing related things which are hard to debug.
+		/// This method uses all the tricks to do its best.
+		///
+		/// *****************************************************************************************************************************
+		/// NOTE: This method actual resides in libpalaso. However, there was a fix made to it which we needed in 3.7, and in an
+		/// attempt to prevent destabilizing 3.7, we decided not to include the 20-something changes made to libpalaso after our
+		/// 3.7 tag on the Teamcity build of libpalaso. So, we simply copied the method here which includes the fix.
+		/// Since this change is only for 3.7, we shouldn't ever need to remove it as 3.8+ use the libpalaso version.
+		/// http://issues.bloomlibrary.org/youtrack/issue/BL-4141
+		/// *****************************************************************************************************************************
+		///
+		/// </summary>
+		/// <returns>returns true if the directory is fully deleted</returns>
+		public static bool DeleteDirectoryRobust(string path, bool overrideReadOnly = true)
+		{
+			// ReSharper disable EmptyGeneralCatchClause
+			for (int i = 0; i < 40; i++) // each time, we sleep a little. This will try for up to 2 seconds (40*50ms)
+			{
+				if (!Directory.Exists(path))
+					break;
+
+				try
+				{
+					Directory.Delete(path, true);
+				}
+				catch (Exception)
+				{
+				}
+
+				if (!Directory.Exists(path))
+					break;
+
+				try
+				{
+					//try to clear it out a bit
+					string[] dirs = Directory.GetDirectories(path);
+					string[] files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories);
+					foreach (string filePath in files)
+					{
+						try
+						{
+							if (overrideReadOnly)
+							{
+								File.SetAttributes(filePath, FileAttributes.Normal);
+							}
+							File.Delete(filePath);
+						}
+						catch (Exception)
+						{
+						}
+					}
+					foreach (var dir in dirs)
+					{
+						DeleteDirectoryRobust(dir);
+					}
+
+				}
+				catch (Exception)//yes, even these simple queries can throw exceptions, as stuff suddenly is deleted based on our prior request
+				{
+				}
+				//sleep and let some OS things catch up
+				Thread.Sleep(50);
+			}
+
+			return !Directory.Exists(path);
+			// ReSharper restore EmptyGeneralCatchClause
+		}
+	}
+}


### PR DESCRIPTION
This fix is only for Version3.7 and should not be merged to other branches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1434)
<!-- Reviewable:end -->
