### PR TITLE
BL-4602 Don't fill error reports with Amazon stuff

### DIFF
--- a/src/BloomExe/web/UrlLookup.cs
+++ b/src/BloomExe/web/UrlLookup.cs
@@ -112,7 +112,10 @@ namespace Bloom.web
 			catch (Exception e)
 			{
 				_internetAvailable = false;
-				Logger.WriteEvent("Exception while attempting look up of URL type " + urlType + ": " + e);
+				var msg = e.ToString();
+				if (urlType == UrlType.IssueTrackingSystem || urlType == UrlType.IssueTrackingSystemBackend)
+					msg = e.Message;
+				Logger.WriteEvent($"Exception while attempting look up of URL type {urlType}: {msg}");
 			}
 			return false;
 		}


### PR DESCRIPTION
* factor out message string
* limit IssueTrackingSystem to exception Message
* this eliminates long innerExceptions from Amazon
   filling up the error reports

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1675)
<!-- Reviewable:end -->
