### PR TITLE
BL-4235 Specify paragraph spacing proportionally

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -318,6 +318,8 @@ export default class StyleEditor {
             styleAndLang += ' p';
         }
 
+        styleAndLang = styleAndLang.toLowerCase();
+
         for (var i = 0; i < ruleList.length; i++) {
             var index = ruleList[i].cssText.indexOf('{');
             if (index === -1) {
@@ -479,7 +481,7 @@ export default class StyleEditor {
     }
 
     getParagraphSpaceOptions() {
-        return ['0 pt', '6 pt', '12 pt', '18 pt'];
+        return ['0', '0.5', '0.75', '1', '1.25'];
     }
 
     // Returns an object giving the current selection for each format control.
@@ -538,9 +540,9 @@ export default class StyleEditor {
 
         var marginBelowString = paraBox.css('margin-bottom');
         var paraSpacePx = parseInt(marginBelowString);
-        var paraSpacePt = this.ConvertPxToPt(paraSpacePx, false);
+        var paraSpaceEm = paraSpacePx / pxSize;
         var paraSpaceOptions = this.getParagraphSpaceOptions();
-        var paraSpacing = StyleEditor.GetClosestValueInList(paraSpaceOptions, paraSpacePt);
+        var paraSpacing = StyleEditor.GetClosestValueInList(paraSpaceOptions, paraSpaceEm);
 
         var indentString = paraBox.css('text-indent');
         var indentNumber = parseInt(indentString);
@@ -1168,7 +1170,7 @@ export default class StyleEditor {
         if (this.ignoreControlChanges) {
             return;
         }
-        var paraSpacing = $('#para-spacing-select').val().replace(' ', '');
+        var paraSpacing = $('#para-spacing-select').val() + "em";
         var rule = this.getStyleRule(true, true);
         rule.style.setProperty('margin-bottom', paraSpacing, 'important');
         this.cleanupAfterStyleChange();
@@ -1194,12 +1196,15 @@ export default class StyleEditor {
         }
         var rule = this.getStyleRule(true, true); // rule that is language-independent for child paras
         if ($('#indent-none').hasClass('selectedIcon')) {
-            //rule.style.setProperty("border-style", "none");
-            rule.style.removeProperty('text-indent');
-            rule.style.removeProperty('margin-left');
+            // It's tempting to remove the property. However, we apply normal-style as a class to
+            // parent bloom-translationGroup elements so everything inherits from it by default.
+            // If we just remove these properties from a rule for some other style, no other
+            // style will be able to override a 'normal-style' indent.
+            rule.style.setProperty('text-indent', '0', 'important');
+            rule.style.setProperty('margin-left', '0', 'important');
         } else if ($('#indent-indented').hasClass('selectedIcon')) {
             rule.style.setProperty('text-indent', '20pt', 'important');
-            rule.style.removeProperty('margin-left');
+            rule.style.setProperty('margin-left', '0', 'important');
         } else if ($('#indent-hanging').hasClass('selectedIcon')) {
             rule.style.setProperty('text-indent', '-20pt', 'important');
             rule.style.setProperty('margin-left', '20pt', 'important');

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -315,10 +315,10 @@ export default class StyleEditor {
         }
 
         if (forChildParas) {
-            styleAndLang += ' p';
+            styleAndLang += ' > p';
         }
 
-        styleAndLang = styleAndLang.toLowerCase();
+        let lookFor = styleAndLang.toLowerCase();
 
         for (var i = 0; i < ruleList.length; i++) {
             var index = ruleList[i].cssText.indexOf('{');
@@ -328,7 +328,7 @@ export default class StyleEditor {
             // The rule we want is one whose selector is the string we want.
             // The substring strips off the initial period and the rule body, leaving the selector.
             var match = ruleList[i].cssText.trim().substring(1, index).toLowerCase().trim();
-            if (match === styleAndLang) {
+            if (match === lookFor) {
                 return <CSSStyleRule>ruleList[i];
             }
         }
@@ -554,7 +554,7 @@ export default class StyleEditor {
         }
 
         return {
-            ptSize: ptSize,
+            ptSize: ptSize.toString(),
             fontName: fontName,
             lineHeight: lineHeight,
             wordSpacing: wordSpacing,


### PR DESCRIPTION
Also fixes a problem where a normal-style indent could
not be overridden and another where duplicate style rules
were being made if the style name included caps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1495)
<!-- Reviewable:end -->
