### PR TITLE
BL-4581 Move license image right on rtl

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
@@ -127,7 +127,7 @@ mixin factoryStandard-credits-interiorPage
 		+credits-contents
 
 mixin block-licenseAndCopyright
-	.bloom-metaData.licenseAndCopyrightBlock(data-functiononhintclick="bookMetadataEditor",data-hint="Click to Edit Copyright & License")
+	.bloom-metaData.licenseAndCopyrightBlock(data-functiononhintclick="bookMetadataEditor",data-hint="Click to Edit Copyright & License",lang="V")
 		.copyright(data-derived="copyright", lang="*").Credits-Page-style
 			| {copyright}
 		.licenseBlock


### PR DESCRIPTION
* if vernacular lang is rtl, license image should be on
   right side

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1717)
<!-- Reviewable:end -->
