### PR TITLE
Store PageZoom as integer instead of float (BL-5045)

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -674,7 +674,7 @@ namespace Bloom.Edit
 		/// </remarks>
 		private void SetupPageZoom()
 		{
-			var pageZoom = Settings.Default.PageZoom ?? "1.0";
+			var pageZoom = (float)_view.Zoom / 100F;
 			var body = _domForCurrentPage.Body;
 			var pageDiv = body.SelectSingleNode("//div[contains(concat(' ', @class, ' '), ' bloom-page ')]") as XmlElement;
 			if (pageDiv != null)

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1396,20 +1396,40 @@ namespace Bloom.Edit
 			// Whatever the user may have saved (e.g., from earlier use of ctrl-wheel), we'll make this an expected multiple-of-10 percent.
 			get
 			{
-				float zoom;
-				if (float.TryParse(Settings.Default.PageZoom ?? "1.0", out zoom))
-					return (int)Math.Round(zoom * 10F) * 10;
-				else
+				// we used to store floating point numbers, but we now store integer percentages (30%-990% or more?).
+				var zoomString = Settings.Default.PageZoom;
+				if (String.IsNullOrWhiteSpace(zoomString))
 					return 100;
+				if (zoomString.Contains('.'))
+				{
+					float zoomFloat;
+					if (float.TryParse(zoomString, out zoomFloat))
+						return (int)Math.Round(zoomFloat * 10F) * 10;
+					else
+						return 100;
+				}
+				int zoomInt;
+				if (int.TryParse(Settings.Default.PageZoom, out zoomInt))
+				{
+					// we can't go below 30 (30%), so those must be old floating point values that rounded to an integer.
+					if (zoomInt < 30)
+						return zoomInt * 100;
+					else
+						return zoomInt;
+				}
+				else
+				{
+					return 100;
+				}
 			}
 			set
 			{
-				Settings.Default.PageZoom = (value / 100.0).ToString();
+				Settings.Default.PageZoom = value.ToString();
 				Settings.Default.Save();
 				if (_browser1 != null)
 				{
 					RunJavaScript("if (typeof(FrameExports) !=='undefined') {FrameExports.getPageFrameExports().setZoom(" +
-					              Settings.Default.PageZoom + ");}");
+								(value / 100.0).ToString() + ");}");
 				}
 			}
 		}


### PR DESCRIPTION
This avoids differing values for decimal point (period vs comma) when
parsing the zoom value.