### PR TITLE
Fix packge build for Version3.8

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -23,6 +23,7 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 	build/getDependencies-Linux.sh
+	export HOME=/tmp && \
 	. ./environ && \
 		xbuild /t:SetAssemblyVersion /p:RootDir=$(shell pwd) /p:BUILD_NUMBER=$(FULL_BUILD_NUMBER) build/Bloom.proj && \
 		xbuild /p:Configuration=$(BUILD) "Bloom.sln"


### PR DESCRIPTION
In a pbuilder environment the HOME environment variable is set to
`/nonexistent`. This causes build failures with NuGet and npm.
As a workaround we set HOME to /tmp.

(cherry picked from commit 06c472857d6fff8f9ca0b6ac423ae53eefd2cf9b)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1726)
<!-- Reviewable:end -->
