### PR TITLE
BL-5087 Add bulk upload capability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 trim_trailing_whitespace = true
 insert_final_newline = true
-charset = utf-8
+//charset = utf-8 (due to VS2017 bug)
 indent_size = 4
 
 [*.{cs,csproj,sln}]

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -308,6 +308,7 @@
     <Compile Include="Book\CurrentEditableCollectionSelection.cs" />
     <Compile Include="CLI\DownloadBookCommand.cs" />
     <Compile Include="CLI\GetUsedFontsCommand.cs" />
+    <Compile Include="CLI\UploadCommand.cs" />
     <Compile Include="CLI\HydrateBookCommand.cs" />
     <Compile Include="Edit\BookSettingsTool.cs" />
     <Compile Include="Edit\ToolboxTool.cs" />

--- a/src/BloomExe/Book/BookInfo.cs
+++ b/src/BloomExe/Book/BookInfo.cs
@@ -25,6 +25,7 @@ namespace Bloom.Book
 	public class BookInfo
 	{
 		private const string kTopicPrefix = "topic:";
+		private const string kBookshelfPrefix = "bookshelf:";
 
 		private BookMetaData _metadata;
 
@@ -313,6 +314,24 @@ namespace Bloom.Book
 			}
 		}
 
+		/// <summary>
+		/// Allow mass uploader to set a bookshelf tag before uploading.
+		/// </summary>
+		public string SetBookshelf
+		{
+			set
+			{
+				var bookshelvesToSet = SplitList(value); // we're only ever setting one at this point, but that could change
+				EnsureBookshelfPrefixes(bookshelvesToSet);
+				if (MetaData.Tags == null)
+					MetaData.Tags = bookshelvesToSet;
+				else
+					// Leave all the non-bookshelf tags intact. Replace all existing bookshelves.
+					MetaData.Tags = MetaData.Tags.Where(t => !TagIsBookshelf(t)).Union(bookshelvesToSet).ToArray();
+				Save();
+			}
+		}
+
 		public int PageCount
 		{
 			get { return MetaData.PageCount; }
@@ -408,22 +427,36 @@ namespace Bloom.Book
 			}
 		}
 
-		private bool TagIsTopic(string tag)
+		private static bool TagIsTopic(string tag)
 		{
 			return tag.StartsWith(kTopicPrefix) || !tag.Contains(":");
 		}
 
-		private string GetTopicNameFromTag(string tag)
+		private static string GetTopicNameFromTag(string tag)
 		{
 			return tag.StartsWith(kTopicPrefix) ? tag.Substring(kTopicPrefix.Length) : tag;
 		}
 
-		private void EnsureTopicPrefixes(string[] topics)
+		private static void EnsureTopicPrefixes(string[] topics)
 		{
 			for (int i = 0; i < topics.Length; i++)
 			{
 				if (!topics[i].StartsWith(kTopicPrefix))
 					topics[i] = kTopicPrefix + topics[i];
+			}
+		}
+
+		private static bool TagIsBookshelf(string tag)
+		{
+			return tag.StartsWith(kBookshelfPrefix) || !tag.Contains(":");
+		}
+
+		private static void EnsureBookshelfPrefixes(string[] bookshelfs)
+		{
+			for (int i = 0; i < bookshelfs.Length; i++)
+			{
+				if (!bookshelfs[i].StartsWith(kBookshelfPrefix))
+					bookshelfs[i] = kBookshelfPrefix + bookshelfs[i];
 			}
 		}
 	}

--- a/src/BloomExe/CLI/UploadCommand.cs
+++ b/src/BloomExe/CLI/UploadCommand.cs
@@ -10,14 +10,14 @@ namespace Bloom.CLI
 	/// <summary>
 	/// Uploads a book or folder of books to BloomLibrary
 	/// usage:
-	///		upload --path {path to book or collection directory}
+	///		upload [--excludeAudio/-x] {path to book or collection directory}
 	/// </summary>
 	class UploadCommand
 	{
 		public static int Handle(UploadParameters options)
 		{
 			// This task will be all the program does. We need to do enough setup so that
-			// the download code can work, then tear it down.
+			// the upload code can work, then tear it down.
 			Program.SetUpErrorHandling();
 			try
 			{
@@ -32,7 +32,7 @@ namespace Bloom.CLI
 					// Since Bloom is not a normal console app, when run from a command line, the new command prompt
 					// appears at once. The extra newlines here are attempting to separate this from our output.
 					Console.WriteLine("\nstarting upload");
-					transfer.UploadFolder(options.Path, applicationContainer);
+					transfer.UploadFolder(options.Path, applicationContainer, options.ExcludeAudio);
 					Console.WriteLine(("\nupload complete\n"));
 				}
 				return 0;
@@ -54,6 +54,9 @@ namespace Bloom.CLI
 [Verb("upload", HelpText = "Upload a book or folder of books to bloomlibrary.org.")]
 public class UploadParameters
 {
-	[Option("path", HelpText = "path to the book or folder, determined automatically", Required = true)]
+	[Value(0, MetaName = "path", HelpText = "Path to the book or folder, determined automatically.", Required = true)]
 	public string Path { get; set; }
+
+	[Option('x', "excludeAudio", HelpText = "Option excludes audio files from upload", Required = false)]
+	public bool ExcludeAudio { get; set; }
 }

--- a/src/BloomExe/CLI/UploadCommand.cs
+++ b/src/BloomExe/CLI/UploadCommand.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Diagnostics;
+using Bloom.Properties;
+using Bloom.WebLibraryIntegration;
+using CommandLine;
+using L10NSharp;
+
+namespace Bloom.CLI
+{
+	/// <summary>
+	/// Uploads a book or folder of books to BloomLibrary
+	/// usage:
+	///		upload --path {path to book or collection directory}
+	/// </summary>
+	class UploadCommand
+	{
+		public static int Handle(UploadParameters options)
+		{
+			// This task will be all the program does. We need to do enough setup so that
+			// the download code can work, then tear it down.
+			Program.SetUpErrorHandling();
+			try
+			{
+				using (var applicationContainer = new ApplicationContainer())
+				{
+					Program.SetUpLocalization(applicationContainer);
+					Browser.SetUpXulRunner();
+					Browser.XulRunnerShutdown += Program.OnXulRunnerShutdown;
+					LocalizationManager.SetUILanguage(Settings.Default.UserInterfaceLanguage, false);
+					var transfer = new BookTransfer(new BloomParseClient(), ProjectContext.CreateBloomS3Client(),
+						applicationContainer.BookThumbNailer, new BookDownloadStartingEvent());
+					// Since Bloom is not a normal console app, when run from a command line, the new command prompt
+					// appears at once. The extra newlines here are attempting to separate this from our output.
+					Console.WriteLine("\nstarting upload");
+					transfer.UploadFolder(options.Path, applicationContainer);
+					Console.WriteLine(("\nupload complete\n"));
+				}
+				return 0;
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine(ex.Message);
+				Console.WriteLine(ex.Message);
+				Console.WriteLine(ex.StackTrace);
+				return 1;
+			}
+		}
+	}
+}
+
+// Used with https://github.com/gsscoder/commandline, which we get via nuget.
+// (using the beta of commandline 2.0, as of Bloom 3.8)
+
+[Verb("upload", HelpText = "Upload a book or folder of books to bloomlibrary.org.")]
+public class UploadParameters
+{
+	[Option("path", HelpText = "path to the book or folder, determined automatically", Required = true)]
+	public string Path { get; set; }
+}

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -80,6 +80,9 @@ namespace Bloom
 			// We use crowdin for localizing, and they require a directory per language setup.
 			LocalizationManager.UseLanguageCodeFolders = true;
 
+#if DEBUG
+			//MessageBox.Show("Attach debugger now");
+#endif
 			// Bloom has several command line scenarios, without a coherent system for them.
 			// The following is how we will do things from now on, and things can be moved
 			// into this as time allows. See CommandLineOptions.cs.
@@ -112,7 +115,6 @@ namespace Bloom
 				return exitCode; // we're done
 			}
 
-			//Debug.Fail("Attach Now");
 			try
 			{
 				Application.EnableVisualStyles();
@@ -253,21 +255,6 @@ namespace Bloom
 
 					using (_applicationContainer = new ApplicationContainer())
 					{
-						if (args.Length == 2 && args[0].ToLowerInvariant() == "--upload")
-						{
-							// A special path to upload chunks of stuff. This is not currently documented and is not very robust.
-							// - User must log in before running this
-							// - For best results each bloom book needs to be part of a collection in its parent folder
-							// - little error checking (e.g., we don't apply the usual constraints that a book must have title and licence info)
-							SetUpLocalization();
-							Browser.SetUpXulRunner();
-							Browser.XulRunnerShutdown += OnXulRunnerShutdown;
-							var transfer = new BookTransfer(new BloomParseClient(), ProjectContext.CreateBloomS3Client(),
-								_applicationContainer.BookThumbNailer, new BookDownloadStartingEvent()) /*not hooked to anything*/;
-							transfer.UploadFolder(args[1], _applicationContainer);
-							return 1;
-						}
-
 						InstallerSupport.MakeBloomRegistryEntries(args);
 						BookDownloadSupport.EnsureDownloadFolderExists();
 

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -83,15 +83,16 @@ namespace Bloom
 			// Bloom has several command line scenarios, without a coherent system for them.
 			// The following is how we will do things from now on, and things can be moved
 			// into this as time allows. See CommandLineOptions.cs.
-			if (args1.Length > 0 && new[] {"--help", "hydrate", "download", "getfonts"}.Contains(args1[0])) //restrict using the commandline parser to cases were it should work
+			if (args1.Length > 0 && new[] {"--help", "hydrate", "upload", "download", "getfonts"}.Contains(args1[0])) //restrict using the commandline parser to cases were it should work
 			{
 #if !__MonoCS__
 				AttachConsole(-1);
 #endif
 				var exitCode = CommandLine.Parser.Default.ParseArguments(args1,
-					new[] {typeof (HydrateParameters), typeof (DownloadBookOptions), typeof (GetUsedFontsParameters)})
+					new[] {typeof (HydrateParameters), typeof(UploadParameters), typeof(DownloadBookOptions), typeof (GetUsedFontsParameters)})
 					.MapResult(
 						(HydrateParameters opts) => HandlePrepareCommandLine(opts),
+						(UploadParameters opts) => UploadCommand.Handle(opts),
 						(DownloadBookOptions opts) => DownloadBookCommand.HandleSilentDownload(opts),
 						(GetUsedFontsParameters opts) => GetUsedFontsCommand.Handle(opts),
 						errors =>
@@ -438,6 +439,11 @@ namespace Bloom
 			if (_debugServerStarter != null)
 				_debugServerStarter.Dispose();
 			_debugServerStarter = null;
+		}
+
+		internal static void SetProjectContext(ProjectContext projectContext)
+		{
+			_projectContext = projectContext;
 		}
 
 		private static void Run()

--- a/src/BloomExe/Publish/PublishView.Designer.cs
+++ b/src/BloomExe/Publish/PublishView.Designer.cs
@@ -76,6 +76,7 @@ namespace Bloom.Publish
 			// _makePdfBackgroundWorker
 			//
 			this._makePdfBackgroundWorker.WorkerSupportsCancellation = true;
+			this._makePdfBackgroundWorker.WorkerReportsProgress = true;
 			this._makePdfBackgroundWorker.DoWork += new System.ComponentModel.DoWorkEventHandler(this._makePdfBackgroundWorker_DoWork);
 			//
 			// _workingIndicator

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -98,7 +98,10 @@ namespace Bloom.Publish
 			// Adding this renderer prevents a white line from showing up under the components.
 			_menusToolStrip.Renderer = new EditingView.FixedToolStripRenderer();
 
-			GeckoPreferences.Default["pdfjs.disabled"] = false;
+			// As far as I can tell, this is not needed anymore, and its presence,
+			// at least in this place in the code, causes errors when running command-line tools
+			// like UploadCommand which needs a PublishView but must not have something fully initialized.
+			//GeckoPreferences.Default["pdfjs.disabled"] = false;
 			SetupLocalization();
 			localizationChangedEvent.Subscribe(o =>
 			{

--- a/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
@@ -189,7 +189,8 @@ namespace Bloom.WebLibraryIntegration
 		/// </summary>
 		/// <param name="storageKeyOfBookFolder"></param>
 		/// <param name="pathToBloomBookDirectory"></param>
-		public void UploadBook(string storageKeyOfBookFolder, string pathToBloomBookDirectory, IProgress progress, string pdfToInclude = null, bool includeAudio = false)
+		/// <param name="excludeAudio">If true, audio files are not uploaded.</param>
+		public void UploadBook(string storageKeyOfBookFolder, string pathToBloomBookDirectory, IProgress progress, string pdfToInclude = null, bool excludeAudio = false)
 		{
 			BaseUrl = null;
 			BookOrderUrlOfRecentUpload = null;
@@ -222,9 +223,9 @@ namespace Bloom.WebLibraryIntegration
 
 			var destDirName = Path.Combine(wrapperPath, Path.GetFileName(pathToBloomBookDirectory));
 			CopyDirectory(pathToBloomBookDirectory, destDirName);
-			if (!includeAudio)
+			if (excludeAudio)
 			{
-				// Don't upload audio (todo: test).
+				// Don't upload audio.
 				string audioDir = Path.Combine(destDirName, "audio");
 				if (Directory.Exists(audioDir))
 					SIL.IO.RobustIO.DeleteDirectory(audioDir, true);

--- a/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
@@ -183,14 +183,13 @@ namespace Bloom.WebLibraryIntegration
 
 
 		/// <summary>
-				/// The thing here is that we need to guarantee unique names at the top level, so we wrap the books inside a folder
-				/// with some unique name. As this involves copying the folder it is also a convenient place to omit any PDF files
-				/// except the one we want.
-				/// </summary>
-				/// <param name="storageKeyOfBookFolder"></param>
-				/// <param name="pathToBloomBookDirectory"></param>
-			public
-			void UploadBook(string storageKeyOfBookFolder, string pathToBloomBookDirectory, IProgress progress,  string pdfToInclude = null)
+		/// The thing here is that we need to guarantee unique names at the top level, so we wrap the books inside a folder
+		/// with some unique name. As this involves copying the folder it is also a convenient place to omit any PDF files
+		/// except the one we want.
+		/// </summary>
+		/// <param name="storageKeyOfBookFolder"></param>
+		/// <param name="pathToBloomBookDirectory"></param>
+		public void UploadBook(string storageKeyOfBookFolder, string pathToBloomBookDirectory, IProgress progress, string pdfToInclude = null, bool includeAudio = false)
 		{
 			BaseUrl = null;
 			BookOrderUrlOfRecentUpload = null;
@@ -223,10 +222,13 @@ namespace Bloom.WebLibraryIntegration
 
 			var destDirName = Path.Combine(wrapperPath, Path.GetFileName(pathToBloomBookDirectory));
 			CopyDirectory(pathToBloomBookDirectory, destDirName);
-			// Don't upload audio (todo: test).
-			string audioDir = Path.Combine(destDirName, "audio");
-			if (Directory.Exists(audioDir))
-				SIL.IO.RobustIO.DeleteDirectory(audioDir, true);
+			if (!includeAudio)
+			{
+				// Don't upload audio (todo: test).
+				string audioDir = Path.Combine(destDirName, "audio");
+				if (Directory.Exists(audioDir))
+					SIL.IO.RobustIO.DeleteDirectory(audioDir, true);
+			}
 			var unwantedPdfs = Directory.EnumerateFiles(destDirName, "*.pdf").Where(x => Path.GetFileName(x) != pdfToInclude);
 			foreach (var file in unwantedPdfs)
 				RobustFile.Delete(file);


### PR DESCRIPTION
This PR consists of 3 commits:
1 - Andrew's unsubmitted work for uploading Bible Storying Videos
2 - My work to get it creating pdfs and tagging with bookshelf name
3 - Making the process restartable
This is a command line addition to Bloom that I run from a 1 line .bat
file. Bloom needs to be called with "upload" verb, optional flag to
exclude audio files (--excludeAudio or -x), path of directory tree to
upload (e.g. K:\EnablingWriters).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1892)
<!-- Reviewable:end -->
