### PR TITLE
Show page numbers in edit mode BL-4796

### DIFF
--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
@@ -14,7 +14,7 @@ BODY {
 
 /* this is handy for debugging page numbering in the thumbnail list
 .bloom-page::after {
-    content: counter(pageNumber);
+    content: attr(data-page-number);
     position: absolute;
     bottom: 7px;
     left: 10px;

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -589,4 +589,26 @@ h2 {
     order: 2;
 }
 
+
+//Enhance: I think these could be computed, based on the current margin
+@OddPageNumberPosition: 57px;
+@EvenPageNumberPosition: 60px;
+
+.numberedPage{
+    &:after {
+        content: attr(data-page-number);
+        font-size: 14pt;
+        position: absolute;
+        bottom: 20px;
+    }
+    &.side-left:after { // side-___ maintained by c#
+        left: @OddPageNumberPosition;
+    }
+    &.side-right:after { // side-___ maintained by c#
+        right: @EvenPageNumberPosition;
+        text-align: right;
+    }
+}
+
+
 //... to be continued. We sandwich most other sheets between this one and the languageDisplay.css, which comes last-ish

--- a/src/BloomBrowserUI/bookPreview/previewMode.less
+++ b/src/BloomBrowserUI/bookPreview/previewMode.less
@@ -88,46 +88,6 @@ div.coverBottomBookTopic DIV.topicN1
 {
     border: none;
 }
-/*------Page Numbering------*/
-//DIV.bloom-startPageNumbering
-body {
-    counter-reset: pageNumber;
-}
-.numberedPage, .countPageButDoNotShowNumber
-{
-    counter-increment: pageNumber;
-}
-.numberedPage:after{
-  content: counter(pageNumber);
-    font-size: 14pt;
-  position: absolute;
-  bottom: 20px;
-}
-
-@OddPageNumberPosition: 57px;
-@EvenPageNumberPosition: 60px;
-
-.numberedPage:nth-of-type(odd):after{
-    left: @OddPageNumberPosition;
-}
-.numberedPage:nth-of-type(even):after{
-    right: @EvenPageNumberPosition;
-    text-align: right;
-}
-
-//in right-to-left books, the way our pdf booklet maker works, it just reverses
-//the page order. In doing so, what use to be odd becomes even, and our margins
-//and page numbering logic needs to switch accordingly.
-.rightToLeft {
-    .numberedPage:nth-of-type(odd):after {
-        right: @EvenPageNumberPosition;
-        left: auto;
-    }
-    .numberedPage:nth-of-type(even):after {
-        left: @OddPageNumberPosition;
-        right: auto;
-    }
-}
 
 .bloom-draggableLabel
 {

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -913,7 +913,7 @@ namespace Bloom.Book
 			bookDOM.RemoveMetaElement("SuitableForMakingVernacularBooks", () => null,
 				val => BookInfo.IsSuitableForVernacularLibrary = val == "yes" || val == "definitely");
 
-			bookDOM.UpdateSideClassOfAllPages(_collectionSettings.IsLanguage1Rtl);
+			bookDOM.UpdatePageNumberAndSideClassOfPages(_collectionSettings.CharactersForDigitsForPageNumbers, _collectionSettings.IsLanguage1Rtl);
 
 			UpdateTextsNewlyChangedToRequiresParagraph(bookDOM);
 
@@ -1648,12 +1648,15 @@ namespace Bloom.Book
 			BookStarter.SetupIdAndLineage(templatePageDiv, newPageDiv);
 			BookStarter.SetupPage(newPageDiv, _collectionSettings, _bookData.MultilingualContentLanguage2, _bookData.MultilingualContentLanguage3);//, LockedExceptForTranslation);
 			SizeAndOrientation.UpdatePageSizeAndOrientationClasses(newPageDiv, GetLayout());
+
+
 			newPageDiv.RemoveAttribute("title"); //titles are just for templates [Review: that's not true for front matter pages, but at the moment you can't insert those, so this is ok]C:\dev\Bloom\src\BloomExe\StyleSheetService.cs
 			// If we're a template, make the new page a template one.
 			HtmlDom.MakePageWithTemplateStatus(IsSuitableForMakingShells, newPageDiv);
 			var elementOfPageBefore = FindPageDiv(pageBefore);
 			elementOfPageBefore.ParentNode.InsertAfter(newPageDiv, elementOfPageBefore);
 
+			OrderOrNumberOfPagesChanged();
 			BuildPageCache();
 			var newPage = GetPages().First(p=>p.GetDivNodeForThisPage() == newPageDiv);
 			Guard.AgainstNull(newPage,"could not find the page we just added");
@@ -1797,6 +1800,7 @@ namespace Bloom.Book
 
 			ClearPagesCache();
 			//_pagesCache.Remove(page);
+			OrderOrNumberOfPagesChanged();
 
 			var pageNode = FindPageDiv(page);
 		   pageNode.ParentNode.RemoveChild(pageNode);
@@ -1807,6 +1811,12 @@ namespace Bloom.Book
 				_pageListChangedEvent.Raise(null);
 
 			InvokeContentsChanged(null);
+		}
+
+		private void OrderOrNumberOfPagesChanged()
+		{
+			OurHtmlDom.UpdatePageNumberAndSideClassOfPages(_collectionSettings.CharactersForDigitsForPageNumbers,
+				_collectionSettings.IsLanguage1Rtl);
 		}
 
 		private void ClearPagesCache()
@@ -1943,7 +1953,7 @@ namespace Bloom.Book
 			{
 				body.InsertAfter(pageDiv, pages[indexOfItemAfterRelocation-1]);
 			}
-			OurHtmlDom.UpdateSideClassOfAllPages(_collectionSettings.IsLanguage1Rtl);
+			OrderOrNumberOfPagesChanged();
 			BuildPageCache();
 			Save();
 			InvokeContentsChanged(null);

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -37,13 +37,45 @@ namespace Bloom.Collection
 		private LanguageLookupModel _lookupIsoCode = new LanguageLookupModel();
 		private Dictionary<string, string> _isoToLangNameDictionary = new Dictionary<string, string>();
 
-		public static readonly string[] PageNumberStyleKeys =
-		{
-			"Decimal", "Arabic-Indic", "Armenian", "Upper-Armenian", "Lower-Armenian", "Bengali",
-			"Cambodian", "Khmer", "Cjk-Decimal", "Devanagari", "Georgian", "Gujarati", "Gurmukhi",
-			"Hebrew", "Kannada", "Lao", "Malayalam", "Mongolian", "Myanmar", "Oriya", "Persian",
-			"Tamil", "Telugu", "Thai", "Tibetan"
-		};
+		public static readonly Dictionary<string, string> CssNumberStylesToCultureOrDigits =
+			new Dictionary<string, string>()
+			{
+				// Initially, Bloom used CSS for page numbering and css counter styles for
+				// controlling the script the page numbers are drawn in. For various reasons
+				// we then switched to having code keep the page number in data-page-number,
+				// so we can't make use of that CSS feature anymore but want to keep the same
+				// list and keep working for users of previous versions.
+				// In this dictionary, we're pairing css counting styles (the key) with either
+				// a Microsoft culture that happens to implement it or, if that can't be found,
+				// then the 10 digits of used by the script. As a side benefit, this will allow us to support
+				// other number systems, if people request them (so long as they can be represented by just
+				// replacing digits).
+				{ "Arabic-Indic", "ar-SA"}, // not certain that this is correct one
+				{ "Armenian", "hy-AM"},
+				{ "Upper-Armenian", "hy-AM"},
+				//{ "Lower-Armenian", ""},//haven't found the culture or list of number for this
+				{ "Bengali", "bn-BD"},
+				{ "Cambodian", "km-KH"},
+				{ "Khmer", "km-KH"},
+				{ "Cjk-Decimal", "〇一二三四五六七八九"},// haven't found a culture for this
+				{ "Decimal", "" },
+				{ "Devanagari", "hi-IN"},
+				{ "Georgian", "ka-GE"},
+				{ "Gujarati", "gu-IN"},
+				{ "Gurmukhi", "pa-IN"},
+				{ "Hebrew", "he-IL"},
+				{ "Kannada", "kn-IN"},
+				{ "Lao", "lo-LA"},
+				{ "Malayalam", "ml-IN"},
+				{ "Mongolian", "mn-Mong-MN"},
+				{ "Myanmar", "my-MM"},
+				{ "Oriya", "୦୧୨୩୪୫୬୭୮୯"}, // haven't found a culture for this
+				{ "Persian", "fa-IR"},
+				{ "Tamil", "ta-IN"},
+				{ "Telugu", "te-IN"},
+				{ "Thai", "th-TH"},
+				{ "Tibetan", "bo-CN"}
+			};
 
 		/// <summary>
 		/// for moq in unit tests only
@@ -348,7 +380,6 @@ namespace Bloom.Collection
 				{
 					AddFontCssRule(sb, "[lang='" + Language3Iso639Code + "']", DefaultLanguage3FontName, IsLanguage3Rtl, Language3LineHeight);
 				}
-				AddNumberingStyleCssRule(sb, PageNumberStyle);
 				RobustFile.WriteAllText(path, sb.ToString());
 			}
 			catch (Exception error)
@@ -357,20 +388,6 @@ namespace Bloom.Collection
 			}
 		}
 
-		// styleNameKey must be the non-localized version
-		private void AddNumberingStyleCssRule(StringBuilder sb, string styleNameKey)
-		{
-			var mediaSelector = "@media print";
-			var selector = " .numberedPage:after";
-			sb.AppendLine();
-			sb.AppendLine(mediaSelector);
-			sb.AppendLine("{");
-			sb.AppendLine(selector);
-			sb.AppendLine(" {");
-			sb.AppendLine("  content: counter(pageNumber, " + styleNameKey.ToLower() + ");");
-			sb.AppendLine(" }");
-			sb.AppendLine("}");
-		}
 
 		private void AddFontCssRule(StringBuilder sb, string selector, string fontName, bool isRtl, decimal lineHeight)
 		{
@@ -400,7 +417,10 @@ namespace Bloom.Collection
 				XMatterPackName = GetValue(library, "XMatterPack", "Factory");
 
 				var style = GetValue(library, "PageNumberStyle", "Decimal");
-				PageNumberStyle = PageNumberStyleKeys.Contains(style) ? style : "Decimal";
+
+				//for historical (and maybe future?) reasons, we collect the page number style as one of the
+				//CSS counter number styles
+				PageNumberStyle = CssNumberStylesToCultureOrDigits.Keys.Contains(style) ? style : "Decimal";
 
 				BrandingProjectName = GetValue(library, "BrandingProjectName", "Default");
 
@@ -743,8 +763,48 @@ namespace Bloom.Collection
 		}
 
 		/// <summary>
+		/// The user settings can define a number system. This gives the digits, 0..9 of the selected system.
+		/// </summary>
+		public string CharactersForDigitsForPageNumbers
+		{
+			get
+			{
+				string info;
+				if(CssNumberStylesToCultureOrDigits.TryGetValue(PageNumberStyle, out info))
+				{
+					if (info.Length == 10) // string of digits
+						return info; //we've just listed the digits out, no need to look up a culture
+
+					if(info.Length == 5) // Microsoft culture code
+					{
+						try
+						{
+							var digits = new CultureInfo(info).NumberFormat.NativeDigits;
+							Debug.Assert(digits.Length == 10);
+							var joined = string.Join("", digits);
+							Debug.Assert(joined.Length == 10);
+							return joined;
+						}
+						catch(CultureNotFoundException)
+						{
+							// fall through to default return value
+						}
+						catch(Exception)
+						{
+							//there's no scenario
+							//where this is worth stopping people in their tracks. I just want a
+							//problem report saying "Hey page numbers don't look right on this machine".
+						}
+					}
+				}
+				//Missing or malformed value for this identifier.
+				return "0123456789";
+			}
+		}
+
+		/// <summary>
 		/// The collection settings point to object which might not exist. For example, the xmatter pack might not exist.
-		/// So this should be called as soon as it is ok to show some UI. It will find any dependencies it can't meet,
+		/// So this should be called as soon as it is OK to show some UI. It will find any dependencies it can't meet,
 		/// revert them to defaults, and notify the user.
 		/// </summary>
 		public void CheckAndFixDependencies(BloomFileLocator bloomFileLocator)

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -24,6 +24,7 @@ namespace Bloom.Collection
 		private readonly PageRefreshEvent _pageRefreshEvent;
 		private bool _restartRequired;
 		private bool _loaded;
+		private List<string> _styleNames = new List<string>();
 
 		public CollectionSettingsDialog(CollectionSettings collectionSettings, XMatterPackFinder xmatterPackFinder, QueueRenameOfCollection queueRenameOfCollection, PageRefreshEvent pageRefreshEvent)
 		{
@@ -192,7 +193,10 @@ namespace Bloom.Collection
 			}
 			if (_numberStyleCombo.SelectedItem != null)
 			{
-				_collectionSettings.PageNumberStyle = CollectionSettings.PageNumberStyleKeys[_numberStyleCombo.SelectedIndex]; // this must be the non-localized version
+				// have to do this lookup because we need the non-localized version of the name, and
+				// we can't get at the original dictionary by index
+				var styleName = _styleNames[_numberStyleCombo.SelectedIndex];
+				_collectionSettings.PageNumberStyle = styleName;
 			}
 			if (_brandingCombo.SelectedItem != null)
 			{
@@ -314,11 +318,12 @@ namespace Bloom.Collection
 			}
 		}
 
-
 		private void LoadPageNumberStyleCombo()
 		{
-			foreach (var styleKey in CollectionSettings.PageNumberStyleKeys)
+			_styleNames.Clear();
+			foreach (var styleKey in CollectionSettings.CssNumberStylesToCultureOrDigits.Keys)
 			{
+				_styleNames.Add(styleKey);
 				var localizedStyle =
 					LocalizationManager.GetString("CollectionSettingsDialog.BookMakingTab.PageNumberingStyle." + styleKey, styleKey);
 				_numberStyleCombo.Items.Add(localizedStyle);

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -804,5 +804,67 @@ namespace BloomTests.Book
 			var ego = dom.RawDom.SelectSingleNode("//div[@id='ego']") as XmlElement;
 			Assert.AreEqual(expected, dom.GetPageNumberOfPage(ego), "Failed " + description);
 		}
+
+		[Test]
+		public void UpdatePageNumberAndSideClassOfPages_TestSideClasses()
+		{
+			var dom = new HtmlDom(@"<html ><head></head><body>
+					<div id='cover' class='bloom-page side-foo'/>
+					<div id='insideFrontCover' class='bloom-page side-foo'/>
+					<div id='firstWhitePage' class='bloom-page side-foo'/>
+				</body></html>");
+
+			dom.UpdatePageNumberAndSideClassOfPages("abcdefghij", false /* not rtl */);
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='cover' and contains(@class,'side-right')]", 1);
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='insideFrontCover' and contains(@class,'side-left')]", 1);
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='firstWhitePage' and contains(@class,'side-right')]", 1);
+		}
+
+
+		[Test]
+		public void UpdatePageNumberAndSideClassOfPages_RightToLeft_TestSideClasses()
+		{
+			var dom = new HtmlDom(@"<html ><head></head><body>
+					<div id='cover' class='bloom-page side-foo'/>
+					<div id='insideFrontCover' class='bloom-page side-foo'/>
+					<div id='firstWhitePage' class='bloom-page side-foo'/>
+				</body></html>");
+
+			dom.UpdatePageNumberAndSideClassOfPages("abcdefghij", true /* rtl */);
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='cover' and contains(@class,'side-left')]", 1);
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='insideFrontCover' and contains(@class,'side-right')]", 1);
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='firstWhitePage' and contains(@class,'side-left')]", 1);
+		}
+
+		[TestCase("12", "")] // just use default (0..9)
+		[TestCase("bc", "abcdefghij")] // provide explicit digits
+		public void UpdatePageNumberAndSideClassOfPages_TestPageNumbers(string page12Number, string numberStyleOrDigits)
+		{
+			var dom = new HtmlDom(@"<html ><head></head><body>
+					<div id='frontmatter' class='bloom-page' data-page-number='99'/>
+					<div  class='bloom-page numberedPage'/>
+					<div  class='bloom-page numberedPage'/>
+					<div  class='bloom-page numberedPage'/>
+					<div  class='bloom-page numberedPage'/>
+					<div  class='bloom-page numberedPage'/>
+					<div  class='bloom-page numberedPage'/>
+					<div  class='bloom-page numberedPage'/>
+					<div  class='bloom-page numberedPage'/>
+					<div  class='bloom-page numberedPage'/>
+					<div  class='bloom-page numberedPage'/>
+					<div  class='bloom-page numberedPage'/>
+					<div id='12' class='bloom-page numberedPage'/>
+				</body></html>");
+
+			dom.UpdatePageNumberAndSideClassOfPages(numberStyleOrDigits, false /* not rtl */);
+			// we don't have to test anything except that a number does get added or updated,
+			// because the testing of the number logic is done on the GetPageNumberOfPage() method
+
+			//this first one wasn't marked for getting a page number
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='frontmatter' and @data-page-number='']", 1);
+			//should be page 2 ('c' in our pretend script)
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath($"//div[@id='12' and @data-page-number='{page12Number}']", 1);
+
+		}
 	}
 }

--- a/src/BloomTests/Collection/CollectionSettingsTests.cs
+++ b/src/BloomTests/Collection/CollectionSettingsTests.cs
@@ -133,5 +133,17 @@ namespace BloomTests.Collection
 			settings.Language3Iso639Code = lang3;
 			Assert.That(settings.LicenseDescriptionLanguagePriorities, Is.EqualTo(results));
 		}
+
+		[TestCase("", "2")] // default
+		[TestCase("Decimal", "2")]
+		[TestCase("Devanagari", "२")]
+		[TestCase("Khmer", "២")]
+		[TestCase("Cjk-Decimal", "二")]
+		public void CharactersForDigitsForPageNumbers_Tests(string numberStyleName, string digitForNumber2)
+		{
+			var settings = CreateCollectionSettings(_folder.Path, "test");
+			settings.PageNumberStyle = numberStyleName;
+			Assert.AreEqual(digitForNumber2, settings.CharactersForDigitsForPageNumbers.Substring(2,1));
+		}
 	}
 }


### PR DESCRIPTION
Page numbering was done in css, but counting approach that doesn't work if, as in edit mode, we only show one page.

This completely switches responsibility for determining page numbers & their representation in the required script to c#.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1751)
<!-- Reviewable:end -->
