### PR TITLE
Fix progressDiv null error BL-4929

### DIFF
--- a/src/BloomBrowserUI/react_components/progressBox.tsx
+++ b/src/BloomBrowserUI/react_components/progressBox.tsx
@@ -18,14 +18,26 @@ export default class ProgressBox extends React.Component<{}, ComponentState> {
             var e = JSON.parse(event.data);
             if (e.id === "progress") {
                 self.setState({ progress: self.state.progress + "<br/>" + e.payload });
-                // Scroll the window to the bottom. Must be done AFTER painting once, so we
-                // get a real current scroll height.
-                window.requestAnimationFrame(() => {
-                    let progressDiv = document.getElementById("progress");
-                    progressDiv.scrollTop = progressDiv.scrollHeight;
-                });
+                this.tryScrollToBottom();
             }
         });
+    }
+
+    tryScrollToBottom() {
+        // Must be done AFTER painting once, so we
+        // get a real current scroll height.
+        let progressDiv = document.getElementById("progress-box");
+
+        // in my testing in FF, this worked the first time
+        if (progressDiv)
+            progressDiv.scrollTop = progressDiv.scrollHeight;
+        // but there apparently have been times when the div wasn't around
+        // yet, so we do this:
+        else {
+            window.requestAnimationFrame(() => this.tryScrollToBottom());
+            // note, I have tested what happens if the element is *never* found (due to some future bug).
+            // Tests show that everyhing stays responsive.
+        }
     }
 
     //TODO: make box messages scroll to bottom whenever a new message arrives


### PR DESCRIPTION
The real error turned out to be a simple change of id. But before I figured that out, I had made the code a bit more robust. Since there I found an instance of this error in the youtrack history, unsolved, it's possible that this will be useful, so I left that in there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1818)
<!-- Reviewable:end -->
