### PR TITLE
BL-4470 allow labels in sources to wrap

### DIFF
--- a/src/BloomExe/CollectionTab/ListHeader.cs
+++ b/src/BloomExe/CollectionTab/ListHeader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace Bloom.CollectionTab
@@ -17,11 +18,35 @@ namespace Bloom.CollectionTab
 
 		public void AdjustWidth()
 		{
+			Label.AutoSize = true;
 			using (var g = CreateGraphics())
 			{
 				var size = g.MeasureString(Label.Text, Label.Font);
 				Width = (int)size.Width + 6;
 			}
+		}
+
+		/// <summary>
+		/// This one is used to make it (and the label) the right size to fit
+		/// in the specified width by wrapping the text if necessary
+		/// </summary>
+		public void AdjustSize(int width)
+		{
+			Label.AutoSize = false; // otherwise we can't change it.
+			var textSize = TextRenderer.MeasureText(Label.Text, Label.Font,
+				// The Label has margins of 3, so we need six pixels for that twice
+				new Size(width - 6, Int32.MaxValue),
+				TextFormatFlags.WordBreak);
+			var oldTop = Label.Top;
+			// Found experimentally to make it hold the text without clipping
+			Label.Size = new Size(textSize.Width, textSize.Height + 3);
+			// Keeps original design spacing.
+			this.Size = new Size(Label.Width + 6, Label.Height + 14);
+			// The label is anchored 'bottom' for possibly historical reasons.
+			// But as we resize both controls we want to keep it at the same position.
+			// If we don't enforce this it will move down as the outer control gets bigger,
+			// and since the label gets bigger too it will be clipped.
+			Label.Top = oldTop;
 		}
 	}
 }


### PR DESCRIPTION
Also contains a workaround for a bug
in FlowLayoutPanel that prevents it noticing
changed child widths

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1613)
<!-- Reviewable:end -->
