### PR TITLE
Fix .editorconfig to not break VSCode on Linux

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 [*]
 trim_trailing_whitespace = true
 insert_final_newline = true
-end_of_line = crlf
 charset = utf-8
 indent_size = 4
 


### PR DESCRIPTION
Line endings should be controlled by the git configuration.
Specifying crlf immediately changes every line of every file on Linux,
which makes VSCode unusable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1502)
<!-- Reviewable:end -->
