### PR TITLE
[3.8]BL-4199 Arithmetic pages equals

### DIFF
--- a/src/BloomBrowserUI/templates/template books/Arithmetic Template/ArithmeticTemplate.less
+++ b/src/BloomBrowserUI/templates/template books/Arithmetic Template/ArithmeticTemplate.less
@@ -98,3 +98,7 @@
     height: 90px;
 }
 
+.Equation-style {
+    font-size: 28pt !important;
+    text-align: center !important;
+}

--- a/src/BloomBrowserUI/templates/template books/Arithmetic Template/ArithmeticTemplate.pug
+++ b/src/BloomBrowserUI/templates/template books/Arithmetic Template/ArithmeticTemplate.pug
@@ -40,8 +40,6 @@ html
 		title 'Arithmetic'
 		+stylesheets('ArithmeticTemplate.css')
 		+standardStyles
-		style(type="text/css" title="userModifiedStyles")
-			| .Equation-style { font-size: 28pt !important; text-align: center !important; }
 	body
 		+dataDiv
 			+bookVariable-title('en', 'Arithmetic')


### PR DESCRIPTION
* moved Equation-style from Usermodifiedstyles
   (where it couldn't move to a different template)
   to ArithmeticTemplate.less (which does go with
   the page to another template)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1444)
<!-- Reviewable:end -->
