### PR TITLE
BL-4919 restore previewMode.css to bloomd

### DIFF
--- a/src/BloomExe/Book/BookCompressor.cs
+++ b/src/BloomExe/Book/BookCompressor.cs
@@ -95,8 +95,7 @@ namespace Bloom.Book
 				// or displaying collections but not needed by the reader. The most important is probably
 				// eliminating the pdf, which can be very large. Note that we do NOT eliminate the
 				// basic thumbnail.png, as we want eventually to extract that to use in the Reader UI.
-				if (fileName=="thumbnail-70.png" || fileName=="thumbnail-256.png"
-					|| fileName == "previewmode.css")
+				if (fileName=="thumbnail-70.png" || fileName=="thumbnail-256.png")
 					continue;
 				if (fileName == "meta.json" && omitMetaJson)
 					continue;

--- a/src/BloomTests/Book/BookCompressorTests.cs
+++ b/src/BloomTests/Book/BookCompressorTests.cs
@@ -49,6 +49,7 @@ namespace BloomTests.Book
 			// interesting files.
 			var expectedFiles = Directory.GetFiles(testBook.FolderPath).ToList();
 			expectedFiles.Add("thumbnail.png"); // We should NOT eliminate thumbnail.png, which we eventually want for the reader book chooser UI.
+			expectedFiles.Add("previewMode.css"); // Somewhat sadly, we need this, e.g., for rules that hide the page labels.
 
 			// This unwanted file has to be real; just putting some text in it leads to out-of-memory failures when Bloom
 			// tries to make its background transparent.
@@ -57,7 +58,7 @@ namespace BloomTests.Book
 			File.Copy(SIL.IO.FileLocator.GetFileDistributedWithApplication(_pathToTestImages, "shirt.png"), Path.Combine(testBook.FolderPath, "thumbnail-70.png"));
 			File.WriteAllText(Path.Combine(testBook.FolderPath, "book.BloomBookOrder"), @"This is unwanted");
 			File.WriteAllText(Path.Combine(testBook.FolderPath, "book.pdf"), @"This is unwanted");
-			File.WriteAllText(Path.Combine(testBook.FolderPath, "previewMode.css"), @"This is unwanted");
+			File.WriteAllText(Path.Combine(testBook.FolderPath, "previewMode.css"), @"This is wanted");
 			File.WriteAllText(Path.Combine(testBook.FolderPath, "meta.json"), @"This is unwanted");
 
 			using (var bloomdTempFile = TempFile.WithFilenameInTempFolder(testBook.Title + BookCompressor.ExtensionForDeviceBloomBook))


### PR DESCRIPTION
Was purposely omitted, but turns out to be needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1823)
<!-- Reviewable:end -->
