### PR TITLE
BL-4428 Remove need for Templates to be named Template

### DIFF
--- a/src/BloomBrowserUI/templates/template books/Big Book/template/NotForAddPage.txt
+++ b/src/BloomBrowserUI/templates/template books/Big Book/template/NotForAddPage.txt
@@ -1,0 +1,1 @@
+Pages here are designed for big books and not suitable for use in other kinds.

--- a/src/BloomBrowserUI/templates/template books/Decodable Reader/template/NotForAddPage.txt
+++ b/src/BloomBrowserUI/templates/template books/Decodable Reader/template/NotForAddPage.txt
@@ -1,0 +1,1 @@
+Pages here duplicate ones in Basic Book; we don't need to offer them again in Add Page.

--- a/src/BloomBrowserUI/templates/template books/Leveled Reader/template/NotForAddPage.txt
+++ b/src/BloomBrowserUI/templates/template books/Leveled Reader/template/NotForAddPage.txt
@@ -1,0 +1,1 @@
+Pages here duplicate ones in Basic Book; we don't need to offer them again in Add Page.

--- a/src/BloomBrowserUI/templates/template books/Picture Dictionary/template/NotForAddPage.txt
+++ b/src/BloomBrowserUI/templates/template books/Picture Dictionary/template/NotForAddPage.txt
@@ -1,0 +1,1 @@
+Pages here are quite specialized; we don't want them to show up generally in Add Page.

--- a/src/BloomBrowserUI/templates/template books/Template Starter/ReadMe-en.md
+++ b/src/BloomBrowserUI/templates/template books/Template Starter/ReadMe-en.md
@@ -1,13 +1,13 @@
 This special template lets you make your own templates. A template provides a set of related page layouts that an author can choose from in writing an original book. Usually the text blocks and picture blocks on template pages will be empty, ready for an author to fill in. Sometimes there may be standard text or pictures that should be on every copy of the page.
 There are two ways people can use your template. The first way is to start new books. For example, imagine student books that have one page for each school day of the week. You could make a template with 5 pages, each with places to type in text and choose pictures. Curriculum authors could select your template and make a new book, one for each week<sup>[1](#note1)</sup>.
 
-The second way people can use templates is as source of new pages, regardless of how they started the book. For example, in some places, each book requires a page as part of a government approval process. You might make a template containing that page and give it to others in your country. Then, when people translate a shellbook, they go to the end of the book and click “Add Page”. The page you made will appear in their list of choices. Some other ideas for templates are alphabet charts, glossaries, and instructions on how to use the book in a classroom.
+The second way people can use templates is as source of new pages, regardless of how they started the book. For example, in some places, each book requires a page as part of a government approval process. You might make a template containing that page and give it to others in your country. Then, when people translate a shellbook, they go to the end of the book and click “Add Page”. The page you made will appear in their list of choices. Some other ideas for templates are alphabet charts, glossaries, and instructions on how to use the book in a classroom. (If the pages in your book are not suitable to use this way, you can suppress it by creating a file in the book's template folder called NotForAddPage.txt. If you like, you can put an explanation in the file, but Bloom only cares that it exists.)
 
 When you add pages to your template, make sure to give each one useful label<sup>[2](#note2),[3](@note3)</sup>:
 
 ![custom label](customLabel.png)
 
- Also consider adding a description of your template, like the one you are reading now. To do this, put a text file named ReadMe-en.md in your template's folder. This file should follow the <a href="http://spec.commonmark.org/dingus/">markdown standard</a>. To provide your instructions in other languages, make version of that file that change the "en" to another language's two letter code. For example ReadMe-fr.md would be shown when Bloom is set to show labels in French. You can also include screenshots, like we have in this document.
+ Also consider adding a description of your template, like the one you are reading now. To do this, put a text file named ReadMe-en.md in your template's folder. This file should follow the <a href="http://spec.commonmark.org/dingus/">markdown standard</a>. To provide your instructions in other languages, make versions of that file that change the "en" to another language's two letter code. For example ReadMe-fr.md would be shown when Bloom is set to show labels in French. You can also include screenshots, like we have in this document.
 
 When the Add Page dialog box shows your template pages, it will show a thumbnail:
 
@@ -25,4 +25,4 @@ Notes:
 
 <a name="note2">2</a>: People will not be able to translate your labels and descriptions into other national languages. If this is a problem, please contact the Bloom team.
 
-<a name="note3">3</a>: If you want to the Add Page screen to also provide a short description of the page, you'll need to quite Bloom and edit the template's html in Notepad, like this: ![page description](pageDescription.png)
+<a name="note3">3</a>: If you want the Add Page screen to also provide a short description of the page, you'll need to quit Bloom and edit the template's html in Notepad, like this: ![page description](pageDescription.png)

--- a/src/BloomBrowserUI/templates/xMatter/TemplateStarter-XMatter/TemplateStarter-XMatter.pug
+++ b/src/BloomBrowserUI/templates/xMatter/TemplateStarter-XMatter/TemplateStarter-XMatter.pug
@@ -13,7 +13,7 @@ html
 				label.bubble Simple line drawings look best. Instead of using this page, you can also make your own thumbnail.png file and set it to Read-only so Bloom doesn't write over it.
 
 		+page-xmatter("About").bloom-frontMatter(data-export='front-matter-about')#26e4a8d9-c61c-496d-9f37-2cc274d28b32
-			| Template Title (must end with the word "Template")
+			| Template Title
 			+field("V,en").title
 				+editable(kLanguageForPrototypeOnly)(data-book='bookTitle')
 

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -14,6 +14,7 @@ using Bloom.Collection;
 using Bloom.Edit;
 using Bloom.ImageProcessing;
 using Bloom.Publish;
+using Bloom.web.controllers;
 using Bloom.WebLibraryIntegration;
 using L10NSharp;
 using MarkdownSharp;
@@ -1655,6 +1656,19 @@ namespace Bloom.Book
 					if (File.Exists(sourcePath))
 						File.Copy(sourcePath, destinationPath);
 				}
+			}
+
+			if (this.IsSuitableForMakingShells)
+			{
+				// If we just added the first template page to a template, it's now usable for adding
+				// pages to other books. But the thumbnail for that template, and the template folder
+				// it lives in, won't get created unless the user chooses Add Page again.
+				// Even if he doesn't (maybe it's a one-page template), we want it to have the folder
+				// that identifies it as a template book for the add pages dialog.
+				// (We don't want to do so when the book is first created, because it's no good in
+				// Add Pages until it has at least one addable page.)
+				var templateFolderPath = Path.Combine(FolderPath, PageTemplatesApi.TemplateFolderName);
+				Directory.CreateDirectory(templateFolderPath); // harmless if it exists already
 			}
 
 			Save();

--- a/src/BloomExe/web/controllers/PageTemplatesApi.cs
+++ b/src/BloomExe/web/controllers/PageTemplatesApi.cs
@@ -19,6 +19,7 @@ namespace Bloom.web.controllers
 	/// </summary>
 	public class PageTemplatesApi
 	{
+		public const string TemplateFolderName = "template";
 		private readonly SourceCollectionsList _sourceCollectionsList;
 		private readonly BookSelection _bookSelection;
 		private readonly PageSelection _pageSelection;
@@ -213,19 +214,20 @@ namespace Bloom.web.controllers
 			// 2) Look in their current collection...this is the first one used to make sourceBookPaths
 
 			// 3) Next look through the books that came with bloom and other that this user has installed (e.g. via download or bloompack)
-			//    and add in all other template books that are designed for inclusion in other books. These should end in "template.htm{l}".
-			//    Requiring the book to end in the word "template" is low budget, but fast. Maybe we'll do something better later.
-			//    (It's unfortunate that we have to check for .html as well as htm. Our own templates end in html, while user-created ones
-			//    end in .htm, Bloom's standard for created books.)
-			var pathToCurrentTemplateLC = pathToCurrentTemplateHtml.ToLowerInvariant();
+			//    and add in all other template books that are designed for inclusion in other books. These should contain a folder
+			//    called "template" (which contains thumbnails of the pages that can be inserted).
+			//    Template books whose pages are not suitable for extending Add Pages can be identified by creating a file
+			//    template/NotForAddPage.txt (which can contain any explanation you like).
 			bookTemplatePaths.AddRange(sourceBookPaths
 				.Where(path =>
-					{
-						var pathLC = path.ToLowerInvariant();
-						if (pathLC.Equals(pathToCurrentTemplateLC))
-							return false;
-						return pathLC.EndsWith("template.html") || pathLC.EndsWith("basic book.html") || pathLC.EndsWith("template.htm");
-					})
+				{
+					if (string.IsNullOrEmpty(path))
+						return false; // not sure how this happens.
+					var pathToTemplatesFolder = Path.Combine(Path.GetDirectoryName(path), TemplateFolderName);
+					if (!Directory.Exists(pathToTemplatesFolder))
+						return false;
+					return !File.Exists(Path.Combine(pathToTemplatesFolder, "NotForAddPage.txt"));
+				})
 				.Select(path => Platform.IsWindows ? path.ToLowerInvariant() : path));
 
 			var indexOfBasicBook = bookTemplatePaths.FindIndex(p => p.ToLowerInvariant().Contains("basic book"));

--- a/src/BloomExe/web/controllers/PageTemplatesApi.cs
+++ b/src/BloomExe/web/controllers/PageTemplatesApi.cs
@@ -226,7 +226,7 @@ namespace Bloom.web.controllers
 					var pathToTemplatesFolder = Path.Combine(Path.GetDirectoryName(path), TemplateFolderName);
 					if (!Directory.Exists(pathToTemplatesFolder))
 						return false;
-					return !File.Exists(Path.Combine(pathToTemplatesFolder, "NotForAddPage.txt"));
+					return !RobustFile.Exists(Path.Combine(pathToTemplatesFolder, "NotForAddPage.txt"));
 				})
 				.Select(path => Platform.IsWindows ? path.ToLowerInvariant() : path));
 


### PR DESCRIPTION
Now instead we look for a subfolder called "template"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1564)
<!-- Reviewable:end -->
