### PR TITLE
Fix TextOverPicture drag handle

### DIFF
--- a/src/BloomBrowserUI/bookLayout/textOverPicture.less
+++ b/src/BloomBrowserUI/bookLayout/textOverPicture.less
@@ -44,6 +44,7 @@
             left: -12px;
             top: -12px;
             cursor: move;
+            z-index: @dragHandleZIndex; // keep above textbox
         }
         .bloom-translationGroup {
             background: transparent; // don't want to worry about what background the image has

--- a/src/BloomBrowserUI/templates/common-mixins.less
+++ b/src/BloomBrowserUI/templates/common-mixins.less
@@ -91,3 +91,4 @@
 @imageContainerZIndex: 1000;
 @textOverPictureZIndex: @imageContainerZIndex + 1;
 @formatButtonZIndex: @textOverPictureZIndex + 1;
+@dragHandleZIndex: @textOverPictureZIndex + 1;


### PR DESCRIPTION
* dragHandle zindex needed to be higher than textbox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1737)
<!-- Reviewable:end -->
