### PR TITLE
Fix problem with hanging tests due to l10nsharp changes

### DIFF
--- a/src/BloomTests/Book/BookCopyrightAndLicenseTests.cs
+++ b/src/BloomTests/Book/BookCopyrightAndLicenseTests.cs
@@ -34,6 +34,7 @@ namespace BloomTests.Book
 			});
 			ErrorReport.IsOkToInteractWithUser = false;
 
+			LocalizationManager.UseLanguageCodeFolders = true;
 			var localizationDirectory = FileLocator.GetDirectoryDistributedWithApplication("localization");
 			_localizationManager = LocalizationManager.Create("fr", "Bloom", "Bloom", "1.0.0", localizationDirectory, "SIL/Bloom",
 				null, "", new string[] {});

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -34,6 +34,7 @@ namespace BloomTests.Book
 			});
 			ErrorReport.IsOkToInteractWithUser = false;
 
+			LocalizationManager.UseLanguageCodeFolders = true;
 			var localizationDirectory = FileLocator.GetDirectoryDistributedWithApplication("localization");
 			_localizationManager = LocalizationManager.Create("fr", "Bloom", "Bloom", "1.0.0", localizationDirectory, "SIL/Bloom",
 				null, "");

--- a/src/BloomTests/web/EnhancedImageServerTests.cs
+++ b/src/BloomTests/web/EnhancedImageServerTests.cs
@@ -33,6 +33,7 @@ namespace BloomTests.web
 		{
 			Logger.Init();
 			_folder = new TemporaryFolder("ImageServerTests");
+			LocalizationManager.UseLanguageCodeFolders = true;
 			var localizationDirectory = FileLocator.GetDirectoryDistributedWithApplication("localization");
 			LocalizationManager.Create("fr", "Bloom", "Bloom", "1.0.0", localizationDirectory, "SIL/Bloom", null, "", new string[] { });
 


### PR DESCRIPTION
This won't fix one failing test (that requires a L10NSharp fix), but will fix the problem with the tests hanging and timing out on TeamCity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1764)
<!-- Reviewable:end -->
