### PR TITLE
BL-3624 allow editing original contributions

### DIFF
--- a/DistFiles/factoryCollections/Sample Shells/The Moon and the Cap/The Moon and the Cap.htm
+++ b/DistFiles/factoryCollections/Sample Shells/The Moon and the Cap/The Moon and the Cap.htm
@@ -240,17 +240,17 @@
 
                 <div lang="z" contenteditable="true" class="bloom-editable bloom-copyFromOtherLanguageIfNecessary Credits-Page-style" data-book="originalAcknowledgments"></div>
 
-                <div lang="es" contenteditable="true" class="bloom-editable bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary Credits-Page-style bloom-contentNational2" data-book="originalAcknowledgments">
+                <div lang="es" contenteditable="true" class="bloom-editable bloom-copyFromOtherLanguageIfNecessary Credits-Page-style bloom-contentNational2" data-book="originalAcknowledgments">
                     <p><span id="i719b8fb5-fc85-4a3c-9789-8f04387b8da5" class="audio-sentence">Originally published by Pratham Books,&nbsp; a not-for-profit organization that publishes quality books for children in multiple Indian languages.</span> <span id="b96db38e-60c6-4c6f-9d18-341d134d894f" class="audio-sentence">Their mission is to "see a book in every child's hand" and democratize the joy of reading.</span><br></br>
                     <span id="i5ea0f55a-f4c1-4b25-9d0d-6902bb67c5ca" class="audio-sentence">www.prathambooks.org</span></p>
                 </div>
 
-                <div lang="bo" contenteditable="true" class="bloom-editable bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary Credits-Page-style bloom-contentNational1" data-book="originalAcknowledgments">
+                <div lang="bo" contenteditable="true" class="bloom-editable bloom-copyFromOtherLanguageIfNecessary Credits-Page-style bloom-contentNational1" data-book="originalAcknowledgments">
                     <p>Originally published by Pratham Books,&nbsp; a not-for-profit organization that publishes quality books for children in multiple Indian languages. Their mission is to "see a book in every child's hand" and democratize the joy of reading.<br></br>
                     www.prathambooks.org</p>
                 </div>
 
-                <div lang="en" contenteditable="true" class="bloom-editable bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary Credits-Page-style bloom-content1" data-book="originalAcknowledgments">
+                <div lang="en" contenteditable="true" class="bloom-editable bloom-copyFromOtherLanguageIfNecessary Credits-Page-style bloom-content1" data-book="originalAcknowledgments">
                     <p><span id="i719b8fb5-fc85-4a3c-9789-8f04387b8da5" class="audio-sentence">Originally published by Pratham Books,&nbsp; a not-for-profit organization that publishes quality books for children in multiple Indian languages.</span> <span id="b96db38e-60c6-4c6f-9d18-341d134d894f" class="audio-sentence">Their mission is to "see a book in every child's hand" and democratize the joy of reading.</span><br></br>
                     <span id="i5ea0f55a-f4c1-4b25-9d0d-6902bb67c5ca" class="audio-sentence">www.prathambooks.org</span></p>
                 </div>
@@ -323,7 +323,7 @@
                 <label class="bubble">The contributions made by writers, illustrators, editors, etc., in {lang}</label>
                 <div lang="z" contenteditable="true" class="bloom-editable credits bloom-copyFromOtherLanguageIfNecessary Content-On-Title-Page-style" data-book="originalContributions"></div>
 
-                <div lang="es" contenteditable="true" class="bloom-editable credits bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary Content-On-Title-Page-style bloom-contentNational2" data-book="originalContributions">
+                <div lang="es" contenteditable="true" class="bloom-editable credits bloom-copyFromOtherLanguageIfNecessary Content-On-Title-Page-style bloom-contentNational2" data-book="originalContributions">
                     Written by Noni<br></br>
                     <br></br>
                     Illustrations by Angie and Upesh<br></br>
@@ -332,7 +332,7 @@
                     Commission scolaire des Découvreurs
                 </div>
 
-                <div lang="bo" contenteditable="true" class="bloom-editable credits bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary Content-On-Title-Page-style bloom-contentNational1" data-book="originalContributions">
+                <div lang="bo" contenteditable="true" class="bloom-editable credits bloom-copyFromOtherLanguageIfNecessary Content-On-Title-Page-style bloom-contentNational1" data-book="originalContributions">
                     <p>Written by Noni<br></br>
                     <br></br>
                     Illustrations by Angie and Upesh<br></br>
@@ -341,7 +341,7 @@
                     Commission scolaire des Découvreurs</p>
                 </div>
 
-                <div lang="en" contenteditable="true" class="bloom-editable credits bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary Content-On-Title-Page-style bloom-content1" data-book="originalContributions">
+                <div lang="en" contenteditable="true" class="bloom-editable credits bloom-copyFromOtherLanguageIfNecessary Content-On-Title-Page-style bloom-content1" data-book="originalContributions">
                     <p>Written by Noni<br></br>
                     <br></br>
                     Illustrations by Angie and Upesh</p>

--- a/DistFiles/factoryCollections/Sample Shells/Vaccinations/Vaccinations.htm
+++ b/DistFiles/factoryCollections/Sample Shells/Vaccinations/Vaccinations.htm
@@ -164,12 +164,12 @@
       <div class="bloom-translationGroup originalAcknowledgments">
         <label class="bubble">Original (or Shell) Acknowledgments in {lang}</label>
 
-        <div class="bloom-editable bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary inside-cover-original-acknowledgments-style bloom-content1" data-book="originalAcknowledgments" contenteditable="true" lang="en">
+        <div class="bloom-editable bloom-copyFromOtherLanguageIfNecessary inside-cover-original-acknowledgments-style bloom-content1" data-book="originalAcknowledgments" contenteditable="true" lang="en">
           The material in this booklet was borrowed with permission from the book "Yu Tu i Ken Daunim Sik Long Ples",
           originally published by Liklik Buk Information Centre, Free Mail Bag, Unitech, LAE. Illustrations adapted by Anis Ka'abu.
         </div>
 
-        <div class="bloom-editable bloom-readOnlyInTranslationMode bloom-copyFromOtherLanguageIfNecessary inside-cover-original-acknowledgments-style bloom-contentNational1" data-book="originalAcknowledgments" contenteditable="true" lang="tpi">
+        <div class="bloom-editable bloom-copyFromOtherLanguageIfNecessary inside-cover-original-acknowledgments-style bloom-contentNational1" data-book="originalAcknowledgments" contenteditable="true" lang="tpi">
           The material in this booklet was borrowed with permission from the book "Yu Tu i Ken Daunim Sik Long Ples",
           originally published by Liklik Buk Information Centre, Free Mail Bag, Unitech, LAE. Illustrations adapted by Anis Ka'abu.
         </div>

--- a/src/BloomBrowserUI/xMatter/BigBook-XMatter/BigBook-XMatter.jadeUnused
+++ b/src/BloomBrowserUI/xMatter/BigBook-XMatter/BigBook-XMatter.jadeUnused
@@ -57,7 +57,7 @@ html
 
 			+field-prototypeDeclaredExplicity
 				label.bubble When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.
-				+editable("N1").bloom-readOnlyInTranslationMode.bloom-copyFromOtherLanguageIfNecessary(data-book='originalAcknowledgments')
+				+editable("N1").bloom-copyFromOtherLanguageIfNecessary(data-book='originalAcknowledgments')
 			+field-prototypeDeclaredExplicity
 				label.bubble When you make a book from a shell, use this box to tell who did the translation.
 				+editable("N1").versionAcknowledgments.bloom-readOnlyInEditMode(data-book="versionAcknowledgments")

--- a/src/BloomBrowserUI/xMatter/bloom-xmatter-mixins.jade
+++ b/src/BloomBrowserUI/xMatter/bloom-xmatter-mixins.jade
@@ -55,7 +55,7 @@ mixin field-acknowledgments-localizedVersion
 mixin field-acknowledgments-originalVersion
 	+field-prototypeDeclaredExplicity().originalAcknowledgments
 		label.bubble Original (or Shell) Acknowledgments in {lang}
-		+editable(kLanguageForPrototypeOnly).bloom-readOnlyInTranslationMode.bloom-copyFromOtherLanguageIfNecessary.Credits-Page-style(data-book='originalAcknowledgments')
+		+editable(kLanguageForPrototypeOnly).bloom-copyFromOtherLanguageIfNecessary.Credits-Page-style(data-book='originalAcknowledgments')
 			| {Original Acknowledgments}
 
 
@@ -175,7 +175,7 @@ mixin title-page-contents
 		+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Title-Page-style(data-book='bookTitle')
 	+field-prototypeDeclaredExplicity#originalContributions
 		label.bubble The contributions made by writers, illustrators, editors, etc., in {lang}
-		+editable(kLanguageForPrototypeOnly).credits.bloom-readOnlyInTranslationMode.bloom-copyFromOtherLanguageIfNecessary.Content-On-Title-Page-style(data-book='originalContributions')
+		+editable(kLanguageForPrototypeOnly).credits.bloom-copyFromOtherLanguageIfNecessary.Content-On-Title-Page-style(data-book='originalContributions')
 	+field-prototypeDeclaredExplicity#funding
 		label.bubble Use this to acknowledge any funding agencies.
 		+editable(kLanguageForPrototypeOnly).funding.Content-On-Title-Page-style.bloom-copyFromOtherLanguageIfNecessary(data-book='funding')

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -895,11 +895,6 @@ namespace Bloom.Book
 		private string PossiblyCopyFromAnotherLanguage(XmlElement element, string languageCodeOfTargetField, DataSet data, string key)
 		{
 			string classes = element.GetAttribute("class");
-			if (!string.IsNullOrEmpty(classes))
-			{
-				// if this field is normally read-only, make it readable so they can do any translation that might be needed
-				element.SetAttribute("class", classes.Replace("bloom-readOnlyInTranslationMode", ""));
-			}
 
 			if (!classes.Contains("bloom-copyFromOtherLanguageIfNecessary"))
 			{


### PR DESCRIPTION
Remove some over-enthusiastic code that makes anything empty editable
(but not permanently, because the factory xmatter gets restored later).
Remove cases where bloom-copyFromOtherLanguageIfNecessary also has
bloom-readOnlyInTranslationMode so the user can translate the copied material.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1449)
<!-- Reviewable:end -->
