### PR TITLE
BL-5013 Update CC icon on license change

### DIFF
--- a/src/BloomExe/ImageProcessing/ImageServer.cs
+++ b/src/BloomExe/ImageProcessing/ImageServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -98,6 +98,7 @@ namespace Bloom.ImageProcessing
 				processImage = false;
 			}
 
+			var originalImageFile = imageFile;
 			if (processImage)
 			{
 				// thumbnail requests have the thumbnail parameter set in the query string
@@ -107,7 +108,7 @@ namespace Bloom.ImageProcessing
 				if (string.IsNullOrEmpty(imageFile)) return false;
 			}
 
-			info.ReplyWithImage(imageFile);
+			info.ReplyWithImage(imageFile, originalImageFile);
 			return true;
 		}
 
@@ -120,11 +121,11 @@ namespace Bloom.ImageProcessing
 			return (new[] { ".png", ".jpg", ".jpeg"}.Contains(extension));
 		}
 
-		static HashSet<string> _imageExtentions = new HashSet<string>(new[] { ".jpg", "jpeg", ".png", ".svg" });
+		static HashSet<string> _imageExtensions = new HashSet<string>(new[] { ".jpg", "jpeg", ".png", ".svg" });
 
 		internal static bool IsImageTypeThatCanBeReturned(string path)
 		{
-			return _imageExtentions.Contains((Path.GetExtension(path) ?? "").ToLowerInvariant());
+			return _imageExtensions.Contains((Path.GetExtension(path) ?? "").ToLowerInvariant());
 		}
 	}
 }

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -1,7 +1,6 @@
-﻿// Copyright (c) 2014-2015 SIL International
+// Copyright (c) 2014-2017 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -14,7 +13,6 @@ using BloomTemp;
 using L10NSharp;
 using SIL.IO;
 using Bloom.Collection;
-using Bloom.Publish;
 using Bloom.Publish.Epub;
 using Bloom.Workspace;
 using Newtonsoft.Json;
@@ -212,7 +210,7 @@ namespace Bloom.Api
 		protected override bool ProcessRequest(IRequestInfo info)
 		{
 			if (CurrentCollectionSettings != null && CurrentCollectionSettings.SettingsFilePath != null)
-				info.DoNotCacheFolder = Path.GetDirectoryName(CurrentCollectionSettings.SettingsFilePath);
+				info.DoNotCacheFolder = Path.GetDirectoryName(CurrentCollectionSettings.SettingsFilePath).Replace('\\','/');
 
 			var localPath = GetLocalPathWithoutQuery(info);
 
@@ -692,13 +690,6 @@ namespace Bloom.Api
 		protected override bool IsRecursiveRequestContext(HttpListenerContext context)
 		{
 			return base.IsRecursiveRequestContext(context) || context.Request.QueryString["generateThumbnaiIfNecessary"] == "true";
-		}
-
-
-		private static void ReplyWithFileContentAndType(IRequestInfo info, string path)
-		{
-			info.ContentType = GetContentType(Path.GetExtension(path));
-			info.ReplyWithFileContent(path);
 		}
 
 		private bool ProcessCssFile(IRequestInfo info, string incomingPath)

--- a/src/BloomExe/web/IRequestInfo.cs
+++ b/src/BloomExe/web/IRequestInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014 SIL International
+// Copyright (c) 2014 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 namespace Bloom.Api
@@ -18,8 +18,8 @@ namespace Bloom.Api
 		string RawUrl { get; }
 		bool HaveOutput { get; }
 		void WriteCompleteOutput(string s);
-		void ReplyWithFileContent(string path);
-		void ReplyWithImage(string path);
+		void ReplyWithFileContent(string path, string originalPath = null);
+		void ReplyWithImage(string path, string originalPath = null);
 		void WriteError(int errorCode);
 		void WriteError(int errorCode, string errorDescription);
 		System.Collections.Specialized.NameValueCollection GetQueryParameters();

--- a/src/BloomExe/web/controllers/ApiRequest.cs
+++ b/src/BloomExe/web/controllers/ApiRequest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
@@ -83,23 +83,25 @@ namespace Bloom.Api
 			_requestInfo.ContentType = "text/plain";
 			_requestInfo.WriteCompleteOutput(text);
 		}
+
 		public void ReplyWithJson(string json)
 		{
 			//Debug.WriteLine(this.Requestinfo.LocalPathWithoutQuery + ": " + json);
 			_requestInfo.ContentType = "application/json";
 			_requestInfo.WriteCompleteOutput(json);
 		}
+
 		public void ReplyWithJson(object objectToMakeJson)
 		{
 			//Debug.WriteLine(this.Requestinfo.LocalPathWithoutQuery + ": " + json);
 			_requestInfo.ContentType = "application/json";
 			_requestInfo.WriteCompleteOutput(JsonConvert.SerializeObject(objectToMakeJson));
 		}
+
 		public void ReplyWithImage(string imagePath)
 		{
 			_requestInfo.ReplyWithImage(imagePath);
 		}
-
 
 		public void Failed(string text)
 		{

--- a/src/BloomTests/PretendRequestInfo.cs
+++ b/src/BloomTests/PretendRequestInfo.cs
@@ -1,7 +1,6 @@
-﻿// Copyright (c) 2014 SIL International
+// Copyright (c) 2014 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System.Collections.Specialized;
-using System.IO;
 using System.Text;
 using SIL.IO;
 
@@ -58,14 +57,14 @@ namespace Bloom.Api
 			HaveOutput = true;
 		}
 
-		public void ReplyWithFileContent(string path)
+		public void ReplyWithFileContent(string path, string originalPath = null)
 		{
 			ReplyImagePath = path;
 			WriteCompleteOutput(RobustFile.ReadAllText(path));
 			HaveOutput = true;
 		}
 
-		public void ReplyWithImage(string path)
+		public void ReplyWithImage(string path, string originalPath = null)
 		{
 			ReplyImagePath = path;
 		}


### PR DESCRIPTION
Caching of images was not playing well with
resizing of images
* Removed one unused method
* Changed all cache-related paths to use fwd slashes
* When resizing images, used the original path to
   decide whether to cache or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1862)
<!-- Reviewable:end -->
