### PR TITLE
Fix Text Box Properties dialog tab header font size (BL-4294)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.less
+++ b/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.less
@@ -22,6 +22,9 @@
 }
 
 #text-properties-dialog {
+    H2{
+        font-size:10pt;
+    }
     .tab-page {
         .main-label {
             width: 420px;


### PR DESCRIPTION
The style setting was copied from the Format dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1507)
<!-- Reviewable:end -->
