### PR TITLE
BL-5321 Fix problem with links in Template Starter Readme

### DIFF
--- a/src/BloomBrowserUI/gulpfile.js
+++ b/src/BloomBrowserUI/gulpfile.js
@@ -202,8 +202,11 @@ gulp.task('markdownTemplateReadme', function () {
         .pipe(debug({ title: 'md:' }))
         .pipe(tap(function (file) {
             var result = markdownIt.render(file.contents.toString());
-	    // this is converted to full HTML in C# code, adding base href and link to css file
-            file.contents = new Buffer(result);
+            // wrap the generated HTML in a document and make it use our standard stylesheet.
+            // strip out the string we insert to obfuscate email addresses in source code.
+            file.contents = new Buffer(`<html><head><meta charset='utf-8'><link rel='stylesheet' href='../../../bookPreview/BookReadme.css' type='text/css' /></head><body>
+                ` + result.replace("removethis", "") + `
+                </body></html>`);
             file.path = gutil.replaceExtension(file.path, '.htm');
             return;
         }))

--- a/src/BloomBrowserUI/templates/template books/Big Book/ReadMe-en.md
+++ b/src/BloomBrowserUI/templates/template books/Big Book/ReadMe-en.md
@@ -14,4 +14,4 @@ If you send us that text, we can include it in a future version of the template.
 # Feedback {i18n="bigbook.feedback"}
 Please give and vote on [suggestions](http://bloomlibrary.org/suggestions) {i18n="bigbook.feedbackvoting"}
 
-Please report problems to [issues@bloomremovelibrary.org](mailto:issues@bloomremovelibrary.org?subject=Big&nbsp;Book&nbsp;Problem). {i18n="bigbook.reportsbugs"}
+Please report problems to [issues@bloomremovethislibrary.org](mailto:issues@bloomremovethislibrary.org?subject=Big&nbsp;Book&nbsp;Problem). {i18n="bigbook.reportsbugs"}

--- a/src/BloomBrowserUI/templates/template books/Picture Dictionary/ReadMe-en.md
+++ b/src/BloomBrowserUI/templates/template books/Picture Dictionary/ReadMe-en.md
@@ -7,4 +7,4 @@ This book is currently marked "experimental" because we know of several problems
 # Feedback {i18n="picture.dictionary.feedback"}
 Please give and vote on [suggestions](http://bloomlibrary.org/suggestions) {i18n="picture.dictionary.feedbackvoting"}
 
-Please report problems to [issues@bloomremovelibrary.org](mailto:issues@bloomremovelibrary.org?subject=Picture&nbsp;Dictionary&nbsp;Problem). {i18n="picture.dictionary.reportbugs"}
+Please report problems to [issues@bloomremovethislibrary.org](mailto:issues@bloomremovethislibrary.org?subject=Picture&nbsp;Dictionary&nbsp;Problem). {i18n="picture.dictionary.reportbugs"}

--- a/src/BloomBrowserUI/templates/template books/Template Starter/ReadMe-en.md
+++ b/src/BloomBrowserUI/templates/template books/Template Starter/ReadMe-en.md
@@ -3,12 +3,12 @@
 This special template lets you make your own templates. A template provides a set of related page layouts that an author can choose from in writing an original book. Usually the text blocks and picture blocks on template pages will be empty, ready for an author to fill in. Sometimes there may be standard text or pictures that should be on every copy of the page.
 There are two ways people can use your template. The first way is to start new books. For example, imagine student books that have one page for each school day of the week. You could make a template with 5 pages, each with places to type in text and choose pictures. Curriculum authors could select your template and make a new book, one for each week<sup>[1](#note1)</sup>. {i18n="template.starter.firstusage"}
 
-The second way people can use templates is as source of new pages, regardless of how they started the book. For example, in some places, each book requires a page as part of a government approval process. You might make a template containing that page and give it to others in your country. Then, when people translate a shellbook, they go to the end of the book and click “Add Page”. The page you made will appear in their list of choices. Some other ideas for templates are alphabet charts, glossaries, and instructions on how to use the book in a classroom. <sup>[2](#note1)</sup> {i18n="template.starter.secondusage"}
+The second way people can use templates is as source of new pages, regardless of how they started the book. For example, in some places, each book requires a page as part of a government approval process. You might make a template containing that page and give it to others in your country. Then, when people translate a shellbook, they go to the end of the book and click “Add Page”. The page you made will appear in their list of choices. Some other ideas for templates are alphabet charts, glossaries, and instructions on how to use the book in a classroom. <sup>[2](#note2)</sup> {i18n="template.starter.secondusage"}
 
 Making templates is just like making any other custom book; all the same controls are available for making and customizing pages. But since you will probably be sharing with other people, there are a number of things you can do to help users of your template: {i18n="template.starter.waystohelp"}
 
 ## Label Your Pages {i18n="template.starter.labelpages"}
-When you add pages to your template, make sure to give each one a useful label<sup>[3](#note2),[4](@note3)</sup>: {i18n="template.starter.labeleachpage"}
+When you add pages to your template, make sure to give each one a useful label<sup>[3](#note3),[4](#note4)</sup>: {i18n="template.starter.labeleachpage"}
 
 ![custom label](ReadMeImages/customLabel.png) {i18n="template.starter.labelexample"}
 
@@ -36,12 +36,12 @@ For local colleagues, an easy way to distribute your template is via a Bloom Pac
 
 ## Notes {i18n="template.starter.notes"}
 
-<a name="note1">1</a>: These books could later be combined using the forthcoming Folio feature. Note that Bloom 3.9 does not yet give you a way to indicate that a page should be automatically included in new books; the author will have to add each one from the Add Page dialog. {i18n="template.starter.nothingautomatic"}
+<a id="note1">1</a>: These books could later be combined using the forthcoming Folio feature. Note that Bloom 3.9 does not yet give you a way to indicate that a page should be automatically included in new books; the author will have to add each one from the Add Page dialog. {i18n="template.starter.nothingautomatic"}
 
-<a name="note2">2</a>: If you don't want the pages in your template to show up in the Add Page dialog, you can indicate this to Bloom by creating a file in the book's template folder called NotForAddPage.txt. {i18n="template.starter.nametonotaddpage"}
+<a id="note2">2</a>: If you don't want the pages in your template to show up in the Add Page dialog, you can indicate this to Bloom by creating a file in the book's template folder called NotForAddPage.txt. {i18n="template.starter.nametonotaddpage"}
 
-<a name="note3">3</a>: People will not be able to translate your labels and descriptions into other national languages. If this is a problem, please contact the Bloom team. {i18n="template.starter.labelsnottranslatable"}
+<a id="note3">3</a>: People will not be able to translate your labels and descriptions into other national languages. If this is a problem, please contact the Bloom team. {i18n="template.starter.labelsnottranslatable"}
 
-<a name="note4">4</a>: If you want the Add Page screen to also provide a short description of the page, you'll need to quit Bloom and edit the template's html in Notepad, like this: ![](ReadMeImages/pageDescription.png) {i18n="template.starter.editrawhtml"}
+<a id="note4">4</a>: If you want the Add Page screen to also provide a short description of the page, you'll need to quit Bloom and edit the template's html in Notepad, like this: ![](ReadMeImages/pageDescription.png) {i18n="template.starter.editrawhtml"}
 
 

--- a/src/BloomBrowserUI/templates/template books/Wall Calendar/ReadMe-en.md
+++ b/src/BloomBrowserUI/templates/template books/Wall Calendar/ReadMe-en.md
@@ -10,4 +10,4 @@ Thanks to Bruce Cox (SIL Cameroon) for getting this template started. {i18n="wal
 # Feedback {i18n="wall.calendar.feedback"}
 Please give and vote on [suggestions](http://bloomlibrary.org/suggestions) {i18n="wall.calendar.feedbackvoting"}
 
-Please report problems to [issues@bloomremovelibrary.org](mailto:issues@bloomremovelibrary.org?subject=Wall&nbsp;Calendar&nbsp;Problem). {i18n="wall.calendar.reportbugs"}
+Please report problems to [issues@bloomremovethislibrary.org](mailto:issues@bloomremovethislibrary.org?subject=Wall&nbsp;Calendar&nbsp;Problem). {i18n="wall.calendar.reportbugs"}

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1461,21 +1461,6 @@ namespace Bloom.Book
 			return false; // not found
 		}
 
-
-		public string GetAboutBookHtml
-		{
-			get
-			{
-				var contents = RobustFile.ReadAllText(AboutBookHtmlPath);
-				contents = contents.Replace("remove", "");//used to hide email addresses in the html from scanners (probably unnecessary.... do they scan .htm files?
-
-				var pathToCss = _storage.GetFileLocator().LocateFileWithThrow("BookReadme.css");
-				var pathAsUrl = "file://" + AboutBookHtmlPath.Replace('\\', '/').Replace(" ", "%20");
-				var html = $"<html><head><meta charset='utf-8'><base href='{pathAsUrl}'><link rel='stylesheet' href='file://{pathToCss}' type='text/css'><head/><body>{contents}</body></html>";
-				return html;
-			}
-		}
-
 		public bool HasAboutBookInformationToShow
 		{
 			get

--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -124,7 +124,9 @@ namespace Bloom
 			// See http://kb.mozillazine.org/About:config_entries, http://www.davidtan.org/tips-reduce-firefox-memory-cache-usage
 			// and http://forums.macrumors.com/showthread.php?t=1838393.
 			GeckoPreferences.User["memory.free_dirty_pages"] = true;
-			GeckoPreferences.User["browser.sessionhistory.max_entries"] = 0;
+			// Do NOT set this to zero. Somehow that disables following hyperlinks within a document (e.g., the ReadMe
+			// for the template starter, BL-5321).
+			GeckoPreferences.User["browser.sessionhistory.max_entries"] = 1;
 			GeckoPreferences.User["browser.sessionhistory.max_total_viewers"] = 0;
 			GeckoPreferences.User["browser.cache.memory.enable"] = false;
 

--- a/src/BloomExe/CollectionTab/LibraryBookView.cs
+++ b/src/BloomExe/CollectionTab/LibraryBookView.cs
@@ -143,7 +143,7 @@ namespace Bloom.CollectionTab
 				if (_bookSelection.CurrentSelection.HasAboutBookInformationToShow)
 				{
 					_splitContainerForPreviewAndAboutBrowsers.Panel2Collapsed = false;
-					_readmeBrowser.NavigateRawHtml(_bookSelection.CurrentSelection.GetAboutBookHtml);
+					_readmeBrowser.Navigate(_bookSelection.CurrentSelection.AboutBookHtmlPath, false);
 					_readmeBrowser.Visible = true;
 				}
 				_reshowPending = false;


### PR DESCRIPTION
- Readme-en.htm is now fully generated by the build
- Some link targets are corrected
- base url is no longer needed (the fundamental problem)
- removed a gecko preference that was preventing link following

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/1994)
<!-- Reviewable:end -->
