### PR TITLE
Restore proper handling of translated .txt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ DistFiles/license.htm
 DistFiles/AdobeColorProfileEULA.htm
 DistFiles/IntegrityFailureAdvice-*.htm
 DistFiles/infoPages/TrainingVideos-*.htm
+DistFiles/localization/*.htm

--- a/DistFiles/localization/README.md
+++ b/DistFiles/localization/README.md
@@ -30,7 +30,10 @@ pull request to avoid overwhelming the git log with possibly 99% translation cha
   a "100% match" displaying.
 
 - Adding or removing leading or trailing spaces in the *source* element content automatically
-  does the same in the *target* element content (translation).
+  does the same in the *target* element content (translation) without changing the approved
+  status of the *trans-unit* element.  Except if the content contains internal html markup, then
+  the *target* element is not changed and the *approved* status of the *trans-unit* element is
+  cleared.  (This appears to be a corner case in crowdin's code that may or not be intentional.)
 
 - Adding, removing, or reordering *trans-unit* elements in the English xliff file without
   changing them merely causes the corresponding addition, removal, or reordering in the
@@ -96,6 +99,9 @@ pull request to avoid overwhelming the git log with possibly 99% translation cha
   by uploading to crowdin, remove any *approved* attribute from the *trans-unit* element* unless
   you are absolutely sure of the translation as an expert speaker and translator.
 
+- If you change the leading or trailing spaces in a translation, check to ensure that the same
+  is done on crowdin after uploading the file, and restore any approved status that was cleared
+  by a failure to update the translated string automatically.
 
 ## Merging crowdin pull requests
 

--- a/src/BloomExe/BloomFileLocator.cs
+++ b/src/BloomExe/BloomFileLocator.cs
@@ -238,10 +238,18 @@ namespace Bloom
 			var pathInDesiredLanguage = GetLocalizedFilePath(pathToEnglishFile);
 			if (RobustFile.Exists(pathInDesiredLanguage))
 				return pathInDesiredLanguage;
-			Debug.Assert(pathToEnglishFile.ToLowerInvariant().EndsWith(".htm") || pathToEnglishFile.ToLowerInvariant().EndsWith(".html"));
-			if (!pathToEnglishFile.ToLowerInvariant().EndsWith(".htm") && !pathToEnglishFile.ToLowerInvariant().EndsWith(".html"))
-				return pathToEnglishFile;
-			CreateLocalizedHtmlFile(pathToEnglishFile, pathInDesiredLanguage);
+			if (pathToEnglishFile.ToLowerInvariant().EndsWith("-en.txt"))
+			{
+				// The xliff based translation process does not (yet?) handle plain .txt files.
+				pathInDesiredLanguage = pathToEnglishFile.Replace("-en.", "-" + LocalizationManager.UILanguageId + ".");
+			}
+			else
+			{
+				Debug.Assert(pathToEnglishFile.ToLowerInvariant().EndsWith(".htm") || pathToEnglishFile.ToLowerInvariant().EndsWith(".html"));
+				if (!pathToEnglishFile.ToLowerInvariant().EndsWith(".htm") && !pathToEnglishFile.ToLowerInvariant().EndsWith(".html"))
+					return pathToEnglishFile;
+				CreateLocalizedHtmlFile(pathToEnglishFile, pathInDesiredLanguage);
+			}
 			return RobustFile.Exists(pathInDesiredLanguage) ? pathInDesiredLanguage : pathToEnglishFile;
 		}
 

--- a/src/BloomTests/UpdateVersionTableTests.cs
+++ b/src/BloomTests/UpdateVersionTableTests.cs
@@ -82,6 +82,7 @@ namespace BloomTests
 			var t = new UpdateVersionTable {URLOfTable = "http://notthere7blah/foo.txt"};
 			//the jenkins server gets a ProtocolError, while my desktop gets a NameResolutionFailure
 			var e = t.LookupURLOfUpdate().Error.Status;
+			//This test can fail if the ISP "helpfully" returns a custom advertising filled access failure page.
 			Assert.IsTrue(e  == WebExceptionStatus.NameResolutionFailure || e == WebExceptionStatus.ProtocolError );
 		}
 		[Test]


### PR DESCRIPTION
Also add a couple of (helpful?) comments to tests and tweak the document
describing our localization process to describe corner case of leading or
trailing whitespace changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1906)
<!-- Reviewable:end -->
