### PR TITLE
BL-4344 hint-per-field handles {lang}

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/BloomHintBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/js/BloomHintBubbles.ts
@@ -192,7 +192,11 @@ export default class BloomHintBubbles {
         onFocusOnly = onFocusOnly || source.hasClass('bloom-showOnlyWhenTargetHasFocus') || bloomQtipUtils.mightCauseHorizontallyOverlappingBubbles(target);
 
         // get the localized string
-        if (!doNotLocalize) {
+        if (doNotLocalize) {
+            // still need to substitute {lang} if any
+            whatToSay = theOneLocalizationManager.insertLangIntoHint(whatToSay, target);
+        }
+        else {
             if (whatToSay.startsWith('*')) whatToSay = whatToSay.substr(1);
             whatToSay = theOneLocalizationManager.getLocalizedHint(whatToSay, target);
         }

--- a/src/BloomBrowserUI/lib/localizationManager/localizationManager.ts
+++ b/src/BloomBrowserUI/lib/localizationManager/localizationManager.ts
@@ -260,6 +260,12 @@ export class LocalizationManager {
                 var translated = this.getText.apply(this, args);
 
                 // stick in the language
+                return this.insertLangIntoHint(translated, targetElement);
+        }
+
+        // Hints sometimes have a {lang} tag in the text that needs to be substituted.
+        insertLangIntoHint(whatToSay, targetElement: any) {
+                var translated = whatToSay;
                 if (translated.indexOf('{lang}') != -1) {
                         //This is the preferred approach, but it's not working yet.
                         //var languageName = localizationManager.dictionary[$(targetElement).attr('lang')];

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -399,13 +399,19 @@ namespace Bloom.Api
 					// Used to select the best label to show in a hint bubble when a bloom-translationGroup has multiple
 					// labels with different languages.
 					var bubbleLangs = new List<string>();
-					bubbleLangs.Add(_bookSelection.CurrentSelection.CollectionSettings.Language1Iso639Code);
 					bubbleLangs.Add(LocalizationManager.UILanguageId);
 					if (_bookSelection.CurrentSelection.MultilingualContentLanguage2 != null)
 						bubbleLangs.Add(_bookSelection.CurrentSelection.MultilingualContentLanguage2);
 					if (_bookSelection.CurrentSelection.MultilingualContentLanguage3 != null)
 						bubbleLangs.Add(_bookSelection.CurrentSelection.MultilingualContentLanguage3);
 					bubbleLangs.AddRange(new [] { "en", "fr", "sp", "ko", "zh-Hans"});
+					// If we don't have a hint in the UI language or any major language, it's still
+					// possible the page was made just for this langauge and has a hint in that language.
+					// Not sure whether this should be before or after the list above.
+					// Definitely wants to be after UILangage, otherwise we get the surprising result
+					// that in a French collection these hints stay French even when all the rest of the
+					// UI changes to English.
+					bubbleLangs.Add(_bookSelection.CurrentSelection.CollectionSettings.Language1Iso639Code);
 					// if it isn't available in any of those we'll arbitrarily take the first one.
 					info.ContentType = "application/json";
 					info.WriteCompleteOutput(JsonConvert.SerializeObject(new { langs = bubbleLangs }));


### PR DESCRIPTION
Also makes current UI language the first choice
for localizing user-created hint bubbles

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1590)
<!-- Reviewable:end -->
