### PR TITLE
BL-5243 Detect and inform about Defender

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1654,6 +1654,16 @@
         <source xml:lang="en">Bloom was unable to start its own HTTP listener that it uses to talk to its embedded Firefox browser. If this happens even if you just restarted your computer, ask someone to investigate if you have an aggressive firewall product installed. The agressive firewall product may need to be uninstalled before you can use Bloom.</source>
         <note>ID: Errors.CannotConnectToBloomServer</note>
       </trans-unit>
+      <trans-unit id="Errors.DefenderFolderProtection">
+        <source xml:lang="en">This might be caused by Windows Defender "Controlled Folder Access" or some other virus protection.</source>
+        <note>ID: Errors.DefenderFolderProtection</note>
+        <note>After an October 2017 windows update, this appears when Bloom opens a collection and tries to write out the collection settings.</note>
+      </trans-unit>
+      <trans-unit id="Errors.DefenderFolderProtectionHeading">
+        <source xml:lang="en">This program cannot write to the folder {0}.</source>
+        <note>ID: Errors.DefenderFolderProtectionHeading</note>
+        <note>This only happens on Windows after an October 2017 update, {0} is the folder that Bloom failed to write to.</note>
+      </trans-unit>
       <trans-unit id="Errors.DeniedAccess">
         <source xml:lang="en">Your computer denied Bloom access to the book. You may need technical help in setting the operating system permissions for this file.</source>
         <note>ID: Errors.DeniedAccess</note>

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -297,6 +297,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Book\BookSelectionChangedEventArgs.cs" />
+    <Compile Include="MiscUI\DefenderFolderProtectionCheck.cs" />
     <Compile Include="Publish\Android\usb\AndroidDeviceUsbConnection.cs" />
     <Compile Include="ApplicationContainer.cs" />
     <Compile Include="BloomFileLocator.cs" />

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 using System.Xml.Linq;
 using System.Xml.Serialization;
 using Bloom.Book;
+using Bloom.MiscUI;
 using Bloom.ToPalaso;
 using DesktopAnalytics;
 using L10NSharp;
@@ -135,6 +136,14 @@ namespace Bloom.Collection
 			:this()
 		{
 			SettingsFilePath = desiredOrExistingSettingsFilePath;
+			// We check for a Windows Defender "Controlled Access" problem when we start Bloom,
+			// but the user may have moved their startup collection to a "safe" place and now be opening a different
+			// collection in a "controlled" place. Test again with this settings file path.
+			// 'FolderPath' is the directory part of 'SettingsFilePath'.
+			if (!DefenderFolderProtectionCheck.CanWriteToDirectory(FolderPath))
+			{
+				Environment.Exit(-1);
+			}
 			CollectionName = Path.GetFileNameWithoutExtension(desiredOrExistingSettingsFilePath);
 			var libraryDirectory = Path.GetDirectoryName(desiredOrExistingSettingsFilePath);
 			var parentDirectoryPath = Path.GetDirectoryName(libraryDirectory);
@@ -444,10 +453,9 @@ namespace Bloom.Collection
 			}
 			catch (Exception error)
 			{
-				SIL.Reporting.ErrorReport.NotifyUserOfProblem(error, "Bloom was unable to update this file: {0}",path);
+				ErrorReport.NotifyUserOfProblem(error, "Bloom was unable to update this file: {0}",path);
 			}
 		}
-
 
 		private void AddFontCssRule(StringBuilder sb, string selector, string fontName, bool isRtl, decimal lineHeight)
 		{

--- a/src/BloomExe/MiscUI/DefenderFolderProtectionCheck.cs
+++ b/src/BloomExe/MiscUI/DefenderFolderProtectionCheck.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.IO;
+using L10NSharp;
+using SIL.IO;
+using SIL.PlatformUtilities;
+using SIL.Reporting;
+using Bloom.Properties;
+
+namespace Bloom.MiscUI
+{
+	/// <summary>
+	/// This class tests for a Windows Defender setting that keeps Bloom from functioning.
+	/// If the bogus setting is active, Bloom will pop up a message to the user and then exit.
+	/// </summary>
+	public static class DefenderFolderProtectionCheck
+	{
+		/// <summary>
+		/// Returns 'true' unless we find we can't run Bloom, in which case it reports the condition and the caller should exit Bloom.
+		/// In Oct of 2017, a Windows update to Defender on some machines set Protections on certain
+		/// basic folders, like MyDocuments! This resulted in throwing an exception any time Bloom tried
+		/// to write out CollectionSettings files!
+		/// </summary>
+		/// <param name="folderToCheck">An optional folder to test for this problem.</param>
+		/// <returns></returns>
+		public static bool CanWriteToDirectory(string folderToCheck = null)
+		{
+			if (!Platform.IsWindows)
+			{
+				return true;
+			}
+			string testPath;
+			testPath = !string.IsNullOrEmpty(folderToCheck) ? Path.Combine(folderToCheck, TestFileName) : GetMruProjectTestPath;
+			try
+			{
+				RobustFile.WriteAllText(testPath, "test contents");
+			}
+			catch (Exception exc)
+			{
+				// Creating a previously non-existent file under these conditions just gives a WinIOError, "could not find file".
+				ReportDefenderProblem(exc, Path.GetDirectoryName(testPath));
+				return false;
+			}
+			finally
+			{
+				Cleanup(testPath);
+			}
+			return true;
+		}
+
+		// We probably care about MyDocuments if we're about to create a "Bloom" directory (new installation)
+		// or a new Collection under "Bloom". But we always care about the actual bloom collection folder, which could be anywhere
+		// on disk. Indeed, one work-around is to move your collection to some place that is not under Defender lock down.
+		// This property should return the folder that either does or will contain the collection we will be opening.
+		private static string GetMruProjectTestPath
+		{
+			get
+			{
+				var path = Settings.Default.MruProjects.Latest;
+				if (!string.IsNullOrEmpty(path))
+				{
+					return Path.Combine(Path.GetDirectoryName(path), TestFileName);
+				}
+
+				return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), TestFileName);
+			}
+		}
+
+		private static string TestFileName
+		{
+			get { return Path.GetFileName(TempFile.CreateAndGetPathButDontMakeTheFile().Path); }
+		}
+
+		private static void ReportDefenderProblem(Exception exc, string failingFolder)
+		{
+			var heading = LocalizationManager.GetString("Errors.DefenderFolderProtectionHeading", "This program cannot write to the folder {0}.");
+			var mainMsg = LocalizationManager.GetString("Errors.DefenderFolderProtection",
+				"This might be caused by Windows Defender \"Controlled Folder Access\" or some other virus protection.");
+			var msg = string.Format(heading, failingFolder) + Environment.NewLine + Environment.NewLine + mainMsg;
+			ErrorReport.NotifyUserOfProblem(exc, msg);
+		}
+
+		private static void Cleanup(string testPath)
+		{
+			// try to clean up behind ourselves
+			try
+			{
+				if (File.Exists(testPath))
+				{
+					File.Delete(testPath);
+				}
+			}
+			catch (Exception)
+			{
+				// but don't try too hard
+			}
+		}
+	}
+}

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -302,6 +302,11 @@ namespace Bloom
 							Environment.Exit(-1);
 						}
 
+						if (!DefenderFolderProtectionCheck.CanWriteToDirectory())
+						{
+							Environment.Exit(-1);
+						}
+
 						LocalizationManager.SetUILanguage(Settings.Default.UserInterfaceLanguage, false);
 
 						// BL-1258: sometimes the newly installed fonts are not available until after Bloom restarts


### PR DESCRIPTION
* Windows Defender update in October 2017 added a
   'feature' called Controlled Folder Access that causes problems
   when saving CollectionSettings in Documents folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1960)
<!-- Reviewable:end -->
