### PR TITLE
Fix some tests that were failing on Linux

### DIFF
--- a/src/BloomExe/BloomFileLocator.cs
+++ b/src/BloomExe/BloomFileLocator.cs
@@ -177,16 +177,23 @@ namespace Bloom
 			return Path.Combine(FactoryTemplateBookDirectory, bookName);
 		}
 
+		/// <summary>
+		/// Get the pathname of the directory containing the executing assembly (Bloom.exe).
+		/// </summary>
+		public static string GetCodeBaseFolder()
+		{
+			var file = Assembly.GetExecutingAssembly().CodeBase.Replace("file://", string.Empty);
+			if (SIL.PlatformUtilities.Platform.IsWindows)
+				file = file.TrimStart('/');
+			return Path.GetDirectoryName(file);
+		}
 
 		/// <summary>
 		/// Check whether this file was installed with Bloom (and likely to be read-only on Linux or for allUsers install).
 		/// </summary>
 		public static bool IsInstalledFileOrDirectory(string filepath)
 		{
-			var file = Assembly.GetExecutingAssembly().CodeBase.Replace("file://", string.Empty);
-			if (SIL.PlatformUtilities.Platform.IsWindows)
-				file = file.TrimStart('/');
-			var folder = Path.GetDirectoryName(file);
+			var folder = GetCodeBaseFolder();
 			if (folder.EndsWith("/output/Debug"))
 				folder = folder.Replace("/Debug", string.Empty);	// files now copied to output/browser for access
 			return filepath.Contains(folder);

--- a/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfProgram.cs
+++ b/src/BloomExe/Publish/MakePdfUsingGeckofxHtmlToPdfProgram.cs
@@ -105,8 +105,7 @@ namespace Bloom.Publish
 			string exePath;
 			var bldr = new StringBuilder();
 			// Codebase is reliable even when Resharper copies the EXE somewhere else for testing.
-			var loc = Assembly.GetExecutingAssembly().CodeBase.Substring((Platform.IsUnix ? "file://" : "file:///").Length);
-			var execDir = Path.GetDirectoryName(loc);
+			var execDir = BloomFileLocator.GetCodeBaseFolder();
 			var fromDirectory = String.Empty;
 			var filePath = Path.Combine(execDir, "BloomPdfMaker.exe");
 			if (!RobustFile.Exists(filePath))

--- a/src/BloomTests/Book/BookTestsBase.cs
+++ b/src/BloomTests/Book/BookTestsBase.cs
@@ -80,7 +80,7 @@ namespace BloomTests.Book
 			_fileLocator.Setup(x => x.LocateFileWithThrow("customBookStyles.css")).Returns(Path.Combine(_tempFolder.Path, "customBookStyles.css"));
 			_fileLocator.Setup(x => x.LocateFileWithThrow("settingsCollectionStyles.css")).Returns(Path.Combine(_testFolder.Path, "settingsCollectionStyles.css"));
 			_fileLocator.Setup(x => x.LocateFileWithThrow("customCollectionStyles.css")).Returns(Path.Combine(_testFolder.Path, "customCollectionStyles.css"));
-			var basicBookPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().CodeBase.Substring(8)) + "/../browser/templates/template books/Basic Book/Basic Book.css";
+			var basicBookPath = BloomFileLocator.GetCodeBaseFolder() + "/../browser/templates/template books/Basic Book/Basic Book.css";
 			_fileLocator.Setup(x => x.LocateFile("Basic Book.css")).Returns(basicBookPath);
 
 			_fileLocator.Setup(x => x.LocateDirectory("Factory-XMatter")).Returns(xMatter.CombineForPath("Factory-XMatter"));


### PR DESCRIPTION
Also refactor the code to use a single method for obtaining the execution
folder from the running assembly.  This was involved in all three test
failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1581)
<!-- Reviewable:end -->
