### PR TITLE
Fix Linux portability problem with clipboards

### DIFF
--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -4,6 +4,9 @@ using System.Windows;
 using Bloom.Api;
 using Bloom.Properties;
 using Bloom.Publish.Android.file;
+using SIL.Windows.Forms.Miscellaneous;
+
+
 #if !__MonoCS__
 using Bloom.Publish.Android.usb;
 #endif
@@ -110,7 +113,7 @@ namespace Bloom.Publish.Android
 
 			server.RegisterEndpointHandler(kApiUrlPart + "textToClipboard", request =>
 			{
-				Clipboard.SetText(request.RequiredPostString());
+				PortableClipboard.SetText(request.RequiredPostString());
 				request.PostSucceeded();
 			}, true);
 		}


### PR DESCRIPTION
It doesn't even compile on Linux without this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1854)
<!-- Reviewable:end -->
