### PR TITLE
Remove ability for user to launch L10NSharp dialog (BL-5111)

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -919,6 +919,9 @@ namespace Bloom
 											Resources.BloomIcon, "issues@bloomlibrary.org", "SIL");
 
 				Settings.Default.UserInterfaceLanguage = LocalizationManager.UILanguageId;
+
+				// If this is removed, change code in WorkspaceView.OnSettingsProtectionChanged
+				LocalizationManager.EnableClickingOnControlToBringUpLocalizationDialog = false; // BL-5111
 			}
 			catch (Exception error)
 			{

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
@@ -288,25 +288,27 @@ namespace Bloom.Workspace
 		{
 			//when we need to use Ctrl+Shift to display stuff, we don't want it also firing up the localization dialog (which shouldn't be done by a user under settings protection anyhow)
 
-			LocalizationManager.EnableClickingOnControlToBringUpLocalizationDialog = !SettingsProtectionSettings.Default.NormallyHidden;
+			// Commented out due to BL-5111
+			//LocalizationManager.EnableClickingOnControlToBringUpLocalizationDialog = !SettingsProtectionSettings.Default.NormallyHidden;
 		}
 
 		private void SetupUiLanguageMenu()
 		{
 			SetupUiLanguageMenuCommon(_uiLanguageMenu, FinishUiLanguageMenuItemClick);
 
-			_uiLanguageMenu.DropDownItems.Add(new ToolStripSeparator());
-			var menu = _uiLanguageMenu.DropDownItems.Add(LocalizationManager.GetString("CollectionTab.MoreLanguagesMenuItem", "More..."));
-			menu.Click += new EventHandler((a, b) =>
-			{
-				_localizationManager.ShowLocalizationDialogBox(false);
-				SetupUiLanguageMenu();
-				LocalizationManager.ReapplyLocalizationsToAllObjectsInAllManagers(); //review: added this based on its name... does it help?
-				_localizationChangedEvent.Raise(null);
-				// The following is needed for proper display on Linux, and doesn't hurt anything on Windows.
-				// See http://issues.bloomlibrary.org/youtrack/issue/BL-3444.
-				AdjustButtonTextsForLocale();
-			});
+			// Removing this for now (BL-5111)
+			//_uiLanguageMenu.DropDownItems.Add(new ToolStripSeparator());
+			//var menu = _uiLanguageMenu.DropDownItems.Add(LocalizationManager.GetString("CollectionTab.MoreLanguagesMenuItem", "More..."));
+			//menu.Click += new EventHandler((a, b) =>
+			//{
+			//	_localizationManager.ShowLocalizationDialogBox(false);
+			//	SetupUiLanguageMenu();
+			//	LocalizationManager.ReapplyLocalizationsToAllObjectsInAllManagers(); //review: added this based on its name... does it help?
+			//	_localizationChangedEvent.Raise(null);
+			//	// The following is needed for proper display on Linux, and doesn't hurt anything on Windows.
+			//	// See http://issues.bloomlibrary.org/youtrack/issue/BL-3444.
+			//	AdjustButtonTextsForLocale();
+			//});
 		}
 
 		/// <summary>
@@ -942,7 +944,7 @@ namespace Bloom.Workspace
 	{
 		public NoBorderToolStripRenderer() : base(new NoBorderToolStripColorTable())
 		{
-			
+
 		}
 		protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e) { }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1890)
<!-- Reviewable:end -->
