### PR TITLE
BL-4772 don't copy-from-another-language cover page content

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
@@ -188,20 +188,20 @@ mixin title-page-contents
 
 mixin standard-blankInsideFrontCover
 	+page-cover('Inside Front Cover').cover.coverColor.insideFrontCover.bloom-frontMatter(data-export='front-matter-inside-front-cover')#BA00DE13-734C-4036-9901-7040275B9000
-		+field-mono-meta("N1","insideFontCover").Inside-Front-Cover-style.bloom-copyFromOtherLanguageIfNecessary
+		+field-mono-meta("N1","insideFontCover").Inside-Front-Cover-style
 			label.bubble If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.
 
 mixin factoryStandard-insideBackCover
 	// Inside Back Cover
 	+page-xmatter('Inside Back Cover').cover.coverColor.insideBackCover.bloom-backMatter(data-export='back-matter-inside-back-cover')&attributes(attributes)#502BE62F-A4D0-4225-A598-1A203FA73239
-		+field-mono-meta("N1","insideBackCover").Inside-Back-Cover-style.bloom-copyFromOtherLanguageIfNecessary
+		+field-mono-meta("N1","insideBackCover").Inside-Back-Cover-style
 			label.bubble If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.
 
 mixin factoryStandard-outsideBackCover
 	// Outside Back Cover
 	+page-xmatter('Outside Back Cover').cover.coverColor.outsideBackCover.bloom-backMatter(data-export='back-matter-back-cover')&attributes(attributes)#6AB1D898-9E35-498E-99D4-132B46FAFDA4
 		//- +field-mono-version1("N1","If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.").outside-back-cover-style(data-book='outsideBackCover')
-		+field-mono-meta("N1","outsideBackCover").Outside-Back-Cover-style.bloom-copyFromOtherLanguageIfNecessary
+		+field-mono-meta("N1","outsideBackCover").Outside-Back-Cover-style
 			label.bubble If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.
 		+field-back-cover-branding
 


### PR DESCRIPTION
Specifically inside-front-cover, and both inside and outside back cover pages no longer have this property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1741)
<!-- Reviewable:end -->
