### PR TITLE
Make TsLint prefer single quotes around strings

### DIFF
--- a/src/BloomBrowserUI/tslint.json
+++ b/src/BloomBrowserUI/tslint.json
@@ -34,7 +34,7 @@
         ],
         "quotemark": [
             true,
-            "double"
+            "single"
         ],
         "radix": true,
         "semicolon": true,


### PR DESCRIPTION
as per airbnb coding standard 6.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1477)
<!-- Reviewable:end -->
