### PR TITLE
Prevent image on copied page from changing original (BL-3689)

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -856,7 +856,17 @@ namespace Bloom.Edit
 			{
 				try
 				{
-					imageInfo = PalasoImage.FromFileRobustly(existingImagePath);
+					// Copy the old file we're passing in to the dialog.  It's possible that we'll just crop it, and return the modified
+					// image file with an unchanged path.  That's okay, but what if it's from a copied/duplicated page?  Then all the
+					// pages with that image get the modification, which is probably not what is wanted.  Excess files will get trimmed
+					// later when the book is reopened for editing.  See http://issues.bloomlibrary.org/youtrack/issue/BL-3689.
+					var folder = Path.GetDirectoryName(existingImagePath);
+					var newFilename = ImageUtils.GetUnusedFilename(folder, Path.GetFileNameWithoutExtension(existingImagePath), Path.GetExtension(existingImagePath));
+					var newImagePath = Path.Combine(folder, newFilename);
+					RobustFile.Copy(existingImagePath, newImagePath);
+					Debug.WriteLine("Created image copy: " + newImagePath);
+					Logger.WriteEvent("Created image copy: " + newImagePath);
+					imageInfo = PalasoImage.FromFileRobustly(newImagePath);
 				}
 				catch(Exception e)
 				{

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -162,6 +162,15 @@ namespace Bloom.ImageProcessing
 				// See https://silbloom.myjetbrains.com/youtrack/issue/BL-2627 ("Weird Image Problem").
 				basename = Path.GetFileNameWithoutExtension(imageInfo.FileName);
 			}
+			return GetUnusedFilename(bookFolderPath, basename, extension);
+		}
+
+		/// <summary>
+		/// Get an unused filename in the given folder based on the basename and extension.  extension must
+		/// start with a period.
+		/// </summary>
+		internal static string GetUnusedFilename(string bookFolderPath, string basename, string extension)
+		{
 			var i = 0;
 			var suffix = "";
 			while (RobustFile.Exists(Path.Combine(bookFolderPath, basename + suffix + extension)))


### PR DESCRIPTION
This is done by copying the image file to pass in to the select/modify
image dialog (ImageToolboxDialog).  Unused duplicates are weeded out by
the normal process of editing the file later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1594)
<!-- Reviewable:end -->
