### PR TITLE
Fix error in translating HTML files

### DIFF
--- a/DistFiles/localization/pt/Bloom.xlf
+++ b/DistFiles/localization/pt/Bloom.xlf
@@ -2846,12 +2846,6 @@
         <note>Link to find Bloom Reader on Google Play Store</note>
         <target xml:lang="pt-PT" state="translated">Obter o aplicativo BloomReader</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Android.GetBloomReader">
-        <source xml:lang="en">Get Bloom Reader App</source>
-        <note>ID: PublishTab.Android.GetBloomReader</note>
-        <note>Link to find Bloom Reader on Google Play Store</note>
-        <target xml:lang="pt-PT" state="needs-translation">Get Bloom Reader App</target>
-      </trans-unit>
       <trans-unit id="PublishTab.Android.Method">
         <source xml:lang="en">Method</source>
         <note>ID: PublishTab.Android.Method</note>

--- a/src/BloomBrowserUI/gulpfile.js
+++ b/src/BloomBrowserUI/gulpfile.js
@@ -292,7 +292,7 @@ var getXliffFiles = function (htmFile) {
 var getOutputFilename = function(htmFile, xlfFile) {
     var langCode = "";
     if ( xlfFile.search("/ReadMe-") > 0)  // as in "blah/foo/ReadMe-fr.htm"
-        langCode = xlfFile.replace(/.*\/ReadMe-/, "").replace(".htm","");
+        langCode = xlfFile.replace(/.*\/ReadMe-/, "").replace(".xlf","");
     else  // as in "blah/foo/fr/something.htm"
         langCode = xlfFile.split("/").slice(-2, -1)[0]; // penultimate item has the language code
     return htmFile.replace("-en.htm", "-" + langCode + ".htm");

--- a/src/BloomExe/Book/BookStarter.cs
+++ b/src/BloomExe/Book/BookStarter.cs
@@ -96,8 +96,11 @@ namespace Bloom.Book
 				return candidates.First();
 			else
 			{
-				SIL.Reporting.ErrorReport.NotifyUserOfProblem(
-					"There should only be a single htm(l) file in each folder ({0}). [not counting configuration.html or ReadMe-*.htm]", folder);
+				var msg = new System.Text.StringBuilder();
+				msg.AppendLineFormat("There should only be a single htm(l) file in each folder ({0}). [not counting configuration.html or ReadMe-*.htm]:", folder);
+				foreach (var f in candidates)
+					msg.AppendLineFormat("    {0}", f);
+				SIL.Reporting.ErrorReport.NotifyUserOfProblem(msg.ToString());
 				throw new ApplicationException();
 			}
 
@@ -105,7 +108,7 @@ namespace Bloom.Book
 
 		private static bool IsPathToReadMeHtm(string path)
 		{
-			return Regex.IsMatch(Path.GetFileName(path), "^ReadMe-[a-z]{2,3}(-[A-Z]{2})?(\\.xlf)?\\.htm$");
+			return Regex.IsMatch(Path.GetFileName(path), "^ReadMe-[a-z]{2,3}(-[A-Z]{2})?\\.htm$");
 		}
 
 		private string GetMetaValue(XmlDocument Dom, string name, string defaultValue)


### PR DESCRIPTION
Also enhance error message to include filenames and remove duplicate
entry from Portuguese Bloom.xlf.  (duplicate not in English)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1930)
<!-- Reviewable:end -->
