### PR TITLE
Translate HTML files during the gulp build process (BL-5189)

### DIFF
--- a/build/getDependencies-Linux.sh
+++ b/build/getDependencies-Linux.sh
@@ -31,10 +31,10 @@ where_curl=$(type -P curl)
 where_wget=$(type -P wget)
 if [ "$where_curl" != "" ]
 then
-copy_curl $1 $2
+copy_curl "$1" "$2"
 elif [ "$where_wget" != "" ]
 then
-copy_wget $1 $2
+copy_wget "$1" "$2"
 else
 echo "Missing curl or wget"
 exit 1
@@ -46,9 +46,9 @@ copy_curl() {
 echo "curl: $2 <= $1"
 if [ -e "$2" ] && [ "$force" != "1" ]
 then
-curl -# -L -z $2 -o $2 $1
+curl -# -L -z "$2" -o "$2" "$1"
 else
-curl -# -L -o $2 $1
+curl -# -L -o "$2" "$1"
 fi
 }
 
@@ -57,7 +57,7 @@ echo "wget: $2 <= $1"
 f1=$(basename $1)
 f2=$(basename $2)
 cd $(dirname $2)
-wget -q -L -N $1
+wget -q -L -N "$1"
 # wget has no true equivalent of curl's -o option.
 # Different versions of wget handle (or not) % escaping differently.
 # A URL query is the only reason why $f1 and $f2 should differ.
@@ -159,7 +159,7 @@ cd -
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=XliffForHtml_LinuxMasterContinuous
 #     clean: false
 #     revision: latest.lastSuccessful
-#     paths: {"HtmlXliff.*"=>"lib/dotnet"}
+#     paths: {"HtmlXliff.*"=>"lib/dotnet", "HtmlAgilityPack.*"=>"lib/dotnet"}
 #     VCS: https://github.com/sillsdev/XliffForHtml [refs/heads/master]
 # [13] build: palaso-linux64-master Continuous (Libpalaso_PalasoLinux64masterContinuous)
 #     project: libpalaso
@@ -213,6 +213,7 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/bt351/latest.las
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt351/latest.lastSuccessful/TidyManaged.dll.config ../lib/dotnet/TidyManaged.dll.config
 copy_auto http://build.palaso.org/guestAuth/repository/download/XliffForHtml_LinuxMasterContinuous/latest.lastSuccessful/HtmlXliff.exe ../lib/dotnet/HtmlXliff.exe
 copy_auto http://build.palaso.org/guestAuth/repository/download/XliffForHtml_LinuxMasterContinuous/latest.lastSuccessful/HtmlXliff.exe.mdb ../lib/dotnet/HtmlXliff.exe.mdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/XliffForHtml_LinuxMasterContinuous/latest.lastSuccessful/HtmlAgilityPack.dll ../lib/dotnet/HtmlAgilityPack.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/SIL.BuildTasks.dll ../build/SIL.BuildTasks.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/Newtonsoft.Json.dll ../lib/dotnet/Newtonsoft.Json.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/SIL.Core.dll ../lib/dotnet/SIL.Core.dll
@@ -243,5 +244,5 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_Palaso
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/NDesk.DBus.dll ../lib/dotnet/NDesk.DBus.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoLinux64masterContinuous/latest.lastSuccessful/NDesk.DBus.dll.config ../lib/dotnet/NDesk.DBus.dll.config
 # extract downloaded zip files
-unzip -uqo ../Downloads/pdfjs-viewer.zip -d ../DistFiles/pdf
+unzip -uqo ../Downloads/pdfjs-viewer.zip -d "../DistFiles/pdf"
 # End of script

--- a/build/getDependencies-windows.sh
+++ b/build/getDependencies-windows.sh
@@ -31,10 +31,10 @@ where_curl=$(type -P curl)
 where_wget=$(type -P wget)
 if [ "$where_curl" != "" ]
 then
-copy_curl $1 $2
+copy_curl "$1" "$2"
 elif [ "$where_wget" != "" ]
 then
-copy_wget $1 $2
+copy_wget "$1" "$2"
 else
 echo "Missing curl or wget"
 exit 1
@@ -46,9 +46,9 @@ copy_curl() {
 echo "curl: $2 <= $1"
 if [ -e "$2" ] && [ "$force" != "1" ]
 then
-curl -# -L -z $2 -o $2 $1
+curl -# -L -z "$2" -o "$2" "$1"
 else
-curl -# -L -o $2 $1
+curl -# -L -o "$2" "$1"
 fi
 }
 
@@ -57,7 +57,7 @@ echo "wget: $2 <= $1"
 f1=$(basename $1)
 f2=$(basename $2)
 cd $(dirname $2)
-wget -q -L -N $1
+wget -q -L -N "$1"
 # wget has no true equivalent of curl's -o option.
 # Different versions of wget handle (or not) % escaping differently.
 # A URL query is the only reason why $f1 and $f2 should differ.
@@ -159,7 +159,7 @@ cd -
 #     URL: http://build.palaso.org/viewType.html?buildTypeId=XliffForHtml_WindowsMasterContinuous
 #     clean: false
 #     revision: latest.lastSuccessful
-#     paths: {"HtmlXliff.*"=>"lib/dotnet"}
+#     paths: {"HtmlXliff.*"=>"lib/dotnet", "HtmlAgilityPack.*"=>"lib/dotnet"}
 #     VCS: https://github.com/sillsdev/XliffForHtml [refs/heads/master]
 # [13] build: palaso-win32-master-nostrongname Continuous (Libpalaso_PalasoWin32masterNostrongnameContinuous)
 #     project: libpalaso
@@ -236,6 +236,7 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/bt349/latest.las
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt349/latest.lastSuccessful/libtidy.dll ../lib/dotnet/libtidy.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/XliffForHtml_WindowsMasterContinuous/latest.lastSuccessful/HtmlXliff.exe ../lib/dotnet/HtmlXliff.exe
 copy_auto http://build.palaso.org/guestAuth/repository/download/XliffForHtml_WindowsMasterContinuous/latest.lastSuccessful/HtmlXliff.pdb ../lib/dotnet/HtmlXliff.pdb
+copy_auto http://build.palaso.org/guestAuth/repository/download/XliffForHtml_WindowsMasterContinuous/latest.lastSuccessful/HtmlAgilityPack.dll ../lib/dotnet/HtmlAgilityPack.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterNostrongnameContinuous/latest.lastSuccessful/SIL.BuildTasks.dll ../build/SIL.BuildTasks.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterNostrongnameContinuous/latest.lastSuccessful/SIL.BuildTasks.AWS.dll ../build/SIL.BuildTasks.AWS.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterNostrongnameContinuous/latest.lastSuccessful/AWSSDK.Core.dll ../build/AWSSDK.Core.dll
@@ -253,6 +254,6 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_Palaso
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterNostrongnameContinuous/latest.lastSuccessful/SIL.WritingSystems.dll ../lib/dotnet/SIL.WritingSystems.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_PalasoWin32masterNostrongnameContinuous/latest.lastSuccessful/taglib-sharp.dll ../lib/dotnet/taglib-sharp.dll
 # extract downloaded zip files
-unzip -uqo ../Downloads/ghostscript-win32.zip -d ../DistFiles/ghostscript
-unzip -uqo ../Downloads/pdfjs-viewer.zip -d ../DistFiles/pdf
+unzip -uqo ../Downloads/ghostscript-win32.zip -d "../DistFiles/ghostscript"
+unzip -uqo ../Downloads/pdfjs-viewer.zip -d "../DistFiles/pdf"
 # End of script

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -140,8 +140,8 @@
       <HintPath>..\..\output\$(Configuration)\Geckofx-Winforms.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.4.9.5, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\lib\dotnet\HtmlAgilityPack.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>

--- a/src/BloomExe/BloomFileLocator.cs
+++ b/src/BloomExe/BloomFileLocator.cs
@@ -236,105 +236,19 @@ namespace Bloom
 		/// </summary>
 		public static string GetBestLocalizedFile(string pathToEnglishFile)
 		{
-			var pathInDesiredLanguage = GetLocalizedFilePath(pathToEnglishFile);
+			var langId = LocalizationManager.UILanguageId;
+			var pathInDesiredLanguage = pathToEnglishFile.Replace("-en.", "-" + langId + ".");
 			if (RobustFile.Exists(pathInDesiredLanguage))
 				return pathInDesiredLanguage;
-			if (pathToEnglishFile.ToLowerInvariant().EndsWith("-en.txt"))
-			{
-				// The xliff based translation process does not (yet?) handle plain .txt files.
-				pathInDesiredLanguage = pathToEnglishFile.Replace("-en.", "-" + LocalizationManager.UILanguageId + ".");
-			}
-			else
-			{
-				Debug.Assert(pathToEnglishFile.ToLowerInvariant().EndsWith(".htm") || pathToEnglishFile.ToLowerInvariant().EndsWith(".html"));
-				if (!pathToEnglishFile.ToLowerInvariant().EndsWith(".htm") && !pathToEnglishFile.ToLowerInvariant().EndsWith(".html"))
-					return pathToEnglishFile;
-				CreateLocalizedHtmlFile(pathToEnglishFile, pathInDesiredLanguage);
-			}
-			return RobustFile.Exists(pathInDesiredLanguage) ? pathInDesiredLanguage : pathToEnglishFile;
-		}
-
-		/// <summary>
-		/// Localized files are created and stored in the localizations folder of the Bloom application
-		/// data folder.  The filenames are tagged with the target language code.  The template book
-		/// ReadMe files are stored in subfolders with the same name as the template folder to keep them
-		/// unambiguous.
-		/// </summary>
-		private static string GetLocalizedFilePath(string pathToEnglishFile)
-		{
-			var cacheDir = Path.Combine(ProjectContext.GetBloomAppDataFolder(), "localizations");
-			var bareFilename = Path.GetFileNameWithoutExtension(pathToEnglishFile);
-			if (bareFilename == "ReadMe-en")
-			{
-				var folder = Path.GetFileName(Path.GetDirectoryName(pathToEnglishFile));
-				cacheDir = Path.Combine(cacheDir, folder);
-			}
-			// Ensure the cache directory exists in case we need to create the file.
-			Directory.CreateDirectory(cacheDir);
-			return Path.Combine(cacheDir, Path.GetFileName(pathToEnglishFile).Replace("-en.", "-" + LocalizationManager.UILanguageId + "."));
-		}
-
-		/// <summary>
-		/// The localized xliff files are stored under DistFiles/localization in two different ways.  The general
-		/// location is in a subfolder with the language code as its name, and the .xlf file named without any
-		/// embedded language code.  For the template books which all have ReadMe files of the same name, the
-		/// xliff file is stored in a subfolder with the same name as the template book's folder, and the language
-		/// code is embedded in the file name as expected (ReadMe-en.xlf, ReadMe-fr.xlf, etc.).
-		/// </summary>
-		/// <remarks>
-		/// The Windows installer omits the DistFiles level of the directory tree while the Linux package includes
-		/// it.  See https://issues.bloomlibrary.org/youtrack/issue/BL-5190.
-		/// </remarks>
-		private static string GetLocalizedXliffPath(string pathToEnglishFile)
-		{
-			var baseDir = SIL.IO.FileLocator.DirectoryOfApplicationOrSolution;
-			var xliffBareFile = Path.GetFileNameWithoutExtension(pathToEnglishFile);
-			var folder = Path.GetFileName(Path.GetDirectoryName(pathToEnglishFile));
-			var xliffDir = Path.Combine(baseDir, "DistFiles", "localization");	// Linux runtime, developers
-			var path = GetLocalizedXliffPath(xliffDir, folder, xliffBareFile);
-			if (RobustFile.Exists(path))
-				return path;
-			var xliffDir1 = Path.Combine(baseDir, "localization");	// Windows runtime
-			return GetLocalizedXliffPath(xliffDir1, folder, xliffBareFile);
-		}
-
-		private static string GetLocalizedXliffPath(string xliffDir, string subDir, string xliffBareFile)
-		{
-			Debug.Assert(xliffBareFile.EndsWith("-en"));
-			if (xliffBareFile.EndsWith("-en"))
-				xliffBareFile = xliffBareFile.Substring(0, xliffBareFile.Length - 3);
-			var langId = LocalizationManager.UILanguageId;
-			var xliffPath = Path.Combine(xliffDir, langId, xliffBareFile + ".xlf");
-			if (RobustFile.Exists(xliffPath))
-				return xliffPath;
-			xliffPath = Path.Combine(xliffDir, subDir, xliffBareFile + "-" + langId + ".xlf");
-			if (RobustFile.Exists(xliffPath))
-				return xliffPath;
-			// We may have an xliff file identified by only language when langId includes country, for example "es" vs "es-ES".
-			// If that happens, try finding the file with only the language code without the country code.
 			if (langId.Contains('-'))
 			{
+				// Ignore any country (or script) code to see if we can find a match to the generic language.
 				langId = langId.Substring(0, langId.IndexOf('-'));
-				xliffPath = Path.Combine(xliffDir, langId, xliffBareFile + ".xlf");
-				if (RobustFile.Exists(xliffPath))
-					return xliffPath;
-				xliffPath = Path.Combine(xliffDir, subDir, xliffBareFile + "-" + langId + ".xlf");
+				pathInDesiredLanguage = pathToEnglishFile.Replace("-en.", "-" + langId + ".");
+				if (RobustFile.Exists(pathInDesiredLanguage))
+					return pathInDesiredLanguage;
 			}
-			return xliffPath;
-		}
-
-		/// <summary>
-		/// Use HtmlXliff to translate the English HTML file into another language using the translated xliff file
-		/// corresponding to this HTML file.
-		/// </summary>
-		private static void CreateLocalizedHtmlFile(string pathToEnglishFile, string pathInDesiredLanguage)
-		{
-			var xliffPath = GetLocalizedXliffPath(pathToEnglishFile);
-			if (!RobustFile.Exists(xliffPath))
-				return;
-			HtmlXliff injector = HtmlXliff.Load(pathToEnglishFile);
-			var hdoc = injector.InjectTranslations(xliffPath, true);
-			hdoc.Save(pathInDesiredLanguage, Encoding.UTF8);
+			return pathToEnglishFile;	// can't find a localized version, fall back to English
 		}
 
 		/// <summary>

--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -9,7 +9,6 @@
   <package id="DesktopAnalytics" version="1.2.4.1" targetFramework="net461" />
   <package id="EasyHttp" version="1.6.86.0" targetFramework="net461" />
   <package id="Fleck" version="0.14.0.59" targetFramework="net461" />
-  <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net461" />
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net461" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net40-Client" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net461" />

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -10,7 +10,6 @@
   <package id="DesktopAnalytics" version="1.2.4.1" targetFramework="net461" />
   <package id="EasyHttp" version="1.6.86.0" targetFramework="net461" />
   <package id="Fleck" version="0.14.0.59" targetFramework="net461" />
-  <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net461" />
   <package id="JsonFx" version="2.0.1209.2802" targetFramework="net461" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net40-Client" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net461" />


### PR DESCRIPTION
This happens after they are created by markdown or pug processing.

This requires that HtmlAgilityPack be pulled from TeamCity as an artifact of XliffForHtml/HtmlXliff
instead of being downloaded as a nuget package so that HtmlXliff.exe can be run before the
nuget packages are downloaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1928)
<!-- Reviewable:end -->
