### PR TITLE
BL-4820 Fix Device16x9Landscape

### DIFF
--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
@@ -101,6 +101,32 @@ BODY {
                 transform: scale(0.115);
             }
         }
+        &.Device16x9Portrait {
+            height: 67px;
+            width: 40px;
+            .bloom-page {
+                transform: scale(0.092);
+            }
+        }
+        &.Device16x9Landscape {
+            height: 43px;
+            width: 70px;
+            .bloom-page {
+                transform: scale(0.095);
+            }
+        }
+        &.A6Portrait {
+            .bloom-page {
+                transform: scale(0.11);
+            }
+        }
+        &.A6Landscape {
+            height: 51px;
+            width: 69px;
+            .bloom-page {
+                transform: scale(0.12);
+            }
+        }
 
         //http://stackoverflow.com/questions/17824060/ios-safari-runs-out-of-memory-with-webkit-transform
         transform-style: preserve-3d;

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -174,7 +174,7 @@ page be the full page, regardless of the contents.
 To compensate, the code asks wkthmlpdf to zoom the page by 9.1%, which an invisble 1px border added by
 preview.css.
 
-Changes here generally require similar changes in EpubMaker.FixPictureSizes().
+Changes here generally require similar changes in EpubMaker.FixPictureSizes() and pageThumbnailList.less.
 */
 .bloom-page {
     &.Device16x9Portrait{
@@ -188,6 +188,12 @@ Changes here generally require similar changes in EpubMaker.FixPictureSizes().
         max-width: @Device16x9Landscape-Width;
         min-height: @Device16x9Landscape-Height;
         max-height: @Device16x9Landscape-Height;
+    }
+    &.PictureStoryLandscape{
+        min-width: @PictureStoryLandscape-Width;
+        max-width: @PictureStoryLandscape-Width;
+        min-height: @PictureStoryLandscape-Height;
+        max-height: @PictureStoryLandscape-Height;
     }
     &.A5Portrait {
         min-width: @A5Portrait-Width;
@@ -318,13 +324,13 @@ Changes here generally require similar changes in EpubMaker.FixPictureSizes().
     top: @MarginTop;
 }
 
-.Device16x9Landscape{
+.Device16x9Landscape, .PictureStoryLandscape{
     //TODO: This is only for videos
     background-color: black;
     img{ background-color: white; } // so that transparent images show
 }
 
-.Device16x9Landscape, .Device16x9Portrait{
+.Device16x9Landscape, .Device16x9Portrait, .PictureStoryLandscape{
     .origami-toggle{display:none}
     .pageLabel{display:none}
 
@@ -356,26 +362,31 @@ Changes here generally require similar changes in EpubMaker.FixPictureSizes().
         }
         top:0;
         left:0 !important;
-    }
-
-    .Device16x9Portrait & {
-        .SetMarginBoxDevice(@Device16x9Portrait-Width, @Device16x9Portrait-Height);
 
         //that makes the margin box actually have no margin. Which looks good for the image, but
         //looks bad for the text. So here we re-introduce a margin... a bit of a hack
         .bloom-editable{
-            margin-left: 10px;
-            width: ~"calc(100% - 20px)"; // 10px for the left, 10px for the right
+            margin-left: @DeviceMargin;
+            width: calc(~"100% - "(@DeviceMargin*2)); // 10px for the left, 10px for the right
         }
+    }
+
+    .Device16x9Portrait & {
+        .SetMarginBoxDevice(@Device16x9Portrait-Width, @Device16x9Portrait-Height);
     }
 
     .Device16x9Landscape & {
         .SetMarginBoxDevice(@Device16x9Landscape-Width, @Device16x9Landscape-Height);
-
-        //make the top half take up the whole screen
-        .position-top{bottom: 0 !important;}
-        .position-bottom{display:none;}
     }
+
+    .PictureStoryLandscape & {
+        .SetMarginBoxDevice(@PictureStoryLandscape-Width, @PictureStoryLandscape-Height);
+
+        // make the top half take up the whole screen
+        .position-top{ bottom: 0 !important; }
+        .position-bottom{ display: none; }
+    }
+
     .A3Landscape & {
         .SetMarginBox(@A3Landscape-Width, @A3Landscape-Height);
     }

--- a/src/BloomBrowserUI/templates/common-mixins.less
+++ b/src/BloomBrowserUI/templates/common-mixins.less
@@ -28,10 +28,15 @@
 
 @defaultLineHeight: 1.5em;//no units! No em!!!! em makes children inside have a lineheight that matches the font of the overall box, regardless of the thing's font-size. See https://developer.mozilla.org/en-US/docs/Web/CSS/line-height
 
+// N.B. New formats must also work something out in pageThumbnailList.less.
 @Device16x9Portrait-Width: 100mm;
 @Device16x9Portrait-Height: @Device16x9Portrait-Width * 16 / 9;
 @Device16x9Landscape-Height: @Device16x9Portrait-Width;
 @Device16x9Landscape-Width: @Device16x9Portrait-Height;
+@DeviceMargin: 10px;
+
+@PictureStoryLandscape-Height: @Device16x9Landscape-Height;
+@PictureStoryLandscape-Width: @Device16x9Landscape-Width;
 
 @A4Portrait-Height: 297mm;
 @A4Portrait-Width: 210mm;


### PR DESCRIPTION
* pageThumbnailList.less - mostly indent changes
   except for A6 and Device16x9 sizes
* main fix is in basePage.less

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1755)
<!-- Reviewable:end -->
