### PR TITLE
BR-5380 make LibTidy output breaks correctly

### DIFF
--- a/src/BloomExe/XmlHtmlConverter.cs
+++ b/src/BloomExe/XmlHtmlConverter.cs
@@ -325,6 +325,10 @@ namespace Bloom
 			var xml = xmlStringBuilder.ToString();
 			xml = AddFillerToKeepTidyFromRemovingEmptyElements(xml);
 
+			// Tidy will convert <br /> to <br></br> which is not valid and produces an unexpected double line break.
+			var BrPlaceholder = "$$ConvertThisBackToBr$$";
+			xml = xml.Replace("<br />", BrPlaceholder);
+
 			// Now re-write as html, indented nicely
 			string html;
 			using (var tidy = Document.FromString(xml))
@@ -362,6 +366,7 @@ namespace Bloom
 			}
 
 			// Now revert the stuff we did to make it "safe from libtidy"
+			html = html.Replace(BrPlaceholder, "<br>");
 			html = RemoveFillerInEmptyElements(html);
 			return html;
 		}

--- a/src/BloomTests/XmlHtmlConverterTests.cs
+++ b/src/BloomTests/XmlHtmlConverterTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml;
 using Bloom;
+using Bloom.Book;
 using NUnit.Framework;
 using SIL.IO;
 
@@ -171,6 +172,20 @@ namespace BloomTests
 				found = xml.Select((c, i) => xml.Substring(i)).Count(sub => sub.StartsWith("<br />"));
 			}
 			Assert.AreEqual(1, found);
+		}
+
+		[Test]
+		public void SaveDOMAsHtml5_SavesBrCorrectly()
+		{
+			var dom = new XmlDocument();
+			dom.LoadXml("<html><body><br /></body></html>");
+			using (var temp = new TempFile())
+			{
+				XmlHtmlConverter.SaveDOMAsHtml5(dom, temp.Path);
+				var text = File.ReadAllText(temp.Path);
+				Assert.That(text, Does.Contain("<br>"));
+				Assert.That(text, Does.Not.Contain("</br>"));
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
<br /> should convert to HTML as <br> (or possibly leave as <br />, but definitely not <br></br>)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2071)
<!-- Reviewable:end -->
