### PR TITLE
Fix missing non-breaking space in Spanish ReaderSetup.PoweredBy (BL-5300)

### DIFF
--- a/DistFiles/localization/es/Bloom.xlf
+++ b/DistFiles/localization/es/Bloom.xlf
@@ -5658,7 +5658,7 @@ Desea seguir?</target>
       <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <note>ID: ReaderSetup.PoweredBy</note>
-        <target xml:lang="es-ES">Con tecnología de</target>
+        <target xml:lang="es-ES">Con tecnología de </target>
       </trans-unit>
       <trans-unit id="ReaderSetup.Punctuation" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Punctuation</source>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2102)
<!-- Reviewable:end -->
