### PR TITLE
Turn off formatOnSave in VS Code for 3.7 (BL-4101)

### DIFF
--- a/src/BloomBrowserUI/.vscode/settings.json
+++ b/src/BloomBrowserUI/.vscode/settings.json
@@ -10,6 +10,6 @@
 
     // Controls if the editor will insert spaces for tabs. Accepted values:  "auto", true, false. If set to "auto", the value will be guessed when a file is opened.
 	"editor.detectIndentation": true,
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false, //turned off for 3.7 as it doesn't have .editorconfig which makes the formatting changes different from 3.8
     "typescript.tsdk": "./node_modules/typescript/lib"
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1462)
<!-- Reviewable:end -->
