### PR TITLE
BL-4233 Improve template box hints

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -521,18 +521,23 @@ function SetupElements(container) {
 
     // Copy source texts out to their own div, where we can make a bubble with tabs out of them
     // We do this because if we made a bubble out of the div, that would suck up the vernacular editable area, too,
+    var sourceBubbleDivs = [];
     if ($(container).find(".bloom-preventSourceBubbles").length === 0) {
         $(container).find("*.bloom-translationGroup").not(".bloom-readOnlyInTranslationMode").each(function () {
             if ($(this).find("textarea, div").length > 1) {
-                BloomSourceBubbles.ProduceSourceBubbles(this);
+                if (BloomSourceBubbles.ProduceSourceBubbles(this)) {
+                    sourceBubbleDivs.push(this);
+                }
             }
         });
     }
 
-    //NB: this should be after the ProduceSourceBubbles(), so that it can remove labels that
-    //would otherwise be underfoot when we call this. This would happen with the Book Title
-    //when there are source languages to show
-    BloomHintBubbles.addHintBubbles(container);
+    //NB: this should be after the ProduceSourceBubbles(), because hint-bubbles are lower
+    // priority, and should not show if we already have a source bubble.
+    // (Eventually we may make the hint part of the source bubble when there is one...Bl-4295.)
+    // This would happen with the Book Title, which would have both
+    // when there are source languages to show
+    BloomHintBubbles.addHintBubbles(container, sourceBubbleDivs);
 
     // Add overflow event handlers so that when a div is overfull,
     // we add the overflow class and it gets a red background or something

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.ts
@@ -26,13 +26,14 @@ export default class BloomSourceBubbles {
     // for translation.
     // param 'group' is a .bloom-translationGroup DIV
     // optional param 'newIso' is defined when the user clicks on a language in the dropdown box
-    public static ProduceSourceBubbles(group: HTMLElement, newIso?: string): void {
+    // Returns true if it actually made a source bubble.
+    public static ProduceSourceBubbles(group: HTMLElement, newIso?: string): boolean {
         var divForBubble = BloomSourceBubbles.MakeSourceTextDivForGroup(group, newIso);
-        if(divForBubble == null) return;
+        if(divForBubble == null) return false;
 
         // Do easytabs transformation on the cloned div 'divForBubble' with the first tab selected,
         divForBubble = BloomSourceBubbles.CreateTabsFromDiv(divForBubble);
-        if (divForBubble == null) return;
+        if (divForBubble == null) return false;
 
         // If divForBubble contains more than two languages, create a dropdown menu to contain the
         // extra possibilities. The menu will show (x), where x is the number of items in the dropdown.
@@ -41,8 +42,7 @@ export default class BloomSourceBubbles {
         // Turns the tabbed and linked div bundle into a qtip bubble attached to the bloom-translationGroup (group).
         // Also makes sure the tooltips are setup correctly.
         BloomSourceBubbles.CreateAndShowQtipBubbleFromDiv(group, divForBubble);
-
-        BloomSourceBubbles.HideLabelsThatWouldBeUnderfoot(group);
+        return true;
     }
 
     // Cleans up a clone of the original translationGroup
@@ -57,6 +57,10 @@ export default class BloomSourceBubbles {
         divForBubble.removeAttr('style');
         divForBubble.removeClass(); //remove them all
         divForBubble.addClass("ui-sourceTextsForBubble");
+        // For now, we don't want labels (hints) in the source bubbles. BL-4295 discusses possibly changing this.
+        divForBubble.find("label.bubble").each( (index, element) => {
+            $(element).remove();
+        });
 
         //make the source texts in the bubble read-only and remove any user font size adjustments
         divForBubble.find("textarea, div").each(function() {
@@ -383,12 +387,6 @@ export default class BloomSourceBubbles {
             if (maxHeight) {
                 $tip.css('max-height', '');
             }
-        });
-    }
-
-    private static HideLabelsThatWouldBeUnderfoot(groupElement: HTMLElement) {
-        $(groupElement).find("label.bubble").each( (index, element) => {
-            $(element).remove();
         });
     }
 }


### PR DESCRIPTION
- fixes old code that was deleting bubble labels
- uses a new strategy to prevent getting source bubbles AND hints
- removes hints from (wrong place in) source bubbles
- hints for auto-language groups show once for whole group

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1508)
<!-- Reviewable:end -->
