### PR TITLE
Fix package build for version 3.9

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -33,6 +33,7 @@ override_dh_auto_build:
 	    tar xf node-v6.10.1-linux-x86.tar.xz && \
 	    export PATH="`pwd`/node-v6.10.1-linux-x86/bin:$$PATH"; \
 	fi && \
+	export HOME=/tmp && \
 	. ./environ && \
 		xbuild /t:SetAssemblyVersion /p:RootDir=$(shell pwd) /p:BUILD_NUMBER=$(FULL_BUILD_NUMBER) build/Bloom.proj && \
 		xbuild /p:Configuration=$(BUILD) "Bloom.sln"


### PR DESCRIPTION
In a pbuilder environment the HOME environment variable is set to
`/nonexistent`. This causes build failures with NuGet and npm.
As a workaround we set HOME to /tmp.

(cherry picked from commit 06c472857d6fff8f9ca0b6ac423ae53eefd2cf9b)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1727)
<!-- Reviewable:end -->
