### PR TITLE
Fix somewhat obscure crash when changing UI language in collection chooser (BL-4434)

### DIFF
--- a/src/BloomExe/CollectionCreating/LanguageIdControl.Designer.cs
+++ b/src/BloomExe/CollectionCreating/LanguageIdControl.Designer.cs
@@ -19,6 +19,7 @@ namespace Bloom.CollectionCreating
 			{
 				components.Dispose();
 			}
+			_lookupISOControl.ReadinessChanged -= OnLookupISOControlReadinessChanged;
 			base.Dispose(disposing);
 		}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1566)
<!-- Reviewable:end -->
