### PR TITLE
Fix BL-4901

### DIFF
--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -168,6 +168,14 @@ namespace Bloom
 
 		internal const string kChannelNameForUnitTests ="TestChannel";
 
+		public static bool IsDevOrAlpha
+		{
+			get
+			{
+				var channel = ApplicationUpdateSupport.ChannelName.ToLowerInvariant();
+				return channel.Contains("developer") || channel.Contains("alpha") || channel.Contains("unstable");
+			}
+		}
 		public static string ChannelName
 		{
 			get

--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -101,7 +101,7 @@ namespace Bloom.Edit
 			{
 				if (RobustFile.Exists(GetPathToSegment(id)))
 				{
-					request.Succeeded();
+					request.PostSucceeded();
 					return;
 				}
 			}
@@ -186,7 +186,7 @@ namespace Bloom.Edit
 				//we requested to stop. A few seconds later (2, looking at the library code today), it will
 				//actually close the file and raise the Stopped event
 				Recorder.Stop();
-				request.Succeeded();
+				request.PostSucceeded();
 				//ReportSuccessfulRecordingAnalytics();
 			}
 			catch (Exception)
@@ -415,7 +415,7 @@ namespace Bloom.Edit
 					if(dev.ProductName == name)
 					{
 						RecordingDevice = dev;
-						request.Succeeded();
+						request.PostSucceeded();
 						return;
 					}
 				}
@@ -440,14 +440,14 @@ namespace Bloom.Edit
 			var path = GetPathToSegment(request.RequiredParam("id"));
 			if(!RobustFile.Exists(path))
 			{
-				request.Succeeded();
+				request.PostSucceeded();
 			}
 			else
 			{
 				try
 				{
 					RobustFile.Delete(path);
-					request.Succeeded();
+					request.PostSucceeded();
 				}
 				catch(IOException e)
 				{

--- a/src/BloomExe/HelpLauncher.cs
+++ b/src/BloomExe/HelpLauncher.cs
@@ -31,7 +31,7 @@ namespace Bloom
 				var topic = request.LocalPath().ToLowerInvariant().Replace("api/help","");
 				Show(Application.OpenForms.Cast<Form>().Last(), topic);
 				//if this is called from a simple html anchor, we don't want the browser to do anything
-				request.SucceededDoNotNavigate();
+				request.ExternalLinkSucceeded();
 			}, true); // opening a form, definitely UI thread
 		}
 	}

--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -55,7 +55,7 @@ namespace Bloom.Publish.Android
 				else // post
 				{
 					Settings.Default.PublishAndroidMethod = request.RequiredPostString();
-					request.SucceededDoNotNavigate();
+					request.PostSucceeded();
 				}
 			}, true);
 
@@ -64,35 +64,35 @@ namespace Bloom.Publish.Android
 			{
 				SetState("UsbStarted");
 				_usbPublisher.Connect(request.CurrentBook);
-				request.SucceededDoNotNavigate();
+				request.PostSucceeded();
 			}, true);
 
 			server.RegisterEndpointHandler(kApiUrlPart + "usb/stop", request =>
 			{
 				_usbPublisher.Stop();
 				SetState("stopped");
-				request.Succeeded();
+				request.PostSucceeded();
 			}, true);
 #endif
 			server.RegisterEndpointHandler(kApiUrlPart + "wifi/start", request =>
 			{
 				_wifiPublisher.Start(request.CurrentBook, request.CurrentCollectionSettings);
 				SetState("ServingOnWifi");
-				request.SucceededDoNotNavigate();
+				request.PostSucceeded();
 			}, true);
 
 			server.RegisterEndpointHandler(kApiUrlPart + "wifi/stop", request =>
 			{
 				_wifiPublisher.Stop();
 				SetState("stopped");
-				request.Succeeded();
+				request.PostSucceeded();
 			}, true);
 
 			server.RegisterEndpointHandler(kApiUrlPart + "file/save", request =>
 			{
 				FilePublisher.Save(request.CurrentBook);
 				SetState("stopped");
-				request.Succeeded();
+				request.PostSucceeded();
 			}, true);
 
 			server.RegisterEndpointHandler(kApiUrlPart + "cleanup", request =>
@@ -102,7 +102,7 @@ namespace Bloom.Publish.Android
 #endif
 				_wifiPublisher.Stop();
 				SetState("stopped");
-				request.Succeeded();
+				request.PostSucceeded();
 			}, true);
 		}
 

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -408,11 +408,16 @@ namespace Bloom.Publish
 			{
 				Controls.Remove(_epubPreviewControl);
 			}
-			if (displayMode != PublishModel.DisplayModes.Android && _androidControl != null && Controls.Contains(_androidControl))
+			if(displayMode != PublishModel.DisplayModes.Android && _androidControl != null && Controls.Contains(_androidControl))
 			{
 				Controls.Remove(_androidControl);
-				_androidControl.Dispose();
-				_androidControl = null;
+
+				// disposal of the browser is good but it hides a multitude of sins that we'd rather catch and fix during development. E.g. BL-4901
+				if(!ApplicationUpdateSupport.IsDevOrAlpha)
+				{
+					_androidControl.Dispose();
+					_androidControl = null;
+				}
 			}
 			if (displayMode != PublishModel.DisplayModes.Upload && displayMode != PublishModel.DisplayModes.EPUB && displayMode != PublishModel.DisplayModes.Android)
 				_pdfViewer.Visible = true;

--- a/src/BloomExe/web/IRequestInfo.cs
+++ b/src/BloomExe/web/IRequestInfo.cs
@@ -27,7 +27,7 @@ namespace Bloom.Api
 		string GetPostJson();
 		string GetPostString();
 		HttpMethods HttpMethod { get; }
-		void SucceededDoNotNavigate();
+		void ExternalLinkSucceeded();
 		string DoNotCacheFolder { set; }
 	}
 }

--- a/src/BloomExe/web/ReadersApi.cs
+++ b/src/BloomExe/web/ReadersApi.cs
@@ -88,7 +88,7 @@ namespace Bloom.Api
 			switch (lastSegment)
 			{
 				case "test":
-					request.Succeeded();
+					request.PostSucceeded();
 					break;
 
 				case "readerToolSettings":
@@ -99,7 +99,7 @@ namespace Bloom.Api
 						var path = DecodableReaderTool.GetReaderToolsSettingsFilePath(request.CurrentCollectionSettings);
 						var content = request.RequiredPostJson();
 						RobustFile.WriteAllText(path, content, Encoding.UTF8);
-						request.Succeeded();
+						request.PostSucceeded();
 					}
 					break;
 
@@ -127,7 +127,7 @@ namespace Bloom.Api
 					}
 
 					SaveSynphonyLanguageData(langdata);
-					request.Succeeded();
+					request.PostSucceeded();
 					break;
 
 				case "sampleTextsList":
@@ -145,12 +145,12 @@ namespace Bloom.Api
 
 				case "makeLetterAndWordList":
 					MakeLetterAndWordList(request.RequiredPostValue("settings"), request.RequiredPostValue("allWords"));
-					request.Succeeded();
+					request.PostSucceeded();
 					break;
 
 				case "openTextsFolder":
 					OpenTextsFolder();
-					request.Succeeded();
+					request.PostSucceeded();
 					break;
 
 				case "chooseAllowedWordsListFile":
@@ -165,7 +165,7 @@ namespace Bloom.Api
 					{
 						case HttpMethods.Delete:
 							RecycleAllowedWordListFile(request.RequiredParam("fileName"));
-							request.Succeeded();
+							request.PostSucceeded();
 							break;
 						case HttpMethods.Get:
 							var fileName = request.RequiredParam("fileName");

--- a/src/BloomExe/web/RequestInfo.cs
+++ b/src/BloomExe/web/RequestInfo.cs
@@ -64,11 +64,10 @@ namespace Bloom.Api
 		}
 
 		//used when an anchor has given us info, but we don't actually want the browser to navigate
-		public void SucceededDoNotNavigate()
+		public void ExternalLinkSucceeded()
 		{
-			_actualContext.Response.StatusCode = 202; //Accepted. Request accepted but not completed yet, it will continue asynchronously.
+			_actualContext.Response.StatusCode = 200; //Completed
 			HaveOutput = true;
-			return;
 		}
 
 		public string DoNotCacheFolder { get; set; }

--- a/src/BloomExe/web/controllers/AddOrChangePageApi.cs
+++ b/src/BloomExe/web/controllers/AddOrChangePageApi.cs
@@ -47,7 +47,7 @@ namespace Bloom.web.controllers
 			{
 				_templateInsertionCommand.Insert(templatePage as Page);
 				_pageRefreshEvent.Raise(PageRefreshEvent.SaveBehavior.JustRedisplay); // needed to get the styles updated
-				request.Succeeded();
+				request.PostSucceeded();
 				return;
 			}
 		}
@@ -68,7 +68,7 @@ namespace Bloom.web.controllers
 					pageChanged.UpdateLineage(new[] { templatePage.Id });
 
 				_pageRefreshEvent.Raise(PageRefreshEvent.SaveBehavior.JustRedisplay);
-				request.Succeeded();
+				request.PostSucceeded();
 			}
 		}
 

--- a/src/BloomExe/web/controllers/ApiRequest.cs
+++ b/src/BloomExe/web/controllers/ApiRequest.cs
@@ -59,7 +59,11 @@ namespace Bloom.Api
 			}
 		}
 
-		public void Succeeded()
+		/// <summary>
+		/// This is safe to use with axios.Post. See BL-4901. There, not returning any text at all
+		/// caused some kind of problem in axios.post(), after the screen had been shut down.
+		/// </summary>
+		public void PostSucceeded()
 		{
 			_requestInfo.ContentType = "text/plain";
 			_requestInfo.WriteCompleteOutput("OK");
@@ -68,9 +72,9 @@ namespace Bloom.Api
 		//Used when an anchor has given us info, but we don't actually want the browser to navigate
 		//For example, anchors that lead to help lead to an api handler that opens help but then
 		//calls this so that the browser just stays where it was.
-		public void SucceededDoNotNavigate()
+		public void ExternalLinkSucceeded()
 		{
-			_requestInfo.SucceededDoNotNavigate();
+			_requestInfo.ExternalLinkSucceeded();
 		}
 
 		public void ReplyWithText(string text)

--- a/src/BloomExe/web/controllers/BookSettingsApi.cs
+++ b/src/BloomExe/web/controllers/BookSettingsApi.cs
@@ -56,7 +56,7 @@ namespace Bloom.Api
 					// and we have no access to put the editable DOM into the right template/non-template state.
 					_pageRefreshEvent.Raise(PageRefreshEvent.SaveBehavior.JustRedisplay);
 #endif
-					request.Succeeded();
+					request.PostSucceeded();
 					break;
 				default:
 					throw new ArgumentOutOfRangeException();

--- a/src/BloomExe/web/controllers/ExternalLinkController.cs
+++ b/src/BloomExe/web/controllers/ExternalLinkController.cs
@@ -85,7 +85,7 @@ namespace Bloom.web
 				try
 				{
 					Process.Start(browser, "\"file:///" + cleanUrl + queryPart + "\"");
-					request.SucceededDoNotNavigate();
+					request.ExternalLinkSucceeded();
 					return;
 				}
 				catch (Exception)
@@ -97,7 +97,7 @@ namespace Bloom.web
 			// If the above failed, either for lack of default browser or exception, try this:
 			Process.Start("\"" + cleanUrl + "\"");
 
-			request.SucceededDoNotNavigate();
+			request.ExternalLinkSucceeded();
 		}
 
 		private static bool TryGetDefaultBrowserPathWindowsOnly(out string defaultBrowserPath)

--- a/src/BloomTests/PretendRequestInfo.cs
+++ b/src/BloomTests/PretendRequestInfo.cs
@@ -100,7 +100,7 @@ namespace Bloom.Api
 		{
 			return "";
 		}
-		public void SucceededDoNotNavigate(){}
+		public void ExternalLinkSucceeded(){}
 		public string DoNotCacheFolder { get; set; }
 
 		public string RawUrl { get; private set; }

--- a/src/BloomTests/web/controllers/EndpointHandlerTests.cs
+++ b/src/BloomTests/web/controllers/EndpointHandlerTests.cs
@@ -64,7 +64,7 @@ namespace BloomTests.web
 		public void Get_EndPointHasTwoSegments_Works()
 		{
 			var result = ApiTest.GetString(_server, endPoint: "parent/child", query: "color=blue", returnType: ApiTest.ContentType.Text,
-				 handler: request => request.Succeeded());
+				 handler: request => request.PostSucceeded());
 			Assert.That(result, Is.EqualTo("OK"));
 		}
 
@@ -73,7 +73,7 @@ namespace BloomTests.web
 		public void Get_EndPointCaseIsIgnored()
 		{
 			var result = ApiTest.GetString(_server, endPoint: "fooBAR", endOfUrlForTest:"FOObar",
-				 handler: request => request.Succeeded());
+				 handler: request => request.PostSucceeded());
 			Assert.That(result, Is.EqualTo("OK"));
 		}
 
@@ -81,13 +81,13 @@ namespace BloomTests.web
 		public void Get_Unrecognized_Throws()
 		{
 			Assert.Throws<System.Net.WebException>(() => ApiTest.GetString(_server, endPoint: "foo[0-9]bar", endOfUrlForTest: "foobar",
-				 handler: request => request.Succeeded()));
+				 handler: request => request.PostSucceeded()));
 		}
 		[Test]
 		public void Get_RegexEndPoint()
 		{
 			var result = ApiTest.GetString(_server, endPoint: "foo[0-9]bar", endOfUrlForTest: "foo7bar",
-				 handler: request => request.Succeeded());
+				 handler: request => request.PostSucceeded());
 			Assert.That(result, Is.EqualTo("OK"));
 		}
 	}


### PR DESCRIPTION
The problem was that the c# reply to the POST did not contain any text (not even an "OK"). I don't know why it should, actually. But without that, the JS POST eventually throws the error we were seeing in BL-4901.

In order to prevent this error in the future, I have renamed 2 of the methods so that it will be clear which one to use:

request.SucceededDoNotNavigate() --> request.ExternalLinkSucceeded()
request.Succeeded() --> request.PostSucceeded()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1833)
<!-- Reviewable:end -->
