### PR TITLE
Pin TypeScript to the version 2.1 series

### DIFF
--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -35,7 +35,7 @@
     "select2": "^4.0.2",
     "time-require": "^0.1.2",
     "toastr": "^2.1.2",
-    "typescript": "^2.0.3",
+    "typescript": "~2.1.6",
     "underscore": "^1.8.3",
     "xregexp": "^3.0.0"
   },


### PR DESCRIPTION
Version 2.2 has a breaking change that keeps Bloom from building.
Pinning to the 2.0 series apparently pins only to the version 2 series
since this allowed 2.1.* and 2.2.* to be downloaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1524)
<!-- Reviewable:end -->
