### PR TITLE
Protect paragraph-oriented html from backspace and delete BL-4423

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -24,11 +24,15 @@ export default class BloomField {
     static ManageField(bloomEditableDiv: HTMLElement) {
 
         BloomField.PreventRemovalOfSomeElements(bloomEditableDiv);
+        BloomField.ManageWhatHappensIfTheyDeleteEverything(bloomEditableDiv);
+        // ManageWhatHappensIfTheyDeleteEverything() is actually enough, it cleans things up. But can still show some momentary cursor
+        // weirdness. So at least in this common case, we prevent the backspace altogether.
         BloomField.PreventBackspaceAtStartFromRemovingParagraph(bloomEditableDiv);
-        BloomField.MakeShiftEnterInsertLineBreak(bloomEditableDiv);
-        BloomField.MakeTabEnterTabElement(bloomEditableDiv);
         BloomField.PreventArrowingOutIntoField(bloomEditableDiv);
         BloomField.PreventBackspaceAtStartFromMovingTextIntoEmbeddedImageCaption(bloomEditableDiv);
+
+        BloomField.MakeShiftEnterInsertLineBreak(bloomEditableDiv);
+        BloomField.MakeTabEnterTabElement(bloomEditableDiv);
 
         /*  The following is assumed to not be needed currently (3.9)... probably not needed
             since we added ckeditor.
@@ -285,9 +289,9 @@ export default class BloomField {
         // if the user types (ctrl+a, del) then we get an empty element or '<br></br>', and need to get a <p> in there.
         // if the user types (ctrl+a, 'blah'), then we get blah outside of any paragraph
 
-        $(field).on("input", function (e) {
+        $(field).keyup(e => {
             if ($(this).find('p').length === 0) {
-                BloomField.ModifyForParagraphMode(this);
+                BloomField.ModifyForParagraphMode(field);
 
                 // Now put the cursor in the paragraph, *after* the character they may have just typed or the
                 // text they just pasted.
@@ -303,7 +307,7 @@ export default class BloomField {
     private static PreventRemovalOfSomeElements(field: HTMLElement) {
         var numberThatShouldBeThere = $(field).find(".bloom-preventRemoval").length;
         if (numberThatShouldBeThere > 0) {
-            $(field).on("input", function (e) {
+            $(field).keyup(e => {
                 if ($(this).find(".bloom-preventRemoval").length < numberThatShouldBeThere) {
                     document.execCommand('undo');
                     e.preventDefault();

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -27,21 +27,25 @@ export default class BloomField {
         BloomField.PreventBackspaceAtStartFromRemovingParagraph(bloomEditableDiv);
         BloomField.MakeShiftEnterInsertLineBreak(bloomEditableDiv);
         BloomField.MakeTabEnterTabElement(bloomEditableDiv);
-
-        //the following is assumed to not be needed currently... probably since we added ckeditor.
-        // BloomField.ModifyForParagraphMode(bloomEditableDiv);
-        // $(bloomEditableDiv).blur(function () {
-        //     BloomField.ModifyForParagraphMode(this);
-        // });
-        // $(bloomEditableDiv).focusin(function () {
-        //     BloomField.HandleFieldFocus(this);
-        // });
-
         BloomField.PreventArrowingOutIntoField(bloomEditableDiv);
         BloomField.PreventBackspaceAtStartFromMovingTextIntoEmbeddedImageCaption(bloomEditableDiv);
 
-        //BloomField.PrepareNonParagraphField(bloomEditableDiv);
-        //BloomField.ManageWhatHappensIfTheyDeleteEverythingNonParagraph(bloomEditableDiv);
+        /*  The following is assumed to not be needed currently (3.9)... probably not needed
+            since we added ckeditor.
+            However this code is retained because this is *very* expensive code to get these
+            kinds of low-level html editor methods working right, so it
+            makes sense to leave them here in case we have analogous situations come up.
+
+            BloomField.ModifyForParagraphMode(bloomEditableDiv);
+            $(bloomEditableDiv).blur(function () {
+                BloomField.ModifyForParagraphMode(this);
+            });
+            $(bloomEditableDiv).focusin(function () {
+                BloomField.HandleFieldFocus(this);
+            });
+            BloomField.PrepareNonParagraphField(bloomEditableDiv);
+            BloomField.ManageWhatHappensIfTheyDeleteEverythingNonParagraph(bloomEditableDiv);
+        */
     }
 
     private static MakeTabEnterTabElement(field: HTMLElement) {
@@ -111,7 +115,6 @@ export default class BloomField {
                 }
                 e.stopPropagation();
                 e.preventDefault();
-
             }
         });
     }
@@ -258,9 +261,11 @@ export default class BloomField {
         }
     }
 
+    /* Currently unused. See note in ManageField().
     private static HandleFieldFocus(field: HTMLElement) {
         BloomField.MoveCursorToEdgeOfField(field, CursorPosition.start);
     }
+    */
 
     private static MoveCursorToEdgeOfField(field: HTMLElement, position: CursorPosition) {
         var range = document.createRange();
@@ -393,6 +398,7 @@ export default class BloomField {
             }
         }
     }
+
     private static PreventBackspaceAtStartFromRemovingParagraph(field: HTMLElement) {
         $(field).keydown(e => {
             if (e.which === 8 /* backspace*/) {

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -21,45 +21,43 @@
 // for any element marked with a 'bloom-preventRemoval' class.
 
 export default class BloomField {
-    static ManageField(bloomEditableDiv:HTMLElement) {
+    static ManageField(bloomEditableDiv: HTMLElement) {
 
         BloomField.PreventRemovalOfSomeElements(bloomEditableDiv);
+        BloomField.PreventBackspaceAtStartFromRemovingParagraph(bloomEditableDiv);
+        BloomField.MakeShiftEnterInsertLineBreak(bloomEditableDiv);
+        BloomField.MakeTabEnterTabElement(bloomEditableDiv);
 
-        if(BloomField.RequiresParagraphs(bloomEditableDiv)) {
-            BloomField.ModifyForParagraphMode(bloomEditableDiv);
-            BloomField.ManageWhatHappensIfTheyDeleteEverything(bloomEditableDiv);
-            BloomField.PreventArrowingOutIntoField(bloomEditableDiv);
-            BloomField.PreventBackspaceAtStartFromMovingTextIntoEmbeddedImageCaption(bloomEditableDiv);
-            BloomField.MakeTabEnterTabElement(bloomEditableDiv);
-            BloomField.MakeShiftEnterInsertLineBreak(bloomEditableDiv);
+        //the following is assumed to not be needed currently... probably since we added ckeditor.
+        // BloomField.ModifyForParagraphMode(bloomEditableDiv);
+        // $(bloomEditableDiv).blur(function () {
+        //     BloomField.ModifyForParagraphMode(this);
+        // });
+        // $(bloomEditableDiv).focusin(function () {
+        //     BloomField.HandleFieldFocus(this);
+        // });
 
-            $(bloomEditableDiv).blur(function () {
-                BloomField.ModifyForParagraphMode(this);
-            });
-            $(bloomEditableDiv).focusin(function () {
-                BloomField.HandleFieldFocus(this);
-            });
-        }
-        else{
-            BloomField.PrepareNonParagraphField(bloomEditableDiv);
-            BloomField.ManageWhatHappensIfTheyDeleteEverythingNonParagraph(bloomEditableDiv);
-        }
+        BloomField.PreventArrowingOutIntoField(bloomEditableDiv);
+        BloomField.PreventBackspaceAtStartFromMovingTextIntoEmbeddedImageCaption(bloomEditableDiv);
+
+        //BloomField.PrepareNonParagraphField(bloomEditableDiv);
+        //BloomField.ManageWhatHappensIfTheyDeleteEverythingNonParagraph(bloomEditableDiv);
     }
 
     private static MakeTabEnterTabElement(field: HTMLElement) {
         $(field).keydown(e => {
             if (e.which === 9) {
-                    //note: some people introduce a new element, <tab>. That has the advantage
-                    //of having a stylesheet-controllable width. However, Firefox leave the
-                    //cursor in side of the <tab></tab>, and though we could manage
-                    //to get out of that, what if someone moved back into it? Etc. etc.
-                    //So I'm going with the conservative choice for now, which is the em space,
-                    //which is about as wide as 4 spaces.
-                    document.execCommand("insertHTML", false, "&emsp;");
-                    e.stopPropagation();
-                    e.preventDefault();
-                }
+                //note: some people introduce a new element, <tab>. That has the advantage
+                //of having a stylesheet-controllable width. However, Firefox leave the
+                //cursor in side of the <tab></tab>, and though we could manage
+                //to get out of that, what if someone moved back into it? Etc. etc.
+                //So I'm going with the conservative choice for now, which is the em space,
+                //which is about as wide as 4 spaces.
+                document.execCommand("insertHTML", false, "&emsp;");
+                e.stopPropagation();
+                e.preventDefault();
             }
+        }
         );
     }
 
@@ -152,7 +150,7 @@ export default class BloomField {
         //The following checks the top level elemenents and only allows divs; the two items
         //that we expect in there are the div for the "imagePusherDowner" and the div for
         //the image - container(which in turn contains the caption).
-        $(divToProtect).children().filter(function() {
+        $(divToProtect).children().filter(function () {
             return this.localName.toLowerCase() != 'div';
         }).each(function () {
             //divToProtect.removeChild(this);
@@ -181,7 +179,7 @@ export default class BloomField {
                     //see if it is one those. Anything marked with bloom-preventRemoval is probably not something we want to
                     //be merging with.
                     var previousElement = $(sel.anchorNode).closest('P').prev();
-                    if(previousElement.length>0 && previousElement[0] == divToProtect) {
+                    if (previousElement.length > 0 && previousElement[0] == divToProtect) {
                         e.stopPropagation();
                         e.preventDefault();
                         console.log("Prevented Backspace");
@@ -193,8 +191,8 @@ export default class BloomField {
 
     // Without this, ctrl+a followed by a left-arrow or right-arrow gets you out of all paragraphs,
     // so you can start messing things up.
-    private static PreventArrowingOutIntoField(field:HTMLElement) {
-        $(field).keydown(function(e) {
+    private static PreventArrowingOutIntoField(field: HTMLElement) {
+        $(field).keydown(function (e) {
             var leftArrowPressed = e.which === 37;
             var rightArrowPressed = e.which === 39;
             if (leftArrowPressed || rightArrowPressed) {
@@ -207,16 +205,16 @@ export default class BloomField {
         });
     }
 
-    private static EnsureStartsWithParagraphElement(field:HTMLElement) {
-        if ($(field).children().length > 0 && ( $(field).children().first().prop("tagName").toLowerCase() === 'p')) {
+    private static EnsureStartsWithParagraphElement(field: HTMLElement) {
+        if ($(field).children().length > 0 && ($(field).children().first().prop("tagName").toLowerCase() === 'p')) {
             return;
         }
         $(field).prepend('<p></p>');
     }
 
-    private static EnsureEndsWithParagraphElement(field:HTMLElement) {
+    private static EnsureEndsWithParagraphElement(field: HTMLElement) {
         //Enhance: move any errant paragraphs to after the imageContainer
-        if($(field).children().length > 0 && ( $(field).children().last().prop("tagName").toLowerCase() === 'p')) {
+        if ($(field).children().length > 0 && ($(field).children().last().prop("tagName").toLowerCase() === 'p')) {
             return;
         }
         $(field).append('<p></p>');
@@ -229,7 +227,7 @@ export default class BloomField {
             var node = nodes[n];
             if (node.nodeType === 3) {//Node.TEXT_NODE
                 var paragraph = document.createElement('p');
-                if(node.textContent.trim() !== '') {
+                if (node.textContent.trim() !== '') {
                     paragraph.textContent = node.textContent;
                     node.parentNode.insertBefore(paragraph, node);
                 }
@@ -244,38 +242,32 @@ export default class BloomField {
     //      text doesn't get any of the formatting assigned to paragraphs)
     // 2) when this field was already used by the user, and then later switched to paragraph mode.
     // 3) corner cases that aren't handled by as-you-edit events. E.g., pressing "ctrl+a DEL"
-    private static ModifyForParagraphMode(field:HTMLElement) {
+    private static ModifyForParagraphMode(field: HTMLElement) {
         BloomField.ConvertTopLevelTextNodesToParagraphs(field);
         $(field).find('br').remove();
 
         // in cases where we are embedding images inside of bloom-editables, the paragraphs actually have to go at the
         // end, for reason of wrapping. See SHRP C1P4 Pupils Book
         //if(x.startsWith('<div')){
-        if($(field).find('.bloom-keepFirstInField').length > 0){
+        if ($(field).find('.bloom-keepFirstInField').length > 0) {
             BloomField.EnsureEndsWithParagraphElement(field);
             return;
         }
-        else{
-               BloomField.EnsureStartsWithParagraphElement(field);
+        else {
+            BloomField.EnsureStartsWithParagraphElement(field);
         }
     }
 
-    private static RequiresParagraphs(field : HTMLElement) : boolean {
-        return $(field).closest('.bloom-requiresParagraphs').length > 0
-                //this signal used to let the css add this conversion after some SIL-LEAD SHRP books were already typed
-            || ($(field).css('border-top-style') === 'dashed');
+    private static HandleFieldFocus(field: HTMLElement) {
+        BloomField.MoveCursorToEdgeOfField(field, CursorPosition.start);
     }
 
-    private static HandleFieldFocus(field:HTMLElement) {
-       BloomField.MoveCursorToEdgeOfField(field, CursorPosition.start);
-    }
-
-    private static MoveCursorToEdgeOfField(field: HTMLElement, position: CursorPosition ){
+    private static MoveCursorToEdgeOfField(field: HTMLElement, position: CursorPosition) {
         var range = document.createRange();
-        if(position === CursorPosition.start) {
+        if (position === CursorPosition.start) {
             range.selectNodeContents($(field).find('p').first()[0]);
         }
-        else{
+        else {
             range.selectNodeContents($(field).find('p').last()[0]);
         }
         range.collapse(position === CursorPosition.start);//true puts it at the start
@@ -303,9 +295,9 @@ export default class BloomField {
     // around the picture. The problem is that the user can do (ctrl+a, del) to start over on the text, and
     // inadvertently remove the embedded images. So we introduced the "bloom-preventRemoval" class, and this
     // tries to safeguard elements bearing that class.
-    private static PreventRemovalOfSomeElements(field:HTMLElement) {
+    private static PreventRemovalOfSomeElements(field: HTMLElement) {
         var numberThatShouldBeThere = $(field).find(".bloom-preventRemoval").length;
-        if(numberThatShouldBeThere > 0) {
+        if (numberThatShouldBeThere > 0) {
             $(field).on("input", function (e) {
                 if ($(this).find(".bloom-preventRemoval").length < numberThatShouldBeThere) {
                     document.execCommand('undo');
@@ -334,24 +326,24 @@ export default class BloomField {
     // This bug mentions the cursor being in the wrong place: https://bugzilla.mozilla.org/show_bug.cgi?id=904846
     // The reason this is for "non paragraph fields" is that these are the only kind that can be empty. Fields with <p>'s are never
     // totally empty, so they escape this bug.
-    private static PrepareNonParagraphField(field:HTMLElement) {
-        if ($(field).text() === '') {
-            //add a span with only a zero-width space in it
-            //enhance: a zero-width placeholder would be a bit better, but theOneLibSynphony doesn't know this is a space: //$(this).html('<span class="bloom-ui">&#8203;</span>');
-            $(field).html('&nbsp;');
-            //now we tried deleting it immediately, or after a pause, but that doesn't help. So now we don't delete it until they type or paste something.
-            // REMOVE: why was this doing it for all of the elements? $(container).find(".bloom-editable").one('paste keypress', FixUpOnFirstInput);
-            $(field).one('paste keypress', this.FixUpOnFirstInput);
-        }
-    }
+    // private static PrepareNonParagraphField(field: HTMLElement) {
+    //     if ($(field).text() === '') {
+    //         //add a span with only a zero-width space in it
+    //         //enhance: a zero-width placeholder would be a bit better, but theOneLibSynphony doesn't know this is a space: //$(this).html('<span class="bloom-ui">&#8203;</span>');
+    //         $(field).html('&nbsp;');
+    //         //now we tried deleting it immediately, or after a pause, but that doesn't help. So now we don't delete it until they type or paste something.
+    //         // REMOVE: why was this doing it for all of the elements? $(container).find(".bloom-editable").one('paste keypress', FixUpOnFirstInput);
+    //         $(field).one('paste keypress', this.FixUpOnFirstInput);
+    //     }
+    // }
 
-    private static ManageWhatHappensIfTheyDeleteEverythingNonParagraph(field: HTMLElement) {
-        // if the user deletes everthing then we get an empty element, and we may need the bug work around described above.
-        // see https://silbloom.myjetbrains.com/youtrack/issue/BL-2274.
-        $(field).on("input", function (e) {
-                BloomField.PrepareNonParagraphField(this);
-        });
-    }
+    // private static ManageWhatHappensIfTheyDeleteEverythingNonParagraph(field: HTMLElement) {
+    //     // if the user deletes everthing then we get an empty element, and we may need the bug work around described above.
+    //     // see https://silbloom.myjetbrains.com/youtrack/issue/BL-2274.
+    //     $(field).on("input", function (e) {
+    //         BloomField.PrepareNonParagraphField(this);
+    //     });
+    // }
 
 
     //In PrepareNonParagraphField(), to work around a FF bug, we made a text box non-empty so that the cursor would show up correctly.
@@ -401,11 +393,28 @@ export default class BloomField {
             }
         }
     }
+    private static PreventBackspaceAtStartFromRemovingParagraph(field: HTMLElement) {
+        $(field).keydown(e => {
+            if (e.which === 8 /* backspace*/) {
+                var sel = window.getSelection();
+                //Are we at the start of a paragraph with nothing selected?
+                if (sel.anchorOffset == 0 && sel.isCollapsed) {
+                    //Are we in the first paragraph?
+                    var previousElement = $(sel.anchorNode).closest('P').prev();
+                    if (previousElement.length == 0) {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        console.log("Prevented Backspace");
+                    }
+                }
+            }
+        });
+    }
 }
 enum CursorPosition { start, end }
-interface FFSelection extends Selection{
+interface FFSelection extends Selection {
     //This is nonstandard, but supported by firefox. So we have to tell typescript about it
-    modify(alter:string, direction:string, granularity:string):Selection;
+    modify(alter: string, direction: string, granularity: string): Selection;
 }
 interface JQuery {
     reverse(): JQuery;

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -728,7 +728,7 @@ export function bootstrap() {
                 // ranges with the first one being empty.
                 var selection = editor.getSelection();
                 var textSelected = selection.getSelectedText();
-                var show = (textSelected.length > 0);
+                var show = (textSelected && textSelected.length > 0);
                 var bar = $("body").find("." + editor.id);
                 localizeCkeditorTooltips(bar);
                 show ? bar.show() : bar.hide();

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
@@ -149,7 +149,7 @@ import './bloomSynphonyExtensions.js'; //add several functions to LanguageData
             var html = $(this).html();
 
             // ignore empty elements
-            if ((html.trim().length > 0) && (html !== '<br>')) {
+            if ((html.trim().length > 0) && (text.trim().length > 0)) {
                 html = theOneLibSynphony.wrap_words_extra(html, results.sight_words, cssSightWord, ' data-segment="word"');
                 html = theOneLibSynphony.wrap_words_extra(html, results.possible_words, cssPossibleWord, ' data-segment="word"');
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -410,25 +410,29 @@ function doKeypressMarkup(): void {
         // more reliable insertion-point-preservation, at the cost of some temporarily inaccurate
         // markup.
         const editableDiv = $(selection.anchorNode).parents(".bloom-editable")[0];
-        const ckeditorOfThisBox = (<any>editableDiv).bloomCkEditor;
-        const ckeditorSelection = ckeditorOfThisBox.getSelection();
+        // In 3.9, this is null when you press backspace in an empty box; the selection.anchorNode is itself a .bloom-editable, so
+        // presumably we could adjust the above query to still get the div it's looking for.
+        if (editableDiv) {
+            const ckeditorOfThisBox = (<any>editableDiv).bloomCkEditor;
+            const ckeditorSelection = ckeditorOfThisBox.getSelection();
 
-        // there is also createBookmarks2(), which avoids actually inserting anything. That has the
-        // advantage that changing a character in the middle of a word will allow the entire word to
-        // be evaluated by the markup routine. However, testing shows that the cursor then doesn't
-        // actually go back to where it was: it gets shifted to the right.
-        const bookmarks = ckeditorSelection.createBookmarks(true);
-        currentTool.updateMarkup();
+            // there is also createBookmarks2(), which avoids actually inserting anything. That has the
+            // advantage that changing a character in the middle of a word will allow the entire word to
+            // be evaluated by the markup routine. However, testing shows that the cursor then doesn't
+            // actually go back to where it was: it gets shifted to the right.
+            const bookmarks = ckeditorSelection.createBookmarks(true);
+            currentTool.updateMarkup();
 
-        //set the selection to wherever our bookmark node ended up
-        //NB: in BL-3900: "Decodable & Talking Book tools delete text after longpress", it was here,
-        //restoring the selection, that we got interference with longpress's replacePreviousLetterWithText(),
-        // in some way that is still not understood. This was fixed by changing all this to trigger on
-        // a different event (keydown instead of keypress).
-        ckeditorOfThisBox.getSelection().selectBookmarks(bookmarks);
-
+            //set the selection to wherever our bookmark node ended up
+            //NB: in BL-3900: "Decodable & Talking Book tools delete text after longpress", it was here,
+            //restoring the selection, that we got interference with longpress's replacePreviousLetterWithText(),
+            // in some way that is still not understood. This was fixed by changing all this to trigger on
+            // a different event (keydown instead of keypress).
+            ckeditorOfThisBox.getSelection().selectBookmarks(bookmarks);
+        }
         // clear this value to prevent unnecessary calls to clearTimeout() for timeouts that have already expired.
         keypressTimer = null;
+
     }, 500);
 }
 


### PR DESCRIPTION
Might be easiest to review by commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1580)
<!-- Reviewable:end -->
