### PR TITLE
BL-4444 suppress internal Gecko errors

### DIFF
--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -433,6 +433,10 @@ namespace Bloom
 		{
 			if(e.Message.StartsWith("[JavaScript Warning"))
 				return;
+			// This is an attempt, based on the log in BL-4444, to eliminate JS errors
+			// with stack traces that indicate they occurred in gecko's own source code.
+			if (e.Message.Contains("{file: \"chrome://"))
+				return;
 			if (e.Message.StartsWith("[JavaScript Error"))
 				ReportJavaScriptError(new GeckoJavaScriptException(e.Message));
 			Debug.WriteLine(e.Message);

--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -433,10 +433,15 @@ namespace Bloom
 		{
 			if(e.Message.StartsWith("[JavaScript Warning"))
 				return;
-			// This is an attempt, based on the log in BL-4444, to eliminate JS errors
-			// with stack traces that indicate they occurred in gecko's own source code.
-			if (e.Message.Contains("{file: \"chrome://"))
+#if !DEBUG
+			// We don't want developers to miss any JS errors.
+			// (Eventually, with a better version of gecko, we may be able to filter exceptions that have already been caught.)
+			// Here we will put special cases, as specific as possible, for JS errors we've decided we don't want
+			// Len or other testers to report.
+			// This is an attempt, based on the log in BL-4444, to eliminate an error in Gecko that happens when Bloom is first run on a non-English OS.
+			if (e.Message.Contains("TypeError: window.arguments is undefined\" {file: \"chrome://global/content/alerts/alert.js\" line: 41}"))
 				return;
+#endif
 			if (e.Message.StartsWith("[JavaScript Error"))
 				ReportJavaScriptError(new GeckoJavaScriptException(e.Message));
 			Debug.WriteLine(e.Message);


### PR DESCRIPTION
Attempts to suppress at least some errors
Gecko outputs to console and then handles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1597)
<!-- Reviewable:end -->
