### PR TITLE
Fix dropdown hiding behind the dialog (BL-4386)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.less
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.less
@@ -1,6 +1,7 @@
 //putting (less) here makes it actually start this file off with the contents of the select2.css,
 //which we're doing for convenience so that we don't have to get it in the installer and then import it explictly
 @import (less) '../../node_modules/select2/dist/css/select2.css';
+@import (reference) "../css/bloomDialog.less";  // needed for @dialogZindexPlusOne
 
 #format-toolbar {
     *{
@@ -78,9 +79,9 @@
     }
 }
 
-//the select2 dropdown gets appended to the body, not to our dialog, so it needs a really high z-index to show above the dialog.
+//the select2 dropdown gets appended to the body, not to our dialog, so its z-index must be at least as high as the dialog's z-index
 .select2-container{
-    z-index: 30000;
+    z-index: @dialogZindexPlusOne;
 }
 
 #spacingRow{

--- a/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.less
+++ b/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.less
@@ -1,12 +1,13 @@
 //putting (less) here makes it actually start this file off with the contents of the select2.css,
 //which we're doing for convenience so that we don't have to get it in the installer and then import it explictly
 @import (less) '../../node_modules/select2/dist/css/select2.css';
+@import (reference) "../css/bloomDialog.less";  // needed for @dialogZindexPlusOne
 
 @hint-tab-indent: 20px;
 
-//the select2 dropdown gets appended to the body, not to our dialog, so it needs a really high z-index to show above the dialog.
+//the select2 dropdown gets appended to the body, not to our dialog, so its z-index must be at least as high as the dialog's z-index
 .select2-container{
-    z-index: 30000;
+    z-index: @dialogZindexPlusOne;
 }
 
 // select2 select controls are way too narrow if we don't force a width.

--- a/src/BloomBrowserUI/bookEdit/css/bloomDialog.less
+++ b/src/BloomBrowserUI/bookEdit/css/bloomDialog.less
@@ -26,6 +26,10 @@
 // with z-index as high as 50,000; so I made this a round number higher
 // than that.
 @dialogZindex: 60000;
+// Note that  the z-index for the select2 dropdowns used in both ../StyleEditor/StyleEditor.less
+// and ../TextBoxProperties/TextBoxProperties.less must be at least as large as or larger than the
+// dialog's z-index.  (See http://issues.bloomlibrary.org/youtrack/issue/BL-4386.)
+@dialogZindexPlusOne: 60001;
 
 .bloomDialogContainer {
     h2.tab {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1554)
<!-- Reviewable:end -->
