### PR TITLE
Cleanup Android Publishing Classes

### DIFF
--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -16,6 +16,7 @@ using Bloom.ImageProcessing;
 using Bloom.WebLibraryIntegration;
 using Bloom.Workspace;
 using Bloom.Api;
+using Bloom.Publish.Android;
 using Bloom.web;
 using Bloom.web.controllers;
 //using Chorus;

--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -1,184 +1,73 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.RegularExpressions;
-using Bloom.Collection;
-using Bloom.Publish;
-using Bloom.Publish.Android;
+﻿using Bloom.Api;
 using Bloom.Publish.Android.wifi;
 using Bloom.web;
-using SIL.Code;
 
-namespace Bloom.Api
+namespace Bloom.Publish.Android
 {
 	/// <summary>
 	/// Handles api request dealing with the publishing of books to an Android device
 	/// </summary>
-	class PublishToAndroidApi
+	public class PublishToAndroidApi
 	{
 		private const string kApiUrlPart = "publish/android/";
 		private const string kWebsocketStateId = "publish/android/state";
+		private readonly WiFiPublisher _wifiPublisher;
 		private readonly UsbPublisher _usbPublisher;
 		private readonly BloomWebSocketServer _webSocketServer;
-		private readonly WebSocketProgress _progress;
-		private WiFiAdvertiser _wifiAdvertiser;
-		private BloomReaderUDPListener _wifiListener;
-		private Book.Book _book;
 
-		public PublishToAndroidApi(CollectionSettings collectionSettings, BloomWebSocketServer bloomWebSocketServer)
+		public PublishToAndroidApi(BloomWebSocketServer bloomWebSocketServer)
 		{
 			_webSocketServer = bloomWebSocketServer;
-			_progress = new WebSocketProgress(_webSocketServer);
-			_usbPublisher = new UsbPublisher(_progress);
-			_usbPublisher.UsbConnected += OnUsbConnected;
-			_usbPublisher.UsbConnectionFailed += OnUsbConnectionFailed;
-			_usbPublisher.SendBookSucceeded += OnSendBookSucceeded;
-			_usbPublisher.SendBookFailed += OnSendBookFailed;
+			var progress = new WebSocketProgress(_webSocketServer);
+			_wifiPublisher = new WiFiPublisher(progress);
+			_usbPublisher = new UsbPublisher(progress)
+			{
+				Stopped = () => SetState("stopped")
+			};
 		}
 
 		public void RegisterWithServer(EnhancedImageServer server)
 		{
-			server.RegisterEndpointHandler(kApiUrlPart + "usb/start", UsbStartHandler, true);
-			server.RegisterEndpointHandler(kApiUrlPart + "usb/stop", StopHandler, true);
-			server.RegisterEndpointHandler(kApiUrlPart + "wifi/start", WiFiStartHandler, true);
-			server.RegisterEndpointHandler(kApiUrlPart + "wifi/stop", StopHandler, true);
-			server.RegisterEndpointHandler(kApiUrlPart + "cleanup", StopHandler, true);
-		}
-
-		private void UsbStartHandler(ApiRequest request)
-		{
-			_book = request.CurrentBook;
-			SetState("UsbStarted");
-			_usbPublisher.Connect();
-			request.SucceededDoNotNavigate();
-		}
-
-		private void WiFiStartHandler(ApiRequest request)
-		{
-			if (_wifiAdvertiser != null)
+			server.RegisterEndpointHandler(kApiUrlPart + "usb/start", request =>
 			{
-				CloseDownWiFiServing();
-			}
+				SetState("UsbStarted");
+				_usbPublisher.Connect();
+				request.SucceededDoNotNavigate();
+			}, true);
 
-			// This listens for a BloomReader to request a book.
-			// It requires a firewall hole allowing Bloom to receive messages on _portToListen.
-			// We initialize it before starting the Advertiser to avoid any chance of a race condition
-			// where a BloomReader manages to request an advertised book before we start the listener.
-			_wifiListener = new BloomReaderUDPListener();
-			_wifiListener.NewMessageReceived += (sender, args) =>
+			server.RegisterEndpointHandler(kApiUrlPart + "usb/stop", request =>
 			{
-				var androidIpAddress = Encoding.UTF8.GetString(args.Data);
-				SendBookOverWiFi(request.CurrentBook, androidIpAddress);
-			};
+				_usbPublisher.Stop();
+				SetState("stopped");
+				request.Succeeded();
+			}, true);
 
-			_wifiAdvertiser = new WiFiAdvertiser(_progress)
+			server.RegisterEndpointHandler(kApiUrlPart + "wifi/start", request =>
 			{
-				BookTitle = request.CurrentBook.Title,
-				TitleLanguage = request.CurrentCollectionSettings.Language1Iso639Code,
-				BookVersion = MakeVersionCode(File.ReadAllText(request.CurrentBook.GetPathHtmlFile()))
-			};
-			// Review: not sure this is what we want for a version. Basically, it allows the Android (by saving it) to avoid downloading
-			// a book that is exactly what it has already...with the risk that it might miss binary changes to images, if nothing changes
-			// in the HTML. However, this doesn't prevent overwriting a newer book with an older one. Another option would be to
-			// send the file modify time (as well or instead). Or we can institute some system of versioning books...
+				_wifiPublisher.Start(request.CurrentBook, request.CurrentCollectionSettings);
+				SetState("ServingOnWifi");
+				request.SucceededDoNotNavigate();
+			}, true);
 
-			_wifiAdvertiser.Start();
+			server.RegisterEndpointHandler(kApiUrlPart + "wifi/stop", request =>
+			{
+				_wifiPublisher.Stop();
+				SetState("stopped");
+				request.Succeeded();
+			}, true);
 
-			SetState("ServingOnWifi");
-			request.SucceededDoNotNavigate();
-
-			_progress.WriteMessage(
-				"On the Android, run Bloom Reader, open the menu and choose 'Receive Books from WiFi'.");
-			_progress.WriteMessage("You can do this on as many devices as you like. Make sure each device is connected to the same network as this computer.");
+			server.RegisterEndpointHandler(kApiUrlPart + "cleanup", request =>
+			{
+				_usbPublisher.Stop();
+				_wifiPublisher.Stop();
+				SetState("stopped");
+				request.Succeeded();
+			}, true);
 		}
 
 		private void SetState(string state)
 		{
 			_webSocketServer.Send(kWebsocketStateId, state);
-		}
-
-		public static string MakeVersionCode(string fileContent)
-		{
-			var simplified = fileContent;
-			// In general, whitespace sequences are equivalent to a single space.
-			// If the user types multiple spaces all but one will be turned to &nbsp;
-			simplified = new Regex(@"\s+").Replace(simplified," ");
-			// Between the end of one tag and the start of the next white space doesn't count at all
-			simplified = new Regex(@">\s+<").Replace(simplified, "><");
-			// Page IDs (actually any element ids) are ignored
-			// (the bit before the 'id' matches an opening wedge followed by anything but a closing one,
-			// and is transferred to the output by $1. Then we look for an id='whatever', with optional
-			// whitespace, where (['\"]) matches either kind of opening quote while \2 matches the same one at the end.
-			// The question mark makes sure we end with the first possible closing quote.
-			// Then we grab everything up to the closing wedge and transfer that to the output as $3.)
-			simplified = new Regex("(<[^>]*)\\s*id\\s*=\\s*(['\"]).*?\\2\\s*([^>]*>)").Replace(simplified, "$1$3");
-			var bytes = Encoding.UTF8.GetBytes(simplified);
-			return Convert.ToBase64String(SHA256Managed.Create().ComputeHash(bytes));
-		}
-
-		private void SendBookOverWiFi(Book.Book book, string androidIpAddress)
-		{
-			try
-			{
-				WiFiPublisher.SendBookToClientOnLocalSubNet(book, androidIpAddress, _progress);
-			}
-			catch (Exception e)
-			{
-				// This method is called on a background thread in response to receiving a request from Bloom Reader.
-				// Exceptions somehow get discarded, so there is no point in letting them propagate further.
-				_progress.WriteError("Sending the book failed. Possibly the device was disconnected? If you can't see a reason for this the following may be helpful to report to the developers:");
-				_progress.WriteError(e.Message);
-				_progress.WriteError(e.StackTrace);
-				Debug.Fail("got exception " + e.Message + " sending book");
-			}
-		}
-
-		private void StopHandler(ApiRequest request)
-		{
-			if (_wifiAdvertiser == null)
-			{
-				// either closed without pressing any connect button, or used the USB one.
-				_usbPublisher.CancelConnect();
-			}
-			else
-			{
-				// Enhance: should we do something if a transfer is in progress? Here or in Dispose?
-				CloseDownWiFiServing();
-			}
-			SetState("stopped");
-			request.Succeeded();
-		}
-
-		private void CloseDownWiFiServing()
-		{
-			_wifiAdvertiser.Stop();
-			_wifiAdvertiser.Dispose();
-			_wifiAdvertiser = null;
-			_wifiListener.StopListener();
-			_wifiListener = null;
-		}
-
-		private void OnUsbConnectionFailed(object sender, EventArgs args)
-		{
-			SetState("stopped");
-		}
-
-		private void OnUsbConnected(object sender, EventArgs args)
-		{
-			Guard.AgainstNull(_book, "_book");
-			_usbPublisher.SendBookAsync(_book);
-		}
-
-		private void OnSendBookSucceeded(object sender, EventArgs args)
-		{
-			SetState("stopped");
-		}
-
-		private void OnSendBookFailed(object sender, EventArgs args)
-		{
-			SetState("stopped");
 		}
 	}
 }

--- a/src/BloomExe/Publish/Android/wifi/WiFiAdvertiser.cs
+++ b/src/BloomExe/Publish/Android/wifi/WiFiAdvertiser.cs
@@ -6,7 +6,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using Bloom.Api;
-using Bloom.web;
+using SIL.Progress;
 
 namespace Bloom.Publish.Android.wifi
 {
@@ -30,13 +30,12 @@ namespace Bloom.Publish.Android.wifi
 		private const int Port = 5913; // must match port in BloomReader NewBookListenerService.startListenForUDPBroadcast
 		private string _currentIpAddress;
 		private byte[] _sendBytes; // Data we send in each advertisement packet
+		private readonly IProgress _progress;
 
-		internal WiFiAdvertiser(WebSocketProgress progress)
+		internal WiFiAdvertiser(IProgress progress)
 		{
-			Progress = progress;
+			_progress = progress;
 		}
-
-		private WebSocketProgress Progress { get; }
 
 		public void Start()
 		{
@@ -55,7 +54,7 @@ namespace Bloom.Publish.Android.wifi
 
 		private void Work()
 		{
-			Progress.WriteStatus("Advertising book to Bloom Readers on local network...");
+			_progress.WriteStatus("Advertising book to Bloom Readers on local network...");
 			try
 			{
 				while (true)
@@ -67,13 +66,13 @@ namespace Bloom.Publish.Android.wifi
 			}
 			catch (ThreadAbortException)
 			{
-				Progress.WriteStatus("Stopped Advertising.");
-				//Progress.WriteVerbose("Advertiser Thread Aborting (that's normal)");
+				_progress.WriteStatus("Stopped Advertising.");
+				//_progress.WriteVerbose("Advertiser Thread Aborting (that's normal)");
 				_client.Close();
 			}
 			catch (Exception error)
 			{
-				Progress.WriteError("Application", string.Format("Error in Advertiser: {0}", error.Message), EventLogEntryType.Error);
+				_progress.WriteError("Application", string.Format("Error in Advertiser: {0}", error.Message), EventLogEntryType.Error);
 			}
 		}
 		public static void SendCallback(IAsyncResult args)

--- a/src/BloomExe/Publish/Android/wifi/WiFiPublisher.cs
+++ b/src/BloomExe/Publish/Android/wifi/WiFiPublisher.cs
@@ -1,18 +1,102 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
 using Bloom.Book;
+using Bloom.Collection;
 using SIL.IO;
 using SIL.Progress;
 
 namespace Bloom.Publish.Android.wifi
 {
-
 	/// <summary>
 	/// Runs a service on the local net that advertises a book and then delivers it to Androids that request it
 	/// </summary>
 	public class WiFiPublisher
 	{
+		private readonly IProgress _progress;
+		private WiFiAdvertiser _wifiAdvertiser;
+		private BloomReaderUDPListener _wifiListener;
+		public const string ProtocolVersion = "1.0";
+
+		public WiFiPublisher(IProgress progress)
+		{
+			_progress = progress;
+		}
+
+		public void Start(Book.Book book, CollectionSettings collectionSettings)
+		{
+			if (_wifiAdvertiser != null)
+			{
+				Stop();
+			}
+
+			// This listens for a BloomReader to request a book.
+			// It requires a firewall hole allowing Bloom to receive messages on _portToListen.
+			// We initialize it before starting the Advertiser to avoid any chance of a race condition
+			// where a BloomReader manages to request an advertised book before we start the listener.
+			_wifiListener = new BloomReaderUDPListener();
+			_wifiListener.NewMessageReceived += (sender, args) =>
+			{
+				var androidIpAddress = Encoding.UTF8.GetString(args.Data);
+				SendBookOverWiFi(book, androidIpAddress);
+			};
+
+			_wifiAdvertiser = new WiFiAdvertiser(_progress)
+			{
+				BookTitle = book.Title,
+				TitleLanguage = collectionSettings.Language1Iso639Code,
+				BookVersion = MakeVersionCode(File.ReadAllText(book.GetPathHtmlFile()))
+			};
+
+			_wifiAdvertiser.Start();
+
+			_progress.WriteMessage(
+				"On the Android, run Bloom Reader, open the menu and choose 'Receive Books from WiFi'.");
+			_progress.WriteMessage("You can do this on as many devices as you like. Make sure each device is connected to the same network as this computer.");
+		}
+
+		// Review: not sure this is what we want for a version. Basically, it allows the Android (by saving it) to avoid downloading
+		// a book that is exactly what it has already...with the risk that it might miss binary changes to images, if nothing changes
+		// in the HTML. However, this doesn't prevent overwriting a newer book with an older one. Another option would be to
+		// send the file modify time (as well or instead). Or we can institute some system of versioning books...
+		public static string MakeVersionCode(string fileContent)
+		{
+			var simplified = fileContent;
+			// In general, whitespace sequences are equivalent to a single space.
+			// If the user types multiple spaces all but one will be turned to &nbsp;
+			simplified = new Regex(@"\s+").Replace(simplified, " ");
+			// Between the end of one tag and the start of the next white space doesn't count at all
+			simplified = new Regex(@">\s+<").Replace(simplified, "><");
+			// Page IDs (actually any element ids) are ignored
+			// (the bit before the 'id' matches an opening wedge followed by anything but a closing one,
+			// and is transferred to the output by $1. Then we look for an id='whatever', with optional
+			// whitespace, where (['\"]) matches either kind of opening quote while \2 matches the same one at the end.
+			// The question mark makes sure we end with the first possible closing quote.
+			// Then we grab everything up to the closing wedge and transfer that to the output as $3.)
+			simplified = new Regex("(<[^>]*)\\s*id\\s*=\\s*(['\"]).*?\\2\\s*([^>]*>)").Replace(simplified, "$1$3");
+			var bytes = Encoding.UTF8.GetBytes(simplified);
+			return Convert.ToBase64String(SHA256Managed.Create().ComputeHash(bytes));
+		}
+
+		public void Stop()
+		{
+			if(_wifiAdvertiser != null)
+			{
+				_wifiAdvertiser.Stop();
+				_wifiAdvertiser.Dispose();
+				_wifiAdvertiser = null;
+			}
+			if(_wifiListener != null)
+			{
+				_wifiListener.StopListener();
+				_wifiListener = null;
+			}
+		}
+
 		/// <summary>
 		/// Send the book to a client over local network, typically WiFi (at least on Android end).
 		/// This is currently called on the UDPListener thread.
@@ -26,7 +110,7 @@ namespace Bloom.Publish.Android.wifi
 		/// </summary>
 		/// <param name="book"></param>
 		/// <param name="androidIpAddress"></param>
-		public static void SendBookToClientOnLocalSubNet(Book.Book book, string androidIpAddress, IProgress progress)
+		private void SendBookToClientOnLocalSubNet(Book.Book book, string androidIpAddress, IProgress progress)
 		{
 			var androidHttpAddress = "http://" + androidIpAddress + ":5914"; // must match BloomReader SyncServer._serverPort.
 			progress.WriteMessage($"Sending \"{book.Title}\" to device {androidIpAddress}");
@@ -45,6 +129,21 @@ namespace Bloom.Publish.Android.wifi
 			progress.WriteMessage($"Finished sending \"{book.Title}\" to device {androidIpAddress}");
 		}
 
-		public const string ProtocolVersion = "1.0";
+		private void SendBookOverWiFi(Book.Book book, string androidIpAddress)
+		{
+			try
+			{
+				SendBookToClientOnLocalSubNet(book, androidIpAddress, _progress);
+			}
+			catch (Exception e)
+			{
+				// This method is called on a background thread in response to receiving a request from Bloom Reader.
+				// Exceptions somehow get discarded, so there is no point in letting them propagate further.
+				_progress.WriteError("Sending the book failed. Possibly the device was disconnected? If you can't see a reason for this the following may be helpful to report to the developers:");
+				_progress.WriteError(e.Message);
+				_progress.WriteError(e.StackTrace);
+				Debug.Fail("got exception " + e.Message + " sending book");
+			}
+		}
 	}
 }

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -214,7 +214,7 @@
     <Compile Include="WebLibraryIntegration\BloomS3StandardUpDownloadTests.cs" />
     <Compile Include="WebLibraryIntegration\BookTransferTests.cs" />
     <Compile Include="web\controllers\PageTemplatesApiTests.cs" />
-    <Compile Include="web\controllers\PublishToWebApiTests.cs" />
+    <Compile Include="web\controllers\WiFiPublisher.cs" />
     <Compile Include="web\controllers\ReadersApiTests.cs" />
     <Compile Include="web\controllers\ApiTest.cs" />
     <Compile Include="WebLibraryIntegration\ProblemBookUploaderTests.cs" />

--- a/src/BloomTests/web/controllers/WiFiPublisher.cs
+++ b/src/BloomTests/web/controllers/WiFiPublisher.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Bloom.Api;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace BloomTests.web.controllers
 {
-	public class PublishToWebApiTests
+	public class WiFiPublisher
 	{
 		[Test]
 		public void MakeVersionCode_DistinguishesTextChanges()
@@ -16,7 +10,7 @@ namespace BloomTests.web.controllers
 			var template = @"<!DOCTYPE html><html><head></head><body><div>{0}</div></body></html>";
 			var first = string.Format(template, "abc");
 			var second = string.Format(template, "abd");
-			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.Not.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+			Assert.That(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(first), Is.Not.EqualTo(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(second)));
 		}
 
 		[TestCase("abc", "ab c")]
@@ -27,7 +21,7 @@ namespace BloomTests.web.controllers
 			var template = @"<!DOCTYPE html><html><head></head><body><div>{0}</div></body></html>";
 			var first = string.Format(template, firstArg);
 			var second = string.Format(template, secondArg);
-			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.Not.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+			Assert.That(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(first), Is.Not.EqualTo(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(second)));
 		}
 
 		[Test]
@@ -36,7 +30,7 @@ namespace BloomTests.web.controllers
 			var template = @"<!DOCTYPE html><html><head></head><body><div>{0}</div></body></html>";
 			var first = string.Format(template, "abc");
 			var second = string.Format(template, "<p>abc<p>");
-			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.Not.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+			Assert.That(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(first), Is.Not.EqualTo(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(second)));
 		}
 
 		[Test]
@@ -50,7 +44,7 @@ namespace BloomTests.web.controllers
 	<body> <div>abc</div>
 	</body>
 </html>";
-			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+			Assert.That(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(first), Is.EqualTo(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(second)));
 		}
 
 		[Test]
@@ -68,7 +62,7 @@ namespace BloomTests.web.controllers
                         DIV.bloom-page.coverColor       {               background-color: #C2A6BF !important;   }
     </style>
 </head><body><div>abc</div></body></html>";
-			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+			Assert.That(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(first), Is.EqualTo(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(second)));
 		}
 
 		[Test]
@@ -77,7 +71,7 @@ namespace BloomTests.web.controllers
 			var template = @"<!DOCTYPE html><html><head></head><body><div class='bloom-page' id='{0}'>abc</div></body></html>";
 			var first = string.Format(template, "934245d2-94dd-4f40-8b53-279867d8e07b");
 			var second = string.Format(template, "d9a71953-6cf4-475a-8236-36d509ff8e1c");
-			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+			Assert.That(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(first), Is.EqualTo(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(second)));
 		}
 
 		[Test]
@@ -86,7 +80,7 @@ namespace BloomTests.web.controllers
 			var template = @"<!DOCTYPE html><html><head></head><body><div class='bloom-page'>id='{0}'</div></body></html>";
 			var first = string.Format(template, "934245d2-94dd-4f40-8b53-279867d8e07b");
 			var second = string.Format(template, "d9a71953-6cf4-475a-8236-36d509ff8e1c");
-			Assert.That(PublishToAndroidApi.MakeVersionCode(first), Is.Not.EqualTo(PublishToAndroidApi.MakeVersionCode(second)));
+			Assert.That(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(first), Is.Not.EqualTo(Bloom.Publish.Android.wifi.WiFiPublisher.MakeVersionCode(second)));
 		}
 	}
 }


### PR DESCRIPTION
This moves all the logic of each method out to its own class(es), leaving the API to simply run things and manage the state machine, and hide the whole http request/ web socket layer from the classes that do the publishing. With the new UI, the state system is a lot simpler, so that allowed some simplication too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1805)
<!-- Reviewable:end -->
