### PR TITLE
Don't localize channel name in splash screen (BL-4451)

### DIFF
--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -187,8 +187,8 @@ namespace Bloom
 					// the status ("channel") of the program on Linux.  Use this package name on Linux to
 					// help screen shots clarify immediately which Linux package is being used.  (and to help
 					// testers remember?)
-					if (path.Contains("/bloom-desktop-unstable/"))
-						return "bloom-desktop-unstable";
+					if (path.Contains("/bloom-desktop-alpha/"))
+						return "bloom-desktop-alpha";
 					if (path.Contains ("/bloom-desktop-beta/"))
 						return "bloom-desktop-beta";
 					return "Release";

--- a/src/BloomExe/SplashScreen.cs
+++ b/src/BloomExe/SplashScreen.cs
@@ -59,7 +59,7 @@ namespace Bloom
 			Focus();
 			var channel = ApplicationUpdateSupport.ChannelName;
 			_channelLabel.Visible = channel.ToLowerInvariant() != "release";
-			_channelLabel.Text = LocalizationManager.GetDynamicString("Bloom", "SplashScreen." + channel, channel);
+			_channelLabel.Text = channel;	// No need to localize this: seen only by testers or special users (BL-4451)
 			BringToFront();
 		}
 


### PR DESCRIPTION
Also tweak Linux alpha package channel name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1589)
<!-- Reviewable:end -->
