### PR TITLE
Fix case-sensitivity of \U vs \u in unicode specifiers (BL-4247)

### DIFF
--- a/DistFiles/localization/Bloom.en.tmx
+++ b/DistFiles/localization/Bloom.en.tmx
@@ -3468,6 +3468,12 @@
         <seg>Powered by </seg>
       </tuv>
     </tu>
+    <tu tuid="ReaderSetup.Punctuation">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Punctuation</seg>
+      </tuv>
+    </tu>
     <tu tuid="ReaderSetup.ReaderLevels">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -3538,6 +3544,18 @@
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
         <seg>Maximum Words in each Sentence</seg>
+      </tuv>
+    </tu>
+    <tu tuid="ReaderSetup.SentencePunctuation.Header">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Special Sentence-Ending Punctuation</seg>
+      </tuv>
+    </tu>
+    <tu tuid="ReaderSetup.SentencePunctuation.Help">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Bloom already knows which characters in the world's languages always mark the end of sentences. To add others, enter the Unicode character escapes here. For example for Thai script languages, enter \U0020 to tell Bloom that normal spaces are used to break sentences.</seg>
       </tuv>
     </tu>
     <tu tuid="ReaderSetup.SetUpDecodableReaderTool">

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/bloomSynphonyExtensions.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/bloomSynphonyExtensions.js
@@ -86,7 +86,7 @@ LibSynphony.prototype.setExtraSentencePunctuation = function(extra) {
     // Replace characters that are magic in regexp. As a special case, period is simply removed, since it's already
     // sentence-terminating. If they want to use backslash, they will just have to double it; we can't fix it
     // because we want to allow \u0020 etc. I don't know why <> need to be replaced but they don't work otherwise.
-    var extraRe = extra.replace('^', '\\u005E').replace('$', '\\u0024').replace('.', '')
+    var extraRe = extra.replace('\\U', '\\u').replace('^', '\\u005E').replace('$', '\\u0024').replace('.', '')
       .replace('*', '\\u002A').replace('~', '\\u007E').replace('[', '\\u005B').replace(']', '\\u005D')
       .replace('<', '\\u003C').replace('>', '\\u003E');
     LibSynphony.prototype.extraSentencePunct = extraRe;

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
@@ -6,6 +6,7 @@
  * Created Apr 24, 2014 by Phil Hopper
  *
  */
+import {theOneLibSynphony} from './synphony_lib';
 
 describe("jquery.text-markup", function() {
 
@@ -93,6 +94,24 @@ describe("jquery.text-markup", function() {
         // check 2 word sentences
         var result = $('div').getMaxSentenceLength();
         expect(result).toBe(6);
+    });
+
+    it("getMaxSentenceLength - Thai", function() {
+
+        // This is the same five-word sentence repeated with a space between.
+        $('#text_entry1').html("ฉัน​มี​ยุง​ใน​บ้าน ฉัน​มี​ยุง​ใน​บ้าน");
+
+        var extraPunctuationToTest = ['\\u0020', '\\U0020'];
+
+        for (var i = 0; i < extraPunctuationToTest.length; i++) {
+            theOneLibSynphony.setExtraSentencePunctuation(extraPunctuationToTest[i]);
+
+            var result = $('div').getMaxSentenceLength();
+            expect(result).toBe(5);
+        }
+
+        // Reset it for the next test
+        theOneLibSynphony.setExtraSentencePunctuation('');
     });
 
     it("getTotalWordCount", function() {

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/split_sentencesSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/split_sentencesSpec.js
@@ -35,16 +35,40 @@ describe("Splitting text into sentences", function() {
 
     it("Split into sentences, get word count (space is sentence-separating)", function() {
 
+        var extraPunctuationToTest = ['\\u0020', '\\U0020'];
         var inputText = "One Two Three";
-        theOneLibSynphony.setExtraSentencePunctuation('\\u0020');
-        var fragments = theOneLibSynphony.stringToSentences(inputText);
-        var sentences = _.filter(fragments, function(frag) {
-            return frag.isSentence;
-        });
-        expect(sentences.length).toBe(3);
-        expect(sentences[0].wordCount()).toBe(1);
-        expect(sentences[1].wordCount()).toBe(1);
-        expect(sentences[2].wordCount()).toBe(1);
+
+        for (var i = 0; i < extraPunctuationToTest.length; i++) {
+            theOneLibSynphony.setExtraSentencePunctuation(extraPunctuationToTest[i]);
+            var fragments = theOneLibSynphony.stringToSentences(inputText);
+            var sentences = _.filter(fragments, function(frag) {
+                return frag.isSentence;
+            });
+            expect(sentences.length).toBe(3);
+            expect(sentences[0].wordCount()).toBe(1);
+            expect(sentences[1].wordCount()).toBe(1);
+            expect(sentences[2].wordCount()).toBe(1);
+        }
+
+        // Reset it for the next test
+        theOneLibSynphony.setExtraSentencePunctuation('');
+    });
+
+    it("Split into sentences, get word count (space is sentence-separating) - Thai", function() {
+
+        var extraPunctuationToTest = ['\\u0020', '\\U0020'];
+        var inputText = "ฉัน​มี​ยุง​ใน​บ้าน ฉัน​มี​ยุง​ใน​บ้าน";
+
+        for (var i = 0; i < extraPunctuationToTest.length; i++) {
+            theOneLibSynphony.setExtraSentencePunctuation(extraPunctuationToTest[i]);
+            var fragments = theOneLibSynphony.stringToSentences(inputText);
+            var sentences = _.filter(fragments, function(frag) {
+                return frag.isSentence;
+            });
+            expect(sentences.length).toBe(2);
+            expect(sentences[0].wordCount()).toBe(5);
+            expect(sentences[1].wordCount()).toBe(5);
+        }
 
         // Reset it for the next test
         theOneLibSynphony.setExtraSentencePunctuation('');

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/ReaderSetup.jade
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/ReaderSetup.jade
@@ -21,7 +21,7 @@ html
 		// script(src='/bloom/bookEdit/toolbox/decodableReader/readerSetup/readerSetup.io.js')
 		// script(src='/bloom/bookEdit/toolbox/decodableReader/readerSetup/readerSetup.ui.js')
 		// script(type='text/javascript') $(function() {$("#dlstabs").tabs();});
-		
+
 		script(src='/bloom/commonBundle.js')
 		script(src='/bloom/readerSetupBundle.js')
 	body
@@ -50,12 +50,10 @@ html
 							i(data-i18n='ReaderSetup.Letters.LetterHelp3') it's
 							span(data-i18n='ReaderSetup.Letters.LetterHelp4')
 								= '.'
-					label(data-i18n='ReaderSetup.SentencePunctuation.Header') Special Sentence ending punctuation
+					label(data-i18n='ReaderSetup.SentencePunctuation.Header') Special Sentence-Ending Punctuation
 					br
 					textarea#dls_sentence_punct.book-font(style='height: 55px; width: 325px')
-					p(data-i18n='ReaderSetup.SentencePunctuation.Help') Bloom already knows which characters in the world's languages always mark the end of sentences.
-						| To add others, enter the Unicode character escapes here. For example for Thai script languages, enter \U0020 to tell Bloom that
-						| normal spaces are used to break sentences.
+					p(data-i18n='ReaderSetup.SentencePunctuation.Help') Bloom already knows which characters in the world's languages always mark the end of sentences. To add others, enter the Unicode character escapes here. For example for Thai script languages, enter \U0020 to tell Bloom that normal spaces are used to break sentences.
 
 			#dlstabs-1.reader-setup-tab
 				.flex-column


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1494)
<!-- Reviewable:end -->
