### PR TITLE
BL-4235 properly persist spacing and indent rules

### DIFF
--- a/src/BloomExe/XmlHtmlConverter.cs
+++ b/src/BloomExe/XmlHtmlConverter.cs
@@ -46,6 +46,20 @@ namespace Bloom
 			// fix for <br></br> tag doubling
 			content = content.Replace("<br></br>", "<br />");
 
+			// fix for > and similar in <style> element protected by CDATA.
+			// At present we only need to account for this occurring once.
+			// See Browser.SaveCustomizedCssRules.
+			var startOfCdata = content.IndexOf(Browser.CdataPrefix, StringComparison.InvariantCulture);
+			const string restoreCdataHere = "/****RestoreCDATAHere*****/";
+			var endOfCdata = content.IndexOf(Browser.CdataSuffix, StringComparison.InvariantCulture);
+			var savedCData = "";
+			if (startOfCdata >= 0 && endOfCdata >= startOfCdata)
+			{
+				endOfCdata += Browser.CdataSuffix.Length;
+				savedCData = content.Substring(startOfCdata, endOfCdata - startOfCdata);
+				content = content.Substring(0, startOfCdata) + restoreCdataHere + content.Substring(endOfCdata, content.Length - endOfCdata);
+			}
+
 			//using (var temp = new TempFile())
 			var temp = new TempFile();
 			{
@@ -115,6 +129,8 @@ namespace Bloom
 						// not in the data returned by editor.getData().  Since assigning to div.innerHTML doesn't
 						// affect what gets written to the file, this hack was implemented instead.
 						newContents = Regex.Replace(newContents, @"(<br></br>|<br ?/>)[\r\n]*</p>", "</p>");
+
+						newContents = newContents.Replace(restoreCdataHere, savedCData);
 
 						// Don't let spaces between <strong>, <em>, or <u> elements be removed. (BL-2484)
 						dom.PreserveWhitespace = true;

--- a/src/BloomExe/XmlHtmlConverter.cs
+++ b/src/BloomExe/XmlHtmlConverter.cs
@@ -52,11 +52,11 @@ namespace Bloom
 			var startOfCdata = content.IndexOf(Browser.CdataPrefix, StringComparison.InvariantCulture);
 			const string restoreCdataHere = "/****RestoreCDATAHere*****/";
 			var endOfCdata = content.IndexOf(Browser.CdataSuffix, StringComparison.InvariantCulture);
-			var savedCData = "";
+			var savedCdata = "";
 			if (startOfCdata >= 0 && endOfCdata >= startOfCdata)
 			{
 				endOfCdata += Browser.CdataSuffix.Length;
-				savedCData = content.Substring(startOfCdata, endOfCdata - startOfCdata);
+				savedCdata = content.Substring(startOfCdata, endOfCdata - startOfCdata);
 				content = content.Substring(0, startOfCdata) + restoreCdataHere + content.Substring(endOfCdata, content.Length - endOfCdata);
 			}
 
@@ -130,7 +130,7 @@ namespace Bloom
 						// affect what gets written to the file, this hack was implemented instead.
 						newContents = Regex.Replace(newContents, @"(<br></br>|<br ?/>)[\r\n]*</p>", "</p>");
 
-						newContents = newContents.Replace(restoreCdataHere, savedCData);
+						newContents = newContents.Replace(restoreCdataHere, savedCdata);
 
 						// Don't let spaces between <strong>, <em>, or <u> elements be removed. (BL-2484)
 						dom.PreserveWhitespace = true;

--- a/src/BloomTests/XmlHtmlConverterTests.cs
+++ b/src/BloomTests/XmlHtmlConverterTests.cs
@@ -264,6 +264,13 @@ namespace BloomTests
 			Assert.That(xml.Trim(), Is.EqualTo(styleContent.Trim()));
 		}
 
+		// I don't know of a use case where we want tidy to convert an unprotected > into an entity.
+		// There are very few places where these characters can occur unprotected in HTML.
+		// However, trying to parse something as XHTML that has them will fail, making the document
+		// unusable. So it seems best to let Tidy make its best effort to fix anything that
+		// isn't specifically marked up as being in a block of CDATA.
+		// This test confirms that we aren't interfering with Tidy's behavior except in
+		// the one special case we care about.
 		[Test]
 		public void GetXmlDomFromHtml_HasUnProtectedGtInStylesheet_Converts()
 		{

--- a/src/BloomTests/XmlHtmlConverterTests.cs
+++ b/src/BloomTests/XmlHtmlConverterTests.cs
@@ -246,5 +246,37 @@ namespace BloomTests
 			// The XmlDocument.PreserveWhitespace setting appears to insert newlines that we don't care about.
 			Assert.AreEqual("<div><u><i style=\"test\"></i></u></div>", xml);
 		}
+
+		[Test]
+		public void GetXmlDomFromHtml_HasProtectedGtInStylesheet_DoesNotConvert()
+		{
+			var styleContent = @"
+	/*<![CDATA[*/
+	.BigWords-style { font-size: 45pt ! important; text-align: center ! important; }
+	.normal-style { text-align: initial ! important; }
+	.normal-style > p { text-indent: -20pt ! important; margin-left: 20pt ! important; margin-bottom: 1em ! important; }
+	/*]]>*/
+	";
+			var html = @"<!DOCTYPE html><html><head><style>" + styleContent + "</style></head><body></body></html>";
+			var dom = XmlHtmlConverter.GetXmlDomFromHtml(html);
+			var xml = dom.DocumentElement.GetElementsByTagName("style")[0].InnerXml;
+			// Trim because it may mess with leading or trailing white space in ways we don't care about.
+			Assert.That(xml.Trim(), Is.EqualTo(styleContent.Trim()));
+		}
+
+		[Test]
+		public void GetXmlDomFromHtml_HasUnProtectedGtInStylesheet_Converts()
+		{
+			var styleContent = @"
+	.BigWords-style { font-size: 45pt ! important; text-align: center ! important; }
+	.normal-style { text-align: initial ! important; }
+	.normal-style > p { text-indent: -20pt ! important; margin-left: 20pt ! important; margin-bottom: 1em ! important; }
+	";
+			var html = @"<!DOCTYPE html><html><head><style>" + styleContent + "</style></head><body></body></html>";
+			var dom = XmlHtmlConverter.GetXmlDomFromHtml(html);
+			var xml = dom.DocumentElement.GetElementsByTagName("style")[0].InnerXml;
+			// Trim because it may mess with leading or trailing white space in ways we don't care about.
+			Assert.That(xml.Trim(), Is.EqualTo(styleContent.Replace(">", "&gt;").Trim()));
+		}
 	}
 }


### PR DESCRIPTION
Handle occurrence of > in style rules by wrapping in CDATA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1531)
<!-- Reviewable:end -->
