### PR TITLE
Fix misplaced buttons on Linux (BL-5043)

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryView.Designer.cs
+++ b/src/BloomExe/CollectionTab/LibraryView.Designer.cs
@@ -64,7 +64,7 @@
             this._makeBloomPackButton,
             this._settingsButton,
             this._openCreateCollectionButton});
-			this._toolStrip.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
+			this._toolStrip.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
 			this._L10NSharpExtender.SetLocalizableToolTip(this._toolStrip, null);
 			this._L10NSharpExtender.SetLocalizationComment(this._toolStrip, null);
 			this._L10NSharpExtender.SetLocalizationPriority(this._toolStrip, L10NSharp.LocalizationPriority.NotLocalizable);


### PR DESCRIPTION
This should be safe for Windows, but I have no way to test it at the
moment.  Flow style layout engines in Mono are notoriously less capable
than in .Net.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1874)
<!-- Reviewable:end -->
