### PR TITLE
BL-5471 Make UI Language Menu stay open

### DIFF
--- a/src/BloomExe/Workspace/WorkspaceView.Designer.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.Designer.cs
@@ -217,6 +217,8 @@
 			this._uiLanguageMenu.Name = "_uiLanguageMenu";
 			this._uiLanguageMenu.Size = new System.Drawing.Size(56, 19);
 			this._uiLanguageMenu.Text = "English";
+			this._uiLanguageMenu.DropDown.AutoClose = false;
+
 			// 
 			// _helpMenu
 			// 

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Globalization;
 using System.Threading;
 using System.Windows.Forms;
 using Bloom.Collection;
@@ -61,6 +60,8 @@ namespace Bloom.Workspace
 		public static float DPIOfThisAccount;
 		private ZoomControl _zoomControl;
 		private static LanguageLookupModel _lookupIsoCode = new LanguageLookupModel();
+
+		private bool _uiLangMenuIsOpening;
 
 		public delegate WorkspaceView Factory(Control libraryView);
 
@@ -298,6 +299,7 @@ namespace Bloom.Workspace
 		private void SetupUiLanguageMenu()
 		{
 			SetupUiLanguageMenuCommon(_uiLanguageMenu, FinishUiLanguageMenuItemClick);
+			_uiLanguageMenu.DropDown.Opening += UiLanguageMenuDropDown_Opening;
 
 			// Removing this for now (BL-5111)
 			//_uiLanguageMenu.DropDownItems.Add(new ToolStripSeparator());
@@ -312,6 +314,28 @@ namespace Bloom.Workspace
 			//	// See http://issues.bloomlibrary.org/youtrack/issue/BL-3444.
 			//	AdjustButtonTextsForLocale();
 			//});
+		}
+
+		private void UiLanguageMenuDropDown_Opening(object sender, EventArgs e)
+		{
+			_uiLangMenuIsOpening = true;
+			_uiLanguageMenu.Click += CloseUiLanguageMenu; // clicking the menu button itself will close the menu
+			_uiLanguageMenu.DropDown.Click += CloseUiLanguageMenu; // clicking a menu item also closes the menu
+		}
+
+		private void CloseUiLanguageMenu(object sender, EventArgs e)
+		{
+			if (_uiLangMenuIsOpening)
+			{
+				_uiLangMenuIsOpening = false;
+				return;
+			}
+			var dropdown = _uiLanguageMenu.DropDown;
+			dropdown.AutoClose = true;
+			_uiLanguageMenu.HideDropDown();
+			dropdown.AutoClose = false;
+			_uiLanguageMenu.Click -= CloseUiLanguageMenu;
+			_uiLanguageMenu.DropDown.Click -= CloseUiLanguageMenu;
 		}
 
 		/// <summary>


### PR DESCRIPTION
* It was too easy to mouse over the Help menu and
   close the UI Language menu by accident
* the menu stays open until:
   a) the user clicks an item in the dropdown, or
   b) the user clicks the menu button to close the
       dropdown w/o changing UI language.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2096)
<!-- Reviewable:end -->
