### PR TITLE
Save user's UI language selection (cherry pick from 3.9) (BL-4545)

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -330,6 +330,7 @@ namespace Bloom
 				UniqueToken.ReleaseToken();
 			}
 			Settings.Default.FirstTimeRun = false;
+			Settings.Default.Save();
 			return 0;
 		}
 

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -947,7 +947,7 @@ namespace Bloom
 		private static string GetDesiredUiLanguage(string installedStringFileFolder)
 		{
 			var desiredLanguage = Settings.Default.UserInterfaceLanguage;
-			if (Settings.Default.FirstTimeRun || String.IsNullOrEmpty(desiredLanguage) || !Settings.Default.UserInterfaceLanguageSetExplicitly)
+			if (String.IsNullOrEmpty(desiredLanguage) || !Settings.Default.UserInterfaceLanguageSetExplicitly)
 			{
 				// Nothing has been explicitly selected by the user yet, so try to get a localization for the same language.
 				// First try for an exact match.  (This is motivated by the Chinese localization which specifies more than

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -331,6 +331,7 @@ namespace Bloom.Workspace
 			LocalizationManager.SetUILanguage(tag.IetfLanguageTag, true);
 			Settings.Default.UserInterfaceLanguage = tag.IetfLanguageTag;
 			Settings.Default.UserInterfaceLanguageSetExplicitly = true;
+			Settings.Default.Save();
 			item.Select();
 			UpdateMenuTextToShorterNameOfSelection(toolStripButton, tag);
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1667)
<!-- Reviewable:end -->
