### PR TITLE
Warn user about wrong layout for Android publishing (BL-5274)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2065,6 +2065,23 @@
         <source xml:lang="en">Pages can not be re-ordered when you are translating a book.</source>
         <note>ID: PageList.CantMoveWhenTranslating</note>
       </trans-unit>
+      <trans-unit id="PublishTab.AdobeEulaTitle">
+        <source xml:lang="en">Adobe Color Profile License Agreement</source>
+        <note>ID: PublishTab.AdobeEulaTitle</note>
+        <note>dialog title for license agreement</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+        <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
+        <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+        <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
+        <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+        <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
+        <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
+      </trans-unit>
       <trans-unit id="PublishTab.Android.bloomdFileFormatLabel">
         <source xml:lang="en">Bloom Book for Devices</source>
         <note>ID: PublishTab.Android.bloomdFileFormatLabel</note>
@@ -2224,22 +2241,10 @@
         <note>ID: PublishTab.Android.Wifi.Stop</note>
         <note>Button that tells Bloom to stop offering this book on the wifi network.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeEulaTitle">
-        <source xml:lang="en">Adobe Color Profile License Agreement</source>
-        <note>ID: PublishTab.AdobeEulaTitle</note>
-        <note>dialog title for license agreement</note>
-      </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
-        <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
-        <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
-      </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
-        <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
-        <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
-      </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
-        <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
-        <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
+      <trans-unit id="PublishTab.Android.WrongLayout.Message">
+        <source xml:lang="en">The layout of this book is currently "{0}". Bloom Reader will display it using "{1}", so text might not fit. To see if anything needs adjusting, go back to the Edit Tab and change the layout to "{1}".</source>
+        <note>ID: PublishTab.Android.WrongLayout.Message</note>
+        <note>{0} and {1} are book layout tags.</note>
       </trans-unit>
       <trans-unit id="PublishTab.AndroidButton-tooltip" sil:dynamic="true">
         <source xml:lang="en">Publish to an Android device.</source>

--- a/src/BloomBrowserUI/react_components/progressBox.tsx
+++ b/src/BloomBrowserUI/react_components/progressBox.tsx
@@ -20,7 +20,11 @@ export default class ProgressBox extends React.Component<ComponentProps, Compone
         WebSocketManager.addListener(props.lifetimeLabel, event => {
             var e = JSON.parse(event.data);
             if (e.id === "progress") {
-                self.setState({ progress: self.state.progress + "<br/>" + e.payload });
+                if (e.style) {
+                    self.setState({progress: self.state.progress + "<br/>" + "<span style='" + e.style +"'>" + e.payload + "</span>"});
+                } else {
+                    self.setState({ progress: self.state.progress + "<br/>" + e.payload });
+                }
                 this.tryScrollToBottom();
             }
         });

--- a/src/BloomExe/Publish/Android/AndroidView.cs
+++ b/src/BloomExe/Publish/Android/AndroidView.cs
@@ -49,5 +49,29 @@ namespace Bloom.Publish.Android
 			// This is important so the react stuff can do its cleanup
 			_browser.WebBrowser.Navigate("about:blank");
 		}
+
+		/// <summary>
+		/// Check for either "Device16x9Portrait" or "Device16x9Landscape" layout.
+		/// Complain to the user if another layout is currently chosen.
+		/// </summary>
+		/// <remarks>
+		/// See https://issues.bloomlibrary.org/youtrack/issue/BL-5274.
+		/// </remarks>
+		static internal void CheckBookLayout(Bloom.Book.Book book, Bloom.web.WebSocketProgress progress)
+		{
+			var layout = book.GetLayout();
+			var desiredLayoutSize = "Device16x9";
+			if (layout.SizeAndOrientation.PageSizeName != desiredLayoutSize)
+			{
+				// The progress object has been initialized to use an id prefix.  So we'll access L10NSharp explicitly here.  We also want to make the string blue,
+				// which requires a special argument.
+				var msgFormat = L10NSharp.LocalizationManager.GetString("PublishTab.Android.WrongLayout.Message",
+					"The layout of this book is currently \"{0}\". Bloom Reader will display it using \"{1}\", so text might not fit. To see if anything needs adjusting, go back to the Edit Tab and change the layout to \"{1}\".",
+					"{0} and {1} are book layout tags.");
+				var desiredLayout = desiredLayoutSize + layout.SizeAndOrientation.OrientationName;
+				var msg = String.Format(msgFormat, layout.SizeAndOrientation.ToString(), desiredLayout, Environment.NewLine);
+				progress.MessageWithStyleWithoutLocalizing(msg, "color:blue");
+			}
+		}
 	}
 }

--- a/src/BloomExe/Publish/Android/usb/UsbPublisher.cs
+++ b/src/BloomExe/Publish/Android/usb/UsbPublisher.cs
@@ -40,6 +40,7 @@ namespace Bloom.Publish.Android.usb
 				// to figure out what was connected.
 				lock (this)
 				{
+					AndroidView.CheckBookLayout(book, _progress);
 					if (_connectionHandler != null)
 					{
 						// we're in an odd state...should only be able to click the button that calls this

--- a/src/BloomExe/Publish/Android/wifi/WiFiPublisher.cs
+++ b/src/BloomExe/Publish/Android/wifi/WiFiPublisher.cs
@@ -74,6 +74,7 @@ namespace Bloom.Publish.Android.wifi
 				BookVersion = Book.Book.MakeVersionCode(File.ReadAllText(pathHtmlFile), pathHtmlFile)
 			};
 
+			AndroidView.CheckBookLayout(book, _progress);
 			_wifiAdvertiser.Start();
 
 			_progress.Message(id: "WifiInstructions1",

--- a/src/BloomExe/web/BloomWebSocketServer.cs
+++ b/src/BloomExe/web/BloomWebSocketServer.cs
@@ -78,11 +78,13 @@ namespace Bloom.Api
 			Application.Exit();
 		}
 
-		public void Send(string eventId, string eventData)
+		public void Send(string eventId, string eventData, string eventStyle = null)
 		{
 			dynamic e = new DynamicJson();
 			e.id = eventId;
 			e.payload = eventData;
+			if (!String.IsNullOrEmpty(eventStyle))
+				e.style = eventStyle;
 
 			//note, if there is no open socket, this isn't going to do anything, and
 			//that's (currently) fine.

--- a/src/BloomExe/web/WebSocketProgress.cs
+++ b/src/BloomExe/web/WebSocketProgress.cs
@@ -45,6 +45,11 @@ namespace Bloom.web
 			_bloomWebSocketServer.Send("progress", message);
 		}
 
+		public void MessageWithStyleWithoutLocalizing(string message, string style)
+		{
+			_bloomWebSocketServer.Send("progress", message, style);
+		}
+
 		public void Message(string id, string message, string comment = null)
 		{
 			MessageWithoutLocalizing(LocalizationManager.GetDynamicString(appId: "Bloom", id: _l10IdPrefix + id, englishText: message, comment: comment));


### PR DESCRIPTION
Note that this doesn't affect the "Save Bloom Reader File" option for
publishing to Android.

I also fixed an alphabetization glitch in the Bloom.xlf file.  Note that
changing the order of trans-unit elements does not affect any of the
translations on crowdin except for matching reordering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1962)
<!-- Reviewable:end -->
