### PR TITLE
BL-3691 Use zh-CN for zh-Hans

### DIFF
--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -716,7 +716,27 @@ namespace Bloom.Collection
 		/// </summary>
 		public IEnumerable<string> LicenseDescriptionLanguagePriorities
 		{
-			get { return new[] { Language1Iso639Code, Language2Iso639Code, Language3Iso639Code, "en" }; }
+			get
+			{
+				var result = new[] { Language1Iso639Code, Language2Iso639Code, Language3Iso639Code, "en" };
+				// reverse-order loop so that given e.g. zh-Hans followed by zh-Hant we insert zh-CN after the second one.
+				// That is, we'll prefer either of the explicit variants to the fall-back.
+				for (int i = result.Length - 1; i >= 0; i--)
+				{
+					var culture = result[i];
+					if (culture.Length <= 2)
+						continue;
+					var extra = culture.Substring(0, 2); // Generally insert corresponding language for longer culture
+					if (extra == "zh")
+						extra = "zh-CN"; // Insert this instead for Chinese
+					if (result.IndexOf(extra) >= 0)
+						continue;
+					var temp = result.ToList();
+					temp.Insert(i + 1, extra);
+					result = temp.ToArray();
+				}
+				return result;
+			}
 		}
 
 		/// <summary>

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -959,7 +959,7 @@ namespace Bloom
 				{
 					if (lang == UserInterfaceCulture.IetfLanguageTag)
 						return UserInterfaceCulture.IetfLanguageTag;
-					if (lang.StartsWith(UserInterfaceCulture.TwoLetterISOLanguageName))
+					if (localeMatchingLanguage == null && lang.StartsWith(UserInterfaceCulture.TwoLetterISOLanguageName))
 						localeMatchingLanguage = lang;
 				}
 				// No exact match; did we find one that is at least the right language? If so use that.

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -949,14 +949,22 @@ namespace Bloom
 			var desiredLanguage = Settings.Default.UserInterfaceLanguage;
 			if (String.IsNullOrEmpty(desiredLanguage) || !Settings.Default.UserInterfaceLanguageSetExplicitly)
 			{
-				// Nothing has been explicitly selected by the user yet, so try to get a localization for the same language.
-				// First try for an exact match.  (This is motivated by the Chinese localization which specifies more than
-				// just the base language tag.)
+				// Nothing has been explicitly selected by the user yet, so try to get a localization for the system language.
+				// First try for an exact match, or failing that a localization with the same language.
+				// (This is motivated by the Chinese localization which currently specifies zh-CN. LM might eventually
+				// support multiple variants for a single language like zh-CN or zh-Hans, at which point both might be in the
+				// list and we'd want the best match. In the meantime we want zh-Hans to find zh-CN. See BL-3691.)
+				string localeMatchingLanguage = null;
 				foreach  (var lang in LocalizationManager.GetAvailableUILanguageTags(installedStringFileFolder, "Bloom"))
 				{
 					if (lang == UserInterfaceCulture.IetfLanguageTag)
 						return UserInterfaceCulture.IetfLanguageTag;
+					if (lang.StartsWith(UserInterfaceCulture.TwoLetterISOLanguageName))
+						localeMatchingLanguage = lang;
 				}
+				// No exact match; did we find one that is at least the right language? If so use that.
+				if (localeMatchingLanguage != null)
+					return localeMatchingLanguage;
 				// If exact matches fail, return the base language tag.  If that doesn't match in the LM.Create method,
 				// then L10NSharp will prompt the user to select one of the available localizations.
 				return UserInterfaceCulture.TwoLetterISOLanguageName;

--- a/src/BloomTests/Collection/CollectionSettingsTests.cs
+++ b/src/BloomTests/Collection/CollectionSettingsTests.cs
@@ -107,5 +107,31 @@ namespace BloomTests.Collection
 			Assert.IsTrue(Regex.Match(css, @"@media\s+print\s+{\s+\.numberedPage:after\s+{\s+content:\s+counter\(pageNumber,\s+" + oldNumberStyle + @"\);\s+}\s+}").Success,
 							  "Css did not generate PageNumber style rule match.");
 		}
+
+		[TestCase("en", "es", "de", new[] {"en", "es", "de", "en"})] // we don't really need it, but English is put at the end even if already present
+		[TestCase("id", "es", "de", new[] { "id", "es", "de", "en" })] // more typical case where adding English is important
+		[TestCase("zh-CN", "es", "de", new[] { "zh-CN", "es", "de", "en" })] // zh-CN does not require an insertion
+		[TestCase("zh-Hans", "es", "de", new[] { "zh-Hans", "zh-CN", "es", "de", "en" })] // any other zh-X requires zh-CN to be inserted following it.
+		[TestCase("es", "zh-Hans", "de", new[] { "es", "zh-Hans", "zh-CN", "de", "en" })] // try in all 3 positions.
+		[TestCase("es", "id", "zh-Hant", new[] { "es", "id", "zh-Hant", "zh-CN", "en" })]
+		[TestCase("es", "zh-Hans", "zh-Hant", new[] { "es", "zh-Hans", "zh-Hant", "zh-CN", "en" })] // if we have two locale-specific ones, the insertion should be after both.
+		[TestCase("fr-CA", "es", "de", new[] { "fr-CA", "fr", "es", "de", "en" })] // any fr-X requires fr inserted after it
+		[TestCase("es", "fr-CA", "de", new[] { "es", "fr-CA", "fr", "de", "en" })]
+		[TestCase("es", "id", "fr-LU", new[] { "es", "id", "fr-LU", "fr", "en" })]
+		// given two fr-X codes, insert fr after the last of them. The main point here is that fr should be tried after fr-FR and fr-LU.
+		// But the result here is actually debatable: should es be preferred to fr in this case?
+		// Maybe the right result is fr-FR, fr-LU, fr, es, en in this case, since the original order indicates that French is better than Spanish?
+		// But it's a very obscure and unlikely case; I think we can live with what the current algorithm does.
+		[TestCase("fr-FR", "es", "fr-LU", new[] {"fr-FR", "es", "fr-LU", "fr", "en" })]
+		[TestCase("zh-Hans", "fr-CA", "es-SV", new[] { "zh-Hans", "zh-CN", "fr-CA", "fr", "es-SV", "es", "en" })] // all three!!
+		[TestCase("fr", "fr-CA", "de", new[] { "fr", "fr-CA", "de", "en" })] // already have the fall-back, don't add again.
+		public void LicenseDescriptionLanguagePriorities_Results(string lang1, string lang2, string lang3, string[] results)
+		{
+			var settings = CreateCollectionSettings(_folder.Path, "test");
+			settings.Language1Iso639Code = lang1;
+			settings.Language2Iso639Code = lang2;
+			settings.Language3Iso639Code = lang3;
+			Assert.That(settings.LicenseDescriptionLanguagePriorities, Is.EqualTo(results));
+		}
 	}
 }


### PR DESCRIPTION
zh-CN will be used as default UI language for any variant of zh as system language
zh-CN will be used for license on page if any variant of zh requested. For any other variant, we will try the plain language code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1682)
<!-- Reviewable:end -->
