### PR TITLE
Fix paste from Word (more betterer) (BL-4775)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -851,7 +851,27 @@ export default class AudioRecording {
         var test = fragment.text.replace(/<br *[^>]*\/?>/g, " ");
         // and some may contain only nbsp
         test = test.replace("&nbsp;", " ");
-        return !test.match(/^\s*$/);
+        if (this.isWhiteSpace(test))
+            return false;
+        if (this.isEmptyHtml(test))
+            return false;
+        return true;
+    }
+
+    private isEmptyHtml(possibleHtml: string): Boolean {
+        var parser = new DOMParser();
+        var doc = parser.parseFromString(possibleHtml, "text/xml");
+        if (doc && doc.firstChild) {
+            var content = doc.firstChild.textContent;
+            return this.isWhiteSpace(content);
+        }
+        return false;
+    }
+
+    private isWhiteSpace(test: string): Boolean {
+        if (test.match(/^\s*$/))
+            return true;
+        return false;
     }
 
     private fireCSharpEvent(eventName, eventData): void {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -853,17 +853,21 @@ export default class AudioRecording {
         test = test.replace("&nbsp;", " ");
         if (this.isWhiteSpace(test))
             return false;
-        if (this.isEmptyHtml(test))
-            return false;
-        return true;
+        return this.isTextOrHtmlWithText(test);
     }
 
-    private isEmptyHtml(possibleHtml: string): Boolean {
+    private isTextOrHtmlWithText(textOrHtml: string): Boolean {
         var parser = new DOMParser();
-        var doc = parser.parseFromString(possibleHtml, "text/xml");
-        if (doc && doc.firstChild) {
-            var content = doc.firstChild.textContent;
-            return this.isWhiteSpace(content);
+        var doc = parser.parseFromString(textOrHtml, "text/html");
+        if (doc && doc.documentElement) { //paranoia
+            // on error, parseFromString returns a document with a parseerror element
+            // rather than throwing an exception, so check for that
+            if (doc.getElementsByTagName('parsererror').length > 0) {
+                return false;
+            }
+            // textContent is the aggregation of the text nodes of all children
+            var content = doc.documentElement.textContent;
+            return !this.isWhiteSpace(content);
         }
         return false;
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.js
@@ -77,21 +77,46 @@ describe("audio recording tests", function() {
         expect(spans.last().attr('class')).toBe('audio-sentence');
         expect(spans.first().next().attr('class')).toBe('audio-sentence');
     });
-    //reviewSlog: this is broken because it now emits more spaces.
-   /* it("handles leading space and <br>", function() {
-        var div = $("<div>\
-            <br class=''></br>\
-            <br></br>\
-            Long dispela taim i gat wanpela bikpela taun i gat planti manmeri. Nem bilong dispela taun em Nineveh.</div>");
+
+    // We can get something like this when we paste from Word
+    it("ignores empty spans", function () {
+        var div = $('<div>This is the first sentence.<span data-cke-bookmark="1" style="display: none;" id="cke_bm_35C"> </span></div>');
         var recording = new AudioRecording();
         recording.makeSentenceSpans(div);
         var spans = div.find("span");
         expect(spans.length).toBe(2);
-        // I'm not sure why we get this leading space in the first span; somehow that's how stuff currently comes
-        // out of the libsynphony.stringToSentences code. It doesn't seem to cause a problem in Bloom.
-        expect(spans[0].innerHTML).toBe('            Long dispela taim i gat wanpela bikpela taun i gat planti manmeri.');
-        expect(spans[1].innerHTML).toBe('Nem bilong dispela taun em Nineveh.');
-        // Again, I'm a bit surprised that it works out to so much leading space, but it looks right in the running program.
-        expect(div.text()).toBe('                                    Long dispela taim i gat wanpela bikpela taun i gat planti manmeri. Nem bilong dispela taun em Nineveh.');
-    });*/
+        expect(spans[0].innerHTML).toBe('This is the first sentence.');
+        expect(spans[1].innerHTML).toBe(' ');
+        expect(spans.first().attr('class')).toBe('audio-sentence');
+        expect(spans.last().attr('class')).not.toContain('audio-sentence');
+    });
+
+    // We can get something like this when we paste from Word
+    it("ignores empty span and <br>", function () {
+        var p = $('<p><span data-cke-bookmark="1" style="display: none;" id="cke_bm_35C">&nbsp;</span><br></p>');
+        var recording = new AudioRecording();
+        recording.makeSentenceSpans(p);
+        var spans = p.find("span");
+        expect(spans.length).toBe(1);
+        expect(spans[0].innerHTML).toBe('&nbsp;');
+        expect(spans.first().attr('class')).not.toContain('audio-sentence');
+    });
+
+    //reviewSlog: this is broken because it now emits more spaces.
+    /* it("handles leading space and <br>", function() {
+         var div = $("<div>\
+             <br class=''></br>\
+             <br></br>\
+             Long dispela taim i gat wanpela bikpela taun i gat planti manmeri. Nem bilong dispela taun em Nineveh.</div>");
+         var recording = new AudioRecording();
+         recording.makeSentenceSpans(div);
+         var spans = div.find("span");
+         expect(spans.length).toBe(2);
+         // I'm not sure why we get this leading space in the first span; somehow that's how stuff currently comes
+         // out of the libsynphony.stringToSentences code. It doesn't seem to cause a problem in Bloom.
+         expect(spans[0].innerHTML).toBe('            Long dispela taim i gat wanpela bikpela taun i gat planti manmeri.');
+         expect(spans[1].innerHTML).toBe('Nem bilong dispela taun em Nineveh.');
+         // Again, I'm a bit surprised that it works out to so much leading space, but it looks right in the running program.
+         expect(div.text()).toBe('                                    Long dispela taim i gat wanpela bikpela taun i gat planti manmeri. Nem bilong dispela taun em Nineveh.');
+     });*/
 });

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.js
@@ -79,7 +79,7 @@ describe("audio recording tests", function() {
     });
 
     // We can get something like this when we paste from Word
-    it("ignores empty spans", function () {
+    it("ignores empty span", function () {
         var div = $('<div>This is the first sentence.<span data-cke-bookmark="1" style="display: none;" id="cke_bm_35C"> </span></div>');
         var recording = new AudioRecording();
         recording.makeSentenceSpans(div);

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -422,10 +422,10 @@ function doKeypressMarkup(): void {
             // actually go back to where it was: it gets shifted to the right.
             const bookmarks = ckeditorSelection.createBookmarks(true);
 
-        // For some reason, we have cases, mostly (always?) on paste, where
-        // ckeditor is inserting tons of comments which are messing with our parsing
-        // See http://issues.bloomlibrary.org/youtrack/issue/BL-4775
-        removeCommentsFromEditableHtml(editableDiv);
+            // For some reason, we have cases, mostly (always?) on paste, where
+            // ckeditor is inserting tons of comments which are messing with our parsing
+            // See http://issues.bloomlibrary.org/youtrack/issue/BL-4775
+            removeCommentsFromEditableHtml(editableDiv);
 
             currentTool.updateMarkup();
 
@@ -442,8 +442,10 @@ function doKeypressMarkup(): void {
     }, 500);
 }
 
-function removeCommentsFromEditableHtml(editable: HTMLElement) {
-    editable.innerHTML = editable.innerHTML.replace(/<!--.*?-->/g, "");
+// exported for testing
+export function removeCommentsFromEditableHtml(editable: HTMLElement) {
+    // [\s\S] is a hack representing every character (including newline)
+    editable.innerHTML = editable.innerHTML.replace(/<!--[\s\S]*?-->/g, "");
 }
 
 var resizeTimer;

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -421,6 +421,12 @@ function doKeypressMarkup(): void {
             // be evaluated by the markup routine. However, testing shows that the cursor then doesn't
             // actually go back to where it was: it gets shifted to the right.
             const bookmarks = ckeditorSelection.createBookmarks(true);
+
+        // For some reason, we have cases, mostly (always?) on paste, where
+        // ckeditor is inserting tons of comments which are messing with our parsing
+        // See http://issues.bloomlibrary.org/youtrack/issue/BL-4775
+        removeCommentsFromEditableHtml(editableDiv);
+
             currentTool.updateMarkup();
 
             //set the selection to wherever our bookmark node ended up
@@ -434,6 +440,10 @@ function doKeypressMarkup(): void {
         keypressTimer = null;
 
     }, 500);
+}
+
+function removeCommentsFromEditableHtml(editable: HTMLElement) {
+    editable.innerHTML = editable.innerHTML.replace(/<!--.*?-->/g, "");
 }
 
 var resizeTimer;
@@ -519,4 +529,4 @@ $(document).ready(function () {
 
 $(parent.window.document).ready(function () {
     $(parent.window.document).find('#pure-toggle-right').change(function () { showToolboxChanged(!this.checked); });
-})
+});

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolboxSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolboxSpec.ts
@@ -1,0 +1,23 @@
+import { removeCommentsFromEditableHtml } from "./toolbox";
+
+describe("toolbox tests", function () {
+    it("removeCommentsFromEditableHtml removes comments correctly including ones with new lines", function () {
+        var p = document.createElement("p");
+        var span1 = document.createElement("span");
+        span1.appendChild(document.createTextNode("text"));
+        p.appendChild(span1);
+        p.appendChild(document.createComment("comment"));
+        var span2 = document.createElement("span");
+        span2.appendChild(document.createComment("another \r\ncomment"));
+        span2.appendChild(document.createTextNode("more "));
+        span2.appendChild(document.createComment(""));
+        span2.appendChild(document.createTextNode("text"));
+        p.appendChild(span2);
+
+        // validate our setup
+        expect(p.innerHTML).toBe("<span>text</span><!--comment--><span><!--another \r\ncomment-->more <!---->text</span>");
+
+        removeCommentsFromEditableHtml(p);
+        expect(p.innerHTML).toBe("<span>text</span><span>more text</span>");
+    });
+});


### PR DESCRIPTION
The previous fix for BL-4775 helped at save-page time,
but this helps at actual paste time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1756)
<!-- Reviewable:end -->
