### PR TITLE
Revise zooming to get dialogs to position correctly (BL-4172)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -1,7 +1,9 @@
 /// <reference path="../../typings/jquery/jquery.d.ts" />
 /// <reference path="../StyleEditor/StyleEditor.ts" />
+/// <reference path="../js/bloomQtipUtils.ts" />
 
 import theOneLocalizationManager from '../../lib/localizationManager/localizationManager';
+import bloomQtipUtils from '../js/bloomQtipUtils';
 
 interface qtipInterface extends JQuery {
         qtip(options: string): JQuery;
@@ -158,7 +160,8 @@ export default class OverflowChecker {
                                         content: '<img height="20" width="20" style="vertical-align:middle" src="/bloom/BloomBrowserUI/images/Attention.svg">' + overflowText,
                                         show: { event: 'mouseenter' },
                                         hide: { event: 'mouseleave' },
-                                        position: { my: 'top right', at: 'right bottom' }
+                                        position: { my: 'top right', at: 'right bottom' },
+                                        container: bloomQtipUtils.qtipZoomContainer()
                                 });
                         });
                 }
@@ -189,7 +192,8 @@ export default class OverflowChecker {
                                                 content: '<img height="20" width="20" style="vertical-align:middle" src="/bloom/BloomBrowserUI/images/Attention.svg">' + overflowText,
                                                 show: { event: 'enterBorder' }, // nonstandard events triggered by mouse move in code below
                                                 hide: { event: 'leaveBorder' },
-                                                position: { my: 'top right', at: 'right bottom' }
+                                                position: { my: 'top right', at: 'right bottom' },
+                                                container: bloomQtipUtils.qtipZoomContainer()
                                         });
                                 });
                                 var showing = false;

--- a/src/BloomBrowserUI/bookEdit/js/BloomHintBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/js/BloomHintBubbles.ts
@@ -234,7 +234,8 @@ export default class BloomHintBubbles {
             at: 'right center',
             my: 'left center',
             viewport: $(window),
-            adjust: { method: 'none' }
+            adjust: { method: 'none' },
+            container: bloomQtipUtils.qtipZoomContainer()
         };
 
         var theClasses = 'ui-tooltip-shadow ui-tooltip-plain';

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -22,6 +22,7 @@ import "long-press/jquery.longpress.js"
 import "jquery.hotkeys"; //makes the on(keydown work with keynames)
 import "../../lib/jquery.resize"; // makes jquery resize work on all elements
 import { getToolboxFrameExports } from "./bloomFrames";
+import { EditableDivUtils } from './editableDivUtils';
 
 
 //promise may be needed to run tests with phantomjs
@@ -655,17 +656,14 @@ export function bootstrap() {
         // reviewSlog does this application work?
         if (!theEvent.ctrlKey) return;
         // look for an existing transform:scale setting and extract the scale. If not found, use 1.0 as starting point.
-        var styleString = $("body").attr("style");
-        var scale = 1.0;
-        var searchData = /scale\(([^,]*),/.exec(styleString);
-        if (searchData) {
-            scale = parseFloat(searchData[1]);
-        }
+        var scale = EditableDivUtils.getPageScale();
         // Dividing by 20 seems to make it zoom at a manageable rate, at least with my mouse.
         // The limitation to zooming between 1/3 and 3 times is arbitrary.
         scale = Math.min(Math.max(scale - theEvent.deltaY / 20, 0.33), 3.0);
-        // This works with a rule in editMode.less that makes the transform's origin the top left
-        $("body").attr("style", "transform: scale(" + scale + "," + scale + ")");
+        $("div#page-scaling-container").attr("style", "transform: scale(" + scale + "); transform-origin: top left;");
+        // Setting this style is all we want to do in this context.
+        e.preventDefault();
+        e.cancelBubble = true;
     });
 
     /* reviewSlog typescript just couldn't cope with this. Our browser has this built in , so it's ok

--- a/src/BloomBrowserUI/bookEdit/js/bloomNotices.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomNotices.ts
@@ -7,6 +7,7 @@
 import theOneLocalizationManager from '../../lib/localizationManager/localizationManager';
 //import '../../lib/jquery.qtip.js'
 //import '../../lib/jquery.qtipSecondary.js'
+import bloomQtipUtils from './bloomQtipUtils';
 
 export default class BloomNotices {
     public static addExperimentalNotice(container: HTMLElement): void {
@@ -25,6 +26,7 @@ export default class BloomNotices {
                     classes: 'ui-tooltip-red',
                     tip: { corner: false }
                 }
+                , container: bloomQtipUtils.qtipZoomContainer()
             });
         });
     }
@@ -58,6 +60,7 @@ export default class BloomNotices {
                     style: {
                         classes: theClasses
                     }
+                    , container: bloomQtipUtils.qtipZoomContainer()
                 });
             }
         });

--- a/src/BloomBrowserUI/bookEdit/js/bloomQtipUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomQtipUtils.ts
@@ -60,4 +60,13 @@ export default class bloomQtipUtils {
         // Later note: using a real button just absorbs the click event. Other things work better
         //   http://stackoverflow.com/questions/10317128/how-to-make-a-div-contenteditable-and-draggable
     }
+
+    // In editing most (if not all) of the qtips need to be contained by a special div that handles
+    // the zooming (scaling) of the page content.  If they are not contained by this div, 1) they don't
+    // zoom/scale and 2) they appear on the screen in the same location as if the page content they are
+    // supposed to attach to isn't zoomed/scaled.  If they are attached further in than this special
+    // div, then the bubble is squeezed to fit inside the inner zoomed area.
+    public static qtipZoomContainer(): JQuery {
+        return $("div#page-scaling-container");
+    }
 }

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -117,6 +117,17 @@ export class EditableDivUtils {
         }
     }
 
+    // look for an existing transform:scale setting and extract the scale. If not found, use 1.0 as starting point.
+    static getPageScale(): number {
+        var scale = 1.0;
+        var styleString = $("div#page-scaling-container").attr("style");
+        var searchData = /transform: *scale\(([0-9.]*)/.exec(styleString);
+        if (searchData) {
+            scale = parseFloat(searchData[1]);
+        }
+        return scale;
+    }
+
     static adjustDraggableOptionsForScaleBug(dialogBox: JQuery, scale: number) {
         dialogBox.draggable({
             // BL-4293 the 'start' and 'drag' functions here work around a known bug in jqueryui.

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.ts
@@ -296,7 +296,8 @@ export default class BloomSourceBubbles {
                     adjust: {
                         x: 0,
                         y: 0
-                    }
+                    },
+                    container: bloomQtipUtils.qtipZoomContainer()
                 },
                 content: divForBubble,
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettings.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettings.ts
@@ -35,5 +35,5 @@ export function handleBookSettingCheckboxClick(clickedButton: any) {
 export function handleResetZoom(clickedButton: any) {
     var pageDom = <HTMLIFrameElement>parent.window.document.getElementById('page');
     var pageBody = $(pageDom.contentWindow.document.body);
-    $(pageBody).css('transform', 'scale(' + 1.0 + ',' + 1.0 + ')');
+    $(pageBody).find("div#page-scaling-container").css('transform', 'scale(1.0)');
 }

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -985,6 +985,9 @@ namespace Bloom.Book
 			// and then see whether it contains bloom-ui surrounded by spaces.
 			// However, we need to do this in the edited page before copying to the storage page, since we are about to suck
 			// info from the edited page into the dataDiv and we don't want the bloom-ui elements in there either!
+			// Note that EditingView.CleanHtmlAndCopyToPageDom() and EditingModel.SavePageFrameStateAndCleanupFrame() also remove bits
+			// of html that are used during editing but are not saved to disk.  (The first calls javascript to deal with items inserted
+			// by javascript, and the second removes items added by the EditingModel class.)
 			foreach(
 				var node in
 					edittedPageDiv.SafeSelectNodes("//*[contains(concat(' ', @class, ' '), ' bloom-ui ')]").Cast<XmlNode>().ToArray())


### PR DESCRIPTION
This involved moving the transform:scale css from the body element to a
outer div element created especially for holding the scale factor.  With
this fix, the dialogs and dropdowns just positioned themselves nicely,
and the tooltips needed only a minor tweak to continue working as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1610)
<!-- Reviewable:end -->
