### PR TITLE
VERSION 3.8 ONLY - Fix dropdown hiding behind the dialog (BL-4386)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.less
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.less
@@ -1,6 +1,7 @@
 //putting (less) here makes it actually start this file off with the contents of the select2.css,
 //which we're doing for convenience so that we don't have to get it in the installer and then import it explictly
 @import (less) '../../node_modules/select2/dist/css/select2.css';
+@import (reference) "../css/bloomDialog.less";  // needed for @dialogZindexPlusOne
 
 #format-toolbar {
     *{
@@ -76,9 +77,9 @@
     }
 }
 
-//the select2 dropdown gets appended to the body, not to our dialog, so it needs a really high z-index to show above the dialog.
+//the select2 dropdown gets appended to the body, not to our dialog, so its z-index must be at least as high as the dialog's z-index
 .select2-container{
-    z-index: 30000;
+    z-index: @dialogZindexPlusOne;
 }
 
 #spacingRow{

--- a/src/BloomBrowserUI/bookEdit/css/bloomDialog.less
+++ b/src/BloomBrowserUI/bookEdit/css/bloomDialog.less
@@ -25,6 +25,10 @@
 // with z-index as high as 50,000; so I made this a round number higher
 // than that.
 @dialogZindex: 60000;
+// Note that  the z-index for the select2 dropdowns used in both ../StyleEditor/StyleEditor.less
+// and ../TextBoxProperties/TextBoxProperties.less must be at least as large as or larger than the
+// dialog's z-index.  (See http://issues.bloomlibrary.org/youtrack/issue/BL-4386.)
+@dialogZindexPlusOne: 60001;
 
 .bloomDialogContainer .selectedIcon {
     background-color: rgb(201, 224, 247);


### PR DESCRIPTION
(cherry picked from commit 97fb569f43e84df0b07784bd897cf30f9169a0c8)

# Conflicts:
#	src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.less

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1629)
<!-- Reviewable:end -->
