### PR TITLE
Fix bloomd thumbnails & give wysiwyg preview in publish BL-5346

### DIFF
--- a/src/BloomExe/Book/BookCompressor.cs
+++ b/src/BloomExe/Book/BookCompressor.cs
@@ -52,7 +52,7 @@ namespace Bloom.Book
 			if(coverImagePath != null)
 			{
 				var thumbPath = Path.Combine(destinationFolder, "thumbnail.png");
-				RuntimeImageProcessor.GenerateThumbnail(coverImagePath, thumbPath, heightAndWidth, heightAndWidth, backColor);
+				RuntimeImageProcessor.GenerateEBookThumbnail(coverImagePath, thumbPath, heightAndWidth, heightAndWidth, backColor);
 			}
 			// else, BR shows a default thumbnail for the book
 		}

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -440,6 +440,7 @@ namespace Bloom.Publish
 					_pdfViewer.Visible = false;
 					break;
 				case PublishModel.DisplayModes.ShowPdf:
+					Logger.WriteEvent("Entering Publish PDF Screen");
 					if (RobustFile.Exists(_model.PdfFilePath))
 					{
 						_pdfViewer.Visible = true;
@@ -468,6 +469,7 @@ namespace Bloom.Publish
 					break;
 				case PublishModel.DisplayModes.Upload:
 				{
+					Logger.WriteEvent("Entering Publish Upload Screen");
 					_workingIndicator.Visible = false; // If we haven't finished creating the PDF, we will indicate that in the progress window.
 					_saveButton.Enabled = _printButton.Enabled = false; // Can't print or save in this mode...wouldn't be obvious what would be saved.
 					_pdfViewer.Visible = false;
@@ -482,6 +484,7 @@ namespace Bloom.Publish
 				}
 				case PublishModel.DisplayModes.EPUB:
 				{
+					Logger.WriteEvent("Entering Publish Epub Screen");
 					// We may reuse this for the process of generating the ePUB staging files. For now, skip it.
 					_workingIndicator.Visible = false;
 					_printButton.Enabled = false; // don't know how to print an ePUB
@@ -504,6 +507,7 @@ namespace Bloom.Publish
 				}
 				case PublishModel.DisplayModes.Android:
 				{
+					Logger.WriteEvent("Entering Publish Android Screen");
 					_workingIndicator.Visible = false;
 					_printButton.Enabled = false;
 					_pdfViewer.Visible = false;

--- a/src/BloomExe/web/controllers/ApiRequest.cs
+++ b/src/BloomExe/web/controllers/ApiRequest.cs
@@ -145,7 +145,10 @@ namespace Bloom.Api
 			}
 			catch (Exception e)
 			{
-				SIL.Reporting.ErrorReport.ReportNonFatalExceptionWithMessage(e, info.RawUrl);
+				//Hard to reproduce, but I got one of these supertooltip disposal errors in a yellow box
+				//while switching between publish tabs (e.g. /bloom/api/publish/android/cleanup).
+				//I don't think these are worth alarming the user about, so let's be sensitive to what channel we're on.
+				NonFatalProblem.Report(ModalIf.Alpha, PassiveIf.All, "Error in " + info.RawUrl, exception: e);
 				return false;
 			}
 			return true;


### PR DESCRIPTION
Now produced the requested thumbnail size
Now centers cover image
Shows actual thumbnail in publish instead of an html simulation
Heuristic to frame line art (actually just pngs) differently than full color (actually just jpgs).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2012)
<!-- Reviewable:end -->
