### PR TITLE
Prevent copying/deleting files in template books (BL-5061)

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -281,11 +281,28 @@ namespace Bloom.Book
 		}
 
 		/// <summary>
+		/// Determine whether the folder contains static content that might be read-only.
+		/// For example, template books are read-only on Linux and Windows --allUsers.
+		/// </summary>
+		/// <remarks>
+		/// See https://issues.bloomlibrary.org/youtrack/issue/BL-5061.
+		/// </remarks>
+		public static bool IsStaticContent(string folderPath)
+		{
+			// Checking just /browser/ or just /templates/ might accidently trigger on
+			// a book named "browser" or "templates".
+			// Convert \ to / for Window's sake.  It shouldn't exist in a Linux folder path.
+			return folderPath.Replace('\\','/').Contains("/browser/templates/");
+		}
+
+		/// <summary>
 		/// Compare the images we find in the top level of the book folder to those referenced
 		/// in the dom, and remove any unreferenced on
 		/// </summary>
 		public void CleanupUnusedImageFiles()
 		{
+			if (IsStaticContent(_folderPath))
+				return;
 			//Collect up all the image files in our book's directory
 			var imageFiles = new List<string>();
 			var imageExtentions = new HashSet<string>(new []{ ".jpg", ".png", ".svg" });

--- a/src/BloomExe/Book/XMatterHelper.cs
+++ b/src/BloomExe/Book/XMatterHelper.cs
@@ -201,6 +201,8 @@ namespace Bloom.Book
 		{
 			if (branding == null)
 				return; // in testing.
+			if (BookStorage.IsStaticContent(bookFolderPath))
+				return;
 			var prefix = BrandingApi.kApiBrandingImage + "?id=";
 			foreach (XmlElement imageElt in newPageDiv.SafeSelectNodes("//img"))
 			{


### PR DESCRIPTION
These operations fail on Linux and on Windows when installed --allUsers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1872)
<!-- Reviewable:end -->
