### PR TITLE
Warn user about wrong layout for Android publishing (BL-5274)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2065,6 +2065,23 @@
         <source xml:lang="en">Pages can not be re-ordered when you are translating a book.</source>
         <note>ID: PageList.CantMoveWhenTranslating</note>
       </trans-unit>
+      <trans-unit id="PublishTab.AdobeEulaTitle">
+        <source xml:lang="en">Adobe Color Profile License Agreement</source>
+        <note>ID: PublishTab.AdobeEulaTitle</note>
+        <note>dialog title for license agreement</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+        <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
+        <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+        <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
+        <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+        <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
+        <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
+      </trans-unit>
       <trans-unit id="PublishTab.Android.bloomdFileFormatLabel">
         <source xml:lang="en">Bloom Book for Devices</source>
         <note>ID: PublishTab.Android.bloomdFileFormatLabel</note>
@@ -2224,22 +2241,15 @@
         <note>ID: PublishTab.Android.Wifi.Stop</note>
         <note>Button that tells Bloom to stop offering this book on the wifi network.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeEulaTitle">
-        <source xml:lang="en">Adobe Color Profile License Agreement</source>
-        <note>ID: PublishTab.AdobeEulaTitle</note>
-        <note>dialog title for license agreement</note>
+      <trans-unit id="PublishTab.Android.WrongLayout.Caption">
+        <source xml:lang="en">Wrong Layout for Android Devices</source>
+        <note>ID: PublishTab.Android.WrongLayout.Caption</note>
+        <note>message box caption</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
-        <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
-        <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
-      </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
-        <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
-        <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
-      </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
-        <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
-        <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
+      <trans-unit id="PublishTab.Android.WrongLayout.Message">
+        <source xml:lang="en">The layout of this book is currently "{0}". Bloom Reader will display it using "{1}", so text might not fit. To see if anything needs adjusting, go back to the Edit Tab and change the layout to "{1}".</source>
+        <note>ID: PublishTab.Android.WrongLayout.Message</note>
+        <note>{0} and {1} are book layout tags</note>
       </trans-unit>
       <trans-unit id="PublishTab.AndroidButton-tooltip" sil:dynamic="true">
         <source xml:lang="en">Publish to an Android device.</source>

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -504,6 +504,25 @@ namespace Bloom.Publish
 				}
 				case PublishModel.DisplayModes.Android:
 				{
+					// Check for either "Device 16x9" or "Device 16x9 Landscape" layout.
+					// Complain to the user if another layout is currently chosen.
+					// See https://issues.bloomlibrary.org/youtrack/issue/BL-5274.
+					var desiredLayout = "Device16x9";
+					if (_model.PageLayout.SizeAndOrientation.PageSizeName != desiredLayout)
+					{
+						desiredLayout = desiredLayout + _model.PageLayout.SizeAndOrientation.OrientationName;
+						var msgFormat = LocalizationManager.GetString("PublishTab.Android.WrongLayout.Message",
+							"The layout of this book is currently \"{0}\". Bloom Reader will display it using \"{1}\", so text might not fit. To see if anything needs adjusting, go back to the Edit Tab and change the layout to \"{1}\".",
+							"{0} and {1} are book layout tags");
+						var msg = String.Format(msgFormat, _model.PageLayout.SizeAndOrientation.ToString(), desiredLayout);
+						var heading = LocalizationManager.GetString("PublishTab.Android.WrongLayout.Caption",
+							"Wrong Layout for Android Devices",
+							"message box caption");
+						var response = MessageBox.Show(msg, "Heading", MessageBoxButtons.OKCancel);
+						if (response == DialogResult.Cancel)
+							break;
+					}
+
 					_workingIndicator.Visible = false;
 					_printButton.Enabled = false;
 					_pdfViewer.Visible = false;


### PR DESCRIPTION
Also fixed an alphabetization glitch in the Bloom.xlf file.  Note that
changing the order of trans-unit elements does not affect any of the
translations on crowdin except for matching reordering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1961)
<!-- Reviewable:end -->
