### PR TITLE
Backport the Linux fix for private SIL tidy library version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Package: bloom-desktop
 Architecture: any
 Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  mono4-sil, libgdiplus4-sil, gtklp,
- chmsee, libtidy5,
+ chmsee, libtidy-sil,
  fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,
  optipng, libsndfile1,
  wmctrl, lame

--- a/environ
+++ b/environ
@@ -56,6 +56,9 @@ else
 	MONO_GAC_PREFIX="${MONO_PREFIX}:/usr"
 fi
 
+# point to our private version of libtidy
+LD_LIBRARY_PATH="/opt/tidy-sil/lib:${LD_LIBRARY_PATH}"
+
 ################################################################################################
 
 MONO_TRACE_LISTENER="Console.Out"


### PR DESCRIPTION
THIS SHOULD NOT BE MERGED INTO Version4.0 OR master!

Both files in this change are Linux specific.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1992)
<!-- Reviewable:end -->
