### PR TITLE
Fix Linux Bloom 4.0 to use new libtidy-sil package (BL-4988)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Package: bloom-desktop-alpha
 Architecture: any
 Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  mono4-sil, libgdiplus4-sil, gtklp,
- chmsee, libtidy5,
+ chmsee, libtidy-sil,
  fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,
  optipng, libsndfile1,
  wmctrl, lame, ghostscript

--- a/environ
+++ b/environ
@@ -56,6 +56,9 @@ else
 	MONO_GAC_PREFIX="${MONO_PREFIX}:/usr"
 fi
 
+# point to our private version of libtidy
+LD_LIBRARY_PATH="/opt/tidy-sil/lib:${LD_LIBRARY_PATH}"
+
 ################################################################################################
 
 MONO_TRACE_LISTENER="Console.Out"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1901)
<!-- Reviewable:end -->
