### PR TITLE
Add HTMLDOM.GetPageNumberOfPage()

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -392,6 +392,11 @@ namespace Bloom.Book
 			element.SetAttribute("class", (classes + " " + className).Trim());
 		}
 
+		public static bool HasClass(XmlElement element, string className)
+		{
+			var classes = element.GetAttribute("class");
+			return classes.Contains(className);
+		}
 
 		/// <summary>
 		/// Applies the XSLT, and returns an XML dom
@@ -1387,6 +1392,43 @@ namespace Bloom.Book
 			{
 				RemoveMetaElement("lockedDownAsShell");
 			}
+		}
+
+		/// <summary>
+		/// Given a page or a child of a page, return the page
+		/// </summary>
+		private XmlElement GetPageDivOfElement(XmlElement element)
+		{
+			return element.SelectSingleNode("ancestor-or-self::div[contains(@class,'bloom-page')]") as XmlElement;
+		}
+
+		/// <summary>
+		/// Figure out what page number would be shown on the page
+		/// </summary>
+		public int GetPageNumberOfPage(XmlElement pageDiv )
+		{
+			var allPages = RawDom.SelectNodes("html/body/div[contains(@class,'bloom-page')]").Cast<XmlElement>();
+
+			var pageNumber = 0;
+			foreach(var p in allPages)
+			{
+				if(HtmlDom.HasClass(p, "numberedPage") || HtmlDom.HasClass(p, "countPageButDoNotShowNumber"))
+				{
+					++pageNumber;
+				}
+				if(HtmlDom.HasClass(p, "bloom-startPageNumbering"))
+				{
+					pageNumber=1;
+				}
+				if (p == pageDiv)
+					return pageNumber;
+			}
+			return -1;
+		}
+
+		public XmlElement FindPageById(string pageId)
+		{
+			return RawDom.SafeSelectNodes("//body/div[@id='" + pageId + "']").Cast<XmlElement>().FirstOrDefault();
 		}
 	}
 }

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -394,8 +394,7 @@ namespace Bloom.Book
 
 		public static bool HasClass(XmlElement element, string className)
 		{
-			var classes = element.GetAttribute("class");
-			return classes.Contains(className);
+			return GetClasses(element).Contains(className);
 		}
 
 		/// <summary>

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -774,9 +774,6 @@ namespace BloomTests.Book
 			}
 			Assert.That(countEmpty, Is.EqualTo(2));
 		}
-		//countPageButDoNotShowNumber
-			//bloom-startPageNumbering
-
 
 		[TestCase("first page", 1,
 			"<div id='ego' class='bloom-page numberedPage'/>" +
@@ -793,6 +790,8 @@ namespace BloomTests.Book
 			2, " <div class='bloom-page countPageButDoNotShowNumber'/><div id='ego' class='bloom-page numberedPage'/>")]
 		[TestCase("bloom-startPageNumbering restarts numbering", 1,
 			"<div class='bloom-page numberedPage'></div><div id='ego' class='bloom-page bloom-startPageNumbering'/>")]
+		[TestCase("page not found for this item", -1,
+			"<div id='ego'/>")]
 		[TestCase("the works", 2, "<div class='bloom-page'/>" +
 								"<div class='bloom-page numberedPage'/>" +
 								"<div class='bloom-page bloom-startPageNumbering'/>" +

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -774,5 +774,36 @@ namespace BloomTests.Book
 			}
 			Assert.That(countEmpty, Is.EqualTo(2));
 		}
+		//countPageButDoNotShowNumber
+			//bloom-startPageNumbering
+
+
+		[TestCase("first page", 1,
+			"<div id='ego' class='bloom-page numberedPage'/>" +
+			"<div class='bloom-page numberedPage'/>" +
+			"<div class='bloom-page numberedPage'/>")]
+		// REVIEW: should we be returning string so that we can say "cover", for example?
+		[TestCase("on a page that itself is not numbered", 0,
+			"<div id='ego' class='bloom-page'/>")]
+		[TestCase("first page is numbered, this is second numbered page", 2,
+			"<div class='bloom-page numberedPage'></div><div id='ego' class='bloom-page numberedPage'/>")]
+		[TestCase("first page is not numbered",
+			1, " <div class='bloom-page'/><div id='ego' class='bloom-page numberedPage'/>")]
+		[TestCase("previous page is countPageButDoNotShowNumber",
+			2, " <div class='bloom-page countPageButDoNotShowNumber'/><div id='ego' class='bloom-page numberedPage'/>")]
+		[TestCase("bloom-startPageNumbering restarts numbering", 1,
+			"<div class='bloom-page numberedPage'></div><div id='ego' class='bloom-page bloom-startPageNumbering'/>")]
+		[TestCase("the works", 2, "<div class='bloom-page'/>" +
+								"<div class='bloom-page numberedPage'/>" +
+								"<div class='bloom-page bloom-startPageNumbering'/>" +
+								"<div id='ego' class='bloom-page numberedPage'/>" +
+								"<div class='bloom-page numberedPage'/>" +
+								"<div class='bloom-page numberedPage'/>")]
+		public void GetPageNumberOfPage_ReturnsExpectedNumber(string description, int expected, string contents)
+		{
+			var dom = new HtmlDom(@"<html ><head></head><body><div id='bloomDataDiv'></div>" + contents + "</body></html>");
+			var ego = dom.RawDom.SelectSingleNode("//div[@id='ego']") as XmlElement;
+			Assert.AreEqual(expected, dom.GetPageNumberOfPage(ego), "Failed " + description);
+		}
 	}
 }

--- a/src/SquirrelInstaller/Bloom.nuspec
+++ b/src/SquirrelInstaller/Bloom.nuspec
@@ -9,7 +9,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
 	<description>{Bloom description and version provided by build script}</description>
     <releaseNotes>None</releaseNotes>
-    <copyright>Copyright SIL International 2016</copyright>
+    <copyright>Copyright SIL International 2017</copyright>
 	<iconUrl>https://s3.amazonaws.com/bloomlibrary.org/squirrel/BloomSetup.ico</iconUrl>
   </metadata>
 	<files>


### PR DESCRIPTION
This will be useful for showing page numbers when page is in isolation, computing illustration credits that list the page, and making Table of Contents.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1744)
<!-- Reviewable:end -->
