### PR TITLE
Add usually-empty pages back into device xmatter

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/Device-XMatter/Device-XMatter.pug
+++ b/src/BloomBrowserUI/templates/xMatter/Device-XMatter/Device-XMatter.pug
@@ -15,13 +15,31 @@ html
 
 	// Credits at the end
 
-	+page-xmatter("Title Page").titlePage.bloom-backMatter&attributes(attributes)#5ecd48df-e9ab-4a07-afd4-6a24d03983ee
+	+page-xmatter("Title Page").titlePage.bloom-backMatter&attributes(attributes)#898b6622-837b-49cd-9938-2de76f6d4b17
 		+title-page-contents
 
-	+page-xmatter("Credits Page").bloom-backMatter.credits&attributes(attributes)#CCDB9CCC-5DCC-4D55-86B5-6DD2A5303ACC
+	+page-xmatter("Credits Page").bloom-backMatter.credits&attributes(attributes)#898b6622-837b-49cd-9938-2de76f6d4b18
 		+credits-contents
 
-	+page-xmatter("The End").bloom-backMatter.theEndPage#aaa140ba-981a-44d4-a0cf-510f7367aaaa
+
+
+	//- In paper book, this is the inside front cover
+	//- When making a .bloomd, Bloom will remove this if it is empty.
+	+page-cover('Inside Front Cover').cover.coverColor.insideFrontCover.bloom-backMatter#898b6622-837b-49cd-9938-2de76f6d4b19
+		+field-mono-meta("N1","insideFontCover").Inside-Front-Cover-style
+
+	//- In paper books, this is the inside back cover
+	//- When making a .bloomd, Bloom will remove this if it is empty.
+	+page-xmatter('Inside Back Cover').cover.coverColor.insideBackCover.bloom-backMatter#898b6622-837b-49cd-9938-2de76f6d4b20
+		+field-mono-meta("N1","insideBackCover").Inside-Back-Cover-style
+
+	//- In paper books, this is the outside back cover
+	//- When making a .bloomd, Bloom will remove this if it is empty.
+	+page-xmatter('Outside Back Cover').cover.coverColor.outsideBackCover.bloom-backMatter#898b6622-837b-49cd-9938-2de76f6d4b21
+		//- +field-mono-version1("N1","If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.").outside-back-cover-style(data-book='outsideBackCover')
+		+field-mono-meta("N1","outsideBackCover").Outside-Back-Cover-style
+
+	+page-xmatter("The End").bloom-backMatter.theEndPage#898b6622-837b-49cd-9938-2de76f6d4b22
 		//- would be nice to use data-collection instead of data-book, but that isn't working in Bloom these
 		//- days (was a version 1-ish feature that never got used, and atrophied).
 		//- When we do have it, that would save typing it in for each book in the Local Language... and ideally it would also overwrite
@@ -34,3 +52,5 @@ html
 			+editable("es")
 				p Fin
 		+field-back-cover-branding
+
+

--- a/src/BloomBrowserUI/templates/xMatter/Device-XMatter/description-en.txt
+++ b/src/BloomBrowserUI/templates/xMatter/Device-XMatter/description-en.txt
@@ -1,1 +1,1 @@
-This is automatically applied when publishing to Bloom Reader (Android).
+This is automatically applied when publishing to Bloom Reader (Android). It moves front matter pages (other than the cover) to the back.


### PR DESCRIPTION
Do not merge until the main part of BL-5312 is merged.
The main part of BL-5312 will delete these if they are empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1980)
<!-- Reviewable:end -->
