### PR TITLE
Fix problem with odd characters in book names (BL-5037)

### DIFF
--- a/src/BloomExe/UrlPathString.cs
+++ b/src/BloomExe/UrlPathString.cs
@@ -45,7 +45,7 @@ namespace Bloom
 			// decode it.
 
 			if(!strictlyTreatAsEncoded && Regex.IsMatch(unencoded,"%[A-Fa-f0-9]{2}"))
-					unencoded = HttpUtility.UrlDecode(unencoded);
+				unencoded = HttpUtility.UrlDecode(unencoded.Replace("+", "%2B"));	// preserve + as + (as above)
 			return new UrlPathString(unencoded);
 		}
 
@@ -71,6 +71,19 @@ namespace Bloom
 				x  = HttpUtility.UrlEncode(x);
 				//now do our own encoding for the protected space
 				return x.Replace(standInForSpace,"%20");
+			}
+		}
+
+		/// <summary>
+		/// Get the URL encoding but with / and : decoded so that we get a normal looking URL path.
+		/// </summary>
+		/// <value>The URL encoded for http path.</value>
+		public string UrlEncodedForHttpPath
+		{
+			get
+			{
+				var x = UrlEncoded;
+				return x.Replace("%2f","/").Replace("%3a",":");
 			}
 		}
 

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -150,12 +150,10 @@ namespace Bloom.Api
 			var key = pathToSimulatedPageFile.Replace('\\', '/');
 			if (isCurrentPageContent)
 			{
-				// We need to UrlEncode the single and double quote characters so they will play nicely with JavaScript.
-				url = EscapeUrlQuotes(url);
-				// When JavaScript inserts our path into the html it replaces the three magic html characters with these substitutes.
-				// We need to modify our key so that when the JavaScript comes looking for the page its modified url will
-				// generate the right key.
-				key = SimulateJavaScriptHandlingOfHtml(key);
+				// We need to UrlEncode the single and double quote characters, and the space character,
+				// so they will play nicely with HTML.
+				var urlPath = UrlPathString.CreateFromUnencodedString(url);
+				url = urlPath.UrlEncodedForHttpPath;
 			}
 			if(setAsCurrentPageForDebugging)
 			{
@@ -167,26 +165,6 @@ namespace Bloom.Api
 				_urlToSimulatedPageContent[key] = html5String;
 			}
 			return new SimulatedPageFile() {Key = url};
-		}
-
-		/// <summary>
-		/// When JavaScript inserts a url into an html document, it replaces the three magic html characters
-		/// with these substitutes.
-		/// </summary>
-		/// <remarks>Also used by PretendRequestInfo for testing</remarks>
-		public static string SimulateJavaScriptHandlingOfHtml(string url)
-		{
-			return url.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
-		}
-
-		private static string EscapeUrlQuotes(string originalUrl)
-		{
-			return originalUrl.Replace("'", "%27").Replace("\"", "%22");
-		}
-
-		private static string UnescapeUrlQuotes(string escapedUrl)
-		{
-			return escapedUrl.Replace("%27", "'").Replace("%22", "\"");
 		}
 
 		internal static void RemoveSimulatedPageFile(string key)
@@ -482,9 +460,8 @@ namespace Bloom.Api
 		{
 			string modPath = localPath;
 			string path = null;
-			// When JavaScript inserts our path into the html it replaces the three magic html characters with these substitutes.
-			// We need to convert back in order to match our key. Then, reverse the change we made to deal with quotation marks.
-			string tempPath = UnescapeUrlQuotes(modPath.Replace("&lt;", "<").Replace("&gt;", ">").Replace("&amp;", "&"));
+			var urlPath = UrlPathString.CreateFromUrlEncodedString(modPath);
+			var tempPath = urlPath.NotEncoded;
 			if (RobustFile.Exists(tempPath))
 				modPath = tempPath;
 			try

--- a/src/BloomTests/PretendRequestInfo.cs
+++ b/src/BloomTests/PretendRequestInfo.cs
@@ -25,13 +25,12 @@ namespace Bloom.Api
 			// In the real request, RawUrl does not include this prefix
 			RawUrl = url.Replace(ServerBase.ServerUrl, "");
 
-			// When JavaScript inserts a real path into the html it replaces the three magic html characters with these substitutes.
-			// For this PretendRequestInfo we simulate that by doing the replace here in the url.
-			if (forSrcAttr)
-				url = EnhancedImageServer.SimulateJavaScriptHandlingOfHtml(url);
-
 			// Reducing the /// emulates a behavior of the real HttpListener
-			LocalPathWithoutQuery = url.Replace(ServerBase.ServerUrl, "").Replace("/bloom/OriginalImages///", "/bloom/OriginalImages/").Replace("/bloom///", "/bloom/").UnescapeCharsForHttp();
+			var urlToDecode = url.Replace(ServerBase.ServerUrl, "").Replace("/bloom/OriginalImages///", "/bloom/OriginalImages/").Replace("/bloom///", "/bloom/").UnescapeCharsForHttp();
+			// Use the same decoding logic as in the "real" RequestInfo.
+			var pathWithoutLiteralPlusSigns = urlToDecode.Replace("+","%2B");
+			LocalPathWithoutQuery = System.Web.HttpUtility.UrlDecode(pathWithoutLiteralPlusSigns);
+
 		}
 
 		public string LocalPathWithoutQuery { get; set; }


### PR DESCRIPTION
Apparently some processing have moved from javascript to C#.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1866)
<!-- Reviewable:end -->
