### PR TITLE
Extract xliff from pug and markdown files

### DIFF
--- a/DistFiles/IntegrityFailureAdvice-en.md
+++ b/DistFiles/IntegrityFailureAdvice-en.md
@@ -13,7 +13,7 @@ After you submit this report, we will contact you and help you work this out. In
 
 * Run the Bloom installer again, and see if it starts up OK this time. {i18n="integrity.todo.ideas.Reinstall"}
 
-* If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at **{installFolder}**. {i18n="integrity.todo.ideas.Antivirus"}
+* If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at **{{installFolder}}**. {i18n="integrity.todo.ideas.Antivirus"}
     * AVAST: [Instructions](http://www.getavast.net/support/managing-exceptions). {i18n="integrity.todo.ideas.AVAST"}
     * Norton Antivirus: [Instructions from Symantec](https://support.symantec.com/en_US/article.HOWTO80920.html). {i18n="integrity.todo.ideas.Norton"}
     * AVG: [Instructions from AVG](https://support.avg.com/SupportArticleView?l=en_US&urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning). {i18n="integrity.todo.ideas.AVG"}

--- a/DistFiles/leveledRTInfo/leveledReaderInfo-en.pug
+++ b/DistFiles/leveledRTInfo/leveledReaderInfo-en.pug
@@ -3,20 +3,20 @@ html
 	head
 		meta(charset='UTF-8')
 	body
-		h1(id='Vocabulary') Vocabulary
-		p At beginning levels, use simple words that are familiar to children. If it is possible in your language, use words with only one syllable. As children move up to higher levels, you can begin to use words with more syllables. You can begin to use less familiar words. Children should be able to guess the meaning of these less familiar words from the context of the surrounding words and sentences, as well as from the illustrations.
-		h1(id='Formatting') Formatting
-		p Beginner readers will benefit from a larger font with clear spacing between words. Having the words or sentences in the same location on each page is also helpful. As readers progress to higher levels, font size and spacing will decrease and sentences can appear in different locations on the page.
-		p To increase the font size, line-spacing, and word-spacing in Bloom, click in a text box and then on the grey "cog" icon in the lower left-hand corner. If you do this and then make a template book, books made with that template will also use those font settings.
-		h1(id='Predictability') Predictability
-		p
+		h1(id='Vocabulary' i18n='leveled.reader.vocabulary') Vocabulary
+		p(i18n='leveled.reader.start.simple') At beginning levels, use simple words that are familiar to children. If it is possible in your language, use words with only one syllable. As children move up to higher levels, you can begin to use words with more syllables. You can begin to use less familiar words. Children should be able to guess the meaning of these less familiar words from the context of the surrounding words and sentences, as well as from the illustrations.
+		h1(id='Formatting' i18n='leveled.reader.formatting') Formatting
+		p(i18n='leveled.reader.start.large') Beginner readers will benefit from a larger font with clear spacing between words. Having the words or sentences in the same location on each page is also helpful. As readers progress to higher levels, font size and spacing will decrease and sentences can appear in different locations on the page.
+		p(i18n='leveled.reader.increase.sizes') To increase the font size, line-spacing, and word-spacing in Bloom, click in a text box and then on the grey "cog" icon in the lower left-hand corner. If you do this and then make a template book, books made with that template will also use those font settings.
+		h1(id='Predictability' i18n='leveled.reader.predictability') Predictability
+		p(i18n='leveled.reader.repeat.patterns')
 			em Predictability
 			|  in a text means that the reader can guess what would come next. You can increase predictability by using repeated patterns. Here are some patterns you can use:
 		ul
-			li Repetition - repeating parts of the text, for example, using the same sentence with each page and just changing one word in the sentence
-			li Sequencing - a story with a known sequence such as the days of the week or that uses numbers in a pattern
-			li Building Sequence - a story with a pattern that is repeated and added to with each new page
-			li Rhyme - a story with a pattern or sequence that also includes rhyme. For example:
+			li(i18n='leveled.reader.repetition') Repetition - repeating parts of the text, for example, using the same sentence with each page and just changing one word in the sentence
+			li(i18n='leveled.reader.sequencing') Sequencing - a story with a known sequence such as the days of the week or that uses numbers in a pattern
+			li(i18n='leveled.reader.building.sequence') Building Sequence - a story with a pattern that is repeated and added to with each new page
+			li(i18n='leveled.reader.rhyme') Rhyme - a story with a pattern or sequence that also includes rhyme. For example:
 				blockquote.poetry
 					pre
 						| Brown Bear, Brown Bear, What do you see?
@@ -25,36 +25,36 @@ html
 						| I see a yellow duck looking at me.
 						| Yellow Duck, Yellow Duck, What do you see?
 					.author - Bill Martin, Jr. and Eric Carle
-		h1(id='IllustrationSupport') Illustration Support
-		p Illustrations provide support to the story. Illustrations relate to the story in different ways at different
+		h1(id='IllustrationSupport' i18n='leveled.reader.illustrations') Illustration Support
+		p(i18n='leveled.reader.illustrations.help') Illustrations provide support to the story. Illustrations relate to the story in different ways at different
 			= ' '
 			em levels
 			|  and for different types of readers (see below). Remember that in many cultures that don't have a lot of printed material around, complex pictures may be difficult to understand.
 		ul
-			li For
+			li(i18n='leveled.reader.illustrations.emergent.reader') For
 				= ' '
 				strong Emergent Readers
 				|  the pictures should closely match the storyline. The reader should be able to predict the story line just by looking at the pictures. The illustrations at this level should be simple.
-			li For
+			li(i18n='leveled.reader.illustrations.early.reader') For
 				= ' '
 				strong Early Readers
 				|  the pictures should offer some support to the story line. As the amount of text increases, the reader is less reliant on the pictures and gets more meaning from the text. The illustrations can be more complex.
-			li For
+			li(i18n='leveled.reader.fluent.reader') For
 				= ' '
 				strong Fluent Readers
 				|  the pictures should offer little or no support to the story line. The reader relies more on the text than the pictures for meaning. The illustrations can be even more complex.
-		h1(id='ChoiceOfTopic') Choice of Topic
-		p Books can be on many topics. When developing books for beginning readers, choose topics that are familiar to them. Readers will be eager to read and will read more if they are reading about things they find interesting and familiar. For more experienced readers, topics can include information that the reader is not already familiar with.
+		h1(id='ChoiceOfTopic' i18n='leveled.reader.topic.choice') Choice of Topic
+		p(i18n='leveled.reader.topic.choice.discussion') Books can be on many topics. When developing books for beginning readers, choose topics that are familiar to them. Readers will be eager to read and will read more if they are reading about things they find interesting and familiar. For more experienced readers, topics can include information that the reader is not already familiar with.
 		ul
-			li For
+			li(i18n='leveled.reader.topic.choice.emergent.reader') For
 				= ' '
 				strong Emergent Readers
 				|  the book should be concrete, should focus on one idea/theme, and should be familiar and easy to understand.
-			li For
+			li(i18n='leveled.reader.topic.choice.early.reader') For
 				= ' '
 				strong Early Readers
 				| , develop a story around a familiar concept but in greater depth.
-			li For
+			li(i18n='leveled.reader.topic.choice.fluent.reader') For
 				= ' '
 				strong Fluent Readers
 				|  the concepts can expand beyond what is familiar, be more varied, and be abstract.

--- a/DistFiles/localization/en/Big Book/ReadMe.xlf
+++ b/DistFiles/localization/en/Big Book/ReadMe.xlf
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
+  <file original="ReadMe-en.md" datatype="html" source-language="en">
+    <body>
+      <trans-unit id="bigbook.title">
+        <source xml:lang="en">About Big Books</source>
+        <note>ID: bigbook.title</note>
+      </trans-unit>
+      <trans-unit id="bigbook.use">
+        <source xml:lang="en">Big Books are designed for teachers to hold and read in front of a class. For more information, see this <g id="genid-1" ctype="x-html-a" html:href="http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf">PDF from Scholastic</g>. </source>
+        <note>ID: bigbook.use</note>
+      </trans-unit>
+      <trans-unit id="bigbook.printing">
+        <source xml:lang="en">Printing a Big Book</source>
+        <note>ID: bigbook.printing</note>
+      </trans-unit>
+      <trans-unit id="bigbook.printing.enlargeA4">
+        <source xml:lang="en">To make things more manageable, this template is set at A4 Landscape, with large fonts.
+You can easily produce books that are A3 (twice as large).
+Just take your A4 PDF to a printer and ask them to enlarge it to A3. </source>
+        <note>ID: bigbook.printing.enlargeA4</note>
+      </trans-unit>
+      <trans-unit id="bigbook.limits">
+        <source xml:lang="en">Limitations of this version</source>
+        <note>ID: bigbook.limits</note>
+      </trans-unit>
+      <trans-unit id="bigbook.limits.smallscreen">
+        <source xml:lang="en">If you are using a small screen, it can be hard to read the credits page. Try using CTRL+mouse wheel to zoom in to the page so you can edit it. </source>
+        <note>ID: bigbook.limits.smallscreen</note>
+      </trans-unit>
+      <trans-unit id="bigbook.limits.Englishtemplate">
+        <source xml:lang="en">This version includes an "Instructions for Teachers" page that is already filled out, in English.
+If you would like to have instructions in a different language, you can delete that text and type in your own.
+If you send us that text, we can include it in a future version of the template. </source>
+        <note>ID: bigbook.limits.Englishtemplate</note>
+      </trans-unit>
+      <trans-unit id="bigbook.feedback">
+        <source xml:lang="en">Feedback</source>
+        <note>ID: bigbook.feedback</note>
+      </trans-unit>
+      <trans-unit id="bigbook.feedbackvoting">
+        <source xml:lang="en">Please give and vote on <g id="genid-2" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g> </source>
+        <note>ID: bigbook.feedbackvoting</note>
+      </trans-unit>
+      <trans-unit id="bigbook.reportsbugs">
+        <source xml:lang="en">Please report problems to <g id="genid-3" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g>. </source>
+        <note>ID: bigbook.reportsbugs</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/DistFiles/localization/en/Decodable Reader/ReadMe.xlf
+++ b/DistFiles/localization/en/Decodable Reader/ReadMe.xlf
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
+  <file original="ReadMe-en.md" datatype="html" source-language="en">
+    <body>
+      <trans-unit id="decodable.definition">
+        <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Decodable Reader</g> is a book that carefully limits the letters and words used so that it fits what a new reader is ready to read. Typically a language may have 5 - 10 <g id="genid-2" ctype="x-html-em">decodable stages</g> through which learners progress. </source>
+        <note>ID: decodable.definition</note>
+      </trans-unit>
+      <trans-unit id="decodable.stages">
+        <source xml:lang="en">Bloom helps you to define this sequence of <g id="genid-3" ctype="x-html-em">stages</g> that readers work through. Each book you create will be targeted at one of those stages, and Bloom helps you to make sure that your book is <g id="genid-4" ctype="x-html-em">decodable</g> (figure out-able) by learners at that <g id="genid-5" ctype="x-html-em">stage</g>. </source>
+        <note>ID: decodable.stages</note>
+      </trans-unit>
+      <trans-unit id="decodable.templates">
+        <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-6" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist. </source>
+        <note>ID: decodable.templates</note>
+      </trans-unit>
+      <trans-unit id="decodable.learn">
+        <source xml:lang="en">To learn about using Decodable Readers in Bloom, you can: </source>
+        <note>ID: decodable.learn</note>
+      </trans-unit>
+      <trans-unit id="decodable.learn.videos">
+        <source xml:lang="en">Watch <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
+        <note>ID: decodable.learn.videos</note>
+      </trans-unit>
+      <trans-unit id="decodable.learn.helpindex">
+        <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Decodable Readers".</source>
+        <note>ID: decodable.learn.helpindex</note>
+      </trans-unit>
+      <trans-unit id="decodable.learn.helpmenu">
+        <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
+        <note>ID: decodable.learn.helpmenu</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/DistFiles/localization/en/IntegrityFailureAdvice.xlf
+++ b/DistFiles/localization/en/IntegrityFailureAdvice.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
+  <file original="IntegrityFailureAdvice-en.md" datatype="html" source-language="en">
+    <body>
+      <trans-unit id="integrity.title">
+        <source xml:lang="en">Bloom cannot find some of its own files, and cannot continue</source>
+        <note>ID: integrity.title</note>
+      </trans-unit>
+      <trans-unit id="integrity.causes">
+        <source xml:lang="en">Possible Causes</source>
+        <note>ID: integrity.causes</note>
+      </trans-unit>
+      <trans-unit id="integrity.causes.1">
+        <source xml:lang="en">Your antivirus may have "quarantined" one or more Bloom files. </source>
+        <note>ID: integrity.causes.1</note>
+      </trans-unit>
+      <trans-unit id="integrity.causes.2">
+        <source xml:lang="en">Your computer administrator may have your computer "locked down" to prevent bad things, but in such a way that Bloom could not place these files where they belong.  </source>
+        <note>ID: integrity.causes.2</note>
+      </trans-unit>
+      <trans-unit id="integrity.todo">
+        <source xml:lang="en">What To Do</source>
+        <note>ID: integrity.todo</note>
+      </trans-unit>
+      <trans-unit id="integrity.todo.ideas">
+        <source xml:lang="en">After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas: </source>
+        <note>ID: integrity.todo.ideas</note>
+      </trans-unit>
+      <trans-unit id="integrity.todo.ideas.Reinstall">
+        <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time. </source>
+        <note>ID: integrity.todo.ideas.Reinstall</note>
+      </trans-unit>
+      <trans-unit id="integrity.todo.ideas.Antivirus">
+        <source xml:lang="en">If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>. </source>
+        <note>ID: integrity.todo.ideas.Antivirus</note>
+      </trans-unit>
+      <trans-unit id="integrity.todo.ideas.AVAST">
+        <source xml:lang="en">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">Instructions</g>. </source>
+        <note>ID: integrity.todo.ideas.AVAST</note>
+      </trans-unit>
+      <trans-unit id="integrity.todo.ideas.Norton">
+        <source xml:lang="en">Norton Antivirus: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">Instructions from Symantec</g>. </source>
+        <note>ID: integrity.todo.ideas.Norton</note>
+      </trans-unit>
+      <trans-unit id="integrity.todo.ideas.AVG">
+        <source xml:lang="en">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">Instructions from AVG</g>. </source>
+        <note>ID: integrity.todo.ideas.AVG</note>
+      </trans-unit>
+      <trans-unit id="integrity.todo.ideas.Others">
+        <source xml:lang="en">Others: Google for "whitelist directory name-of-your-antivirus" </source>
+        <note>ID: integrity.todo.ideas.Others</note>
+      </trans-unit>
+      <trans-unit id="integrity.todo.ideas.Restart">
+        <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time. </source>
+        <note>ID: integrity.todo.ideas.Restart</note>
+      </trans-unit>
+      <trans-unit id="integrity.todo.ideas.Retrieve">
+        <source xml:lang="en">You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">this image</g>. </source>
+        <note>ID: integrity.todo.ideas.Retrieve</note>
+      </trans-unit>
+      <trans-unit id="integrity.missing">
+        <source xml:lang="en">Missing Files</source>
+        <note>ID: integrity.missing</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/DistFiles/localization/en/Leveled Reader/Readme.xlf
+++ b/DistFiles/localization/en/Leveled Reader/Readme.xlf
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
+  <file original="ReadMe-en.md" datatype="html" source-language="en">
+    <body>
+      <trans-unit id="leveled.definition">
+        <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Leveled Reader</g> is a book that is written specifically for a learner who is at a certain level of reading development. Levels define targets for word length, sentence length, etc. They also determine appropriate formatting, vocabulary, illustration support, and topic. </source>
+        <note>ID: leveled.definition</note>
+      </trans-unit>
+      <trans-unit id="leveled.levels">
+        <source xml:lang="en">After you have defined a sequence of <g id="genid-2" ctype="x-html-em">levels</g>, you can assign a level to books you create either with this template or the "Decodable Reader Template". As you type into the book, Bloom will help you keep the level in mind and point out when you exceed the limits of the level. </source>
+        <note>ID: leveled.levels</note>
+      </trans-unit>
+      <trans-unit id="leveled.templates">
+        <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-3" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist. </source>
+        <note>ID: leveled.templates</note>
+      </trans-unit>
+      <trans-unit id="leveled.learn">
+        <source xml:lang="en">To learn about using Leveled Readers in Bloom, you can: </source>
+        <note>ID: leveled.learn</note>
+      </trans-unit>
+      <trans-unit id="leveled.learn.videos">
+        <source xml:lang="en">Watch <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
+        <note>ID: leveled.learn.videos</note>
+      </trans-unit>
+      <trans-unit id="leveled.learn.helpindex">
+        <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Leveled Readers".</source>
+        <note>ID: leveled.learn.helpindex</note>
+      </trans-unit>
+      <trans-unit id="leveled.learn.helpmenu">
+        <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
+        <note>ID: leveled.learn.helpmenu</note>
+      </trans-unit>
+      <trans-unit id="leveled.vs.decodable">
+        <source xml:lang="en">Relationship to Decodable Readers</source>
+        <note>ID: leveled.vs.decodable</note>
+      </trans-unit>
+      <trans-unit id="leveled.and.decodable">
+        <source xml:lang="en">So how do leveled reader <g id="genid-5" ctype="x-html-em">levels</g> fit in decodable reader <g id="genid-6" ctype="x-html-em">stages</g>? The two concepts are complementary, and Bloom allows you to set both a <g id="genid-7" ctype="x-html-em">decodable stage</g> and a <g id="genid-8" ctype="x-html-em">leveled reader level</g> for a book you are writing. Typically books at level 1 and possibly level 2 will also need to be written with <g id="genid-9" ctype="x-html-em">decodability stages</g> in mind. Books at the first level or two will also need to be careful about being <g id="genid-10" ctype="x-html-em">decodable</g> (i.e. using letters the reader has learned). So a sequence of books might look like this: </source>
+        <note>ID: leveled.and.decodable</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.level">
+        <source xml:lang="en">Leveled Reader Level</source>
+        <note>ID: leveled.reader.level</note>
+      </trans-unit>
+      <trans-unit id="decodable.stage">
+        <source xml:lang="en">Decodable Stage</source>
+        <note>ID: decodable.stage</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/DistFiles/localization/en/MissingLameModule.xlf
+++ b/DistFiles/localization/en/MissingLameModule.xlf
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
+  <file original="MissingLameModule-en.html" datatype="html" source-language="en">
+    <body>
+      <trans-unit id="missing.lame.please.install">
+        <source xml:lang="en">Please Install LAME</source>
+        <note>ID: missing.lame.please.install</note>
+      </trans-unit>
+      <trans-unit id="missing.lame.bloom.needs.lame">
+        <source xml:lang="en">This book has audio recordings. Bloom can use these to make a "Talking Book" e-book. However, Bloom needs a program called "LAME for Audacity" in order to create the mp3 files that the book will use. Setting it up is easy. First download and run <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>. Next, restart Bloom.
+      </source>
+        <note>ID: missing.lame.bloom.needs.lame</note>
+      </trans-unit>
+      <trans-unit id="missing.lame.audio.optional">
+        <source xml:lang="en">If you prefer to go ahead and publish your book without audio, click <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">here</g>.
+      </source>
+        <note>ID: missing.lame.audio.optional</note>
+      </trans-unit>
+      <trans-unit id="missing.lame.legalities">
+        <source xml:lang="en">Legal Considerations</source>
+        <note>ID: missing.lame.legalities</note>
+      </trans-unit>
+      <trans-unit id="missing.lame.old.patent.issues">
+        <source xml:lang="en">Our understanding is that in a few countries (perhaps only in the USA, and then only until 2017), there are patents covering the creation of mp3's. In correspondence with the patent holder's representative, we were told:
+        <g id="genid-3" ctype="x-html-blockquote">You may need a license if there is any type of subscription, content, service, per unit or itemized revenue for the distribution of mp3, or if there is any advertising present during the presentation of any mp3 content, either on a webpage with any links to your Talking Books, or as part of a messaging system, and this total mp3-associated mp3 revenue exceeds USD $100,000 per year.</g>Therefore, if you are just making Talking Books and giving them away, then only the distributor (e.g. BloomLibrary.org) needs to be concerned about licensing this technology (and since we don't make money from BloomLibrary.org, we don't have to worry, either.) For more information, see <g id="genid-4" ctype="x-html-a" html:href="http://www.mp3licensing.com/">mp3licensing.com</g>.
+      </source>
+        <note>ID: missing.lame.old.patent.issues</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/DistFiles/localization/en/Picture Dictionary/ReadMe.xlf
+++ b/DistFiles/localization/en/Picture Dictionary/ReadMe.xlf
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
+  <file original="ReadMe-en.md" datatype="html" source-language="en">
+    <body>
+      <trans-unit id="picture.dictionary">
+        <source xml:lang="en">About the Picture Dictionary Template</source>
+        <note>ID: picture.dictionary</note>
+      </trans-unit>
+      <trans-unit id="picture.dictionary.use">
+        <source xml:lang="en">Use this template to make a picture dictionary that is monolingual, bilingual, or trilingual. </source>
+        <note>ID: picture.dictionary.use</note>
+      </trans-unit>
+      <trans-unit id="picture.dictionary.limits">
+        <source xml:lang="en">Limitations of this version</source>
+        <note>ID: picture.dictionary.limits</note>
+      </trans-unit>
+      <trans-unit id="picture.dictionary.stillexperimental">
+        <source xml:lang="en">This book is currently marked "experimental" because we know of several problems in layout and convenience. </source>
+        <note>ID: picture.dictionary.stillexperimental</note>
+      </trans-unit>
+      <trans-unit id="picture.dictionary.feedback">
+        <source xml:lang="en">Feedback</source>
+        <note>ID: picture.dictionary.feedback</note>
+      </trans-unit>
+      <trans-unit id="picture.dictionary.feedbackvoting">
+        <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g> </source>
+        <note>ID: picture.dictionary.feedbackvoting</note>
+      </trans-unit>
+      <trans-unit id="picture.dictionary.reportbugs">
+        <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g>. </source>
+        <note>ID: picture.dictionary.reportbugs</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/DistFiles/localization/en/Template Starter/ReadMe.xlf
+++ b/DistFiles/localization/en/Template Starter/ReadMe.xlf
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
+  <file original="ReadMe-en.md" datatype="html" source-language="en">
+    <body>
+      <trans-unit id="template.starter">
+        <source xml:lang="en">How to use the Template Starter</source>
+        <note>ID: template.starter</note>
+      </trans-unit>
+      <trans-unit id="template.starter.firstusage">
+        <source xml:lang="en">This special template lets you make your own templates. A template provides a set of related page layouts that an author can choose from in writing an original book. Usually the text blocks and picture blocks on template pages will be empty, ready for an author to fill in. Sometimes there may be standard text or pictures that should be on every copy of the page.
+There are two ways people can use your template. The first way is to start new books. For example, imagine student books that have one page for each school day of the week. You could make a template with 5 pages, each with places to type in text and choose pictures. Curriculum authors could select your template and make a new book, one for each week<g id="genid-1" ctype="x-html-sup"><g id="genid-2" ctype="x-html-a" html:href="#note1">1</g></g>. </source>
+        <note>ID: template.starter.firstusage</note>
+      </trans-unit>
+      <trans-unit id="template.starter.secondusage">
+        <source xml:lang="en">The second way people can use templates is as source of new pages, regardless of how they started the book. For example, in some places, each book requires a page as part of a government approval process. You might make a template containing that page and give it to others in your country. Then, when people translate a shellbook, they go to the end of the book and click “Add Page”. The page you made will appear in their list of choices. Some other ideas for templates are alphabet charts, glossaries, and instructions on how to use the book in a classroom. <g id="genid-3" ctype="x-html-sup"><g id="genid-4" ctype="x-html-a" html:href="#note1">2</g></g> </source>
+        <note>ID: template.starter.secondusage</note>
+      </trans-unit>
+      <trans-unit id="template.starter.waystohelp">
+        <source xml:lang="en">Making templates is just like making any other custom book; all the same controls are available for making and customizing pages. But since you will probably be sharing with other people, there are a number of things you can do to help users of your template: </source>
+        <note>ID: template.starter.waystohelp</note>
+      </trans-unit>
+      <trans-unit id="template.starter.labelpages">
+        <source xml:lang="en">Label Your Pages</source>
+        <note>ID: template.starter.labelpages</note>
+      </trans-unit>
+      <trans-unit id="template.starter.labeleachpage">
+        <source xml:lang="en">When you add pages to your template, make sure to give each one useful label<g id="genid-5" ctype="x-html-sup"><g id="genid-6" ctype="x-html-a" html:href="#note2">3</g>,<g id="genid-7" ctype="x-html-a" html:href="@note3">4</g></g>: </source>
+        <note>ID: template.starter.labeleachpage</note>
+      </trans-unit>
+      <trans-unit id="template.starter.labelexample">
+        <source xml:lang="en">![custom label](ReadMeImages/customLabel.png)</source>
+        <note>ID: template.starter.labelexample</note>
+      </trans-unit>
+      <trans-unit id="template.starter.thumbnails">
+        <source xml:lang="en">Check Your Thumbnails</source>
+        <note>ID: template.starter.thumbnails</note>
+      </trans-unit>
+      <trans-unit id="template.starter.thumbnails.onlyonce">
+        <source xml:lang="en">To speed things up, Bloom only makes this thumbnail once, and stores it in the "template" subdirectory of your template: </source>
+        <note>ID: template.starter.thumbnails.onlyonce</note>
+      </trans-unit>
+      <trans-unit id="template.starter.thumbnails.update">
+        <source xml:lang="en">If you later make a change to the page, the thumbnail will be out of date. To fix that, click the "Add Page" button, and Bloom will regenerate those thumbnails. If the automatically generated thumbnail doesn't convey the purpose of the page, you can make your own. Just make sure to mark the file as "Read Only" so that Bloom doesn't overwrite it. You can also make your thumbnails as svgs, if you like (that's what we do for templates we ship with Bloom).  In any case, make sure to click "Add Page" at least once before distributing your template, so that all the thumbnails are already generated. </source>
+        <note>ID: template.starter.thumbnails.update</note>
+      </trans-unit>
+      <trans-unit id="template.starter.document">
+        <source xml:lang="en">Document Your Template</source>
+        <note>ID: template.starter.document</note>
+      </trans-unit>
+      <trans-unit id="template.starter.describeyours">
+        <source xml:lang="en">Also consider adding a description of your template, like the one you are reading now. To do this, put a text file named ReadMe-en.md in your template's folder. This file should follow the <g id="genid-8" ctype="x-html-a" html:href="http://spec.commonmark.org/dingus/">markdown standard</g>. To provide your instructions in other languages, make versions of that file that change the "en" to each language's two letter code. For example ReadMe-fr.md would be shown when Bloom is set to show labels in French. You can also include screenshots, like we have in this document. Place any images you use in a folder named "ReadMeImages", so that images are referenced like this: </source>
+        <note>ID: template.starter.describeyours</note>
+      </trans-unit>
+      <trans-unit id="template.starter.thumbnailsshown">
+        <source xml:lang="en">When the Add Page dialog box shows your template pages, it will show a thumbnail: </source>
+        <note>ID: template.starter.thumbnailsshown</note>
+      </trans-unit>
+      <trans-unit id="template.starter.share">
+        <source xml:lang="en">Share Your Template</source>
+        <note>ID: template.starter.share</note>
+      </trans-unit>
+      <trans-unit id="template.starter.share.publish">
+        <source xml:lang="en">Remember that Bloom is about planting seeds, about sharing. So plan to share your template on the BloomLibrary for people around the world to find. This takes just a few clicks in the Publish Tab. </source>
+        <note>ID: template.starter.share.publish</note>
+      </trans-unit>
+      <trans-unit id="template.starter.share.bloompack">
+        <source xml:lang="en">For local colleagues, an easy way to distribute your template is via a Bloom Pack. In the collections tab, right-click on your template's thumbnail. Choose 'Make Bloom Pack'. Save that somewhere, for example to a USB Key. Then take it to another computer, double click on the file you made, and your template will be added to the "Sources for New Books" on that computer. </source>
+        <note>ID: template.starter.share.bloompack</note>
+      </trans-unit>
+      <trans-unit id="template.starter.notes">
+        <source xml:lang="en">Notes</source>
+        <note>ID: template.starter.notes</note>
+      </trans-unit>
+      <trans-unit id="template.starter.nothingautomatic">
+        <source xml:lang="en">
+          <g id="genid-9" ctype="x-html-a" html:name="note1">1</g>: These books could later be combined using the forthcoming Folio feature. Note that Bloom 3.9 does not yet give you a way to indicate that a page should be automatically included in new books; the author will have to add each one from the Add Page dialog. </source>
+        <note>ID: template.starter.nothingautomatic</note>
+      </trans-unit>
+      <trans-unit id="template.starter.nametonotaddpage">
+        <source xml:lang="en">
+          <g id="genid-10" ctype="x-html-a" html:name="note2">2</g>: If you don't want the pages in your template to show up in the Add Page dialog, you can indicate this to Bloom by creating a file in the book's template folder called NotForAddPage.txt. </source>
+        <note>ID: template.starter.nametonotaddpage</note>
+      </trans-unit>
+      <trans-unit id="template.starter.labelsnottranslatable">
+        <source xml:lang="en">
+          <g id="genid-11" ctype="x-html-a" html:name="note3">3</g>: People will not be able to translate your labels and descriptions into other national languages. If this is a problem, please contact the Bloom team. </source>
+        <note>ID: template.starter.labelsnottranslatable</note>
+      </trans-unit>
+      <trans-unit id="template.starter.editrawhtml">
+        <source xml:lang="en">
+          <g id="genid-12" ctype="x-html-a" html:name="note4">4</g>: If you want to the Add Page screen to also provide a short description of the page, you'll need to quit Bloom and edit the template's html in Notepad, like this: <x id="genid-13" ctype="image" html:src="ReadMeImages/pageDescription.png" html:alt="" /> </source>
+        <note>ID: template.starter.editrawhtml</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/DistFiles/localization/en/TrainingVideos.xlf
+++ b/DistFiles/localization/en/TrainingVideos.xlf
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
+  <file original="TrainingVideos-en.md" datatype="html" source-language="en">
+    <body>
+      <trans-unit id="training.videos">
+        <source xml:lang="en">Bloom Training Videos</source>
+        <note>ID: training.videos</note>
+      </trans-unit>
+      <trans-unit id="training.videos.watch">
+        <source xml:lang="en">If you are connected to the internet now, you can watch videos in your web browser: </source>
+        <note>ID: training.videos.watch</note>
+      </trans-unit>
+      <trans-unit id="training.videos.all">
+        <source xml:lang="en">
+          <g id="genid-1" ctype="x-html-a" html:href="http://tiny.cc/bloomVimeo">All videos</g>
+        </source>
+        <note>ID: training.videos.all</note>
+      </trans-unit>
+      <trans-unit id="training.videos.intro">
+        <source xml:lang="en">Introductory Videos</source>
+        <note>ID: training.videos.intro</note>
+      </trans-unit>
+      <trans-unit id="training.videos.whofor">
+        <source xml:lang="en">
+          <g id="genid-2" ctype="x-html-a" html:href="https://vimeo.com/114043219">Bloom: Who is it for</g>
+        </source>
+        <note>ID: training.videos.whofor</note>
+      </trans-unit>
+      <trans-unit id="training.videos.templates">
+        <source xml:lang="en">
+          <g id="genid-3" ctype="x-html-a" html:href="https://vimeo.com/114024308">Understanding Templates and Shell Books</g>
+        </source>
+        <note>ID: training.videos.templates</note>
+      </trans-unit>
+      <trans-unit id="training.videos.basicbook">
+        <source xml:lang="en">
+          <g id="genid-4" ctype="x-html-a" html:href="https://vimeo.com/112825489">Using the Basic Book template</g>
+        </source>
+        <note>ID: training.videos.basicbook</note>
+      </trans-unit>
+      <trans-unit id="training.videos.readers">
+        <source xml:lang="en">
+          <g id="genid-5" ctype="x-html-a" html:href="http://tiny.cc/usingBloomReaderTemplates">Using Decodable and Leveled Reader Templates (several videos)</g>
+        </source>
+        <note>ID: training.videos.readers</note>
+      </trans-unit>
+      <trans-unit id="training.videos.advanced">
+        <source xml:lang="en">Advanced Topics</source>
+        <note>ID: training.videos.advanced</note>
+      </trans-unit>
+      <trans-unit id="training.videos.formatting">
+        <source xml:lang="en">
+          <g id="genid-6" ctype="x-html-a" html:href="https://vimeo.com/117820891">Changing the format of text</g>
+        </source>
+        <note>ID: training.videos.formatting</note>
+      </trans-unit>
+      <trans-unit id="training.videos.custompage">
+        <source xml:lang="en">
+          <g id="genid-7" ctype="x-html-a" html:href="https://vimeo.com/116868148">Using the Custom Page template</g>
+        </source>
+        <note>ID: training.videos.custompage</note>
+      </trans-unit>
+      <trans-unit id="training.videos.specialcharacters">
+        <source xml:lang="en">
+          <g id="genid-8" ctype="x-html-a" html:href="https://vimeo.com/117927599">Inserting special characters</g>
+        </source>
+        <note>ID: training.videos.specialcharacters</note>
+      </trans-unit>
+      <trans-unit id="training.videos.readertemplates">
+        <source xml:lang="en">
+          <g id="genid-9" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">Making a set of Decodable and Leveled Reader Templates (several videos)</g>
+        </source>
+        <note>ID: training.videos.readertemplates</note>
+      </trans-unit>
+      <trans-unit id="training.videos.offline">
+        <source xml:lang="en">Offline Viewing</source>
+        <note>ID: training.videos.offline</note>
+      </trans-unit>
+      <trans-unit id="training.videos.download">
+        <source xml:lang="en">If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer: </source>
+        <note>ID: training.videos.download</note>
+      </trans-unit>
+      <trans-unit id="training.videos.hires">
+        <source xml:lang="en">
+          <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">High Resolution</g> (Large files)</source>
+        <note>ID: training.videos.hires</note>
+      </trans-unit>
+      <trans-unit id="training.videos.lores">
+        <source xml:lang="en">
+          <g id="genid-11" ctype="x-html-a" html:href="http://tiny.cc/bloomSDVideos">Low Resolution</g> (Smaller files)</source>
+        <note>ID: training.videos.lores</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/DistFiles/localization/en/Wall Calendar/ReadMe.xlf
+++ b/DistFiles/localization/en/Wall Calendar/ReadMe.xlf
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
+  <file original="ReadMe-en.md" datatype="html" source-language="en">
+    <body>
+      <trans-unit id="wall.calendar">
+        <source xml:lang="en">About the Wall Calendar Template</source>
+        <note>ID: wall.calendar</note>
+      </trans-unit>
+      <trans-unit id="wall.calendar.use">
+        <source xml:lang="en">Using this template, you can make an A5-size 12 month calendar, with a picture and quotation on the top page, and days on the bottom. The calendar will use the names of months and days in your language. </source>
+        <note>ID: wall.calendar.use</note>
+      </trans-unit>
+      <trans-unit id="wall.calendar.limits">
+        <source xml:lang="en">Limitations of this version</source>
+        <note>ID: wall.calendar.limits</note>
+      </trans-unit>
+      <trans-unit id="wall.calendar.noshells">
+        <source xml:lang="en">Currently, you cannot make a "shell" for other languages to use. </source>
+        <note>ID: wall.calendar.noshells</note>
+      </trans-unit>
+      <trans-unit id="wall.calendar.credits">
+        <source xml:lang="en">Credits</source>
+        <note>ID: wall.calendar.credits</note>
+      </trans-unit>
+      <trans-unit id="wall.calendar.thanks">
+        <source xml:lang="en">Thanks to Bruce Cox (SIL Cameroon) for getting this template started. </source>
+        <note>ID: wall.calendar.thanks</note>
+      </trans-unit>
+      <trans-unit id="wall.calendar.feedback">
+        <source xml:lang="en">Feedback</source>
+        <note>ID: wall.calendar.feedback</note>
+      </trans-unit>
+      <trans-unit id="wall.calendar.feedbackvoting">
+        <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g> </source>
+        <note>ID: wall.calendar.feedbackvoting</note>
+      </trans-unit>
+      <trans-unit id="wall.calendar.reportbugs">
+        <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g>. </source>
+        <note>ID: wall.calendar.reportbugs</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/DistFiles/localization/en/bloomEpubPreview.xlf
+++ b/DistFiles/localization/en/bloomEpubPreview.xlf
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
+  <file original="bloomEpubPreview-en.html" datatype="html" source-language="en">
+    <body>
+      <trans-unit id="epubpreview.describe">
+        <source xml:lang="en">This is an <g id="genid-1" ctype="x-html-a" html:href="https://en.wikipedia.org/wiki/ePUB">ePUB</g> (e-book) version of your book. <g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">It contains audio, so that new readers can listen as they read.</g>
+      </source>
+        <note>ID: epubpreview.describe</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.recording.butnotalk">
+        <source xml:lang="en">This book has some recordings, but this audio is not included in the ePUB.</source>
+        <note>ID: epubpreview.recording.butnotalk</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.preview">
+        <source xml:lang="en">Preview</source>
+        <note>ID: epubpreview.preview</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.resizing">
+        <source xml:lang="en">You can resize the preview by dragging the lower right corner of this simulated device. See how your book will look on screens of various sizes.</source>
+        <note>ID: epubpreview.resizing</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.readium">
+        <source xml:lang="en">This page uses the <g id="genid-3" ctype="x-html-a" html:href="http://readium.org/">Readium</g> ePUB reader. Books will likely look different on different readers.
+      </source>
+        <note>ID: epubpreview.readium</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.talkingbookpreview">
+        <source xml:lang="en">The preview here cannot yet play Talking Books. You can listen to it using Adobe's Free <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html">Digital Editions</g> e-book reader.
+      </source>
+        <note>ID: epubpreview.talkingbookpreview</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.ontodevice">
+        <source xml:lang="en">Getting this book onto your Device</source>
+        <note>ID: epubpreview.ontodevice</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.usingdropbox">
+        <source xml:lang="en">A handy way to get books to your phone is to set up Dropbox or similar service on both your computer and your phone/tablet. Just click Save ePUB and then choose your Dropbox folder. On your phone, open the Dropbox app and select your book. If you are using a laptop, you can also try the free <g id="genid-5" ctype="x-html-a" html:href="http://www.ushareit.com/">ShareIt</g> program to send files from your laptop to a phone or tablet.
+      </source>
+        <note>ID: epubpreview.usingdropbox</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.recommended.reader">
+        <source xml:lang="en">Recommended Reader</source>
+        <note>ID: epubpreview.recommended.reader</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.gitden.okay">
+        <source xml:lang="en">Our testing has shown <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Gitden Reader</g> to be a good choice for Android and IOS (IPhone &amp; IPad) devices.
+      </source>
+        <note>ID: epubpreview.gitden.okay</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.gitden.limits">
+        <source xml:lang="en">To listen to this Talking Book using Gitden on a phone or tablet, you will need to disable Gitden's "Text To Speech" feature. Then it will show you the audio controls.</source>
+        <note>ID: epubpreview.gitden.limits</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.make.it.talk">
+        <source xml:lang="en">Make it Talk</source>
+        <note>ID: epubpreview.make.it.talk</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.talking.book.tool">
+        <source xml:lang="en">If you want to make a "Talking Book" that new readers can read-along with, use Bloom's <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">Talking Book Tool</g> to add voice recordings.
+      </source>
+        <note>ID: epubpreview.talking.book.tool</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.write.us">
+        <source xml:lang="en">Write to us!</source>
+        <note>ID: epubpreview.write.us</note>
+      </trans-unit>
+      <trans-unit id="epubpreview.use.help.report">
+        <source xml:lang="en">Are you interested in distributing Bloom books for use on phones and other ebook readers? Is there something you would need us to do before it is useful for you? Please use the Help:Report A Problem command to send us feedback. Thanks!</source>
+        <note>ID: epubpreview.use.help.report</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/DistFiles/localization/en/leveledReaderInfo.xlf
+++ b/DistFiles/localization/en/leveledReaderInfo.xlf
@@ -1,0 +1,108 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
+  <file original="leveledReaderInfo-en.html" datatype="html" source-language="en">
+    <body>
+      <trans-unit id="leveled.reader.vocabulary">
+        <source xml:lang="en">Vocabulary</source>
+        <note>ID: leveled.reader.vocabulary</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.start.simple">
+        <source xml:lang="en">At beginning levels, use simple words that are familiar to children. If it is possible in your language, use words with only one syllable. As children move up to higher levels, you can begin to use words with more syllables. You can begin to use less familiar words. Children should be able to guess the meaning of these less familiar words from the context of the surrounding words and sentences, as well as from the illustrations.</source>
+        <note>ID: leveled.reader.start.simple</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.formatting">
+        <source xml:lang="en">Formatting</source>
+        <note>ID: leveled.reader.formatting</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.start.large">
+        <source xml:lang="en">Beginner readers will benefit from a larger font with clear spacing between words. Having the words or sentences in the same location on each page is also helpful. As readers progress to higher levels, font size and spacing will decrease and sentences can appear in different locations on the page.</source>
+        <note>ID: leveled.reader.start.large</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.increase.sizes">
+        <source xml:lang="en">To increase the font size, line-spacing, and word-spacing in Bloom, click in a text box and then on the grey "cog" icon in the lower left-hand corner. If you do this and then make a template book, books made with that template will also use those font settings.</source>
+        <note>ID: leveled.reader.increase.sizes</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.predictability">
+        <source xml:lang="en">Predictability</source>
+        <note>ID: leveled.reader.predictability</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.repeat.patterns">
+        <source xml:lang="en">
+          <g id="genid-1" ctype="x-html-em">Predictability</g> in a text means that the reader can guess what would come next. You can increase predictability by using repeated patterns. Here are some patterns you can use:</source>
+        <note>ID: leveled.reader.repeat.patterns</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.repetition">
+        <source xml:lang="en">Repetition - repeating parts of the text, for example, using the same sentence with each page and just changing one word in the sentence</source>
+        <note>ID: leveled.reader.repetition</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.sequencing">
+        <source xml:lang="en">Sequencing - a story with a known sequence such as the days of the week or that uses numbers in a pattern</source>
+        <note>ID: leveled.reader.sequencing</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.building.sequence">
+        <source xml:lang="en">Building Sequence - a story with a pattern that is repeated and added to with each new page</source>
+        <note>ID: leveled.reader.building.sequence</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.rhyme">
+        <source xml:lang="en">Rhyme - a story with a pattern or sequence that also includes rhyme. For example:
+        <g id="genid-2" ctype="x-html-blockquote" html:class="poetry">
+          <g id="genid-3" ctype="x-html-pre">Brown Bear, Brown Bear, What do you see?
+I see a red bird looking at me.
+Red Bird, Red Bird, What do you see?
+I see a yellow duck looking at me.
+Yellow Duck, Yellow Duck, What do you see?</g>
+          <g id="genid-4" ctype="x-html-div" html:class="author">- Bill Martin, Jr. and Eric Carle</g>
+        </g>
+      </source>
+        <note>ID: leveled.reader.rhyme</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.illustrations">
+        <source xml:lang="en">Illustration Support</source>
+        <note>ID: leveled.reader.illustrations</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.illustrations.help">
+        <source xml:lang="en">Illustrations provide support to the story. Illustrations relate to the story in different ways at different <g id="genid-5" ctype="x-html-em">levels</g> and for different types of readers (see below). Remember that in many cultures that don't have a lot of printed material around, complex pictures may be difficult to understand.
+    </source>
+        <note>ID: leveled.reader.illustrations.help</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.illustrations.emergent.reader">
+        <source xml:lang="en">For <g id="genid-6" ctype="x-html-strong">Emergent Readers</g> the pictures should closely match the storyline. The reader should be able to predict the story line just by looking at the pictures. The illustrations at this level should be simple.
+      </source>
+        <note>ID: leveled.reader.illustrations.emergent.reader</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.illustrations.early.reader">
+        <source xml:lang="en">For <g id="genid-7" ctype="x-html-strong">Early Readers</g> the pictures should offer some support to the story line. As the amount of text increases, the reader is less reliant on the pictures and gets more meaning from the text. The illustrations can be more complex.
+      </source>
+        <note>ID: leveled.reader.illustrations.early.reader</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.fluent.reader">
+        <source xml:lang="en">For <g id="genid-8" ctype="x-html-strong">Fluent Readers</g> the pictures should offer little or no support to the story line. The reader relies more on the text than the pictures for meaning. The illustrations can be even more complex.
+      </source>
+        <note>ID: leveled.reader.fluent.reader</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.topic.choice">
+        <source xml:lang="en">Choice of Topic</source>
+        <note>ID: leveled.reader.topic.choice</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.topic.choice.discussion">
+        <source xml:lang="en">Books can be on many topics. When developing books for beginning readers, choose topics that are familiar to them. Readers will be eager to read and will read more if they are reading about things they find interesting and familiar. For more experienced readers, topics can include information that the reader is not already familiar with.</source>
+        <note>ID: leveled.reader.topic.choice.discussion</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.topic.choice.emergent.reader">
+        <source xml:lang="en">For <g id="genid-9" ctype="x-html-strong">Emergent Readers</g> the book should be concrete, should focus on one idea/theme, and should be familiar and easy to understand.
+      </source>
+        <note>ID: leveled.reader.topic.choice.emergent.reader</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.topic.choice.early.reader">
+        <source xml:lang="en">For <g id="genid-10" ctype="x-html-strong">Early Readers</g>, develop a story around a familiar concept but in greater depth.
+      </source>
+        <note>ID: leveled.reader.topic.choice.early.reader</note>
+      </trans-unit>
+      <trans-unit id="leveled.reader.topic.choice.fluent.reader">
+        <source xml:lang="en">For <g id="genid-11" ctype="x-html-strong">Fluent Readers</g> the concepts can expand beyond what is familiar, be more varied, and be abstract.
+      </source>
+        <note>ID: leveled.reader.topic.choice.fluent.reader</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/build/Bloom.proj
+++ b/build/Bloom.proj
@@ -108,7 +108,28 @@
 	<MSBuild Projects="$(RootDir)/$(Solution)"
 			 Targets="Rebuild"
 			 Properties="Configuration=$(Configuration)" />
+	<CallTarget Targets="ExtractXliffFromHtml"/>
   </Target>
+
+	<PropertyGroup>
+		<!-- we can't trust the system mono on Linux since we build with our own version -->
+		<HtmlXliffProgram Condition="'$(OS)'=='Windows_NT'">$(RootDir)/output/$(Configuration)/HtmlXliff.exe</HtmlXliffProgram>
+		<HtmlXliffProgram Condition="'$(OS)'!='Windows_NT'">/opt/mono4-sil/bin/mono $(RootDir)/output/$(Configuration)/HtmlXliff.exe</HtmlXliffProgram>
+	</PropertyGroup>
+
+	<Target Name="ExtractXliffFromHtml">
+		<Exec Command='$(HtmlXliffProgram) -o "$(RootDir)/DistFiles/localization/en/Decodable Reader/ReadMe.xlf" "$(RootDir)/src/BloomBrowserUI/templates/template books/Decodable Reader/ReadMe-en.md"'/>
+		<Exec Command='$(HtmlXliffProgram) -o "$(RootDir)/DistFiles/localization/en/Picture Dictionary/ReadMe.xlf" "$(RootDir)/src/BloomBrowserUI/templates/template books/Picture Dictionary/ReadMe-en.md"'/>
+		<Exec Command='$(HtmlXliffProgram) -o "$(RootDir)/DistFiles/localization/en/Wall Calendar/ReadMe.xlf" "$(RootDir)/src/BloomBrowserUI/templates/template books/Wall Calendar/ReadMe-en.md"'/>
+		<Exec Command='$(HtmlXliffProgram) -o "$(RootDir)/DistFiles/localization/en/Leveled Reader/Readme.xlf" "$(RootDir)/src/BloomBrowserUI/templates/template books/Leveled Reader/ReadMe-en.md"'/>
+		<Exec Command='$(HtmlXliffProgram) -o "$(RootDir)/DistFiles/localization/en/Big Book/ReadMe.xlf" "$(RootDir)/src/BloomBrowserUI/templates/template books/Big Book/ReadMe-en.md"'/>
+		<Exec Command='$(HtmlXliffProgram) -o "$(RootDir)/DistFiles/localization/en/Template Starter/ReadMe.xlf" "$(RootDir)/src/BloomBrowserUI/templates/template books/Template Starter/ReadMe-en.md"'/>
+		<Exec Command='$(HtmlXliffProgram) -o "$(RootDir)/DistFiles/localization/en/bloomEpubPreview.xlf" "$(RootDir)/output/browser/ePUB/bloomEpubPreview-en.html"'/>
+		<Exec Command='$(HtmlXliffProgram) -o "$(RootDir)/DistFiles/localization/en/MissingLameModule.xlf" "$(RootDir)/output/browser/ePUB/MissingLameModule-en.html"'/>
+		<Exec Command='$(HtmlXliffProgram) -o "$(RootDir)/DistFiles/localization/en/TrainingVideos.xlf" "$(RootDir)/DistFiles/infoPages/TrainingVideos-en.md"'/>
+		<Exec Command='$(HtmlXliffProgram) -o "$(RootDir)/DistFiles/localization/en/IntegrityFailureAdvice.xlf" "$(RootDir)/DistFiles/IntegrityFailureAdvice-en.md"'/>
+		<Exec Command='$(HtmlXliffProgram) -o "$(RootDir)/DistFiles/localization/en/leveledReaderInfo.xlf" "$(RootDir)/DistFiles/leveledRTInfo/leveledReaderInfo-en.html"'/>
+	</Target>
 
 	<ItemGroup>
 		<TestAssemblies Include="$(RootDir)/output/$(Configuration)/BloomTests.dll"/>

--- a/build/getDependencies-Linux.sh
+++ b/build/getDependencies-Linux.sh
@@ -85,82 +85,82 @@ cd -
 #     revision: latest.lastSuccessful
 #     paths: {"*.*"=>"DistFiles/"}
 #     VCS: https://github.com/BloomBooks/BloomPlayer [refs/heads/master]
-# [2] build: Squirrel (Bloom_Squirrel)
-#     project: Bloom
-#     URL: http://build.palaso.org/viewType.html?buildTypeId=Bloom_Squirrel
-#     clean: false
-#     revision: latest.lastSuccessful
-#     paths: {"ICSharpCode.SharpZipLib.*"=>"lib/dotnet"}
-#     VCS: https://github.com/BloomBooks/Squirrel.Windows.git [refs/heads/master]
-# [3] build: YouTrackSharp (Bloom_YouTrackSharp)
+# [2] build: YouTrackSharp (Bloom_YouTrackSharp)
 #     project: Bloom
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=Bloom_YouTrackSharp
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"bin/YouTrackSharp.dll"=>"lib/dotnet", "bin/YouTrackSharp.pdb"=>"lib/dotnet"}
 #     VCS: https://github.com/BloomBooks/YouTrackSharp.git [LinuxCompatible]
-# [4] build: Bloom Help 4.0 (Bloom_Help_BloomHelp40)
+# [3] build: Bloom Help 4.0 (Bloom_Help_BloomHelp40)
 #     project: Help
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=Bloom_Help_BloomHelp40
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"*.chm"=>"DistFiles"}
-# [5] build: pdf.js (bt401)
+# [4] build: pdf.js (bt401)
 #     project: BuildTasks
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=bt401
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"pdfjs-viewer.zip!**"=>"DistFiles/pdf"}
 #     VCS: https://github.com/mozilla/pdf.js.git [gh-pages]
-# [6] build: GeckofxHtmlToPdf-xenial64-continuous (GeckofxHtmlToPdf_GeckofxHtmlToPdfXenial64continuous)
+# [5] build: GeckofxHtmlToPdf-xenial64-continuous (GeckofxHtmlToPdf_GeckofxHtmlToPdfXenial64continuous)
 #     project: GeckofxHtmlToPdf
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=GeckofxHtmlToPdf_GeckofxHtmlToPdfXenial64continuous
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"Args.dll"=>"lib/dotnet", "GeckofxHtmlToPdf.exe"=>"lib/dotnet", "GeckofxHtmlToPdf.exe.config"=>"lib/dotnet"}
 #     VCS: https://github.com/BloomBooks/geckofxHtmlToPdf [refs/heads/master]
-# [7] build: L10NSharp xliff Mono continuous (L10NSharpXliffMonoContinuous)
+# [6] build: L10NSharp xliff Mono continuous (L10NSharpXliffMonoContinuous)
 #     project: L10NSharp
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=L10NSharpXliffMonoContinuous
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"L10NSharp.dll*"=>"lib/dotnet/"}
 #     VCS: https://github.com/sillsdev/l10nsharp [xliff]
-# [8] build: icucil-linux64-Continuous (bt281)
+# [7] build: icucil-linux64-Continuous (bt281)
 #     project: Libraries
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=bt281
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"icu.net.*"=>"lib/dotnet/icu48"}
 #     VCS: https://github.com/sillsdev/icu-dotnet [master]
-# [9] build: icucil-linux64-icu55 Continuous (Icu55)
+# [8] build: icucil-linux64-icu55 Continuous (Icu55)
 #     project: Libraries
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=Icu55
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"icu.net.*"=>"lib/dotnet/icu55"}
 #     VCS: https://github.com/sillsdev/icu-dotnet [master]
-# [10] build: icucil-precise64-icu52 Continuous (bt413)
+# [9] build: icucil-precise64-icu52 Continuous (bt413)
 #     project: Archived
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=bt413
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"icu.net.*"=>"lib/dotnet/icu52"}
 #     VCS: https://github.com/sillsdev/icu-dotnet [master]
-# [11] build: PdfDroplet-Linux-Dev-Continuous (bt344)
+# [10] build: PdfDroplet-Linux-Dev-Continuous (bt344)
 #     project: PdfDroplet
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=bt344
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"PdfDroplet.exe"=>"lib/dotnet", "PdfSharp.dll*"=>"lib/dotnet"}
 #     VCS: https://github.com/sillsdev/pdfDroplet [master]
-# [12] build: TidyManaged-master-linux64-continuous (bt351)
+# [11] build: TidyManaged-master-linux64-continuous (bt351)
 #     project: TidyManaged
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=bt351
 #     clean: false
 #     revision: latest.lastSuccessful
 #     paths: {"TidyManaged.dll*"=>"lib/dotnet"}
 #     VCS: https://github.com/BloomBooks/TidyManaged.git [master]
+# [12] build: Linux master continuous (XliffForHtml_LinuxMasterContinuous)
+#     project: XliffForHtml
+#     URL: http://build.palaso.org/viewType.html?buildTypeId=XliffForHtml_LinuxMasterContinuous
+#     clean: false
+#     revision: latest.lastSuccessful
+#     paths: {"HtmlXliff.*"=>"lib/dotnet"}
+#     VCS: https://github.com/sillsdev/XliffForHtml [refs/heads/master]
 # [13] build: palaso-linux64-master Continuous (Libpalaso_PalasoLinux64masterContinuous)
 #     project: libpalaso
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=Libpalaso_PalasoLinux64masterContinuous
@@ -186,8 +186,6 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/bt396/latest.las
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt396/latest.lastSuccessful/MSBuild.Community.Tasks.dll ../build/MSBuild.Community.Tasks.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt396/latest.lastSuccessful/MSBuild.Community.Tasks.Targets ../build/MSBuild.Community.Tasks.Targets
 copy_auto http://build.palaso.org/guestAuth/repository/download/BPContinuous/latest.lastSuccessful/bloomPlayer.js ../DistFiles/bloomPlayer.js
-copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/ICSharpCode.SharpZipLib.dll ../lib/dotnet/ICSharpCode.SharpZipLib.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/ICSharpCode.SharpZipLib.xml ../lib/dotnet/ICSharpCode.SharpZipLib.xml
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_YouTrackSharp/latest.lastSuccessful/bin/YouTrackSharp.dll ../lib/dotnet/YouTrackSharp.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_YouTrackSharp/latest.lastSuccessful/bin/YouTrackSharp.pdb ../lib/dotnet/YouTrackSharp.pdb
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Help_BloomHelp40/latest.lastSuccessful/Bloom.chm ../DistFiles/Bloom.chm
@@ -212,6 +210,8 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/bt344/latest.las
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt344/latest.lastSuccessful/PdfSharp.dll ../lib/dotnet/PdfSharp.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt351/latest.lastSuccessful/TidyManaged.dll ../lib/dotnet/TidyManaged.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt351/latest.lastSuccessful/TidyManaged.dll.config ../lib/dotnet/TidyManaged.dll.config
+copy_auto http://build.palaso.org/guestAuth/repository/download/XliffForHtml_LinuxMasterContinuous/latest.lastSuccessful/HtmlXliff.exe ../lib/dotnet/HtmlXliff.exe
+copy_auto http://build.palaso.org/guestAuth/repository/download/XliffForHtml_LinuxMasterContinuous/latest.lastSuccessful/HtmlXliff.exe.mdb ../lib/dotnet/HtmlXliff.exe.mdb
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/SIL.BuildTasks.dll ../build/SIL.BuildTasks.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/Newtonsoft.Json.dll ../lib/dotnet/Newtonsoft.Json.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/SIL.Core.dll ../lib/dotnet/SIL.Core.dll

--- a/build/getDependencies-windows.sh
+++ b/build/getDependencies-windows.sh
@@ -154,7 +154,14 @@ cd -
 #     revision: latest.lastSuccessful
 #     paths: {"*.*"=>"lib/dotnet"}
 #     VCS: https://github.com/BloomBooks/TidyManaged.git [master]
-# [12] build: palaso-win32-master-nostrongname Continuous (Libpalaso_PalasoWin32masterNostrongnameContinuous)
+# [12] build: Windows master continuous (XliffForHtml_WindowsMasterContinuous)
+#     project: XliffForHtml
+#     URL: http://build.palaso.org/viewType.html?buildTypeId=XliffForHtml_WindowsMasterContinuous
+#     clean: false
+#     revision: latest.lastSuccessful
+#     paths: {"HtmlXliff.*"=>"lib/dotnet"}
+#     VCS: https://github.com/sillsdev/XliffForHtml [refs/heads/master]
+# [13] build: palaso-win32-master-nostrongname Continuous (Libpalaso_PalasoWin32masterNostrongnameContinuous)
 #     project: libpalaso
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=Libpalaso_PalasoWin32masterNostrongnameContinuous
 #     clean: false
@@ -184,11 +191,11 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_PortableDe
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_PortableDevicesFromPodcastUtitlies/latest.lastSuccessful/PodcastUtilities.PortableDevices.pdb ../lib/dotnet/PodcastUtilities.PortableDevices.pdb
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_PortableDevicesFromPodcastUtitlies/latest.lastSuccessful/Interop.PortableDeviceApiLib.dll ../lib/dotnet/Interop.PortableDeviceApiLib.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_PortableDevicesFromPodcastUtitlies/latest.lastSuccessful/Interop.PortableDeviceTypesLib.dll ../lib/dotnet/Interop.PortableDeviceTypesLib.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/7z.dll ../lib/dotnet/7z.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/7z.exe ../lib/dotnet/7z.exe
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/DeltaCompressionDotNet.MsDelta.dll ../lib/dotnet/DeltaCompressionDotNet.MsDelta.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/DeltaCompressionDotNet.PatchApi.dll ../lib/dotnet/DeltaCompressionDotNet.PatchApi.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/DeltaCompressionDotNet.dll ../lib/dotnet/DeltaCompressionDotNet.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/ICSharpCode.SharpZipLib.dll ../lib/dotnet/ICSharpCode.SharpZipLib.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/ICSharpCode.SharpZipLib.xml ../lib/dotnet/ICSharpCode.SharpZipLib.xml
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/Microsoft.Data.Edm.dll ../lib/dotnet/Microsoft.Data.Edm.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/Microsoft.Data.Edm.xml ../lib/dotnet/Microsoft.Data.Edm.xml
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/Microsoft.Data.OData.dll ../lib/dotnet/Microsoft.Data.OData.dll
@@ -199,6 +206,7 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/l
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/Mono.Cecil.dll ../lib/dotnet/Mono.Cecil.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/NuGet.Squirrel.dll ../lib/dotnet/NuGet.Squirrel.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/Setup.exe ../lib/dotnet/Setup.exe
+copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/SharpCompress.dll ../lib/dotnet/SharpCompress.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/Splat.dll ../lib/dotnet/Splat.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/Squirrel.dll ../lib/dotnet/Squirrel.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/StubExecutable.exe ../lib/dotnet/StubExecutable.exe
@@ -208,8 +216,6 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/l
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/Update-Mono.exe ../lib/dotnet/Update-Mono.exe
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/Update.com ../lib/dotnet/Update.com
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/Update.exe ../lib/dotnet/Update.exe
-copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/WpfAnimatedGif.dll ../lib/dotnet/WpfAnimatedGif.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/WpfAnimatedGif.xml ../lib/dotnet/WpfAnimatedGif.xml
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/WriteZipToSetup.exe ../lib/dotnet/WriteZipToSetup.exe
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/rcedit.exe ../lib/dotnet/rcedit.exe
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_Squirrel/latest.lastSuccessful/signtool.exe ../lib/dotnet/signtool.exe
@@ -227,6 +233,8 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/bt54/latest.last
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt349/latest.lastSuccessful/TidyManaged.dll ../lib/dotnet/TidyManaged.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt349/latest.lastSuccessful/TidyManaged.dll.config ../lib/dotnet/TidyManaged.dll.config
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt349/latest.lastSuccessful/libtidy.dll ../lib/dotnet/libtidy.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/XliffForHtml_WindowsMasterContinuous/latest.lastSuccessful/HtmlXliff.exe ../lib/dotnet/HtmlXliff.exe
+copy_auto http://build.palaso.org/guestAuth/repository/download/XliffForHtml_WindowsMasterContinuous/latest.lastSuccessful/HtmlXliff.pdb ../lib/dotnet/HtmlXliff.pdb
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterNostrongnameContinuous/latest.lastSuccessful/SIL.BuildTasks.dll ../build/SIL.BuildTasks.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterNostrongnameContinuous/latest.lastSuccessful/SIL.BuildTasks.AWS.dll ../build/SIL.BuildTasks.AWS.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterNostrongnameContinuous/latest.lastSuccessful/AWSSDK.Core.dll ../build/AWSSDK.Core.dll

--- a/src/BloomBrowserUI/ePUB/MissingLameModule-en.pug
+++ b/src/BloomBrowserUI/ePUB/MissingLameModule-en.pug
@@ -6,17 +6,17 @@ html
 		link(rel='stylesheet', type='text/css', href='bloomEPUBPreview.css')
 	body
 		#missingLame
-			h3 Please Install LAME
-			p
+			h3(i18n="missing.lame.please.install") Please Install LAME
+			p(i18n="missing.lame.bloom.needs.lame")
 				| This book has audio recordings. Bloom can use these to make a "Talking Book" e-book. However, Bloom needs a program called "LAME for Audacity" in order to create the mp3 files that the book will use. Setting it up is easy. First download and run
 				+link('http://lame.buanzo.org/#lamewindl') 'Lame_v3.99 for Windows.exe'
 				| . Next, restart Bloom.
-			p
+			p(i18n="missing.lame.audio.optional")
 				| If you prefer to go ahead and publish your book without audio, click
 				+link('javascript:void(0)')#proceedWithoutAudio here
 				| .
-			h3 Legal Considerations
-			p
+			h3(i18n="missing.lame.legalities") Legal Considerations
+			p(i18n="missing.lame.old.patent.issues")
 				| Our understanding is that in a few countries (perhaps only in the USA, and then only until 2017), there are patents covering the creation of mp3's. In correspondence with the patent holder's representative, we were told:
 				blockquote
 					| You may need a license if there is any type of subscription, content, service, per unit or itemized revenue for the distribution of mp3, or if there is any advertising present during the presentation of any mp3 content, either on a webpage with any links to your Talking Books, or as part of a messaging system, and this total mp3-associated mp3 revenue exceeds USD $100,000 per year.

--- a/src/BloomBrowserUI/ePUB/bloomEpubPreview-en.pug
+++ b/src/BloomBrowserUI/ePUB/bloomEpubPreview-en.pug
@@ -12,42 +12,42 @@ html
 	//_AudioSituationClass_ is replaced at runtime
 	body._AudioSituationClass_
 		#sideColumn
-			p
+			p(i18n="epubpreview.describe")
 				| This is an
 				+link-followed-by-space('https://en.wikipedia.org/wiki/ePUB') ePUB
 				| (e-book) version of your book.
 				+space
 				span.showForTalkingBooks It contains audio, so that new readers can listen as they read.
-			p.showWhenHaveAudioButNotMakingTalkingBook This book has some recordings, but this audio is not included in the ePUB.
-			h3 Preview
-			p You can resize the preview by dragging the lower right corner of this simulated device. See how your book will look on screens of various sizes.
-			p
+			p.showWhenHaveAudioButNotMakingTalkingBook(i18n="epubpreview.recording.butnotalk") This book has some recordings, but this audio is not included in the ePUB.
+			h3(i18n="epubpreview.preview") Preview
+			p(i18n="epubpreview.resizing") You can resize the preview by dragging the lower right corner of this simulated device. See how your book will look on screens of various sizes.
+			p(i18n="epubpreview.readium")
 				| This page uses the
 				+link-followed-by-space('http://readium.org/') Readium
 				| ePUB reader. Books will likely look different on different readers.
-			p.showForTalkingBooks
+			p.showForTalkingBooks(i18n="epubpreview.talkingbookpreview")
 				| The preview here cannot yet play Talking Books. You can listen to it using Adobe's Free
 				+link-followed-by-space('http://www.adobe.com/solutions/ebook/digital-editions.html') Digital Editions
 				| e-book reader.
-			h3 Getting this book onto your Device
-			p
+			h3(i18n="epubpreview.ontodevice") Getting this book onto your Device
+			p(i18n="epubpreview.usingdropbox")
 				| A handy way to get books to your phone is to set up Dropbox or similar service on both your computer and your phone/tablet. Just click Save ePUB and then choose your Dropbox folder. On your phone, open the Dropbox app and select your book. If you are using a laptop, you can also try the free
 				+link-followed-by-space('http://www.ushareit.com/') ShareIt
 				| program to send files from your laptop to a phone or tablet.
-			h3 Recommended Reader
-			p
+			h3(i18n="epubpreview.recommended.reader") Recommended Reader
+			p(i18n="epubpreview.gitden.okay")
 				| Our testing has shown
 				+link-followed-by-space('/bloom/api/help/Concepts/Gitden_Reader.htm') Gitden Reader
 				| to be a good choice for Android and IOS (IPhone &amp; IPad) devices.
-			p.showForTalkingBooks
+			p.showForTalkingBooks(i18n="epubpreview.gitden.limits")
 				| To listen to this Talking Book using Gitden on a phone or tablet, you will need to disable Gitden's "Text To Speech" feature. Then it will show you the audio controls.
-			h3.showWhenNoAudio Make it Talk
-			p.showWhenNoAudio
+			h3.showWhenNoAudio(i18n="epubpreview.make.it.talk") Make it Talk
+			p.showWhenNoAudio(i18n="epubpreview.talking.book.tool")
 				| If you want to make a "Talking Book" that new readers can read-along with, use Bloom's
 				+link-followed-by-space('/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm') Talking Book Tool
 				| to add voice recordings.
-			h3 Write to us!
-			p Are you interested in distributing Bloom books for use on phones and other ebook readers? Is there something you would need us to do before it is useful for you? Please use the Help:Report A Problem command to send us feedback. Thanks!
+			h3(i18n="epubpreview.write.us") Write to us!
+			p(i18n="epubpreview.use.help.report") Are you interested in distributing Bloom books for use on phones and other ebook readers? Is there something you would need us to do before it is useful for you? Please use the Help:Report A Problem command to send us feedback. Thanks!
 		#device.ui-resizable
 			iframe(src='readium-cloudreader.htm?epub={EPUBFOLDER}')
 			#BottomRightHandle.ui-resizable-handle.ui-resizable-se.ui-icon.ui-icon-grip-diagonal-se

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -158,6 +158,9 @@
     <Reference Include="L10NSharp">
       <HintPath>..\..\lib\dotnet\L10NSharp.dll</HintPath>
     </Reference>
+    <Reference Include="HtmlXliff">
+      <HintPath>..\..\lib\dotnet\HtmlXliff.exe</HintPath>
+    </Reference>
     <Reference Include="Markdig">
       <HintPath>..\..\packages\Markdig.0.13.0\lib\net40\Markdig.dll</HintPath>
     </Reference>

--- a/src/BloomExe/MiscUI/BloomIntegrityDialog.cs
+++ b/src/BloomExe/MiscUI/BloomIntegrityDialog.cs
@@ -79,7 +79,8 @@ namespace Bloom.MiscUI
 				{
 					var installFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
 							.CombineForPath(Application.ProductName);
-					message = RobustFile.ReadAllText(messagePath).Replace("{installFolder}", installFolder);
+					message = RobustFile.ReadAllText(messagePath).Replace("{{installFolder}}", installFolder);//new
+					message = RobustFile.ReadAllText(messagePath).Replace("{installFolder}", installFolder);  //old
 				}
 
 				message = message + Environment.NewLine + Environment.NewLine + errors.ToString();


### PR DESCRIPTION
Add the generated xliff files to source control for crowd-in to find.
As long as the pug and markdown files don't change, and the HtmlXliff
program doesn't change, generating these files afresh shouldn't cause
any differences.

This is the first step of a projected 3-step process.  The second step is
to extract translated xliff files from the translated HTML related file.
The third step is to actually change the program to remove the translated
pug and markdown and create the translated HTML files at build time and
add them to the installer and package.  The program behavior (and maybe
the content of the installer) won't change until the third step.  But we still
might want to consider whether this should be merged even if it looks
okay.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1798)
<!-- Reviewable:end -->
