### PR TITLE
Parse timespans invariantly for epubs (BL-4374)

### DIFF
--- a/src/BloomExe/Publish/EpubMaker.cs
+++ b/src/BloomExe/Publish/EpubMaker.cs
@@ -357,7 +357,9 @@ namespace Bloom.Publish
 				var dataDurationAttr = span.Attributes["data-duration"];
 				if(dataDurationAttr != null)
 				{
-					pageDuration += TimeSpan.FromSeconds(Double.Parse(dataDurationAttr.Value));
+					// Make sure we parse "3.14159" properly since that's the form we'll see regardless of current locale.
+					// (See http://issues.bloomlibrary.org/youtrack/issue/BL-4374.)
+					pageDuration += TimeSpan.FromSeconds(Double.Parse(dataDurationAttr.Value, System.Globalization.CultureInfo.InvariantCulture));
 				}
 				else
 				{


### PR DESCRIPTION
This is the only Double.Parse() call in the Bloom source tree.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1573)
<!-- Reviewable:end -->
