### PR TITLE
BL-4633 Fix crash in GetPageBody()

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -979,18 +979,33 @@ namespace Bloom.Edit
 			return _browser1.WebBrowser.Window.Document.GetElementById("pure-toggle-right") as GeckoInputElement;
 		}
 
+		/// <summary>
+		/// Currently only called by EditingModel.SavePageFrameState()
+		/// </summary>
+		/// <returns>May return null if the GeckoWebBrowser's Window isn't fully initialized somehow</returns>
 		public GeckoElement GetPageBody()
 		{
-			var frame = _browser1.WebBrowser.Window.Document.GetElementById("page") as GeckoIFrameElement;
-			if(frame == null)
+			GeckoElementCollection elements;
+			try
+			{
+				var frame = _browser1.WebBrowser.Window.Document.GetElementById("page") as GeckoIFrameElement;
+				if(frame == null)
+					return null;
+				// The following line looks like it should work, but it doesn't (at least not reliably in Geckofx45).
+				// return frame.ContentDocument.Body;
+				// On a fast shutdown of Bloom, while it is redisplaying, we can get an empty enumeration.
+				// See http://issues.bloomlibrary.org/youtrack/issue/BL-3988.
+				elements = frame.ContentWindow.Document.GetElementsByTagName("body");
+				if (elements.Length == 0)
+					return null;
+			}
+			catch (ArgumentException ex)
+			{
+				if (ex.Source != "Geckofx-Core")
+					throw;
+				Logger.WriteEvent("Geckofx-Core ArgumentException thrown (BL-4633). Probably a GeckoWindow.get_Document() failure, not fully initialized?");
 				return null;
-			// The following line looks like it should work, but it doesn't (at least not reliably in Geckofx45).
-			// return frame.ContentDocument.Body;
-			// On a fast shutdown of Bloom, while it is redisplaying, we can get an empty enumeration.
-			// See http://issues.bloomlibrary.org/youtrack/issue/BL-3988.
-			var elements = frame.ContentWindow.Document.GetElementsByTagName("body");
-			if (elements.Length == 0)
-				return null;
+			}
 			return elements.First();
 		}
 


### PR DESCRIPTION
Agatha got a "Window does not have a global JSObject" exception from the Geckofx-Core. This prevents that exception crashing Bloom. Comments in the code suggest that a failure here only indicates a timing problem that keeps Bloom from saving the zoom state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1669)
<!-- Reviewable:end -->
