### PR TITLE
NOT FOR DOWNSTREAM Remove problematic support for <meta xmatter> in 3.8 only

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -952,9 +952,7 @@ namespace Bloom.Book
 
 		private void BringXmatterHtmlUpToDate(HtmlDom bookDOM)
 		{
-			//by default, this comes from the collection, but the book can select one, including "null" to select the factory-supplied empty xmatter
-			var nameOfXMatterPack = OurHtmlDom.GetMetaValue("xMatter", _collectionSettings.XMatterPackName);
-			nameOfXMatterPack = Storage.HandleRetiredXMatterPacks(OurHtmlDom, nameOfXMatterPack);
+			var nameOfXMatterPack = Storage.HandleRetiredXMatterPacks(OurHtmlDom, _collectionSettings.XMatterPackName);
 			var helper = new XMatterHelper(bookDOM, nameOfXMatterPack, _storage.GetFileLocator());
 			//note, we determine this before removing xmatter to fix the situation where there is *only* xmatter, no content, so if
 			//we wait until we've removed the xmatter, we no how no way of knowing what size/orientation they had before the update.

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -802,10 +802,11 @@ namespace Bloom.Book
 				}
 
 				Dom.UpdatePageDivs();
-
-				UpdateSupportFiles();
-
-				CleanupUnusedImageFiles();
+				if(forSelectedBook)
+				{
+					UpdateSupportFiles();
+					CleanupUnusedImageFiles();
+				}
 			}
 		}
 
@@ -858,9 +859,7 @@ namespace Bloom.Book
 				}
 			}
 
-			//by default, this comes from the collection, but the book can select one, including "null" to select the factory-supplied empty xmatter
-			var nameOfXMatterPack = _dom.GetMetaValue("xMatter", _collectionSettings.XMatterPackName);
-			nameOfXMatterPack = HandleRetiredXMatterPacks(_dom, nameOfXMatterPack);
+			var nameOfXMatterPack = HandleRetiredXMatterPacks(_dom, _collectionSettings.XMatterPackName);
 
 			try
 			{
@@ -990,8 +989,7 @@ namespace Bloom.Book
 			//clear out any old ones
 			_dom.RemoveXMatterStyleSheets();
 
-			var nameOfXMatterPack = _dom.GetMetaValue("xMatter", _collectionSettings.XMatterPackName);
-			nameOfXMatterPack = HandleRetiredXMatterPacks(dom, nameOfXMatterPack);
+			var nameOfXMatterPack = HandleRetiredXMatterPacks(dom, _collectionSettings.XMatterPackName);
 			var helper = new XMatterHelper(_dom, nameOfXMatterPack, _fileLocator);
 
 			EnsureHasLinkToStyleSheet(dom, Path.GetFileName(helper.PathToStyleSheetForPaperAndOrientation));


### PR DESCRIPTION
For 3.8, we didn't need this tag, so it's safer to just remove knowledge of it altogether since it's about to be released.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1614)
<!-- Reviewable:end -->
