### PR TITLE
BL-5390 fix some socket timing problems

### DIFF
--- a/src/BloomExe/web/BloomWebSocketServer.cs
+++ b/src/BloomExe/web/BloomWebSocketServer.cs
@@ -101,7 +101,7 @@ namespace Bloom.Api
 						// I don't know if Sending on a closed socket would throw, so we'll catch it in any case
 						try
 						{
-							socket.Send(e.ToString());
+							socket?.Send(e.ToString());
 						}
 						catch (Exception error)
 						{
@@ -122,7 +122,7 @@ namespace Bloom.Api
 					foreach(var socket in _allSockets.ToArray())
 					{
 						Debug.WriteLine($"*** This socket was still open and is being closed during shutdown: \"{socket?.ConnectionInfo?.SubProtocol}\"");
-						socket.Close();
+						socket?.Close();
 					}
 					_allSockets.Clear();
 					_server.Dispose();


### PR DESCRIPTION
* sometimes 'socket' is generating an "Object ref
   not set to an instance" error even though closed
   sockets are supposed to delete themselves

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2054)
<!-- Reviewable:end -->
