### PR TITLE
Don't show old PDF while creating new PDF or ePUB (BL-4518)

### DIFF
--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -389,6 +389,7 @@ namespace Bloom.Publish
 					_workingIndicator.Cursor = Cursors.WaitCursor;
 					Cursor = Cursors.WaitCursor;
 					_workingIndicator.Visible = true;
+					_pdfViewer.Visible = false;
 					break;
 				case PublishModel.DisplayModes.ShowPdf:
 					if (RobustFile.Exists(_model.PdfFilePath))


### PR DESCRIPTION
I accidentally created the PR on master and it got merged there already.  Here it is again, based on Version3.9.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1639)
<!-- Reviewable:end -->
