### PR TITLE
Mark html from markdown as being in utf-8 encoding (BL-5256)

### DIFF
--- a/src/BloomBrowserUI/gulpfile.js
+++ b/src/BloomBrowserUI/gulpfile.js
@@ -187,8 +187,8 @@ gulp.task('markdownHelp', function () {
             file.contents = new Buffer(
                 //here we are assigning an unfortunately named stylesheet that goes with all Bloom help pages
                 `<html><head><meta charset='utf-8'><link rel='stylesheet' href='help.css' type='text/css'/></head><body>
-                    ` + result + `
-                    </body></html>`);
+` + result + `
+</body></html>`);
             file.path = gutil.replaceExtension(file.path, '.htm');
             return;
         }))
@@ -202,6 +202,7 @@ gulp.task('markdownTemplateReadme', function () {
         .pipe(debug({ title: 'md:' }))
         .pipe(tap(function (file) {
             var result = markdownIt.render(file.contents.toString());
+	    // this is converted to full HTML in C# code, adding base href and link to css file
             file.contents = new Buffer(result);
             file.path = gutil.replaceExtension(file.path, '.htm');
             return;
@@ -215,7 +216,10 @@ gulp.task('markdownDistInfo', function () {
         .pipe(debug({ title: 'md:' }))
         .pipe(tap(function (file) {
             var result = markdownIt.render(file.contents.toString());
-            file.contents = new Buffer(result);
+	    // convert to full HTML, ensuring that the file is known to be utf-8.
+            file.contents = new Buffer(`<html><head><meta charset='utf-8'></head><body>
+` + result + `
+</body></html>`);
             file.path = gutil.replaceExtension(file.path, '.htm');
             return;
         }))

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1471,7 +1471,7 @@ namespace Bloom.Book
 
 				var pathToCss = _storage.GetFileLocator().LocateFileWithThrow("BookReadme.css");
 				var pathAsUrl = "file://" + AboutBookHtmlPath.Replace('\\', '/').Replace(" ", "%20");
-				var html = $"<html><head><base href='{pathAsUrl}'><link rel='stylesheet' href='file://{pathToCss}' type='text/css'><head/><body>{contents}</body></html>";
+				var html = $"<html><head><meta charset='utf-8'><base href='{pathAsUrl}'><link rel='stylesheet' href='file://{pathToCss}' type='text/css'><head/><body>{contents}</body></html>";
 				return html;
 			}
 		}


### PR DESCRIPTION
This also ensures that the markdown output is a complete HTML file, not just a
fragment when being displayed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1956)
<!-- Reviewable:end -->
