### PR TITLE
Rename package for Version4.0 to bloom-desktop-beta

### DIFF
--- a/debian/README
+++ b/debian/README
@@ -1,5 +1,5 @@
-The Debian Package bloom-desktop-alpha
---------------------------------------
+The Debian Package bloom-desktop-beta
+-------------------------------------
 
 This is a native package, because the packaging is maintained by the project
 itself.

--- a/debian/bloom-beta
+++ b/debian/bloom-beta
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-LIB=/usr/lib/bloom-desktop-alpha
-SHARE=/usr/share/bloom-desktop-alpha
+LIB=/usr/lib/bloom-desktop-beta
+SHARE=/usr/share/bloom-desktop-beta
 
 cd "$SHARE"
 RUNMODE=INSTALLED

--- a/debian/bloom-beta.appdata.xml
+++ b/debian/bloom-beta.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2016 SIL International -->
 <component type="desktop">
-	<id>bloom-alpha.desktop</id>
+	<id>bloom-beta.desktop</id>
 	<metadata_license>MIT</metadata_license>
 	<project_license>MIT</project_license>
 	<name>Bloom</name>
@@ -47,7 +47,7 @@
 	</provides>
 
 	<releases>
-		<release version="3.6" date="2016-04-19">
+		<release version="4.0" date="2017-11-17">
 		</release>
 	</releases>
 </component>

--- a/debian/bloom-beta.desktop
+++ b/debian/bloom-beta.desktop
@@ -1,9 +1,9 @@
 [Desktop Entry]
 Version=1.0
-Name=Bloom Alpha
+Name=Bloom Beta
 Comment=Literacy materials development for language communities
-Exec=bloom-alpha %u
-Icon=bloom-alpha
+Exec=bloom-beta %u
+Icon=bloom-beta
 Terminal=false
 Type=Application
 Categories=Education;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+bloom-desktop-beta (4.0.0) stable; urgency=medium
+
+  * Rename the package to bloom-desktop-beta.
+  * More bug fixes and enhancements: see the source repository log for details.
+
+ -- Stephen McConnel <stephen_mcconnel@sil.org>  Fri, 17 Nov 2017 11:03:57 -0700
+
 bloom-desktop-alpha (4.0.0) stable; urgency=medium
 
   * Up the version number on the master (alpha) branch to 4.0.

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: bloom-desktop-alpha
+Source: bloom-desktop-beta
 Section: x11
 Priority: extra
 Maintainer: Stephen McConnel <stephen_mcconnel@sil.org>
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
  libgtk2.0-cil (>= 2.12.10), libgtk2.0-dev (>= 2.14), libasound2-dev,
  icu-devtools | libicu-dev (<< 52)
 
-Package: bloom-desktop-alpha
+Package: bloom-desktop-beta
 Architecture: any
 Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  mono4-sil, libgdiplus4-sil, gtklp,
@@ -24,7 +24,7 @@ Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  optipng, libsndfile1,
  wmctrl, lame, ghostscript
 Suggests: art-of-reading
-Replaces: bloom-desktop, bloom-desktop-beta
+Replaces: bloom-desktop, bloom-desktop-alpha
 Conflicts: bloom-desktop-unstable
 Description: Literacy materials development for language communities
  Bloom Desktop is an application that dramatically "lowers the bar" for

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,5 +1,5 @@
 ﻿Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: bloom-desktop-alpha
+Upstream-Name: bloom-desktop-beta
 Source: https://github.com/BloomBooks/BloomDesktop
 
 Files: *
@@ -25,117 +25,117 @@ License: MIT
  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/bookEdit/css/origami.css
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/bookEdit/css/origami.css
 Copyright: 2014 Simon Hagström
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/factoryCollections/Templates/Wall Calendar/form2object.js
+Files: /usr/lib/bloom-desktop-beta/DistFiles/factoryCollections/Templates/Wall Calendar/form2object.js
 Copyright: 2010 Maxim Vasiliev
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/factoryCollections/Templates/Wall Calendar/mootools-*.js
+Files: /usr/lib/bloom-desktop-beta/DistFiles/factoryCollections/Templates/Wall Calendar/mootools-*.js
 Copyright: 2006-2010 Valerio Proietti & MooTools Developers
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/factoryCollections/Templates/Wall Calendar/mootools-more-1.4.0.1.js [embedded Element.Measure.js]
+Files: /usr/lib/bloom-desktop-beta/DistFiles/factoryCollections/Templates/Wall Calendar/mootools-more-1.4.0.1.js [embedded Element.Measure.js]
 Copyright: 2008 Daniel Steigerwald
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/pdf/web/l10n.js
+Files: /usr/lib/bloom-desktop-beta/DistFiles/pdf/web/l10n.js
 Copyright: 2011-2013 Fabien Cazenave, Mozilla
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/bookEdit/editor/sortable version/jquery-1.8.3.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/bookEdit/editor/sortable version/jquery-1.8.3.js
 Copyright: 2012 jQuery Foundation and other contributors
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery-1.10.1.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery-1.10.1.js
 Copyright: 2013 jQuery Foundation, Inc. and other contributors
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/bookEdit/editor/*/jquery-2.0.3.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/bookEdit/editor/*/jquery-2.0.3.js
 Copyright: 2005, 2013 jQuery Foundation, Inc. and other contributors
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/bookEdit/editor/*/jquery.gridly.*
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/bookEdit/editor/*/jquery.gridly.*
 Copyright: 2013 Kevin Sylvestre
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/bookEdit/editor/gridster version/jquery.gridster.*
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/bookEdit/editor/gridster version/jquery.gridster.*
 Copyright: 2013 ducksboard
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/bookEdit/editor/sortable version/jquery-ui-1.9.2.custom.*
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/bookEdit/editor/sortable version/jquery-ui-1.9.2.custom.*
 Copyright: 2013 jQuery Foundation and other contributors
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery-ui-1.10.3.custom.min.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery-ui-1.10.3.custom.min.js
 Copyright: 2013 jQuery Foundation and other contributors
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/bookEdit/js/toolbar/jquery.toolbar.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/bookEdit/js/toolbar/jquery.toolbar.js
 Copyright: 2013 Paul Kinzett
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/**/split-pane.*
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/**/split-pane.*
 Copyright: 2014 Simon Hagström
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery.betanum.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery.betanum.js
 Copyright: 2012 Kevin Sheedy
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery.betanum.js [embedded jquery.caret.js]
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery.betanum.js [embedded jquery.caret.js]
 Copyright: 2011 Luke Morton
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery.myimgscale.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery.myimgscale.js
 Copyright: 2011 Doug Jones, Kelly Meath, Marshal
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/long-press/jquery.longpress.*
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/long-press/jquery.longpress.*
 Copyright: 2013 Quentin Thiaucourt
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/long-press/jquery.mousewheel.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/long-press/jquery.mousewheel.js
 Copyright: 2011 Brandon Aaron
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/test/lib/jasmine-jquery-2.0.5.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/test/lib/jasmine-jquery-2.0.5.js
 Copyright: 2010-2014 Wojciech Zawistowski, Travis Jeffery
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/Analytics.NET.dll
+Files: /usr/lib/bloom-desktop-beta/Analytics.NET.dll
 Copyright: 2013 Segment
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/Autofac.*
+Files: /usr/lib/bloom-desktop-beta/Autofac.*
 Copyright: 2008 Autofac Contributors
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/NDesk.DBus.dll*
+Files: /usr/lib/bloom-desktop-beta/NDesk.DBus.dll*
 Copyright: Copyright 2006 Alp Toker <alp@atoker.com>
 License: MIT
 Comment: URL = https://www.nuget.org/packages/NDesk.DBus/
 
-Files: /usr/lib/bloom-desktop-alpha/NetSparkle.Net40.dll
+Files: /usr/lib/bloom-desktop-beta/NetSparkle.Net40.dll
 Copyright: 2010 Dirk Eisenberg
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/Newtonsoft.Json.dll
+Files: /usr/lib/bloom-desktop-beta/Newtonsoft.Json.dll
 Copyright: 2008 James Newton-King
 License: MIT
 Comment: URL = https://www.nuget.org/packages/Newtonsoft.Json/
 
-Files: /usr/lib/bloom-desktop-alpha/PdfSharp.dll
+Files: /usr/lib/bloom-desktop-beta/PdfSharp.dll
 Copyright: 2005-2014 empira Software GmbH, Troisdorf (Germany)
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/TidyManaged.dll*
+Files: /usr/lib/bloom-desktop-beta/TidyManaged.dll*
 Copyright: 2009 Mark Beaton
 License: MIT
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/pdf/*
+Files: /usr/lib/bloom-desktop-beta/DistFiles/pdf/*
 Copyright: 2012 Mozilla Foundation
 License: Apache-2.0
 
@@ -311,31 +311,31 @@ License: Apache-2.0
  .
  END OF TERMS AND CONDITIONS
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/pdf/build/pdf.worker.js [MurmurHash3]
+Files: /usr/lib/bloom-desktop-beta/DistFiles/pdf/build/pdf.worker.js [MurmurHash3]
 Copyright: 2014 Opera Software ASA
 License: Apache-2.0
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/pdf/web/viewer.js [GrabToPan]
+Files: /usr/lib/bloom-desktop-beta/DistFiles/pdf/web/viewer.js [GrabToPan]
 Copyright: 2013 Rob Wu <gwnRob@gmail.com>
 License: Apache-2.0
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/bookEdit/js/toolbar/bootstrap.icons.css
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/bookEdit/js/toolbar/bootstrap.icons.css
 Copyright: 2012 Twitter, Inc
 License: Apache-2.0
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/tabpane.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/tabpane.js
 Copyright: 2002, 2003, 2006 Erik Arvidsson
 License: Apache-2.0
 
-Files: /usr/lib/bloom-desktop-alpha/AWSSDK.dll
+Files: /usr/lib/bloom-desktop-beta/AWSSDK.dll
 Copyright: 2009-2013 Amazon.com, Inc. or its affiliates
 License: Apache-2.0
 
-Files: /usr/lib/bloom-desktop-alpha/RestSharp.dll
+Files: /usr/lib/bloom-desktop-beta/RestSharp.dll
 Copyright: 2010 John Sheehan
 License: Apache-2.0
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/factoryCollections/Sample Shells/Vaccinations/*
+Files: /usr/lib/bloom-desktop-beta/DistFiles/factoryCollections/Sample Shells/Vaccinations/*
 Copyright: 1996 SIL Papua New Guinea
 License: CC-BY-NC-3.0
 
@@ -668,7 +668,7 @@ License: CC-BY-NC-3.0
  .
      Creative Commons may be contacted at https://creativecommons.org/.
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery.sizes.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery.sizes.js
 Copyright: 2008-2010 Bram Stein
 License: BSD-3-Clause
 
@@ -699,12 +699,12 @@ License: BSD-3-Clause
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
 
-Files: /usr/lib/bloom-desktop-alpha/Enchant.Net.dll*
+Files: /usr/lib/bloom-desktop-beta/Enchant.Net.dll*
 Copyright: 2007-2008 Eric Scott Albright
 License: LGPL-2.1
 Comment: URL = https://github.com/AbiWord/enchantdotnet
 
-Files: /usr/lib/bloom-desktop-alpha/taglib-sharp.dll
+Files: /usr/lib/bloom-desktop-beta/taglib-sharp.dll
 Copyright: 2005, 2007 Brian Nickel, 2006 Novell, Inc., 2002, 2003 Scott Wheeler (Original Implementation)
 License: LGPL-2.1
 Comment: URL = https://github.com/mono/taglib-sharp
@@ -1169,7 +1169,7 @@ License: LGPL-2.1
  .
                       END OF TERMS AND CONDITIONS
 
-Files: /usr/lib/bloom-desktop-alpha/ICSharpCode.SharpZipLib.dll
+Files: /usr/lib/bloom-desktop-beta/ICSharpCode.SharpZipLib.dll
 Copyright: 2001-2010 Mike Krueger, John Reilly
 License: GPL-2 with exception
  The library is released under the GPL with the following exception:
@@ -1478,7 +1478,7 @@ License: GPL-2
  .
                       END OF TERMS AND CONDITIONS
 
-Files: /usr/lib/bloom-desktop-alpha/TechTalk.JiraRestClient.dll
+Files: /usr/lib/bloom-desktop-beta/TechTalk.JiraRestClient.dll
 Copyright: 2013, TechTalk Software Support Handelsgesellschaft m.b.H.
 License: TechTalk
  Redistribution and use in source and binary forms, with or without
@@ -1506,7 +1506,7 @@ License: TechTalk
  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/pdf/web/cmaps/*
+Files: /usr/lib/bloom-desktop-beta/DistFiles/pdf/web/cmaps/*
 Copyright: 1990-2009 Adobe Systems Incorporated
 License: Adobe
  Redistribution and use in source and binary forms, with or
@@ -1541,7 +1541,7 @@ License: Adobe
  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/pdf/web/compressed.tracemonkey-pldi-09.pdf
+Files: /usr/lib/bloom-desktop-beta/DistFiles/pdf/web/compressed.tracemonkey-pldi-09.pdf
 Copyright: 2009 ACM
 License: ACM
  Permission to make digital or hard copies of all or part of this work for
@@ -1551,69 +1551,69 @@ License: ACM
  to republish, to post on servers or to redistribute to lists, requires prior
  specific permission and/or a fee.
 
-Files: /usr/lib/bloom-desktop-alpha/Vulcan.Uczniowie.HelpProvider.dll
+Files: /usr/lib/bloom-desktop-beta/Vulcan.Uczniowie.HelpProvider.dll
 Copyright: 2007 VULCAN
 License: Free
 : 
 (http: //www.wiktorzychla.com/2007/08/context-help-made-easy-reloaded.html)
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/factoryCollections/Templates/Wall Calendar/jquery-1.6.4.js
+Files: /usr/lib/bloom-desktop-beta/DistFiles/factoryCollections/Templates/Wall Calendar/jquery-1.6.4.js
 Copyright: 2011 John Resig
 License: MIT or GPL-2
 
-Files: /usr/lib/bloom-desktop-alpha/DistFiles/factoryCollections/Templates/Wall Calendar/jquery-1.6.4.js [Sizzle.js]
+Files: /usr/lib/bloom-desktop-beta/DistFiles/factoryCollections/Templates/Wall Calendar/jquery-1.6.4.js [Sizzle.js]
 Copyright: 2011 The Dojo Foundation
 License: MIT or BSD or GPL
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery.js
 Copyright: 2011 John Resig
 License: MIT or GPL-2
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery.js [Sizzle.js]
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery.js [Sizzle.js]
 Copyright: 2011 The Dojo Foundation
 License: MIT or BSD or GPL
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery-ui.*
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery-ui.*
 Copyright: 2011 AUTHORS.txt (http://jqueryui.com/about)
 License: MIT or GPL-2
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/**/jquery-ui-1.8.16.custom.css
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/**/jquery-ui-1.8.16.custom.css
 Copyright: 2011 AUTHORS.txt (http://jqueryui.com/about)
 License: MIT or GPL-2
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/themes/bloom-jqueryui-theme/jquery-ui-dialog.custom.css
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/themes/bloom-jqueryui-theme/jquery-ui-dialog.custom.css
 Copyright: 2011 AUTHORS.txt (http://jqueryui.com/about)
 License: MIT or GPL-2
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/bookEdit/js/jquery.hotkeys.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/bookEdit/js/jquery.hotkeys.js
 Copyright: 2010 John Resig
 License: MIT or GPL-2
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery.easytabs*.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery.easytabs*.js
 Copyright: 2010-2011 Steve Schwartz (JangoSteve)
 License: MIT or GPL
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery.hashchange.min.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery.hashchange.min.js
 Copyright: 2010 "Cowboy" Ben Alman
 License: MIT or GPL
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery.qtip.*
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery.qtip.*
 Copyright: 2013 Craig Michael Thompson
 License: MIT or GPL
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery.resize.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery.resize.js
 Copyright: 2010 "Cowboy" Ben Alman
 License: MIT or GPL
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/jquery.watermark.js
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/jquery.watermark.js
 Copyright: 2009-2011 Todd Northrop
 License: MIT or GPL-2
 
-Files: /usr/lib/bloom-desktop-alpha/BloomBrowserUI/lib/oldjquery.qtip*
+Files: /usr/lib/bloom-desktop-beta/BloomBrowserUI/lib/oldjquery.qtip*
 Copyright: 2009-2010 Craig Michael Thompson
 License: MIT or GPL-2
 
-Files: /usr/lib/bloom-desktop-alpha/Ionic.Zip.dll
+Files: /usr/lib/bloom-desktop-beta/Ionic.Zip.dll
 Copyright: 2006-2011 Dino Chiesa
 License: MS-PL
 Comment: URL = http://www.codeplex.com/DotNetZip
@@ -1669,32 +1669,32 @@ License: MS-PL
      contributors exclude the implied warranties of merchantability, fitness for
      a particular purpose and non-infringement.
 
-Files: /usr/lib/bloom-desktop-alpha/CommandLine.dll
+Files: /usr/lib/bloom-desktop-beta/CommandLine.dll
 Copyright: 2005 - 2013 Giacomo Stelluti Scala
 License: MIT
 Comment: URL = https://www.nuget.org/packages/CommandLineParser/
 
-Files: /usr/lib/bloom-desktop-alpha/MarkdownDeep.dll
+Files: /usr/lib/bloom-desktop-beta/MarkdownDeep.dll
 Copyright: 2010-2011 Topten Software
 License: Apache-2.0
 Comment: URL = https://www.nuget.org/packages/MarkdownDeep.NET/
 
-Files: /usr/lib/bloom-desktop-alpha/L10NSharp.dll
+Files: /usr/lib/bloom-desktop-beta/L10NSharp.dll
 Copyright: 2010-2014 SIL International
 License: MIT
 Comment: URL = https://github.com/sillsdev/l10nsharp/
 
-Files: /usr/lib/bloom-desktop-alpha/ibusdotnet.dll
+Files: /usr/lib/bloom-desktop-beta/ibusdotnet.dll
 Copyright: 2015 SIL International
 License: MIT
 Comment: URL = https://www.nuget.org/packages/ibusdotnet/
 
-Files: /usr/lib/bloom-desktop-alpha/icu.net.dll
+Files: /usr/lib/bloom-desktop-beta/icu.net.dll
 Copyright: 2007-2016 SIL International
 License: MIT
 Comment: URL = https://github.com/sillsdev/icu-dotnet
 
-Files: /usr/lib/bloom-desktop-alpha/Spart.dll
+Files: /usr/lib/bloom-desktop-beta/Spart.dll
 Copyright: 2003 Jonathan de Halleux, portions 2014 SIL International
 License: Zlib
 Comment: URL = https://github.com/sillsdev/spart
@@ -1722,7 +1722,7 @@ License: Zlib
  .
     3. This notice may not be removed or altered from any source distribution.
 
-Files: /usr/lib/bloom-desktop-alpha/ColorProfiles/*
+Files: /usr/lib/bloom-desktop-beta/ColorProfiles/*
 Copyright: 2013 Adobe Systems, Inc.
-License: ColorProfileDistributionLicense (/usr/lib/bloom-desktop-alpha/DistFiles/AdobeColorProfileEULA.md)
+License: ColorProfileDistributionLicense (/usr/lib/bloom-desktop-beta/DistFiles/AdobeColorProfileEULA.md)
 Comment: URL=https://www.adobe.com/support/downloads/iccprofiles/iccprofiles_win.html

--- a/debian/install
+++ b/debian/install
@@ -1,7 +1,7 @@
-lib/dotnet/SIL.Core.dll.mdb usr/lib/bloom-desktop-alpha/
-lib/dotnet/SIL.Media.dll.mdb usr/lib/bloom-desktop-alpha/
-lib/dotnet/SIL.Windows.Forms.dll.mdb usr/lib/bloom-desktop-alpha/
-lib/dotnet/SIL.Windows.Forms.GeckoBrowserAdapter.dll.mdb usr/lib/bloom-desktop-alpha/
-lib/dotnet/SIL.Windows.Forms.Keyboarding.dll.mdb usr/lib/bloom-desktop-alpha/
-lib/dotnet/SIL.Windows.Forms.WritingSystems.dll.mdb usr/lib/bloom-desktop-alpha/
-lib/dotnet/SIL.WritingSystems.dll.mdb usr/lib/bloom-desktop-alpha/
+lib/dotnet/SIL.Core.dll.mdb usr/lib/bloom-desktop-beta/
+lib/dotnet/SIL.Media.dll.mdb usr/lib/bloom-desktop-beta/
+lib/dotnet/SIL.Windows.Forms.dll.mdb usr/lib/bloom-desktop-beta/
+lib/dotnet/SIL.Windows.Forms.GeckoBrowserAdapter.dll.mdb usr/lib/bloom-desktop-beta/
+lib/dotnet/SIL.Windows.Forms.Keyboarding.dll.mdb usr/lib/bloom-desktop-beta/
+lib/dotnet/SIL.Windows.Forms.WritingSystems.dll.mdb usr/lib/bloom-desktop-beta/
+lib/dotnet/SIL.WritingSystems.dll.mdb usr/lib/bloom-desktop-beta/

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@
 export MONO_PREFIX = /opt/mono4-sil
 export BUILD = Release
 
-PACKAGE = bloom-desktop-alpha
+PACKAGE = bloom-desktop-beta
 DESTDIR = debian/$(PACKAGE)
 LIB     = usr/lib/$(PACKAGE)
 SHARE   = usr/share/$(PACKAGE)
@@ -64,13 +64,13 @@ override_dh_auto_install:
 	chmod -R a+rX,og-w $(DESTDIR)/$(LIB)/browser
 	# Install wrapper script
 	install -d $(DESTDIR)/usr/bin
-	install debian/bloom-alpha $(DESTDIR)/usr/bin
+	install debian/bloom-beta $(DESTDIR)/usr/bin
 	# Add to Applications menu
 	install -d $(DESTDIR)/usr/share/pixmaps
-	install -m 644 debian/bloom.png $(DESTDIR)/usr/share/pixmaps/bloom-alpha.png
-	install -m 644 debian/bloom.svg $(DESTDIR)/usr/share/pixmaps/bloom-alpha.svg
+	install -m 644 debian/bloom.png $(DESTDIR)/usr/share/pixmaps/bloom-beta.png
+	install -m 644 debian/bloom.svg $(DESTDIR)/usr/share/pixmaps/bloom-beta.svg
 	install -d $(DESTDIR)/usr/share/applications
-	desktop-file-install --dir $(DESTDIR)/usr/share/applications debian/bloom-alpha.desktop
+	desktop-file-install --dir $(DESTDIR)/usr/share/applications debian/bloom-beta.desktop
 	# Install icon for our mime type so that it shows up as icon for a bloompack
 	# NOTE: mime type installation is handled by dh_installmime
 	install -d $(DESTDIR)/usr/share/icons/hicolor/48x48/mimetypes/
@@ -84,7 +84,7 @@ override_dh_auto_install:
 	# REVIEW: the specs are not completely clear where the file should go: /usr/share/appdata,
 	# /usr/share/app-info/xmls, or /usr/share/metainfo.
 	install -d $(DESTDIR)/usr/share/appdata
-	install -m 644 debian/bloom-alpha.appdata.xml $(DESTDIR)/usr/share/appdata
+	install -m 644 debian/bloom-beta.appdata.xml $(DESTDIR)/usr/share/appdata
 
 # Don't export any assemblies to other packages
 override_dh_makeclilibs:


### PR DESCRIPTION
This is needed for making Version4.0 the official beta on Linux.
DO NOT MERGE THIS TO master!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1974)
<!-- Reviewable:end -->
