### PR TITLE
BL-5056 Handle captive portal better

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -292,6 +292,9 @@
     </Compile>
     <Compile Include="AboutMemory.Designer.cs">
       <DependentUpon>AboutMemory.cs</DependentUpon>
+    </Compile>
+    <Compile Include="BloomWebClient.cs">
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="Book\BookSelectionChangedEventArgs.cs" />
     <Compile Include="Publish\Android\usb\AndroidDeviceUsbConnection.cs" />

--- a/src/BloomExe/BloomWebClient.cs
+++ b/src/BloomExe/BloomWebClient.cs
@@ -1,0 +1,22 @@
+using System.Net;
+
+namespace Bloom
+{
+	/// <summary>
+	/// We need a class that inherits from both System.Net.WebClient and this interface
+	/// so that we can test what happens when Bloom is used behind a captive portal.
+	/// </summary>
+	public class BloomWebClient : WebClient, IBloomWebClient
+	{
+	}
+
+	/// <summary>
+	/// Allows moq-ing of DownloadString to return a simulated captive portal.
+	/// </summary>
+	public interface IBloomWebClient
+	{
+		// WebClient method
+		string DownloadString(string url);
+	}
+
+}

--- a/src/BloomExe/WebLibraryIntegration/LoginDialog.cs
+++ b/src/BloomExe/WebLibraryIntegration/LoginDialog.cs
@@ -1,10 +1,9 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Bloom.Properties;
-using Bloom.Publish;
 using Bloom.Publish.BloomLibrary;
 using L10NSharp;
 using SIL.Code;
@@ -13,7 +12,7 @@ using SIL.Reporting;
 namespace Bloom.WebLibraryIntegration
 {
 	/// <summary>
-	/// this class manages a the login process for Bloom, including signing up for new accounts.
+	/// this class manages the login process for Bloom, including signing up for new accounts.
 	/// (This is a bit clumsy, but makes it easy to switch to login if the user enters a known address,
 	/// or switch to signup if the user tries to log in with an unknown email.
 	/// It also saves passing another object around.)


### PR DESCRIPTION
On my developer machine, triggering the captive portal code results in a Yellow screen error that the user can "Continue" from. If I understand the NonFatalProblem.Report() params correctly, on a Beta or higher release it would just "toast".
This only handles the version upgrade case, unfortunately there are several other areas where Bloom accesses the internet that are not handled here.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1869)
<!-- Reviewable:end -->
