### PR TITLE
BL-5122 prevent JS error by removing use of local storage

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/decodableReader/decodableReaderToolboxPanel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/decodableReader/decodableReaderToolboxPanel.ts
@@ -13,8 +13,7 @@ export default class DecodableReaderToolboxPanel implements ITabModel {
     beginRestoreSettings(settings: string): JQueryPromise<void> {
         return beginInitializeDecodableReaderTool().then(() => {
             if (settings['decodableReaderState']) {
-                var state = theOneLibSynphony.dbGet('drt_state');
-                if (!state) state = new DRTState();
+                var state = new DRTState();
                 var decState = settings['decodableReaderState'];
                 if (decState.startsWith("stage:")) {
                     var parts = decState.split(";");

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.d.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.d.ts
@@ -22,9 +22,7 @@ export class LanguageData {
 
 export class LibSynphony {
 
-    dbGet(key: string): any;
-    dbSet(key: string, value: any): void;
-  setExtraSentencePunctuation(extra: string): void;
+    setExtraSentencePunctuation(extra: string): void;
     stringToSentences(textHTML: string): TextFragment[];
     langDataFromString(langDataString: string): boolean;
     getWordsFromHtmlString(textHTML: string): string[];

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.js
@@ -578,51 +578,6 @@ LibSynphony.prototype.wrap_words_extra = function (storyHTML, aWords, cssClass, 
 };
 
 /**
- * Detects if the browser has the localStorage object.
- * @returns {Boolean}
- */
-LibSynphony.prototype.supportsHTML5Storage = function () {
-
-    try {
-        return 'localStorage' in window && window['localStorage'] !== null;
-    } catch (e) {
-        return false;
-    }
-};
-
-/**
- * Gets data previously stored locally in the browser.
- * @param {String} key
- * @returns {Array|Object}
- */
-LibSynphony.prototype.dbGet = function (key) {
-
-    if (this.supportsHTML5Storage()) {
-        var item = localStorage.getItem(key);
-        if (!item)
-            return null;
-        return JSON.parse(item);
-    } else {
-        alert('Local storage is not supported in your browser.');
-    }
-};
-
-/**
- * Stores data locally in the browser.
- * @param {string} key
- * @param {Object} value
- */
-LibSynphony.prototype.dbSet = function (key, value) {
-
-    if (this.supportsHTML5Storage()) {
-        var json = JSON.stringify(value);
-        localStorage.setItem(key, json);
-    } else {
-        alert('Local storage is not supported in your browser.');
-    }
-};
-
-/**
  * Construct a "StoryCheckResults" Class
  *
  * @param {Array} focus_words The words used in the story from the current stage

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -1163,13 +1163,8 @@ export class ReaderToolsModel {
         var active = toolbox.accordion('option', 'active');
         if (isNaN(active)) return;
 
-        var state = new DRTState();
-        state.stage = this.stageNumber;
-        state.level = this.levelNumber;
-        state.markupType = this.currentMarkupType;
         ToolBox.fireCSharpToolboxEvent('saveToolboxSettingsEvent', "state\tdecodableReader\t" + "stage:" + this.stageNumber + ";sort:" + this.sort);
         ToolBox.fireCSharpToolboxEvent('saveToolboxSettingsEvent', "state\tleveledReader\t" + this.levelNumber);
-        theOneLibSynphony.dbSet('drt_state', state);
     }
 
     restoreState(): void {
@@ -1178,8 +1173,7 @@ export class ReaderToolsModel {
         var toolbox = $('#toolbox');
         if (typeof toolbox.accordion !== 'function') return;
 
-        var state = theOneLibSynphony.dbGet('drt_state');
-        if (!state) state = new DRTState();
+        var state = new DRTState();
 
         if (!this.currentMarkupType) this.currentMarkupType = state.markupType;
         this.setStageNumber(state.stage);

--- a/src/BloomExe/Edit/DecodableReaderTool.cs
+++ b/src/BloomExe/Edit/DecodableReaderTool.cs
@@ -1,7 +1,9 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Bloom.Collection;
+using Bloom.Properties;
 using SIL.IO;
 
 namespace Bloom.Edit
@@ -68,5 +70,34 @@ namespace Bloom.Edit
 		/// See the API handler for more remarks on it.
 		/// </remarks>
 		public const string kSynphonyLanguageDataFileNameFormat = "ReaderToolsWords-{0}.json";
+
+		private const string StagePrefix = "stage:";
+
+		public override void SaveDefaultState()
+		{
+			base.SaveDefaultState();
+			// We expect the state to be something like "stage:6;sort:byLength"
+			// Enhance: someday we'd like to make the state json.
+			if (State == null)
+				return;
+
+			var stageString = State.Split(';')[0].Split(':')[1];
+			int stage;
+			if (Int32.TryParse(stageString, out stage))
+			{
+				Settings.Default.CurrentStage = stage;
+				Settings.Default.Save();
+			}
+		}
+
+		public override string DefaultState()
+		{
+			// Currently we are not saving and restoring the sort method.
+			// However the default MUST provide one, since the JS is definitely expecting
+			// a string with two settings separated by semi-colon; so we just put the
+			// general default here. Unfortunately that duplicates knowledge that
+			// must be elsewhere also but I'm not sure how to avoid it.
+			return StagePrefix + Settings.Default.CurrentStage + @";sort:alphabetic";
+		}
 	}
 }

--- a/src/BloomExe/Edit/LeveledReaderTool.cs
+++ b/src/BloomExe/Edit/LeveledReaderTool.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Bloom.Properties;
 
 namespace Bloom.Edit
 {
@@ -10,5 +11,21 @@ namespace Bloom.Edit
 	{
 		public const string StaticToolId = "leveledReader";  // Avoid changing value; see ToolboxTool.JsonToolId
 		public override string ToolId { get { return StaticToolId; } }
+
+		public override void SaveDefaultState()
+		{
+			base.SaveDefaultState();
+			int level;
+			if (Int32.TryParse(State, out level))
+			{
+				Settings.Default.CurrentLevel = level;
+				Settings.Default.Save();
+			}
+		}
+
+		public override string DefaultState()
+		{
+			return Settings.Default.CurrentLevel.ToString();
+		}
 	}
 }

--- a/src/BloomExe/Edit/ToolboxTool.cs
+++ b/src/BloomExe/Edit/ToolboxTool.cs
@@ -57,6 +57,15 @@ namespace Bloom.Edit
 		[JsonProperty("state")]
 		public string State { get; set; }
 
+		public virtual void SaveDefaultState()
+		{
+		}
+
+		public virtual string DefaultState()
+		{
+			return null;
+		}
+
 		public static ToolboxTool CreateFromToolId(string toolId)
 		{
 			switch (toolId)

--- a/src/BloomExe/Edit/ToolboxView.cs
+++ b/src/BloomExe/Edit/ToolboxView.cs
@@ -120,6 +120,14 @@ namespace Bloom.Edit
 			{
 				if (!String.IsNullOrEmpty(tool.State))
 					settings.Add(tool.StateName, tool.State);
+				else
+				{
+					var defaultState = tool.DefaultState();
+					if (!string.IsNullOrEmpty(defaultState))
+					{
+						settings.Add(tool.StateName, defaultState);
+					}
+				}
 			}
 
 			request.ReplyWithJson(settings);
@@ -230,7 +238,10 @@ namespace Bloom.Edit
 			var item = tools.FirstOrDefault(t => t.ToolId == toolName);
 
 			if (item != null)
+			{
 				item.State = state;
+				item.SaveDefaultState();
+			}
 		}
 
 		private static void UpdateActiveToolSetting(Book.Book book, string toolName, bool enabled)

--- a/src/BloomExe/Properties/Settings.Designer.cs
+++ b/src/BloomExe/Properties/Settings.Designer.cs
@@ -334,6 +334,7 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool AdobeColorProfileEula2003Accepted {
@@ -346,6 +347,7 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string BloomDeviceFileExportFolder {
@@ -358,6 +360,7 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string PublishAndroidMethod {
@@ -366,6 +369,32 @@ namespace Bloom.Properties {
             }
             set {
                 this["PublishAndroidMethod"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        public int CurrentStage {
+            get {
+                return ((int)(this["CurrentStage"]));
+            }
+            set {
+                this["CurrentStage"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1")]
+        public int CurrentLevel {
+            get {
+                return ((int)(this["CurrentLevel"]));
+            }
+            set {
+                this["CurrentLevel"] = value;
             }
         }
     }

--- a/src/BloomExe/Properties/Settings.settings
+++ b/src/BloomExe/Properties/Settings.settings
@@ -83,5 +83,11 @@
     <Setting Name="PublishAndroidMethod" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="CurrentStage" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">1</Value>
+    </Setting>
+    <Setting Name="CurrentLevel" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">1</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/BloomExe/app.config
+++ b/src/BloomExe/app.config
@@ -82,6 +82,12 @@
       <setting name="PublishAndroidMethod" serializeAs="String">
         <value />
       </setting>
+      <setting name="CurrentStage" serializeAs="String">
+        <value>1</value>
+      </setting>
+      <setting name="CurrentLevel" serializeAs="String">
+        <value>1</value>
+      </setting>
     </Bloom.Properties.Settings>
   </userSettings>
   <system.diagnostics>


### PR DESCRIPTION
Still a kludge, because something goes wrong BEFORE we try to save data in local storage, but this may be a more robust way of preventing it from hurting us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1903)
<!-- Reviewable:end -->
