### PR TITLE
BL-4545 Save setting FirstTimeRun to false

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -330,6 +330,7 @@ namespace Bloom
 				UniqueToken.ReleaseToken();
 			}
 			Settings.Default.FirstTimeRun = false;
+			Settings.Default.Save();
 			return 0;
 		}
 

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -325,6 +325,7 @@ namespace Bloom.Workspace
 			LocalizationManager.SetUILanguage(tag.IetfLanguageTag, true);
 			Settings.Default.UserInterfaceLanguage = tag.IetfLanguageTag;
 			Settings.Default.UserInterfaceLanguageSetExplicitly = true;
+			Settings.Default.Save();
 			item.Select();
 			UpdateMenuTextToShorterNameOfSelection(toolStripButton, tag);
 


### PR DESCRIPTION
Without this, Bloom always thinks it is running for the
first time, which among other things makes it revert
to the system UI language.
(Also made it save new UI lang selection immediately.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1642)
<!-- Reviewable:end -->
