### PR TITLE
BL-4328 Properly handle copy page from other book

### DIFF
--- a/src/BloomExe/Command.cs
+++ b/src/BloomExe/Command.cs
@@ -155,12 +155,12 @@ namespace Bloom
 		public event EventHandler<PageInsertEventArgs> InsertPage;
 		public Page MostRecentInsertedTemplatePage;
 
-		public void Insert(Page page, XmlNode userStyleNodeFromNewPage)
+		public void Insert(Page page)
 		{
 			if (InsertPage != null)
 			{
 				MostRecentInsertedTemplatePage = page;
-				InsertPage.Invoke(page, new PageInsertEventArgs(true, userStyleNodeFromNewPage));
+				InsertPage.Invoke(page, new PageInsertEventArgs(true));
 			}
 		}
 	}
@@ -168,16 +168,10 @@ namespace Bloom
 	public class PageInsertEventArgs : EventArgs
 	{
 		public bool FromTemplate;
-		private XmlNode _userStyles;
 
-		public PageInsertEventArgs(bool fromTemplate, XmlNode userStyles)
+		public PageInsertEventArgs(bool fromTemplate)
 		{
 			FromTemplate = fromTemplate;
-			_userStyles = userStyles;
 		}
-
-		public bool HasStyles { get { return _userStyles != null; } }
-
-		public XmlNode InsertedPageUserStylesNode { get { return _userStyles; } }
 	}
 }

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -338,11 +338,11 @@ namespace Bloom.Edit
 
 		public bool CanCopyPage
 		{
-			// It seems sensible to allow copying xmatter pages, but they have classes set on them which I think will cause
-			// Bloom to delete them when the book is next opened...needs research if we want to allow this, and probably
-			// some special-case code to adjust page classes. They also tend to be singletons, which may cause problems if
-			// we let the user make multiple ones. Note that we don't need the editability restrictions here, since
-			// copy doesn't modify this book.
+			// Currently we don't want to allow copying xmatter pages. If we ever do, some research and non-trivial change
+			// will probably be needed, not just removing the restriction. Xmatter pages have classes set on them which will cause
+			// Bloom to delete them when the book is next opened. They also tend to be singletons, which may cause problems if
+			// we let the user make multiple ones.
+			// Note that we don't need the editability restrictions here, since copy doesn't modify this book.
 			get { return _pageSelection != null && _pageSelection.CurrentSelection != null && !_pageSelection.CurrentSelection.IsXMatter; }
 		}
 

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -34,6 +34,7 @@ namespace Bloom.Edit
 		private readonly DeletePageCommand _deletePageCommand;
 		private readonly LocalizationChangedEvent _localizationChangedEvent;
 		private readonly CollectionSettings _collectionSettings;
+		private readonly SourceCollectionsList _sourceCollectionsList;
 		//private readonly SendReceiver _sendReceiver;
 		private HtmlDom _domForCurrentPage;
 		// We dispose of this when we create a new one. It may hang around a little longer than needed, but memory
@@ -77,7 +78,8 @@ namespace Bloom.Edit
 			CollectionSettings collectionSettings,
 			//SendReceiver sendReceiver,
 			EnhancedImageServer server,
-			BloomWebSocketServer webSocketServer)
+			BloomWebSocketServer webSocketServer,
+			SourceCollectionsList sourceCollectionsList)
 		{
 			_bookSelection = bookSelection;
 			_pageSelection = pageSelection;
@@ -87,6 +89,7 @@ namespace Bloom.Edit
 			//_sendReceiver = sendReceiver;
 			_server = server;
 			_webSocketServer = webSocketServer;
+			_sourceCollectionsList = sourceCollectionsList;
 			_templatePagesDict = null;
 
 			bookSelection.SelectionChanged += OnBookSelectionChanged;
@@ -144,6 +147,7 @@ namespace Bloom.Edit
 
 		private Form _oldActiveForm;
 		private XmlElement _pageDivFromCopyPage;
+		private string _bookPathFromCopyPage;
 
 		/// <summary>
 		/// we need to guarantee that we save *before* any other tabs try to update, hence this "about to change" event
@@ -288,12 +292,6 @@ namespace Bloom.Edit
 		private void OnInsertPage(object page, PageInsertEventArgs e)
 		{
 			CurrentBook.InsertPageAfter(DeterminePageWhichWouldPrecedeNextInsertion(), page as Page);
-			if (e.HasStyles)
-			{
-				var existingUserStyles = CurrentBook.GetOrCreateUserModifiedStyleElementFromStorage();
-				var newMergedUserStyleXml = HtmlDom.MergeUserStylesOnInsertion(existingUserStyles, e.InsertedPageUserStylesNode);
-				existingUserStyles.InnerXml = newMergedUserStyleXml;
-			}
 			//_view.UpdatePageList(false);  InsertPageAfter calls this via pageListChangedEvent.  See BL-3632 for trouble this causes.
 			//_pageSelection.SelectPage(newPage);
 			if(e.FromTemplate)
@@ -340,7 +338,12 @@ namespace Bloom.Edit
 
 		public bool CanCopyPage
 		{
-			get { return CanDuplicatePage; }
+			// It seems sensible to allow copying xmatter pages, but they have classes set on them which I think will cause
+			// Bloom to delete them when the book is next opened...needs research if we want to allow this, and probably
+			// some special-case code to adjust page classes. They also tend to be singletons, which may cause problems if
+			// we let the user make multiple ones. Note that we don't need the editability restrictions here, since
+			// copy doesn't modify this book.
+			get { return _pageSelection != null && _pageSelection.CurrentSelection != null && !_pageSelection.CurrentSelection.IsXMatter; }
 		}
 
 		public bool CanDeletePage
@@ -1204,12 +1207,28 @@ namespace Bloom.Edit
 			// We have to clone this so that if the user changes the page after doing the copy,
 			// when they paste they get the page as it was, not as it is now.
 			_pageDivFromCopyPage = (XmlElement) page.GetDivNodeForThisPage().CloneNode(true);
+			_bookPathFromCopyPage = page.Book.GetPathHtmlFile();
 		}
 
-		public void PastePage(IPage page)
+		/// <summary>
+		/// Paste the previously saved _pageDivFromCopyPage as a new page.
+		/// </summary>
+		/// <param name="pageToPasteAfter">This is NOT the page we are to paste!</param>
+		public void PastePage(IPage pageToPasteAfter)
 		{
-			var pageForPasting = new Page(page.Book, _pageDivFromCopyPage, "not used", "not used", x => _pageDivFromCopyPage);
-			OnInsertPage(pageForPasting, new PageInsertEventArgs(false, null));
+			var templateBook = pageToPasteAfter.Book; // default is to assume it's from the same book
+			bool fromAnotherBook = templateBook.GetPathHtmlFile() != _bookPathFromCopyPage;
+			if (fromAnotherBook)
+			{
+				// Copying from some other book. We need an actual book object, just like when we insert a page from a template,
+				// at least in order to properly copy any images and styles used on the page that are not in the
+				// destination book.
+				// If for some reason (since renamed?) we can't get it, just do the best we can...images and styles may
+				// not be right, but we can still paste the content of the page.
+				templateBook = _sourceCollectionsList.FindAndCreateTemplateBookByFullPath(_bookPathFromCopyPage) ?? templateBook;
+			}
+			var pageForPasting = new Page(templateBook, _pageDivFromCopyPage, "not used", "not used", x => _pageDivFromCopyPage);
+			OnInsertPage(pageForPasting, new PageInsertEventArgs(false)); // false => don't need analytics on use of template pages
 		}
 	}
 }

--- a/src/BloomExe/Edit/PageSelection.cs
+++ b/src/BloomExe/Edit/PageSelection.cs
@@ -12,7 +12,13 @@ namespace Bloom.Edit
 		public event EventHandler SelectionChanging; // before it changes
 		public event EventHandler SelectionChanged; // after it changed
 
-		public bool SelectPage(IPage page)
+		/// <summary>
+		/// Should pass prepareAlreadyDone true iff you previously called PrepareToSelectPage
+		/// </summary>
+		/// <param name="page"></param>
+		/// <param name="prepareAlreadyDone"></param>
+		/// <returns></returns>
+		public bool SelectPage(IPage page, bool prepareAlreadyDone = false)
 		{
 #if __MonoCS__
 			// If we haven't finished displaying the previously selected page, we can't select another page yet.
@@ -21,7 +27,8 @@ namespace Bloom.Edit
 				return false;
 #endif
 			//enhance... make pre-change event cancellable
-			InvokeSelectionChanging();
+			if (!prepareAlreadyDone)
+				PrepareToSelectPage();
 			_currentSelection = page;
 
 			InvokeSelectionChanged();
@@ -33,7 +40,10 @@ namespace Bloom.Edit
 			get { return _currentSelection; }
 		}
 
-		private void InvokeSelectionChanging()
+		/// <summary>
+		/// If you call this, you should later call SelectPage(..., true).
+		/// </summary>
+		public void PrepareToSelectPage()
 		{
 			EventHandler handler = SelectionChanging;
 			if (handler != null)

--- a/src/BloomExe/web/controllers/AddOrChangePageApi.cs
+++ b/src/BloomExe/web/controllers/AddOrChangePageApi.cs
@@ -41,11 +41,10 @@ namespace Bloom.web.controllers
 
 		private void HandleAddPage(ApiRequest request)
 		{
-			XmlNode userStylesOnPage;
-			var templatePage = GetPageTemplateAndUserStyles(request, out userStylesOnPage);
+			var templatePage = GetPageTemplateAndUserStyles(request);
 			if (templatePage != null)
 			{
-				_templateInsertionCommand.Insert(templatePage as Page, userStylesOnPage);
+				_templateInsertionCommand.Insert(templatePage as Page);
 				_pageRefreshEvent.Raise(PageRefreshEvent.SaveBehavior.JustRedisplay); // needed to get the styles updated
 				request.Succeeded();
 				return;
@@ -54,20 +53,12 @@ namespace Bloom.web.controllers
 
 		private void HandleChangeLayout(ApiRequest request)
 		{
-			XmlNode userStylesOnPage;
-			var templatePage = GetPageTemplateAndUserStyles(request, out userStylesOnPage);
+			var templatePage = GetPageTemplateAndUserStyles(request);
 			if (templatePage != null)
 			{
 				var pageToChange = /*PageChangingLayout ??*/ _pageSelection.CurrentSelection;
 				var book = _pageSelection.CurrentSelection.Book;
-				book.UpdatePageToTemplate(book.OurHtmlDom, templatePage.GetDivNodeForThisPage(), pageToChange.Id);
-				if (userStylesOnPage != null)
-				{
-					var existingUserStyles = book.GetOrCreateUserModifiedStyleElementFromStorage();
-					var newMergedUserStyleXml = HtmlDom.MergeUserStylesOnInsertion(existingUserStyles, userStylesOnPage);
-					existingUserStyles.InnerXml = newMergedUserStyleXml;
-					book.Save();
-				}
+				book.UpdatePageToTemplate(book.OurHtmlDom, templatePage, pageToChange.Id);
 				// The Page objects are cached in the page list and may be used if we issue another
 				// change layout command. We must update their lineage so the right "current layout"
 				// will be shown if the user changes the layout of the same page again.
@@ -80,9 +71,8 @@ namespace Bloom.web.controllers
 			}
 		}
 
-		private IPage GetPageTemplateAndUserStyles(ApiRequest request, out XmlNode userStylesOnPage)
+		private IPage GetPageTemplateAndUserStyles(ApiRequest request)
 		{
-			userStylesOnPage = null;
 			var requestData = DynamicJson.Parse(request.RequiredPostJson());
 			//var templateBookUrl = request.RequiredParam("templateBookUrl");
 			var templateBookPath = HttpUtility.HtmlDecode(requestData.templateBookPath);
@@ -100,8 +90,6 @@ namespace Bloom.web.controllers
 				request.Failed("Could not find the page " + requestData.pageId + " in the template book " + requestData.templateBookUrl);
 				return null;
 			}
-			var domForPage = templateBook.GetEditableHtmlDomForPage(page);
-			userStylesOnPage = HtmlDom.GetUserModifiableStylesUsedOnPage(domForPage); // could be empty
 			return page;
 		}
 	}

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Book\BookCollectionTests.cs" />
     <Compile Include="Book\BookCopyrightAndLicenseTests.cs" />
     <Compile Include="Book\BookInfoTests.cs" />
+    <Compile Include="Book\TestBook.cs" />
     <Compile Include="Book\UserPrefsTests.cs" />
     <Compile Include="Book\BookTestsBase.cs" />
     <Compile Include="CLI\HydrateBookCommandTests.cs" />

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -605,7 +605,7 @@ namespace BloomTests.Book
 		}
 
 		[Test]
-		public void MergeUserModifiedStyles_NewStyleHasLangAttr_BothKept()
+		public void MergeUserModifiedStyles_NewStyleHasLangAttr_Ignored()
 		{
 			var bookDom = new HtmlDom(
 				@"<html>
@@ -637,7 +637,7 @@ namespace BloomTests.Book
 			var xpath = "//style[@title=\"userModifiedStyles\" and contains(text(),'font-size: ginormous;')]";
 			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath(xpath, 1);
 			var xpath2 = "//style[@title=\"userModifiedStyles\" and contains(text(),\".MyTest-style[lang='en'] { font-size: smaller;\")]";
-			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath(xpath2, 1);
+			AssertThatXmlIn.Dom(bookDom.RawDom).HasNoMatchForXpath(xpath2);
 		}
 
 		[Test]
@@ -647,7 +647,7 @@ namespace BloomTests.Book
 				@"<html>
 					<head>
 						<style type='text/css' title='userModifiedStyles'>
-							.MyTest-style { font-size: ginormous; }</style>
+							.SomeOther-style { font-size: ginormous; }</style>
 					</head>
 					<body>
 						<div class='MyTest-style bogus'></div>

--- a/src/BloomTests/Book/PageMigrationTests.cs
+++ b/src/BloomTests/Book/PageMigrationTests.cs
@@ -418,6 +418,9 @@ namespace BloomTests.Book
 						<div aria-describedby='qtip-0' data-hasqtip='true' class='bloom-editable BigWords-style bloom-content1' contenteditable='true' lang='en'>
 							There was an old man called Bilanga who was very tall and also not yet married.
 						</div>
+						<div aria-describedby='qtip-0' data-hasqtip='true' class='bloom-editable bloom-content1' contenteditable='true' lang='fr'>
+							Some french
+						</div>
 					</div>
 				</div>
 			</div>
@@ -432,7 +435,7 @@ namespace BloomTests.Book
 		  <div style='bottom: 76%' class='split-pane-component position-top'>
 			<div class='split-pane-component-inner'>
 			  <div class='bloom-translationGroup bloom-trailingElement normal-style'>
-				<div lang='z' contenteditable='true' class='bloom-content1 bloom-editable'>
+				<div lang='z' contenteditable='true' class='bloom-content1 bloom-editable FancyNew-style'>
 				</div>
 			  </div>
 			</div>
@@ -467,8 +470,8 @@ namespace BloomTests.Book
 	  </div>
 	</div>"));
 			var template = (XmlElement) newPageDom.SafeSelectNodes("//div[@id='newTemplate']")[0];
-
-			book.UpdatePageToTemplate(book.OurHtmlDom, template, "thePage");
+			var templatePage = new Page(book, template, "dummy", "id", x => { return template; });
+			book.UpdatePageToTemplate(book.OurHtmlDom, templatePage, "thePage");
 
 			var newPage = (XmlElement)dom.SafeSelectNodes(".//div[@id='thePage']")[0];
 			Assert.That(newPage.Attributes["class"].Value, Is.EqualTo("A5Portrait bloom-page numberedPage customPage bloom-combinedPage bloom-monolingual"));
@@ -476,8 +479,11 @@ namespace BloomTests.Book
 			// We kept the image
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath(".//img[@data-license='cc-by-nc-sa' and @data-copyright='Copyright © 2012, LASI' and @src='erjwx3bl.q3c.png']", 1); // the one in the first page has slightly different attrs
 			CheckEditableText(newPage, "en", "There was an old man called Bilanga who was very tall and also not yet married.");
+			CheckEditableText(newPage, "fr", "Some french");
 			// We should have kept the second one in the new page even though we didn't put anything in it (and there is one in the first page, too).
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath(".//div[contains(@class, 'bloom-translationGroup')]", 3);
+			// The English and French should both have ended up with this, also the inserted empty div for xyz.
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath(".//div[contains(@class, 'bloom-editable') and contains(@class, ' FancyNew-style')]", 3);
 		}
 
 		// Enhance: if there are ever cases where there are multiple image containers to migrate, test this.

--- a/src/BloomTests/Book/TestBook.cs
+++ b/src/BloomTests/Book/TestBook.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Bloom;
+using Bloom.Book;
+using Bloom.Collection;
+using Bloom.Edit;
+using BloomTemp;
+using SIL.IO;
+
+namespace BloomTests.Book
+{
+	/// <summary>
+	/// This class supports book tests that need real books. A temporary folder is created and hangs around as long as this
+	/// TestBook class exists. This should be considered a work-in-progress, I just built as much as I needed for
+	/// one test. It might be useful to enhance it with more default state for the book (e.g., images) or static
+	/// create methods with various arguments. Could even be worth implementing a fluent language
+	/// so you can do something like TestBook.CreateBook().WithStyles(...).WithImage(name, content).WithContent(...).Book.
+	/// </summary>
+	public class TestBook : IDisposable
+	{
+		private TemporaryFolder _folder;
+
+		public Bloom.Book.Book Book;
+
+		public string BookFolder;
+
+		public string BookPath;
+
+		public TestBook(string testName, string content)
+		{
+			_folder = new TemporaryFolder(testName);
+			BookFolder = _folder.FolderPath;
+			BookPath = Path.Combine(_folder.FolderPath, testName + ".htm");
+			File.WriteAllText(BookPath, content);
+			var settings = CreateDefaultCollectionsSettings();
+			var codeBaseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().CodeBase.Substring(8));
+			// This is minimal...if the content doesn't specify xmatter Bloom defaults to Traditional
+			// and needs the file locator to know this folder so it can find it.
+			// May later need to include more folders or allow the individual tests to do so.
+			var locator = new FileLocator(new string[] { codeBaseDir + "/../browser/templates/xmatter"});
+			var storage = new BookStorage(BookFolder, locator, new BookRenamedEvent(), settings);
+			// very minimal...enhance if we need to test something that can really find source collections.
+			var templatefinder = new SourceCollectionsList();
+			Book = new Bloom.Book.Book(new BookInfo(BookFolder, true), storage, templatefinder, settings, new PageSelection(), new PageListChangedEvent(), new BookRefreshEvent() );
+		}
+
+		protected CollectionSettings CreateDefaultCollectionsSettings()
+		{
+			return new CollectionSettings(new NewCollectionSettings() { PathToSettingsFile = CollectionSettings.GetPathForNewSettings(BookFolder, "test"), Language1Iso639Code = "xyz", Language2Iso639Code = "en", Language3Iso639Code = "fr" });
+		}
+
+		// Since this is just for testing I didn't bother with the usual mess to catch/cleanup
+		// if someone forgets to dispose.
+		public void Dispose()
+		{
+			_folder.Dispose();
+		}
+	}
+}


### PR DESCRIPTION
Lots of stuff came up while dealing with this
- Need to keep track of the source book so we can copy pictures
- Need to copy styles. This led to a major refactor of the
copy/merge styles.
- Changed behavior so if destination has a style, no part of source
definition of that style will be transferred. Should also fix BL-4426.
- Found and fixed yet another problem where change layout would
not switch to the style of the new layout

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1576)
<!-- Reviewable:end -->
