### PR TITLE
BL-647 Fix jumping StyleEditor for zoom

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -634,7 +634,7 @@ export default class StyleEditor {
                     return a.toLowerCase().localeCompare(b.toLowerCase());
                 });
 
-                var html = '<div id="format-toolbar" class="bloom-ui bloomDialogContainer">'
+                var html = '<div id="format-toolbar" class="bloom-ui bloomDialogContainer" style="visibility: hidden;">'
                     + '<div data-i18n="EditTab.FormatDialog.Format" class="bloomDialogTitleBar">Format</div>';
                 if (noFormatChange) {
                     var translation = theOneLocalizationManager.getText('BookEditor.FormattingDisabled', 'Sorry, Reader Templates do not allow changes to formatting.');
@@ -755,9 +755,8 @@ export default class StyleEditor {
                         new WebFXTabPane($('#tabRoot').get(0), false, null);
                     }
                 }
-                var offset = $('#formatButton').offset();
-                toolbar.offset({ left: offset.left + 30, top: offset.top - 30 });
-                EditableDivUtils.positionInViewport(toolbar);
+                var orientOnButton = $('#formatButton');
+                EditableDivUtils.positionDialogAndSetDraggable(toolbar, orientOnButton);
                 toolbar.draggable("enable");
 
                 $('html').off('click.toolbar');

--- a/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.ts
+++ b/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.ts
@@ -37,7 +37,7 @@ export default class TextBoxProperties {
             // if not already set, this will return 'Auto'
             var languageGroup = propDlg.getTextBoxLanguage(targetBox);
 
-            var html = '<div id="text-properties-dialog" class="bloom-ui bloomDialogContainer">'
+            var html = '<div id="text-properties-dialog" class="bloom-ui bloomDialogContainer" style="visibility: hidden;">'
                 + '<div data-i18n="EditTab.TextBoxProperties.Title" class="bloomDialogTitleBar">Text Box Properties</div>';
             if (noFormatChange) {
                 // Review gjm: Is this true for this dialog?
@@ -97,9 +97,9 @@ export default class TextBoxProperties {
             // It just needs to delay one 'cycle'.
             // http://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful
             setTimeout(function () {
-                var offset = $(propDlg.boxBeingEdited).find('.formatButton').offset(); // make sure we get the right button!
-                dialogElement.offset({ left: offset.left + 30, top: offset.top - 30 });
-                EditableDivUtils.positionInViewport(dialogElement);
+                // Make sure we get the right button!
+                var orientOnButton = $(propDlg.boxBeingEdited).find('.formatButton');
+                EditableDivUtils.positionDialogAndSetDraggable(dialogElement, orientOnButton);
                 dialogElement.draggable("enable");
 
                 $('html').off('click.dialogElement');

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -94,42 +94,42 @@ export class EditableDivUtils {
     }
 
     // Positions the dialog box so that it is completely visible, so that it does not extend below the
-    // current viewport.
+    // current viewport. Method takes into consideration zoom factor. If the dialog is draggable,
+    // it also modifies the draggable options to account for a scrolling bug in jqueryui.
     // @param dialogBox
-    static positionInViewport(dialogBox: JQuery): void {
+    static positionDialogAndSetDraggable(dialogBox: JQuery, gearIcon: JQuery): void {
+        // A zoom on the body affects offset but not outerHeight, which messes things up if we don't account for it.
+        var scale = dialogBox[0].getBoundingClientRect().height / dialogBox[0].offsetHeight;
+        var adjustmentFactor = 30;
+        var pxAdjToScale = (adjustmentFactor / scale).toFixed(); // rounded to nearest integer
+        var myOptionValue = 'left+' + pxAdjToScale + ' top-' + pxAdjToScale;
 
-        // get the current size and position of the dialogBox
-        var elem: HTMLElement = dialogBox[0];
-        var top = elem.offsetTop;
-        var height = elem.offsetHeight;
+        // Set the dialog 30px (adjusted for 'scale') to the right and up from the gear icon.
+        // If it won't fit there for some reason, .position() will 'fit' it in by moving it away from the viewport edges.
+        dialogBox.position({ my: myOptionValue, at: 'right top', of: gearIcon, collision: 'fit' });
 
-        // get the top of the dialogBox in relation to the top of its containing elements
-        while (elem.offsetParent) {
-            elem = <HTMLElement>elem.offsetParent;
-            top += elem.offsetTop;
-        }
+        // unless we're debugging, the dialog html should be initially created with visibility set to 'hidden'
+        dialogBox.css('visibility', 'visible');
 
-        // diff is the portion of the dialogBox that is below the viewport
-        var diff = (top + height) - (window.pageYOffset + window.innerHeight);
-        if (diff > 0) {
-            var offset = dialogBox.offset();
-
-            // the extra 30 pixels is for padding
-            dialogBox.offset({ left: offset.left, top: offset.top - diff - 30 });
-        }
         if (dialogBox.is('.ui-draggable')) {
-            dialogBox.draggable({
-                // BL-4293 the 'start' and 'drag' functions here work around a known bug in jqueryui.
-                // fix adapted from majcherek2048's about 2/3 down this page https://bugs.jqueryui.com/ticket/3740.
-                // If we upgrade our jqueryui to a version that doesn't have this bug (1.10.3 or later?),
-                // we'll need to back out this change.
-                start: function () {
-                    $(this).data('startingScrollTop', $('html').scrollTop());
-                },
-                drag: function (event, ui) {
-                    ui.position.top -= $(this).data('startingScrollTop');
-                }
-            });
+            EditableDivUtils.adjustDraggableOptionsForScaleBug(dialogBox, scale);
         }
+    }
+
+    static adjustDraggableOptionsForScaleBug(dialogBox: JQuery, scale: number) {
+        dialogBox.draggable({
+            // BL-4293 the 'start' and 'drag' functions here work around a known bug in jqueryui.
+            // fix adapted from majcherek2048's about 2/3 down this page https://bugs.jqueryui.com/ticket/3740.
+            // If we upgrade our jqueryui to a version that doesn't have this bug (1.10.3 or later?),
+            // we'll need to back out this change.
+            start: function (event, ui) {
+                $(this).data('startingScrollTop', $('html').scrollTop());
+                $(this).data('startingScrollLeft', $('html').scrollLeft());
+            },
+            drag: function (event, ui) {
+                ui.position.top = (ui.position.top - $(this).data('startingScrollTop')) / scale;
+                ui.position.left = (ui.position.left - $(this).data('startingScrollLeft')) / scale;
+            }
+        });
     }
 }


### PR DESCRIPTION
* includes some renaming and refactoring for code
   used by both StyleEditor and TextBoxProperties
* fixes dragging when zoomed or scrolled
* initial placement is better than 3.7, tho' still not
   perfect when zoomed for textBoxProperties

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1516)
<!-- Reviewable:end -->
