### PR TITLE
BL-4901 shut down AndroidView without JS errors

### DIFF
--- a/src/BloomBrowserUI/react_components/progressBox.tsx
+++ b/src/BloomBrowserUI/react_components/progressBox.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import WebSocketManager from "../utils/WebSocketManager";
 
 
 interface ComponentState {
@@ -14,7 +15,7 @@ export default class ProgressBox extends React.Component<{}, ComponentState> {
         let self = this;
         this.state = { progress: "" };
         //get progress messages from c#
-        this.getWebSocket().addEventListener("message", event => {
+        WebSocketManager.addListener(event => {
             var e = JSON.parse(event.data);
             if (e.id === "progress") {
                 self.setState({ progress: self.state.progress + "<br/>" + e.payload });
@@ -46,16 +47,5 @@ export default class ProgressBox extends React.Component<{}, ComponentState> {
         return (
             <div id="progress-box" dangerouslySetInnerHTML={{ __html: this.state.progress }} />
         );
-    }
-
-    // Enhance: We want to extract this higher up. See http://issues.bloomlibrary.org/youtrack/issue/BL-4804
-    private getWebSocket(): WebSocket {
-        let kSocketName = "webSocket";
-        if (typeof window.top[kSocketName] === "undefined") {
-            // Enhance: ask the server for the socket so that we aren't assuming that it is the current port + 1
-            let websocketPort = parseInt(window.location.port, 10) + 1;
-            window.top[kSocketName] = new WebSocket("ws://127.0.0.1:" + websocketPort.toString());
-        }
-        return window.top[kSocketName];
     }
 }

--- a/src/BloomBrowserUI/utils/WebSocketManager.ts
+++ b/src/BloomBrowserUI/utils/WebSocketManager.ts
@@ -1,0 +1,50 @@
+const kSocketName = "webSocket";
+
+// This class manages a websocket, currently at the window level, currently with
+// a fixed name. (Possible enhancement: support top window level).
+// You can add listeners (for "message") with addListener(),
+// and close the socket with closeSocket().
+// Alternatively, using setCloseId, you can make the manager listen for a message
+// with that ID. When received, it will remove all listeners and close the socket.
+// Only one client per page needs to do this.
+// (Without this, our web socket server does eventually receive a close notification
+// when this window goes away, but various inscrutable JavaScript exceptions are raised.)
+export default class WebSocketManager {
+
+    private static listeners: ((event: MessageEvent) => void)[] = new Array();
+
+    public static getWebSocket(): WebSocket {
+        if (!window[kSocketName]) {
+            //currently we use a different port for this websocket, and it's the main port + 1
+            let websocketPort = parseInt(window.location.port, 10) + 1;
+            window[kSocketName] = new WebSocket("ws://127.0.0.1:" + websocketPort.toString());
+        }
+        return window[kSocketName];
+    }
+
+    public static closeSocket(): void {
+        let webSocket: WebSocket = window[kSocketName];
+        if (webSocket) {
+            while (this.listeners.length) {
+                webSocket.removeEventListener("message", this.listeners.pop());
+            }
+            webSocket.close();
+            window[kSocketName] = null;
+        }
+    }
+
+    public static addListener(listener: (ev: MessageEvent) => void): void {
+        this.getWebSocket().addEventListener("message", listener);
+        this.listeners.push(listener);
+    }
+
+    public static setCloseId(id: string): void {
+        let closeListener = (event: MessageEvent) => {
+            var e = JSON.parse(event.data);
+            if (e.id === id) {
+                this.closeSocket();
+            }
+        }
+        this.addListener(closeListener);
+    }
+}

--- a/src/BloomExe/Publish/Android/AndroidView.cs
+++ b/src/BloomExe/Publish/Android/AndroidView.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using Bloom.Api;
 using SIL.PlatformUtilities;
 
 namespace Bloom.Publish.Android
@@ -10,9 +11,11 @@ namespace Bloom.Publish.Android
 	public partial class AndroidView : UserControl
 	{
 		private Browser _browser;
+		private BloomWebSocketServer _webSocketServer;
 
-		public AndroidView(NavigationIsolator isolator)
+		public AndroidView(NavigationIsolator isolator, BloomWebSocketServer webSocketServer)
 		{
+			_webSocketServer = webSocketServer;
 			InitializeComponent();
 
 			_browser = new Browser();
@@ -43,6 +46,10 @@ namespace Bloom.Publish.Android
 
 		public void Deactivate()
 		{
+			// This allows the WebSocketManager to clean up all the listeners and close the socket.
+			// This prevents various JS errors that get raised (BL-4901) if we wait for it to get
+			// closed as the page goes away.
+			_webSocketServer.Send("closeAndroidUISocket", "");
 			// This is important so the react stuff can do its cleanup
 			_browser.WebBrowser.Navigate("about:blank");
 		}

--- a/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
@@ -661,7 +661,7 @@ namespace Bloom.WebLibraryIntegration
 				}
 				var publishModel = new PublishModel(bookSelection, new PdfMaker(), currentEditableCollectionSelection, null, server, _thumbnailer, null);
 				publishModel.PageLayout = book.GetLayout();
-				var view = new PublishView(publishModel, new SelectedTabChangedEvent(), new LocalizationChangedEvent(), this, null, null);
+				var view = new PublishView(publishModel, new SelectedTabChangedEvent(), new LocalizationChangedEvent(), this, null, null, null);
 				string dummy;
 				// Normally we let the user choose which languages to upload. Here, just the ones that have complete information.
 				var langDict = book.AllLanguages;


### PR DESCRIPTION
Also the beginnings of BL-4804, creating a framework for managing the JS side of websockets cleanly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1830)
<!-- Reviewable:end -->
