### PR TITLE
Make bloom-desktop-beta depend on lame (BL-4213)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  chmsee, libtidy5,
  fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,
  optipng, libsndfile1,
- wmctrl
+ wmctrl, lame
 Suggests: art-of-reading
 Replaces: bloom-desktop, bloom-desktop-alpha
 Conflicts: bloom-desktop-unstable


### PR DESCRIPTION
DO NOT MERGE THIS COMMIT TO ANOTHER BRANCH.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1454)
<!-- Reviewable:end -->
