### PR TITLE
Add target elements to xliff files extracted from HTML

### DIFF
--- a/DistFiles/localization/en/Big Book/ReadMe.xlf
+++ b/DistFiles/localization/en/Big Book/ReadMe.xlf
@@ -4,46 +4,56 @@
     <body>
       <trans-unit id="bigbook.title">
         <source xml:lang="en">About Big Books</source>
+        <target />
         <note>ID: bigbook.title</note>
       </trans-unit>
       <trans-unit id="bigbook.use">
         <source xml:lang="en">Big Books are designed for teachers to hold and read in front of a class. For more information, see this <g id="genid-1" ctype="x-html-a" html:href="http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf">PDF from Scholastic</g>. </source>
+        <target />
         <note>ID: bigbook.use</note>
       </trans-unit>
       <trans-unit id="bigbook.printing">
         <source xml:lang="en">Printing a Big Book</source>
+        <target />
         <note>ID: bigbook.printing</note>
       </trans-unit>
       <trans-unit id="bigbook.printing.enlargeA4">
         <source xml:lang="en">To make things more manageable, this template is set at A4 Landscape, with large fonts.
 You can easily produce books that are A3 (twice as large).
 Just take your A4 PDF to a printer and ask them to enlarge it to A3. </source>
+        <target />
         <note>ID: bigbook.printing.enlargeA4</note>
       </trans-unit>
       <trans-unit id="bigbook.limits">
         <source xml:lang="en">Limitations of this version</source>
+        <target />
         <note>ID: bigbook.limits</note>
       </trans-unit>
       <trans-unit id="bigbook.limits.smallscreen">
-        <source xml:lang="en">If you are using a small screen, it can be hard to read the credits page. Try zooming in using the +/- zoom control at the top-right of your screen so you can edit it.</source>
+        <source xml:lang="en">If you are using a small screen, it can be hard to read the credits page. Try zooming in using the +/- zoom control at the top-right of your screen so you can edit it. </source>
+        <target />
         <note>ID: bigbook.limits.smallscreen</note>
       </trans-unit>
       <trans-unit id="bigbook.limits.Englishtemplate">
         <source xml:lang="en">This version includes an "Instructions for Teachers" page that is already filled out, in English.
 If you would like to have instructions in a different language, you can delete that text and type in your own.
 If you send us that text, we can include it in a future version of the template. </source>
+        <target />
         <note>ID: bigbook.limits.Englishtemplate</note>
       </trans-unit>
       <trans-unit id="bigbook.feedback">
         <source xml:lang="en">Feedback</source>
+        <target />
         <note>ID: bigbook.feedback</note>
       </trans-unit>
       <trans-unit id="bigbook.feedbackvoting">
         <source xml:lang="en">Please give and vote on <g id="genid-2" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g> </source>
+        <target />
         <note>ID: bigbook.feedbackvoting</note>
       </trans-unit>
       <trans-unit id="bigbook.reportsbugs">
         <source xml:lang="en">Please report problems to <g id="genid-3" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g>. </source>
+        <target />
         <note>ID: bigbook.reportsbugs</note>
       </trans-unit>
     </body>

--- a/DistFiles/localization/en/Decodable Reader/ReadMe.xlf
+++ b/DistFiles/localization/en/Decodable Reader/ReadMe.xlf
@@ -4,30 +4,37 @@
     <body>
       <trans-unit id="decodable.definition">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Decodable Reader</g> is a book that carefully limits the letters and words used so that it fits what a new reader is ready to read. Typically a language may have 5 - 10 <g id="genid-2" ctype="x-html-em">decodable stages</g> through which learners progress. </source>
+        <target />
         <note>ID: decodable.definition</note>
       </trans-unit>
       <trans-unit id="decodable.stages">
         <source xml:lang="en">Bloom helps you to define this sequence of <g id="genid-3" ctype="x-html-em">stages</g> that readers work through. Each book you create will be targeted at one of those stages, and Bloom helps you to make sure that your book is <g id="genid-4" ctype="x-html-em">decodable</g> (figure out-able) by learners at that <g id="genid-5" ctype="x-html-em">stage</g>. </source>
+        <target />
         <note>ID: decodable.stages</note>
       </trans-unit>
       <trans-unit id="decodable.templates">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-6" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist. </source>
+        <target />
         <note>ID: decodable.templates</note>
       </trans-unit>
       <trans-unit id="decodable.learn">
         <source xml:lang="en">To learn about using Decodable Readers in Bloom, you can: </source>
+        <target />
         <note>ID: decodable.learn</note>
       </trans-unit>
       <trans-unit id="decodable.learn.videos">
         <source xml:lang="en">Watch <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
+        <target />
         <note>ID: decodable.learn.videos</note>
       </trans-unit>
       <trans-unit id="decodable.learn.helpindex">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Decodable Readers".</source>
+        <target />
         <note>ID: decodable.learn.helpindex</note>
       </trans-unit>
       <trans-unit id="decodable.learn.helpmenu">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
+        <target />
         <note>ID: decodable.learn.helpmenu</note>
       </trans-unit>
     </body>

--- a/DistFiles/localization/en/IntegrityFailureAdvice.xlf
+++ b/DistFiles/localization/en/IntegrityFailureAdvice.xlf
@@ -4,62 +4,77 @@
     <body>
       <trans-unit id="integrity.title">
         <source xml:lang="en">Bloom cannot find some of its own files, and cannot continue</source>
+        <target />
         <note>ID: integrity.title</note>
       </trans-unit>
       <trans-unit id="integrity.causes">
         <source xml:lang="en">Possible Causes</source>
+        <target />
         <note>ID: integrity.causes</note>
       </trans-unit>
       <trans-unit id="integrity.causes.1">
         <source xml:lang="en">Your antivirus may have "quarantined" one or more Bloom files. </source>
+        <target />
         <note>ID: integrity.causes.1</note>
       </trans-unit>
       <trans-unit id="integrity.causes.2">
         <source xml:lang="en">Your computer administrator may have your computer "locked down" to prevent bad things, but in such a way that Bloom could not place these files where they belong.  </source>
+        <target />
         <note>ID: integrity.causes.2</note>
       </trans-unit>
       <trans-unit id="integrity.todo">
         <source xml:lang="en">What To Do</source>
+        <target />
         <note>ID: integrity.todo</note>
       </trans-unit>
       <trans-unit id="integrity.todo.ideas">
         <source xml:lang="en">After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas: </source>
+        <target />
         <note>ID: integrity.todo.ideas</note>
       </trans-unit>
       <trans-unit id="integrity.todo.ideas.Reinstall">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time. </source>
+        <target />
         <note>ID: integrity.todo.ideas.Reinstall</note>
       </trans-unit>
       <trans-unit id="integrity.todo.ideas.Antivirus">
         <source xml:lang="en">If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>. </source>
+        <target />
         <note>ID: integrity.todo.ideas.Antivirus</note>
       </trans-unit>
       <trans-unit id="integrity.todo.ideas.AVAST">
         <source xml:lang="en">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">Instructions</g>. </source>
+        <target />
         <note>ID: integrity.todo.ideas.AVAST</note>
       </trans-unit>
       <trans-unit id="integrity.todo.ideas.Norton">
         <source xml:lang="en">Norton Antivirus: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">Instructions from Symantec</g>. </source>
+        <target />
         <note>ID: integrity.todo.ideas.Norton</note>
       </trans-unit>
       <trans-unit id="integrity.todo.ideas.AVG">
         <source xml:lang="en">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">Instructions from AVG</g>. </source>
+        <target />
         <note>ID: integrity.todo.ideas.AVG</note>
       </trans-unit>
       <trans-unit id="integrity.todo.ideas.Others">
         <source xml:lang="en">Others: Google for "whitelist directory name-of-your-antivirus" </source>
+        <target />
         <note>ID: integrity.todo.ideas.Others</note>
       </trans-unit>
       <trans-unit id="integrity.todo.ideas.Restart">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time. </source>
+        <target />
         <note>ID: integrity.todo.ideas.Restart</note>
       </trans-unit>
       <trans-unit id="integrity.todo.ideas.Retrieve">
         <source xml:lang="en">You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">this image</g>. </source>
+        <target />
         <note>ID: integrity.todo.ideas.Retrieve</note>
       </trans-unit>
       <trans-unit id="integrity.missing">
         <source xml:lang="en">Missing Files</source>
+        <target />
         <note>ID: integrity.missing</note>
       </trans-unit>
     </body>

--- a/DistFiles/localization/en/Leveled Reader/Readme.xlf
+++ b/DistFiles/localization/en/Leveled Reader/Readme.xlf
@@ -4,46 +4,57 @@
     <body>
       <trans-unit id="leveled.definition">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Leveled Reader</g> is a book that is written specifically for a learner who is at a certain level of reading development. Levels define targets for word length, sentence length, etc. They also determine appropriate formatting, vocabulary, illustration support, and topic. </source>
+        <target />
         <note>ID: leveled.definition</note>
       </trans-unit>
       <trans-unit id="leveled.levels">
         <source xml:lang="en">After you have defined a sequence of <g id="genid-2" ctype="x-html-em">levels</g>, you can assign a level to books you create either with this template or the "Decodable Reader Template". As you type into the book, Bloom will help you keep the level in mind and point out when you exceed the limits of the level. </source>
+        <target />
         <note>ID: leveled.levels</note>
       </trans-unit>
       <trans-unit id="leveled.templates">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-3" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist. </source>
+        <target />
         <note>ID: leveled.templates</note>
       </trans-unit>
       <trans-unit id="leveled.learn">
         <source xml:lang="en">To learn about using Leveled Readers in Bloom, you can: </source>
+        <target />
         <note>ID: leveled.learn</note>
       </trans-unit>
       <trans-unit id="leveled.learn.videos">
         <source xml:lang="en">Watch <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
+        <target />
         <note>ID: leveled.learn.videos</note>
       </trans-unit>
       <trans-unit id="leveled.learn.helpindex">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Leveled Readers".</source>
+        <target />
         <note>ID: leveled.learn.helpindex</note>
       </trans-unit>
       <trans-unit id="leveled.learn.helpmenu">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
+        <target />
         <note>ID: leveled.learn.helpmenu</note>
       </trans-unit>
       <trans-unit id="leveled.vs.decodable">
         <source xml:lang="en">Relationship to Decodable Readers</source>
+        <target />
         <note>ID: leveled.vs.decodable</note>
       </trans-unit>
       <trans-unit id="leveled.and.decodable">
         <source xml:lang="en">So how do leveled reader <g id="genid-5" ctype="x-html-em">levels</g> fit in decodable reader <g id="genid-6" ctype="x-html-em">stages</g>? The two concepts are complementary, and Bloom allows you to set both a <g id="genid-7" ctype="x-html-em">decodable stage</g> and a <g id="genid-8" ctype="x-html-em">leveled reader level</g> for a book you are writing. Typically books at level 1 and possibly level 2 will also need to be written with <g id="genid-9" ctype="x-html-em">decodability stages</g> in mind. Books at the first level or two will also need to be careful about being <g id="genid-10" ctype="x-html-em">decodable</g> (i.e. using letters the reader has learned). So a sequence of books might look like this: </source>
+        <target />
         <note>ID: leveled.and.decodable</note>
       </trans-unit>
       <trans-unit id="leveled.reader.level">
         <source xml:lang="en">Leveled Reader Level</source>
+        <target />
         <note>ID: leveled.reader.level</note>
       </trans-unit>
       <trans-unit id="decodable.stage">
         <source xml:lang="en">Decodable Stage</source>
+        <target />
         <note>ID: decodable.stage</note>
       </trans-unit>
     </body>

--- a/DistFiles/localization/en/MissingLameModule.xlf
+++ b/DistFiles/localization/en/MissingLameModule.xlf
@@ -4,16 +4,19 @@
     <body>
       <trans-unit id="missing.lame.please.install">
         <source xml:lang="en">Please Install LAME</source>
+        <target />
         <note>ID: missing.lame.please.install</note>
       </trans-unit>
       <trans-unit id="missing.lame.bloom.needs.lame">
         <source xml:lang="en">This book has audio recordings. Bloom can use these to make a "Talking Book" e-book. However, Bloom needs a program called "LAME for Audacity" in order to create the mp3 files that the book will use. Setting it up is easy. First download and run <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>. Next, restart Bloom.
       </source>
+        <target />
         <note>ID: missing.lame.bloom.needs.lame</note>
       </trans-unit>
       <trans-unit id="missing.lame.audio.optional">
         <source xml:lang="en">If you prefer to go ahead and publish your book without audio, click <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">here</g>.
       </source>
+        <target />
         <note>ID: missing.lame.audio.optional</note>
       </trans-unit>
     </body>

--- a/DistFiles/localization/en/Picture Dictionary/ReadMe.xlf
+++ b/DistFiles/localization/en/Picture Dictionary/ReadMe.xlf
@@ -4,30 +4,37 @@
     <body>
       <trans-unit id="picture.dictionary">
         <source xml:lang="en">About the Picture Dictionary Template</source>
+        <target />
         <note>ID: picture.dictionary</note>
       </trans-unit>
       <trans-unit id="picture.dictionary.use">
         <source xml:lang="en">Use this template to make a picture dictionary that is monolingual, bilingual, or trilingual. </source>
+        <target />
         <note>ID: picture.dictionary.use</note>
       </trans-unit>
       <trans-unit id="picture.dictionary.limits">
         <source xml:lang="en">Limitations of this version</source>
+        <target />
         <note>ID: picture.dictionary.limits</note>
       </trans-unit>
       <trans-unit id="picture.dictionary.stillexperimental">
         <source xml:lang="en">This book is currently marked "experimental" because we know of several problems in layout and convenience. </source>
+        <target />
         <note>ID: picture.dictionary.stillexperimental</note>
       </trans-unit>
       <trans-unit id="picture.dictionary.feedback">
         <source xml:lang="en">Feedback</source>
+        <target />
         <note>ID: picture.dictionary.feedback</note>
       </trans-unit>
       <trans-unit id="picture.dictionary.feedbackvoting">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g> </source>
+        <target />
         <note>ID: picture.dictionary.feedbackvoting</note>
       </trans-unit>
       <trans-unit id="picture.dictionary.reportbugs">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g>. </source>
+        <target />
         <note>ID: picture.dictionary.reportbugs</note>
       </trans-unit>
     </body>

--- a/DistFiles/localization/en/Template Starter/ReadMe.xlf
+++ b/DistFiles/localization/en/Template Starter/ReadMe.xlf
@@ -4,91 +4,112 @@
     <body>
       <trans-unit id="template.starter">
         <source xml:lang="en">How to use the Template Starter</source>
+        <target />
         <note>ID: template.starter</note>
       </trans-unit>
       <trans-unit id="template.starter.firstusage">
         <source xml:lang="en">This special template lets you make your own templates. A template provides a set of related page layouts that an author can choose from in writing an original book. Usually the text blocks and picture blocks on template pages will be empty, ready for an author to fill in. Sometimes there may be standard text or pictures that should be on every copy of the page.
 There are two ways people can use your template. The first way is to start new books. For example, imagine student books that have one page for each school day of the week. You could make a template with 5 pages, each with places to type in text and choose pictures. Curriculum authors could select your template and make a new book, one for each week<g id="genid-1" ctype="x-html-sup"><g id="genid-2" ctype="x-html-a" html:href="#note1">1</g></g>. </source>
+        <target />
         <note>ID: template.starter.firstusage</note>
       </trans-unit>
       <trans-unit id="template.starter.secondusage">
         <source xml:lang="en">The second way people can use templates is as source of new pages, regardless of how they started the book. For example, in some places, each book requires a page as part of a government approval process. You might make a template containing that page and give it to others in your country. Then, when people translate a shellbook, they go to the end of the book and click “Add Page”. The page you made will appear in their list of choices. Some other ideas for templates are alphabet charts, glossaries, and instructions on how to use the book in a classroom. <g id="genid-3" ctype="x-html-sup"><g id="genid-4" ctype="x-html-a" html:href="#note1">2</g></g> </source>
+        <target />
         <note>ID: template.starter.secondusage</note>
       </trans-unit>
       <trans-unit id="template.starter.waystohelp">
         <source xml:lang="en">Making templates is just like making any other custom book; all the same controls are available for making and customizing pages. But since you will probably be sharing with other people, there are a number of things you can do to help users of your template: </source>
+        <target />
         <note>ID: template.starter.waystohelp</note>
       </trans-unit>
       <trans-unit id="template.starter.labelpages">
         <source xml:lang="en">Label Your Pages</source>
+        <target />
         <note>ID: template.starter.labelpages</note>
       </trans-unit>
       <trans-unit id="template.starter.labeleachpage">
         <source xml:lang="en">When you add pages to your template, make sure to give each one useful label<g id="genid-5" ctype="x-html-sup"><g id="genid-6" ctype="x-html-a" html:href="#note2">3</g>,<g id="genid-7" ctype="x-html-a" html:href="@note3">4</g></g>: </source>
+        <target />
         <note>ID: template.starter.labeleachpage</note>
       </trans-unit>
       <trans-unit id="template.starter.labelexample">
         <source xml:lang="en">![custom label](ReadMeImages/customLabel.png)</source>
+        <target />
         <note>ID: template.starter.labelexample</note>
       </trans-unit>
       <trans-unit id="template.starter.thumbnails">
         <source xml:lang="en">Check Your Thumbnails</source>
+        <target />
         <note>ID: template.starter.thumbnails</note>
       </trans-unit>
       <trans-unit id="template.starter.thumbnails.onlyonce">
         <source xml:lang="en">To speed things up, Bloom only makes this thumbnail once, and stores it in the "template" subdirectory of your template: </source>
+        <target />
         <note>ID: template.starter.thumbnails.onlyonce</note>
       </trans-unit>
       <trans-unit id="template.starter.thumbnails.update">
         <source xml:lang="en">If you later make a change to the page, the thumbnail will be out of date. To fix that, click the "Add Page" button, and Bloom will regenerate those thumbnails. If the automatically generated thumbnail doesn't convey the purpose of the page, you can make your own. Just make sure to mark the file as "Read Only" so that Bloom doesn't overwrite it. You can also make your thumbnails as svgs, if you like (that's what we do for templates we ship with Bloom).  In any case, make sure to click "Add Page" at least once before distributing your template, so that all the thumbnails are already generated. </source>
+        <target />
         <note>ID: template.starter.thumbnails.update</note>
       </trans-unit>
       <trans-unit id="template.starter.document">
         <source xml:lang="en">Document Your Template</source>
+        <target />
         <note>ID: template.starter.document</note>
       </trans-unit>
       <trans-unit id="template.starter.describeyours">
         <source xml:lang="en">Also consider adding a description of your template, like the one you are reading now. To do this, put a text file named ReadMe-en.md in your template's folder. This file should follow the <g id="genid-8" ctype="x-html-a" html:href="http://spec.commonmark.org/dingus/">markdown standard</g>. To provide your instructions in other languages, make versions of that file that change the "en" to each language's two letter code. For example ReadMe-fr.md would be shown when Bloom is set to show labels in French. You can also include screenshots, like we have in this document. Place any images you use in a folder named "ReadMeImages", so that images are referenced like this: </source>
+        <target />
         <note>ID: template.starter.describeyours</note>
       </trans-unit>
       <trans-unit id="template.starter.thumbnailsshown">
         <source xml:lang="en">When the Add Page dialog box shows your template pages, it will show a thumbnail: </source>
+        <target />
         <note>ID: template.starter.thumbnailsshown</note>
       </trans-unit>
       <trans-unit id="template.starter.share">
         <source xml:lang="en">Share Your Template</source>
+        <target />
         <note>ID: template.starter.share</note>
       </trans-unit>
       <trans-unit id="template.starter.share.publish">
         <source xml:lang="en">Remember that Bloom is about planting seeds, about sharing. So plan to share your template on the BloomLibrary for people around the world to find. This takes just a few clicks in the Publish Tab. </source>
+        <target />
         <note>ID: template.starter.share.publish</note>
       </trans-unit>
       <trans-unit id="template.starter.share.bloompack">
         <source xml:lang="en">For local colleagues, an easy way to distribute your template is via a Bloom Pack. In the collections tab, right-click on your template's thumbnail. Choose 'Make Bloom Pack'. Save that somewhere, for example to a USB Key. Then take it to another computer, double click on the file you made, and your template will be added to the "Sources for New Books" on that computer. </source>
+        <target />
         <note>ID: template.starter.share.bloompack</note>
       </trans-unit>
       <trans-unit id="template.starter.notes">
         <source xml:lang="en">Notes</source>
+        <target />
         <note>ID: template.starter.notes</note>
       </trans-unit>
       <trans-unit id="template.starter.nothingautomatic">
         <source xml:lang="en">
           <g id="genid-9" ctype="x-html-a" html:name="note1">1</g>: These books could later be combined using the forthcoming Folio feature. Note that Bloom 3.9 does not yet give you a way to indicate that a page should be automatically included in new books; the author will have to add each one from the Add Page dialog. </source>
+        <target />
         <note>ID: template.starter.nothingautomatic</note>
       </trans-unit>
       <trans-unit id="template.starter.nametonotaddpage">
         <source xml:lang="en">
           <g id="genid-10" ctype="x-html-a" html:name="note2">2</g>: If you don't want the pages in your template to show up in the Add Page dialog, you can indicate this to Bloom by creating a file in the book's template folder called NotForAddPage.txt. </source>
+        <target />
         <note>ID: template.starter.nametonotaddpage</note>
       </trans-unit>
       <trans-unit id="template.starter.labelsnottranslatable">
         <source xml:lang="en">
           <g id="genid-11" ctype="x-html-a" html:name="note3">3</g>: People will not be able to translate your labels and descriptions into other national languages. If this is a problem, please contact the Bloom team. </source>
+        <target />
         <note>ID: template.starter.labelsnottranslatable</note>
       </trans-unit>
       <trans-unit id="template.starter.editrawhtml">
         <source xml:lang="en">
           <g id="genid-12" ctype="x-html-a" html:name="note4">4</g>: If you want to the Add Page screen to also provide a short description of the page, you'll need to quit Bloom and edit the template's html in Notepad, like this: <x id="genid-13" ctype="image" html:src="ReadMeImages/pageDescription.png" html:alt="" /> </source>
+        <target />
         <note>ID: template.starter.editrawhtml</note>
       </trans-unit>
     </body>

--- a/DistFiles/localization/en/TrainingVideos.xlf
+++ b/DistFiles/localization/en/TrainingVideos.xlf
@@ -4,90 +4,107 @@
     <body>
       <trans-unit id="training.videos">
         <source xml:lang="en">Bloom Training Videos</source>
+        <target />
         <note>ID: training.videos</note>
       </trans-unit>
       <trans-unit id="training.videos.watch">
         <source xml:lang="en">If you are connected to the internet now, you can watch videos in your web browser: </source>
+        <target />
         <note>ID: training.videos.watch</note>
       </trans-unit>
       <trans-unit id="training.videos.all">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-a" html:href="http://tiny.cc/bloomVimeo">All videos</g>
         </source>
+        <target />
         <note>ID: training.videos.all</note>
       </trans-unit>
       <trans-unit id="training.videos.intro">
         <source xml:lang="en">Introductory Videos</source>
+        <target />
         <note>ID: training.videos.intro</note>
       </trans-unit>
       <trans-unit id="training.videos.whofor">
         <source xml:lang="en">
           <g id="genid-2" ctype="x-html-a" html:href="https://vimeo.com/114043219">Bloom: Who is it for</g>
         </source>
+        <target />
         <note>ID: training.videos.whofor</note>
       </trans-unit>
       <trans-unit id="training.videos.templates">
         <source xml:lang="en">
           <g id="genid-3" ctype="x-html-a" html:href="https://vimeo.com/114024308">Understanding Templates and Shell Books</g>
         </source>
+        <target />
         <note>ID: training.videos.templates</note>
       </trans-unit>
       <trans-unit id="training.videos.basicbook">
         <source xml:lang="en">
           <g id="genid-4" ctype="x-html-a" html:href="https://vimeo.com/112825489">Using the Basic Book template</g>
         </source>
+        <target />
         <note>ID: training.videos.basicbook</note>
       </trans-unit>
       <trans-unit id="training.videos.readers">
         <source xml:lang="en">
           <g id="genid-5" ctype="x-html-a" html:href="http://tiny.cc/usingBloomReaderTemplates">Using Decodable and Leveled Reader Templates (several videos)</g>
         </source>
+        <target />
         <note>ID: training.videos.readers</note>
       </trans-unit>
       <trans-unit id="training.videos.advanced">
         <source xml:lang="en">Advanced Topics</source>
+        <target />
         <note>ID: training.videos.advanced</note>
       </trans-unit>
       <trans-unit id="training.videos.formatting">
         <source xml:lang="en">
           <g id="genid-6" ctype="x-html-a" html:href="https://vimeo.com/117820891">Changing the format of text</g>
         </source>
+        <target />
         <note>ID: training.videos.formatting</note>
       </trans-unit>
       <trans-unit id="training.videos.custompage">
         <source xml:lang="en">
           <g id="genid-7" ctype="x-html-a" html:href="https://vimeo.com/116868148">Using the Custom Page template</g>
         </source>
+        <target />
         <note>ID: training.videos.custompage</note>
       </trans-unit>
       <trans-unit id="training.videos.specialcharacters">
         <source xml:lang="en">
           <g id="genid-8" ctype="x-html-a" html:href="https://vimeo.com/117927599">Inserting special characters</g>
         </source>
+        <target />
         <note>ID: training.videos.specialcharacters</note>
       </trans-unit>
       <trans-unit id="training.videos.readertemplates">
         <source xml:lang="en">
           <g id="genid-9" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">Making a set of Decodable and Leveled Reader Templates (several videos)</g>
         </source>
+        <target />
         <note>ID: training.videos.readertemplates</note>
       </trans-unit>
       <trans-unit id="training.videos.offline">
         <source xml:lang="en">Offline Viewing</source>
+        <target />
         <note>ID: training.videos.offline</note>
       </trans-unit>
       <trans-unit id="training.videos.download">
         <source xml:lang="en">If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer: </source>
+        <target />
         <note>ID: training.videos.download</note>
       </trans-unit>
       <trans-unit id="training.videos.hires">
         <source xml:lang="en">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">High Resolution</g> (Large files)</source>
+        <target />
         <note>ID: training.videos.hires</note>
       </trans-unit>
       <trans-unit id="training.videos.lores">
         <source xml:lang="en">
           <g id="genid-11" ctype="x-html-a" html:href="http://tiny.cc/bloomSDVideos">Low Resolution</g> (Smaller files)</source>
+        <target />
         <note>ID: training.videos.lores</note>
       </trans-unit>
     </body>

--- a/DistFiles/localization/en/Wall Calendar/ReadMe.xlf
+++ b/DistFiles/localization/en/Wall Calendar/ReadMe.xlf
@@ -4,38 +4,47 @@
     <body>
       <trans-unit id="wall.calendar">
         <source xml:lang="en">About the Wall Calendar Template</source>
+        <target />
         <note>ID: wall.calendar</note>
       </trans-unit>
       <trans-unit id="wall.calendar.use">
         <source xml:lang="en">Using this template, you can make an A5-size 12 month calendar, with a picture and quotation on the top page, and days on the bottom. The calendar will use the names of months and days in your language. </source>
+        <target />
         <note>ID: wall.calendar.use</note>
       </trans-unit>
       <trans-unit id="wall.calendar.limits">
         <source xml:lang="en">Limitations of this version</source>
+        <target />
         <note>ID: wall.calendar.limits</note>
       </trans-unit>
       <trans-unit id="wall.calendar.noshells">
         <source xml:lang="en">Currently, you cannot make a "shell" for other languages to use. </source>
+        <target />
         <note>ID: wall.calendar.noshells</note>
       </trans-unit>
       <trans-unit id="wall.calendar.credits">
         <source xml:lang="en">Credits</source>
+        <target />
         <note>ID: wall.calendar.credits</note>
       </trans-unit>
       <trans-unit id="wall.calendar.thanks">
         <source xml:lang="en">Thanks to Bruce Cox (SIL Cameroon) for getting this template started. </source>
+        <target />
         <note>ID: wall.calendar.thanks</note>
       </trans-unit>
       <trans-unit id="wall.calendar.feedback">
         <source xml:lang="en">Feedback</source>
+        <target />
         <note>ID: wall.calendar.feedback</note>
       </trans-unit>
       <trans-unit id="wall.calendar.feedbackvoting">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g> </source>
+        <target />
         <note>ID: wall.calendar.feedbackvoting</note>
       </trans-unit>
       <trans-unit id="wall.calendar.reportbugs">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g>. </source>
+        <target />
         <note>ID: wall.calendar.reportbugs</note>
       </trans-unit>
     </body>

--- a/DistFiles/localization/en/bloomEpubPreview.xlf
+++ b/DistFiles/localization/en/bloomEpubPreview.xlf
@@ -5,67 +5,82 @@
       <trans-unit id="epubpreview.describe">
         <source xml:lang="en">This is an <g id="genid-1" ctype="x-html-a" html:href="https://en.wikipedia.org/wiki/ePUB">ePUB</g> (e-book) version of your book. <g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">It contains audio, so that new readers can listen as they read.</g>
       </source>
+        <target />
         <note>ID: epubpreview.describe</note>
       </trans-unit>
       <trans-unit id="epubpreview.recording.butnotalk">
         <source xml:lang="en">This book has some recordings, but this audio is not included in the ePUB.</source>
+        <target />
         <note>ID: epubpreview.recording.butnotalk</note>
       </trans-unit>
       <trans-unit id="epubpreview.preview">
         <source xml:lang="en">Preview</source>
+        <target />
         <note>ID: epubpreview.preview</note>
       </trans-unit>
       <trans-unit id="epubpreview.resizing">
         <source xml:lang="en">You can resize the preview by dragging the lower right corner of this simulated device. See how your book will look on screens of various sizes.</source>
+        <target />
         <note>ID: epubpreview.resizing</note>
       </trans-unit>
       <trans-unit id="epubpreview.readium">
         <source xml:lang="en">This page uses the <g id="genid-3" ctype="x-html-a" html:href="http://readium.org/">Readium</g> ePUB reader. Books will likely look different on different readers.
       </source>
+        <target />
         <note>ID: epubpreview.readium</note>
       </trans-unit>
       <trans-unit id="epubpreview.talkingbookpreview">
         <source xml:lang="en">The preview here cannot yet play Talking Books. You can listen to it using Adobe's Free <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html">Digital Editions</g> e-book reader.
       </source>
+        <target />
         <note>ID: epubpreview.talkingbookpreview</note>
       </trans-unit>
       <trans-unit id="epubpreview.ontodevice">
         <source xml:lang="en">Getting this book onto your Device</source>
+        <target />
         <note>ID: epubpreview.ontodevice</note>
       </trans-unit>
       <trans-unit id="epubpreview.usingdropbox">
         <source xml:lang="en">A handy way to get books to your phone is to set up Dropbox or similar service on both your computer and your phone/tablet. Just click Save ePUB and then choose your Dropbox folder. On your phone, open the Dropbox app and select your book. If you are using a laptop, you can also try the free <g id="genid-5" ctype="x-html-a" html:href="http://www.ushareit.com/">ShareIt</g> program to send files from your laptop to a phone or tablet.
       </source>
+        <target />
         <note>ID: epubpreview.usingdropbox</note>
       </trans-unit>
       <trans-unit id="epubpreview.recommended.reader">
         <source xml:lang="en">Recommended Reader</source>
+        <target />
         <note>ID: epubpreview.recommended.reader</note>
       </trans-unit>
       <trans-unit id="epubpreview.gitden.okay">
         <source xml:lang="en">Our testing has shown <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Gitden Reader</g> to be a good choice for Android and IOS (IPhone &amp; IPad) devices.
       </source>
+        <target />
         <note>ID: epubpreview.gitden.okay</note>
       </trans-unit>
       <trans-unit id="epubpreview.gitden.limits">
         <source xml:lang="en">To listen to this Talking Book using Gitden on a phone or tablet, you will need to disable Gitden's "Text To Speech" feature. Then it will show you the audio controls.</source>
+        <target />
         <note>ID: epubpreview.gitden.limits</note>
       </trans-unit>
       <trans-unit id="epubpreview.make.it.talk">
         <source xml:lang="en">Make it Talk</source>
+        <target />
         <note>ID: epubpreview.make.it.talk</note>
       </trans-unit>
       <trans-unit id="epubpreview.talking.book.tool">
         <source xml:lang="en">If you want to make a "Talking Book" that new readers can read-along with, use Bloom's <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">Talking Book Tool</g> to add voice recordings.
       </source>
+        <target />
         <note>ID: epubpreview.talking.book.tool</note>
       </trans-unit>
       <trans-unit id="epubpreview.write.us">
         <source xml:lang="en">Write to us!</source>
+        <target />
         <note>ID: epubpreview.write.us</note>
       </trans-unit>
       <trans-unit id="epubpreview.use.help.report">
         <source xml:lang="en">Are you interested in distributing Bloom books for use on phones and other ebook readers? Is there something you would need us to do before it is useful for you? Please use the Help:Report A Problem command to send us feedback. Thanks!</source>
+        <target />
         <note>ID: epubpreview.use.help.report</note>
       </trans-unit>
     </body>

--- a/DistFiles/localization/en/leveledReaderInfo.xlf
+++ b/DistFiles/localization/en/leveledReaderInfo.xlf
@@ -4,43 +4,53 @@
     <body>
       <trans-unit id="leveled.reader.vocabulary">
         <source xml:lang="en">Vocabulary</source>
+        <target />
         <note>ID: leveled.reader.vocabulary</note>
       </trans-unit>
       <trans-unit id="leveled.reader.start.simple">
         <source xml:lang="en">At beginning levels, use simple words that are familiar to children. If it is possible in your language, use words with only one syllable. As children move up to higher levels, you can begin to use words with more syllables. You can begin to use less familiar words. Children should be able to guess the meaning of these less familiar words from the context of the surrounding words and sentences, as well as from the illustrations.</source>
+        <target />
         <note>ID: leveled.reader.start.simple</note>
       </trans-unit>
       <trans-unit id="leveled.reader.formatting">
         <source xml:lang="en">Formatting</source>
+        <target />
         <note>ID: leveled.reader.formatting</note>
       </trans-unit>
       <trans-unit id="leveled.reader.start.large">
         <source xml:lang="en">Beginner readers will benefit from a larger font with clear spacing between words. Having the words or sentences in the same location on each page is also helpful. As readers progress to higher levels, font size and spacing will decrease and sentences can appear in different locations on the page.</source>
+        <target />
         <note>ID: leveled.reader.start.large</note>
       </trans-unit>
       <trans-unit id="leveled.reader.increase.sizes">
         <source xml:lang="en">To increase the font size, line-spacing, and word-spacing in Bloom, click in a text box and then on the grey "cog" icon in the lower left-hand corner. If you do this and then make a template book, books made with that template will also use those font settings.</source>
+        <target />
         <note>ID: leveled.reader.increase.sizes</note>
       </trans-unit>
       <trans-unit id="leveled.reader.predictability">
         <source xml:lang="en">Predictability</source>
+        <target />
         <note>ID: leveled.reader.predictability</note>
       </trans-unit>
       <trans-unit id="leveled.reader.repeat.patterns">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-em">Predictability</g> in a text means that the reader can guess what would come next. You can increase predictability by using repeated patterns. Here are some patterns you can use:</source>
+        <target />
         <note>ID: leveled.reader.repeat.patterns</note>
       </trans-unit>
       <trans-unit id="leveled.reader.repetition">
         <source xml:lang="en">Repetition - repeating parts of the text, for example, using the same sentence with each page and just changing one word in the sentence</source>
+        <target />
         <note>ID: leveled.reader.repetition</note>
       </trans-unit>
       <trans-unit id="leveled.reader.sequencing">
         <source xml:lang="en">Sequencing - a story with a known sequence such as the days of the week or that uses numbers in a pattern</source>
+        <target />
         <note>ID: leveled.reader.sequencing</note>
       </trans-unit>
       <trans-unit id="leveled.reader.building.sequence">
         <source xml:lang="en">Building Sequence - a story with a pattern that is repeated and added to with each new page</source>
+        <target />
         <note>ID: leveled.reader.building.sequence</note>
       </trans-unit>
       <trans-unit id="leveled.reader.rhyme">
@@ -54,53 +64,64 @@ Yellow Duck, Yellow Duck, What do you see?</g>
           <g id="genid-4" ctype="x-html-div" html:class="author">- Bill Martin, Jr. and Eric Carle</g>
         </g>
       </source>
+        <target />
         <note>ID: leveled.reader.rhyme</note>
       </trans-unit>
       <trans-unit id="leveled.reader.illustrations">
         <source xml:lang="en">Illustration Support</source>
+        <target />
         <note>ID: leveled.reader.illustrations</note>
       </trans-unit>
       <trans-unit id="leveled.reader.illustrations.help">
         <source xml:lang="en">Illustrations provide support to the story. Illustrations relate to the story in different ways at different <g id="genid-5" ctype="x-html-em">levels</g> and for different types of readers (see below). Remember that in many cultures that don't have a lot of printed material around, complex pictures may be difficult to understand.
     </source>
+        <target />
         <note>ID: leveled.reader.illustrations.help</note>
       </trans-unit>
       <trans-unit id="leveled.reader.illustrations.emergent.reader">
         <source xml:lang="en">For <g id="genid-6" ctype="x-html-strong">Emergent Readers</g> the pictures should closely match the storyline. The reader should be able to predict the story line just by looking at the pictures. The illustrations at this level should be simple.
       </source>
+        <target />
         <note>ID: leveled.reader.illustrations.emergent.reader</note>
       </trans-unit>
       <trans-unit id="leveled.reader.illustrations.early.reader">
         <source xml:lang="en">For <g id="genid-7" ctype="x-html-strong">Early Readers</g> the pictures should offer some support to the story line. As the amount of text increases, the reader is less reliant on the pictures and gets more meaning from the text. The illustrations can be more complex.
       </source>
+        <target />
         <note>ID: leveled.reader.illustrations.early.reader</note>
       </trans-unit>
       <trans-unit id="leveled.reader.fluent.reader">
         <source xml:lang="en">For <g id="genid-8" ctype="x-html-strong">Fluent Readers</g> the pictures should offer little or no support to the story line. The reader relies more on the text than the pictures for meaning. The illustrations can be even more complex.
       </source>
+        <target />
         <note>ID: leveled.reader.fluent.reader</note>
       </trans-unit>
       <trans-unit id="leveled.reader.topic.choice">
         <source xml:lang="en">Choice of Topic</source>
+        <target />
         <note>ID: leveled.reader.topic.choice</note>
       </trans-unit>
       <trans-unit id="leveled.reader.topic.choice.discussion">
         <source xml:lang="en">Books can be on many topics. When developing books for beginning readers, choose topics that are familiar to them. Readers will be eager to read and will read more if they are reading about things they find interesting and familiar. For more experienced readers, topics can include information that the reader is not already familiar with.</source>
+        <target />
         <note>ID: leveled.reader.topic.choice.discussion</note>
       </trans-unit>
       <trans-unit id="leveled.reader.topic.choice.emergent.reader">
         <source xml:lang="en">For <g id="genid-9" ctype="x-html-strong">Emergent Readers</g> the book should be concrete, should focus on one idea/theme, and should be familiar and easy to understand.
       </source>
+        <target />
         <note>ID: leveled.reader.topic.choice.emergent.reader</note>
       </trans-unit>
       <trans-unit id="leveled.reader.topic.choice.early.reader">
         <source xml:lang="en">For <g id="genid-10" ctype="x-html-strong">Early Readers</g>, develop a story around a familiar concept but in greater depth.
       </source>
+        <target />
         <note>ID: leveled.reader.topic.choice.early.reader</note>
       </trans-unit>
       <trans-unit id="leveled.reader.topic.choice.fluent.reader">
         <source xml:lang="en">For <g id="genid-11" ctype="x-html-strong">Fluent Readers</g> the concepts can expand beyond what is familiar, be more varied, and be abstract.
       </source>
+        <target />
         <note>ID: leveled.reader.topic.choice.fluent.reader</note>
       </trans-unit>
     </body>


### PR DESCRIPTION
This was recommended by the crowdin technical support to ensure that
crowdin produces valid xliff 1.2 files.

This set of files was generated by HtmlXliff during the build process.  A separate checkin will be needed
for the Bloom.xlf and Palaso.xlf files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1879)
<!-- Reviewable:end -->
