### PR TITLE
Don't honor xmatter tag if it come from a bloom prior to 3.9. BL-4480

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -135,6 +135,14 @@ namespace Bloom.Book
 			_storage.Dom.RemoveExtraBookTitles();
             _storage.Dom.RemoveExtraContentTypesMetas();
 			Guard.Against(OurHtmlDom.RawDom.InnerXml=="","Bloom could not parse the xhtml of this document");
+
+			// We introduced "template starter" in 3.9, but books you made with it could be used in 3.8 etc.
+			// If those books came back to 3.9 or greater (which would happen eventually), 
+			// they would still have this tag that they didn't really understand, and which should have been removed.
+			if(_storage.Dom.GetGeneratorVersion() < 3.9)
+			{
+				_storage.Dom.RemoveMetaElement("xmatter");
+			}
 		}
 
 		void _storage_FolderPathChanged(object sender, EventArgs e)

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -1330,6 +1331,22 @@ namespace Bloom.Book
 				// Assume that they are going to change the name. Note as of 3.9 at least, we don't have a way of localizing these.
 				label.RemoveAttribute("data-i18n");
 			}
+		}
+
+		/// <summary>
+		/// Reads the Generator meta tag.
+		/// </summary>
+		/// <returns> the version if it can find it, else 0</returns>
+		public float GetGeneratorVersion()
+		{
+			var generator = GetMetaValue("Generator", "");
+			var match = Regex.Match(generator, "[0-9]+\\.[0-9]+");
+			float version;
+			if (match.Success && float.TryParse(match.Captures[0].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out version))
+			{
+				return version;
+			}
+			return 0;
 		}
 	}
 }

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -63,6 +63,7 @@ namespace BloomTests.Book
 			Assert.AreEqual("new", dom.BaseForRelativePaths);
 		}
 
+
 		[Test]
 		public void RemoveMetaValue_IsThere_RemovesIt()
 		{
@@ -103,6 +104,16 @@ namespace BloomTests.Book
 			dom.LoadXml(@"<div class=''/>");
 			HtmlDom.AddClassIfMissing((XmlElement)dom.FirstChild, "two");
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("div[@class='two']", 1);
+		}
+
+		[Test]
+		[TestCase(null, 0)]
+		[TestCase("Foobar 6 !", 0)]
+		[TestCase("Bloom Version 3.8.0 (apparent build date: 28-Mar-2017)", 3.8f)]
+		public void GetGeneratorVersion_Works(string value, float expected)
+		{
+			var dom = new HtmlDom($@"<html><head><meta name='Generator' content='{value}'></meta></head></html>");
+			Assert.AreEqual(expected, dom.GetGeneratorVersion());
 		}
 
 		[Test]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1622)
<!-- Reviewable:end -->
