### PR TITLE
BL-5243 fix failing tests when creating new collection

### DIFF
--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -132,20 +132,13 @@ namespace Bloom.Collection
 			:this()
 		{
 			SettingsFilePath = desiredOrExistingSettingsFilePath;
-			// We check for a Windows Defender "Controlled Access" problem when we start Bloom,
-			// but the user may have moved their startup collection to a "safe" place and now be opening a different
-			// collection in a "controlled" place. Test again with this settings file path.
-			// 'FolderPath' is the directory part of 'SettingsFilePath'.
-			if (!DefenderFolderProtectionCheck.CanWriteToDirectory(FolderPath))
-			{
-				Environment.Exit(-1);
-			}
 			CollectionName = Path.GetFileNameWithoutExtension(desiredOrExistingSettingsFilePath);
 			var libraryDirectory = Path.GetDirectoryName(desiredOrExistingSettingsFilePath);
 			var parentDirectoryPath = Path.GetDirectoryName(libraryDirectory);
 
 			if (RobustFile.Exists(desiredOrExistingSettingsFilePath))
 			{
+				DoDefenderFolderProtectionCheck();
 				Load();
 			}
 			else
@@ -156,7 +149,20 @@ namespace Bloom.Collection
 				if (!Directory.Exists(libraryDirectory))
 					Directory.CreateDirectory(libraryDirectory);
 
+				DoDefenderFolderProtectionCheck();
 				Save();
+			}
+		}
+
+		private void DoDefenderFolderProtectionCheck()
+		{
+			// We check for a Windows Defender "Controlled Access" problem when we start Bloom,
+			// but the user may have moved their startup collection to a "safe" place and now be opening a different
+			// collection in a "controlled" place. Test again with this settings file path.
+			// 'FolderPath' is the directory part of 'SettingsFilePath'.
+			if (!DefenderFolderProtectionCheck.CanWriteToDirectory(FolderPath))
+			{
+				Environment.Exit(-1);
 			}
 		}
 


### PR DESCRIPTION
Moved the Defender protection check to AFTER we've created the directories we're testing.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1976)
<!-- Reviewable:end -->
