### PR TITLE
Replace MarkdownSharp with Markdig

### DIFF
--- a/DistFiles/IntegrityFailureAdvice-en.md
+++ b/DistFiles/IntegrityFailureAdvice-en.md
@@ -1,26 +1,26 @@
-##Bloom cannot find some of its own files, and cannot continue
+## Bloom cannot find some of its own files, and cannot continue {i18n="integrity.title"}
 
-###Possible Causes
+### Possible Causes {i18n="integrity.causes"}
 
-1) Your antivirus may have "quarantined" one or more Bloom files.
+1) Your antivirus may have "quarantined" one or more Bloom files. {i18n="integrity.causes.1"}
 
-2) Your computer administrator may have your computer "locked down" to prevent bad things, but in such a way that Bloom could not place these files where they belong. 
+2) Your computer administrator may have your computer "locked down" to prevent bad things, but in such a way that Bloom could not place these files where they belong.  {i18n="integrity.causes.2"}
 
-###What To Do
+### What To Do {i18n="integrity.todo"}
 
-After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas:
+After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas: {i18n="integrity.todo.ideas"}
 
 
-* Run the Bloom installer again, and see if it starts up OK this time.
+* Run the Bloom installer again, and see if it starts up OK this time. {i18n="integrity.todo.ideas.Reinstall"}
 
-* If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at **{installFolder}**.
-    * AVAST: [Instructions](http://www.getavast.net/support/managing-exceptions).
-    * Norton Antivirus: [Instructions from Symantec](https://support.symantec.com/en_US/article.HOWTO80920.html).
-    * AVG: [Instructions from AVG](https://support.avg.com/SupportArticleView?l=en_US&urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning).
-    * Others: Google for "whitelist directory name-of-your-antivirus"
+* If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at **{installFolder}**. {i18n="integrity.todo.ideas.Antivirus"}
+    * AVAST: [Instructions](http://www.getavast.net/support/managing-exceptions). {i18n="integrity.todo.ideas.AVAST"}
+    * Norton Antivirus: [Instructions from Symantec](https://support.symantec.com/en_US/article.HOWTO80920.html). {i18n="integrity.todo.ideas.Norton"}
+    * AVG: [Instructions from AVG](https://support.avg.com/SupportArticleView?l=en_US&urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning). {i18n="integrity.todo.ideas.AVG"}
+    * Others: Google for "whitelist directory name-of-your-antivirus" {i18n="integrity.todo.ideas.Others"}
 
-    * Run the Bloom installer again, and see if it starts up OK this time.
+    * Run the Bloom installer again, and see if it starts up OK this time. {i18n="integrity.todo.ideas.Restart"}
 
-* You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see [this image](https://i.imgur.com/dlRrsSN.png).
+* You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see [this image](https://i.imgur.com/dlRrsSN.png). {i18n="integrity.todo.ideas.Retrieve"}
 
-###Missing Files
+### Missing Files {i18n="integrity.missing"}

--- a/DistFiles/infoPages/TrainingVideos-en.md
+++ b/DistFiles/infoPages/TrainingVideos-en.md
@@ -1,26 +1,26 @@
-#Bloom Training Videos 
+# Bloom Training Videos {i18n="training.videos"}
 
-If you are connected to the internet now, you can watch videos in your web browser:
+If you are connected to the internet now, you can watch videos in your web browser: {i18n="training.videos.watch"}
 
-- [All videos](http://tiny.cc/bloomVimeo)
+- ::[All videos](http://tiny.cc/bloomVimeo)::{i18n="training.videos.all"}
 
-### Introductory Videos
+### Introductory Videos {i18n="training.videos.intro"}
 
-- [Bloom: Who is it for](https://vimeo.com/114043219)
-- [Understanding Templates and Shell Books](https://vimeo.com/114024308)
-- [Using the Basic Book template](https://vimeo.com/112825489)
-- [Using Decodable and Leveled Reader Templates (several videos)](http://tiny.cc/usingBloomReaderTemplates)
+- ::[Bloom: Who is it for](https://vimeo.com/114043219)::{i18n="training.videos.whofor"}
+- ::[Understanding Templates and Shell Books](https://vimeo.com/114024308)::{i18n="training.videos.templates"}
+- ::[Using the Basic Book template](https://vimeo.com/112825489)::{i18n="training.videos.basicbook"}
+- ::[Using Decodable and Leveled Reader Templates (several videos)](http://tiny.cc/usingBloomReaderTemplates)::{i18n="training.videos.readers"}
 
-### Advanced Topics
+### Advanced Topics {i18n="training.videos.advanced"}
 
-- [Changing the format of text](https://vimeo.com/117820891)
-- [Using the Custom Page template](https://vimeo.com/116868148)
-- [Inserting special characters](https://vimeo.com/117927599)
-- [Making a set of Decodable and Leveled Reader Templates (several videos)](http://tiny.cc/8vbwux)
+- ::[Changing the format of text](https://vimeo.com/117820891)::{i18n="training.videos.formatting"}
+- ::[Using the Custom Page template](https://vimeo.com/116868148)::{i18n="training.videos.custompage"}
+- ::[Inserting special characters](https://vimeo.com/117927599)::{i18n="training.videos.specialcharacters"}
+- ::[Making a set of Decodable and Leveled Reader Templates (several videos)](http://tiny.cc/8vbwux)::{i18n="training.videos.readertemplates"}
 
-### Offline Viewing
+### Offline Viewing {i18n="training.videos.offline"}
 
-If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer: 
+If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer: {i18n="training.videos.download"}
 
-- [High Resolution](http://tiny.cc/bloomHDVideos) (Large files)
-- [Low Resolution](http://tiny.cc/bloomSDVideos) (Smaller files)
+- ::[High Resolution](http://tiny.cc/bloomHDVideos) (Large files)::{i18n="training.videos.hires"}
+- ::[Low Resolution](http://tiny.cc/bloomSDVideos) (Smaller files)::{i18n="training.videos.lores"}

--- a/src/BloomBrowserUI/templates/template books/Big Book/ReadMe-en.md
+++ b/src/BloomBrowserUI/templates/template books/Big Book/ReadMe-en.md
@@ -1,17 +1,17 @@
-# About Big Books
-Big Books are designed for teachers to hold and read in front of a class. For more information, see this [PDF from Scholastic](http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf).
-# Printing a Big Book
+# About Big Books {i18n="bigbook.title"}
+Big Books are designed for teachers to hold and read in front of a class. For more information, see this [PDF from Scholastic](http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf). {i18n="bigbook.use"}
+# Printing a Big Book {i18n="bigbook.printing"}
 To make things more manageable, this template is set at A4 Landscape, with large fonts.
 You can easily produce books that are A3 (twice as large).
-Just take your A4 PDF to a printer and ask them to enlarge it to A3.
-# Limitations of this version
-If you are using a small screen, it can be hard to read the credits page. Try using CTRL+mouse wheel to zoom in to the page so you can edit it.
+Just take your A4 PDF to a printer and ask them to enlarge it to A3. {i18n="bigbook.printing.enlargeA4"}
+# Limitations of this version {i18n="bigbook.limits"}
+If you are using a small screen, it can be hard to read the credits page. Try using CTRL+mouse wheel to zoom in to the page so you can edit it. {i18n="bigbook.limits.smallscreen"}
 
 This version includes an "Instructions for Teachers" page that is already filled out, in English.
 If you would like to have instructions in a different language, you can delete that text and type in your own.
-If you send us that text, we can include it in a future version of the template.
+If you send us that text, we can include it in a future version of the template. {i18n="bigbook.limits.Englishtemplate"}
 
-#Feedback
-Please give and vote on [suggestions](http://bloomlibrary.org/suggestions)
+# Feedback {i18n="bigbook.feedback"}
+Please give and vote on [suggestions](http://bloomlibrary.org/suggestions) {i18n="bigbook.feedbackvoting"}
 
-Please report problems to [issues@bloomremovelibrary.org](mailto:issues@bloomremovelibrary.org?subject=Big&nbsp;Book&nbsp;Problem).
+Please report problems to [issues@bloomremovelibrary.org](mailto:issues@bloomremovelibrary.org?subject=Big&nbsp;Book&nbsp;Problem). {i18n="bigbook.reportsbugs"}

--- a/src/BloomBrowserUI/templates/template books/Decodable Reader/ReadMe-en.md
+++ b/src/BloomBrowserUI/templates/template books/Decodable Reader/ReadMe-en.md
@@ -1,11 +1,11 @@
-A **Decodable Reader** is a book that carefully limits the letters and words used so that it fits what a new reader is ready to read. Typically a language may have 5 - 10 *decodable stages* through which learners progress. 
+A **Decodable Reader** is a book that carefully limits the letters and words used so that it fits what a new reader is ready to read. Typically a language may have 5 - 10 *decodable stages* through which learners progress. {i18n="decodable.definition"}
 
-Bloom helps you to define this sequence of *stages* that readers work through. Each book you create will be targeted at one of those stages, and Bloom helps you to make sure that your book is *decodable* (figure out-able) by learners at that *stage*.
+Bloom helps you to define this sequence of *stages* that readers work through. Each book you create will be targeted at one of those stages, and Bloom helps you to make sure that your book is *decodable* (figure out-able) by learners at that *stage*. {i18n="decodable.stages"}
 
-You can also make a Bloom Pack of *templates* that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.
+You can also make a Bloom Pack of *templates* that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist. {i18n="decodable.templates"}
 
-To learn about using Decodable Readers in Bloom, you can:
+To learn about using Decodable Readers in Bloom, you can: {i18n="decodable.learn"}
 
-- Watch [these instructional videos](http://tiny.cc/8vbwux).
-- Go to the Help menu, choose 'Help', and look in the index under "Decodable Readers".
-- Go to the Help menu and choose: "Building Reader Templates".
+- ::Watch [these instructional videos](http://tiny.cc/8vbwux).::{i18n="decodable.learn.videos"}
+- ::Go to the Help menu, choose 'Help', and look in the index under "Decodable Readers".::{i18n="decodable.learn.helpindex"}
+- ::Go to the Help menu and choose: "Building Reader Templates".::{i18n="decodable.learn.helpmenu"}

--- a/src/BloomBrowserUI/templates/template books/Leveled Reader/ReadMe-en.md
+++ b/src/BloomBrowserUI/templates/template books/Leveled Reader/ReadMe-en.md
@@ -1,23 +1,23 @@
-A **Leveled Reader** is a book that is written specifically for a learner who is at a certain level of reading development. Levels define targets for word length, sentence length, etc. They also determine appropriate formatting, vocabulary, illustration support, and topic.
+A **Leveled Reader** is a book that is written specifically for a learner who is at a certain level of reading development. Levels define targets for word length, sentence length, etc. They also determine appropriate formatting, vocabulary, illustration support, and topic. {i18n="leveled.definition"}
 
-After you have defined a sequence of *levels*, you can assign a level to books you create either with this template or the "Decodable Reader Template". As you type into the book, Bloom will help you keep the level in mind and point out when you exceed the limits of the level.
+After you have defined a sequence of *levels*, you can assign a level to books you create either with this template or the "Decodable Reader Template". As you type into the book, Bloom will help you keep the level in mind and point out when you exceed the limits of the level. {i18n="leveled.levels"}
 
-You can also make a Bloom Pack of *templates* that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.
+You can also make a Bloom Pack of *templates* that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist. {i18n="leveled.templates"}
 
-To learn about using Leveled Readers in Bloom, you can:
+To learn about using Leveled Readers in Bloom, you can: {i18n="leveled.learn"}
 
-- Watch [these instructional videos](http://tiny.cc/8vbwux).
-- Go to the Help menu, choose 'Help', and look in the index under "Leveled Readers".
-- Go to the Help menu and choose: "Building Reader Templates".
+- ::Watch [these instructional videos](http://tiny.cc/8vbwux).::{i18n="leveled.learn.videos"}
+- ::Go to the Help menu, choose 'Help', and look in the index under "Leveled Readers".::{i18n="leveled.learn.helpindex"}
+- ::Go to the Help menu and choose: "Building Reader Templates".::{i18n="leveled.learn.helpmenu"}
 
-###Relationship to Decodable Readers
+### Relationship to Decodable Readers {i18n="leveled.vs.decodable"}
 
-So how do leveled reader *levels* fit in decodable reader *stages*? The two concepts are complementary, and Bloom allows you to set both a *decodable stage* and a *leveled reader level* for a book you are writing. Typically books at level 1 and possibly level 2 will also need to be written with *decodability stages* in mind. Books at the first level or two will also need to be careful about being *decodable* (i.e. using letters the reader has learned). So a sequence of books might look like this:
+So how do leveled reader *levels* fit in decodable reader *stages*? The two concepts are complementary, and Bloom allows you to set both a *decodable stage* and a *leveled reader level* for a book you are writing. Typically books at level 1 and possibly level 2 will also need to be written with *decodability stages* in mind. Books at the first level or two will also need to be careful about being *decodable* (i.e. using letters the reader has learned). So a sequence of books might look like this: {i18n="leveled.and.decodable"}
 
 <table>
   <tr style="font-weight:bold">
-    <td style="width:10em">Leveled Reader Level</td>
-    <td>Decodable Stage</td>
+    <td style="width:10em" i18n="leveled.reader.level">Leveled Reader Level</td>
+    <td i18n="decodable.stage">Decodable Stage</td>
   </tr>
   <tr>    <td>1</td>    <td>1</td>  </tr>
     <tr>    <td>1</td>    <td>2</td>  </tr>

--- a/src/BloomBrowserUI/templates/template books/Picture Dictionary/ReadMe-en.md
+++ b/src/BloomBrowserUI/templates/template books/Picture Dictionary/ReadMe-en.md
@@ -1,10 +1,10 @@
-# About the Picture Dictionary Template
-Use this template to make a picture dictionary that is monolingual, bilingual, or trilingual.
+# About the Picture Dictionary Template {i18n="picture.dictionary"}
+Use this template to make a picture dictionary that is monolingual, bilingual, or trilingual. {i18n="picture.dictionary.use"}
 
-#Limitations of this version
-This book is currently marked "experimental" because we know of several problems in layout and convenience.
+# Limitations of this version {i18n="picture.dictionary.limits"}
+This book is currently marked "experimental" because we know of several problems in layout and convenience. {i18n="picture.dictionary.stillexperimental"}
 
-#Feedback
-Please give and vote on [suggestions](http://bloomlibrary.org/suggestions)
+# Feedback {i18n="picture.dictionary.feedback"}
+Please give and vote on [suggestions](http://bloomlibrary.org/suggestions) {i18n="picture.dictionary.feedbackvoting"}
 
-Please report problems to [issues@bloomremovelibrary.org](mailto:issues@bloomremovelibrary.org?subject=Picture&nbsp;Dictionary&nbsp;Problem).
+Please report problems to [issues@bloomremovelibrary.org](mailto:issues@bloomremovelibrary.org?subject=Picture&nbsp;Dictionary&nbsp;Problem). {i18n="picture.dictionary.reportbugs"}

--- a/src/BloomBrowserUI/templates/template books/Template Starter/ReadMe-en.md
+++ b/src/BloomBrowserUI/templates/template books/Template Starter/ReadMe-en.md
@@ -1,47 +1,47 @@
-# How to use the Template Starter
+# How to use the Template Starter {i18n="template.starter"}
 
 This special template lets you make your own templates. A template provides a set of related page layouts that an author can choose from in writing an original book. Usually the text blocks and picture blocks on template pages will be empty, ready for an author to fill in. Sometimes there may be standard text or pictures that should be on every copy of the page.
-There are two ways people can use your template. The first way is to start new books. For example, imagine student books that have one page for each school day of the week. You could make a template with 5 pages, each with places to type in text and choose pictures. Curriculum authors could select your template and make a new book, one for each week<sup>[1](#note1)</sup>.
+There are two ways people can use your template. The first way is to start new books. For example, imagine student books that have one page for each school day of the week. You could make a template with 5 pages, each with places to type in text and choose pictures. Curriculum authors could select your template and make a new book, one for each week<sup>[1](#note1)</sup>. {i18n="template.starter.firstusage"}
 
-The second way people can use templates is as source of new pages, regardless of how they started the book. For example, in some places, each book requires a page as part of a government approval process. You might make a template containing that page and give it to others in your country. Then, when people translate a shellbook, they go to the end of the book and click “Add Page”. The page you made will appear in their list of choices. Some other ideas for templates are alphabet charts, glossaries, and instructions on how to use the book in a classroom. <sup>[2](#note1)</sup>
+The second way people can use templates is as source of new pages, regardless of how they started the book. For example, in some places, each book requires a page as part of a government approval process. You might make a template containing that page and give it to others in your country. Then, when people translate a shellbook, they go to the end of the book and click “Add Page”. The page you made will appear in their list of choices. Some other ideas for templates are alphabet charts, glossaries, and instructions on how to use the book in a classroom. <sup>[2](#note1)</sup> {i18n="template.starter.secondusage"}
 
-Making templates is just like making any other custom book; all the same controls are available for making and customizing pages. But since you will probably be sharing with other people, there are a number of things you can do to help users of your template:
+Making templates is just like making any other custom book; all the same controls are available for making and customizing pages. But since you will probably be sharing with other people, there are a number of things you can do to help users of your template: {i18n="template.starter.waystohelp"}
 
-## Label Your Pages
-When you add pages to your template, make sure to give each one useful label<sup>[3](#note2),[4](@note3)</sup>:
+## Label Your Pages {i18n="template.starter.labelpages"}
+When you add pages to your template, make sure to give each one useful label<sup>[3](#note2),[4](@note3)</sup>: {i18n="template.starter.labeleachpage"}
 
-![custom label](ReadMeImages/customLabel.png)
+![custom label]{i18n="template.starter.labelexample"}(ReadMeImages/customLabel.png)
 
-## Check Your Thumbnails
-To speed things up, Bloom only makes this thumbnail once, and stores it in the "template" subdirectory of your template:
+## Check Your Thumbnails {i18n="template.starter.thumbnails"}
+To speed things up, Bloom only makes this thumbnail once, and stores it in the "template" subdirectory of your template: {i18n="template.starter.thumbnails.onlyonce"}
 
 ![](ReadMeImages/pageThumbnailFiles.png)
 
- If you later make a change to the page, the thumbnail will be out of date. To fix that, click the "Add Page" button, and Bloom will regenerate those thumbnails. If the automatically generated thumbnail doesn't convey the purpose of the page, you can make your own. Just make sure to mark the file as "Read Only" so that Bloom doesn't overwrite it. You can also make your thumbnails as svgs, if you like (that's what we do for templates we ship with Bloom).  In any case, make sure to click "Add Page" at least once before distributing your template, so that all the thumbnails are already generated.
+ If you later make a change to the page, the thumbnail will be out of date. To fix that, click the "Add Page" button, and Bloom will regenerate those thumbnails. If the automatically generated thumbnail doesn't convey the purpose of the page, you can make your own. Just make sure to mark the file as "Read Only" so that Bloom doesn't overwrite it. You can also make your thumbnails as svgs, if you like (that's what we do for templates we ship with Bloom).  In any case, make sure to click "Add Page" at least once before distributing your template, so that all the thumbnails are already generated. {i18n="template.starter.thumbnails.update"}
 
-## Document Your Template
+## Document Your Template {i18n="template.starter.document"}
 
-Also consider adding a description of your template, like the one you are reading now. To do this, put a text file named ReadMe-en.md in your template's folder. This file should follow the <a href="http://spec.commonmark.org/dingus/">markdown standard</a>. To provide your instructions in other languages, make versions of that file that change the "en" to each language's two letter code. For example ReadMe-fr.md would be shown when Bloom is set to show labels in French. You can also include screenshots, like we have in this document. Place any images you use in a folder named "ReadMeImages", so that images are referenced like this:
+Also consider adding a description of your template, like the one you are reading now. To do this, put a text file named ReadMe-en.md in your template's folder. This file should follow the <a href="http://spec.commonmark.org/dingus/">markdown standard</a>. To provide your instructions in other languages, make versions of that file that change the "en" to each language's two letter code. For example ReadMe-fr.md would be shown when Bloom is set to show labels in French. You can also include screenshots, like we have in this document. Place any images you use in a folder named "ReadMeImages", so that images are referenced like this: {i18n="template.starter.describeyours"}
 
 `![](ReadMeImages/someExample.png)`
 
-When the Add Page dialog box shows your template pages, it will show a thumbnail:
+When the Add Page dialog box shows your template pages, it will show a thumbnail: {i18n="template.starter.thumbnailsshown"}
 
 ![](ReadMeImages/thumbnailInAddPage.png)
 
-## Share Your Template
-Remember that Bloom is about planting seeds, about sharing. So plan to share your template on the BloomLibrary for people around the world to find. This takes just a few clicks in the Publish Tab.
+## Share Your Template {i18n="template.starter.share"}
+Remember that Bloom is about planting seeds, about sharing. So plan to share your template on the BloomLibrary for people around the world to find. This takes just a few clicks in the Publish Tab. {i18n="template.starter.share.publish"}
 
-For local colleagues, an easy way to distribute your template is via a Bloom Pack. In the collections tab, right-click on your template's thumbnail. Choose 'Make Bloom Pack'. Save that somewhere, for example to a USB Key. Then take it to another computer, double click on the file you made, and your template will be added to the "Sources for New Books" on that computer.
+For local colleagues, an easy way to distribute your template is via a Bloom Pack. In the collections tab, right-click on your template's thumbnail. Choose 'Make Bloom Pack'. Save that somewhere, for example to a USB Key. Then take it to another computer, double click on the file you made, and your template will be added to the "Sources for New Books" on that computer. {i18n="template.starter.share.bloompack"}
 
-## Notes
+## Notes {i18n="template.starter.notes"}
 
-<a name="note1">1</a>: These books could later be combined using the forthcoming Folio feature. Note that Bloom 3.9 does not yet give you a way to indicate that a page should be automatically included in new books; the author will have to add each one from the Add Page dialog.
+<a name="note1">1</a>: These books could later be combined using the forthcoming Folio feature. Note that Bloom 3.9 does not yet give you a way to indicate that a page should be automatically included in new books; the author will have to add each one from the Add Page dialog. {i18n="template.starter.nothingautomatic"}
 
-<a name="note2">2</a>: If you don't want the pages in your template to show up in the Add Page dialog, you can indicate this to Bloom by creating a file in the book's template folder called NotForAddPage.txt.
+<a name="note2">2</a>: If you don't want the pages in your template to show up in the Add Page dialog, you can indicate this to Bloom by creating a file in the book's template folder called NotForAddPage.txt. {i18n="template.starter.nametonotaddpage"}
 
-<a name="note3">3</a>: People will not be able to translate your labels and descriptions into other national languages. If this is a problem, please contact the Bloom team.
+<a name="note3">3</a>: People will not be able to translate your labels and descriptions into other national languages. If this is a problem, please contact the Bloom team. {i18n="template.starter.labelsnottranslatable"}
 
-<a name="note4">4</a>: If you want to the Add Page screen to also provide a short description of the page, you'll need to quit Bloom and edit the template's html in Notepad, like this: ![](ReadMeImages/pageDescription.png)
+<a name="note4">4</a>: If you want to the Add Page screen to also provide a short description of the page, you'll need to quit Bloom and edit the template's html in Notepad, like this: ![](ReadMeImages/pageDescription.png) {i18n="template.starter.editrawhtml"}
 
 

--- a/src/BloomBrowserUI/templates/template books/Wall Calendar/ReadMe-en.md
+++ b/src/BloomBrowserUI/templates/template books/Wall Calendar/ReadMe-en.md
@@ -1,13 +1,13 @@
-# About the Wall Calendar Template
-Using this template, you can make an A5-size 12 month calendar, with a picture and quotation on the top page, and days on the bottom. The calendar will use the names of months and days in your language.
+# About the Wall Calendar Template {i18n="wall.calendar"}
+Using this template, you can make an A5-size 12 month calendar, with a picture and quotation on the top page, and days on the bottom. The calendar will use the names of months and days in your language. {i18n="wall.calendar.use"}
 
-#Limitations of this version
-Currently, you cannot make a "shell" for other languages to use.
+# Limitations of this version {i18n="wall.calendar.limits"}
+Currently, you cannot make a "shell" for other languages to use. {i18n="wall.calendar.noshells"}
 
-#Credits
-Thanks to Bruce Cox (SIL Cameroon) for getting this template started.
+# Credits {i18n="wall.calendar.credits"}
+Thanks to Bruce Cox (SIL Cameroon) for getting this template started. {i18n="wall.calendar.thanks"}
 
-#Feedback
-Please give and vote on [suggestions](http://bloomlibrary.org/suggestions)
+# Feedback {i18n="wall.calendar.feedback"}
+Please give and vote on [suggestions](http://bloomlibrary.org/suggestions) {i18n="wall.calendar.feedbackvoting"}
 
-Please report problems to [issues@bloomremovelibrary.org](mailto:issues@bloomremovelibrary.org?subject=Wall&nbsp;Calendar&nbsp;Problem).
+Please report problems to [issues@bloomremovelibrary.org](mailto:issues@bloomremovelibrary.org?subject=Wall&nbsp;Calendar&nbsp;Problem). {i18n="wall.calendar.reportbugs"}

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -158,20 +158,8 @@
     <Reference Include="L10NSharp">
       <HintPath>..\..\lib\dotnet\L10NSharp.dll</HintPath>
     </Reference>
-    <Reference Include="MarkdownDeep, Version=1.5.4615.26275, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MarkdownDeep.NET.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <!-- On Windows, Squirrel.dll provides the MarkdownSharp class in addition
-	 to all the Squirrel specific classes.  But Linux/Mono cannot handle
-	 referencing Squirrel.dll because it references some Windows specific
-	 assemblies internally.  So for Linux, we have to provide MarkdownSharp
-	 separately by itself.  (Note that trying to reference both Squirrel
-	 and MarkdownSharp on Windows causes fatal confusion in dereferencing.)
-    -->
-    <Reference Include="MarkdownSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Markdig">
+      <HintPath>..\..\packages\Markdig.0.13.0\lib\net40\Markdig.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -17,7 +17,7 @@ using Bloom.Publish;
 using Bloom.web.controllers;
 using Bloom.WebLibraryIntegration;
 using L10NSharp;
-using MarkdownSharp;
+using Markdig;
 using SIL.Code;
 using SIL.Extensions;
 using SIL.IO;
@@ -1463,9 +1463,9 @@ namespace Bloom.Book
 		{
 			get
 			{
-				var options = new MarkdownOptions() {LinkEmails = true, AutoHyperlink=true};
-				var m = new Markdown(options);
-				var contents = m.Transform(RobustFile.ReadAllText(AboutBookMarkdownPath));
+				// enable autolinks from text `http://`, `https://`, `ftp://`, `mailto:`, `www.xxx.yyy`
+				var pipeline = new MarkdownPipelineBuilder().UseAutoLinks().UseCustomContainers().UseGenericAttributes().Build();
+				var contents = Markdown.ToHtml(RobustFile.ReadAllText(AboutBookMarkdownPath), pipeline);
 				contents = contents.Replace("remove", "");//used to hide email addresses in the md from scanners (probably unnecessary.... do they scan .md files?
 
 				var pathToCss = _storage.GetFileLocator().LocateFileWithThrow("BookReadme.css");

--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -11,7 +11,7 @@
   <package id="Fleck" version="0.14.0.59" targetFramework="net461" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net461" />
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net461" />
-  <package id="MarkdownDeep.NET" version="1.5" targetFramework="net461" />
+  <package id="Markdig" version="0.13.0 " targetFramework="net461" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net461" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
@@ -23,6 +23,5 @@
   <!-- Linux specific packages.  Changes above this line must be copied to ../packages.config -->
   <package id="Geckofx45.32.Linux" version="45.0.23.0" targetFramework="net461" />
   <package id="Geckofx45.64.Linux" version="45.0.23.0" targetFramework="net461" />
-  <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net461" />
   <package id="SharpFont" version="3.1.0" targetFramework="net461" />
 </packages>

--- a/src/BloomExe/MiscUI/MarkDownTextBox.cs
+++ b/src/BloomExe/MiscUI/MarkDownTextBox.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using Gecko;
-using MarkdownSharp;
+using Markdig;
 using SIL.Windows.Forms.Extensions;
 
 namespace Bloom.MiscUI
@@ -23,8 +23,9 @@ namespace Bloom.MiscUI
 		{
 			if(this.DesignModeAtAll())
 				return;
-			 var markdownTransformer = new Markdown();
-			_htmlLabel.HTML = markdownTransformer.Transform(_markdown);
+			// enable autolinks from text `http://`, `https://`, `ftp://`, `mailto:`, `www.xxx.yyy`
+			var pipeline = new MarkdownPipelineBuilder().UseAutoLinks().UseCustomContainers().UseGenericAttributes().Build();
+			_htmlLabel.HTML = Markdown.ToHtml(_markdown, pipeline);
 		}
 
 		[Browsable(true), Category("MarkDownText")]

--- a/src/BloomExe/Registration/LicenseDialog.cs
+++ b/src/BloomExe/Registration/LicenseDialog.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Reflection;
 using System.Text;
 using System.Windows.Forms;
-using MarkdownSharp;
+using Markdig;
 using SIL.IO;
 
 namespace Bloom.Registration
@@ -40,8 +40,6 @@ namespace Bloom.Registration
 			_licenseBrowser.Name = "licenseBrowser";
 			_licenseBrowser.Size = new Size(_acceptButton.Right - 12, _acceptButton.Top - 24);
 			Controls.Add(_licenseBrowser);
-			var options = new MarkdownOptions() { LinkEmails = true, AutoHyperlink = true };
-			var m = new Markdown(options);
 			var locale = CultureInfo.CurrentUICulture.Name;
 			string licenseFilePath = BloomFileLocator.GetFileDistributedWithApplication(licenseMdFile);
 			var localizedLicenseFilePath = licenseFilePath.Substring(0, licenseFilePath.Length - 3) + "-" + locale + ".md";
@@ -59,7 +57,9 @@ namespace Bloom.Registration
 				}
 			}
 			var markdown = prolog + RobustFile.ReadAllText(licenseFilePath, Encoding.UTF8);
-			var contents = m.Transform(markdown);
+			// enable autolinks from text `http://`, `https://`, `ftp://`, `mailto:`, `www.xxx.yyy`
+			var pipeline = new MarkdownPipelineBuilder().UseAutoLinks().UseCustomContainers().UseGenericAttributes().Build();
+			var contents = Markdown.ToHtml(markdown, pipeline);
 			var html = string.Format("<html><head><head/><body style=\"font-family:sans-serif\">{0}</body></html>", contents);
 			_licenseBrowser.NavigateRawHtml(html);
 			_licenseBrowser.Visible = true;

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <!-- If you edit this file, don't forget to also edit ./Linux/packages.config appropriately! -->
   <package id="Analytics" version="2.0.2" targetFramework="net461" />
@@ -12,7 +12,7 @@
   <package id="Fleck" version="0.14.0.59" targetFramework="net461" />
   <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net461" />
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net461" />
-  <package id="MarkdownDeep.NET" version="1.5" targetFramework="net461" />
+  <package id="Markdig" version="0.13.0 " targetFramework="net461" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net461" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
@@ -23,5 +23,4 @@
   <package id="TechTalk.JiraRestClient.RestSharp105" version="2.3.0.1" targetFramework="net461" />
   <!-- Windows specific packages.  Changes above this line must be copied to ./Linux/packages.config -->
   <package id="Geckofx45" version="45.0.28" targetFramework="net461" />
-  <!-- required by libtidy -->
 </packages>


### PR DESCRIPTION
Also remove apparently unused reference to MarkdownDeep.

This is the first step of the new localization approach to markdown files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1793)
<!-- Reviewable:end -->
