### PR TITLE
BL-4226 find Arithmetic pages in Arithmetic Template

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -603,6 +603,9 @@ namespace Bloom.Book
 				{
 					if (templateKey.ToLowerInvariant() == "basicbook")//catch this pre-beta spelling with no space
 						templateKey = "Basic Book";
+					// Template was renamed for 3.8 (and needs to end in Template, see PageTemplatesApi.GetBookTemplatePaths)
+					if (templateKey.ToLowerInvariant() == "arithmetic")
+						templateKey = "Arithmetic Template";
 					// We can assume that a book's "TemplateBook" does not change over time.  To be even safer,
 					// we'll add a check for the same "TemplateKey" to allow reusing a cached "TemplateBook".
 					// See https://silbloom.myjetbrains.com/youtrack/issue/BL-3782.


### PR DESCRIPTION
This template folder was renamed, causing old books based
on it to have problems finding pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1451)
<!-- Reviewable:end -->
