### PR TITLE
Prevent spurious exceptions from Gecko during startup

### DIFF
--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -73,7 +73,12 @@ namespace Bloom
 				var folder = Path.GetDirectoryName(file);
 				xulRunnerPath = Path.Combine(folder, "Firefox");
 			}
+#if !__MonoCS__
+			// This function seems to be newer than our Linux version of GeckoFx (as of Feb 2017, GeckFx45 rev 23 on Linux).
+			// It somehow prevents a spurious complaint by the debugger that an exception inside XpCom.initialize() is not handled
+			// (although it is).
 			Xpcom.EnableProfileMonitoring = false;
+#endif
 			Xpcom.Initialize(xulRunnerPath);
 
 			var errorsToHide = new List<string>

--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -73,6 +73,7 @@ namespace Bloom
 				var folder = Path.GetDirectoryName(file);
 				xulRunnerPath = Path.Combine(folder, "Firefox");
 			}
+			Xpcom.EnableProfileMonitoring = false;
 			Xpcom.Initialize(xulRunnerPath);
 
 			var errorsToHide = new List<string>


### PR DESCRIPTION
Some of us have been seeing a couple of allegedly unhandled
not-implemented exceptions in Gecko land during XpCom.initialize.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1467)
<!-- Reviewable:end -->
