### PR TITLE
Fix page re-ordering message

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1115,7 +1115,7 @@
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
       <trans-unit id="EditTab.HowToUnlockBook">
-        <source xml:lang="en">To unlock this shellbook, go into the toolbox on the right, find the gear icon, and click 'Allow changes to this shellbook'.</source>
+        <source xml:lang="en">To unlock this shellbook, click the lock icon in the lower left corner.</source>
         <note>ID: EditTab.HowToUnlockBook</note>
       </trans-unit>
       <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1374,7 +1374,7 @@ namespace Bloom.Edit
 		public static string GetInstructionsForUnlockingBook()
 		{
 			return LocalizationManager.GetString("EditTab.HowToUnlockBook",
-							"To unlock this shellbook, go into the toolbox on the right, find the gear icon, and click 'Allow changes to this shellbook'.");
+							"To unlock this shellbook, click the lock icon in the lower left corner.");
 		}
 
 		// The zoom factor that is shown in the top right of the toolbar (a percent).


### PR DESCRIPTION
* in a locked book, the message now matches
   the new page controls for unlocking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2046)
<!-- Reviewable:end -->
