### PR TITLE
BL-4839 Remove getting vcruntime140.dll through nuget

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1392,11 +1392,4 @@ cp -p "$(SolutionDir)lib/dotnet/GeckofxHtmlToPdf.exe.config" "$(OutDir)BloomPdfM
     <Copy SourceFiles="@(BloomPdfMakerArgs)" DestinationFolder="$(OutDir)" />
     <Copy SourceFiles="@(IccFiles)" DestinationFolder="$(OutDir)/ColorProfiles" />
   </Target>
-  <Import Project="..\..\packages\runtime.win7-x86.vcruntime140.14.00.24406.0-r160\build\net40\runtime.win7-x86.vcruntime140.targets" Condition="'$(OS)'=='Windows_NT' and Exists('..\..\packages\runtime.win7-x86.vcruntime140.14.00.24406.0-r160\build\net40\runtime.win7-x86.vcruntime140.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild" Condition="'$(OS)'=='Windows_NT'">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\runtime.win7-x86.vcruntime140.14.00.24406.0-r160\build\net40\runtime.win7-x86.vcruntime140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\runtime.win7-x86.vcruntime140.14.00.24406.0-r160\build\net40\runtime.win7-x86.vcruntime140.targets'))" />
-  </Target>
 </Project>

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <!-- If you edit this file, don't forget to also edit ./Linux/packages.config appropriately! -->
   <package id="Analytics" version="2.0.2" targetFramework="net461" />
@@ -24,5 +24,4 @@
   <!-- Windows specific packages.  Changes above this line must be copied to ./Linux/packages.config -->
   <package id="Geckofx45" version="45.0.28" targetFramework="net461" />
   <!-- required by libtidy -->
-  <package id="runtime.win7-x86.vcruntime140" version="14.00.24406.0-r160" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Supposedly libtidy no longer needs it...we hope nothing else does either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1796)
<!-- Reviewable:end -->
