### PR TITLE
Handle listener being null BL-4868

### DIFF
--- a/src/BloomExe/Publish/Android/wifi/BloomReaderUDPListener.cs
+++ b/src/BloomExe/Publish/Android/wifi/BloomReaderUDPListener.cs
@@ -69,7 +69,8 @@ namespace Bloom.Publish.Android.wifi
 			if (_listening)
 			{
 				_listening = false;
-				_listener.Close(); // forcibly end communication
+				_listener?.Close(); // forcibly end communication
+				_listener = null;
 			}
 		}
 	}


### PR DESCRIPTION
It's not clear how BL-4968 happened, but I just made it tolerant of that situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1819)
<!-- Reviewable:end -->
