### PR TITLE
BL-647 Fix jumping StyleEditor and Text Box Properties dialogs

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -579,7 +579,7 @@ export default class StyleEditor {
 
         //make the button stay at the bottom if we overflow and thus scroll
         //review: It's not clear to me that this is actually working (JH 3/19/2016)
-        $(targetBox).on("scroll", e => { this.AdjustFormatButton(e.target) });
+        $(targetBox).on("scroll", e => { this.AdjustFormatButton(e.target); });
 
 
         // And in case we are starting out on a centerVertically page we might need to adjust it now
@@ -713,7 +713,9 @@ export default class StyleEditor {
 
                 var toolbar = $('#format-toolbar');
                 toolbar.find('*[data-i18n]').localize();
-                toolbar.draggable({ distance: 10, scroll: false, containment: $('html') });
+                toolbar.draggable({
+                    distance: 10, scroll: false, containment: $('html')
+                });
                 toolbar.draggable("disable"); // until after we make sure it's in the Viewport
                 toolbar.css('opacity', 1.0);
                 if (!noFormatChange) {

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -117,5 +117,19 @@ export class EditableDivUtils {
             // the extra 30 pixels is for padding
             dialogBox.offset({ left: offset.left, top: offset.top - diff - 30 });
         }
+        if (dialogBox.is('.ui-draggable')) {
+            dialogBox.draggable({
+                // BL-4293 the 'start' and 'drag' functions here work around a known bug in jqueryui.
+                // fix adapted from majcherek2048's about 2/3 down this page https://bugs.jqueryui.com/ticket/3740.
+                // If we upgrade our jqueryui to a version that doesn't have this bug (1.10.3 or later?),
+                // we'll need to back out this change.
+                start: function () {
+                    $(this).data('startingScrollTop', $('html').scrollTop());
+                },
+                drag: function (event, ui) {
+                    ui.position.top -= $(this).data('startingScrollTop');
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
* if we ever upgrade our jqueryUI to a newer version
   we'll need to undo this change
* there is a comment to that effect in the code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1505)
<!-- Reviewable:end -->
