### PR TITLE
Submit collection settings with problem report book (BL-4267)

### DIFF
--- a/src/BloomExe/MiscUI/ProblemReporterDialog.cs
+++ b/src/BloomExe/MiscUI/ProblemReporterDialog.cs
@@ -356,6 +356,7 @@ namespace Bloom.MiscUI
 							zip.AddDirectory(Book.FolderPath);
 							if (WantReaderInfo())
 								AddReaderInfo(zip);
+							AddCollectionSettings(zip);
 							zip.Save();
 						}
 						catch (Exception error)
@@ -429,6 +430,16 @@ namespace Bloom.MiscUI
 			return false;
 		}
 
+		private void AddCollectionSettings(BloomZipFile zip)
+		{
+			// When sending Book, add the project settings files as well.
+			var collectionFolder = System.IO.Path.GetDirectoryName(Book.FolderPath);
+			foreach (var file in Directory.GetFiles(collectionFolder, "*CollectionStyles.css"))
+				zip.AddTopLevelFile(file);
+			foreach (var file in Directory.GetFiles(collectionFolder, "*.bloomCollection"))
+				zip.AddTopLevelFile(file);
+		}
+
 		/// <summary>
 		/// Will become the summary of the issue. Include {0} for the user name
 		/// </summary>
@@ -466,6 +477,9 @@ namespace Bloom.MiscUI
 				if (_includeBook.Visible && _includeBook.Checked) // only Visible if Book is not null
 				{
 					zip.AddDirectory(Book.FolderPath);
+					if (WantReaderInfo())
+						AddReaderInfo(zip);
+					AddCollectionSettings(zip);
 				}
 			}
 			if (_includeScreenshot.Checked)
@@ -512,8 +526,7 @@ namespace Bloom.MiscUI
 			bldr.AppendLine(_description.Text);
 			bldr.AppendLine();
 			GetAdditionalEnvironmentInfo(bldr);
-			if (WantReaderInfo())
-				GetAdditionalFileInfo(bldr);
+			GetAdditionalFileInfo(bldr);
 			GetStandardErrorReportingProperties(bldr, appendLog);
 			return bldr.ToString();
 		}
@@ -559,10 +572,17 @@ namespace Bloom.MiscUI
 			bldr.AppendLine();
 			bldr.AppendLine("=Additional Files Bundled With Book=");
 			var collectionFolder = Path.GetDirectoryName(Book.FolderPath);
-			foreach (var file in Directory.GetFiles(collectionFolder, "ReaderTools*-*.json"))
+			if (WantReaderInfo())
+			{
+				foreach (var file in Directory.GetFiles(collectionFolder, "ReaderTools*-*.json"))
+					bldr.AppendLine(file);
+				ListFolderContents(Path.Combine(collectionFolder, "Allowed Words"), bldr);
+				ListFolderContents(Path.Combine(collectionFolder, "Sample Texts"), bldr);
+			}
+			foreach (var file in Directory.GetFiles(collectionFolder, "*CollectionStyles.css"))
 				bldr.AppendLine(file);
-			ListFolderContents(Path.Combine(collectionFolder, "Allowed Words"), bldr);
-			ListFolderContents(Path.Combine(collectionFolder, "Sample Texts"), bldr);
+			foreach (var file in Directory.GetFiles(collectionFolder, "*.bloomCollection"))
+				bldr.AppendLine(file);
 		}
 
 		private void ListFolderContents(string folder, StringBuilder bldr)


### PR DESCRIPTION
If you decide this should go onto Version3.7, it shouldn't be too hard to rebase this change.  I did notice one omission in the previous enhancement that was made to Version3.7: the previous enhancement didn't do anything if the user had to fall back to email submission instead of being able to submit directly to youtrack.  That has been fixed in this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1478)
<!-- Reviewable:end -->
