### PR TITLE
Fix ambiguous definition in Device xmatter

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/Device-XMatter/Device-XMatter.pug
+++ b/src/BloomBrowserUI/templates/xMatter/Device-XMatter/Device-XMatter.pug
@@ -25,7 +25,7 @@ html
 
 	//- In paper book, this is the inside front cover
 	//- When making a .bloomd, Bloom will remove this if it is empty.
-	+page-cover('Inside Front Cover').cover.coverColor.insideFrontCover.bloom-backMatter#898b6622-837b-49cd-9938-2de76f6d4b19
+	+page-xmatter('Inside Front Cover').cover.coverColor.insideFrontCover.bloom-backMatter#898b6622-837b-49cd-9938-2de76f6d4b19
 		+field-mono-meta("N1","insideFontCover").Inside-Front-Cover-style
 
 	//- In paper books, this is the inside back cover

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2009,11 +2009,11 @@ namespace Bloom.Book
 			if (upperBounds < 0)
 				upperBounds = 10000;
 
-			return indexOfItemAfterRelocation > GetIndexLastFrontkMatterPage ()
+			return indexOfItemAfterRelocation > GetIndexOfLastFrontMatterPage ()
 				&& indexOfItemAfterRelocation < upperBounds;
 		}
 
-		internal int GetIndexLastFrontkMatterPage()
+		private int GetIndexOfLastFrontMatterPage()
 		{
 			XmlElement lastFrontMatterPage =
 				OurHtmlDom.RawDom.SelectSingleNode("(/html/body/div[contains(@class,'bloom-frontMatter')])[last()]") as XmlElement;


### PR DESCRIPTION
* page-cover mixin assumed frontMatter, whereas
   we want Inside Front Cover to be backMatter in
   Device
* having both front and backMatter classes
   messed up the page reordering mechanism

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2089)
<!-- Reviewable:end -->
