### PR TITLE
Find xliff files with bare language codes

### DIFF
--- a/src/BloomExe/BloomFileLocator.cs
+++ b/src/BloomExe/BloomFileLocator.cs
@@ -288,11 +288,25 @@ namespace Bloom
 			Debug.Assert(xliffBareFile.EndsWith("-en"));
 			if (xliffBareFile.EndsWith("-en"))
 				xliffBareFile = xliffBareFile.Substring(0, xliffBareFile.Length - 3);
-			var xliffPath = Path.Combine(xliffDir, LocalizationManager.UILanguageId, xliffBareFile + ".xlf");
+			var langId = LocalizationManager.UILanguageId;
+			var xliffPath = Path.Combine(xliffDir, langId, xliffBareFile + ".xlf");
 			if (RobustFile.Exists(xliffPath))
 				return xliffPath;
 			var folder = Path.GetFileName(Path.GetDirectoryName(pathToEnglishFile));
-			return Path.Combine(xliffDir, folder, xliffBareFile + "-" + LocalizationManager.UILanguageId + ".xlf");
+			xliffPath = Path.Combine(xliffDir, folder, xliffBareFile + "-" + langId + ".xlf");
+			if (RobustFile.Exists(xliffPath))
+				return xliffPath;
+			// We may have an xliff file identified by only language when langId includes country, for example "es" vs "es-ES".
+			// If that happens, try finding the file with only the language code without the country code.
+			if (langId.Contains('-'))
+			{
+				langId = langId.Substring(0, langId.IndexOf('-'));
+				xliffPath = Path.Combine(xliffDir, langId, xliffBareFile + ".xlf");
+				if (RobustFile.Exists(xliffPath))
+					return xliffPath;
+				xliffPath = Path.Combine(xliffDir, folder, xliffBareFile + "-" + langId + ".xlf");
+			}
+			return xliffPath;
 		}
 
 		/// <summary>


### PR DESCRIPTION
LocalizationManager.UILanguageIdThe UILanguageCode may be something like
"es-ES" when the translated xliff file may use only "es" in its pathname.
This appears to be an artifact of how Crowdin treats some languages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1914)
<!-- Reviewable:end -->
