### PR TITLE
 Add draggable text over pictures boxes

### DIFF
--- a/DistFiles/localization/Bloom.en.tmx
+++ b/DistFiles/localization/Bloom.en.tmx
@@ -1172,6 +1172,12 @@
         <seg>Add Page...</seg>
       </tuv>
     </tu>
+    <tu tuid="EditTab.AddTextBoxToImage">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Add Text Box To Image</seg>
+      </tuv>
+    </tu>
     <tu tuid="EditTab.BackMatter.InsideBackCoverTextPrompt">
       <prop type="x-dynamic">true</prop>
       <tuv xml:lang="en">
@@ -1326,6 +1332,12 @@
     <tu tuid="EditTab.DeletePageButton.ToolTipWhenDisabled">
       <tuv xml:lang="en">
         <seg>This page cannot be removed</seg>
+      </tuv>
+    </tu>
+    <tu tuid="EditTab.DeleteTextBoxFromImage">
+      <prop type="x-dynamic">true</prop>
+      <tuv xml:lang="en">
+        <seg>Delete Text Box From Image</seg>
       </tuv>
     </tu>
     <tu tuid="EditTab.DirectFormatting.Bold">

--- a/artwork/draghandle-grey.svg
+++ b/artwork/draghandle-grey.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="6.4148741mm"
+   height="6.4139175mm"
+   viewBox="0 0 22.729869 22.726479"
+   id="svg4197"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="draghandle.svg">
+  <defs
+     id="defs4199" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.2"
+     inkscape:cx="23.249557"
+     inkscape:cy="-12.910662"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1839"
+     inkscape:window-height="1177"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata4202">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(22.793506,221.85818)">
+    <path
+       style="fill:#91928f;fill-opacity:1"
+       id="path4182"
+       d="m -0.19678053,-210.80592 -3.63784997,-2.96218 c -0.28638,-0.28638 -0.77411,-0.085 -0.77411,0.32217 l 0,1.82116 -5.6827405,0 0,-5.68274 1.8211605,0 c 0.40272,0 0.60407,-0.48773 0.32217,-0.77411 l -2.9532305,-3.64232 c -0.17899,-0.17898 -0.46536,-0.17898 -0.63987,0 l -2.96218,3.63785 c -0.28638,0.28637 -0.085,0.77411 0.32217,0.77411 l 1.82116,0 0,5.68274 -5.68274,0 0,-1.82116 c 0,-0.40272 -0.48773,-0.60408 -0.77411,-0.32218 l -3.64232,2.95324 c -0.17898,0.17898 -0.17898,0.46536 0,0.63986 l 3.63785,2.96219 c 0.28637,0.28637 0.77411,0.085 0.77411,-0.32217 l 0,-1.82116 5.68274,0 0,5.68274 -1.82116,0 c -0.40272,0 -0.60408,0.48772 -0.32218,0.7741 l 2.94876,3.63785 c 0.17899,0.17898 0.46536,0.17898 0.63987,0 l 2.9621905,-3.63785 c 0.28637,-0.28638 0.085,-0.7741 -0.32218,-0.7741 l -1.8211605,0 0,-5.68274 5.6827405,0 0,1.82116 c 0,0.40271 0.48773,0.60407 0.77411,0.32217 l 3.63784997,-2.94876 c 0.18793,-0.17899 0.18793,-0.46536 0.009,-0.63987 z"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1,5 +1,5 @@
 /*This stylesheet applied when a book is being edited. It does things like show that images can be changed by click on them.*/
-
+@import "../../templates/common-mixins.less";
 @import "../sourceBubbles/sourceBubbles.less";
 
 BODY
@@ -361,15 +361,15 @@ DIV.marginBox
     font-size: 10pt;
     height: 20px;
     width: 20px;
+    z-index: @formatButtonZIndex;
     img{
         position: absolute;
         bottom: 0;
         left: 0;
     }
-}
-#formatButton:Hover
-{
-    color: #000000;
+    &:Hover {
+        color: #000000;
+    }
 }
 /*Toolbox*/
 #pagedragtoolbox
@@ -554,6 +554,10 @@ div.cke_float {
 
     span.cke_toolgroup { margin: 0 !important; }
   }
+}
+
+.bloom-textOverPicture .bloom-editable {
+    padding-top: 1px; // for some reason this is needed to keep edit/non-edit text spacing the same
 }
 
 div.long-press-popup {z-index: 15005} // in front of hint bubbles

--- a/src/BloomBrowserUI/bookEdit/editViewFrame.ts
+++ b/src/BloomBrowserUI/bookEdit/editViewFrame.ts
@@ -14,40 +14,41 @@ export { showAddPageDialog };
 
 //Called by c# using FrameExports.handleUndo()
 export function handleUndo(): void {
-        // First see if origami is active and knows about something we can undo.
-        var contentWindow = getPageFrameExports();
-        if (contentWindow && (<any>contentWindow).origamiCanUndo()) {
-                (<any>contentWindow).origamiUndo();
-        }
-        // Undoing changes made by commands and dialogs in the toolbox can't be undone using
-        // ckeditor, and has its own mechanism. Look next to see whether we know about any Undos there.
-        var toolboxWindow = getToolboxFrameExports();
-        if (toolboxWindow && (<any>toolboxWindow).canUndo()) {
-                (<any>toolboxWindow).undo();
-        }
-        else if (contentWindow && contentWindow.ckeditorCanUndo()) {
-                contentWindow.ckeditorUndo();
-        }
-        // See also Browser.Undo; if all else fails we ask the C# browser object to Undo.
+    // First see if origami is active and knows about something we can undo.
+    var contentWindow = getPageFrameExports();
+    if (contentWindow && (<any>contentWindow).origamiCanUndo()) {
+        (<any>contentWindow).origamiUndo();
+    }
+    // Undoing changes made by commands and dialogs in the toolbox can't be undone using
+    // ckeditor, and has its own mechanism. Look next to see whether we know about any Undos there.
+    var toolboxWindow = getToolboxFrameExports();
+    if (toolboxWindow && (<any>toolboxWindow).canUndo()) {
+        (<any>toolboxWindow).undo();
+    }
+    else if (contentWindow && contentWindow.ckeditorCanUndo()) {
+        contentWindow.ckeditorUndo();
+    }
+    // See also Browser.Undo; if all else fails we ask the C# browser object to Undo.
 }
 
 export function switchContentPage(newSource: string) {
-        let iframe = (<HTMLIFrameElement>document.getElementById('page'));
-        iframe.src = newSource;
-        // I don't fully understand why the load is necessary; it seems that without it
-        // the old page content is still around and applyToolboxStateToPage() works on that
-        // instead of the new page.
-        $(iframe).load(() =>
-                getToolboxFrameExports().applyToolboxStateToPage());
+    this.getPageFrameExports().pageUnloading();
+    let iframe = (<HTMLIFrameElement>document.getElementById('page'));
+    iframe.src = newSource;
+    // I don't fully understand why the load is necessary; it seems that without it
+    // the old page content is still around and applyToolboxStateToPage() works on that
+    // instead of the new page.
+    $(iframe).load(() =>
+        getToolboxFrameExports().applyToolboxStateToPage());
 }
 
 // This function allows code in the toolbox (or other) frame to create a dialog with dynamic content in the root frame
 // (so that it can be dragged anywhere in the gecko window). The dialog() function behaves strangely (e.g., draggable doesn't work)
 // if the jquery wrapper for the element is created in a different frame than the parent of the dialog element.
 export function showDialog(dialogContents: string, options: any): JQuery {
-        var dialogElement = $(dialogContents).appendTo($('body'));
-        dialogElement.dialog(options);
-        return dialogElement;
+    var dialogElement = $(dialogContents).appendTo($('body'));
+    dialogElement.dialog(options);
+    return dialogElement;
 }
 
 // This allows closing a dialog opened in the outer frame window. Apparently a dialog must be closed by
@@ -62,30 +63,30 @@ export function toolboxIsShowing() { return (<HTMLInputElement>$(document).find(
 // (The value passed to the task function will be the value from getToolboxFrameExports(). Unfortunately we
 // haven't yet managed to declare a type for that, so I can't easily specify it here.)
 export function doWhenToolboxLoaded(task: (toolboxFrameExports: any) => any) {
-        let toolboxWindow = getToolboxFrameExports();
-        if (toolboxWindow) {
-                task(toolboxWindow);
-        }
-        else {
-                setTimeout(() => {
-                        doWhenToolboxLoaded(task);
-                }, 10);
-        }
+    let toolboxWindow = getToolboxFrameExports();
+    if (toolboxWindow) {
+        task(toolboxWindow);
+    }
+    else {
+        setTimeout(() => {
+            doWhenToolboxLoaded(task);
+        }, 10);
+    }
 }
 
 //Called by c# using FrameExports.canUndo()
 export function canUndo(): string {
-        // See comments on handleUndo()
-        var contentWindow = getPageFrameExports();
-        if (contentWindow && (<any>contentWindow).origamiCanUndo()) { return 'yes'; }
-        var toolboxWindow = getToolboxFrameExports();
-        if (toolboxWindow && (<any>toolboxWindow).canUndo()) {
-                return 'yes';
-        }
-        if (contentWindow && contentWindow.ckeditorCanUndo()) {
-                return 'yes';
-        }
-        return "fail"; //go ask the browser
+    // See comments on handleUndo()
+    var contentWindow = getPageFrameExports();
+    if (contentWindow && (<any>contentWindow).origamiCanUndo()) { return 'yes'; }
+    var toolboxWindow = getToolboxFrameExports();
+    if (toolboxWindow && (<any>toolboxWindow).canUndo()) {
+        return 'yes';
+    }
+    if (contentWindow && contentWindow.ckeditorCanUndo()) {
+        return 'yes';
+    }
+    return "fail"; //go ask the browser
 }
 
 //noinspection JSUnusedGlobalSymbols

--- a/src/BloomBrowserUI/bookEdit/editablePage.ts
+++ b/src/BloomBrowserUI/bookEdit/editablePage.ts
@@ -11,16 +11,10 @@ import '../lib/jquery.myimgscale.js'; //scaleImage()
 
 // This exports the functions that should be accessible from other IFrames or from C#.
 // For example, FrameExports.getPageFrameExports().pageSelectionChanging() can be called.
-import { pageSelectionChanging } from './js/bloomEditing';
-export { pageSelectionChanging };
-import { disconnectForGarbageCollection } from './js/bloomEditing';
-export { disconnectForGarbageCollection };
-import { origamiCanUndo } from './js/origami';
-export { origamiCanUndo }
-import { origamiUndo } from './js/origami';
-export { origamiUndo }
-import { setZoom } from './js/bloomEditing';
-export { setZoom };
+import { pageSelectionChanging, pageUnloading, disconnectForGarbageCollection, setZoom } from "./js/bloomEditing";
+export { pageSelectionChanging, pageUnloading, disconnectForGarbageCollection, setZoom };
+import { origamiCanUndo, origamiUndo } from "./js/origami";
+export { origamiCanUndo, origamiUndo }
 
 var styleSheets = [
     'themes/bloom-jqueryui-theme/jquery-ui-1.8.16.custom.css',
@@ -89,7 +83,6 @@ window['PasteImageCredits'] = () => {
 }
 
 $(document).ready(function () {
-
     $('body').find('*[data-i18n]').localize();
     bootstrap();
 });

--- a/src/BloomBrowserUI/bookEdit/img/dragHandleGrey.svg
+++ b/src/BloomBrowserUI/bookEdit/img/dragHandleGrey.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="6.4148741mm"
+   height="6.4139175mm"
+   viewBox="0 0 22.729869 22.726479"
+   id="svg4197"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="draghandle.svg">
+  <defs
+     id="defs4199" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.2"
+     inkscape:cx="23.249557"
+     inkscape:cy="-12.910662"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1839"
+     inkscape:window-height="1177"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata4202">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(22.793506,221.85818)">
+    <path
+       style="fill:#91928f;fill-opacity:1"
+       id="path4182"
+       d="m -0.19678053,-210.80592 -3.63784997,-2.96218 c -0.28638,-0.28638 -0.77411,-0.085 -0.77411,0.32217 l 0,1.82116 -5.6827405,0 0,-5.68274 1.8211605,0 c 0.40272,0 0.60407,-0.48773 0.32217,-0.77411 l -2.9532305,-3.64232 c -0.17899,-0.17898 -0.46536,-0.17898 -0.63987,0 l -2.96218,3.63785 c -0.28638,0.28637 -0.085,0.77411 0.32217,0.77411 l 1.82116,0 0,5.68274 -5.68274,0 0,-1.82116 c 0,-0.40272 -0.48773,-0.60408 -0.77411,-0.32218 l -3.64232,2.95324 c -0.17898,0.17898 -0.17898,0.46536 0,0.63986 l 3.63785,2.96219 c 0.28637,0.28637 0.77411,0.085 0.77411,-0.32217 l 0,-1.82116 5.68274,0 0,5.68274 -1.82116,0 c -0.40272,0 -0.60408,0.48772 -0.32218,0.7741 l 2.94876,3.63785 c 0.17899,0.17898 0.46536,0.17898 0.63987,0 l 2.9621905,-3.63785 c 0.28637,-0.28638 0.085,-0.7741 -0.32218,-0.7741 l -1.8211605,0 0,-5.68274 5.6827405,0 0,1.82116 c 0,0.40271 0.48773,0.60407 0.77411,0.32217 l 3.63784997,-2.94876 c 0.18793,-0.17899 0.18793,-0.46536 0.009,-0.63987 z"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -9,162 +9,170 @@ import theOneLocalizationManager from '../../lib/localizationManager/localizatio
 declare function ResetRememberedSize(element: HTMLElement);
 
 export function cleanupImages() {
-        $('.bloom-imageContainer').css('opacity', '');//comes in on img containers from an old version of myimgscale, and is a major problem if the image is missing
-        $('.bloom-imageContainer').css('overflow', '');//review: also comes form myimgscale; is it a problem?
+    $('.bloom-imageContainer').css('opacity', '');//comes in on img containers from an old version of myimgscale, and is a major problem if the image is missing
+    $('.bloom-imageContainer').css('overflow', '');//review: also comes form myimgscale; is it a problem?
 
 }
 
-export function SetupImagesInContainer(container)
-{
-        $(container).find(".bloom-imageContainer img").each(function() {
-                SetupImage(this);
-        });
+export function SetupImagesInContainer(container) {
+    $(container).find(".bloom-imageContainer img").each(function () {
+        SetupImage(this);
+    });
 
-        $(container).find(".bloom-imageContainer").each(function() {
-                SetupImageContainer(this);
-        });
+    $(container).find(".bloom-imageContainer").each(function () {
+        SetupImageContainer(this);
+    });
 
-        //todo: this had problems. Check out the later approach, seen in draggableLabel (e.g. move handle on the inside, using a background image on a div)
-        $(container).find(".bloom-draggable").mouseenter(function() {
-                $(this).prepend("<button class='moveButton' title='Move'></button>");
-                $(this).find(".moveButton").mousedown(function(e) {
-                        //reviewSlog added the <any>
-                        $(this).parent().trigger(<any>e);
-                });
+    //todo: this had problems. Check out the later approach, seen in draggableLabel (e.g. move handle on the inside, using a background image on a div)
+    $(container).find(".bloom-draggable").mouseenter(function () {
+        $(this).prepend("<button class='moveButton' title='Move'></button>");
+        $(this).find(".moveButton").mousedown(function (e) {
+            //reviewSlog added the <any>
+            $(this).parent().trigger(<any>e);
         });
-        $(container).find(".bloom-draggable").mouseleave(function() {
-                $(this).find(".moveButton").each(function() {
-                        $(this).remove()
-                });
+    });
+    $(container).find(".bloom-draggable").mouseleave(function () {
+        $(this).find(".moveButton").each(function () {
+            $(this).remove()
         });
+    });
 
-        $(container).find("img").each(function () {
-                SetAlternateTextOnImages(this);
-        });
+    $(container).find("img").each(function () {
+        SetAlternateTextOnImages(this);
+    });
 }
 
 export function SetupImage(image) {
-        //This is needed to support captioned, inline images, as in  SIL LEAD's Uganda P4 Pupils Books.
-        //In these cases, the captions went from 1 to many lines, and
-        //the container needs to grow to hold the caption (else the text doesn't flow around the caption). But as it
-        //grows, we don't want the image to also keep moving downwards so that it is centered within the container.
-        //The images also are going to look best left aligned.
-        var doCenterImage = !$(image).parent().hasClass('bloom-alignImageTopLeft');
+    //This is needed to support captioned, inline images, as in  SIL LEAD's Uganda P4 Pupils Books.
+    //In these cases, the captions went from 1 to many lines, and
+    //the container needs to grow to hold the caption (else the text doesn't flow around the caption). But as it
+    //grows, we don't want the image to also keep moving downwards so that it is centered within the container.
+    //The images also are going to look best left aligned.
+    var doCenterImage = !$(image).parent().hasClass('bloom-alignImageTopLeft');
 
-        var options = { scale: "fit", center: doCenterImage }
+    var options = { scale: "fit", center: doCenterImage }
 
-        //make images scale up to their container without distorting their proportions, while being centered within it.
-        $(image).scaleImage(options); //uses jquery.myimgscale.js
+    //make images scale up to their container without distorting their proportions, while being centered within it.
+    $(image).scaleImage(options); //uses jquery.myimgscale.js
 
-        // when the image changes, we need to scale again:
-        $(image).load(function () {
-                $(this).scaleImage(options);
-        });
+    // when the image changes, we need to scale again:
+    $(image).load(function () {
+        $(this).scaleImage(options);
+    });
 
-        //and when their parent is resized by the user, we need to scale again:
-        $(image).parent().resize(function () {
-                $(this).find("img").scaleImage(options);
-                try {
-                        ResetRememberedSize(this);
-                } catch (error) {
-                        console.log(error);
-                }
-        });
+    //and when their parent is resized by the user, we need to scale again:
+    $(image).parent().resize(function () {
+        $(this).find("img").scaleImage(options);
+        try {
+            ResetRememberedSize(this);
+        } catch (error) {
+            console.log(error);
+        }
+    });
 }
 
 function GetButtonModifier(container) {
-        var buttonModifier = '';
-        var imageButtonWidth = 87;
-        var imageButtonHeight = 52;
-        var $container = $(container);
-        if ($container.height() < imageButtonHeight * 2) {
-                buttonModifier = 'smallButtonHeight';
-        }
-        if ($container.width() < imageButtonWidth * 2) {
-                buttonModifier += ' smallButtonWidth';
+    var buttonModifier = '';
+    var imageButtonWidth = 87;
+    var imageButtonHeight = 52;
+    var $container = $(container);
+    if ($container.height() < imageButtonHeight * 2) {
+        buttonModifier = 'smallButtonHeight';
+    }
+    if ($container.width() < imageButtonWidth * 2) {
+        buttonModifier += ' smallButtonWidth';
 
-        }
-        if ($container.width() < imageButtonWidth) {
-                buttonModifier += ' verySmallButtons';
-        }
-        return buttonModifier;
+    }
+    if ($container.width() < imageButtonWidth) {
+        buttonModifier += ' verySmallButtons';
+    }
+    return buttonModifier;
 }
 
 //Bloom "imageContainer"s are <div>'s with wrap an <img>, and automatically proportionally resize
 //the img to fit the available space
 function SetupImageContainer(containerDiv) {
-        $(containerDiv).mouseenter(function () {
-                var $this = $(this);
-                var img = $this.find('img');
-                if (img.length === 0) //TODO check for bloom-backgroundImage to make sure this isn't just a case of a missing <img>
-                                img = containerDiv; //using a backgroundImage
+    $(containerDiv).mouseenter(function () {
+        var $this = $(this);
+        var img = $this.find('img');
+        if (img.length === 0) //TODO check for bloom-backgroundImage to make sure this isn't just a case of a missing <img>
+            img = containerDiv; //using a backgroundImage
 
-                var buttonModifier = GetButtonModifier($this);
+        var buttonModifier = GetButtonModifier($this);
 
-                $this.prepend('<button class="miniButton cutImageButton disabled '+ buttonModifier + '" title="' +
-                        theOneLocalizationManager.getText('EditTab.Image.CutImage') + '"></button>');
-                $this.prepend('<button class="miniButton copyImageButton disabled ' + buttonModifier + '" title="' +
-                        theOneLocalizationManager.getText('EditTab.Image.CopyImage') + '"></button>');
-                $this.prepend('<button class="pasteImageButton imageButton ' + buttonModifier +
-                        '" title="' + theOneLocalizationManager.getText('EditTab.Image.PasteImage') + '"></button>');
-                $this.prepend('<button class="changeImageButton imageButton ' + buttonModifier +
-                        '" title="' + theOneLocalizationManager.getText('EditTab.Image.ChangeImage') + '"></button>');
+        $this.prepend('<button class="miniButton cutImageButton disabled ' + buttonModifier + '" title="' +
+            theOneLocalizationManager.getText('EditTab.Image.CutImage') + '"></button>');
+        $this.prepend('<button class="miniButton copyImageButton disabled ' + buttonModifier + '" title="' +
+            theOneLocalizationManager.getText('EditTab.Image.CopyImage') + '"></button>');
+        $this.prepend('<button class="pasteImageButton imageButton ' + buttonModifier +
+            '" title="' + theOneLocalizationManager.getText('EditTab.Image.PasteImage') + '"></button>');
+        $this.prepend('<button class="changeImageButton imageButton ' + buttonModifier +
+            '" title="' + theOneLocalizationManager.getText('EditTab.Image.ChangeImage') + '"></button>');
 
-                SetImageTooltip(containerDiv, img);
+        SetImageTooltip(containerDiv, img);
 
-                if (IsImageReal(img)) {
-                        $this.prepend('<button class="editMetadataButton imageButton ' + buttonModifier + '" title="' +
-                                theOneLocalizationManager.getText('EditTab.Image.EditMetadata') + '"></button>');
-                        $this.find('.miniButton').each(function() {
-                                $(this).removeClass('disabled');
-                        });
-                }
+        if (IsImageReal(img)) {
+            $this.prepend('<button class="editMetadataButton imageButton ' + buttonModifier + '" title="' +
+                theOneLocalizationManager.getText('EditTab.Image.EditMetadata') + '"></button>');
+            $this.find('.miniButton').each(function () {
+                $(this).removeClass('disabled');
+            });
+        }
 
-                $this.addClass('hoverUp');
-        })
+        $this.addClass('hoverUp');
+    })
         .mouseleave(function () {
-                var $this = $(this);
-                $this.removeClass('hoverUp');
-                $this.find('.changeImageButton').each(function () {
-                        $(this).remove();
-                });
-                $this.find('.pasteImageButton').each(function () {
-                        $(this).remove();
-                });
-                $this.find('.miniButton').each(function() {
-                        $(this).remove();
-                });
-                $this.find('.editMetadataButton').each(function () {
-                        if (!$(this).hasClass('imgMetadataProblem')) {
-                                $(this).remove();
-                        }
-                });
+            var $this = $(this);
+            $this.removeClass('hoverUp');
+            $this.find('.changeImageButton').each(function () {
+                $(this).remove();
+            });
+            $this.find('.pasteImageButton').each(function () {
+                $(this).remove();
+            });
+            $this.find('.miniButton').each(function () {
+                $(this).remove();
+            });
+            $this.find('.editMetadataButton').each(function () {
+                if (!$(this).hasClass('imgMetadataProblem')) {
+                    $(this).remove();
+                }
+            });
         });
 }
 
 function SetImageTooltip(container, img) {
-        axios.get<string>('/bloom/api/image/info', { params: { image: GetRawImageUrl(img) } }).then(result => {
-                var image:any = result.data;
-                const kBrowserDpi = 96; // this appears to be constant even on higher dpi screens. See http://www.w3.org/TR/css3-values/#absolute-lengths
-                var dpi = Math.round(image.width / ($(img).width() / kBrowserDpi));
-                var info = image.name + "\n"
-                        + getFileLengthString(image.bytes) + "\n"
-                        + image.width + " x " + image.height + "\n"
-                        + dpi + " DPI (should be 300-600)\n"
-                        + "Bit Depth: " + image.bitDepth.toString();
-                container.title = info;
-        });
+    var url = GetRawImageUrl(img);
+    // Don't try to go getting image info for a built in Bloom image (like cogGrey.svg).
+    // It'll just throw an exception.
+    if (url.startsWith("/bloom/")) {
+        container.title = "";
+        return;
+    }
+    axios.get<string>("/bloom/api/image/info", { params: { image: GetRawImageUrl(img) } }).then(result => {
+        var image: any = result.data;
+        // This appears to be constant even on higher dpi screens.
+        // (See http://www.w3.org/TR/css3-values/#absolute-lengths)
+        const kBrowserDpi = 96;
+        var dpi = Math.round(image.width / ($(img).width() / kBrowserDpi));
+        var info = image.name + "\n"
+            + getFileLengthString(image.bytes) + "\n"
+            + image.width + " x " + image.height + "\n"
+            + dpi + " DPI (should be 300-600)\n"
+            + "Bit Depth: " + image.bitDepth.toString();
+        container.title = info;
+    });
 }
 
-function getFileLengthString(bytes) :String {
-        var units = ['Bytes', 'KB', 'MB'];
-        for (var i = units.length; i-- > 0;) {
-                var unit = Math.pow(1024, i);
-                if (bytes >= unit)
-                        //reviewSlog
-                        return (Math.round(bytes / unit * 100) / 100).toFixed(2).toString() + ' ' + units[i];
-                        //return parseFloat(Math.round(bytes / unit * 100) / 100).toFixed(2) + ' ' + units[i];
-        }
+function getFileLengthString(bytes): String {
+    var units = ['Bytes', 'KB', 'MB'];
+    for (var i = units.length; i-- > 0;) {
+        var unit = Math.pow(1024, i);
+        if (bytes >= unit)
+            //reviewSlog
+            return (Math.round(bytes / unit * 100) / 100).toFixed(2).toString() + ' ' + units[i];
+        //return parseFloat(Math.round(bytes / unit * 100) / 100).toFixed(2) + ' ' + units[i];
+    }
 }
 
 // IsImageReal returns true if the img tag refers to a non-placeholder image
@@ -172,163 +180,163 @@ function getFileLengthString(bytes) :String {
 // - we don't want to offer to edit placeholder credits
 // - we don't want to activate the minibuttons for cut/copy
 function IsImageReal(img) {
-        return GetRawImageUrl(img).toLowerCase().indexOf('placeholder') == -1; //don't offer to edit placeholder credits
+    return GetRawImageUrl(img).toLowerCase().indexOf('placeholder') == -1; //don't offer to edit placeholder credits
 }
 
 // Gets the src attribute out of images, and the background-image:url() of everything else
 function GetRawImageUrl(imgOrDivWithBackgroundImage) {
-        if ($(imgOrDivWithBackgroundImage).hasAttr("src")) {
-                return $(imgOrDivWithBackgroundImage).attr("src");
-        }
-        //handle divs with background-image in an inline style attribute
-        if ($(imgOrDivWithBackgroundImage).hasAttr("style")) {
-                var style = $(imgOrDivWithBackgroundImage).attr("style");
-                // see http://stackoverflow.com/questions/9723889/regex-to-match-urls-in-inline-styles-div-style-url
-                //var result = (/url\(\s*(['"]?)(.*?)\1\s*\)/.exec(style) || [])[2];
-                return (/url\s*\(\s*(['"]?)(.*?)\1\s*\)/.exec(style) || [])[2];
-        }
-        return "";
+    if ($(imgOrDivWithBackgroundImage).hasAttr("src")) {
+        return $(imgOrDivWithBackgroundImage).attr("src");
+    }
+    //handle divs with background-image in an inline style attribute
+    if ($(imgOrDivWithBackgroundImage).hasAttr("style")) {
+        var style = $(imgOrDivWithBackgroundImage).attr("style");
+        // see http://stackoverflow.com/questions/9723889/regex-to-match-urls-in-inline-styles-div-style-url
+        //var result = (/url\(\s*(['"]?)(.*?)\1\s*\)/.exec(style) || [])[2];
+        return (/url\s*\(\s*(['"]?)(.*?)\1\s*\)/.exec(style) || [])[2];
+    }
+    return "";
 }
 export function SetImageElementUrl(imgOrDivWithBackgroundImage, url) {
-        if (imgOrDivWithBackgroundImage.tagName.toLowerCase() === "img") {
-                imgOrDivWithBackgroundImage.src = url;
-        }
-        else {
-                imgOrDivWithBackgroundImage.style = "background-image:url('"+url+"')";
-        }
+    if (imgOrDivWithBackgroundImage.tagName.toLowerCase() === "img") {
+        imgOrDivWithBackgroundImage.src = url;
+    }
+    else {
+        imgOrDivWithBackgroundImage.style = "background-image:url('" + url + "')";
+    }
 }
 //While the actual metadata is embedded in the images (Bloom/palaso does that), Bloom sticks some metadata in data-* attributes
 // so that we can easily & quickly get to the here.
 export function SetOverlayForImagesWithoutMetadata(container) {
-        $(container).find("*[style*='background-image']").each(function () {
-                SetOverlayForImagesWithoutMetadataInner(this, this);
-        });
+    $(container).find("*[style*='background-image']").each(function () {
+        SetOverlayForImagesWithoutMetadataInner(this, this);
+    });
 
-        //Do the same for any img elements inside
-        $(container).find(".bloom-imageContainer").each(function () {
-                var img = $(this).find('img');
-                SetOverlayForImagesWithoutMetadataInner($(img).parent(), img);
-        });
+    //Do the same for any img elements inside
+    $(container).find(".bloom-imageContainer").each(function () {
+        var img = $(this).find('img');
+        SetOverlayForImagesWithoutMetadataInner($(img).parent(), img);
+    });
 }
 
 function SetOverlayForImagesWithoutMetadataInner(container, img) {
-         if (!IsImageReal(img)) {
-                return;
-        }
+    if (!IsImageReal(img)) {
+        return;
+    }
 
+    UpdateOverlay(container, img);
+
+    //and if the bloom program changes these values (i.e. the user changes them using bloom), I
+    //haven't figured out a way (apart from polling) to know that. So for now I'm using a hack
+    //where Bloom calls click() on the image when it wants an update, and we detect that here.
+    $(img).click(function () {
         UpdateOverlay(container, img);
-
-        //and if the bloom program changes these values (i.e. the user changes them using bloom), I
-        //haven't figured out a way (apart from polling) to know that. So for now I'm using a hack
-        //where Bloom calls click() on the image when it wants an update, and we detect that here.
-        $(img).click(function () {
-                UpdateOverlay(container, img);
-        });
+    });
 }
 
 function UpdateOverlay(container, img) {
 
-        $(container).find("button.imgMetadataProblem").each(function () {
-                $(this).remove();
-        });
+    $(container).find("button.imgMetadataProblem").each(function () {
+        $(this).remove();
+    });
 
-        //review: should we also require copyright, illustrator, etc? In many contexts the id of the work-for-hire illustrator isn't available
-        var copyright = $(img).attr('data-copyright');
-        if (!copyright || copyright.length === 0) {
+    //review: should we also require copyright, illustrator, etc? In many contexts the id of the work-for-hire illustrator isn't available
+    var copyright = $(img).attr('data-copyright');
+    if (!copyright || copyright.length === 0) {
 
-                var buttonModifier = GetButtonModifier(container);
+        var buttonModifier = GetButtonModifier(container);
 
-                $(container).prepend("<button class='editMetadataButton imageButton imgMetadataProblem " + buttonModifier + "' title='Image is missing information on Credits, Copyright, or License'></button>");
-        }
+        $(container).prepend("<button class='editMetadataButton imageButton imgMetadataProblem " + buttonModifier + "' title='Image is missing information on Credits, Copyright, or License'></button>");
+    }
 }
 
 // Instead of "missing", we want to show it in the right ui language. We also want the text
 // to indicate that it might not be missing, just didn't load (this happens on slow machines)
 // TODO: internationalize
 function SetAlternateTextOnImages(element) {
-        if (GetRawImageUrl(element).length > 0) { //don't show this on the empty license image when we don't know the license yet
-                var nameWithoutQueryString = GetRawImageUrl(element).split("?")[0];
-                $(element).attr('alt', 'This picture, ' + nameWithoutQueryString + ', is missing or was loading too slowly.');
-        } else {
-                $(element).attr('alt', '');//don't be tempted to show something like a '?' unless you fix the result when you have a custom book license on top of that '?'
-        }
+    if (GetRawImageUrl(element).length > 0) { //don't show this on the empty license image when we don't know the license yet
+        var nameWithoutQueryString = GetRawImageUrl(element).split("?")[0];
+        $(element).attr('alt', 'This picture, ' + nameWithoutQueryString + ', is missing or was loading too slowly.');
+    } else {
+        $(element).attr('alt', '');//don't be tempted to show something like a '?' unless you fix the result when you have a custom book license on top of that '?'
+    }
 }
 
 export function SetupResizableElement(element) {
-        $(element).mouseenter(
-                function () {
-                        $(this).addClass("ui-mouseOver")
-                }).mouseleave(function () {
-                        $(this).removeClass("ui-mouseOver")
-                });
-        var childImgContainer = $(element).find(".bloom-imageContainer");
-        // A Picture Dictionary Word-And-Image
-        if ($(childImgContainer).length > 0) {
-                /* The case here is that the thing with this class actually has an
-                 inner image, as is the case for the Picture Dictionary.
-                 The key, non-obvious, difficult requirement is keeping the text below
-                 a picture dictionary item centered underneath the image.  I'd be
-                 surprised if this wasn't possible in CSS, but I'm not expert enough.
-                 So, I switched from having the image container be resizable, to having the
-                 whole div (image+headwords) be resizable, then use the "alsoResize"
-                 parameter to make the imageContainer resize.  Then, in order to make
-                 the image resize in real-time as you're dragging, I use the "resize"
-                 event to scale the image up proportionally (and centered) inside the
-                 newly resized container.
-                 */
-                var img = $(childImgContainer).find("img");
-                $(element).resizable({
-                        handles: 'nw, ne, sw, se',
-                        containment: "parent",
-                        alsoResize: childImgContainer,
-                        resize: function (event, ui) {
-                                img.scaleImage({ scale: "fit" })
-                        }
-                });
-                return $(element);
-        }
-                //An Image Container div (which must have an inner <img>
-        else if ($(element).hasClass('bloom-imageContainer')) {
-                var img = $(element).find("img");
-                $(element).resizable({
-                        handles: 'nw, ne, sw, se',
-                        containment: "parent",
-                        resize: function (event, ui) {
-                                img.scaleImage({ scale: "fit" })
-                        }
-                });
-        }
-                // some other kind of resizable
-        else {
-                $(element).resizable({
-                        handles: 'nw, ne, sw, se',
-                        containment: "parent",
-                        stop: ResizeUsingPercentages,
-                        start: function (e, ui) {
-                                if ($(ui.element).css('top') == '0px' && $(ui.element).css('left') == '0px') {
-                                        $(ui.element).data('doRestoreRelativePosition', 'true');
-                                }
-                        }
-                });
-        }
+    $(element).mouseenter(
+        function () {
+            $(this).addClass("ui-mouseOver")
+        }).mouseleave(function () {
+            $(this).removeClass("ui-mouseOver")
+        });
+    var childImgContainer = $(element).find(".bloom-imageContainer");
+    // A Picture Dictionary Word-And-Image
+    if ($(childImgContainer).length > 0) {
+        /* The case here is that the thing with this class actually has an
+         inner image, as is the case for the Picture Dictionary.
+         The key, non-obvious, difficult requirement is keeping the text below
+         a picture dictionary item centered underneath the image.  I'd be
+         surprised if this wasn't possible in CSS, but I'm not expert enough.
+         So, I switched from having the image container be resizable, to having the
+         whole div (image+headwords) be resizable, then use the "alsoResize"
+         parameter to make the imageContainer resize.  Then, in order to make
+         the image resize in real-time as you're dragging, I use the "resize"
+         event to scale the image up proportionally (and centered) inside the
+         newly resized container.
+         */
+        var img = $(childImgContainer).find("img");
+        $(element).resizable({
+            handles: 'nw, ne, sw, se',
+            containment: "parent",
+            alsoResize: childImgContainer,
+            resize: function (event, ui) {
+                img.scaleImage({ scale: "fit" })
+            }
+        });
+        return $(element);
+    }
+    //An Image Container div (which must have an inner <img>
+    else if ($(element).hasClass('bloom-imageContainer')) {
+        var img = $(element).find("img");
+        $(element).resizable({
+            handles: 'nw, ne, sw, se',
+            containment: "parent",
+            resize: function (event, ui) {
+                img.scaleImage({ scale: "fit" })
+            }
+        });
+    }
+    // some other kind of resizable
+    else {
+        $(element).resizable({
+            handles: 'nw, ne, sw, se',
+            containment: "parent",
+            stop: ResizeUsingPercentages,
+            start: function (e, ui) {
+                if ($(ui.element).css('top') == '0px' && $(ui.element).css('left') == '0px') {
+                    $(ui.element).data('doRestoreRelativePosition', 'true');
+                }
+            }
+        });
+    }
 }
 
 //jquery resizable normally uses pixels. This makes it use percentages, which are mor robust across page size/orientation changes
 function ResizeUsingPercentages(e, ui) {
-        var parent = ui.element.parent();
-        ui.element.css({
-                width: ui.element.width() / parent.width() * 100 + "%",
-                height: ui.element.height() / parent.height() * 100 + "%"
-        });
+    var parent = ui.element.parent();
+    ui.element.css({
+        width: ui.element.width() / parent.width() * 100 + "%",
+        height: ui.element.height() / parent.height() * 100 + "%"
+    });
 
-        //after any resize jquery adds an absolute position, which we don't want unless the user has resized
-        //so this removes it, unless we previously noted that the user had moved it
-        if ($(ui.element).data('doRestoreRelativePosition')) {
-                ui.element.css({
-                        position: '',
-                        top: '',
-                        left: ''
-                });
-        }
-        $(ui.element).removeData('hadPreviouslyBeenRelocated');
+    //after any resize jquery adds an absolute position, which we don't want unless the user has resized
+    //so this removes it, unless we previously noted that the user had moved it
+    if ($(ui.element).data('doRestoreRelativePosition')) {
+        ui.element.css({
+            position: '',
+            top: '',
+            left: ''
+        });
+    }
+    $(ui.element).removeData('hadPreviouslyBeenRelocated');
 }

--- a/src/BloomBrowserUI/bookEdit/js/origami.ts
+++ b/src/BloomBrowserUI/bookEdit/js/origami.ts
@@ -104,7 +104,7 @@ function layoutToggleClickHandler() {
     } else {
         marginBox.removeClass('origami-layout-mode');
         marginBox.find('.textBox-identifier').remove();
-        fireCSharpEditEvent('preparePageForEditingAfterOrigamiChangesEvent', '');
+        fireCSharpEditEvent("saveChangesAndRethinkPageEvent", "");
         origamiUndoStack.length = origamiUndoIndex = 0;
         $('html').off('keydown.origami');
     }

--- a/src/BloomBrowserUI/bookEdit/js/textOverPicture.ts
+++ b/src/BloomBrowserUI/bookEdit/js/textOverPicture.ts
@@ -1,0 +1,176 @@
+// This class makes it possible to add and delete textboxes that float over images. These floating
+// textboxes are intended for use in making comic books, but could also be useful in the case of
+// any book that uses a picture where there is space for text within the bounds of the picture.
+// In order to be accessible via a right-click context menu that c# generates, it listens on a websocket
+// that the Bloom C# uses (in Browser.cs).
+///<reference path="../../typings/jquery/jquery.d.ts"/>
+
+import { fireCSharpEditEvent } from "./bloomEditing";
+import { EditableDivUtils } from "./editableDivUtils";
+
+const kSocketName = "webSocket";
+
+// references to "TOP" in the code refer to the actual TextOverPicture box installed in the Bloom page.
+class TextOverPictureManager {
+
+    listenerFunction: (MessageEvent) => void;
+
+    public initializeTextOverPictureManager(): void {
+        this.listenerFunction = event => {
+            var e = JSON.parse(event.data);
+            var locationArray = e.payload.split(","); // mouse right-click coordinates
+            if (e.id === "addTextBox")
+                this.addFloatingTOPBox(locationArray[0], locationArray[1]);
+            if (e.id === "deleteTextBox")
+                this.deleteFloatingTOPBox(locationArray[0], locationArray[1]);
+        };
+        // I (GJM) ran into problems setting the onmessage handler in two places (here and in audioRecording)
+        // The problem can be solved two ways: 1- by giving TextOverPictureManager's socket a different name,
+        // or 2- by switching to using addEventListener("message", eventhandler), which I've done. Also, the
+        // TextOverPictureManager's socket is now on the local window as opposed to window.top as in
+        // audioRecording.ts.
+        this.getWebSocket().addEventListener("message", this.listenerFunction);
+    }
+
+    public removeTextOverPictureListener(): void {
+        this.getWebSocket().removeEventListener("message", this.listenerFunction);
+        this.getWebSocket().close();
+    }
+
+    private getWebSocket(): WebSocket {
+        if (typeof window[kSocketName] === "undefined") {
+            //currently we use a different port for this websocket, and it's the main port + 1
+            let websocketPort = parseInt(window.location.port, 10) + 1;
+            //NB: testing shows that our webSocketServer does receive a close notification when this window goes away
+            window[kSocketName] = new WebSocket("ws://127.0.0.1:" + websocketPort.toString());
+        }
+        return window[kSocketName];
+    }
+
+    // mouseX and mouseY are the location in the viewport of the mouse when right-clicking
+    // to create the context menu
+    private addFloatingTOPBox(mouseX: number, mouseY: number) {
+        var container = this.getImageContainerFromMouse(mouseX, mouseY);
+        if (!container || container.length === 0) {
+            return; // don't add a TOP box if we can't find the containing imageContainer
+        }
+        // add a draggable text bubble to the html dom of the current page
+        const editableDivClasses = "bloom-editable bloom-content1 bloom-visibility-code-on normal-style";
+        const editableDivHtml = "<div class='" + editableDivClasses + "' ><p></p></div>";
+        const transGroupDivClasses = "bloom-translationGroup bloom-leadingElement normal-style";
+        const transGroupHtml = "<div class='" + transGroupDivClasses + "' data-default-languages='V'>" + editableDivHtml + "</div>";
+        const handleHtml = "<div class='bloom-dragHandleTOP'></div>";
+        const wrapperHtml = "<div class='bloom-textOverPicture'>" + handleHtml + transGroupHtml + "</div>";
+        // add textbox as first child of .bloom-imageContainer
+        var firstContainerChild = container.children().first();
+        var wrapperBox = $(wrapperHtml).insertBefore(firstContainerChild);
+        // initial mouseX, mouseY coordinates are relative to viewport
+        this.calculateAndFixInitialLocation(wrapperBox, container, mouseX, mouseY);
+        // I tried to do without this... it didn't work. This causes page changes to get saved and fills
+        // things in for editing.
+        // It causes EditingModel.RethinkPageAndReloadIt() to get run... which eventually causes
+        // makeTextOverPictureBoxDraggableClickableAndResizable to get called by bloomEditing.ts.
+        fireCSharpEditEvent("saveChangesAndRethinkPageEvent", "");
+    }
+
+    // mouseX and mouseY are the location in the viewport of the mouse when right-clicking
+    // to create the context menu
+    private getImageContainerFromMouse(mouseX: number, mouseY: number): JQuery {
+        return $(document.elementFromPoint(mouseX, mouseY)).closest(".bloom-imageContainer");
+    }
+
+    // mouseX and mouseY are the location in the viewport of the mouse when right-clicking
+    // to create the context menu
+    private calculateAndFixInitialLocation(wrapperBox: JQuery, container: JQuery, mouseX: number, mouseY: number) {
+        var scale = EditableDivUtils.getPageScale();
+        var containerPosition = container[0].getBoundingClientRect();
+        var xOffset = ((mouseX - containerPosition.left) / scale);
+        var yOffset = ((mouseY - containerPosition.top) / scale);
+        var location = "left: " + xOffset + "px; top: " + yOffset + "px;";
+        wrapperBox.attr("style", location);
+        this.calculatePercentagesAndFixTextboxPosition(wrapperBox); // translate px to %
+    }
+
+    // mouseX and mouseY are the location in the viewport of the mouse when right-clicking
+    // to create the context menu
+    private deleteFloatingTOPBox(mouseX: number, mouseY: number) {
+        var focusedBubble = $(document.elementFromPoint(mouseX, mouseY)).closest(".bloom-textOverPicture");
+        if (focusedBubble && focusedBubble.length > 0) {
+            focusedBubble.remove();
+        }
+    }
+
+    private makeTOPBoxDraggableAndClickable(thisTOPBox: JQuery, scale: number, TOPManager: TextOverPictureManager): void {
+        var image = this.getImageContainer(thisTOPBox);
+        var imagePos = image[0].getBoundingClientRect();
+        var wrapperBoxRectangle = thisTOPBox[0].getBoundingClientRect();
+        // Containment, drag and stop work when scaled (zoomed) as long as the page has been saved since the zoom
+        // factor was last changed. Therefore we force saving the page after setZoom() in bloomEditing.
+        thisTOPBox.draggable({
+            // adjust containment by scaling
+            containment: [imagePos.left, imagePos.top,
+            imagePos.left + imagePos.width - wrapperBoxRectangle.width,
+            imagePos.top + imagePos.height - wrapperBoxRectangle.height],
+            drag: function (event, ui) {
+                ui.helper.children(".bloom-editable").blur();
+                ui.position.top = (ui.position.top / scale);
+                ui.position.left = (ui.position.left / scale);
+            },
+            handle: ".bloom-dragHandleTOP",
+            stop: function (event, ui) {
+                TOPManager.calculatePercentagesAndFixTextboxPosition(thisTOPBox);
+            }
+        });
+
+        thisTOPBox.find(".bloom-editable").click(function (e) {
+            this.focus();
+        });
+    }
+
+    // Make any added TextOverPictureManager textboxes draggable, clickable, and resizable.
+    // Called by bloomEditing.ts.
+    public makeTextOverPictureBoxDraggableClickableAndResizable() {
+        // get all textOverPicture elements
+        var textOverPictureElems = $("body").find(".bloom-textOverPicture");
+
+        textOverPictureElems.resizable();
+
+        var scale = EditableDivUtils.getPageScale();
+        textOverPictureElems.each((i, textbox) => {
+            var thisTOPbox = $(textbox);
+            this.makeTOPBoxDraggableAndClickable(thisTOPbox, scale, this);
+            if (i === 0) {
+                thisTOPbox.find(".bloom-editable.bloom-visibility-code-on").first().focus();
+            }
+        });
+    }
+
+    private calculatePercentagesAndFixTextboxPosition(wrapperBox: JQuery) {
+        var scale = EditableDivUtils.getPageScale();
+        var container = wrapperBox.closest(".bloom-imageContainer");
+        var pos = wrapperBox.position();
+        // the textbox is contained by the image, and it's actual positioning is now based on the imageContainer too.
+        // so we will position by percentage of container size.
+        var containerSize = {
+            height: container.height(),
+            width: container.width()
+        };
+        wrapperBox.css("left", (pos.left / scale / containerSize.width * 100) + "%")
+            .css("top", (pos.top / scale / containerSize.height * 100) + "%");
+    }
+
+    // Gets the bloom-imageContainer that hosts this TextOverPictureManager textbox.
+    // The imageContainer will define the dragging boundaries for the textbox.
+    private getImageContainer(wrapperBox: JQuery): JQuery {
+        return wrapperBox.parent(".bloom-imageContainer").first();
+    }
+}
+
+export var theOneTextOverPictureManager: TextOverPictureManager;
+
+export function initializeTextOverPictureManager() {
+    if (theOneTextOverPictureManager)
+        return;
+    theOneTextOverPictureManager = new TextOverPictureManager();
+    theOneTextOverPictureManager.initializeTextOverPictureManager();
+}

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -1,5 +1,6 @@
 @import "../templates/common-mixins.less";
 @import "basePage-sharedRules.less";
+@import "textOverPicture.less";
 
 .Browser-Reset() {
     /*+init {*/
@@ -518,7 +519,7 @@ h2 {
         height: ~"calc(100% - 3px)"; //hack: this should logically be 1px, but 3 was needed, so I'm missing something, or maybe it's about rounding and such.
 
         // above so buttons show
-        z-index: 1000;
+        z-index: @imageContainerZIndex;
         // Solves BL-1033 small picture frames cycling red overflow
         overflow: hidden;
     }

--- a/src/BloomBrowserUI/bookLayout/textOverPicture.less
+++ b/src/BloomBrowserUI/bookLayout/textOverPicture.less
@@ -1,0 +1,58 @@
+@import "../templates/common-mixins.less";
+@MinTextBoxWidth: 30px;
+@MinTextBoxHeight: 40px;
+@DefaultTextBoxWidth: 140px;
+@DefaultTextBoxHeight: @MinTextBoxHeight;
+@DragHandleBackgroundColor: transparent;
+
+// Don't show text over picture borders or resizing handles unless hovering over the image
+.bloom-imageContainer:not(.hoverUp) {
+    .bloom-editable {
+        border: none;
+        // keeps text from jumping when switching between hover/nothover states
+        padding-left: 1px;
+        padding-top: 2px;
+        &:after {
+            content: "" !important;
+        }
+    }
+    .ui-resizable-handle {
+        display: none !important;
+    }
+    .bloom-dragHandleTOP {
+        display: none;
+    }
+}
+
+.bloom-imageContainer {
+    .bloom-textOverPicture {
+        position: absolute;
+        width: @DefaultTextBoxWidth;
+        height: @DefaultTextBoxHeight;
+        min-width: @MinTextBoxWidth;
+        min-height: @MinTextBoxHeight;
+        border-radius: 3px;
+        border: none !important; // needed to override ui-draggable blue border
+        z-index: @textOverPictureZIndex;
+        .bloom-dragHandleTOP {
+            position: absolute;
+            background: url('img/dragHandleGrey.svg') no-repeat center;
+            background-size: contain;
+            background-color: @DragHandleBackgroundColor;
+            width: 16px;
+            height: 16px;
+            left: -12px;
+            top: -12px;
+            cursor: move;
+        }
+        .bloom-translationGroup {
+            background: transparent; // don't want to worry about what background the image has
+            border: none;
+            .bloom-editable {
+                min-width: @MinTextBoxWidth - 3;
+                min-height: @MinTextBoxHeight - 3 !important;
+                text-align: center;
+            }
+        }
+    }
+}

--- a/src/BloomBrowserUI/templates/common-mixins.less
+++ b/src/BloomBrowserUI/templates/common-mixins.less
@@ -87,3 +87,7 @@
 @ExtraSpaceForBinding: 10mm;
 @MarginInner: @MarginOuter + @ExtraSpaceForBinding;
 @MarginBalanced: (@MarginOuter + @MarginInner) / 2.0; // for when we want the same left and right margins
+
+@imageContainerZIndex: 1000;
+@textOverPictureZIndex: @imageContainerZIndex + 1;
+@formatButtonZIndex: @textOverPictureZIndex + 1;

--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -20,6 +20,7 @@ using SIL.IO;
 using SIL.Reporting;
 using SIL.Windows.Forms.Miscellaneous;
 using L10NSharp;
+using SIL.Xml;
 
 namespace Bloom
 {
@@ -37,11 +38,15 @@ namespace Bloom
 		private IDisposable _dependentContent;
 		private PasteCommand _pasteCommand;
 		private CopyCommand _copyCommand;
-		private  UndoCommand _undoCommand;
-		private  CutCommand _cutCommand;
+		private UndoCommand _undoCommand;
+		private CutCommand _cutCommand;
 		private bool _disposed;
 		public event EventHandler OnBrowserClick;
 		public static event EventHandler XulRunnerShutdown;
+		// We need some way to pass the cursor location in the Browser context to the EditingView command handlers
+		// for Add/Delete TextOverPicture textboxes. These will store the cursor location when the context menu is
+		// generated.
+		internal Point ContextMenuLocation;
 
 		private static int XulRunnerVersion
 		{
@@ -184,7 +189,7 @@ namespace Bloom
 		/// </summary>
 		public NavigationIsolator Isolator { get; set; }
 
-		public void SetEditingCommands( CutCommand cutCommand, CopyCommand copyCommand, PasteCommand pasteCommand, UndoCommand undoCommand)
+		public void SetEditingCommands(CutCommand cutCommand, CopyCommand copyCommand, PasteCommand pasteCommand, UndoCommand undoCommand)
 		{
 			_cutCommand = cutCommand;
 			_copyCommand = copyCommand;
@@ -239,8 +244,6 @@ namespace Bloom
 				var isTextSelection = IsThereACurrentTextSelection();
 				_cutCommand.Enabled = _browser != null && isTextSelection;
 				_copyCommand.Enabled = _browser != null && isTextSelection;
-				//_cutCommand.Enabled = _browser != null && _browser.CanCutSelection;
-				//_copyCommand.Enabled = _browser != null && _browser.CanCopySelection;
 				_pasteCommand.Enabled = _browser != null && _browser.CanPaste;
 				if (_pasteCommand.Enabled)
 				{
@@ -504,6 +507,7 @@ namespace Bloom
 		{
 			MenuItem FFMenuItem = null;
 			Debug.Assert(!InvokeRequired);
+			ContextMenuLocation = PointToClient(Cursor.Position);
 			if (ContextMenuProvider != null)
 			{
 				var replacesStdMenu = ContextMenuProvider(e);
@@ -515,7 +519,7 @@ namespace Bloom
 					return; // only the provider's items
 			}
 			var m = e.ContextMenu.MenuItems.Add("Edit Stylesheets in Stylizer", OnOpenPageInStylizer);
-			m.Enabled = !string.IsNullOrEmpty(GetPathToStylizer());
+			m.Enabled = !String.IsNullOrEmpty(GetPathToStylizer());
 
 			if(FFMenuItem == null)
 				AddOpenPageInFFItem(e);

--- a/src/BloomExe/Command.cs
+++ b/src/BloomExe/Command.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Xml;
 using Bloom.Book;
 
 namespace Bloom

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -770,7 +770,7 @@ namespace Bloom.Edit
 		internal void AddStandardEventListeners()
 		{
 			AddMessageEventListener("saveToolboxSettingsEvent", SaveToolboxSettings);
-			AddMessageEventListener("preparePageForEditingAfterOrigamiChangesEvent", RethinkPageAndReloadIt);
+			AddMessageEventListener("saveChangesAndRethinkPageEvent", RethinkPageAndReloadIt);
 			AddMessageEventListener("setTopic", SetTopic);
 			AddMessageEventListener("finishSavingPage", FinishSavingPage);
 		}

--- a/src/BloomTests/ElementProxyTests.cs
+++ b/src/BloomTests/ElementProxyTests.cs
@@ -98,5 +98,29 @@ namespace BloomTests
 			Assert.That(elementProxy == new object(), Is.False); // won't exercise current == code, but I think still worth checking.
 			Assert.That(elementProxy.Equals(new object()), Is.False);
 		}
+
+		[Test]
+		public void SelfOrAncestorHasClass_MatchesSelf()
+		{
+			var elementProxy = MakeElement("<div class='blueberry pie'/>");
+			Assert.That(elementProxy.SelfOrAncestorHasClass("blueberry"), Is.True);
+			Assert.That(elementProxy.SelfOrAncestorHasClass("berry"), Is.False);
+			Assert.That(elementProxy.SelfOrAncestorHasClass("pie"), Is.True);
+			Assert.That(elementProxy.SelfOrAncestorHasClass("pieplate"), Is.False);
+		}
+
+		[Test]
+		public void SelfOrAncestorHasClass_MatchesAncestor()
+		{
+			var dom = new XmlDocument();
+			dom.LoadXml("<div class='blueberry pie'><div id='foo' class='foolish'/></div>");
+			var fooDiv = (XmlElement)dom.SelectSingleNode("//div[@id='foo']");
+			var elementProxy = new ElementProxy(fooDiv);
+			Assert.That(elementProxy.SelfOrAncestorHasClass("foolish"), Is.True);
+			Assert.That(elementProxy.SelfOrAncestorHasClass("blueberry"), Is.True);
+			Assert.That(elementProxy.SelfOrAncestorHasClass("berry"), Is.False);
+			Assert.That(elementProxy.SelfOrAncestorHasClass("pie"), Is.True);
+			Assert.That(elementProxy.SelfOrAncestorHasClass("pieplate"), Is.False);
+		}
 	}
 }


### PR DESCRIPTION
* Adds floating text box, drags.
* Switch to using WebSocket
* Added textbox activates properly
* Imported textOverPicture.less to basePage.less
* Textbox background is now transparent, so we only
   show the background of the image itself
* Use standard ready function syntax
* Switched websockets to use addEventListener
   instead of onmessage
* Fix box border colors
* Get resizable working
* Turn off function for xMatter
* Get dragging to work when scaled (zoomed)
* Add wrapper div
* Hide borders, handles, lang when not hovered
* Add drag handle mostly outside top left corner
* Get left-click working
* Fix bloomImages to not get info Bloom edit-only
   images (mostly indent; only real changes are in
   SetImageTooltip()
* Only allow add/delete textbox if not "translation"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1698)
<!-- Reviewable:end -->
