### PR TITLE
Improve XMatter problem handling BL-4472

### DIFF
--- a/DistFiles/localization/Bloom.en.tmx
+++ b/DistFiles/localization/Bloom.en.tmx
@@ -2556,6 +2556,17 @@
         <seg>This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a Bloom Pack that will give you '{0}', or go to Settings:Book Making and change to another Front/Back Matter Pack.</seg>
       </tuv>
     </tu>
+    <tu tuid="Errors.XMatterProblemLabel">
+      <note>This shows in the 'toast' that pops up to notify the user of a non-fatal problem.</note>
+      <tuv xml:lang="en">
+        <seg>Front/Back Matter Problem</seg>
+      </tuv>
+    </tu>
+    <tu tuid="Errors.XMatterSpecifiedByBookNotFound">
+      <tuv xml:lang="en">
+        <seg>This book called for a Front/Back Matter pack named '{0}', but this version of Bloom does not have it, and Bloom could not find it on this computer. The book has been changed to use the Front/Back Matter pages from the Collection Settings.</seg>
+      </tuv>
+    </tu>
     <tu tuid="Errors.ZoneAlarm">
       <tuv xml:lang="en">
         <seg>Bloom cannot start properly, and this symptom has been observed on machines with ZoneAlarm installed. Note: disabling ZoneAlarm does not help. Nor does restarting with it turned off. Something about the installation of ZoneAlarm causes the problem, and so far only uninstalling ZoneAlarm has been shown to fix the problem.</seg>

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -948,10 +948,8 @@ namespace Bloom.Book
 
 		private void BringXmatterHtmlUpToDate(HtmlDom bookDOM)
 		{
-			//by default, this comes from the collection, but the book can select one, including "null" to select the factory-supplied empty xmatter
-			var nameOfXMatterPack = OurHtmlDom.GetMetaValue("xMatter", _collectionSettings.XMatterPackName);
-			nameOfXMatterPack = Storage.HandleRetiredXMatterPacks(OurHtmlDom, nameOfXMatterPack);
-			var helper = new XMatterHelper(bookDOM, nameOfXMatterPack, _storage.GetFileLocator());
+			var helper = new XMatterHelper(bookDOM, CollectionSettings.XMatterPackName, _storage.GetFileLocator());
+
 			//note, we determine this before removing xmatter to fix the situation where there is *only* xmatter, no content, so if
 			//we wait until we've removed the xmatter, we no how no way of knowing what size/orientation they had before the update.
 			// Per BL-3571, if it's using a layout we don't know (e.g., from a newer Bloom) we switch to A5Portrait.

--- a/src/BloomExe/Book/BookStarter.cs
+++ b/src/BloomExe/Book/BookStarter.cs
@@ -362,11 +362,7 @@ namespace Bloom.Book
 				data.WritingSystemAliases.Add("N1", _collectionSettings.Language2Iso639Code);
 				data.WritingSystemAliases.Add("N2", _collectionSettings.Language3Iso639Code);
 
-
-				//by default, this comes from the collection, but the book can select one, inclucing "null" to select the factory-supplied empty xmatter
-				var xmatterName = storage.Dom.GetMetaValue("xmatter", _collectionSettings.XMatterPackName);
-
-				var helper = new XMatterHelper(storage.Dom, xmatterName, _fileLocator);
+				var helper = new XMatterHelper(storage.Dom, _collectionSettings.XMatterPackName, _fileLocator);
 				helper.FolderPathForCopyingXMatterFiles = storage.FolderPath;
 				helper.InjectXMatter(data.WritingSystemAliases, sizeAndOrientation);
 				//TranslationGroupManager.PrepareDataBookTranslationGroups(storage.Dom,languages);

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -32,7 +32,7 @@ namespace Bloom.Collection
 	public class CollectionSettings
 	{
 		private const int kCurrentOneTimeCheckVersionNumber = 1; // bumping this will trigger a new one time check
-
+		public const string kDefaultXmatterName = "Traditional";
 		private string _language1Iso639Code;
 		private LanguageLookupModel _lookupIsoCode = new LanguageLookupModel();
 		private Dictionary<string, string> _isoToLangNameDictionary = new Dictionary<string, string>();
@@ -52,7 +52,7 @@ namespace Bloom.Collection
 		{
 			BrandingProjectName = "Default";
 			PageNumberStyle = "Decimal";
-			XMatterPackName = "Traditional";
+			XMatterPackName = kDefaultXmatterName;
 			Language2Iso639Code = "en";
 			AllowNewBooks = true;
 			CollectionName = "dummy collection";
@@ -717,6 +717,24 @@ namespace Bloom.Collection
 		public IEnumerable<string> LicenseDescriptionLanguagePriorities
 		{
 			get { return new[] { Language1Iso639Code, Language2Iso639Code, Language3Iso639Code, "en" }; }
+		}
+
+		/// <summary>
+		/// The collection settings point to object which might not exist. For example, the xmatter pack might not exist.
+		/// So this should be called as soon as it is ok to show some UI. It will find any dependencies it can't meet,
+		/// revert them to defaults, and notify the user.
+		/// </summary>
+		public void CheckAndFixDependencies(BloomFileLocator bloomFileLocator)
+		{
+			var errorTemplate = LocalizationManager.GetString("Errors.XMatterNotFound",
+					"This Collection called for Front/Back Matter pack named '{0}', but this version of Bloom does not have it, and Bloom could not find it on this computer. The collection has been changed to use the default Front/Back Matter pages.");
+			var errorMessage = String.Format(errorTemplate, XMatterPackName);
+			XMatterPackName = XMatterHelper.MigrateXMatterName(XMatterPackName);
+			if(string.IsNullOrEmpty(XMatterHelper.GetXMatterDirectory(XMatterPackName, bloomFileLocator, errorMessage, false)))
+			{
+				this.XMatterPackName = kDefaultXmatterName;
+				Save();
+			}
 		}
 	}
 }

--- a/src/BloomExe/NonFatalProblem.cs
+++ b/src/BloomExe/NonFatalProblem.cs
@@ -35,6 +35,8 @@ namespace Bloom
 			string moreDetails = null,
 			Exception exception = null)
 		{
+			s_expectedByUnitTest?.ProblemWasReported();
+
 			// Simplify some checks below by tweaking the channel name on Linux.
 			var channel = ApplicationUpdateSupport.ChannelName.ToLowerInvariant();
 			if (channel.EndsWith("-unstable"))
@@ -139,6 +141,33 @@ namespace Bloom
 					return new string[] { "developer", "alpha" };
 				default:
 					return new string[] { };
+			}
+		}
+
+		private static ExpectedByUnitTest s_expectedByUnitTest = null;
+
+		/// <summary>
+		/// use this in unit tests to cleanly check that a message would have been shown.
+		/// E.g.  using (new NonFatalProblem.ExpectedByUnitTest()) {...}
+		/// </summary>
+		public class ExpectedByUnitTest : IDisposable
+		{
+			private bool _reported;
+			public ExpectedByUnitTest()
+			{
+				s_expectedByUnitTest?.Dispose();
+				s_expectedByUnitTest = this;
+			}
+
+			internal void ProblemWasReported()
+			{
+				_reported = true;
+			}
+			public void Dispose()
+			{
+				s_expectedByUnitTest = null;
+				if (!_reported)
+					throw new Exception("NonFatalProblem was expected but wasn't generated.");
 			}
 		}
 	}

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -44,6 +44,8 @@ namespace Bloom
 			SettingsPath = projectSettingsPath;
 			BuildSubContainerForThisProject(projectSettingsPath, parentContainer);
 
+			_scope.Resolve<CollectionSettings>().CheckAndFixDependencies(_scope.Resolve<BloomFileLocator>());
+
 			ProjectWindow = _scope.Resolve <Shell>();
 
 			string collectionDirectory = Path.GetDirectoryName(projectSettingsPath);

--- a/src/BloomTests/Book/XMatterHelperTests.cs
+++ b/src/BloomTests/Book/XMatterHelperTests.cs
@@ -191,7 +191,7 @@ namespace BloomTests.Book
 			XMatterHelper helper1;
 			if (xmatterBook.Contains("DoesNotExist"))
 			{
-				using (new SIL.Reporting.ErrorReport.NonFatalErrorReportExpected())
+				using (new NonFatalProblem.ExpectedByUnitTest())
 				{
 					helper1 = new XMatterHelper(dom1, "Factory", fileLocator);
 				}


### PR DESCRIPTION
1) We were handling un-found collections-settings xmatter as if it were book-by-book problem. Now it is handled when collection is open.
2) We had some repeated and seemingly inconsistent handling of xmatter name migration
3) Changed error messages a bit to indicate that the problem may just be due to different versions of Bloom (actually this is by far the likely case)
4) don't load and check xmatter when all we're doing is getting a name. <--- this may be backported to 3.8, we'll see.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1612)
<!-- Reviewable:end -->
