### PR TITLE
Don't complain about branding api for template books (BL-5139)

### DIFF
--- a/src/BloomExe/web/controllers/BrandingApi.cs
+++ b/src/BloomExe/web/controllers/BrandingApi.cs
@@ -33,7 +33,15 @@ namespace Bloom.Api
 		{
 			server.RegisterEndpointHandler(kBrandingImageUrlPart, request =>
 			{
-				Debug.Fail("Books should no longer have branding api urls");
+#if DEBUG
+				// The book templates are allowed to use the branding api.  All real books
+				// should not use this facility.
+				if (request.CurrentBook == null || request.CurrentBook.FolderPath == null ||
+					!Book.BookStorage.IsStaticContent(request.CurrentBook.FolderPath))
+				{
+					Debug.Fail("Books should no longer have branding api urls");
+				}
+#endif
 				var fileName = request.RequiredFileNameOrPath("id");
 				var path = FindBrandingImageFileIfPossible(_collectionSettings.BrandingProjectName, fileName.NotEncoded);
 


### PR DESCRIPTION
I think this is the proper fix for the Debug messages complaining about books using the branding api.
It ignores the Debug.Fail check for the same set of books that are ignored in CleanupBrandingImages() in Book/XMatterHelper.cs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1922)
<!-- Reviewable:end -->
