### PR TITLE
[3.8]BL-4184 Incomplete DR setup messes w LR counts

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -1193,15 +1193,16 @@ export class ReaderToolsModel {
         // remember how many we are loading so we know when we're finished
         this.allowedWordFilesRemaining = stages.length;
 
-        stages.forEach(function (stage, index) {
+        stages.forEach((stage, index) => {
             // BL-4184: Even if the decodable reader setup doesn't have a filename for each stage,
             // we need to ensure that execution still passes through the "if all loaded" section of
             // the setAllowedWordsListList() method.
-            if (stage.allowedWordsFile)
+            if (stage.allowedWordsFile) {
                 axios.get<string>('/bloom/api/readers/io/allowedWordsList', { params: { 'fileName': stage.allowedWordsFile } })
-                   .then(result => this.setAllowedWordsListList(result.data, index));
-            else
+                    .then(result => this.setAllowedWordsListList(result.data, index));
+            } else {
                 this.setAllowedWordsListList(null, index);
+            }
             // During Linux testing of BL-3498, the this (_this in the TS converted to JS), in the axios.get callback was
             // undefined without this bind().  This .bind() is also the fix for BL-3496.
             // But apparently when we switched to TS v2.0, it's no longer needed
@@ -1213,8 +1214,9 @@ export class ReaderToolsModel {
         // remove this one from the count of files remaining
         this.allowedWordFilesRemaining--;
 
-    if (fileContents)
-        this.synphony.getStages()[stageIndex].setAllowedWordsString(fileContents);
+        if (fileContents) {
+            this.synphony.getStages()[stageIndex].setAllowedWordsString(fileContents);
+        }
 
         // if all loaded...
         if (this.allowedWordFilesRemaining < 1) {


### PR DESCRIPTION
* what worked in 3.7 doesn't quite in 3.8
* apparently function(x,y) {} isn't quite the same as
   (x,y) => {}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1443)
<!-- Reviewable:end -->
