### PR TITLE
Simplify the WebSocket management system

### DIFF
--- a/src/BloomBrowserUI/react_components/progressBox.tsx
+++ b/src/BloomBrowserUI/react_components/progressBox.tsx
@@ -6,16 +6,18 @@ import WebSocketManager from "../utils/WebSocketManager";
 interface ComponentState {
     progress: string;
 }
-
+interface ComponentProps {
+    lifetimeLabel: string;
+}
 // Note that this component does not do localization; we expect the progress messages
 // to already be localized when they are sent over the websocket.
-export default class ProgressBox extends React.Component<{}, ComponentState> {
-    constructor(props) {
+export default class ProgressBox extends React.Component<ComponentProps, ComponentState> {
+    constructor(props: ComponentProps) {
         super(props);
         let self = this;
         this.state = { progress: "" };
         //get progress messages from c#
-        WebSocketManager.addListener(event => {
+        WebSocketManager.addListener(props.lifetimeLabel, event => {
             var e = JSON.parse(event.data);
             if (e.id === "progress") {
                 self.setState({ progress: self.state.progress + "<br/>" + e.payload });

--- a/src/BloomBrowserUI/utils/WebSocketManager.ts
+++ b/src/BloomBrowserUI/utils/WebSocketManager.ts
@@ -1,50 +1,62 @@
-const kSocketName = "webSocket";
-
 // This class manages a websocket, currently at the window level, currently with
 // a fixed name. (Possible enhancement: support top window level).
 // You can add listeners (for "message") with addListener(),
 // and close the socket with closeSocket().
-// Alternatively, using setCloseId, you can make the manager listen for a message
-// with that ID. When received, it will remove all listeners and close the socket.
-// Only one client per page needs to do this.
-// (Without this, our web socket server does eventually receive a close notification
-// when this window goes away, but various inscrutable JavaScript exceptions are raised.)
 export default class WebSocketManager {
 
     private static listeners: ((event: MessageEvent) => void)[] = new Array();
 
-    public static getWebSocket(): WebSocket {
-        if (!window[kSocketName]) {
+    /**
+      *  In an attempt to make it easier to come to grips with some lifetime issues, we
+      * are naming the websocket by a "socketName" and making this private, so
+      * that clients don't have direct access to the client.
+      * Instead the client should call "addListener(socketName)" and then when cleaning
+      * up, call "closeSocket(socketName)".
+      */
+    private static getWebSocket(socketName: string): WebSocket {
+        if (!window[socketName]) {
             //currently we use a different port for this websocket, and it's the main port + 1
             let websocketPort = parseInt(window.location.port, 10) + 1;
-            window[kSocketName] = new WebSocket("ws://127.0.0.1:" + websocketPort.toString());
+            //here we're passing "socketName" in the "subprotocol" parameter, just for ease of identifying
+            //sockets on the server side when debugging.
+            window[socketName] = new WebSocket("ws://127.0.0.1:" + websocketPort.toString(), socketName);
+
+            // the following is a refactored holdover from a situation where we were having trouble
+            // getting the web ui to properly close its own listeners and socket, so we had to
+            // revert to have c# send a message that would close this down. It may or may not be
+            // used, but it's here if we need it. The perfered method is for the client UI to call closeSocket().
+            let closeListener = (event: MessageEvent) => {
+                var e = JSON.parse(event.data);
+                if (e.id === "websocketControl/close/" + socketName) {
+                    this.closeSocket(socketName);
+                }
+            };
+            this.addListener(socketName, closeListener);
         }
-        return window[kSocketName];
+        return window[socketName];
     }
 
-    public static closeSocket(): void {
-        let webSocket: WebSocket = window[kSocketName];
+    /**
+     * Disconnect all listeners and close the websocket.
+     * @param {string} socketName - should use the same name through the lifetime of the window
+     */
+    public static closeSocket(socketName: string): void {
+        let webSocket: WebSocket = window[socketName];
         if (webSocket) {
             while (this.listeners.length) {
                 webSocket.removeEventListener("message", this.listeners.pop());
             }
             webSocket.close();
-            window[kSocketName] = null;
+            window[socketName] = null;
         }
     }
 
-    public static addListener(listener: (ev: MessageEvent) => void): void {
-        this.getWebSocket().addEventListener("message", listener);
+    /**
+     * Find or create a websocket and add a listener to it.
+     * @param {string} socketName - should use the same name through the lifetime of the window
+     */
+    public static addListener(socketName: string, listener: (ev: MessageEvent) => void): void {
+        this.getWebSocket(socketName).addEventListener("message", listener);
         this.listeners.push(listener);
-    }
-
-    public static setCloseId(id: string): void {
-        let closeListener = (event: MessageEvent) => {
-            var e = JSON.parse(event.data);
-            if (e.id === id) {
-                this.closeSocket();
-            }
-        }
-        this.addListener(closeListener);
     }
 }

--- a/src/BloomExe/Publish/Android/AndroidView.cs
+++ b/src/BloomExe/Publish/Android/AndroidView.cs
@@ -46,10 +46,6 @@ namespace Bloom.Publish.Android
 
 		public void Deactivate()
 		{
-			// This allows the WebSocketManager to clean up all the listeners and close the socket.
-			// This prevents various JS errors that get raised (BL-4901) if we wait for it to get
-			// closed as the page goes away.
-			_webSocketServer.Send("closeAndroidUISocket", "");
 			// This is important so the react stuff can do its cleanup
 			_browser.WebBrowser.Navigate("about:blank");
 		}

--- a/src/BloomExe/Publish/Android/wifi/BloomReaderUDPListener.cs
+++ b/src/BloomExe/Publish/Android/wifi/BloomReaderUDPListener.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -56,9 +57,11 @@ namespace Bloom.Publish.Android.wifi
 						//raise event
 						NewMessageReceived?.Invoke(this, new AndroidMessageArgs(bytes));
 					}
-					catch (Exception e)
+					catch(SocketException se)
 					{
-						Console.WriteLine(e.ToString());
+						if(!_listening || se.SocketErrorCode == SocketError.Interrupted)
+							return; // no problem, we're just closing up shop
+						throw se;
 					}
 				}
 			}

--- a/src/BloomExe/web/BloomWebSocketServer.cs
+++ b/src/BloomExe/web/BloomWebSocketServer.cs
@@ -40,13 +40,15 @@ namespace Bloom.Api
 				{
 					socket.OnOpen = () =>
 					{
-						Debug.WriteLine("Backend received an request to open a BloomWebSocketServer socket");
+						// our Typescript WebSocketManager sticks the name of the socket into this subProtocol parameter just for this debugging purpose
+						Debug.WriteLine($"Opening websocket \"{socket.ConnectionInfo?.SubProtocol}\"");
 						_allSockets.Add(socket);
 					};
 					socket.OnClose = () =>
 					{
-						Debug.WriteLine("Backend received an request to close  BloomWebSocketServer socket");
+						Debug.WriteLine($"Closing websocket \"{socket.ConnectionInfo?.SubProtocol}\"");
 						_allSockets.Remove(socket);
+						socket.Close();
 					};
 				});
 			}
@@ -116,6 +118,7 @@ namespace Bloom.Api
 				{
 					foreach(var socket in _allSockets)
 					{
+						Debug.WriteLine($"*** This sockets was still open and is being closed during shutdown: \"{socket.ConnectionInfo?.SubProtocol}\"");
 						socket.Close();
 					}
 					_allSockets.Clear();


### PR DESCRIPTION
With this commit, users of WebSocketManager have to supply a socket name. The ability to send a message that closes down a named socket is retained, but is not currently used as it did not appear to have any measurable effect, for good or ill. 

On the c# side, we now close sockets instead of just removing them from a list. 

For ease in debugging, on both sides, socket names are now available, by hijacking the "subprotocol" field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1832)
<!-- Reviewable:end -->
