### PR TITLE
Fix a green dialog crash on closing after publishing to Android

### DIFF
--- a/src/BloomExe/web/BloomWebSocketServer.cs
+++ b/src/BloomExe/web/BloomWebSocketServer.cs
@@ -116,7 +116,8 @@ namespace Bloom.Api
 			{
 				if(_server != null)
 				{
-					foreach(var socket in _allSockets)
+					// Note that sockets remove themselves from _allSockets when they are closed.
+					foreach(var socket in _allSockets.ToArray())
 					{
 						Debug.WriteLine($"*** This sockets was still open and is being closed during shutdown: \"{socket.ConnectionInfo?.SubProtocol}\"");
 						socket.Close();


### PR DESCRIPTION
This was happening every time on Linux.  I don't know about the
Windows behavior, but the fix should be safe everywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1855)
<!-- Reviewable:end -->
