### PR TITLE
BL-4878 Improve computation of version code

### DIFF
--- a/src/BloomExe/Publish/BloomReaderPublisher.cs
+++ b/src/BloomExe/Publish/BloomReaderPublisher.cs
@@ -198,7 +198,7 @@ namespace Bloom.Publish
 			_progress.WriteMessage($"Sending \"{book.Title}\" to device {androidIpAddress}");
 
 			var publishedFileName = book.Title + BookCompressor.ExtensionForDeviceBloomBook;
-			using (var bloomdTempFile = TempFile.WithFilenameInTempFolder(publishedFileName))
+			using (var bloomdTempFile = TempFile.WithFilenameInTempFolder(BookStorage.SanitizeNameForFileSystem(publishedFileName)))
 			{
 				BookCompressor.CompressBookForDevice(bloomdTempFile.Path, book);
 				using (WebClient myClient = new WebClient())

--- a/src/BloomExe/web/controllers/PublishToAndroidApi.cs
+++ b/src/BloomExe/web/controllers/PublishToAndroidApi.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Diagnostics;
+using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using Bloom.Collection;
 using Bloom.Publish;
 using Bloom.web;
@@ -76,15 +79,47 @@ namespace Bloom.Api
 			// a book that is exactly what it has already...with the risk that it might miss binary changes to images, if nothing changes
 			// in the HTML. However, this doesn't prevent overwriting a newer book with an older one. Another option would be to
 			// send the file modify time (as well or instead). Or we can institute some system of versioning books...
-			_advertiser.BookVersion = Convert.ToBase64String(SHA256Managed.Create().ComputeHash(Encoding.UTF8.GetBytes(server.CurrentBook.RawDom.OuterXml)));
+			_advertiser.BookVersion = MakeVersionCode(File.ReadAllText(server.CurrentBook.GetPathHtmlFile()));
+
 			_advertiser.Start();
 
 			request.SucceededDoNotNavigate();
 		}
 
+		public static string MakeVersionCode(string fileContent)
+		{
+			var simplified = fileContent;
+			// In general, whitespace sequences are equivalent to a single space.
+			// If the user types multiple spaces all but one will be turned to &nbsp;
+			simplified = new Regex(@"\s+").Replace(simplified," ");
+			// Between the end of one tag and the start of the next white space doesn't count at all
+			simplified = new Regex(@">\s+<").Replace(simplified, "><");
+			// Page IDs (actually any element ids) are ignored
+			// (the bit before the 'id' matches an opening wedge followed by anything but a closing one,
+			// and is tranferred to the output by $1. Then we look for an id='whatever', with optional
+			// whitespace, where (['\"]) matches either kind of opening quote while \2 matches the same one at the end.
+			// The question mark makes sure we end with the first possible closing quote.
+			// Then we grab everything up to the closing wedge and transfer that to the output as $3.)
+			simplified = new Regex("(<[^>]*)\\s*id\\s*=\\s*(['\"]).*?\\2\\s*([^>]*>)").Replace(simplified, "$1$3");
+			var bytes = Encoding.UTF8.GetBytes(simplified);
+			return Convert.ToBase64String(SHA256Managed.Create().ComputeHash(bytes));
+		}
+
 		private void SendBookTo(Book.Book book, string androidIpAddress)
 		{
-			_bloomReaderPublisher.SendBookToClientOnLocalSubNet(book, androidIpAddress);
+			try
+			{
+				_bloomReaderPublisher.SendBookToClientOnLocalSubNet(book, androidIpAddress);
+			}
+			catch (Exception e)
+			{
+				// This method is called on a background thread in response to receiving a request from Bloom Reader.
+				// Exceptions somehow get discarded, so there is no point in letting them propagate further.
+				_progress.WriteError("Sending the book failed. Possibly the device was disconnected? If you can't see a reason for this the following may be helpful to report to the developers:");
+				_progress.WriteError(e.Message);
+				_progress.WriteError(e.StackTrace);
+				Debug.Fail("got exception " + e.Message + " sending book");
+			}
 		}
 
 		private void ConnectCancelHandler(ApiRequest request)

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -214,6 +214,7 @@
     <Compile Include="WebLibraryIntegration\BloomS3StandardUpDownloadTests.cs" />
     <Compile Include="WebLibraryIntegration\BookTransferTests.cs" />
     <Compile Include="web\controllers\PageTemplatesApiTests.cs" />
+    <Compile Include="web\controllers\PublishToWebApiTests.cs" />
     <Compile Include="web\controllers\ReadersApiTests.cs" />
     <Compile Include="web\controllers\ApiTest.cs" />
     <Compile Include="WebLibraryIntegration\ProblemBookUploaderTests.cs" />

--- a/src/BloomTests/web/controllers/PublishToWebApiTests.cs
+++ b/src/BloomTests/web/controllers/PublishToWebApiTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bloom.Api;
+using NUnit.Framework;
+
+namespace BloomTests.web.controllers
+{
+	public class PublishToWebApiTests
+	{
+		[Test]
+		public void MakeVersionCode_DistinguishesTextChanges()
+		{
+			var template = @"<!DOCTYPE html><html><head></head><body><div>{0}</div></body></html>";
+			var first = string.Format(template, "abc");
+			var second = string.Format(template, "abd");
+			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.Not.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+		}
+
+		[TestCase("abc", "ab c")]
+		[TestCase("<p>ab&nbsp; cd</p>", "<p>ab cd</p>")]
+		[TestCase("<p>ab</p>  <p>cd</p>", "<p>ab cd</p>")]
+		public void MakeVersionCode_DistinguishesSignificantWhitespaceChanges(string firstArg, string secondArg)
+		{
+			var template = @"<!DOCTYPE html><html><head></head><body><div>{0}</div></body></html>";
+			var first = string.Format(template, firstArg);
+			var second = string.Format(template, secondArg);
+			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.Not.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+		}
+
+		[Test]
+		public void MakeVersionCode_DistinguishesStructuralChanges()
+		{
+			var template = @"<!DOCTYPE html><html><head></head><body><div>{0}</div></body></html>";
+			var first = string.Format(template, "abc");
+			var second = string.Format(template, "<p>abc<p>");
+			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.Not.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+		}
+
+		[Test]
+		public void MakeVersionCode_IgnoresInsignificantWhitespaceChanges()
+		{
+			var first = @"<!DOCTYPE html><html><head></head><body><div>abc</div></body></html>";
+			var second = @"<!DOCTYPE html>
+<html>
+	<head>
+	</head>
+	<body> <div>abc</div>
+	</body>
+</html>";
+			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+		}
+
+		[Test]
+		public void MakeVersionCode_IgnoresIndentsInStylesheet()
+		{
+			var first = @"<!DOCTYPE html><html><head>
+    <style type='text/css'>
+                    DIV.coverColor  TEXTAREA        {               background-color: #C2A6BF !important;   }
+                    DIV.bloom-page.coverColor       {               background-color: #C2A6BF !important;   }
+    </style>
+</head><body><div>abc</div></body></html>";
+			var second = @"<!DOCTYPE html><html><head>
+    <style type='text/css'>
+                        DIV.coverColor  TEXTAREA        {               background-color: #C2A6BF !important;   }
+                        DIV.bloom-page.coverColor       {               background-color: #C2A6BF !important;   }
+    </style>
+</head><body><div>abc</div></body></html>";
+			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+		}
+
+		[Test]
+		public void MakeVersionCode_IgnoresPageIdChanges()
+		{
+			var template = @"<!DOCTYPE html><html><head></head><body><div class='bloom-page' id='{0}'>abc</div></body></html>";
+			var first = string.Format(template, "934245d2-94dd-4f40-8b53-279867d8e07b");
+			var second = string.Format(template, "d9a71953-6cf4-475a-8236-36d509ff8e1c");
+			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+		}
+
+		[Test]
+		public void MakeVersionCode_DoesNotIgnoreIdInContent()
+		{
+			var template = @"<!DOCTYPE html><html><head></head><body><div class='bloom-page'>id='{0}'</div></body></html>";
+			var first = string.Format(template, "934245d2-94dd-4f40-8b53-279867d8e07b");
+			var second = string.Format(template, "d9a71953-6cf4-475a-8236-36d509ff8e1c");
+			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.Not.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+		}
+	}
+}


### PR DESCRIPTION
Ignores insignificant whitespace changes and element id changes (as are made by BringBookUpToDate(), even when no editing has occurred)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1797)
<!-- Reviewable:end -->
