### PR TITLE
BL-5464 Improve Spanish localization

### DIFF
--- a/DistFiles/localization/en/Palaso.xlf
+++ b/DistFiles/localization/en/Palaso.xlf
@@ -397,6 +397,7 @@
       <trans-unit id="MetadataEditor.UnknownLicense">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <note>ID: MetadataEditor.UnknownLicense</note>
+        <note>Space for the translation of this is limited. If you can't make it fit, it's possible to put a couple of extra words below the right end of the message using \n and some white space. See es for an example.</note>
       </trans-unit>
       <trans-unit id="MetadataEditor.YesShareAlike">
         <source xml:lang="en">Yes, as long as others share alike</source>

--- a/DistFiles/localization/es/Palaso.xlf
+++ b/DistFiles/localization/es/Palaso.xlf
@@ -705,7 +705,7 @@
       <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <note>ID: MetadataEditor.UnknownLicense</note>
-        <target xml:lang="es-ES">Comuníquese con el titular de los derechos de autor para solicitar permisos</target>
+        <target xml:lang="es-ES">Comuníquese con el titular de los derechos de autor para\n                                                                  solicitar permisos</target>
         <alt-trans>
           <target xml:lang="es-ES">Comuniquese con el titular de derechos de autor para solicitar permisos</target>
         </alt-trans>


### PR DESCRIPTION
Ues a somewhat nasty trick to squeeze the Spanish localization of "Contact the copyright holder for any permissions" into two lines with the extra stuck on the right. Depends on a change to libpalaso to permit two lines of text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2078)
<!-- Reviewable:end -->
