### PR TITLE
Show left vs. right page layout, even in edit mode BL-4797

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -45,14 +45,14 @@ DIV.bloom-imageContainer
     left: -1px;
     top: -29px;
 }
-DIV.pageLabel
+.pageLabel
 {
     text-align: left;
     /*This black with high transparency gives us a grey on white, and a darker color of whatever the colored background is.*/
     color: rgba(0, 0, 0, 0.2);
     /*+placement:anchor-top-left 0px 19px;*/
     position: absolute;
-    left: 15mm;
+    left: 5mm;
     top: 19px;
     float: left;
     font-family: "Segoe UI", "Open Sans", Arial, sans-serif;

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -428,20 +428,17 @@ Changes here generally require similar changes in EpubMaker.FixPictureSizes().
     }
 }
 
-//Currently, in edit mode there is only one page in the html, so every
-//page looks like page 1 from the view of the css, so showing every page
-//as if it were odd is just confusing for the user.
-//Therefore we only turn on left-vs.right distinctions when when making PDF.
-.publishMode:not(.calendarFold) :not(.outsideFrontCover):not(.outsideBackCover){
-    &.bloom-page:nth-of-type(odd){
+:not(.calendarFold) :not(.outsideFrontCover):not(.outsideBackCover){
+    &.side-left  // maintained by c#
+    {
         .marginBox{
-            /* shifted margin */
             left: @MarginOuter;
         }
     }
-    &.bloom-page:nth-of-type(even){
+
+    &.side-right // maintained by c#
+    {
         .marginBox{
-            /* shifted margin */
             left: @MarginInner;
         }
     }
@@ -456,27 +453,6 @@ Changes here generally require similar changes in EpubMaker.FixPictureSizes().
         /* balanced margin*/
         left: @MarginBalanced;
     }
-}
-
-//in right-to-left books, the way our pdf booklet maker works, it just reverses
-//the page order. In doing so, what use to be odd becomes even, and our margins
-//and page numbering logic needs to switch accordingly. Page numbering is
-//not part of the basePage.less.
-
-.rightToLeft.publishMode:not(.calendarFold) :not(.outsideFrontCover):not(.outsideBackCover){
-  &.bloom-page:nth-of-type(odd) .marginBox  {
-      /* swap margins on right to left */
-      left: @MarginInner;
-  }
-  &.bloom-page:nth-of-type(even) .marginBox  {
-      /* swap margins on right to left */
-      left: @MarginOuter;
-  }
-}
-
-//in edit mode, just split the difference, centering the margin box
-body:not(.publishMode) .marginBox{
-  left: @MarginBalanced;
 }
 
 // pageDescription is for javascript to read, we never display it directly on the page

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -306,6 +306,7 @@ namespace Bloom.Book
 			RuntimeInformationInjector.AddUIDictionaryToDom(pageDom, _collectionSettings);
 			RuntimeInformationInjector.AddUISettingsToDom(pageDom, _collectionSettings, _storage.GetFileLocator());
 			UpdateMultilingualSettings(pageDom);
+
 			if (IsSuitableForMakingShells && !page.IsXMatter)
 			{
 				// We're editing a template page in a template book.
@@ -612,7 +613,6 @@ namespace Bloom.Book
 			return pages[pageIndex];
 		}
 
-		// Reduce repetitive reloading of books when looking up the related "TemplateBook".
 		string _cachedTemplateKey;
 		Book _cachedTemplateBook;
 
@@ -912,6 +912,8 @@ namespace Bloom.Book
 			// If there is nothing there the default of true will survive.
 			bookDOM.RemoveMetaElement("SuitableForMakingVernacularBooks", () => null,
 				val => BookInfo.IsSuitableForVernacularLibrary = val == "yes" || val == "definitely");
+
+			bookDOM.UpdateSideClassOfAllPages(_collectionSettings.IsLanguage1Rtl);
 
 			UpdateTextsNewlyChangedToRequiresParagraph(bookDOM);
 
@@ -1941,6 +1943,7 @@ namespace Bloom.Book
 			{
 				body.InsertAfter(pageDiv, pages[indexOfItemAfterRelocation-1]);
 			}
+			OurHtmlDom.UpdateSideClassOfAllPages(_collectionSettings.IsLanguage1Rtl);
 			BuildPageCache();
 			Save();
 			InvokeContentsChanged(null);

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1338,6 +1338,13 @@ namespace Bloom.Book
 				.OfType<XmlElement>();
 		}
 
+		private IEnumerable<XmlElement> GetPageElements()
+		{
+			return _dom.SafeSelectNodes(
+					"/html/body/div[contains(@class,'bloom-page')]")
+				.OfType<XmlElement>();
+		}
+
 		/// <summary>
 		/// Can switch a page from being a template page or back to a normal page.
 		/// </summary>
@@ -1428,6 +1435,30 @@ namespace Bloom.Book
 		public XmlElement FindPageById(string pageId)
 		{
 			return RawDom.SafeSelectNodes("//body/div[@id='" + pageId + "']").Cast<XmlElement>().FirstOrDefault();
+		}
+
+		/// <summary>
+		/// Updates the side-right and side-left classes of every page div in the supplied dom (be it the full book
+		/// or some subset (e.g. one page))
+		/// </summary>
+		/// <param name="languageIsRightToLeft"></param>
+		/// <param name="startingIndex">If this dom is only a subset of the book, then you need to provide this
+		/// to tell us what the first page index is, of this subset of the full dom.</param>
+		public void UpdateSideClassOfAllPages(bool languageIsRightToLeft, int startingIndex = 0)
+		{
+			var i = startingIndex;
+			foreach(var pageDiv in GetPageElements())
+			{
+				UpdateSideClass(pageDiv, i, languageIsRightToLeft);
+				i++;
+			}
+		}
+
+		private static void UpdateSideClass(XmlElement pageDiv, int indexOfPageZeroBased, bool languageIsRightToLeft)
+		{
+			RemoveClassesBeginingWith(pageDiv, "side-");
+			var rightSideRemainder = languageIsRightToLeft ? 1 : 0;
+			AddClassIfMissing(pageDiv, indexOfPageZeroBased % 2 == rightSideRemainder ? "side-right" : "side-left");
 		}
 	}
 }

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -286,6 +286,10 @@ namespace Bloom.Edit
 			info.Cancel = !CurrentBook.RelocatePage(info.Page, info.IndexOfPageAfterMove);
 			if(!info.Cancel)
 			{
+				// Moving a page actually changes its html to have the new left/right side and page number,
+				// The Book takes care of that, but now we need to actually reload it from the dom.
+				RefreshDisplayOfCurrentPage();
+
 				Analytics.Track("Relocate Page");
 				Logger.WriteEvent("Relocate Page");
 			}


### PR DESCRIPTION
Switch from relying on css counting for left vs. right styling to  using a class maintained by c#. This allows us to show a page in isolation and still show it correctly in this respect.

TODO: how does this impact epub and bloom reader?
TODO: doesn't yet update display of the page when page is reordered

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1748)
<!-- Reviewable:end -->
