### PR TITLE
Approve pre-existing translations carried over from TMX files

### DIFF
--- a/DistFiles/localization/Big Book/ReadMe-ar.xlf
+++ b/DistFiles/localization/Big Book/ReadMe-ar.xlf
@@ -2,22 +2,22 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="ar">
     <body>
-      <trans-unit id="bigbook.title">
+      <trans-unit id="bigbook.title" approved="yes">
         <source xml:lang="en">About Big Books</source>
         <target xml:lang="ar">معلومات حول الكتب الكبيرة</target>
         <note>ID: bigbook.title</note>
       </trans-unit>
-      <trans-unit id="bigbook.use">
+      <trans-unit id="bigbook.use" approved="yes">
         <source xml:lang="en">Big Books are designed for teachers to hold and read in front of a class. For more information, see this <g id="genid-1" ctype="x-html-a" html:href="http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf">PDF from Scholastic</g>.</source>
         <target xml:lang="ar">صُمِمَت الكتب الكبيرة ليتمكن المدرسون من حملها وقراءتها أمام فصل دراسي.للحصول على مزيد من المعلومات، يمكنك الاطلاع على ملف PDF من Scholastic.</target>
         <note>ID: bigbook.use</note>
       </trans-unit>
-      <trans-unit id="bigbook.printing">
+      <trans-unit id="bigbook.printing" approved="yes">
         <source xml:lang="en">Printing a Big Book</source>
         <target xml:lang="ar">طباعة كتاب كبير</target>
         <note>ID: bigbook.printing</note>
       </trans-unit>
-      <trans-unit id="bigbook.printing.enlargeA4">
+      <trans-unit id="bigbook.printing.enlargeA4" approved="yes">
         <source xml:lang="en">To make things more manageable, this template is set at A4 Landscape, with large fonts.
 You can easily produce books that are A3 (twice as large).
 Just take your A4 PDF to a printer and ask them to enlarge it to A3.</source>
@@ -26,17 +26,17 @@ Just take your A4 PDF to a printer and ask them to enlarge it to A3.</source>
 لن يلزمك سوى إضافة A4 PDF إلى طابعة وطلب تكبيرها إلى A3.</target>
         <note>ID: bigbook.printing.enlargeA4</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits">
+      <trans-unit id="bigbook.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="ar">القيود الخاصة بهذا الإصدار</target>
         <note>ID: bigbook.limits</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits.smallscreen">
+      <trans-unit id="bigbook.limits.smallscreen" approved="yes">
         <source xml:lang="en">If you are using a small screen, it can be hard to read the credits page. Try zooming in using the +/- zoom control at the top-right of your screen so you can edit it.</source>
         <target xml:lang="ar">إذا كنت تستخدم شاشة صغيرة، فقد يصعب عليك قراءة صفحة المساهمون في العمل.جرِّب استخدام CTRL+بكرة الماوس لتكبير الصفحة حتى تتمكن من تعديلها.</target>
         <note>ID: bigbook.limits.smallscreen</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits.Englishtemplate">
+      <trans-unit id="bigbook.limits.Englishtemplate" approved="yes">
         <source xml:lang="en">This version includes an "Instructions for Teachers" page that is already filled out, in English.
 If you would like to have instructions in a different language, you can delete that text and type in your own.
 If you send us that text, we can include it in a future version of the template.</source>
@@ -45,17 +45,17 @@ If you send us that text, we can include it in a future version of the template.
 إذا أرسلت إلينا هذا النص، فيمكن أن نضمَّنه في إصدار مستقبلي من النموذج.</target>
         <note>ID: bigbook.limits.Englishtemplate</note>
       </trans-unit>
-      <trans-unit id="bigbook.feedback">
+      <trans-unit id="bigbook.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="ar">تغذية راجعة</target>
         <note>ID: bigbook.feedback</note>
       </trans-unit>
-      <trans-unit id="bigbook.feedbackvoting">
+      <trans-unit id="bigbook.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-2" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="ar">يُرجى المشاركة باقتراحات والتصويت عليها.</target>
         <note>ID: bigbook.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="bigbook.reportsbugs">
+      <trans-unit id="bigbook.reportsbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-3" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="ar">يُرجى الإبلاغ عن المشكلات لدى  <g id="genid-1" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g>.</target>
         <note>ID: bigbook.reportsbugs</note>

--- a/DistFiles/localization/Big Book/ReadMe-bn.xlf
+++ b/DistFiles/localization/Big Book/ReadMe-bn.xlf
@@ -2,22 +2,22 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="bn">
     <body>
-      <trans-unit id="bigbook.title">
+      <trans-unit id="bigbook.title" approved="yes">
         <source xml:lang="en">About Big Books</source>
         <target xml:lang="bn">বড় বইগুলি সম্পর্কে/ বিষয়ক</target>
         <note>ID: bigbook.title</note>
       </trans-unit>
-      <trans-unit id="bigbook.use">
+      <trans-unit id="bigbook.use" approved="yes">
         <source xml:lang="en">Big Books are designed for teachers to hold and read in front of a class. For more information, see this <g id="genid-1" ctype="x-html-a" html:href="http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf">PDF from Scholastic</g>.</source>
         <target xml:lang="bn">বড় বইগুলি এমনভাবে তৈরী যেন শিক্ষকেরা ক্লাশে সবার সামনে ধরে পড়ে শোনাতে পারেন।আরো তথ্যের জন্য, দেখুন <g id="genid-1" ctype="x-html-a" html:href="http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf">স্কলাস্টিক থেকে  PDF</g>। </target>
         <note>ID: bigbook.use</note>
       </trans-unit>
-      <trans-unit id="bigbook.printing">
+      <trans-unit id="bigbook.printing" approved="yes">
         <source xml:lang="en">Printing a Big Book</source>
         <target xml:lang="bn">মুদ্রণ একটি বড় বই</target>
         <note>ID: bigbook.printing</note>
       </trans-unit>
-      <trans-unit id="bigbook.printing.enlargeA4">
+      <trans-unit id="bigbook.printing.enlargeA4" approved="yes">
         <source xml:lang="en">To make things more manageable, this template is set at A4 Landscape, with large fonts.
 You can easily produce books that are A3 (twice as large).
 Just take your A4 PDF to a printer and ask them to enlarge it to A3.</source>
@@ -26,17 +26,17 @@ Just take your A4 PDF to a printer and ask them to enlarge it to A3.</source>
 শুধু একটি প্রিন্টার আপনার A4 পিডিএফ নিতে এবং তাদেরকে জিজ্ঞেস A3 তে যাওয়ার জন্য এটি সম্প্রসারিত করা। </target>
         <note>ID: bigbook.printing.enlargeA4</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits">
+      <trans-unit id="bigbook.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="bn">এই সংস্করণের সীমাবদ্ধতা</target>
         <note>ID: bigbook.limits</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits.smallscreen">
+      <trans-unit id="bigbook.limits.smallscreen" approved="yes">
         <source xml:lang="en">If you are using a small screen, it can be hard to read the credits page. Try zooming in using the +/- zoom control at the top-right of your screen so you can edit it.</source>
         <target xml:lang="bn">আপনি যদি ছোট পর্দা ব্যবহার করেন, তাহলে মুদ্রণ সংক্রান্ত পৃষ্ঠাটি পড়া কঠিন হতে পারে। আপনি সম্পাদনা করার জন্য CTRL + মাউস হুইল ব্যবহার করে পৃষ্ঠাটি ছোট-বড় করতে পারেন। </target>
         <note>ID: bigbook.limits.smallscreen</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits.Englishtemplate">
+      <trans-unit id="bigbook.limits.Englishtemplate" approved="yes">
         <source xml:lang="en">This version includes an "Instructions for Teachers" page that is already filled out, in English.
 If you would like to have instructions in a different language, you can delete that text and type in your own.
 If you send us that text, we can include it in a future version of the template.</source>
@@ -45,17 +45,17 @@ If you send us that text, we can include it in a future version of the template.
 আপনি যদি আমাদের লেখাটি পাঠান তাহলে আমরা সেটিকে টেমপ্লেটের ভবিষ্যৎ সংস্করণের অন্তর্ভুক্ত করতে পারি। </target>
         <note>ID: bigbook.limits.Englishtemplate</note>
       </trans-unit>
-      <trans-unit id="bigbook.feedback">
+      <trans-unit id="bigbook.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="bn">প্রতিক্রিয়া</target>
         <note>ID: bigbook.feedback</note>
       </trans-unit>
-      <trans-unit id="bigbook.feedbackvoting">
+      <trans-unit id="bigbook.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-2" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="bn">দয়া করে ভোট করুন <g id="genid-2" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">পরামর্শ</g> </target>
         <note>ID: bigbook.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="bigbook.reportsbugs">
+      <trans-unit id="bigbook.reportsbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-3" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="bn">সমস্যা হলে রিপোর্ট করুন- <g id="genid-3" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g> </target>
         <note>ID: bigbook.reportsbugs</note>

--- a/DistFiles/localization/Big Book/ReadMe-id.xlf
+++ b/DistFiles/localization/Big Book/ReadMe-id.xlf
@@ -2,22 +2,22 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="id">
     <body>
-      <trans-unit id="bigbook.title">
+      <trans-unit id="bigbook.title" approved="yes">
         <source xml:lang="en">About Big Books</source>
         <target xml:lang="id">Tentang Buku Besar</target>
         <note>ID: bigbook.title</note>
       </trans-unit>
-      <trans-unit id="bigbook.use">
+      <trans-unit id="bigbook.use" approved="yes">
         <source xml:lang="en">Big Books are designed for teachers to hold and read in front of a class. For more information, see this <g id="genid-1" ctype="x-html-a" html:href="http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf">PDF from Scholastic</g>.</source>
         <target xml:lang="id">Buku Besar dirancang bagi guru untuk dipegang dan dibaca di depan kelas. Untuk informasi lebih lanjut, lihat ini <g id="genid-1" ctype="x-html-a" html:href="http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf">PDF dari Scholastic</g>.</target>
         <note>ID: bigbook.use</note>
       </trans-unit>
-      <trans-unit id="bigbook.printing">
+      <trans-unit id="bigbook.printing" approved="yes">
         <source xml:lang="en">Printing a Big Book</source>
         <target xml:lang="id">Mencetak Buku Besar</target>
         <note>ID: bigbook.printing</note>
       </trans-unit>
-      <trans-unit id="bigbook.printing.enlargeA4">
+      <trans-unit id="bigbook.printing.enlargeA4" approved="yes">
         <source xml:lang="en">To make things more manageable, this template is set at A4 Landscape, with large fonts.
 You can easily produce books that are A3 (twice as large).
 Just take your A4 PDF to a printer and ask them to enlarge it to A3.</source>
@@ -26,17 +26,17 @@ Anda dengan mudah dapat membuat buku-buku yang berukuran A3 (dua kali lebih besa
 Cukup dengan membawa ukuran A4 PDF Anda ke printer dan memintanya untuk memperbesar ke A3.</target>
         <note>ID: bigbook.printing.enlargeA4</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits">
+      <trans-unit id="bigbook.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="id">Keterbatasan Versi ini</target>
         <note>ID: bigbook.limits</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits.smallscreen">
+      <trans-unit id="bigbook.limits.smallscreen" approved="yes">
         <source xml:lang="en">If you are using a small screen, it can be hard to read the credits page. Try zooming in using the +/- zoom control at the top-right of your screen so you can edit it.</source>
         <target xml:lang="id">Jika Anda menggunakan layar kecil, akan sulit untuk membaca halaman pengakuan. Coba gunakan roda mouse+CTRL untuk memperbesar halaman tersebut sehingga Anda dapat mengeditnya.</target>
         <note>ID: bigbook.limits.smallscreen</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits.Englishtemplate">
+      <trans-unit id="bigbook.limits.Englishtemplate" approved="yes">
         <source xml:lang="en">This version includes an "Instructions for Teachers" page that is already filled out, in English.
 If you would like to have instructions in a different language, you can delete that text and type in your own.
 If you send us that text, we can include it in a future version of the template.</source>
@@ -45,17 +45,17 @@ Jika Anda ingin memiliki petunjuk dalam bahasa lain, Anda dapat menghapus teks d
 Jika Anda mengirimkan teks itu, kami bisa memasukkannya dalam versi masa depan template tersebut.</target>
         <note>ID: bigbook.limits.Englishtemplate</note>
       </trans-unit>
-      <trans-unit id="bigbook.feedback">
+      <trans-unit id="bigbook.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="id">umpan balik</target>
         <note>ID: bigbook.feedback</note>
       </trans-unit>
-      <trans-unit id="bigbook.feedbackvoting">
+      <trans-unit id="bigbook.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-2" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="id">Silakan berikan dan masukan pendapat Anda pada <g id="genid-2" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">saran</g>.</target>
         <note>ID: bigbook.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="bigbook.reportsbugs">
+      <trans-unit id="bigbook.reportsbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-3" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="id">Silakan laporkan masalah ke <g id="genid-3" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g>.</target>
         <note>ID: bigbook.reportsbugs</note>

--- a/DistFiles/localization/Big Book/ReadMe-sw.xlf
+++ b/DistFiles/localization/Big Book/ReadMe-sw.xlf
@@ -2,22 +2,22 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="sw">
     <body>
-      <trans-unit id="bigbook.title">
+      <trans-unit id="bigbook.title" approved="yes">
         <source xml:lang="en">About Big Books</source>
         <target xml:lang="sw">Kuhusu Vitabu Vikubwa</target>
         <note>ID: bigbook.title</note>
       </trans-unit>
-      <trans-unit id="bigbook.use">
+      <trans-unit id="bigbook.use" approved="yes">
         <source xml:lang="en">Big Books are designed for teachers to hold and read in front of a class. For more information, see this <g id="genid-1" ctype="x-html-a" html:href="http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf">PDF from Scholastic</g>.</source>
         <target xml:lang="sw">Vitabu vikubwa vimebuniwa kwa ajili ya walimu ili kushika na kusoma darasani. Kwa habari zaidi, tazama hii <g id="genid-1" ctype="x-html-a" html:href="http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf">kutoka kwa PDF ya Chuo</g>.</target>
         <note>ID: bigbook.use</note>
       </trans-unit>
-      <trans-unit id="bigbook.printing">
+      <trans-unit id="bigbook.printing" approved="yes">
         <source xml:lang="en">Printing a Big Book</source>
         <target xml:lang="sw">Kuchapisha Kitabu Kikubwa</target>
         <note>ID: bigbook.printing</note>
       </trans-unit>
-      <trans-unit id="bigbook.printing.enlargeA4">
+      <trans-unit id="bigbook.printing.enlargeA4" approved="yes">
         <source xml:lang="en">To make things more manageable, this template is set at A4 Landscape, with large fonts.
 You can easily produce books that are A3 (twice as large).
 Just take your A4 PDF to a printer and ask them to enlarge it to A3.</source>
@@ -26,17 +26,17 @@ Unaweza kutengeneza kwa urahisi vitabu vya A3 (mara mbili zaidi kwa ukubwa).
 Peleka tu A4 PDF yako kwa wapiga chapa na uwaambie waifanye kuwa ya ukubwa wa A3</target>
         <note>ID: bigbook.printing.enlargeA4</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits">
+      <trans-unit id="bigbook.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="sw">Udhaifu wa Tafsiri Hii</target>
         <note>ID: bigbook.limits</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits.smallscreen">
+      <trans-unit id="bigbook.limits.smallscreen" approved="yes">
         <source xml:lang="en">If you are using a small screen, it can be hard to read the credits page. Try zooming in using the +/- zoom control at the top-right of your screen so you can edit it.</source>
         <target xml:lang="sw">Iwapo unatumia skrini ndogo, inaweza kuwa vigumu kusoma ukurasa wa sifa. Jaribu kutumia gurudumu la mausi + CTRL kupanda kwa ukurasa ili uweze kuihariri.</target>
         <note>ID: bigbook.limits.smallscreen</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits.Englishtemplate">
+      <trans-unit id="bigbook.limits.Englishtemplate" approved="yes">
         <source xml:lang="en">This version includes an "Instructions for Teachers" page that is already filled out, in English.
 If you would like to have instructions in a different language, you can delete that text and type in your own.
 If you send us that text, we can include it in a future version of the template.</source>
@@ -45,17 +45,17 @@ Iwapo ungependa kupata maelekezo katika lugha tofauti, unaweza kuyafuta maandish
 Ikiwa utatutumia maandishi hayo, tunaweza kuyajumuisha kwa tafsiri ya wakati ujao ya kigezo.</target>
         <note>ID: bigbook.limits.Englishtemplate</note>
       </trans-unit>
-      <trans-unit id="bigbook.feedback">
+      <trans-unit id="bigbook.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="sw">Majibu</target>
         <note>ID: bigbook.feedback</note>
       </trans-unit>
-      <trans-unit id="bigbook.feedbackvoting">
+      <trans-unit id="bigbook.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-2" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="sw">Tafadhali peana na upige kura kwa <g id="genid-2" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">mapendekezo</g>.</target>
         <note>ID: bigbook.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="bigbook.reportsbugs">
+      <trans-unit id="bigbook.reportsbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-3" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="sw">Tafadhali toa ripoti kuhusu matatizo kwa <g id="genid-3" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g>.</target>
         <note>ID: bigbook.reportsbugs</note>

--- a/DistFiles/localization/Big Book/ReadMe-zh-CN.xlf
+++ b/DistFiles/localization/Big Book/ReadMe-zh-CN.xlf
@@ -2,22 +2,22 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="zh-CN">
     <body>
-      <trans-unit id="bigbook.title">
+      <trans-unit id="bigbook.title" approved="yes">
         <source xml:lang="en">About Big Books</source>
         <target xml:lang="zh-CN">关于大书</target>
         <note>ID: bigbook.title</note>
       </trans-unit>
-      <trans-unit id="bigbook.use">
+      <trans-unit id="bigbook.use" approved="yes">
         <source xml:lang="en">Big Books are designed for teachers to hold and read in front of a class. For more information, see this <g id="genid-1" ctype="x-html-a" html:href="http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf">PDF from Scholastic</g>.</source>
         <target xml:lang="zh-CN">大书是让老师拿着在全班同学面前读的。 想了解更多信息，请参阅<g id="genid-1" ctype="x-html-a" html:href="http://www.scholastic.ca/bigbooks/AGuidetoUsingBigBooksintheClassroom.pdf">Scholastic上的PDF</g></target>
         <note>ID: bigbook.use</note>
       </trans-unit>
-      <trans-unit id="bigbook.printing">
+      <trans-unit id="bigbook.printing" approved="yes">
         <source xml:lang="en">Printing a Big Book</source>
         <target xml:lang="zh-CN">打印大书</target>
         <note>ID: bigbook.printing</note>
       </trans-unit>
-      <trans-unit id="bigbook.printing.enlargeA4">
+      <trans-unit id="bigbook.printing.enlargeA4" approved="yes">
         <source xml:lang="en">To make things more manageable, this template is set at A4 Landscape, with large fonts.
 You can easily produce books that are A3 (twice as large).
 Just take your A4 PDF to a printer and ask them to enlarge it to A3.</source>
@@ -26,17 +26,17 @@ Just take your A4 PDF to a printer and ask them to enlarge it to A3.</source>
 只需把A4尺寸的 PDF带到打印店，让他们放大到A3尺寸。</target>
         <note>ID: bigbook.printing.enlargeA4</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits">
+      <trans-unit id="bigbook.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="zh-CN">本版本的局限性</target>
         <note>ID: bigbook.limits</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits.smallscreen">
+      <trans-unit id="bigbook.limits.smallscreen" approved="yes">
         <source xml:lang="en">If you are using a small screen, it can be hard to read the credits page. Try zooming in using the +/- zoom control at the top-right of your screen so you can edit it.</source>
         <target xml:lang="zh-CN">如果您使用的屏幕较小，版权页可能很难阅读。 使用CTRL +鼠标滚轮放大页面，以便对其进行编辑。</target>
         <note>ID: bigbook.limits.smallscreen</note>
       </trans-unit>
-      <trans-unit id="bigbook.limits.Englishtemplate">
+      <trans-unit id="bigbook.limits.Englishtemplate" approved="yes">
         <source xml:lang="en">This version includes an "Instructions for Teachers" page that is already filled out, in English.
 If you would like to have instructions in a different language, you can delete that text and type in your own.
 If you send us that text, we can include it in a future version of the template.</source>
@@ -45,17 +45,17 @@ If you send us that text, we can include it in a future version of the template.
 如果您可以把用自己语言写成的文本发给我们，我们将会把它收入该模板未来的版本中。</target>
         <note>ID: bigbook.limits.Englishtemplate</note>
       </trans-unit>
-      <trans-unit id="bigbook.feedback">
+      <trans-unit id="bigbook.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="zh-CN">反馈</target>
         <note>ID: bigbook.feedback</note>
       </trans-unit>
-      <trans-unit id="bigbook.feedbackvoting">
+      <trans-unit id="bigbook.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-2" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="zh-CN">请提<g id="genid-2" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">建议</g>并参与投票</target>
         <note>ID: bigbook.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="bigbook.reportsbugs">
+      <trans-unit id="bigbook.reportsbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-3" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="zh-CN">请报告问题<g id="genid-3" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Big%C2%A0Book%C2%A0Problem">issues@bloomremovelibrary.org</g>。</target>
         <note>ID: bigbook.reportsbugs</note>

--- a/DistFiles/localization/Decodable Reader/ReadMe-ar.xlf
+++ b/DistFiles/localization/Decodable Reader/ReadMe-ar.xlf
@@ -2,38 +2,38 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="ar">
     <body>
-      <trans-unit id="decodable.definition">
+      <trans-unit id="decodable.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Decodable Reader</g> is a book that carefully limits the letters and words used so that it fits what a new reader is ready to read. Typically a language may have 5 - 10 <g id="genid-2" ctype="x-html-em">decodable stages</g> through which learners progress.</source>
         <target xml:lang="ar">
           <g id="genid-1" ctype="x-html-strong">كتاب المستوى المحدد</g> هو كتاب يراعي دقة وضع قيود على الأحرف والكلمات المستخدمة حتى تناسب مع ما يستطيع القارئ الجديد قراءته. عادة يتراوح عدد <g id="genid-2" ctype="x-html-strong">مراحل مستوى القراءة</g> في لغة ما بين 5 و10 مراحل يحرز الطلاب خلالها تقدماً.</target>
         <note>ID: decodable.definition</note>
       </trans-unit>
-      <trans-unit id="decodable.stages">
+      <trans-unit id="decodable.stages" approved="yes">
         <source xml:lang="en">Bloom helps you to define this sequence of <g id="genid-3" ctype="x-html-em">stages</g> that readers work through. Each book you create will be targeted at one of those stages, and Bloom helps you to make sure that your book is <g id="genid-4" ctype="x-html-em">decodable</g> (figure out-able) by learners at that <g id="genid-5" ctype="x-html-em">stage</g>.</source>
         <target xml:lang="ar">يساعدك Bloom في تحديد تسلسل <g id="genid-3" ctype="x-html-strong">المراحل</g> هذه التي يمر بها القارئ. يتم توجيه كل كتاب تؤلفه إلى إحدى هذه المراحل، ويساعدك Bloom في التأكد من أن كتابك <g id="genid-4" ctype="x-html-strong">يتبع هذه المراحل</g> (يمكن للطلاب قراءته) في تلك <g id="genid-5" ctype="x-html-strong">المرحلة</g>.</target>
         <note>ID: decodable.stages</note>
       </trans-unit>
-      <trans-unit id="decodable.templates">
+      <trans-unit id="decodable.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-6" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="ar">كما يمكنك إعداد حزمة Bloom من <g id="genid-6" ctype="x-html-strong">نماذج</g> يمكن للآخرين استخدامها لإنشاء الكتب بسرعة بناءً على المستويات والمراحل التي تم تجهيزها بواسطة أحد المختصين بتعليم القراءة والكتابة.</target>
         <note>ID: decodable.templates</note>
       </trans-unit>
-      <trans-unit id="decodable.learn">
+      <trans-unit id="decodable.learn" approved="yes">
         <source xml:lang="en">To learn about using Decodable Readers in Bloom, you can:</source>
         <target xml:lang="ar">للتعرف على معلومات حول استخدام كتب مستويات القراءة في Bloom، يمكنك:</target>
         <note>ID: decodable.learn</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.videos">
+      <trans-unit id="decodable.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="ar">مشاهدة <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">مقاطع الفيديو الإرشادية هذه</g>.</target>
         <note>ID: decodable.learn.videos</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpindex">
+      <trans-unit id="decodable.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Decodable Readers".</source>
         <target xml:lang="ar">اذهب إلى قائمة "مساعدة"، واختار"مساعدة" والاطلاع على الفهرس ضمن "كتب المستويات المحددة".</target>
         <note>ID: decodable.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpmenu">
+      <trans-unit id="decodable.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="ar">اذهب إلى قائمة "مساعدة" واختيار "تصميم نماذج كتب".</target>
         <note>ID: decodable.learn.helpmenu</note>

--- a/DistFiles/localization/Decodable Reader/ReadMe-bn.xlf
+++ b/DistFiles/localization/Decodable Reader/ReadMe-bn.xlf
@@ -2,37 +2,37 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="bn">
     <body>
-      <trans-unit id="decodable.definition">
+      <trans-unit id="decodable.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Decodable Reader</g> is a book that carefully limits the letters and words used so that it fits what a new reader is ready to read. Typically a language may have 5 - 10 <g id="genid-2" ctype="x-html-em">decodable stages</g> through which learners progress.</source>
         <target xml:lang="bn">একটি <g id="genid-1" ctype="x-html-strong">ডিকোডেবল রিডার</g> হল একটি বই যা সতর্কতার সাথে অক্ষর এবং শব্দ কমায় যাতে একজন নতুন পাঠক সহজে তা পড়তে পারে।শিক্ষার্থীদের অগ্রগতির জন্য সাধারণত, একটি ভাষা শেখার প্রক্রিয়ায় ৫-১০টি <g id="genid-2" ctype="x-html-em">ডিকোডেবল পর্যায়</g> আছে।</target>
         <note>ID: decodable.definition</note>
       </trans-unit>
-      <trans-unit id="decodable.stages">
+      <trans-unit id="decodable.stages" approved="yes">
         <source xml:lang="en">Bloom helps you to define this sequence of <g id="genid-3" ctype="x-html-em">stages</g> that readers work through. Each book you create will be targeted at one of those stages, and Bloom helps you to make sure that your book is <g id="genid-4" ctype="x-html-em">decodable</g> (figure out-able) by learners at that <g id="genid-5" ctype="x-html-em">stage</g>.</source>
         <target xml:lang="bn">ব্লুম প্রতিটি পর্যায়ের ধারাগুলোকে সঠিকভাবে বর্ণনা করে যা পাঠকদের কাজ করতে সাহায্য করে।আপনি প্রতিটি বই এক একটি পর্যায়কে লক্ষ্য করে তৈরি করবেন, এবং ব্লুম আপনাকে সাহায্য করবে এটা নিশ্চিত করতে যে তা শিক্ষার্থীদের কাছে ঐ <g id="genid-3" ctype="x-html-em">পর্যায়ে</g> <g id="genid-4" ctype="x-html-em">ডিকোডেবল</g> (নির্ণয় যোগ্য) ।</target>
         <note>ID: decodable.stages</note>
       </trans-unit>
-      <trans-unit id="decodable.templates">
+      <trans-unit id="decodable.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-6" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="bn">আপনি ব্লুম নমুনাগুলো একসাথে রাখতে পারেন যেন অন্যরা তার উপর ভিত্তি করে দ্রুত বই তৈরি করতে পারে যার মাত্রা এবং পর্যায়গুলো একজন সাহিত্য বিশেষজ্ঞ দ্বারা প্রস্তুত করা হয়েছে।</target>
         <note>ID: decodable.templates</note>
       </trans-unit>
-      <trans-unit id="decodable.learn">
+      <trans-unit id="decodable.learn" approved="yes">
         <source xml:lang="en">To learn about using Decodable Readers in Bloom, you can:</source>
         <target xml:lang="bn">ব্লুমের মধ্যে বিভিন্ন পাঠকদের ব্যবহার সম্পর্কে জানতে, আপনি যা করতে পারেন:</target>
         <note>ID: decodable.learn</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.videos">
+      <trans-unit id="decodable.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="bn">দেখুন <g id="genid-5" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">এই নির্দেশনামূলক ভিডিওসমূহ</g>।</target>
         <note>ID: decodable.learn.videos</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpindex">
+      <trans-unit id="decodable.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Decodable Readers".</source>
         <target xml:lang="bn">সহায়তা তালিকাতে যান, নির্বাচন করুন 'সহায়তা' এবং "লেভেলড রিডার" এর নীচে সূচিপত্র দেখুন।</target>
         <note>ID: decodable.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpmenu">
+      <trans-unit id="decodable.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="bn">সহায়তা মেনুতে যান, নির্বাচন করুন: "পাঠকদের নমুনা” তৈরি"।</target>
         <note>ID: decodable.learn.helpmenu</note>

--- a/DistFiles/localization/Decodable Reader/ReadMe-ha.xlf
+++ b/DistFiles/localization/Decodable Reader/ReadMe-ha.xlf
@@ -2,38 +2,38 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="ha">
     <body>
-      <trans-unit id="decodable.definition">
+      <trans-unit id="decodable.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Decodable Reader</g> is a book that carefully limits the letters and words used so that it fits what a new reader is ready to read. Typically a language may have 5 - 10 <g id="genid-2" ctype="x-html-em">decodable stages</g> through which learners progress.</source>
         <target xml:lang="ha">
           <g id="genid-1" ctype="x-html-strong">Mai Karɓar karatun</g> littafi ne da a hankali ya ƙayyade haruffa da kalmomin da aka yi amfani da su saboda su yi daidai da abinda sabon mai karatu zai karanta. Akasari, harshe zai iya samun <g id="genid-2" ctype="x-html-em">matakan karɓar karatun daga</g> 5-10 waɗanda a cikin su ne masu koyo za su gudnar da aikinsu.</target>
         <note>ID: decodable.definition</note>
       </trans-unit>
-      <trans-unit id="decodable.stages">
+      <trans-unit id="decodable.stages" approved="yes">
         <source xml:lang="en">Bloom helps you to define this sequence of <g id="genid-3" ctype="x-html-em">stages</g> that readers work through. Each book you create will be targeted at one of those stages, and Bloom helps you to make sure that your book is <g id="genid-4" ctype="x-html-em">decodable</g> (figure out-able) by learners at that <g id="genid-5" ctype="x-html-em">stage</g>.</source>
         <target xml:lang="ha">Bloom zai taimaka maka wajen bin waɗannan <g id="genid-3" ctype="x-html-em">matakan</g> da mai karatu zai bi. Kowane littafin da ka yi zai bi ɗaya daga cikin waɗancan matakan, kuma Bloom zai taimaka maka wurin tabbatar da litttafinka <g id="genid-4" ctype="x-html-em">zai zama wanda za'a iya karantawa ne</g> a wurin masu koyon karatu a wancan <g id="genid-5" ctype="x-html-em">matakin</g> su kuma iya ganewa.</target>
         <note>ID: decodable.stages</note>
       </trans-unit>
-      <trans-unit id="decodable.templates">
+      <trans-unit id="decodable.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-6" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="ha">Kuma kana iya shirya <g id="genid-6" ctype="x-html-em">muhallin</g> Bloom wanda wasu za su iya amfani da shi don rubuta litattafai cikin hanzari kan matakan da ƙwararren mai koyarwa ya shirya.</target>
         <note>ID: decodable.templates</note>
       </trans-unit>
-      <trans-unit id="decodable.learn">
+      <trans-unit id="decodable.learn" approved="yes">
         <source xml:lang="en">To learn about using Decodable Readers in Bloom, you can:</source>
         <target xml:lang="ha">Domin koyon yadda ake amfani da "Mai Iya Karatu" a Bloom, zaka ka iya:</target>
         <note>ID: decodable.learn</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.videos">
+      <trans-unit id="decodable.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="ha">Kallon <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc.8vbwux">waɗannan hotunan bidiyo na koyarwa</g>.</target>
         <note>ID: decodable.learn.videos</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpindex">
+      <trans-unit id="decodable.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Decodable Readers".</source>
         <target xml:lang="ha">Ka shiga dandalin 'Taimako' sannan ka duba tsari a ƙarƙashin "Masu Iya Karatu" a Bloom.</target>
         <note>ID: decodable.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpmenu">
+      <trans-unit id="decodable.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="ha">Ka gefen neman Taimako ka zaɓi: "Shirya Muhallin Maikaratu".</target>
         <note>ID: decodable.learn.helpmenu</note>

--- a/DistFiles/localization/Decodable Reader/ReadMe-id.xlf
+++ b/DistFiles/localization/Decodable Reader/ReadMe-id.xlf
@@ -2,38 +2,38 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="id">
     <body>
-      <trans-unit id="decodable.definition">
+      <trans-unit id="decodable.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Decodable Reader</g> is a book that carefully limits the letters and words used so that it fits what a new reader is ready to read. Typically a language may have 5 - 10 <g id="genid-2" ctype="x-html-em">decodable stages</g> through which learners progress.</source>
         <target xml:lang="id">
           <g id="genid-1" ctype="x-html-strong">Pembaca yang Bisa Didekodekan</g> adalah buku yang secara cermat membatasi huruf dan kata yang digunakan sehingga pas dengan apa yang siap dibaca oleh pembaca baru. Biasanya, sebuah bahasa dapat memiliki 5 - 10 <g id="genid-2" ctype="x-html-em">tahapan yang dapat didekodekan</g> yang melaluinya pembelajar bisa memperoleh kemajuan.</target>
         <note>ID: decodable.definition</note>
       </trans-unit>
-      <trans-unit id="decodable.stages">
+      <trans-unit id="decodable.stages" approved="yes">
         <source xml:lang="en">Bloom helps you to define this sequence of <g id="genid-3" ctype="x-html-em">stages</g> that readers work through. Each book you create will be targeted at one of those stages, and Bloom helps you to make sure that your book is <g id="genid-4" ctype="x-html-em">decodable</g> (figure out-able) by learners at that <g id="genid-5" ctype="x-html-em">stage</g>.</source>
         <target xml:lang="id">Bloom membantu Anda mendefinisikan urutan <g id="genid-3" ctype="x-html-em">tahapan</g> yang dikerjakan oleh pembaca. Setiap buku yang Anda buat akan ditargetkan pada salah satu tahapan itu, dan Bloom membantu Anda memastikan bahwa buku Anda <g id="genid-4" ctype="x-html-em">dapat didekodekan</g> (bisa dimengerti) oleh pembelajar pada <g id="genid-5" ctype="x-html-em">tahapan</g> tersebut.</target>
         <note>ID: decodable.stages</note>
       </trans-unit>
-      <trans-unit id="decodable.templates">
+      <trans-unit id="decodable.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-6" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="id">Anda juga dapat membuat sebuah Paket Bloom yang terdiri dari <g id="genid-6" ctype="x-html-em">templat</g> yang bisa digunakan orang lain untuk membuat buku dengan cepat berdasarkan tingkatan dan tahapan yang telah disiapkan oleh spesialis literasi.</target>
         <note>ID: decodable.templates</note>
       </trans-unit>
-      <trans-unit id="decodable.learn">
+      <trans-unit id="decodable.learn" approved="yes">
         <source xml:lang="en">To learn about using Decodable Readers in Bloom, you can:</source>
         <target xml:lang="id">Untuk mengetahui tentang cara menggunakan Pembaca yang Dapat Didekodekan di Bloom, Anda dapat:</target>
         <note>ID: decodable.learn</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.videos">
+      <trans-unit id="decodable.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="id">Tonton <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">video petunjuk ini</g>.</target>
         <note>ID: decodable.learn.videos</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpindex">
+      <trans-unit id="decodable.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Decodable Readers".</source>
         <target xml:lang="id">Buka menu Bantuan, pilih "Bantuan', dan cari dalam indeks pada "Pembaca yang Dapat Didekodekan".</target>
         <note>ID: decodable.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpmenu">
+      <trans-unit id="decodable.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="id">Buka menu Bantuan dan pilih: "Membuat Templat Pembaca".</target>
         <note>ID: decodable.learn.helpmenu</note>

--- a/DistFiles/localization/Decodable Reader/ReadMe-ne.xlf
+++ b/DistFiles/localization/Decodable Reader/ReadMe-ne.xlf
@@ -2,39 +2,39 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="ne">
     <body>
-      <trans-unit id="decodable.definition">
+      <trans-unit id="decodable.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Decodable Reader</g> is a book that carefully limits the letters and words used so that it fits what a new reader is ready to read. Typically a language may have 5 - 10 <g id="genid-2" ctype="x-html-em">decodable stages</g> through which learners progress.</source>
         <target xml:lang="ne">
           <g id="genid-1" ctype="x-html-strong">डिकोडेबल पाठ्यपुस्तक</g> एउटा यस्‍तो पुस्तक हो जसले नयाँ पाठकको पढ्ने क्षमताको आधारमा पाठमा प्रयोग हुने अक्षर र शब्दहरूलाई ध्यानपूर्वक सीमित पार्दछ । सामान्यतया कुनै पनि भाषामा 5 - 10 वटा <g id="genid-2" ctype="x-html-em">डिकोडेबल चरणहरू</g> हुन सक्‍छन्। पाठकहरू यी चरणहरू हुँदै अगाडि बढ्छन्।</target>
         <note>ID: decodable.definition</note>
       </trans-unit>
-      <trans-unit id="decodable.stages">
+      <trans-unit id="decodable.stages" approved="yes">
         <source xml:lang="en">Bloom helps you to define this sequence of <g id="genid-3" ctype="x-html-em">stages</g> that readers work through. Each book you create will be targeted at one of those stages, and Bloom helps you to make sure that your book is <g id="genid-4" ctype="x-html-em">decodable</g> (figure out-able) by learners at that <g id="genid-5" ctype="x-html-em">stage</g>.</source>
         <target xml:lang="ne">Bloom ले तपाईं पाठकहरूका लागि यी <g id="genid-3" ctype="x-html-em">चरणहरू</g> को अनुक्रम निर्धारण गर्न मद्दत गर्दछ। तपाईंले बनाउनुभएको हरेक पुस्तकले ती चरणहरू मध्ये एकलाई लक्षित गर्नेछ, र Bloom ले सो <g id="genid-4" ctype="x-html-em">चरण</g> मा रहेका पाठकहरूले तपाईंको पुस्तक <g id="genid-5" ctype="x-html-em">डिकोड गर्न</g> (बुझ्न) सक्छन् भनेर सुनिश्चित गर्न मद्दत गर्दछ।</target>
         <note>ID: decodable.stages</note>
       </trans-unit>
-      <trans-unit id="decodable.templates">
+      <trans-unit id="decodable.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-6" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="ne">तपाईंले <g id="genid-6" ctype="x-html-em">टेम्प्लेटहरू</g> को Bloom प्याक पनि बनाउन सक्नुहुन्छ जसलाई साक्षरता विशेषज्ञले तयार पारेको स्तर र चरणहरूको आधारमा अरूले तुरुन्त पुस्तक बनाउन प्रयोग गर्न सक्छन्।</target>
         <note>ID: decodable.templates</note>
       </trans-unit>
-      <trans-unit id="decodable.learn">
+      <trans-unit id="decodable.learn" approved="yes">
         <source xml:lang="en">To learn about using Decodable Readers in Bloom, you can:</source>
         <target xml:lang="ne">Bloom मा डिकोडेबल पाठ्यपुस्तकहरू कसरी प्रयोग गर्ने भन्ने बारेमा जान्न, तपाईंले निम्नलिखित कुराहरू गर्न सक्नुहुन्छ:</target>
         <note>ID: decodable.learn</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.videos">
+      <trans-unit id="decodable.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="ne">
           <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">यी जानकारीमूलक भिडियोहरू</g> हेर्नुहोस्।</target>
         <note>ID: decodable.learn.videos</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpindex">
+      <trans-unit id="decodable.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Decodable Readers".</source>
         <target xml:lang="ne">मद्दत मेनुमा जानुहोस्, 'मद्दत' चयन गर्नुहोस्, र "डिकोडेबल पाठ्यपुस्तकहरू" अन्तर्गत रहेको सूचकाङ्कमा हेर्नुहोस्।</target>
         <note>ID: decodable.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpmenu">
+      <trans-unit id="decodable.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="ne">मद्दत मेनुमा जानुहोस् र निम्नलिखित चयन गर्नुहोस्: "पाठ्यपुस्तकका टेम्प्लेटहरू बनाउने"।</target>
         <note>ID: decodable.learn.helpmenu</note>

--- a/DistFiles/localization/Decodable Reader/ReadMe-sw.xlf
+++ b/DistFiles/localization/Decodable Reader/ReadMe-sw.xlf
@@ -2,38 +2,38 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="sw">
     <body>
-      <trans-unit id="decodable.definition">
+      <trans-unit id="decodable.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Decodable Reader</g> is a book that carefully limits the letters and words used so that it fits what a new reader is ready to read. Typically a language may have 5 - 10 <g id="genid-2" ctype="x-html-em">decodable stages</g> through which learners progress.</source>
         <target xml:lang="sw">
           <g id="genid-1" ctype="x-html-strong">Chombo cha kusoma kinachoweza kufasiriwa</g> ni kitabu ambacho huweka mpaka kwa umakini kati ya herufi na maneno yaliyotumiwa ili yaweze kusalia kwenye kiwango ambacho kinafaa kile ambacho msomaji wa mara ya kwanza yuko tayari kusoma. Kwa kawaida, lugha inaweza kuwa na awamu 5 - 10 <g id="genid-2" ctype="x-html-em">zinazoweza kufasiriwa</g> ambazo kupitia kwake wasomaji hupiga hatua mbele.</target>
         <note>ID: decodable.definition</note>
       </trans-unit>
-      <trans-unit id="decodable.stages">
+      <trans-unit id="decodable.stages" approved="yes">
         <source xml:lang="en">Bloom helps you to define this sequence of <g id="genid-3" ctype="x-html-em">stages</g> that readers work through. Each book you create will be targeted at one of those stages, and Bloom helps you to make sure that your book is <g id="genid-4" ctype="x-html-em">decodable</g> (figure out-able) by learners at that <g id="genid-5" ctype="x-html-em">stage</g>.</source>
         <target xml:lang="sw">Bloom hukusaidia kueleza mfululizo huu wa <g id="genid-3" ctype="x-html-em">awamu</g> ambao wasomaji hupitia wanaposoma. Kila kitabu utakachotengeneza kitakuwa kinalengwa katika mojawapo ya awamu hizo, na Bloom wanakusaindia kuhakikisha kuwa kitabu chako <g id="genid-4" ctype="x-html-em">kinafasirika</g> (kinaweza kueleweka) na wasomaji katika  <g id="genid-5" ctype="x-html-em">awamu hiyo</g>.</target>
         <note>ID: decodable.stages</note>
       </trans-unit>
-      <trans-unit id="decodable.templates">
+      <trans-unit id="decodable.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-6" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="sw">Unaweza pia kutengeneza seti ya <g id="genid-6" ctype="x-html-em">vielelezo</g> ambavyo watu wengine wanaweza kutumia kuandaa mitazamo inayozingatia ngazi na awamu ambazo zimeandaliwa na mtaalamu wa kusoma na kuandika.</target>
         <note>ID: decodable.templates</note>
       </trans-unit>
-      <trans-unit id="decodable.learn">
+      <trans-unit id="decodable.learn" approved="yes">
         <source xml:lang="en">To learn about using Decodable Readers in Bloom, you can:</source>
         <target xml:lang="sw">Ili kusoma kuhusu matumizi ya Vifaa vya Kusoma vinavyoweza Kufasiriwa kwenye Bloom, unaweza:</target>
         <note>ID: decodable.learn</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.videos">
+      <trans-unit id="decodable.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="sw">Kutazama <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">video hizi za mafundisho</g>.</target>
         <note>ID: decodable.learn.videos</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpindex">
+      <trans-unit id="decodable.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Decodable Readers".</source>
         <target xml:lang="sw">Nenda kwa Menyu ya Usaidizi, chagua 'Usaidizi', na utazame katika kielezo chini ya "Vifaa vya Kusoma vinavyoweza Kufasiriwa".</target>
         <note>ID: decodable.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpmenu">
+      <trans-unit id="decodable.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="sw">Nenda kwa Menyu ya Usaidizi na uchague: "Kutengeneza Vielelezo vya Msomaji".</target>
         <note>ID: decodable.learn.helpmenu</note>

--- a/DistFiles/localization/Decodable Reader/ReadMe-zh-CN.xlf
+++ b/DistFiles/localization/Decodable Reader/ReadMe-zh-CN.xlf
@@ -2,38 +2,38 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="zh-CN">
     <body>
-      <trans-unit id="decodable.definition">
+      <trans-unit id="decodable.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Decodable Reader</g> is a book that carefully limits the letters and words used so that it fits what a new reader is ready to read. Typically a language may have 5 - 10 <g id="genid-2" ctype="x-html-em">decodable stages</g> through which learners progress.</source>
         <target xml:lang="zh-CN">
           <g id="genid-1" ctype="x-html-strong">拼读读物</g>能有效限制书中所使用的字母和单词，目的是让书适合新读者的阅读水平。 一种语言一般会有5-10个<g id="genid-2" ctype="x-html-em">拼读细分阶段</g>，帮助学习者循序渐进地进步。</target>
         <note>ID: decodable.definition</note>
       </trans-unit>
-      <trans-unit id="decodable.stages">
+      <trans-unit id="decodable.stages" approved="yes">
         <source xml:lang="en">Bloom helps you to define this sequence of <g id="genid-3" ctype="x-html-em">stages</g> that readers work through. Each book you create will be targeted at one of those stages, and Bloom helps you to make sure that your book is <g id="genid-4" ctype="x-html-em">decodable</g> (figure out-able) by learners at that <g id="genid-5" ctype="x-html-em">stage</g>.</source>
         <target xml:lang="zh-CN">Bloom能帮您定义这些渐进的<g id="genid-3" ctype="x-html-em">细分阶段</g>。 您创建的每本书都将隶属于一个细分阶段，Bloom会确保您的书能被水平在该<g id="genid-4" ctype="x-html-em">细分阶段</g>的读者<g id="genid-5" ctype="x-html-em">解码</g>（即拼读出来）。</target>
         <note>ID: decodable.stages</note>
       </trans-unit>
-      <trans-unit id="decodable.templates">
+      <trans-unit id="decodable.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-6" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="zh-CN">您还可以制作包含一系列<g id="genid-6" ctype="x-html-em">模板</g>的Bloom资料包，这样别人可以用这些由识字教育专家事先设定好的等级和细分阶段快速创建书籍。</target>
         <note>ID: decodable.templates</note>
       </trans-unit>
-      <trans-unit id="decodable.learn">
+      <trans-unit id="decodable.learn" approved="yes">
         <source xml:lang="en">To learn about using Decodable Readers in Bloom, you can:</source>
         <target xml:lang="zh-CN">要了解在Bloom中如何使用“拼读读物”，您可以：</target>
         <note>ID: decodable.learn</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.videos">
+      <trans-unit id="decodable.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="zh-CN">观看<g id="genid-7" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">这些教学视频</g>。</target>
         <note>ID: decodable.learn.videos</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpindex">
+      <trans-unit id="decodable.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Decodable Readers".</source>
         <target xml:lang="zh-CN">找到“帮助”菜单，选择“帮助”，然后查看“拼读读物”下面的索引。</target>
         <note>ID: decodable.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="decodable.learn.helpmenu">
+      <trans-unit id="decodable.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="zh-CN">找到帮助菜单，然后选择：“创建读物模板”。</target>
         <note>ID: decodable.learn.helpmenu</note>

--- a/DistFiles/localization/Leveled Reader/ReadMe-ar.xlf
+++ b/DistFiles/localization/Leveled Reader/ReadMe-ar.xlf
@@ -2,58 +2,58 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="ar">
     <body>
-      <trans-unit id="leveled.definition">
+      <trans-unit id="leveled.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Leveled Reader</g> is a book that is written specifically for a learner who is at a certain level of reading development. Levels define targets for word length, sentence length, etc. They also determine appropriate formatting, vocabulary, illustration support, and topic.</source>
         <target xml:lang="ar">
           <g id="genid-1" ctype="x-html-strong">كتاب مستوى القارئ</g> هو كتاب يتم إعداده خصيصً لطالب في مرحلة معيَّنة من مراحل تطور القراءة. ويتم من خلال المستويات تحديد أهداف طول الكلمة وطول الجملة وما إلى ذلك. كما أنها تحدد التنسيق المناسب والمفردات ودعم الرسم والموضوع.</target>
         <note>ID: leveled.definition</note>
       </trans-unit>
-      <trans-unit id="leveled.levels">
+      <trans-unit id="leveled.levels" approved="yes">
         <source xml:lang="en">After you have defined a sequence of <g id="genid-2" ctype="x-html-em">levels</g>, you can assign a level to books you create either with this template or the "Decodable Reader Template". As you type into the book, Bloom will help you keep the level in mind and point out when you exceed the limits of the level.</source>
         <target xml:lang="ar">بعد تحديد تسلسل <g id="genid-2" ctype="x-html-strong">للمستويات</g>، يمكنك تعيين مستوى للكتب التي تنشئها سواء باستخدام هذا القالب أو "قالب مراحل القارئ". أثناء إدخال النص في الكتاب، يساعدك Bloom في مراعاة المستوى المُختار وينبهك عند تجاوز حدود هذا المستوى.</target>
         <note>ID: leveled.levels</note>
       </trans-unit>
-      <trans-unit id="leveled.templates">
+      <trans-unit id="leveled.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-3" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="ar">كما يمكنك إعداد حزمة Bloom من <g id="genid-3" ctype="x-html-strong">نماذج</g> يمكن للآخرين استخدامها لإنشاء الكتب بسرعة بناءً على المستويات والمراحل التي تم تجهيزها بواسطة أحد المختصين بتعليم القراءة والكتابة.</target>
         <note>ID: leveled.templates</note>
       </trans-unit>
-      <trans-unit id="leveled.learn">
+      <trans-unit id="leveled.learn" approved="yes">
         <source xml:lang="en">To learn about using Leveled Readers in Bloom, you can:</source>
         <target xml:lang="ar">للتعرف على معلومات حول استخدام كتب مستويات محددة في Bloom، يمكنك:</target>
         <note>ID: leveled.learn</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.videos">
+      <trans-unit id="leveled.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="ar">مشاهدة <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">مقاطع الفيديو الإرشادية هذه</g>.</target>
         <note>ID: leveled.learn.videos</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpindex">
+      <trans-unit id="leveled.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Leveled Readers".</source>
         <target xml:lang="ar">اذهب إلى قائمة "مساعدة"، واختار"مساعدة" والاطلاع على الفهرس ضمن "كتب المستويات المحددة".</target>
         <note>ID: leveled.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpmenu">
+      <trans-unit id="leveled.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="ar">اذهب إلى قائمة "مساعدة" واختيار "تصميم نماذج كتب".</target>
         <note>ID: leveled.learn.helpmenu</note>
       </trans-unit>
-      <trans-unit id="leveled.vs.decodable">
+      <trans-unit id="leveled.vs.decodable" approved="yes">
         <source xml:lang="en">Relationship to Decodable Readers</source>
         <target xml:lang="ar">العلاقة مع كتب مستوى القارئ</target>
         <note>ID: leveled.vs.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.and.decodable">
+      <trans-unit id="leveled.and.decodable" approved="yes">
         <source xml:lang="en">So how do leveled reader <g id="genid-5" ctype="x-html-em">levels</g> fit in decodable reader <g id="genid-6" ctype="x-html-em">stages</g>? The two concepts are complementary, and Bloom allows you to set both a <g id="genid-7" ctype="x-html-em">decodable stage</g> and a <g id="genid-8" ctype="x-html-em">leveled reader level</g> for a book you are writing. Typically books at level 1 and possibly level 2 will also need to be written with <g id="genid-9" ctype="x-html-em">decodability stages</g> in mind. Books at the first level or two will also need to be careful about being <g id="genid-10" ctype="x-html-em">decodable</g> (i.e. using letters the reader has learned). So a sequence of books might look like this:</source>
         <target xml:lang="ar">كيف يمكن أن تتناسب <g id="genid-5" ctype="x-html-strong">مستويات</g> كتاب مستوى محدد مع <g id="genid-6" ctype="x-html-strong">مراحل</g> كتاب مستوى القارئ؟ هناك تكامل بين المفهومين، ويتيح لك Bloom فرصة تعيين <g id="genid-7" ctype="x-html-strong">مرحلة مستوى القارئ</g> و<g id="genid-8" ctype="x-html-strong">كتاب محدد المستوى</g> لاستخدامهما في الكتاب الذي تقوم بتأليفه. في العادة، على كتب مستوى 1 وربما مستوى 2 مراعاة <g id="genid-9" ctype="x-html-strong">مراحل مستوى القارئ</g> أثناء التأليف. كما تحتاج الكتب في المستوى الأول أو الثاني إلى وضع <g id="genid-10" ctype="x-html-strong">مستوى القارئ</g> في عين الاعتبار (أي استخدام الأحرف التي تعلمها القارئ). وبذلك يمكن أن يظهر تسلسل الكتب على النحو التالي:</target>
         <note>ID: leveled.and.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.level">
+      <trans-unit id="leveled.reader.level" approved="yes">
         <source xml:lang="en">Leveled Reader Level</source>
         <target xml:lang="ar">أداة قراءة المستوى المحدد</target>
         <note>ID: leveled.reader.level</note>
       </trans-unit>
-      <trans-unit id="decodable.stage">
+      <trans-unit id="decodable.stage" approved="yes">
         <source xml:lang="en">Decodable Stage</source>
         <target xml:lang="ar">مراحل إمكانية التفكيك</target>
         <note>ID: decodable.stage</note>

--- a/DistFiles/localization/Leveled Reader/ReadMe-bn.xlf
+++ b/DistFiles/localization/Leveled Reader/ReadMe-bn.xlf
@@ -2,59 +2,59 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="bn">
     <body>
-      <trans-unit id="leveled.definition">
+      <trans-unit id="leveled.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Leveled Reader</g> is a book that is written specifically for a learner who is at a certain level of reading development. Levels define targets for word length, sentence length, etc. They also determine appropriate formatting, vocabulary, illustration support, and topic.</source>
         <target xml:lang="bn">
           <g id="genid-1" ctype="x-html-strong">লেভেলড রিডার</g> বইটি লেখা হয়েছে সে সকল শিক্ষার্থীদের জন্য যাদের একটি নির্দিষ্ট পর্যায় পর্যন্ত পড়ার উন্নতি হয়েছে।শব্দের দৈর্ঘ্য, বাক্যের দৈর্ঘ্য ইত্যাদি পর্যায়গুলোর বিভিন্ন লক্ষ্যমাত্রাকে নির্ধারন করে।তারা  উপযুক্ত গঠন, শব্দকোষ, ছবি দ্বারা ব্যাখ্যা, এবং বিষয় ইত্যাদিও নির্ধারণ করে।</target>
         <note>ID: leveled.definition</note>
       </trans-unit>
-      <trans-unit id="leveled.levels">
+      <trans-unit id="leveled.levels" approved="yes">
         <source xml:lang="en">After you have defined a sequence of <g id="genid-2" ctype="x-html-em">levels</g>, you can assign a level to books you create either with this template or the "Decodable Reader Template". As you type into the book, Bloom will help you keep the level in mind and point out when you exceed the limits of the level.</source>
         <target xml:lang="bn">
           <g id="genid-2" ctype="x-html-em">পর্যায়গুলোর</g> ধারা বর্ণনা করার পর, আপনি এই নমুনা অথবা "ডিকোডেবল রিডার নমুনা" দিয়ে তৈরি বইগুলোর একটি পর্যায় নির্ধারণ করে দিতে পারেন।যখন আপনি বইটি লিখতে থাকবেন, ব্লুম আপনাকে পর্যায়গুলো স্মরণ রাখতে সাহায্য করবে এবং যখন আপনি সীমা অতিক্রম করবেন সেটাও জানাবে।</target>
         <note>ID: leveled.levels</note>
       </trans-unit>
-      <trans-unit id="leveled.templates">
+      <trans-unit id="leveled.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-3" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="bn">আপনি ব্লুম নমুনাগুলো একসাথে রাখতে পারেন যেন অন্যরা তার উপর ভিত্তি করে দ্রুত বই তৈরি করতে পারে যার মাত্রা এবং পর্যায়গুলো একজন সাহিত্য বিশেষজ্ঞ দ্বারা প্রস্তুত করা হয়েছে।</target>
         <note>ID: leveled.templates</note>
       </trans-unit>
-      <trans-unit id="leveled.learn">
+      <trans-unit id="leveled.learn" approved="yes">
         <source xml:lang="en">To learn about using Leveled Readers in Bloom, you can:</source>
         <target xml:lang="bn">ব্লুমের মধ্যে বিভিন্ন পাঠকদের ব্যবহার সম্পর্কে জানতে, আপনি যা করতে পারেন:</target>
         <note>ID: leveled.learn</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.videos">
+      <trans-unit id="leveled.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="bn">দেখুন <g id="genid-3" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">এই নির্দেশনামূলক ভিডিওসমূহ</g>।</target>
         <note>ID: leveled.learn.videos</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpindex">
+      <trans-unit id="leveled.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Leveled Readers".</source>
         <target xml:lang="bn">সহায়তা তালিকাতে যান, নির্বাচন করুন 'সহায়তা' এবং "লেভেলড রিডার" এর নীচে সূচিপত্র দেখুন।</target>
         <note>ID: leveled.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpmenu">
+      <trans-unit id="leveled.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="bn">সহায়তা মেনুতে যান, নির্বাচন করুন: "পাঠকদের নমুনা” তৈরি"।</target>
         <note>ID: leveled.learn.helpmenu</note>
       </trans-unit>
-      <trans-unit id="leveled.vs.decodable">
+      <trans-unit id="leveled.vs.decodable" approved="yes">
         <source xml:lang="en">Relationship to Decodable Readers</source>
         <target xml:lang="bn">ডিকোডেবল রিডারসমূহের সাথে সম্পর্ক</target>
         <note>ID: leveled.vs.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.and.decodable">
+      <trans-unit id="leveled.and.decodable" approved="yes">
         <source xml:lang="en">So how do leveled reader <g id="genid-5" ctype="x-html-em">levels</g> fit in decodable reader <g id="genid-6" ctype="x-html-em">stages</g>? The two concepts are complementary, and Bloom allows you to set both a <g id="genid-7" ctype="x-html-em">decodable stage</g> and a <g id="genid-8" ctype="x-html-em">leveled reader level</g> for a book you are writing. Typically books at level 1 and possibly level 2 will also need to be written with <g id="genid-9" ctype="x-html-em">decodability stages</g> in mind. Books at the first level or two will also need to be careful about being <g id="genid-10" ctype="x-html-em">decodable</g> (i.e. using letters the reader has learned). So a sequence of books might look like this:</source>
         <target xml:lang="bn">তাহলে কিভাবে লেভেলড রিডার <g id="genid-4" ctype="x-html-em">পর্যায়সমূহ</g> ডিকোডেবল রিডারসমূহের <g id="genid-5" ctype="x-html-em">স্তরের</g> উপযুক্ত হয়?দুইটি ধারণা হল পরিপূরক, এবং ব্লুম যা আপনাকে আপনার লেখা বইয়ের <g id="genid-6" ctype="x-html-em">ডিকোডেবল স্তর</g> এবং <g id="genid-7" ctype="x-html-em">লেভেলড রিডার লেভেল</g> সাজাতে অনুমতি দেয়।সাধারণত লেভেল ১ এবং সম্ভাব্য লেভেল ২ এর বইগুলো <g id="genid-8" ctype="x-html-em">ডিকোডেবল স্তরের</g> কথা মনে রেখে লেখা প্রয়োজন।প্রথম অথবা দ্বিতীয় লেভেলের বইগুলো <g id="genid-9" ctype="x-html-em">ডিকোডেবল</g> করতেও সতর্ক থাকা প্রয়োজন (উদাহরণস্বরূপ পাঠক যে অক্ষরগুলো শিখেছে তার ব্যবহার)।সুতরাং একটি বইয়ের পর্যায়ক্রম দেখতে এমন হতে পারে:</target>
         <note>ID: leveled.and.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.level">
+      <trans-unit id="leveled.reader.level" approved="yes">
         <source xml:lang="en">Leveled Reader Level</source>
         <target xml:lang="bn">লেভেলড রিডারদের পর্যায়</target>
         <note>ID: leveled.reader.level</note>
       </trans-unit>
-      <trans-unit id="decodable.stage">
+      <trans-unit id="decodable.stage" approved="yes">
         <source xml:lang="en">Decodable Stage</source>
         <target xml:lang="bn">ডিকোডেবল স্তর</target>
         <note>ID: decodable.stage</note>

--- a/DistFiles/localization/Leveled Reader/ReadMe-ha.xlf
+++ b/DistFiles/localization/Leveled Reader/ReadMe-ha.xlf
@@ -2,57 +2,57 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="ha">
     <body>
-      <trans-unit id="leveled.definition">
+      <trans-unit id="leveled.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Leveled Reader</g> is a book that is written specifically for a learner who is at a certain level of reading development. Levels define targets for word length, sentence length, etc. They also determine appropriate formatting, vocabulary, illustration support, and topic.</source>
         <target xml:lang="ha">Shi <g id="genid-1" ctype="x-html-strong">Ayyanannen Maikaratu</g> littafi ne da aka rubuta don amfanin mai koyon da ya ke a wani matakin karatu na cigaba. Matakai na bayyana waɗanda aka rubuta su ta hanyar tsawon kalma, tsawon jimla da sauransu. Kuma suna nuna tsari mafi inganci, sabbin kalmomi, taimakawa misalai da darussa.</target>
         <note>ID: leveled.definition</note>
       </trans-unit>
-      <trans-unit id="leveled.levels">
+      <trans-unit id="leveled.levels" approved="yes">
         <source xml:lang="en">After you have defined a sequence of <g id="genid-2" ctype="x-html-em">levels</g>, you can assign a level to books you create either with this template or the "Decodable Reader Template". As you type into the book, Bloom will help you keep the level in mind and point out when you exceed the limits of the level.</source>
         <target xml:lang="ha">Bayan ka bayyana ma'anar tsarin <g id="genid-2" ctype="x-html-em">matakai</g>, kana iya ba littafin da ka ƙirƙiro mataki ko ta wannan muhallin ko kuma "Muhallin Mai Karatu." A lokacin da kake rubutu a cikin littafin, Bloom zai taimaka maka aje mataki a cikin zuciyarka kuma ka gano duk lokacin da ka wuce iyakar mataki.</target>
         <note>ID: leveled.levels</note>
       </trans-unit>
-      <trans-unit id="leveled.templates">
+      <trans-unit id="leveled.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-3" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="ha">Kuma kana iya shirya <g id="genid-3" ctype="x-html-em">muhallin</g> Bloom wanda wasu za su iya amfani da shi don wallafa littafai cikin hanzari kan matakan da ƙwararren mai koyarwa ya shirya.</target>
         <note>ID: leveled.templates</note>
       </trans-unit>
-      <trans-unit id="leveled.learn">
+      <trans-unit id="leveled.learn" approved="yes">
         <source xml:lang="en">To learn about using Leveled Readers in Bloom, you can:</source>
         <target xml:lang="ha">Don koyo game da yadda ake amfani da Ayyanannen Mai karatu a cikin Bloom, za ka iya:</target>
         <note>ID: leveled.learn</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.videos">
+      <trans-unit id="leveled.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="ha">Kallon <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc.8vbwux">waɗannan hotunan bidiyo na koyarwa</g>.</target>
         <note>ID: leveled.learn.videos</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpindex">
+      <trans-unit id="leveled.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Leveled Readers".</source>
         <target xml:lang="ha">Ka shiga dandalin taimako sannan ka zaɓi 'Taimako', sannan ka duba jerin tsarin a ƙarƙashin "Ayyanannen Maikaratu"</target>
         <note>ID: leveled.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpmenu">
+      <trans-unit id="leveled.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="ha">Ka shiga dandalin Taimako ka zaɓi: "Gina Muhallin Maikaratu".</target>
         <note>ID: leveled.learn.helpmenu</note>
       </trans-unit>
-      <trans-unit id="leveled.vs.decodable">
+      <trans-unit id="leveled.vs.decodable" approved="yes">
         <source xml:lang="en">Relationship to Decodable Readers</source>
         <target xml:lang="ha">Dangantakar Masu karatu</target>
         <note>ID: leveled.vs.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.and.decodable">
+      <trans-unit id="leveled.and.decodable" approved="yes">
         <source xml:lang="en">So how do leveled reader <g id="genid-5" ctype="x-html-em">levels</g> fit in decodable reader <g id="genid-6" ctype="x-html-em">stages</g>? The two concepts are complementary, and Bloom allows you to set both a <g id="genid-7" ctype="x-html-em">decodable stage</g> and a <g id="genid-8" ctype="x-html-em">leveled reader level</g> for a book you are writing. Typically books at level 1 and possibly level 2 will also need to be written with <g id="genid-9" ctype="x-html-em">decodability stages</g> in mind. Books at the first level or two will also need to be careful about being <g id="genid-10" ctype="x-html-em">decodable</g> (i.e. using letters the reader has learned). So a sequence of books might look like this:</source>
         <target xml:lang="ha">To yaya za a fitar da matakan mai karatu <g id="genid-5" ctype="x-html-em">Matakai</g> da za su dace da <g id="genid-6" ctype="x-html-em">matakan</g> maikaratu? Waɗannan abubuwa biyu suna taimakawa junansu, kuma Bloom zai baka damar tsara <g id="genid-7" ctype="x-html-em">matakin farko</g> da <g id="genid-8" ctype="x-html-em">matakin maikaratu</g> don littafin da kake rubutu. Akasari litattafai a mataki na 1 da mai yiwuwa mataki na 2 an so a rubuta su da <g id="genid-9" ctype="x-html-em">matakin karɓa</g> a cikin zuciya. Litattafai a matakin farko ko na biyu suma an so a yi taka-tsan-tsan da su game da <g id="genid-10" ctype="x-html-em">karɓuwa</g> (watau amfani da haruffan da mai karatu ya koya). Tsarin litattafai zai iya kasancewa kamar haka:</target>
         <note>ID: leveled.and.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.level">
+      <trans-unit id="leveled.reader.level" approved="yes">
         <source xml:lang="en">Leveled Reader Level</source>
 	<target />
         <note>ID: leveled.reader.level</note>
       </trans-unit>
-      <trans-unit id="decodable.stage">
+      <trans-unit id="decodable.stage" approved="yes">
         <source xml:lang="en">Decodable Stage</source>
         <target xml:lang="ha">Matakin karɓa </target>
         <note>ID: decodable.stage</note>

--- a/DistFiles/localization/Leveled Reader/ReadMe-id.xlf
+++ b/DistFiles/localization/Leveled Reader/ReadMe-id.xlf
@@ -2,58 +2,58 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="id">
     <body>
-      <trans-unit id="leveled.definition">
+      <trans-unit id="leveled.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Leveled Reader</g> is a book that is written specifically for a learner who is at a certain level of reading development. Levels define targets for word length, sentence length, etc. They also determine appropriate formatting, vocabulary, illustration support, and topic.</source>
         <target xml:lang="id">
           <g id="genid-1" ctype="x-html-strong">Pembaca Bertingkat</g> adalah buku yang ditulis khusus bagi pembelajar yang berada pada tingkat pengembangan membaca tertentu. Tingkat mendefinisikan target untuk panjang kata, panjang kalimat, dsb. Tingkat juga menentukan penyesuaian format, kosa kata, dukungan ilustrasi, dan topik.</target>
         <note>ID: leveled.definition</note>
       </trans-unit>
-      <trans-unit id="leveled.levels">
+      <trans-unit id="leveled.levels" approved="yes">
         <source xml:lang="en">After you have defined a sequence of <g id="genid-2" ctype="x-html-em">levels</g>, you can assign a level to books you create either with this template or the "Decodable Reader Template". As you type into the book, Bloom will help you keep the level in mind and point out when you exceed the limits of the level.</source>
         <target xml:lang="id">Setelah Anda mendefinisikan urutan <g id="genid-2" ctype="x-html-em">tingkat</g>, Anda dapat menetapkan sebuah tingkat pada buku-buku yang Anda buat baik dengan template ini atau pada "Template Pembaca yang Didekodekan". Saat Anda mengetik ke dalam buku, Bloom akan membantu Anda mengingat tingkat dan menunjukkan ketika Anda melewati batas tingkat tersebut.</target>
         <note>ID: leveled.levels</note>
       </trans-unit>
-      <trans-unit id="leveled.templates">
+      <trans-unit id="leveled.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-3" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="id">Anda juga dapat membuat sebuah Paket Bloom yang terdiri dari <g id="genid-3" ctype="x-html-em">template</g> yang bisa digunakan orang lain untuk membuat buku dengan cepat berdasarkan tingkatan dan tahapan yang telah disiapkan oleh spesialis literasi.</target>
         <note>ID: leveled.templates</note>
       </trans-unit>
-      <trans-unit id="leveled.learn">
+      <trans-unit id="leveled.learn" approved="yes">
         <source xml:lang="en">To learn about using Leveled Readers in Bloom, you can:</source>
         <target xml:lang="id">Untuk mempelajari tentang cara menggunakan Pembaca Bertingkat di Bloom, Anda dapat:</target>
         <note>ID: leveled.learn</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.videos">
+      <trans-unit id="leveled.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="id">Tonton <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">video petunjuk ini</g>.</target>
         <note>ID: leveled.learn.videos</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpindex">
+      <trans-unit id="leveled.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Leveled Readers".</source>
         <target xml:lang="id">Buka menu Bantuan, pilih "Bantuan', dan cari dalam indeks pada "Pembaca yang Dapat Didekodekan".</target>
         <note>ID: leveled.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpmenu">
+      <trans-unit id="leveled.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="id">Buka menu Bantuan dan pilih: "Membuat Template Pembaca".</target>
         <note>ID: leveled.learn.helpmenu</note>
       </trans-unit>
-      <trans-unit id="leveled.vs.decodable">
+      <trans-unit id="leveled.vs.decodable" approved="yes">
         <source xml:lang="en">Relationship to Decodable Readers</source>
         <target xml:lang="id">Hubungan dengan Pembaca yang Dapat Didekodekan</target>
         <note>ID: leveled.vs.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.and.decodable">
+      <trans-unit id="leveled.and.decodable" approved="yes">
         <source xml:lang="en">So how do leveled reader <g id="genid-5" ctype="x-html-em">levels</g> fit in decodable reader <g id="genid-6" ctype="x-html-em">stages</g>? The two concepts are complementary, and Bloom allows you to set both a <g id="genid-7" ctype="x-html-em">decodable stage</g> and a <g id="genid-8" ctype="x-html-em">leveled reader level</g> for a book you are writing. Typically books at level 1 and possibly level 2 will also need to be written with <g id="genid-9" ctype="x-html-em">decodability stages</g> in mind. Books at the first level or two will also need to be careful about being <g id="genid-10" ctype="x-html-em">decodable</g> (i.e. using letters the reader has learned). So a sequence of books might look like this:</source>
         <target xml:lang="id">Jadi bagaimana <g id="genid-5" ctype="x-html-em">tingkat</g> pembaca bertingkat sesuai dengan <g id="genid-6" ctype="x-html-em">tahapan</g> pembaca yang dapat didekodekan? Kedua konsep ini saling melengkapi, dan Bloom memungkinkan Anda mengatur sebuah <g id="genid-7" ctype="x-html-em">tahapan yang dapat didekodekan</g> dan sebuah <g id="genid-8" ctype="x-html-em">tingkat pembaca berltingkat</g> untuk buku yang Anda tulis. Biasanya buku pada tingkat 1 dan mungkin tingkat 2 juga harus ditulis dengan mempertimbangkan <g id="genid-9" ctype="x-html-em">tahapan kemampuan mendekodekan</g>. Buku pada tingkat pertama atau tingkat dua juga harus diperhatikan saat <g id="genid-10" ctype="x-html-em">dapat didekodekan</g> (yaitu penggunaan huruf yang telah dipelajari oleh pembaca). Jadi urutan bukunya mungkin akan tampak seperti ini:</target>
         <note>ID: leveled.and.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.level">
+      <trans-unit id="leveled.reader.level" approved="yes">
         <source xml:lang="en">Leveled Reader Level</source>
         <target xml:lang="id">Tingkat Pembaca Bertingkat</target>
         <note>ID: leveled.reader.level</note>
       </trans-unit>
-      <trans-unit id="decodable.stage">
+      <trans-unit id="decodable.stage" approved="yes">
         <source xml:lang="en">Decodable Stage</source>
         <target xml:lang="id">Tahapan Dapat Didekodekan</target>
         <note>ID: decodable.stage</note>

--- a/DistFiles/localization/Leveled Reader/ReadMe-ne.xlf
+++ b/DistFiles/localization/Leveled Reader/ReadMe-ne.xlf
@@ -2,59 +2,59 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="ne">
     <body>
-      <trans-unit id="leveled.definition">
+      <trans-unit id="leveled.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Leveled Reader</g> is a book that is written specifically for a learner who is at a certain level of reading development. Levels define targets for word length, sentence length, etc. They also determine appropriate formatting, vocabulary, illustration support, and topic.</source>
         <target xml:lang="ne">
           <g id="genid-1" ctype="x-html-strong">स्तर तोकिएको पाठ्यपुस्तक</g> विशेष रूपमा पठन क्षमता विकासक्रममा रहेका कुनै निश्चित स्तरका शिक्षार्थीको लागि लेखिएको पुस्तक हो। स्तरले शब्दको, वाक्यको लम्बाई अदि इत्यादिका लक्ष्य निर्धारण गर्दछ। तिनीहरूले उचित ढाँचा, शब्दावली, दृष्टान्त सहायता र शीर्षक पनि निर्धारण गर्दछन्।</target>
         <note>ID: leveled.definition</note>
       </trans-unit>
-      <trans-unit id="leveled.levels">
+      <trans-unit id="leveled.levels" approved="yes">
         <source xml:lang="en">After you have defined a sequence of <g id="genid-2" ctype="x-html-em">levels</g>, you can assign a level to books you create either with this template or the "Decodable Reader Template". As you type into the book, Bloom will help you keep the level in mind and point out when you exceed the limits of the level.</source>
         <target xml:lang="ne">तपाईंले <g id="genid-2" ctype="x-html-em">स्तरहरू</g> को अनुक्रम निर्धारण गरेपछि, यो टेम्प्लेट वा "डिकोडेबल पाठ्यपुस्तक टेम्प्लेट" लाई प्रयोग गरेर  अाफूले बनाएको पुस्तकको स्तर निर्धारण गर्न सक्नुहुन्छ। तपाईंले पुस्तकमा टाइप गर्दै गर्दा, Bloom ले पुस्तकको स्तर ध्यानमा राख्न मद्दत गर्नुका साथै तपाईंले सो स्तरको सीमाहरू नाघ्नुभयो भने त्यसबारे जानकारी गराउनेछ।</target>
         <note>ID: leveled.levels</note>
       </trans-unit>
-      <trans-unit id="leveled.templates">
+      <trans-unit id="leveled.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-3" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="ne">तपाईंले <g id="genid-3" ctype="x-html-em">टेम्प्लेटहरू</g> को Bloom प्याक पनि बनाउन सक्नुहुन्छ जसलाई साक्षरता विशेषज्ञले तयार पारेको स्तर र चरणहरूको आधारमा अरूले तुरुन्त पुस्तक बनाउन प्रयोग गर्न सक्छन्।</target>
         <note>ID: leveled.templates</note>
       </trans-unit>
-      <trans-unit id="leveled.learn">
+      <trans-unit id="leveled.learn" approved="yes">
         <source xml:lang="en">To learn about using Leveled Readers in Bloom, you can:</source>
         <target xml:lang="ne">स्तर तोकिएका पाठ्यपुस्तकहरू कसरी प्रयोग गर्ने भन्ने बारेमा जान्न, तपाईंले निम्नलिखित कुराहरू गर्न सक्नुहुन्छ:</target>
         <note>ID: leveled.learn</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.videos">
+      <trans-unit id="leveled.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="ne">
           <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">यी जानकारीमूलक भिडियोहरू</g> हेर्नुहोस्।</target>
         <note>ID: leveled.learn.videos</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpindex">
+      <trans-unit id="leveled.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Leveled Readers".</source>
         <target xml:lang="ne">मद्दत मेनुमा जानुहोस्, 'मद्दत' चयन गर्नुहोस्, र "स्तर तोकिएको पाठ्यपुस्तकहरू" अन्तर्गत रहेको सूचकाङ्कमा हेर्नुहोस्।</target>
         <note>ID: leveled.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpmenu">
+      <trans-unit id="leveled.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="ne">मद्दत मेनुमा जानुहोस् र निम्नलिखित चयन गर्नुहोस्: "पाठ्यपुस्तकका टेम्प्लेटहरू बनाउने"।</target>
         <note>ID: leveled.learn.helpmenu</note>
       </trans-unit>
-      <trans-unit id="leveled.vs.decodable">
+      <trans-unit id="leveled.vs.decodable" approved="yes">
         <source xml:lang="en">Relationship to Decodable Readers</source>
         <target xml:lang="ne">डिकोडेबल पाठ्यपुस्तकहरूसँग सम्बन्ध</target>
         <note>ID: leveled.vs.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.and.decodable">
+      <trans-unit id="leveled.and.decodable" approved="yes">
         <source xml:lang="en">So how do leveled reader <g id="genid-5" ctype="x-html-em">levels</g> fit in decodable reader <g id="genid-6" ctype="x-html-em">stages</g>? The two concepts are complementary, and Bloom allows you to set both a <g id="genid-7" ctype="x-html-em">decodable stage</g> and a <g id="genid-8" ctype="x-html-em">leveled reader level</g> for a book you are writing. Typically books at level 1 and possibly level 2 will also need to be written with <g id="genid-9" ctype="x-html-em">decodability stages</g> in mind. Books at the first level or two will also need to be careful about being <g id="genid-10" ctype="x-html-em">decodable</g> (i.e. using letters the reader has learned). So a sequence of books might look like this:</source>
         <target xml:lang="ne">स्तर तोकिएको पाठ्यपुस्तकको <g id="genid-5" ctype="x-html-em">स्तर</g> डिकोडेबल पाठ्यपुस्तकको <g id="genid-6" ctype="x-html-em">चरण</g> सँग कसरी  मिल्छन् त? यी दुई अवधारणाहरू एक-अर्काका पूरक हुन्, र Bloom ले तपाईंलाई आफूले लेखिरहेको पुस्तकको लागि <g id="genid-7" ctype="x-html-em">डिकोडेबल चरण</g> र <g id="genid-8" ctype="x-html-em">स्तर तोकिएको पाठ्यपुस्तकको स्तर</g> दुबै निर्धारण गर्न  अनुमति दिन्छ। सामान्यतया स्तर 1 र सम्भवतः स्तर 2 का पुस्तकहरू लेख्दा <g id="genid-9" ctype="x-html-em">डिकोड क्षमता चरणहरू</g> लाई पनि ध्यानमा राख्न जरूरी हुन्छ। पहिलो वा दोस्रो स्तरका पुस्तकहरू लेख्दा <g id="genid-10" ctype="x-html-em">डिकोडेबल</g> (अर्थात्, पाठकले सजिलै अर्थ लगाउन सकिने किसिमका शब्‍द वा अक्षरकेा प्रयेाग भएकेा) छ कि छैन भन्ने कुरामा पनि ध्यान दिन जरूरी हुन्छ (अर्थात्, पाठकले सिकेका अक्षरहरू प्रयोग गर्ने)। तसर्थ पुस्तकहरूको अनुक्रम यस्तो देखिन सक्छ:</target>
         <note>ID: leveled.and.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.level">
+      <trans-unit id="leveled.reader.level" approved="yes">
         <source xml:lang="en">Leveled Reader Level</source>
         <target xml:lang="ne">स्तर तोकिएको पाठ्यपुस्तकको स्तर</target>
         <note>ID: leveled.reader.level</note>
       </trans-unit>
-      <trans-unit id="decodable.stage">
+      <trans-unit id="decodable.stage" approved="yes">
         <source xml:lang="en">Decodable Stage</source>
         <target xml:lang="ne">डिकोडेबल चरण</target>
         <note>ID: decodable.stage</note>

--- a/DistFiles/localization/Leveled Reader/ReadMe-sw.xlf
+++ b/DistFiles/localization/Leveled Reader/ReadMe-sw.xlf
@@ -2,58 +2,58 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="sw">
     <body>
-      <trans-unit id="leveled.definition">
+      <trans-unit id="leveled.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Leveled Reader</g> is a book that is written specifically for a learner who is at a certain level of reading development. Levels define targets for word length, sentence length, etc. They also determine appropriate formatting, vocabulary, illustration support, and topic.</source>
         <target xml:lang="sw">
           <g id="genid-1" ctype="x-html-strong">Kitabu cha ngazi</g> ni kitabu kilichoandikwa ili kutumiwa tu na msomaji aliye katika ngazi fulani ya kuendelea kusoma. Ngazi hueleza malengo ya urefu wa neno, urefu wa sentensi, na mengineyo. Pia huamua muundo, msamiati, usaidizi wa maelezo, na mada inayofaa.</target>
         <note>ID: leveled.definition</note>
       </trans-unit>
-      <trans-unit id="leveled.levels">
+      <trans-unit id="leveled.levels" approved="yes">
         <source xml:lang="en">After you have defined a sequence of <g id="genid-2" ctype="x-html-em">levels</g>, you can assign a level to books you create either with this template or the "Decodable Reader Template". As you type into the book, Bloom will help you keep the level in mind and point out when you exceed the limits of the level.</source>
         <target xml:lang="sw">Baada ya kueleza mfululizo wa <g id="genid-2" ctype="x-html-em">ngazi</g>, unaweza kuweka ngazi kwa vitabu unavyotengeneza kwa kutumia kielelezo hiki au "Kielelezo cha Kitabu Kinachoweza Kufasiriwa". Unapopiga chapa kitabu, Bloom itakusaidia kutunza kiwango ulichofikia na kukuonyesha unapozidisha kiwango kilichotengewa.</target>
         <note>ID: leveled.levels</note>
       </trans-unit>
-      <trans-unit id="leveled.templates">
+      <trans-unit id="leveled.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-3" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="sw">Unaweza pia kutengeneza Seti ya <g id="genid-3" ctype="x-html-em">vielelezo</g> vya Bloom ambayo watu wengine wanaweza kutumia ili kutengeneza vitabu kwa haraka kwa kuzingatia ngazi na awamu ambazo zimeandaliwa na mtaalamu wa kusoma na kuandika.</target>
         <note>ID: leveled.templates</note>
       </trans-unit>
-      <trans-unit id="leveled.learn">
+      <trans-unit id="leveled.learn" approved="yes">
         <source xml:lang="en">To learn about using Leveled Readers in Bloom, you can:</source>
         <target xml:lang="sw">Ili kujifunza kuhusu kutumia Vifaa vya Kusoma Vinavyoweza Kufasiriwa katika Bloom, unaweza:</target>
         <note>ID: leveled.learn</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.videos">
+      <trans-unit id="leveled.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="sw">Tazama <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">video hizi za maelekezo</g>.</target>
         <note>ID: leveled.learn.videos</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpindex">
+      <trans-unit id="leveled.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Leveled Readers".</source>
         <target xml:lang="sw">Nenda kwa menyu ya Usaidizi, chagua 'Usaidizi', na utazame kwenye kielezo kilicho chini ya "Vitabu vya Ngazi".</target>
         <note>ID: leveled.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpmenu">
+      <trans-unit id="leveled.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="sw">Nenda kwa Menyu ya Usaidizi na uchague: "Kutengeneza Vigezo vya Kusoma".</target>
         <note>ID: leveled.learn.helpmenu</note>
       </trans-unit>
-      <trans-unit id="leveled.vs.decodable">
+      <trans-unit id="leveled.vs.decodable" approved="yes">
         <source xml:lang="en">Relationship to Decodable Readers</source>
         <target xml:lang="sw">Uhusiano kwa Vifaa vya Kusoma Vinavyoweza Kufasiriwa</target>
         <note>ID: leveled.vs.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.and.decodable">
+      <trans-unit id="leveled.and.decodable" approved="yes">
         <source xml:lang="en">So how do leveled reader <g id="genid-5" ctype="x-html-em">levels</g> fit in decodable reader <g id="genid-6" ctype="x-html-em">stages</g>? The two concepts are complementary, and Bloom allows you to set both a <g id="genid-7" ctype="x-html-em">decodable stage</g> and a <g id="genid-8" ctype="x-html-em">leveled reader level</g> for a book you are writing. Typically books at level 1 and possibly level 2 will also need to be written with <g id="genid-9" ctype="x-html-em">decodability stages</g> in mind. Books at the first level or two will also need to be careful about being <g id="genid-10" ctype="x-html-em">decodable</g> (i.e. using letters the reader has learned). So a sequence of books might look like this:</source>
         <target xml:lang="sw">Hivyo, ni vipi ambavyo <g id="genid-5" ctype="x-html-em">ngazi</g> za kifaa kilichopewa ngazi hutoshea kwenye <g id="genid-6" ctype="x-html-em">awamu</g> za kifaa cha kusoma zinazoweza kufasiriwa? Dhana hizi mbili zinaweza kutumiwa kwa njia sawa, na Bloom hukuruhusu kutumia <g id="genid-7" ctype="x-html-em">awamu zinazoweza kufasiriwa</g> na <g id="genid-8" ctype="x-html-em">ngazi ya kifaa cha kusoma kilichopewa ngazi</g> kwa kitabu unachoandika. Kwa kawaida vitabu katika ngazi ya 1 na kuna uwezekano pia vile vilivyo katika ngazi ya 2 vitahitaji kuandikwa kwa kutia maanani <g id="genid-9" ctype="x-html-em">awamu zinazoweza kufasiriwa</g>. Vitabu katika ngazi ya kwanza au labda ya pili pia vitahitaji uangalifu kuhusu kuweza <g id="genid-10" ctype="x-html-em">kufasiriwa</g> (yaani kutumia herufi ambazo msomaji amejifunza). Kwa hivyo mfululizo wa vitabu unaweza kuonekana hivi:</target>
         <note>ID: leveled.and.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.level">
+      <trans-unit id="leveled.reader.level" approved="yes">
         <source xml:lang="en">Leveled Reader Level</source>
         <target xml:lang="sw">Ngazi ya Kitabu cha Ngazi</target>
         <note>ID: leveled.reader.level</note>
       </trans-unit>
-      <trans-unit id="decodable.stage">
+      <trans-unit id="decodable.stage" approved="yes">
         <source xml:lang="en">Decodable Stage</source>
         <target xml:lang="sw">Awamu Inayoweza Kufasiriwa</target>
         <note>ID: decodable.stage</note>

--- a/DistFiles/localization/Leveled Reader/ReadMe-zh-CN.xlf
+++ b/DistFiles/localization/Leveled Reader/ReadMe-zh-CN.xlf
@@ -2,58 +2,58 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="zh-CN">
     <body>
-      <trans-unit id="leveled.definition">
+      <trans-unit id="leveled.definition" approved="yes">
         <source xml:lang="en">A <g id="genid-1" ctype="x-html-strong">Leveled Reader</g> is a book that is written specifically for a learner who is at a certain level of reading development. Levels define targets for word length, sentence length, etc. They also determine appropriate formatting, vocabulary, illustration support, and topic.</source>
         <target xml:lang="zh-CN">
           <g id="genid-1" ctype="x-html-strong">分级读物</g>是专门为处于特定阅读发展等级的读者编写的。 等级决定了单词长度、句子长度等指标。 也决定了字体设置、词汇、配图和话题。</target>
         <note>ID: leveled.definition</note>
       </trans-unit>
-      <trans-unit id="leveled.levels">
+      <trans-unit id="leveled.levels" approved="yes">
         <source xml:lang="en">After you have defined a sequence of <g id="genid-2" ctype="x-html-em">levels</g>, you can assign a level to books you create either with this template or the "Decodable Reader Template". As you type into the book, Bloom will help you keep the level in mind and point out when you exceed the limits of the level.</source>
         <target xml:lang="zh-CN">定义好成序列的<g id="genid-2" ctype="x-html-em">等级</g>之后，可以给该模板或“拼读读物模板”制作而成的书分配等级。 当您为该书输入文本时，Bloom会记住该书所属等级的设定并在您超出限制时给予提醒。</target>
         <note>ID: leveled.levels</note>
       </trans-unit>
-      <trans-unit id="leveled.templates">
+      <trans-unit id="leveled.templates" approved="yes">
         <source xml:lang="en">You can also make a Bloom Pack of <g id="genid-3" ctype="x-html-em">templates</g> that others can use to quickly create books based on the levels and stages that have been prepared by a literacy specialist.</source>
         <target xml:lang="zh-CN">您还可以制作包含一系列<g id="genid-3" ctype="x-html-em">模板</g>的Bloom资料包，这样别人可以用这些由识字教育专家事先设定好的等级和细分层次快速创建书籍。</target>
         <note>ID: leveled.templates</note>
       </trans-unit>
-      <trans-unit id="leveled.learn">
+      <trans-unit id="leveled.learn" approved="yes">
         <source xml:lang="en">To learn about using Leveled Readers in Bloom, you can:</source>
         <target xml:lang="zh-CN">要了解在Bloom中如何使用“分级读物”，您可以：</target>
         <note>ID: leveled.learn</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.videos">
+      <trans-unit id="leveled.learn.videos" approved="yes">
         <source xml:lang="en">Watch <g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">these instructional videos</g>.</source>
         <target xml:lang="zh-CN">观看[这些教学视频] (<g id="genid-4" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">http://tiny.cc/8vbwux</g>)。</target>
         <note>ID: leveled.learn.videos</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpindex">
+      <trans-unit id="leveled.learn.helpindex" approved="yes">
         <source xml:lang="en">Go to the Help menu, choose 'Help', and look in the index under "Leveled Readers".</source>
         <target xml:lang="zh-CN">找到“帮助”菜单，选择“帮助”，再查看“分级读物”下面的索引。</target>
         <note>ID: leveled.learn.helpindex</note>
       </trans-unit>
-      <trans-unit id="leveled.learn.helpmenu">
+      <trans-unit id="leveled.learn.helpmenu" approved="yes">
         <source xml:lang="en">Go to the Help menu and choose: "Building Reader Templates".</source>
         <target xml:lang="zh-CN">找到帮助菜单，选择：“创建读物模板”。</target>
         <note>ID: leveled.learn.helpmenu</note>
       </trans-unit>
-      <trans-unit id="leveled.vs.decodable">
+      <trans-unit id="leveled.vs.decodable" approved="yes">
         <source xml:lang="en">Relationship to Decodable Readers</source>
         <target xml:lang="zh-CN">和拼读读物的关系</target>
         <note>ID: leveled.vs.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.and.decodable">
+      <trans-unit id="leveled.and.decodable" approved="yes">
         <source xml:lang="en">So how do leveled reader <g id="genid-5" ctype="x-html-em">levels</g> fit in decodable reader <g id="genid-6" ctype="x-html-em">stages</g>? The two concepts are complementary, and Bloom allows you to set both a <g id="genid-7" ctype="x-html-em">decodable stage</g> and a <g id="genid-8" ctype="x-html-em">leveled reader level</g> for a book you are writing. Typically books at level 1 and possibly level 2 will also need to be written with <g id="genid-9" ctype="x-html-em">decodability stages</g> in mind. Books at the first level or two will also need to be careful about being <g id="genid-10" ctype="x-html-em">decodable</g> (i.e. using letters the reader has learned). So a sequence of books might look like this:</source>
         <target xml:lang="zh-CN">那么分级读物的<g id="genid-5" ctype="x-html-em">等级</g>和拼读读物的“细分阶段”怎么融合？ 这两个概念是互补的，Bloom允许您为正在编写的书既设置<g id="genid-6" ctype="x-html-em">拼读细分阶段</g>,也设置<g id="genid-7" ctype="x-html-em">分级读物等级</g>。 一般来说属于前两个等级的书，编写时需要考虑到<g id="genid-8" ctype="x-html-em">拼读细分阶段</g>。 第一级或第二级的书要注意做到<g id="genid-9" ctype="x-html-em">可拼读</g>（即用读者已经学过的字母）。 因此一个系列的书看起来可能会是这样：</target>
         <note>ID: leveled.and.decodable</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.level">
+      <trans-unit id="leveled.reader.level" approved="yes">
         <source xml:lang="en">Leveled Reader Level</source>
         <target xml:lang="zh-CN">分级读物等级</target>
         <note>ID: leveled.reader.level</note>
       </trans-unit>
-      <trans-unit id="decodable.stage">
+      <trans-unit id="decodable.stage" approved="yes">
         <source xml:lang="en">Decodable Stage</source>
         <target xml:lang="zh-CN">拼读细分阶段</target>
         <note>ID: decodable.stage</note>

--- a/DistFiles/localization/Picture Dictionary/ReadMe-ar.xlf
+++ b/DistFiles/localization/Picture Dictionary/ReadMe-ar.xlf
@@ -2,37 +2,37 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="ar">
     <body>
-      <trans-unit id="picture.dictionary">
+      <trans-unit id="picture.dictionary" approved="yes">
         <source xml:lang="en">About the Picture Dictionary Template</source>
         <target xml:lang="ar">معلومات عن نموذج القاموس المصور</target>
         <note>ID: picture.dictionary</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.use">
+      <trans-unit id="picture.dictionary.use" approved="yes">
         <source xml:lang="en">Use this template to make a picture dictionary that is monolingual, bilingual, or trilingual.</source>
         <target xml:lang="ar">يمكنك استخدام هذا النموذج لإعداد قاموس مصور أحادي أو ثنائي أو ثلاثي اللغة.</target>
         <note>ID: picture.dictionary.use</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.limits">
+      <trans-unit id="picture.dictionary.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="ar">القيود الخاصة بهذا الإصدار</target>
         <note>ID: picture.dictionary.limits</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.stillexperimental">
+      <trans-unit id="picture.dictionary.stillexperimental" approved="yes">
         <source xml:lang="en">This book is currently marked "experimental" because we know of several problems in layout and convenience.</source>
         <target xml:lang="ar">حالياً يُعتَبَر هذا الكتاب "تجريبياً" نظراً لإدراكنا بوجود مشكلات في التخطيط والتصميم المريح.</target>
         <note>ID: picture.dictionary.stillexperimental</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.feedback">
+      <trans-unit id="picture.dictionary.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="ar">تغذية راجعة</target>
         <note>ID: picture.dictionary.feedback</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.feedbackvoting">
+      <trans-unit id="picture.dictionary.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="ar">يُرجى المشاركة <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">باقتراحات</g> والتصويت عليها.</target>
         <note>ID: picture.dictionary.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.reportbugs">
+      <trans-unit id="picture.dictionary.reportbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="ar">يُرجى الإبلاغ عن المشكلات لدى <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g>.</target>
         <note>ID: picture.dictionary.reportbugs</note>

--- a/DistFiles/localization/Picture Dictionary/ReadMe-bn.xlf
+++ b/DistFiles/localization/Picture Dictionary/ReadMe-bn.xlf
@@ -2,38 +2,38 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="bn">
     <body>
-      <trans-unit id="picture.dictionary">
+      <trans-unit id="picture.dictionary" approved="yes">
         <source xml:lang="en">About the Picture Dictionary Template</source>
         <target xml:lang="bn">ছবির অভিধান টেমপ্লেট বিষয়ক</target>
         <note>ID: picture.dictionary</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.use">
+      <trans-unit id="picture.dictionary.use" approved="yes">
         <source xml:lang="en">Use this template to make a picture dictionary that is monolingual, bilingual, or trilingual.</source>
         <target xml:lang="bn">একভাষিক, দ্বিভাষিক, বা ত্রিভাষিক ছবির অভিধান তৈরি করার জন্য এই টেম্পলেট ব্যবহার করুন।</target>
         <note>ID: picture.dictionary.use</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.limits">
+      <trans-unit id="picture.dictionary.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="bn">এই সংস্করণের সীমাবদ্ধতা</target>
         <note>ID: picture.dictionary.limits</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.stillexperimental">
+      <trans-unit id="picture.dictionary.stillexperimental" approved="yes">
         <source xml:lang="en">This book is currently marked "experimental" because we know of several problems in layout and convenience.</source>
         <target xml:lang="bn">লেআউট বিষয়ক সমস্যা এবং আরো কিছু সমস্যার জন্য বর্তমানে এই বইটি চিহ্নিত "পরীক্ষামূলক" হিসেবে চিহ্নিত রয়েছে।</target>
         <note>ID: picture.dictionary.stillexperimental</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.feedback">
+      <trans-unit id="picture.dictionary.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="bn">প্রতিক্রিয়া</target>
         <note>ID: picture.dictionary.feedback</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.feedbackvoting">
+      <trans-unit id="picture.dictionary.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="bn">
           <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">পরামর্শ</g> দিতে দয়া করে</target>
         <note>ID: picture.dictionary.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.reportbugs">
+      <trans-unit id="picture.dictionary.reportbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="bn">
           <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g> সমস্যা রিপোর্ট করুন</target>

--- a/DistFiles/localization/Picture Dictionary/ReadMe-id.xlf
+++ b/DistFiles/localization/Picture Dictionary/ReadMe-id.xlf
@@ -2,37 +2,37 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="id">
     <body>
-      <trans-unit id="picture.dictionary">
+      <trans-unit id="picture.dictionary" approved="yes">
         <source xml:lang="en">About the Picture Dictionary Template</source>
         <target xml:lang="id">Tentang Template Kamus Bergambar</target>
         <note>ID: picture.dictionary</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.use">
+      <trans-unit id="picture.dictionary.use" approved="yes">
         <source xml:lang="en">Use this template to make a picture dictionary that is monolingual, bilingual, or trilingual.</source>
         <target xml:lang="id">Gunakan template ini untuk membuat kamus bergambar yang monolingual, bilingual, atau trilingual.</target>
         <note>ID: picture.dictionary.use</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.limits">
+      <trans-unit id="picture.dictionary.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="id">Keterbatasan Versi ini</target>
         <note>ID: picture.dictionary.limits</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.stillexperimental">
+      <trans-unit id="picture.dictionary.stillexperimental" approved="yes">
         <source xml:lang="en">This book is currently marked "experimental" because we know of several problems in layout and convenience.</source>
         <target xml:lang="id">Buku ini baru saja ditandai "eksperimental" karena kita tahu ada beberapa masalah dalam tata letak dan kemudahannya.</target>
         <note>ID: picture.dictionary.stillexperimental</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.feedback">
+      <trans-unit id="picture.dictionary.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="id">Umpan balik</target>
         <note>ID: picture.dictionary.feedback</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.feedbackvoting">
+      <trans-unit id="picture.dictionary.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="id">Silakan berikan dan masukan pendapat pada <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">saran</g>.</target>
         <note>ID: picture.dictionary.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.reportbugs">
+      <trans-unit id="picture.dictionary.reportbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="id">Silakan laporkan masalah ke <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g>.</target>
         <note>ID: picture.dictionary.reportbugs</note>

--- a/DistFiles/localization/Picture Dictionary/ReadMe-sw.xlf
+++ b/DistFiles/localization/Picture Dictionary/ReadMe-sw.xlf
@@ -2,37 +2,37 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="sw">
     <body>
-      <trans-unit id="picture.dictionary">
+      <trans-unit id="picture.dictionary" approved="yes">
         <source xml:lang="en">About the Picture Dictionary Template</source>
         <target xml:lang="sw">Kuhusu Picha ya Kigezo cha Kamusi</target>
         <note>ID: picture.dictionary</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.use">
+      <trans-unit id="picture.dictionary.use" approved="yes">
         <source xml:lang="en">Use this template to make a picture dictionary that is monolingual, bilingual, or trilingual.</source>
         <target xml:lang="sw">Tumia kigezo hiki ili kutengeneza kamusi ya picha ambayo ni ya lugha moja, lugha mbili, au lugha tatu.</target>
         <note>ID: picture.dictionary.use</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.limits">
+      <trans-unit id="picture.dictionary.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="sw">Udhaifu wa Tafsiri Hii</target>
         <note>ID: picture.dictionary.limits</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.stillexperimental">
+      <trans-unit id="picture.dictionary.stillexperimental" approved="yes">
         <source xml:lang="en">This book is currently marked "experimental" because we know of several problems in layout and convenience.</source>
         <target xml:lang="sw">Kitabu hiki kwa sasa kimewekwa alama ya "kimajaribio" kwa kuwa tunajua kuhusu matatizo kadhaa katika muundo na kufaa kwake.</target>
         <note>ID: picture.dictionary.stillexperimental</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.feedback">
+      <trans-unit id="picture.dictionary.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="sw">Maoni</target>
         <note>ID: picture.dictionary.feedback</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.feedbackvoting">
+      <trans-unit id="picture.dictionary.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="sw">Tafadhali toa na upige kura kwa <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">mapendekezo</g>.</target>
         <note>ID: picture.dictionary.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.reportbugs">
+      <trans-unit id="picture.dictionary.reportbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="sw">Tafadhali toa taarifa kuhusu matatizo kwa <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g>.</target>
         <note>ID: picture.dictionary.reportbugs</note>

--- a/DistFiles/localization/Picture Dictionary/ReadMe-zh-CN.xlf
+++ b/DistFiles/localization/Picture Dictionary/ReadMe-zh-CN.xlf
@@ -2,37 +2,37 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="zh-CN">
     <body>
-      <trans-unit id="picture.dictionary">
+      <trans-unit id="picture.dictionary" approved="yes">
         <source xml:lang="en">About the Picture Dictionary Template</source>
         <target xml:lang="zh-CN">关于图片词典模板</target>
         <note>ID: picture.dictionary</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.use">
+      <trans-unit id="picture.dictionary.use" approved="yes">
         <source xml:lang="en">Use this template to make a picture dictionary that is monolingual, bilingual, or trilingual.</source>
         <target xml:lang="zh-CN">用该模板创建单语，双语或三语图片词典。</target>
         <note>ID: picture.dictionary.use</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.limits">
+      <trans-unit id="picture.dictionary.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="zh-CN">本版本的局限性</target>
         <note>ID: picture.dictionary.limits</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.stillexperimental">
+      <trans-unit id="picture.dictionary.stillexperimental" approved="yes">
         <source xml:lang="en">This book is currently marked "experimental" because we know of several problems in layout and convenience.</source>
         <target xml:lang="zh-CN">这本书目前标记为“实验”性质，因为我们知道在布局和使用便利性方面还存在一些问题。</target>
         <note>ID: picture.dictionary.stillexperimental</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.feedback">
+      <trans-unit id="picture.dictionary.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="zh-CN">反馈</target>
         <note>ID: picture.dictionary.feedback</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.feedbackvoting">
+      <trans-unit id="picture.dictionary.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="zh-CN">请提<g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">建议</g>并参与投票</target>
         <note>ID: picture.dictionary.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="picture.dictionary.reportbugs">
+      <trans-unit id="picture.dictionary.reportbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="zh-CN">请报告问题 <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Picture%C2%A0Dictionary%C2%A0Problem">issues@bloomremovelibrary.org</g>.</target>
         <note>ID: picture.dictionary.reportbugs</note>

--- a/DistFiles/localization/Wall Calendar/ReadMe-ar.xlf
+++ b/DistFiles/localization/Wall Calendar/ReadMe-ar.xlf
@@ -2,47 +2,47 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="ar">
     <body>
-      <trans-unit id="wall.calendar">
+      <trans-unit id="wall.calendar" approved="yes">
         <source xml:lang="en">About the Wall Calendar Template</source>
         <target xml:lang="ar">معلومات عن نماذج تقويم الحائط</target>
         <note>ID: wall.calendar</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.use">
+      <trans-unit id="wall.calendar.use" approved="yes">
         <source xml:lang="en">Using this template, you can make an A5-size 12 month calendar, with a picture and quotation on the top page, and days on the bottom. The calendar will use the names of months and days in your language.</source>
         <target xml:lang="ar">باستخدام هذا النموذج، يمكنك إعداد تقويم يحتوي 12 شهر بحجم A5، مع صورة واقتباس أعلى الصفحة، وأيام في الأسفل. سيستخدم التقويم أسماء الشهور والأيام بلغتك.</target>
         <note>ID: wall.calendar.use</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.limits">
+      <trans-unit id="wall.calendar.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="ar">القيود الخاصة بهذا الإصدار</target>
         <note>ID: wall.calendar.limits</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.noshells">
+      <trans-unit id="wall.calendar.noshells" approved="yes">
         <source xml:lang="en">Currently, you cannot make a "shell" for other languages to use.</source>
         <target xml:lang="ar">في الوقت الحالي، لا يمكنك إنشاء "هيكل" لاستخدامه في لغات أخرى.</target>
         <note>ID: wall.calendar.noshells</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.credits">
+      <trans-unit id="wall.calendar.credits" approved="yes">
         <source xml:lang="en">Credits</source>
         <target xml:lang="ar">المساهمون في العمل</target>
         <note>ID: wall.calendar.credits</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.thanks">
+      <trans-unit id="wall.calendar.thanks" approved="yes">
         <source xml:lang="en">Thanks to Bruce Cox (SIL Cameroon) for getting this template started.</source>
         <target xml:lang="ar">نتوجه بالشكر إلى بروس كوكس (SIL كاميرون) الذي قام باتخاذ الخطوات الأولى لإنشاء هذا النموذج.</target>
         <note>ID: wall.calendar.thanks</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.feedback">
+      <trans-unit id="wall.calendar.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="ar">تغذية راجعة</target>
         <note>ID: wall.calendar.feedback</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.feedbackvoting">
+      <trans-unit id="wall.calendar.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="ar">يُرجى المشاركة <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">باقتراحات</g> والتصويت عليها.</target>
         <note>ID: wall.calendar.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.reportbugs">
+      <trans-unit id="wall.calendar.reportbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="ar">يُرجى الإبلاغ عن المشكلات لدى <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g>.</target>
         <note>ID: wall.calendar.reportbugs</note>

--- a/DistFiles/localization/Wall Calendar/ReadMe-bn.xlf
+++ b/DistFiles/localization/Wall Calendar/ReadMe-bn.xlf
@@ -2,47 +2,47 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="bn">
     <body>
-      <trans-unit id="wall.calendar">
+      <trans-unit id="wall.calendar" approved="yes">
         <source xml:lang="en">About the Wall Calendar Template</source>
         <target xml:lang="bn">দেয়াল পঞ্জিকা টেমপ্লেট বিষয়ক</target>
         <note>ID: wall.calendar</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.use">
+      <trans-unit id="wall.calendar.use" approved="yes">
         <source xml:lang="en">Using this template, you can make an A5-size 12 month calendar, with a picture and quotation on the top page, and days on the bottom. The calendar will use the names of months and days in your language.</source>
         <target xml:lang="bn">এই টেমপ্লেটটি ব্যবহার করে, আপনি ছবি এবং পাতার উপরের অংশে উদ্ধৃতি এবং নীচের অংশে দিন/ বারের নাম সম্বলিত একটি A5 আকারের 12 মাসিক পঞ্জিকা তৈরি করতে পারেন। এই পঞ্জিকায় আপনার ভাষায় মাস এবং দিনের নাম ব্যবহার করা হবে।</target>
         <note>ID: wall.calendar.use</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.limits">
+      <trans-unit id="wall.calendar.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="bn">এই সংস্করণের সীমাবদ্ধতা</target>
         <note>ID: wall.calendar.limits</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.noshells">
+      <trans-unit id="wall.calendar.noshells" approved="yes">
         <source xml:lang="en">Currently, you cannot make a "shell" for other languages to use.</source>
         <target xml:lang="bn">বর্তমানে, আপনি অন্য ভাষায় ব্যবহার করার জন্য 'শেল' তৈরি করতে পারবেন না।</target>
         <note>ID: wall.calendar.noshells</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.credits">
+      <trans-unit id="wall.calendar.credits" approved="yes">
         <source xml:lang="en">Credits</source>
         <target xml:lang="bn">ক্রেডিট</target>
         <note>ID: wall.calendar.credits</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.thanks">
+      <trans-unit id="wall.calendar.thanks" approved="yes">
         <source xml:lang="en">Thanks to Bruce Cox (SIL Cameroon) for getting this template started.</source>
         <target xml:lang="bn">এই টেমপ্লেটটি শুরু করার জন্য Bruce Cox (SIL Cameroon) কে ধন্যবাদ।</target>
         <note>ID: wall.calendar.thanks</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.feedback">
+      <trans-unit id="wall.calendar.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="bn">প্রতিক্রিয়া</target>
         <note>ID: wall.calendar.feedback</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.feedbackvoting">
+      <trans-unit id="wall.calendar.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="bn">দয়া করে ভোট করুন  <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">পরামর্শ </g></target>
         <note>ID: wall.calendar.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.reportbugs">
+      <trans-unit id="wall.calendar.reportbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="bn">সমস্যা রিপোর্ট করুন <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g></target>
         <note>ID: wall.calendar.reportbugs</note>

--- a/DistFiles/localization/Wall Calendar/ReadMe-id.xlf
+++ b/DistFiles/localization/Wall Calendar/ReadMe-id.xlf
@@ -2,47 +2,47 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="id">
     <body>
-      <trans-unit id="wall.calendar">
+      <trans-unit id="wall.calendar" approved="yes">
         <source xml:lang="en">About the Wall Calendar Template</source>
         <target xml:lang="id">Tentang Template Kalender Dinding</target>
         <note>ID: wall.calendar</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.use">
+      <trans-unit id="wall.calendar.use" approved="yes">
         <source xml:lang="en">Using this template, you can make an A5-size 12 month calendar, with a picture and quotation on the top page, and days on the bottom. The calendar will use the names of months and days in your language.</source>
         <target xml:lang="id">Menggunakan template ini, Anda dapat membuat kalender 12 bulan ukuran A5, dengan gambar dan kutipan pada bagian atas halaman, dan nama hari di bagian bawahnya. Kalender akan menggunakan nama-nama bulan dan hari dalam bahasa Anda.</target>
         <note>ID: wall.calendar.use</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.limits">
+      <trans-unit id="wall.calendar.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="id">Keterbatasan Versi ini</target>
         <note>ID: wall.calendar.limits</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.noshells">
+      <trans-unit id="wall.calendar.noshells" approved="yes">
         <source xml:lang="en">Currently, you cannot make a "shell" for other languages to use.</source>
         <target xml:lang="id">Saat ini, Anda tidak dapat membuat "kerangka" untuk bahasa lain untuk digunakan.</target>
         <note>ID: wall.calendar.noshells</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.credits">
+      <trans-unit id="wall.calendar.credits" approved="yes">
         <source xml:lang="en">Credits</source>
         <target xml:lang="id">Pengakuan</target>
         <note>ID: wall.calendar.credits</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.thanks">
+      <trans-unit id="wall.calendar.thanks" approved="yes">
         <source xml:lang="en">Thanks to Bruce Cox (SIL Cameroon) for getting this template started.</source>
         <target xml:lang="id">Ucapan terima kasih untuk Bruce Cox (SIL Kamerun) yang telah membuat template ini dapat dimulai.</target>
         <note>ID: wall.calendar.thanks</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.feedback">
+      <trans-unit id="wall.calendar.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="id">Umpan balik</target>
         <note>ID: wall.calendar.feedback</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.feedbackvoting">
+      <trans-unit id="wall.calendar.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="id">Silakan berikan dan masukan saran Anda pada <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">saran</g>.</target>
         <note>ID: wall.calendar.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.reportbugs">
+      <trans-unit id="wall.calendar.reportbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="id">Silakan laporkan masalah ke <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g>.</target>
         <note>ID: wall.calendar.reportbugs</note>

--- a/DistFiles/localization/Wall Calendar/ReadMe-sw.xlf
+++ b/DistFiles/localization/Wall Calendar/ReadMe-sw.xlf
@@ -2,47 +2,47 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="sw">
     <body>
-      <trans-unit id="wall.calendar">
+      <trans-unit id="wall.calendar" approved="yes">
         <source xml:lang="en">About the Wall Calendar Template</source>
         <target xml:lang="sw">Kuhusu Kielelezo cha Kalenda ya Ukuta</target>
         <note>ID: wall.calendar</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.use">
+      <trans-unit id="wall.calendar.use" approved="yes">
         <source xml:lang="en">Using this template, you can make an A5-size 12 month calendar, with a picture and quotation on the top page, and days on the bottom. The calendar will use the names of months and days in your language.</source>
         <target xml:lang="sw">Kwa kutumia kielelezo hiki, unaweza kutengeneza kalenda ya miezi 12 ya A5, iliyo na picha na dondoo kwenye ukurasa wa juu, na siku upande wa chini. Kalenda hii itatumia majina ya miezi na siku katika lugha yako.</target>
         <note>ID: wall.calendar.use</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.limits">
+      <trans-unit id="wall.calendar.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="sw">Changamoto za toleo hili</target>
         <note>ID: wall.calendar.limits</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.noshells">
+      <trans-unit id="wall.calendar.noshells" approved="yes">
         <source xml:lang="en">Currently, you cannot make a "shell" for other languages to use.</source>
         <target xml:lang="sw">Kwa sasa, huwezi ukatengeneza "sheli" ili kutumika kwa lugha zingine.</target>
         <note>ID: wall.calendar.noshells</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.credits">
+      <trans-unit id="wall.calendar.credits" approved="yes">
         <source xml:lang="en">Credits</source>
         <target xml:lang="sw">Sifa</target>
         <note>ID: wall.calendar.credits</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.thanks">
+      <trans-unit id="wall.calendar.thanks" approved="yes">
         <source xml:lang="en">Thanks to Bruce Cox (SIL Cameroon) for getting this template started.</source>
         <target xml:lang="sw">Shukrani kwa Bruce Cox (SIL Cameroon) kwa kuanzisha kielelezo hiki.</target>
         <note>ID: wall.calendar.thanks</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.feedback">
+      <trans-unit id="wall.calendar.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="sw">Maoni</target>
         <note>ID: wall.calendar.feedback</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.feedbackvoting">
+      <trans-unit id="wall.calendar.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="sw">Tafadhali toa na upige kura kwa <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions/">mapendekezo</g>.</target>
         <note>ID: wall.calendar.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.reportbugs">
+      <trans-unit id="wall.calendar.reportbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="sw">Tafadhali toa taarifa ya matatizo kwa <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g>.</target>
         <note>ID: wall.calendar.reportbugs</note>

--- a/DistFiles/localization/Wall Calendar/ReadMe-zh-CN.xlf
+++ b/DistFiles/localization/Wall Calendar/ReadMe-zh-CN.xlf
@@ -2,47 +2,47 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="ReadMe-en.htm" datatype="html" source-language="en" target-language="zh-CN">
     <body>
-      <trans-unit id="wall.calendar">
+      <trans-unit id="wall.calendar" approved="yes">
         <source xml:lang="en">About the Wall Calendar Template</source>
         <target xml:lang="zh-CN">关于挂历模板</target>
         <note>ID: wall.calendar</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.use">
+      <trans-unit id="wall.calendar.use" approved="yes">
         <source xml:lang="en">Using this template, you can make an A5-size 12 month calendar, with a picture and quotation on the top page, and days on the bottom. The calendar will use the names of months and days in your language.</source>
         <target xml:lang="zh-CN">使用此模板，您可以制作A5尺寸的全年挂历，图片和引用语句在页面上方，页面下方显示日期。 将用您的语言显示日历上的月份和日期。</target>
         <note>ID: wall.calendar.use</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.limits">
+      <trans-unit id="wall.calendar.limits" approved="yes">
         <source xml:lang="en">Limitations of this version</source>
         <target xml:lang="zh-CN">本版本的局限性</target>
         <note>ID: wall.calendar.limits</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.noshells">
+      <trans-unit id="wall.calendar.noshells" approved="yes">
         <source xml:lang="en">Currently, you cannot make a "shell" for other languages to use.</source>
         <target xml:lang="zh-CN">目前无法制作可供其他语言使用的日历“壳”。</target>
         <note>ID: wall.calendar.noshells</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.credits">
+      <trans-unit id="wall.calendar.credits" approved="yes">
         <source xml:lang="en">Credits</source>
         <target xml:lang="zh-CN">致谢</target>
         <note>ID: wall.calendar.credits</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.thanks">
+      <trans-unit id="wall.calendar.thanks" approved="yes">
         <source xml:lang="en">Thanks to Bruce Cox (SIL Cameroon) for getting this template started.</source>
         <target xml:lang="zh-CN">感谢Bruce Cox（SIL喀麦隆）启动了模板的创制工作。</target>
         <note>ID: wall.calendar.thanks</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.feedback">
+      <trans-unit id="wall.calendar.feedback" approved="yes">
         <source xml:lang="en">Feedback</source>
         <target xml:lang="zh-CN">反馈	</target>
         <note>ID: wall.calendar.feedback</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.feedbackvoting">
+      <trans-unit id="wall.calendar.feedbackvoting" approved="yes">
         <source xml:lang="en">Please give and vote on <g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">suggestions</g></source>
         <target xml:lang="zh-CN">请提<g id="genid-1" ctype="x-html-a" html:href="http://bloomlibrary.org/suggestions">建议</g>并参与投票</target>
         <note>ID: wall.calendar.feedbackvoting</note>
       </trans-unit>
-      <trans-unit id="wall.calendar.reportbugs">
+      <trans-unit id="wall.calendar.reportbugs" approved="yes">
         <source xml:lang="en">Please report problems to <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g>.</source>
         <target xml:lang="zh-CN">请报告问题 <g id="genid-2" ctype="x-html-a" html:href="mailto:issues@bloomremovelibrary.org?subject=Wall%C2%A0Calendar%C2%A0Problem">issues@bloomremovelibrary.org</g>.</target>
         <note>ID: wall.calendar.reportbugs</note>

--- a/DistFiles/localization/am/Bloom.xlf
+++ b/DistFiles/localization/am/Bloom.xlf
@@ -2,792 +2,792 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="am" datatype="plaintext" product-version="3.0.000.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="am">ከድምጽ ጋር አዛምዶ ንባብ የማስተማሪያ መሳሪያ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="am">በደረጃ የተከፋፈለ የምንባብ መሳሪያ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="am">ተጨማሪ...</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="am">የላቀ ፕሮግራም ቅንጀቶች</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="am">መጽሐፍ ዝግጅት</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="am">ነባሪ ቅርፀ-ቁምፊ ለ {0}</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="am">ከቀኝ ወደ ግራ የአጻጻፍ ሥርዓት</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="am">ቅንጅቶች</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="am">ቋንቋ 1</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="am">ቋንቋ 2</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="am">ቋንቋ 3</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="am">ቋንቋዎች</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="am">የቋንቋ ዘየ</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="am">አስወግድ</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="am">የBloom ስብስብ ስም</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="am">ሀገር</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="am">ዲስትሪክት</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="am">የፕሮጀክት መረጃ</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="am">ክፍለ ሀገር</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="am">እንደገና ጀምር</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.deleteBook">
+      <trans-unit id="CollectionTab.BookMenu.deleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="am">መጽሐፍን ሰርዝ</target>
         <note>ID: CollectionTab.BookMenu.deleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="am">ስብስቦች</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="am">ስብስቦች</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <target xml:lang="am">ይህን ምንጭ በመጠቀም መጽሐፍ ያዘጋጁ</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="am">ሌላ ስብስብ</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="am">ናሙና ሽፍኖች /Shells/</target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="am">ቅንጅቶች</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="am">ምንጭ ስብስብ</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="am">ተጨማሪ የስብስቦች ዓቃፊን ይክፈቱ</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="am">ብጁዎች</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="am">ይህን መጽሐፍ አርትዕ</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <target xml:lang="am">የምንባብ ብጁን የBloom ጥቅል ያድርጉት...</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="am">ምንጭ ስብስብ</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="am">የአዳዲስ መጽሐፍት ምንጮች</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="am">ተጨማሪ...</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="am">ተወው</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="am">&amp;ተወው</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="am">&amp;እገዛ</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="am">ቀጣይ</target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="am">እሺ</target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="am">&amp;እሺ</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="am">በዚህ ክፍል ውስጥ ያሉ ፊደሎች</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="am">የፊደሎች እና የቃላት ዝርዝር ፋይልን ይክፈቱ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="am">ክፍሎችን አቀናጅ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="am">ክፍል</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="am">በዚህ ደረጃ ላይ ያሉ ቃላት</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="am">ይህ ገጽ በቋሚነት የሚወገድ ይሆናል</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <target xml:lang="am">ጽሑፍ</target>
         <note>ID: EditTab.CustomPage.Text</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <target xml:lang="am">የጽሑፍ ሳጥን</target>
         <note>ID: EditTab.CustomPage.TextBox</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="am">አርትዕ</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <target xml:lang="am">ቁምፊዎች</target>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <target xml:lang="am">ፍጠር</target>
         <note>ID: EditTab.FormatDialog.Create</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <target xml:lang="am"> ቅርፀ-ቁምፊ</target>
         <note>ID: EditTab.FormatDialog.Font</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <target xml:lang="am">በፊደላትና በቃላት መካከል ክፍት ቦታ አሰጣጥ</target>
         <note>ID: EditTab.FormatDialog.Spacing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <target xml:lang="am">ዘይቤ /Style/</target>
         <note>ID: EditTab.FormatDialog.Style</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <target xml:lang="am">የዘይቤ ስም</target>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="am">እጅግ ሰፊ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="am">መደበኛ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="am">ሰፊ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="am">የመጽሐፍ ርዕስ በ{ቋንቋ}</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="am">ምስል ቀይር</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="am">ምስልን ለጥፍ</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="am">ገጾች</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="am">ብጁ ገጾች</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="am">ፊደል ተራ</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="am">መሠረታዊ ጽሑፍ እና ስዕል</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="am">መሠረታዊ ጽሑፍ እና ስዕል</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="am">የክፍያ (ክሬዲትስ) ገጽ</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="am">ብጁ</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="am">የፊትለፊት ሽፋን</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="am">ምስል በግርጌ</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="am">ምስል በመሃል</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="am">የውስጥ የኋላ ሽፋን</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="am">ጽሑፍ ብቻ</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="am">ስዕል ብቻ</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="am">ስዕል ብቻ</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="am">የውጭ የኋላ ሽፋን</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="am">ስዕል በግርጌ</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="am">ስዕል በመሃል</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="am">የርዕስ ገጽ</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="am">ቅዳ</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="am">ቁረጥ</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="am">ገጽን\n አስወግድ</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="am">ገጽን\n አባዛ</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="am">ለጥፍ</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="am">አታድርግ</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="am">ሁለት ቋንቋዎች</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="am">አንድ ቋንቋ</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="am">ሦስት ቋንቋዎች</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="am">የአንባቢ ብጁዎችን መገንባት</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu">
+      <trans-unit id="HelpMenu.Help Menu" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="am">እገዛ</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="am">የአንባቢ ብጁዎችን መጠቀም</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="am">ለአዲስ ቅጅ ይፈትሹ</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="am">ስለ Bloom</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="am">Bloom {0}</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="am">ይህን በድጋሜ አታሳይ</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="am">ትክክለኛ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="am">ለዚህ ደረጃ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="am">ልብ ይበሉ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="am">ደረጃ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="am">ከፍተኛ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="am">በገጽ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="am">በዐረፍተ ነገር</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="am">ተተንባይነት</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="am">ደረጃዎችን አቀናጅ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="am">ይህ መጽሐፍ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="am">ይህ ገጽ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="am">ድምር</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="am">ልዩ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="am">ቃላት</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="am">የቃላት ቁጥር</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="am">ምንጭ ስብስብ</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="am">የዘየ /Vernacular/ ስብስብ</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="am">ሀገር</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="am">ዲስትሪክት</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="am">ክፍለ ሀገር</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="am">የፕሮጀክት ስም</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="am">ወደ Bloom  እንኳን በደህና መጡ</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="am">አዲስ ስብስብ ፍጠር</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="am">አትም</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="am">ቋንቋዎች</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="am">እባክዎ የአጠቃቀም ውሎችን ይቀበሉ</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="am">ርዕስ</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="am">ደረጃ አክል</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="am">ክፍል አክል</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="am">መጽሐፍ</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="am">ከድምጽ ጋር አዛምዶ የማንበቢያ ደረጃዎች</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="am">ፊደሎች</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="am">ፊደሎች እና የፊደሎች አሰካክ</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="am">ደረጃ</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="am">ደረጃ</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="am">የምንባብ ደረጃዎች</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="am">ገጽ</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="am">የምንባብ ደረጃዎች</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="am">ደረጃ {0}ን አስወግድ</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="am">ክፍል {0}ን አስወግድ</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="am">የበፊት እና አዳዲስ ፊደሎች</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="am">ዐረፈተ ነገር</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <target xml:lang="am">የፊደል ተራዎችን ለዚህ ቋንቋ አቀናጅ</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="am">አዲስ የእይታ ቃላት</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="am">የእይታ ቃላት</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="am">ክፍል</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="am">ክፍል</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="am">ክፍሎች</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="am">ለዚህ ደረጃ ሊታወሱ የሚገቡ ነገሮች</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="am">ልዩ</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <target xml:lang="am">ናሙና የጽሑፍ ዓቃፊ</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="am">ፊደሎች</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <target xml:lang="am">የBloom ጥቅልን አስቀምጥ</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <target xml:lang="am">የምንባብ ብጁን የBloom ጥቅል ያድርጉት</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <target xml:lang="am">ዝጋ</target>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="am">መሠረታዊ መጽሐፍ</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="am">ትልቅ መጽሐፍ</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="am">ከድምጽ ጋር ተዛምዶ የሚነበብ</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="am">በደረጃ የተከፋፈለ ምንባብ</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>

--- a/DistFiles/localization/ar/Bloom.xlf
+++ b/DistFiles/localization/ar/Bloom.xlf
@@ -2,3491 +2,3491 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="ar" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="BloomIntegrity.WindowTitle">
+      <trans-unit id="BloomIntegrity.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom Problem</source>
         <target xml:lang="ar">مشكلة في Bloom</target>
         <note>ID: BloomIntegrity.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="BloomIntegrityDialog.ReportProblem">
+      <trans-unit id="BloomIntegrityDialog.ReportProblem" approved="yes">
         <source xml:lang="en">Report Problem</source>
         <target xml:lang="ar">الإبلاغ عن مشكلة</target>
         <note>ID: BloomIntegrityDialog.ReportProblem</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName">
+      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName" approved="yes">
         <source xml:lang="en">Possibly this is an old Bloom Pack created before Bloom Packs could handle special characters in file names. You may be able to get the author to re-create it using a current version. If that's not possible a technical expert may be able to repair things.</source>
         <target xml:lang="ar">من المحتمل أن تكون هذه حزمة Bloom قديمة وتم إنشاؤها قبل تمكين الحزم من التعامل مع الأحرف الخاصة في أسماء الملفات. يمكنك أن تطلب من المؤلف إعادة إنشائها باستخدام إصدار حديث. إذا لم تتمكن من ذلك، فيمكنك الاستعانة بخبير فني لحل المشكلة. </target>
         <note>ID: BloomPackInstallDialog.BadCharsInFileName</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="ar">تثبيت حزمة Bloom</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="ar">مجموعة {0} الآن جاهزة للاستخدام على هذا الكمبيوتر.</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller" approved="yes">
         <source xml:lang="en">Bloom Pack Installer</source>
         <target xml:lang="ar">أداة تثبيت حزمة Bloom</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstaller</note>
         <note>Displayed as the message box title</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack">
+      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack" approved="yes">
         <source xml:lang="en">This BloomPack appears to be incomplete or corrupt.</source>
         <target xml:lang="ar">تبدو حزمة Bloom هذه غير مكتملة أو تالفة.</target>
         <note>ID: BloomPackInstallDialog.CorruptBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.DoesNotExist">
+      <trans-unit id="BloomPackInstallDialog.DoesNotExist" approved="yes">
         <source xml:lang="en">{0} does not exist</source>
         <target xml:lang="ar">لا يوجد {0}</target>
         <note>ID: BloomPackInstallDialog.DoesNotExist</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="ar">لم يتمكن Bloom من تثبيت هذه الحزمة من Bloom </target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="ar">جارٍ الاستخلاص…</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while Bloom Packs are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="ar">جارٍ الآن تشغيل Bloom، إلا أن المحتويات لن تظهر إلى أن يتم تشغيل Bloom مرة أخرى</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.NotInstalled">
+      <trans-unit id="BloomPackInstallDialog.NotInstalled" approved="yes">
         <source xml:lang="en">The Bloom collection will not be installed.</source>
         <target xml:lang="ar">لن يتم تثبيت مجموعة Bloom.</target>
         <note>ID: BloomPackInstallDialog.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="ar">جارٍ فتح {0}…</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Replace">
+      <trans-unit id="BloomPackInstallDialog.Replace" approved="yes">
         <source xml:lang="en">This computer already has a Bloom collection named '{0}'. Do you want to replace it with the one from this Bloom Pack?</source>
         <target xml:lang="ar">يحتوي هذا الكمبيوتر على مجموعة Bloom تحمل الاسم '{0}'. هل تريد استبدالها بالمجموعة المضمَّنة في حزمة Bloom هذه؟ </target>
         <note>ID: BloomPackInstallDialog.Replace</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder">
+      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder" approved="yes">
         <source xml:lang="en">Bloom Packs should have only a single collection folder at the top level of the .ZIP file.</source>
         <target xml:lang="ar">يجب ألا تحتوي حِزم Bloom على أكثر من مجلد مجموعة واحد في أعلى الملف .ZIP.</target>
         <note>ID: BloomPackInstallDialog.SingleCollectionFolder</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.UnableToReplace">
+      <trans-unit id="BloomPackInstallDialog.UnableToReplace" approved="yes">
         <source xml:lang="en">Bloom was not able to remove the existing copy of '{0}'. Quit Bloom if it is running &amp; try again. Otherwise, try again after restarting your computer.</source>
         <target xml:lang="ar">لم يتمكن Bloom من إزالة النسخة الحالية من '{0}'. يُرجى الخروج من Bloom إذا كان في وضعية التشغيل، و إعادة المحاولة. أو حاول مرة أخرى بعد إعادة تشغيل الكمبيوتر. </target>
         <note>ID: BloomPackInstallDialog.UnableToReplace</note>
       </trans-unit>
-      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true">
+      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To select, use your mouse wheel or point at what you want, then release the key.</source>
         <target xml:lang="ar">للتحديد، يمكنك استخدام بكرة الماوس أو ضع المؤشر على ما تريد ثم حرِّر المفتاح.</target>
         <note>ID: BookEditor.CharacterMap.Instructions</note>
         <note>When you hold down a key, a popup appears that lets you choose a related character. These instructions are shown in that popup.</note>
       </trans-unit>
-      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is the default for all text boxes with '{0}' style.</source>
         <target xml:lang="ar">هذا التنسيق هو الخيار الافتراضي لجميع مربعات النصوص التي تحتوي على النمط '{0}'.</target>
         <note>ID: BookEditor.DefaultForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all text boxes with '{0}' style.</source>
         <target xml:lang="ar">هذا التنسيق لجميع مربعات النصوص ذات النمط '{0}'.</target>
         <note>ID: BookEditor.ForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text boxes with '{1}' style.</source>
         <target xml:lang="ar">هذا التنسيق لجميع مربعات النصوص {0} ذات النمط '{1}'.</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true">
+      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sorry, Reader Templates do not allow changes to formatting.</source>
         <target xml:lang="ar">عذراً، لا تسمح نماذج القارئ بإدخال تغييرات على التنسيق.</target>
         <note>ID: BookEditor.FormattingDisabled</note>
       </trans-unit>
-      <trans-unit id="BookStorage.FolderMoved">
+      <trans-unit id="BookStorage.FolderMoved" approved="yes">
         <source xml:lang="en">It appears that some part of the folder path to this book has been moved or renamed. As a result, Bloom cannot save your changes to this page, and will need to exit now. If you haven't been renaming or moving things, please click Details below and report the problem to the developers.</source>
         <target xml:lang="ar">يبدو أنه تم نقل جزء من مسار الملف إلى هذا الكتاب أو تمت إعادة تسميته. نتيجة لذلك، لن يتمكن Bloom من حفظ التغيرات على هذه الصفحة، وسيقوم بالخروج الآن. إذا لم تكن قد نقلت شيئاً أو أعدت تسميته، فيُرجى النقر على "التفاصيل" أدناه وإبلاغ مطوِّري البرنامج بالمشكلة. </target>
         <note>ID: BookStorage.FolderMoved</note>
       </trans-unit>
-      <trans-unit id="Browser.CopyTroubleshootingInfo">
+      <trans-unit id="Browser.CopyTroubleshootingInfo" approved="yes">
         <source xml:lang="en">Copy Troubleshooting Information</source>
         <target xml:lang="ar">نسخ معلومات تحرّي الخلل وإصلاحه</target>
         <note>ID: Browser.CopyTroubleshootingInfo</note>
       </trans-unit>
-      <trans-unit id="Browser.OpenPageInFirefox">
+      <trans-unit id="Browser.OpenPageInFirefox" approved="yes">
         <source xml:lang="en">Open Page in Firefox (which must be in the PATH environment variable).</source>
         <target xml:lang="ar">افتح "صفحة" في Firefox (يجب أن تكون في متغير بيئة PATH).</target>
         <note>ID: Browser.OpenPageInFirefox</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="ar">إعدادات البرنامج المتقدمة</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate" approved="yes">
         <source xml:lang="en">Automatically update Bloom</source>
         <target xml:lang="ar">تحديث Bloom تلقائياً</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AutoUpdate</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="ar">إظهار "الأوامر التجريبية" (مثل تصدير تنسيق XML في InDesign)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="ar">إظهار "القوالب التجريبية" (مثل القاموس المصور)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="ar">(تجريبي) إظهار عناصر التحكم في الإرسال/الاستقبال</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="ar">استخدام خادم الصور للحد من حجم الذاكرة عند استخدام صور كبيرة.</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom is switching the default font for "{0}" to the new "Andika New Basic".</source>
         <target xml:lang="ar">يقوم Bloom بتبديل الخط الافتراضي في "{0}" إلى "Andika New Basic".</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate1</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This will improve the printed output for most languages. If your language is one of the few that need "Andika", you can switch it back in Settings:Book Making.</source>
         <target xml:lang="ar">سيحسن هذا النتيجة المطبوعة لمعظم اللغات.إذا كانت لغتك واحدة من اللغات المعدودة التي تحتاج إلى "Andika"، فيمكنك اختياره مرة أخرى من "الإعدادات:إعداد الكتاب".</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate2</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="ar">إعداد الكتاب</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="ar">الخط الافتراضي ل {0}</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="ar">حزمة المحتوى الأمامي/الخلفي</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="ar">توفير الورق</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver</note>
         <note>Name of a Front/Back Matter Pack that puts credits on the inside of the front cover</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="ar">تقليدي</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional</note>
         <note>Name of the default Front/Back Matter Pack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="ar">نظام الكتابة من اليمين إلى اليسار</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink" approved="yes">
         <source xml:lang="en">Special Script Settings</source>
         <target xml:lang="ar">إعدادات النصوص الخاصة</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="ar">الإعدادات</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="ar">تغيير…</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="ar">اللغة 1</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="ar">اللغة 2</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="ar">اللغة 3</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="ar">اللغات</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="ar">إزالة</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="ar">تعيين…</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="ar">اللغة العامية</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="ar">اللغة 2 (مثل اللغة المحلية)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="ar">اللغة 3 (مثل اللغة الإقليمية) (اختياري)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="ar">اسم مجموعة Bloom</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="ar">البلد</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="ar">المنطقة</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="ar">معلومات المشروع</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="ar">المقاطعة</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="ar">إعادة التشغيل</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="ar">سيقوم Bloom بإغلاق وإعادة فتح هذا المشروع مع تطبيق الإعدادات الجديدة.</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <target xml:lang="ar">إنشاء قالب كتاب في حزمة Bloom…</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdminManagesUpdates">
+      <trans-unit id="CollectionTab.AdminManagesUpdates" approved="yes">
         <source xml:lang="en">Your system administrator manages Bloom updates for this computer.</source>
         <target xml:lang="ar">يدير مشرف النظام تحديثات Bloom لهذا الكمبيوتر.</target>
         <note>ID: CollectionTab.AdminManagesUpdates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="ar">متقدم</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Applying">
+      <trans-unit id="CollectionTab.Applying" approved="yes">
         <source xml:lang="en">Applying updates</source>
         <target xml:lang="ar">تطبيق التحديثات</target>
         <note>ID: CollectionTab.Applying</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="ar">احصل على المزيد من الكتب المرجعية في BloomLibrary.org</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ar">المجموعة المرجعية</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DuplicateBook">
+      <trans-unit id="CollectionTab.BookMenu.DuplicateBook" approved="yes">
         <source xml:lang="en">Duplicate Book</source>
         <target xml:lang="ar">نسخ الكتاب</target>
         <note>ID: CollectionTab.BookMenu.DuplicateBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="ar">حذف الكتاب</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book. These programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="ar">سيفتح Bloom مستند  في برنامج معالجة الكلمات الذي تستخدمه (عادة Word أو LibreOffice). سيكون بإمكانك العمل على النصوص والصور في هذا الكتاب. لا تعمل هذه البرامج لا تعمل بشكل فعال عند حماية التصميم، لذا لا تبالغ في التوقعات. </target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="ar">التصدير إلى Word أو LibreOffice…</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="ar">التصدير بتنسيق XML في InDesign…</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="ar">تحديث الكتاب</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="ar">تحديث الصورة المصغرة</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="ar">موارد لكتب جديدة</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="ar">هذه المجموعة مقفولة، ولذلك لا يمكن إضافة كتب جديدة أو إزالتها.</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="ar">كتب من BloomLibrary.org</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="ar">قم بتحديث جميع الكتب</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="ar">قم بالتحقق من جميع الكتب</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="ar">استرداد الصور المفقودة…</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="ar">سجل المجموعة…</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="ar">ملاحظات المجموعة…</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="ar">المجموعات</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="ar">المجموعات</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="ar">جارٍ التصميم…</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="ar">الكتاب '{0}'</target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="ar">فتح مجلد على القرص</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="ar">تحرير هذا الكتاب</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="ar">الصحة</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="ar">نظراً لأن هذه مجموعة مرجعية، لن يقدم Bloom أي هياكل أولية حالية كموارد لهياكل أولية جديدة. إذا كنت تريد إضافة لغة إلى هيكل أولي، فستحتاج إلى تحرير المجموعة التي تحتوي على الهيكل الأولي، بدلاً من إعداد نسخة منها. كذلك، لا يمكن استخدام تقويم الحائط لإعداد هيكل أولي جديد في الوقت الحالي. </target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="ar">إعداد حزمة Bloom</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source.</source>
         <target xml:lang="ar">إعداد كتاب باستخدام هذا المورد.</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_" approved="yes">
         <source xml:lang="en">Create a book in my language using this source book.</source>
         <target xml:lang="ar">إنشاء كتاب بلغتي باستخدام هذا الكتاب المرجعي.</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate_ToolTip_</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="ar">المزيد…</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="ar">مجموعة أخرى</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_" approved="yes">
         <source xml:lang="en">Open/Create/Get Collection</source>
         <target xml:lang="ar">فتح/إنشاء/الحصول على مجموعة</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton_ToolTip_</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem">
+      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem" approved="yes">
         <source xml:lang="en">Open or Create Another Collection</source>
         <target xml:lang="ar">فتح أو إنشاء مجموعة أخرى </target>
         <note>ID: CollectionTab.OpenCreateCollectionMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="ar">نماذج هيكل</target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="ar">إرسال/استقبال</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="ar">الإعدادات</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ar">المجموعة المرجعية</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="ar">فتح مجلد مجموعات إضافية</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="ar">موارد لهياكل جديدة</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="ar">نماذج</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.TitleMissing">
+      <trans-unit id="CollectionTab.TitleMissing" approved="yes">
         <source xml:lang="en">Title Missing</source>
         <target xml:lang="ar">العنوان مفقود</target>
         <note>ID: CollectionTab.TitleMissing</note>
         <note>Shown as the thumbnail caption when the book doesn't have a title.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UnableToCheckForUpdate">
+      <trans-unit id="CollectionTab.UnableToCheckForUpdate" approved="yes">
         <source xml:lang="en">Could not connect to the server to check for an update. Are you connected to the internet?</source>
         <target xml:lang="ar">تعذر عن الاتصال بالخادم للبحث عن تحديث. هل لديك اتصال بالإنترنت؟</target>
         <note>ID: CollectionTab.UnableToCheckForUpdate</note>
         <note>Shown when Bloom tries to check for an update but can't, for example because it can't connect to the internet, or a problems with our server, etc.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpToDate">
+      <trans-unit id="CollectionTab.UpToDate" approved="yes">
         <source xml:lang="en">Your Bloom is up to date.</source>
         <target xml:lang="ar">برنامج Bloom الذي تستخدمه محدث.</target>
         <note>ID: CollectionTab.UpToDate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateCheckInProgress">
+      <trans-unit id="CollectionTab.UpdateCheckInProgress" approved="yes">
         <source xml:lang="en">Bloom is already working on checking for updates.</source>
         <target xml:lang="ar">برنامج Bloom بصدد البحث عن تحديثات.</target>
         <note>ID: CollectionTab.UpdateCheckInProgress</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateFailed">
+      <trans-unit id="CollectionTab.UpdateFailed" approved="yes">
         <source xml:lang="en">A new version appears to be available, but Bloom could not install it.</source>
         <target xml:lang="ar">يبدو أن هناك إصداراً جديداً، ولكن Bloom غير قادر على تثبيته.</target>
         <note>ID: CollectionTab.UpdateFailed</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateInstalled">
+      <trans-unit id="CollectionTab.UpdateInstalled" approved="yes">
         <source xml:lang="en">Update for {0} is ready.</source>
         <target xml:lang="ar">تحديث {0} جاهز الآن.</target>
         <note>ID: CollectionTab.UpdateInstalled</note>
         <note>Appears after Bloom has downloaded a program update in the background and is ready to switch the user to it the next time they run Bloom.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateNow">
+      <trans-unit id="CollectionTab.UpdateNow" approved="yes">
         <source xml:lang="en">Update Now</source>
         <target xml:lang="ar">التحديث الآن</target>
         <note>ID: CollectionTab.UpdateNow</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdatesAvailable">
+      <trans-unit id="CollectionTab.UpdatesAvailable" approved="yes">
         <source xml:lang="en">A new version of Bloom is available.</source>
         <target xml:lang="ar">يتوفر إصدار جديد من Bloom.</target>
         <note>ID: CollectionTab.UpdatesAvailable</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Updating">
+      <trans-unit id="CollectionTab.Updating" approved="yes">
         <source xml:lang="en">Downloading update to {0} ({1}kb).</source>
         <target xml:lang="ar">جارٍ تنزيل التحديث إلى {0} ({1} كيلوبايت).</target>
         <note>ID: CollectionTab.Updating</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="ar">رجوع</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="ar">إلغاء</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="ar">إل&amp;غاء</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="ar">إ&amp;نهاء</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.Help" sil:dynamic="true">
+      <trans-unit id="Common.Help" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="ar">مساعدة</target>
         <note>ID: Common.Help</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="ar">&amp;مساعدة</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Loading" sil:dynamic="true">
+      <trans-unit id="Common.Loading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Loading...</source>
         <target xml:lang="ar">جارٍ التحميل…</target>
         <note>ID: Common.Loading</note>
         <note>This is shown when Bloom is slowly loading something, so the user doesn't worry about why they don't see the result immediately.</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="ar">ال&amp;تالي</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="ar">التالي</target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="ar">موافق</target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="ar">م&amp;وافق</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="ar">اختياري</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections.</source>
         <target xml:lang="ar">اكتمل تنزيل ({0}).يمكنك الاطلاع عليه في قسم "كتب من BloomLibrary.org" ضمن مجموعاتك.</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="ar">اكتمل التنزيل</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.CopyFailed">
+      <trans-unit id="Download.CopyFailed" approved="yes">
         <source xml:lang="en">Bloom downloaded the book but had problems making it available in Bloom. Please restart your computer and try again. If you get this message again, please click the 'Details' button and report the problem to the Bloom developers.</source>
         <target xml:lang="ar">قام Bloom بتنزيل الكتاب ولكن هناك مشكلات في إتاحته على Bloom. الرجاء إعادة تشغيل الكمبيوتر والمحاولة مرة أخرى. إذا ظهرت هذه الرسالة مرة أخرى، فيُرجى النقر على زر "التفاصيل" وإبلاغ مطوِّري برنامج Bloom بالمشكلة. </target>
         <note>ID: Download.CopyFailed</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="ar">جارٍ تنزيل الكتاب</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="ar">يوجد مشكلة في تنزيل الكتاب.</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="ar">يوجد مشكلة في تنزيل الكتاب. قد تحتاج إلى إعادة تشغيل Bloom أو الحصول على مساعدة فنية. </target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.TimeoutProblemNotice">
+      <trans-unit id="Download.TimeoutProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading the book: something took too long. You can try again at a different time, or write to us at issues@BloomLibrary.org if you cannot get the download to work from your location.</source>
         <target xml:lang="ar">يوجد مشكلة في تنزيل الكتاب: أمر ما يستغرق وقتاً طويلاً. يمكنك إعادة المحاولة في وقت آخر، أو قم بمراسلتنا على العنوان issues@BloomLibrary.org إذا لم تتمكن من تشغيل التنزيل من موقعك. </target>
         <note>ID: Download.TimeoutProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddPageButton">
+      <trans-unit id="EditTab.AddPageDialog.AddPageButton" approved="yes">
         <source xml:lang="en">Add Page</source>
         <target xml:lang="ar">إضافة صفحة</target>
         <note>ID: EditTab.AddPageDialog.AddPageButton</note>
         <note>This is for the button that LAUNCHES the dialog, not the "Add this page" button that is IN the dialog.</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add This Page</source>
         <target xml:lang="ar">إضافة هذه الصفحة</target>
         <note>ID: EditTab.AddPageDialog.AddThisPageButton</note>
         <note>This is for the button inside the dialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use This Layout</source>
         <target xml:lang="ar">استخدام هذا التصميم</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Continue anyway</source>
         <target xml:lang="ar">المتابعة على أي حال</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutContinueCheckbox</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose Different Layout...</source>
         <target xml:lang="ar">اختيار تصميم آخر</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Converting to this layout will cause some content to be lost.</source>
         <target xml:lang="ar">التحويل لهذا التصميم سيؤدي إلى فقدان بعض المحتويات.</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutWillLoseData</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Page...</source>
         <target xml:lang="ar">إضافة صفحة…</target>
         <note>ID: EditTab.AddPageDialog.Title</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="ar">إذا كنت تريد مكاناً لوضع معلومات إضافية حول الكتاب، فيمكنك استخدام هذه الصفحة، وهي التي تظهر داخل الغلاف الخلفي للكتاب.</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="ar">إذا كنت تريد مكاناً لوضع معلومات إضافية حول الكتاب، فيمكنك استخدام هذه الصفحة، وهي التي تظهر داخل الغلاف الخلفي للكتاب.</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Background</source>
         <target xml:lang="ar">الخلفية</target>
         <note>ID: EditTab.TextBoxProperties.Background</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="ar">لغتان</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the HTML used to make this PDF, in Firefox (must be on path)</source>
         <target xml:lang="ar">افتح HTML المستخدم لإعداد PDF، في Firefox (يجب أن يكون على المسار)</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="ar">عذراً، لا يمكن تغيير حقوق الطبع والنشر والترخيص لهذا الكتاب.</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="ar">عذراً، تم قفل هذا الكتاب لغرض عدم تغيير الصور.</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ChooseLayoutButton">
+      <trans-unit id="EditTab.ChooseLayoutButton" approved="yes">
         <source xml:lang="en">Choose Different Layout</source>
         <target xml:lang="ar">اختيار تصميم آخر</target>
         <note>ID: EditTab.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="ar">هل تريد تأكيد حذف الصفحة؟</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="ar">&amp;حذف</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="ar">سيتم حذف هذه الصفحة بشكل دائم.</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="ar">إعدادات تعدد اللغات</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip">
+      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip" approved="yes">
         <source xml:lang="en">Choose language to make this a bilingual or trilingual book</source>
         <target xml:lang="ar">اختر لغة ليصبح هذا الكتاب ثنائي أو ثلاثي اللغة</target>
         <note>ID: EditTab.ContentLanguagesDropdown.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="ar">نسخ</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTip">
+      <trans-unit id="EditTab.CopyButton.ToolTip" approved="yes">
         <source xml:lang="en">Copy (Ctrl+C)</source>
         <target xml:lang="ar">نسخ (Ctrl+C)</target>
         <note>ID: EditTab.CopyButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can copy it</source>
         <target xml:lang="ar">يلزمك تحديد نص حتى تتمكن من نسخه</target>
         <note>ID: EditTab.CopyButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="ar">هل تريد نسخ هذه المعلومات إلى جميع الصور الأخرى في هذا الكتاب؟</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="ar">تغيير التخطيط</target>
         <note>ID: EditTab.CustomPage.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> or </source>
         <target xml:lang="ar"> أو </target>
         <note>ID: EditTab.CustomPage.Or</note>
         <note>Shown between 'Picture' and 'Text' when Custom Page is in Layout mode</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture</source>
         <target xml:lang="ar">الصورة</target>
         <note>ID: EditTab.CustomPage.Picture</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <target xml:lang="ar">النص</target>
         <note>ID: EditTab.CustomPage.Text</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <target xml:lang="ar">مربع النص</target>
         <note>ID: EditTab.CustomPage.TextBox</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="ar">قص</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTip">
+      <trans-unit id="EditTab.CutButton.ToolTip" approved="yes">
         <source xml:lang="en">Cut (Ctrl+X)</source>
         <target xml:lang="ar">قص (Ctrl+X)</target>
         <note>ID: EditTab.CutButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can cut it</source>
         <target xml:lang="ar">يلزمك تحديد نص حتى تتمكن من قصه</target>
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="ar">إزالة\n الصفحة</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTip">
+      <trans-unit id="EditTab.DeletePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Remove this page from the book</source>
         <target xml:lang="ar">إزالة هذه الصفحة من الكتاب</target>
         <note>ID: EditTab.DeletePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be removed</source>
         <target xml:lang="ar">لا يمكن إزالة هذه الصفحة</target>
         <note>ID: EditTab.DeletePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="ar">تكرار\n الصفحة</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
         <target xml:lang="ar">إدراج صفحة جديدة طبق الأصل لهذه الصفحة</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be duplicated</source>
         <target xml:lang="ar">لا يمكن تكرار هذه الصفحة</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="ar">تحرير</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true">
+      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot change these because this is not the original copy.</source>
         <target xml:lang="ar">لا يمكنك تغيير ذلك لأنها ليست النسخة الأصلية.</target>
         <note>ID: EditTab.EditNotAllowed</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord" approved="yes">
         <source xml:lang="en">Sight Word</source>
         <target xml:lang="ar">كلمة بصرية</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable" approved="yes">
         <source xml:lang="en">This word is not decodable in this stage.</source>
         <target xml:lang="ar">هذه الكلمة ليست قابلة للتفكيك في هذه المرحلة.</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true">
+      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This sentence is too long for this level.</source>
         <target xml:lang="ar">هذه الجملة طويلة جداً لهذا المستوى.</target>
         <note>ID: EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong</note>
       </trans-unit>
-      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true">
+      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This page is an experimental prototype which may have many problems, for which we apologize.</source>
         <target xml:lang="ar">نعتذر! هذه الصفحة تُعد نموذجاً تجريبياً و قد تحتوي على عدة مشكلات.</target>
         <note>ID: EditTab.ExperimentalNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="ar">الخط المحدد حاليا هو '{0}'، ولكنه غير مثبَّت على هذا الكمبيوتر.سيتم استخدام خط آخر.</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true" approved="yes">
         <source xml:lang="en">That style already exists. Please choose another name.</source>
         <target xml:lang="ar">هذا النمط موجود بالفعل.الرجاء اختيار اسم آخر.</target>
         <note>ID: EditTab.FormatDialog.AlreadyExists</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="ar">تغيير الحد والخلفية</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <target xml:lang="ar">أحرف</target>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <target xml:lang="ar">إنشاء</target>
         <note>ID: EditTab.FormatDialog.Create</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create a new style</source>
         <target xml:lang="ar">إنشاء نمط جديد</target>
         <note>ID: EditTab.FormatDialog.CreateStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Don't see what you need?</source>
         <target xml:lang="ar">ألا ترى ما تريد؟ </target>
         <note>ID: EditTab.FormatDialog.DontSeeNeed</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Emphasis</source>
         <target xml:lang="ar">تأكيد</target>
         <note>ID: EditTab.FormatDialog.Emphasis</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <target xml:lang="ar">الخط</target>
         <note>ID: EditTab.FormatDialog.Font</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="ar">تغيير واجهة الخط</target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="ar">تغيير حجم النص في جميع المربعات التي تحتوي على النمط '{0}' واللغة '{1}'.\nالحجم الحالي {2} نقطة.</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="ar">تغيير حجم الخط</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Format</source>
         <target xml:lang="ar">التنسيق</target>
         <note>ID: EditTab.FormatDialog.Format</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="ar">تغيير المسافات بين أسطر النص</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New style</source>
         <target xml:lang="ar">نمط جديد</target>
         <note>ID: EditTab.FormatDialog.NewStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please use only alphabetical characters. Numbers at the end are ok, as in "part2".</source>
         <target xml:lang="ar">الرجاء استخدام أحرف هجائية فقط. لا يوجد مشكلة في الأرقام التي تظهر في النهاية، كما في "part2". </target>
         <note>ID: EditTab.FormatDialog.PleaseUseAlpha</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <target xml:lang="ar">المسافات</target>
         <note>ID: EditTab.FormatDialog.Spacing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <target xml:lang="ar">النمط</target>
         <note>ID: EditTab.FormatDialog.Style</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <target xml:lang="ar">اسم النمط</target>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="ar">عرض إضافي</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="ar">طبيعي</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="ar">تغيير المسافات بين الكلمات</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="ar">عريض</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="ar">ضبط التنسيق للنمط</target>
         <note>ID: EditTab.FormatDialogTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="ar">يمكنك استخدام هذه المسافة للمؤلف/الرسام، أو لغرض آخر.</target>
         <note>ID: EditTab.FrontMatter.AuthorIllustratorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="ar">عند إعداد كتاب أصلي، استخدام هذا المربع لتسجيل المساهمات التي قدمها الكُتاب والرسامون والمحررون وما إلى ذلك.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="ar">عند إعداد كتاب من هيكل، يمكنك استخدام هذا المربع للتعريف بمن قام بالترجمة.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="ar">عنوان الكتاب بـ {lang}</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright and License</source>
         <target xml:lang="ar">انقر لتحرير حقوق الطبع والنشر والترخيص</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="ar">استخدام هذا لتوجيه الشكر لأي مؤسسات تمويلية.</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="ar">الرقم الدولي المعياري للكتاب. اتركه فارغاً في حال لا يوجد لديك واحدة منها. </target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.</source>
         <target xml:lang="ar">إذا كنت تريد وضع معلومات إضافية حول الكتاب، فيمكنك استخدام هذه الصفحة، وهي الصفحة التي تظهر داخل الغلاف الأمامي للكتاب.</target>
         <note>ID: EditTab.FrontMatter.InsideFrontCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Name of Translator, in {lang}</source>
         <target xml:lang="ar">اسم المترجم، في {lang}</target>
         <note>ID: EditTab.FrontMatter.NameofTranslatorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="ar">كلمات الشكر الأصلية (أو في الهيكل) في {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="ar">المساهمات التي قدمها الكتاب و الرسامين والمحررين وما إلى ذلك في {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="ar">انقر لاختيار موضوع</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="ar">كلمات الشكر في الإصدار المترجم، في {lang}</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.HowToUnlockBook">
+      <trans-unit id="EditTab.HowToUnlockBook" approved="yes">
         <source xml:lang="en">To unlock this shellbook, go into the toolbox on the right, find the gear icon, and click 'Allow changes to this shellbook'.</source>
         <target xml:lang="ar">لإلغاء قفل هيكل الكتاب هذا، يمكنك النقر على صندوق الأدوات جهة اليمين، والبحث عن رمز الترس، والنقر على "السماح بالتغييرات على هيكل الكتاب هذا".</target>
         <note>ID: EditTab.HowToUnlockBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="ar">تغيير الصورة</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Copy Image</source>
         <target xml:lang="ar">نسخ الصورة</target>
         <note>ID: EditTab.Image.CopyImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cut Image</source>
         <target xml:lang="ar">قص الصورة</target>
         <note>ID: EditTab.Image.CutImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, and License</source>
         <target xml:lang="ar">تحرير المساهمين في العمل وحقوق الطبع والنشر والترخيص للصورة</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="ar">لصق الصورة</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse">
+      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse" approved="yes">
         <source xml:lang="en">Cancel this import</source>
         <target xml:lang="ar">إلغاء هذا الاستيراد</target>
         <note>ID: EditTab.JpegWarningDialog.DoNotUse</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.Photograph">
+      <trans-unit id="EditTab.JpegWarningDialog.Photograph" approved="yes">
         <source xml:lang="en">Use the JPEG file</source>
         <target xml:lang="ar">استخدام الملف JPEG</target>
         <note>ID: EditTab.JpegWarningDialog.Photograph</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WarningText">
+      <trans-unit id="EditTab.JpegWarningDialog.WarningText" approved="yes">
         <source xml:lang="en">The file you’ve chosen is a “JPEG” file. JPEG files are perfect for photographs and color artwork. However, JPEG files are a big problem for black and white line art. Problems include:\n• Fuzziness and grey dots.\n• Large file sizes, making the book hard to share.\n• If there are many large JPEGs, Bloom may not have enough memory to make PDF files.\n\nNote: Because JPEG is “lossy”, converting a JPEG to PNG, TIFF, or BMP actually makes things even worse. If this is black and white line art, you want to get an original scan in one of those formats.\n\nPlease select from one of the following, then click “OK”:</source>
         <target xml:lang="ar">الملف الذي اخترته  هو ملف "JPEG". تُعد ملفات JPEG مثالية للصور والأعمال الفنية الملونة. ولكن، تُمثل ملفات JPEG مشكلة كبيرة للرسم الخطي الأسود والأبيض. من بين المشكلات:\n• النقاط الضبابية والرمادية.\n• تُشكل الملفات الكبيرة صعوبة في مشاركة الكتاب.\n• إذا كان هناك الكثير من JPEG كبيرة، فقد لا يوجد في Bloom ذاكرة كافية لإعداد ملفات PDF.\n\nملاحظة: لأن JPEG ملف مضغوط، تحويل JPEG إلى PNG أو TIFF أو BMP سيؤدي إلى فقدان بعض البيانات و بالتالي النتيجة ستكون أسوأ.إذا كان هذا رسماً خطياً بالأسود والأبيض، يتوجب عليك الحصول على نسخة ضوئية أصلية بأحد هذه التنسيقات.\n\nيُرجى اختيار واحدة مما يلي، ثم انقر على "موافق":</target>
         <note>ID: EditTab.JpegWarningDialog.WarningText</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle">
+      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle" approved="yes">
         <source xml:lang="en">JPEG Warning</source>
         <target xml:lang="ar">JPEG تحذير</target>
         <note>ID: EditTab.JpegWarningDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="ar">يتوفر هذا الخيار في علامة التبويب "نشر" فقط.</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="ar">تغيير التصميم</target>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="ar">لغة واحدة</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NewBookName">
+      <trans-unit id="EditTab.NewBookName" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="ar">الكتاب</target>
         <note>ID: EditTab.NewBookName</note>
         <note>Default file and folder name when you make a new book, but haven't give it a title yet.</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="ar">حتى تتمكن من لصق صورة ما، انسخ صورة واحدة في "الحافظة" من برنامج آخر.</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="ar">لا تتوفر خيارات تصميم أخرى لهذا القالب.</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Overflow" sil:dynamic="true">
+      <trans-unit id="EditTab.Overflow" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This box has more text than will fit</source>
         <target xml:lang="ar">يحتوي هذا المربع على نص أكبر من سعته</target>
         <note>ID: EditTab.Overflow</note>
       </trans-unit>
-      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true">
+      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A container on this page is overflowing</source>
         <target xml:lang="ar">هناك تدفق زائد في حاوية على هذه الصفحة</target>
         <note>ID: EditTab.OverflowContainer</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are.</source>
         <target xml:lang="ar">هذا التغيير غير مسموح به. يجب المحافظة على مكان صفحات المحتوى الأمامي والخلفي. </target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="ar">عملية نقل غير صالحة</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="ar">الصفحات</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="ar">اختار حجم واتجاه صفحة</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="ar">لصق</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTip">
+      <trans-unit id="EditTab.PasteButton.ToolTip" approved="yes">
         <source xml:lang="en">Paste (Ctrl+V)</source>
         <target xml:lang="ar">لصق (Ctrl+V)</target>
         <note>ID: EditTab.PasteButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing on the Clipboard that you can paste here.</source>
         <target xml:lang="ar">لا يوجد شيء في "الحافظة" يمكنك لصقه هنا.</target>
         <note>ID: EditTab.PasteButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Position" sil:dynamic="true">
+      <trans-unit id="EditTab.Position" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Position</source>
         <target xml:lang="ar">الموضع</target>
         <note>ID: EditTab.Position</note>
       </trans-unit>
-      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true">
+      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot put anything in there while making an original book.</source>
         <target xml:lang="ar">لا يمكنك وضع أي شيء هنا أثناء إعداد كتاب أصلي.</target>
         <note>ID: EditTab.ReadOnlyInAuthorMode</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="ar">تغيير الحد والخلفية</target>
         <note>ID: EditTab.StyleEditor.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="ar">تغيير واجهة الخط</target>
         <note>ID: EditTab.StyleEditor.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="ar">تغيير حجم الخط</target>
         <note>ID: EditTab.StyleEditor.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="ar">تغيير المسافات بين أسطر النص</target>
         <note>ID: EditTab.StyleEditor.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="ar">عرض إضافي</target>
         <note>ID: EditTab.StyleEditor.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="ar">طبيعي</target>
         <note>ID: EditTab.StyleEditor.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="ar">تغيير المسافات بين الكلمات</target>
         <note>ID: EditTab.StyleEditor.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="ar">عريض</target>
         <note>ID: EditTab.StyleEditor.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="ar">ضبط التنسيق للنمط</target>
         <note>ID: EditTab.StyleEditorTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="ar">صفحات النموذج</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom">
+      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom" approved="yes">
         <source xml:lang="en">Picture On Bottom</source>
         <target xml:lang="ar">صورة في الأسفل</target>
         <note>ID: EditTab.ThumbnailCaptions.Picture On Bottom</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="ar">المعلومات المتعلقة بالملكية الفكرية للصورة</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="ar">أداة قراءة المراحل التعليمية </target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom can handle only the first {0} words.</source>
         <target xml:lang="ar">بإمكان Bloom التعامل مع أولى كلمات {0} فقط.</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed words in this stage</source>
         <target xml:lang="ar">الكلمات المسموح بها في هذه المرحلة</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles" approved="yes">
         <source xml:lang="en">Text files</source>
         <target xml:lang="ar">ملفات النصوص</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters" approved="yes">
         <source xml:lang="en">Letters: {0}</source>
         <target xml:lang="ar">الأحرف: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage" approved="yes">
         <source xml:lang="en">The following is a generated report of the decodable stages for {0}. You can make any changes you want to this file, but Bloom will not notice your changes. It is just a report.</source>
         <target xml:lang="ar">فيما يلي تقرير تم إنشاؤه من المراحل التعليمية في {0}. يمكنك إجراء أي تغييرات تريدها على هذا الملف، ولكن Bloom لن يلاحظ تلك التغيرات. إنه تقرير فقط. </target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords" approved="yes">
         <source xml:lang="en">New Decodable Words: {0}</source>
         <target xml:lang="ar">الكلمات الجديدة القابلة للتفكيك: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords" approved="yes">
         <source xml:lang="en">New Sight Words: {0}</source>
         <target xml:lang="ar">الكلمات البصرية الجديدة: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage" approved="yes">
         <source xml:lang="en">Stage {0}</source>
         <target xml:lang="ar">المرحلة {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList" approved="yes">
         <source xml:lang="en">Complete Word List</source>
         <target xml:lang="ar">قائمة كلمات كاملة</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="ar">الأحرف في هذه المرحلة</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="ar">فتح ملف قائمة أحرف وكلمات</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Generate a letter and word list report</source>
         <target xml:lang="ar">إنشاء تقرير قائمة أحرف وكلمات</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample words in this stage</source>
         <target xml:lang="ar">نماذج الكلمات في هذه المرحلة</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="ar">إعداد المراحل</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="ar">المرحلة</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="ar">من</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="ar">الكلمات في هذه المرحلة</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="ar">أداة قراءة المستوى المحدد</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="ar">الفعلي</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true" approved="yes">
         <source xml:lang="en">avg per sentence</source>
         <target xml:lang="ar">المتوسط لكل جملة</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Average</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="ar">اختيار الموضوع</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="ar">لهذا المستوى</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="ar">التنسيق</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="ar">استخدام الرسوم</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="ar">تذكر</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="ar">المستوى</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
         <note>Used to create string "Level # of #". The space after this word is added programmatically.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="ar">من</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
         <note>Used to create string "Level # of #". The spaces on each side of this word are added programmatically.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="ar">الحد الأقصى</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="ar">لكل صفحة</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="ar">الجملة الأطول</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="ar">إمكانية التنبؤ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="ar">إعداد المستويات</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="ar">هذا الكتاب</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="ar">هذه الصفحة</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="ar">الإجمالي</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="ar">فريد من نوعه</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="ar">المفردات</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="ar">عدد الكلمات</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="ar">المزيد…</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allow changes to this shellbook</source>
         <target xml:lang="ar">السماح بإدخال تغييرات على هيكل هذا الكتاب</target>
         <note>ID: EditTab.Toolbox.Settings.Unlock</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom normally prevents most changes to shellbooks. If you need to add pages, change images, etc., tick the box below.</source>
         <target xml:lang="ar">يمنع برنامج Bloom عادة معظم التغييرات على هيكل هذا الكتاب. إذا كنت تريد إضافة صفحات أو تغيير الصور أو غير ذلك، فحدد المربع أدناه. </target>
         <note>ID: EditTab.Toolbox.Settings.UnlockShellBookIntroductionText</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState" approved="yes">
         <source xml:lang="en">Bloom recording is in an unusual state, possibly caused by unplugging a microphone. You will need to restart.</source>
         <target xml:lang="ar">تسجيل Bloom في حالة غير طبيعية، قد يكون بسبب فصل ميكروفون . عليك إعادة التشغيل. </target>
         <note>ID: EditTab.Toolbox.TalkingBook.BadState</note>
         <note>This is very low priority for translation.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput" approved="yes">
         <source xml:lang="en">No input device</source>
         <target xml:lang="ar">لا يتوفر جهاز إدخال</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoInput</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic" approved="yes">
         <source xml:lang="en">This computer appears to have no sound recording device available. You will need one to record audio for a talking book.</source>
         <target xml:lang="ar">يبدو أن هذا الكمبيوتر لا يحتوي على جهاز لتسجيل الصوت. ستحتاج إلى جهاز تسجيل صوت لإعداد كتاب ناطق. </target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoMic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage" approved="yes">
         <source xml:lang="en">Please hold the button down until you have finished recording</source>
         <target xml:lang="ar">يُرجى الاستمرار بالضغط على الزر حتى ينتهي التسجيل</target>
         <note>ID: EditTab.Toolbox.TalkingBook.PleaseHoldMessage</note>
         <note>Appears when the speak/record button is pressed very briefly</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="ar">رجوع</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Back</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4) Check</source>
         <target xml:lang="ar">4) التحقق</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Check</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Check that you are recording into the correct device and that these levels are showing blue:</source>
         <target xml:lang="ar">1) تحقق من أنك تقوم بالتسجيل في الجهاز الصحيح وأن هذه المستويات تظهر باللون الأزرق:</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.CheckSettings</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Clear</source>
         <target xml:lang="ar">محو</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Clear</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Talking Book Tool</source>
         <target xml:lang="ar">أداة الكتاب الناطق</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Listen to the whole page</source>
         <target xml:lang="ar">الاستماع إلى الصفحة كاملة</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Listen</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Look at the highlighted sentence</source>
         <target xml:lang="ar">2) انظر إلى الجملة المظللة</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.LookAtSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5) Next</source>
         <target xml:lang="ar">5) التالي</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Next</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3) Speak</source>
         <target xml:lang="ar">3) تحدث</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Speak</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an e-book that can play recordings while highlighting sentences.</source>
         <target xml:lang="ar">أعِدّ كتاب إلكتروني يمكنه تشغيل التسجيلات عند تظليل الجمل.</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.ToolPurpose</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="ar">الجملة الأطول</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="ar">ثلاث لغات</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="ar">تراجع</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTip">
+      <trans-unit id="EditTab.UndoButton.ToolTip" approved="yes">
         <source xml:lang="en">Undo (Ctrl+Z)</source>
         <target xml:lang="ar">تراجع (Ctrl+Z)</target>
         <note>ID: EditTab.UndoButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing to undo</source>
         <target xml:lang="ar">ليس هناك شيء للتراجع عنه</target>
         <note>ID: EditTab.UndoButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="Errors.BookProblem">
+      <trans-unit id="Errors.BookProblem" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.</source>
         <target xml:lang="ar">يواجه Bloom مشكلة في عرض هذا الكتاب. هذا لا يعني أنك عملك فُقِد، ولكن يعني أن هناك شيئاً قديماً أو مفقوداً أو به خطأ. </target>
         <note>ID: Errors.BookProblem</note>
       </trans-unit>
-      <trans-unit id="Errors.BrokenBook">
+      <trans-unit id="Errors.BrokenBook" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong. Consider using the 'Report a Problem' command under the 'Help' menu.</source>
         <target xml:lang="ar">يواجه Bloom مشكلة في عرض هذا الكتاب. هذا لا يعني أنك عملك فُقِد، ولكن يعني أن هناك شيئاً قديماً أو مفقوداً أو به خطأ. جرِّب استخدام أمر "الإبلاغ عن مشكلة" ضمن قائمة "مساعدة". </target>
         <note>ID: Errors.BrokenBook</note>
       </trans-unit>
-      <trans-unit id="Errors.CannotConnectToBloomServer">
+      <trans-unit id="Errors.CannotConnectToBloomServer" approved="yes">
         <source xml:lang="en">Bloom was unable to start its own HTTP listener that it uses to talk to its embedded Firefox browser. If this happens even if you just restarted your computer, ask someone to investigate if you have an aggressive firewall product installed. The agressive firewall product may need to be uninstalled before you can use Bloom.</source>
         <target xml:lang="ar">لم يتمكن Bloom من تشغيل موزع رسائل HTTP الذي يستخدمه للتحدث مع متصفح Firefox المضمَّن به. إذا حدث ذلك حتى بعد إعادة تشغيل الكمبيوتر، فاطلب من شخص ما التحقق مما إذا كان لديك جدار حماية متشدد. قد تحتاج إلى إلغاء تثبيت جدار الحماية المتشدد حتى تتمكن من استخدام Bloom. </target>
         <note>ID: Errors.CannotConnectToBloomServer</note>
       </trans-unit>
-      <trans-unit id="Errors.DeniedAccess">
+      <trans-unit id="Errors.DeniedAccess" approved="yes">
         <source xml:lang="en">Your computer denied Bloom access to the book. You may need technical help in setting the operating system permissions for this file.</source>
         <target xml:lang="ar">رفض الكمبيوتر الخاص بك وصول Bloom إلى الكتاب. قد تحتاج إلى مساعدة فنية في إعداد أذونات نظام التشغيل لهذا الملف. </target>
         <note>ID: Errors.DeniedAccess</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorSelecting">
+      <trans-unit id="Errors.ErrorSelecting" approved="yes">
         <source xml:lang="en">There was a problem selecting the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="ar">حدثت مشكلة أثناء تحديد الكتاب. قد يحل إعادة تشغيل Bloom المشكلة. في حال عدم حل المشكلة، يرجى النقر على زر "التفاصيل" وإبلاغ مطوِّري برنامج Bloom بالمشكلة. </target>
         <note>ID: Errors.ErrorSelecting</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorUpdating">
+      <trans-unit id="Errors.ErrorUpdating" approved="yes">
         <source xml:lang="en">There was a problem updating the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="ar">حدثت مشكلة أثناء تحديث الكتاب. قد يحل إعادة تشغيل Bloom المشكلة. في حال عدم حل المشكلة، يرجى النقر على زر "التفاصيل" وإبلاغ مطوِّري برنامج Bloom بالمشكلة. </target>
         <note>ID: Errors.ErrorUpdating</note>
       </trans-unit>
-      <trans-unit id="Errors.NeedNewerVersion">
+      <trans-unit id="Errors.NeedNewerVersion" approved="yes">
         <source xml:lang="en">{0} requires a newer version of Bloom. Download the latest version of Bloom from {1}.</source>
         <target xml:lang="ar">يتطلب  إصدارًا جديدًا من Bloom. يمكنك تنزيل أحدث إصدار ل Bloom من خلال {1}. </target>
         <note>ID: Errors.NeedNewerVersion</note>
         <note>{0} will get the name of the book, {1} will give a link to open the Bloom Library Web page.</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemDeletingFile">
+      <trans-unit id="Errors.ProblemDeletingFile" approved="yes">
         <source xml:lang="en">Bloom had a problem deleting this file: {0}</source>
         <target xml:lang="ar">واجه Bloom مشكلة أثناء حذف هذا الملف: {0}</target>
         <note>ID: Errors.ProblemDeletingFile</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemImportingPicture">
+      <trans-unit id="Errors.ProblemImportingPicture" approved="yes">
         <source xml:lang="en">Bloom had a problem importing this picture.</source>
         <target xml:lang="ar">واجه Bloom مشكلة أثناء استيراد هذه الصورة.</target>
         <note>ID: Errors.ProblemImportingPicture</note>
       </trans-unit>
-      <trans-unit id="Errors.ReportThisProblemButton">
+      <trans-unit id="Errors.ReportThisProblemButton" approved="yes">
         <source xml:lang="en">Report this problem to Bloom Support</source>
         <target xml:lang="ar">إبلاغ دعم Bloom بهذه المشكلة</target>
         <note>ID: Errors.ReportThisProblemButton</note>
       </trans-unit>
-      <trans-unit id="Errors.SomethingWentWrong">
+      <trans-unit id="Errors.SomethingWentWrong" approved="yes">
         <source xml:lang="en">Sorry, something went wrong.</source>
         <target xml:lang="ar">عذراً، حدث خطأ ما.</target>
         <note>ID: Errors.SomethingWentWrong</note>
       </trans-unit>
-      <trans-unit id="Errors.XMatterNotFound">
+      <trans-unit id="Errors.XMatterNotFound" approved="yes">
         <source xml:lang="en">This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a Bloom Pack that will give you '{0}', or go to Settings:Book Making and change to another Front/Back Matter Pack.</source>
         <target xml:lang="ar">طلب هذا الكتاب حزمة محتوى أمامي/خلفي باسم '{0}'، ولكن تعذر على Bloom العثور عليها في هذا الكمبيوتر. يمكنك تثبيت حزمة Bloom التي تتيح لك '{0}'، أو التوجه إلى "الإعدادات:إعداد الكتاب" والتغيير إلى حزمة محتوى أمامي/خلفي أخرى. </target>
         <note>ID: Errors.XMatterNotFound</note>
       </trans-unit>
-      <trans-unit id="Errors.ZoneAlarm">
+      <trans-unit id="Errors.ZoneAlarm" approved="yes">
         <source xml:lang="en">Bloom cannot start properly, and this symptom has been observed on machines with ZoneAlarm installed. Note: disabling ZoneAlarm does not help. Nor does restarting with it turned off. Something about the installation of ZoneAlarm causes the problem, and so far only uninstalling ZoneAlarm has been shown to fix the problem.</source>
         <target xml:lang="ar">Bloom غير قادر على العمل على نحو سليم، وقد ظهر هذا العَرض على الأجهزة التي تثبِّت ZoneAlarm. ملاحظة: تعطيل ZoneAlarm لن يحل المشكلة. ولن تساعد إعادة التشغيل أثناء إيقافه. هناك أمر ما في تثبيت ZoneAlarm يؤدي إلى حدوث هذه مشكلة، وحتى الآن إلغاء تثبيت ZoneAlarm هو الحل الوحيد. </target>
         <note>ID: Errors.ZoneAlarm</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="ar">تصميم نماذج القارئ</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="ar">البحث عن إصدار جديد</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="ar">معلومات حول Bloom</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <target xml:lang="ar">المستندات</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="ar">مساعدة</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Get Help</source>
         <target xml:lang="ar">الحصول على مساعدة</target>
         <note>ID: HelpMenu.Help Menu_ToolTip_</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem">
+      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem" approved="yes">
         <source xml:lang="en">Key Bloom Concepts</source>
         <target xml:lang="ar">مفاهيم Bloom الرئيسية</target>
         <note>ID: HelpMenu.KeyBloomConceptsToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="ar">تقديم اقتراح</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="ar">التسجيل</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="ar">ملاحظات الإصدار…</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem">
+      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem" approved="yes">
         <source xml:lang="en">Report a Problem...</source>
         <target xml:lang="ar">الإبلاغ عن مشكلة…</target>
         <note>ID: HelpMenu.ReportAProblemToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="ar">إظهار سجل الأحداث</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="ar">استخدام نماذج القارئ</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="ar">موقع ويب</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.trainingVideos">
+      <trans-unit id="HelpMenu.trainingVideos" approved="yes">
         <source xml:lang="en">Training Videos</source>
         <target xml:lang="ar">مقاطع فيديو تدريبية</target>
         <note>ID: HelpMenu.trainingVideos</note>
       </trans-unit>
-      <trans-unit id="InstallProblem.BloomPdfMaker">
+      <trans-unit id="InstallProblem.BloomPdfMaker" approved="yes">
         <source xml:lang="en">A component of Bloom, BloomPdfMaker.exe, seems to be missing. This prevents previews and printing. Antivirus software sometimes does this. You may need technical help to repair the Bloom installation and protect this file from being deleted again.</source>
         <target xml:lang="ar">يبدو أن أحد مكونات Bloom،‏ BloomPdfMaker.exe، مفقود. هذا يمنع المعاينات والطباعة. يؤدي برنامج مكافحة الفيروسات أحياناً إلى حصول هذا. قد تحتاج إلى مساعدة فنية لإصلاح تثبيت Bloom وحماية هذا الملف من الحذف مرة أخرى. </target>
         <note>ID: InstallProblem.BloomPdfMaker</note>
       </trans-unit>
-      <trans-unit id="LameEncoder.Progress">
+      <trans-unit id="LameEncoder.Progress" approved="yes">
         <source xml:lang="en">Converting to mp3</source>
         <target xml:lang="ar">جارٍ التحويل إلى mp3</target>
         <note>ID: LameEncoder.Progress</note>
         <note>Appears in progress indicator</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.RightToLeftCheck">
+      <trans-unit id="LanguageFontDetails.RightToLeftCheck" approved="yes">
         <source xml:lang="en">This script is right to left</source>
         <target xml:lang="ar">هذا النص من اليمين إلى اليسار</target>
         <note>ID: LanguageFontDetails.RightToLeftCheck</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.TallerLinesCheck">
+      <trans-unit id="LanguageFontDetails.TallerLinesCheck" approved="yes">
         <source xml:lang="en">This script requires taller lines</source>
         <target xml:lang="ar">يتطلب هذا النص خطوطاً أطول</target>
         <note>ID: LanguageFontDetails.TallerLinesCheck</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="ar">A4أفقي </target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="ar">A4أفقي جنباً إلى جنب </target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="ar">A4أفقي التقسيم على عدة صفحات </target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="ar">A4عمودي </target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="ar">A4أفقي </target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="ar">A5عمودي </target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="ar">A5عمودي محاذاة سفلية</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Landscape</source>
         <target xml:lang="ar">A6أفقي </target>
         <note>ID: LayoutChoices.A6Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Portrait</source>
         <target xml:lang="ar">A6عمودي </target>
         <note>ID: LayoutChoices.A6Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="ar">B5عمودي </target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">HalfLetterPortrait</source>
         <target xml:lang="ar">HalfLetterPortrait</target>
         <note>ID: LayoutChoices.HalfLetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterLandscape</source>
         <target xml:lang="ar">LetterLandscape</target>
         <note>ID: LayoutChoices.LetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterPortrait</source>
         <target xml:lang="ar">LetterPortrait</target>
         <note>ID: LayoutChoices.LetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">QuarterLetterLandscape</source>
         <target xml:lang="ar">QuarterLetterLandscape</target>
         <note>ID: LayoutChoices.QuarterLetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog.WindowTitle">
+      <trans-unit id="LicenseDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom {0}</source>
         <target xml:lang="ar">Bloom {0}</target>
         <note>ID: LicenseDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog._acceptButton">
+      <trans-unit id="LicenseDialog._acceptButton" approved="yes">
         <source xml:lang="en">I accept the terms of the license agreement</source>
         <target xml:lang="ar">أقبل بنود اتفاقية الترخيص</target>
         <note>ID: LicenseDialog._acceptButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="ar">أوافق على بنود استخدام مكتبة Bloom</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="ar">عنوان البريد الإلكتروني</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="ar">نسيت كلمة المرور</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="ar">&amp;تسجيل الدخول</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="ar">كلمة المرور</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="ar">إ&amp;ظهار كلمة المرور</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="ar">إظهار بنود الاستخدام</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="ar">تسجيل الدخول إلى BloomLibrary.org</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="ar">هناك مجموعة تحمل هذا الاسم على &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nالرجاء اختيار اسم فريد. </target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="ar">اختر اللغة الرئيسية لهذه المجموعة</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="ar">أمثلة: "الكتب الصحية"، "قصص حيوانات PNG"</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="ar">ما الاسم الذي تريد إطلاقه على هذه المجموعة؟</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="ar">مشكلة في اسم المجموعة</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="ar">سيتم إنشاء المجموعة في: {0}</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="ar">جاهز لإنشاء مجموعة جديدة</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FontAndScriptPage">
+      <trans-unit id="NewCollectionWizard.FontAndScriptPage" approved="yes">
         <source xml:lang="en">Font and Script</source>
         <target xml:lang="ar">الخط والنص</target>
         <note>ID: NewCollectionWizard.FontAndScriptPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="ar">اختر نوع المجموعة</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions" approved="yes">
         <source xml:lang="en">If you already have a collection you want to open, click  the 'Cancel' button.</source>
         <target xml:lang="ar">إذا كان أساسا لديك مجموعة تريد فتحها، فانقر على الزر "إلغاء".</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ar">المجموعة المرجعية</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org. You may also make a Bloom Pack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="ar">مجموعة من كتب الهيكل أو نماذج الكتب بلغة واحدة أو أكثر في اتصال أوسع.سيكون بإمكانك تحميل هذه الهياكل إلى BloomLibrary.org.يمكنك أيضًا إعداد حزمة Bloom و تقديمها للآخرين حتى يكون بإمكانهم استخدام هذا الهيكل لإعداد كتب باللهجات العامية.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="ar">مجموعة باللغة العامية/المحلية</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="ar">مجموعة من الكتب بلغة محلية.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="ar">تحديد مكان اللغة</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="ar">البلد</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="ar">المنطقة</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="ar">هذه اختيارية.سيقوم Bloom بوضعهم في المكان المناسب على صفحة العنوان للكتب الذي ستنشئها.</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="ar">المقاطعة</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="ar">{0} كتب</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="ar">إنشاء مجموعة جديدة على Bloom</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="ar">اسم المشروع</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="ar">نعتذر عن إنشاء مجموعة جديدة تحت هذا الاسم.</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="ar">مرحباً بك في Bloom!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="ar">أنت على وشك أن تكون جاهزاً للبدء في إعداد الكتب.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. The first thing we need to do is make one for you.</source>
         <target xml:lang="ar">للحفاظ على البساطة و النظام، يحتفظ Bloom بجميع الكتب التي تنشئها في &lt;i&gt;مجموعة&lt;/i&gt; واحدة أو أكثر. أول ما يتوجب علينا فعله هو إنشاء مجموعة لك. </target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="ar">انقر على 'التالي' للبدء.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InDropboxMessage">
+      <trans-unit id="OpenCreateCloneControl.InDropboxMessage" approved="yes">
         <source xml:lang="en">Bloom detected that this collection is located in your Dropbox folder. This can cause problems as Dropbox sometimes locks Bloom out of its own files. If you have problems, we recommend that you move your collection somewhere else or disable Dropbox while using Bloom.</source>
         <target xml:lang="ar">اكتشف Bloom أن موقع هذه المجموعة في مجلد Dropbox. قد يؤدي هذا إلى حدوث مشكلة نظراً لأن Dropbox أحياناً يمنع Bloom من الوصول إلى الملفات الخاصة به. إذا كنت تواجه بعض المشاكل، فنحن نوصي بنقل مجموعتك إلى مكان آخر أو تعطيل Dropbox أثناء استخدام Bloom. </target>
         <note>ID: OpenCreateCloneControl.InDropboxMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage">
+      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage" approved="yes">
         <source xml:lang="en">This collection is part of your 'Sources for new books' which you can see in the bottom left of the Collections tab. It cannot be opened for editing.</source>
         <target xml:lang="ar">هذه المجموعة جزء من "موارد لكتب جديدة" يمكنك الاطلاع عليها أسفل يسار علامة تبويب "المجموعات". لا يمكن أن تكون مفتوحة للتحرير. </target>
         <note>ID: OpenCreateCloneControl.InSourceCollectionMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="ar">مجموعات Bloom</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="ar">الاستعراض للعثور على مجموعة أخرى على هذا الكمبيوتر</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="ar">النسخ من Chorus Hub على شبكة محلية</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="ar">النسخ من الإنترنت</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="ar">النسخ من محرك أقراص USB</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="ar">إنشاء مجموعة جديدة</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="ar">فتح/إنشاء المجموعات</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="ar">الاطلاع على المزيد</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="ar">هل سبق لشخص آخر استخدام الإرسال/الاستقبال لمشاركة مجموعة معك؟\nاستخدم أحد الأزرار الحمراء هذه لنسخ مجموعاته إلى الكمبيوتر الخاص بك.\nلاحقًا، يمكنم استخدام إرسال/استقبال لمشاركة عملك مرة أخرى معه.</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PageList.CantMoveWhenTranslating">
+      <trans-unit id="PageList.CantMoveWhenTranslating" approved="yes">
         <source xml:lang="en">Pages can not be re-ordered when you are translating a book.</source>
         <target xml:lang="ar">لا يمكن إعادة ترتيب الصفحات عند ترجمة كتاب.</target>
         <note>ID: PageList.CantMoveWhenTranslating</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="ar">الرجاء تثبيت Adobe Reader حتى يتمكن Bloom من عرض الكتاب المكتمل. وحتى يتم ذلك، بإمكانك حفظ كتاب PDF وفتحه باستخدام برنامج آخر. </target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="ar">أمر غريب… هناك خطأ في Adobe Reader عند محاولة عرض PDF هذا. ما زال بإمكانك محاولة حفظ كتاب PDF.</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="ar">للأسف، لم يتمكن Bloom من الحصول علىAdobe Reader وعرضه هنا، ولذلك لن يتمكن Bloom من عرض كتابك المكتمل.\nالرجاء إلغاء تثبيت الإصدار الحالي من "Adobe Reader" و(إعادة) تثبيت "Adobe Reader".\nوحتى يتم ذلك، بإمكانك حفظ كتاب PDF وفتحه باستخدام برنامج آخر. </target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="ar">المحتوى الداخلي للكتيب</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book. Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="ar">أعِدّ كتيب من الصفحات الداخلية للكتاب. سيتم تخطيط الصفحات وإعادة تنظيمها حتى تحصل على كتيب عند طيها.\n</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="ar">تحميل</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="ar">يمكنك التحميل إلى BloomLibrary.org، حيث يمكن للآخرين التنزيل والترجمة إلى لغتهم الخاصة.</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="ar">غلاف الكتيب</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="ar">يمكنك إعداد  من الصفحة الأمامية والخلفية (الجانبان)، حتى تتمكن من الطباعة على ورق ملون.</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubButton">
+      <trans-unit id="PublishTab.EpubButton" approved="yes">
         <source xml:lang="en">ePUB</source>
         <target xml:lang="ar">ePUB</target>
         <note>ID: PublishTab.EpubButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an ePUB (electronic book) out of this book, allowing it to be read on various electronic reading devices.</source>
         <target xml:lang="ar">يمكنك إعداد كتاب إلكتروني (ePUB) باستخدام هذا الكتاب، مما يمكنك من قراءته على عدة أجهزة قراءة إلكترونية.</target>
         <note>ID: PublishTab.EpubRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="ar">لا تعرض هذا مرة أخرى</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="ar">معلومات حول InDesign XML</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation">
+      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation" approved="yes">
         <source xml:lang="en">This PDF viewer can be improved by installing the free Adobe Reader on this computer.</source>
         <target xml:lang="ar">يمكن تحسين عارض PDF هذا من خلال تثبيت برنامج Adobe Reader المجاني على هذا الكمبيوتر.</target>
         <note>ID: PublishTab.Notifications.AdobeReaderRecommendation</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="ar">بسيط</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="ar">يمكنك إعداد PDF من كل صفحة في الكتاب، صفحة واحدة لكل ورقة.</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system PDF viewer</source>
         <target xml:lang="ar">فتح PDF في عارض النظام الافتراضي PDF</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="ar">استبدال الموجود</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="ar">إشعار</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.BadPdf">
+      <trans-unit id="PublishTab.PdfMaker.BadPdf" approved="yes">
         <source xml:lang="en">Bloom had a problem making a PDF of this book. You may need technical help or to contact the developers. But here are some things you can try:</source>
         <target xml:lang="ar">واجه Bloom مشكلة في إعداد PDF من هذا الكتاب. قد تحتاج إلى مساعدة فنية أو إلى الاتصال بمطوِّري البرامج. ولكن هناك بعض الأمور التي يمكنك تجربتها: </target>
         <note>ID: PublishTab.PdfMaker.BadPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory">
+      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory" approved="yes">
         <source xml:lang="en">Try doing this on a computer with more memory</source>
         <target xml:lang="ar">حاول تنفيذ هذا على جهاز كمبيوتر يحتوي على ذاكرة أكبر</target>
         <note>ID: PublishTab.PdfMaker.TryMoreMemory</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryRestart">
+      <trans-unit id="PublishTab.PdfMaker.TryRestart" approved="yes">
         <source xml:lang="en">Restart your computer and try this again right away</source>
         <target xml:lang="ar">أعد تشغيل الكمبيوتر وجرِّب ذلك مرة أخرى في الحال</target>
         <note>ID: PublishTab.PdfMaker.TryRestart</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages">
+      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages" approved="yes">
         <source xml:lang="en">Replace large, high-resolution images in your document with lower-resolution ones</source>
         <target xml:lang="ar">استبدل الصور الكبيرة وعالية الدقة في مستندك بصور أقل دقة</target>
         <note>ID: PublishTab.PdfMaker.TrySmallerImages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="ar">&amp;طباعة…</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="ar">نشر</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="ar">&amp;حفظ PDF…</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveEpub">
+      <trans-unit id="PublishTab.SaveEpub" approved="yes">
         <source xml:lang="en">&amp;Save ePUB...</source>
         <target xml:lang="ar">&amp;حفظ ePUB…</target>
         <note>ID: PublishTab.SaveEpub</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="ar">علامات الاقتصاص</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="ar">كلمات الشكر</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">Additional Requests: </source>
         <target xml:lang="ar">طلبات إضافية:</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="ar">جميع الحقوق محفوظة (يمكنك الاتصال بمالك حقوق الطبع والنشر بشأن أي أذونات).</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="ar">CC-BY-NC</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you. If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="ar">تحتوي BloomLibrary.org على إصدار سابق من هذا الكتاب. إذا قمت بتحميله مرة أخرى، فسيحل محل الإصدار الحالي. </target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="ar">حقوق الطبع والنشر</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="ar">المساهمون في العمل</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="ar">عذراً، حدثت مشكلة أثناء تحميل {0}. فيما يلي بعض التفاصيل. قد تحتاج إلى مساعدة فنية. </target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading.</source>
         <target xml:lang="ar">هناك حقل واحد أو أكثر من الحقول أعلاه بحاجة إلى انتباهك قبل التحميل.</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded. Sometimes this is caused by temporary problems with the servers we use. It's worth trying again in an hour or two. If you regularly get this problem please report it to us.</source>
         <target xml:lang="ar">عذراً، لم ينجح تحميل "{0}". يحدث هذا أحياناً بسبب مشكلات مؤقتة في الخوادم التي نستخدمها. الرجاء إعادة المحاولة خلال ساعة أو ساعتين. في حال مواجهة هذه المشكلة أكثر من مرة، الرجاء إبلاغنا بها. </target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes.</source>
         <target xml:lang="ar">هذا التحميل يعني أنك تؤكد قبولك ببنود استخدام مكتبة Bloom ومنح الحقوق الواردة بها.</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="ar">حدثت مشكلة أثناء تحميل كتابك.</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="ar">اللغات</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="ar">الاستخدام/الترخيص</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="ar">الحساب موجود من قبل</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address. Would you like to log in instead?</source>
         <target xml:lang="ar">لا يمكننا منحك اشتراكاً باستخدام هذا العنوان نظراً لوجود حساب لدينا تحت هذا العنوان. هل تريد تسجيل الدخول بدلاً من ذلك؟</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="ar">تعذر على Bloom الاتصال بالخادم للتحقق من تسجيل دخولك. يُرجى التحقق من اتصال الشبكة.</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="ar">لم تنجح في تسجيل الدخول</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="ar">تعذر على بلوم الاتصال بالخادم لإكمال تسجيل الدخول أو الاشتراك. قد يكون سبب هذه المشكلة الاتصال بالإنترنت أو خادمنا أو أحد الأجهزة بينها.</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="ar">للاشتراك في حساب BloomLibrary.org، يتعين عليك تحديد المربع الذي يشير إلى موافقتك على بنود استخدام BloomLibrary.</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="ar">البريد الإلكتروني المطلوب</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="ar">ليس لدينا مستخدم مسجَّل لديه هذا البريد الإلكتروني. هل تريد الاشتراك؟</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="ar">لم يتطابق معرف المستخدم مع كلمة المرور</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="ar">يرجى الموافقة على بنود الاستخدام</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="ar">الرجاء إدخال عنوان بريد إلكتروني صالح. سنرسل رسالة إلكترونية إلى هذا العنوان حتى تتمكن من إعادة تعيين كلمة المرور. </target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="ar">تعذر على Bloom الاتصال بالخادم لإعادة تعيين كلمة المرور. يُرجى التحقق من اتصال الشبكة. </target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="ar">لم تنجح في إعادة تعيين كلمة المرور</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="ar">إعادة تعيين كلمة المرور</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password.</source>
         <target xml:lang="ar">نحن بصدد إرسال رسالة إلكترونية إلى {0} تحتوي إرشادات حول كيفية إعادة تعيين كلمة المرور.</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="ar">اشترك في مكتبة Bloom.</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="ar">المستخدم غير معروف</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="ar">تعذر على Bloom تسجيل الدخول إلى BloomLibrary.org باستخدام بيانات الاعتماد المحفوظة. يُرجى التحقق من اتصال الشبكة.</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="ar">تسجيل الدخول إلى BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="ar">تسجيل الخروج من BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="ar">جارٍ إعداد معاينة PDF…</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="ar">جارٍ إعداد صورة مصغَّرة…</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.NoLangsFound">
+      <trans-unit id="PublishTab.Upload.NoLangsFound" approved="yes">
         <source xml:lang="en">(None found)</source>
         <target xml:lang="ar">(لم يتم العثور على شيء)</target>
         <note>ID: PublishTab.Upload.NoLangsFound</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="ar">عذراً، إصدار Bloom سطح المكتب لا يتوافق مع الإصدار الحالي من BloomLibrary.org. يُرجى التحديث إلى إصدار أجدد.</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.IncompleteTranslation">
+      <trans-unit id="PublishTab.Upload.IncompleteTranslation" approved="yes">
         <source xml:lang="en">(incomplete translation)</source>
         <target xml:lang="ar">(جزئي)</target>
         <note>ID: PublishTab.Upload.IncompleteTranslation</note>
         <note>This is added after the language name, in order to indicate that some parts of the book have not been translated into this language yet.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="ar">الرجاء تسجيل الدخول إلى BloomLibrary.org (أو الاشتراك) قبل التحميل</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="ar">الرجاء تعيين هذا من علامة التبويب تحرير</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="ar">الاشتراك في BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="ar">الخطوة 1: تأكيد البيانات الوصفية</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="ar">الخطوة 2: التحميل</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="ar">اقتراح: يسهِّل تعيين ترخيص Creative Commons من منح أذونات معيَّنة بشكل واضح للجميع.</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="ar">اقتراح: تسهِّل تراخيص Creative Commons على الآخرين إمكانية استخدام كتابك، حتى إذا لم تكن لديهم فصاحة في لغة الترخيص المخصص.</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="ar">ملخص</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="ar">إظهار بنود الاستخدام</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TimeProblem">
+      <trans-unit id="PublishTab.Upload.TimeProblem" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. This is probably because your computer is set to use the wrong timezone or your system time is badly wrong. See http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html for how to fix this.</source>
         <target xml:lang="ar">حدثت مشكلة أثناء تحميل كتابك. قد يرجع السبب في ذلك تعيين الكمبيوتر الخاص بك على استخدام منطقة زمنية خاطئة أو توقيت نظام غير صحيح تمامًا. راجع http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html لمعرفة كيفية حل المشكلة.</target>
         <note>ID: PublishTab.Upload.TimeProblem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="ar">العنوان</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="ar">تحميل الكتاب</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <target xml:lang="ar">تهانينا، أصبح "{0}" الآن متاحًا على BloomLibrary.org ({1})</target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="ar">غير مسموح بالتحميل</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="ar">حدثت مشكلة أثناء تحميل كتابك. قد تحتاج إلى إعادة تشغيل Bloom أو الحصول على مساعدة فنية.</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="ar">مستوى تقدم التحميل</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="ar">تحميل الكتاب (إلى وضع الحماية)</target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="ar">تحميل البيانات الوصفية للكتاب</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, and topic tags to the BloomLibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="ar">جارٍ تحميل {0}</target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishView._saveButton">
+      <trans-unit id="PublishView._saveButton" approved="yes">
         <source xml:lang="en">Save stub</source>
         <target xml:lang="ar">حفظ stub</target>
         <note>ID: PublishView._saveButton</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="ar">إضافة مستوى</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="ar">إضافة مرحلة</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <target xml:lang="ar">الرجاء إضافة النصوص إلى مجلد "نماذج النص".</target>
         <note>ID: ReaderSetup.AddTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">allowed words</source>
         <target xml:lang="ar">الكلمات المسموح بها</target>
         <note>ID: ReaderSetup.AllowedWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <target xml:lang="ar">ملف الكلمات المسموح بها</target>
         <note>ID: ReaderSetup.AllowedWordsFile</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <target xml:lang="ar">ملف الكلمات المسموح بها</target>
         <note>ID: ReaderSetup.AllowedWordsFileHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Avg</source>
         <target xml:lang="ar">المتوسط</target>
         <note>ID: ReaderSetup.AverageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="ar">الكتاب</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="ar">الحد الأقصى للكلمات في كل كتاب</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose...</source>
         <target xml:lang="ar">اختر…</target>
         <note>ID: ReaderSetup.ChooseAllowedWordsFile</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="ar">انقر على الأحرف لإضافتها إلى هذه المرحلة.</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="ar">الفصل بمسافات</target>
         <note>ID: ReaderSetup.CombinationHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <target xml:lang="ar">مثل "ai oo sh ng th ing"</target>
         <note>ID: ReaderSetup.CombinationHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <target xml:lang="ar">توليفات الأحرف (وحدات الغرافيم)</target>
         <note>ID: ReaderSetup.Combinations</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="ar">مراحل إمكانية التفكيك</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true" approved="yes">
         <source xml:lang="en">File needs .TXT extension</source>
         <target xml:lang="ar">يحتاج الملف إلى امتداد TXT.</target>
         <note>ID: ReaderSetup.FileNeedsTxtExtension</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="ar">أولاً،</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="ar">لا يمكن قراءة هذا التنسيق</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="ar">المساعدة في تصدير الملفات وتحويلها لاستخدامها كنماذج نصوص</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="ar">اللغة</target>
         <note>ID: ReaderSetup.Language</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <target xml:lang="ar">ترتيب الأحرف والأحرف المكوِّنة للكلمات على نحو أبجدي.</target>
         <note>ID: ReaderSetup.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="ar">الفصل بمسافات</target>
         <note>ID: ReaderSetup.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <target xml:lang="ar">مثل "ا ب ج د"</target>
         <note>ID: ReaderSetup.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="ar">الأحرف</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="ar">الأحرف وتوليفات الأحرف</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="ar">لمساعدتك في إعداد كتب إمكانية التفكيك، يحتاج Bloom إلى معرفة الأحرف وتوليفات الأحرف التي ستتناولها في التدريس.</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="ar">يمكنك الفصل بين كل حرف أو توليفة أحرف باستخدام مسافة. فيما يلي مثال لما يمكننا استخدامه للغة الإنجليزية:</target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="ar">لاحظ أن قائمة اللغة الإنجليزية تتضمن رموزًا يتم استخدامها لإعداد كلمات مثل ' في </target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="ar">it's</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="ar">.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="ar">المستوى</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level&amp;nbsp;</source>
         <target xml:lang="ar">المستوى &amp;nbsp;</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="ar">مستويات الكتاب</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="ar">الكلمات المطابقة</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Average Length of Sentences in Book</source>
         <target xml:lang="ar">الحد الأقصى لمتوسط طول الجملة في الكتاب</target>
         <note>ID: ReaderSetup.MaxAverageWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="ar">الحد الأقصى للكلمات الفريدة في كل كتاب</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <target xml:lang="ar">المزيد من الكلمات</target>
         <note>ID: ReaderSetup.MoreWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <target xml:lang="ar">افتح مجلد نموذج النصوص لهذه اللغة.</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="ar">الصفحة</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="ar">الحد الأقصى للكلمات في كل صفحة</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="ar">من إعداد </target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="ar">مستويات القارئ</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="ar">إزالة المستوى {0}</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="ar">إزالة المرحلة {0}</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove from this stage</source>
         <target xml:lang="ar">إزالة من هذه المرحلة</target>
         <note>ID: ReaderSetup.RemoveWordList</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="ar">اسحب الصفوف لإعادة ترتيب المستويات.</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="ar">اسحب الصفوف لإعادة ترتيب المراحل.</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <target xml:lang="ar">قوائم الكلمات ونماذج النصوص</target>
         <note>ID: ReaderSetup.SampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Words</source>
         <target xml:lang="ar">نماذج الكلمات</target>
         <note>ID: ReaderSetup.SampleWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="ar">، محرك بحث لمحو الأمية.</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="ar">الأحرف السابقة والجديدة</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="ar">الجملة</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="ar">الحد الأقصى للكلمات في كل جملة</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="ar">إعداد أداة قارئ لإمكانية التفكيك</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="ar">إعداد أداة قارئ لمستوى المحدد</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up the alphabet for this language.</source>
         <target xml:lang="ar">إعداد الأبجدية لهذه اللغة.</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <target xml:lang="ar">ما المقصود بالكلمات البصرية؟</target>
         <note>ID: ReaderSetup.SightWordHelp</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="ar">كلمات بصرية جديدة</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="ar">الكلمات البصرية</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="ar">المرحلة</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="ar">المرحلة </target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="ar">المراحل</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="ar">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="ar">أمور جديرة بالاهتمام في هذا المستوى:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="ar">فريد من نوعه</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="ar">كلمات</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage. There are two ways to give words to Bloom:</source>
         <target xml:lang="ar">لمساعدتك في إعداد قارئ إمكانية تفكيك، يمكن لبرنامج Bloom اقتراح كلمات تناسب المرحلة الحالية. هناك طريقتان لتقديم كلمات إلى Bloom:</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="ar">2) ضع ملفات النصوص في</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <target xml:lang="ar">مجلد نماذج النصوص</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="ar">1) اكتب الكلمات هنا</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using lists of allowed words to define stages</source>
         <target xml:lang="ar">نستخدم قوائم بالكلمات المسموح بها لتحديد المراحل</target>
         <note>ID: ReaderSetup.Words.UseAllowedWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using letters with sight words to define stages</source>
         <target xml:lang="ar">نستخدم أحرفًا مع كلمات بصرية لتحديد المراحل</target>
         <note>ID: ReaderSetup.Words.UseLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="ar">الأحرف</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this Bloom Pack will carry your latest decodable and leveled reader settings for the \"{0}\" language. Anyone opening this Bloom Pack, who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this Bloom Pack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="ar">علاوة على ذلك، ستنقل حزمة Bloom أحدث إعدادات قارئ إمكانية التفكيك وكتاب المستوى المحدد في اللغة \"{0}\". أي شخص يفتح حزمة Bloom هذه، ثم يفتح مجموعة \"{0}\" بعد ذلك، سيجد أنه تم استبدال قارئ إمكانية التفكيك وكتاب المستوى المحدد لديه بالإعدادات الموجودة في حزمة Bloom هذه. كما سيحصل على المجموعة الحالية للكلمات لاستخدامها في قارئ إمكانية التفكيك.</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="ar">سيتم وضع الكتب التالية داخل نماذج:</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <target xml:lang="ar">حفظ حزمة Bloom</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <target xml:lang="ar">إنشاء نموذج كتاب في حزمة Bloom</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="ar">عنوان البريد الإلكتروني</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="ar">الاسم الأول</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="ar">الرجاء تخصيص دقيقة للتسجيل {0}</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="ar">كيف تستخدم {0}؟</target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="ar">الوقت ضيِّق الآن، سأقوم بذلك لاحقًا.</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="ar">المنظمة</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="ar">&amp;تسجيل</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="ar">اللقب</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="ar">تسجيل {0}</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <target xml:lang="ar">إغلاق</target>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.CouldNotSendToServer">
+      <trans-unit id="ReportProblemDialog.CouldNotSendToServer" approved="yes">
         <source xml:lang="en">Bloom was not able to submit your report directly to our server. Please retry or email {0} to {1}.</source>
         <target xml:lang="ar">لم يتمكن Bloom من إرسال تقريرك إلى خادمنا مباشرة. الرجاء إعادة المحاولة أو إرسال {0} في رسالة إلكترونية إلى {1}.</target>
         <note>ID: ReportProblemDialog.CouldNotSendToServer</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Email">
+      <trans-unit id="ReportProblemDialog.Email" approved="yes">
         <source xml:lang="en">Email</source>
         <target xml:lang="ar">البريد الإلكتروني</target>
         <note>ID: ReportProblemDialog.Email</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeBookButton">
+      <trans-unit id="ReportProblemDialog.IncludeBookButton" approved="yes">
         <source xml:lang="en">Include Book '{0}'</source>
         <target xml:lang="ar">تضمين الكتاب "{0}"</target>
         <note>ID: ReportProblemDialog.IncludeBookButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton">
+      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton" approved="yes">
         <source xml:lang="en">Include this screenshot</source>
         <target xml:lang="ar">تضمين لقطة الشاشة هذه</target>
         <note>ID: ReportProblemDialog.IncludeScreenshotButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Name">
+      <trans-unit id="ReportProblemDialog.Name" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="ar">الاسم</target>
         <note>ID: ReportProblemDialog.Name</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Retry">
+      <trans-unit id="ReportProblemDialog.Retry" approved="yes">
         <source xml:lang="en">Retry</source>
         <target xml:lang="ar">إعادة المحاولة</target>
         <note>ID: ReportProblemDialog.Retry</note>
         <note>Shown if there was an error submitting the report. Lets the user try submitting it again.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SeeDetails">
+      <trans-unit id="ReportProblemDialog.SeeDetails" approved="yes">
         <source xml:lang="en">See what else will be submitted</source>
         <target xml:lang="ar">معرفة ما سيتم إرساله أيضاً</target>
         <note>ID: ReportProblemDialog.SeeDetails</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SubmitButton">
+      <trans-unit id="ReportProblemDialog.SubmitButton" approved="yes">
         <source xml:lang="en">&amp;Submit</source>
         <target xml:lang="ar">&amp;إرسال</target>
         <note>ID: ReportProblemDialog.SubmitButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Submitting">
+      <trans-unit id="ReportProblemDialog.Submitting" approved="yes">
         <source xml:lang="en">Submitting to server...</source>
         <target xml:lang="ar">جارٍ الإرسال إلى الخادم…</target>
         <note>ID: ReportProblemDialog.Submitting</note>
         <note>This is shown while Bloom is sending the problem report to our server.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Success">
+      <trans-unit id="ReportProblemDialog.Success" approved="yes">
         <source xml:lang="en">We received your report, thanks for taking the time to help make Bloom better!</source>
         <target xml:lang="ar">تلقينا تقريرك، ونشكرك على تخصيص وقت للمساعدة في تحسين أداء Bloom.</target>
         <note>ID: ReportProblemDialog.Success</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WhatsTheProblem">
+      <trans-unit id="ReportProblemDialog.WhatsTheProblem" approved="yes">
         <source xml:lang="en">What seems to be the problem?</source>
         <target xml:lang="ar">ما المشكلة في رأيك؟</target>
         <note>ID: ReportProblemDialog.WhatsTheProblem</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WindowTitle">
+      <trans-unit id="ReportProblemDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Report A Problem</source>
         <target xml:lang="ar">الإبلاغ عن مشكلة</target>
         <note>ID: ReportProblemDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Zipping">
+      <trans-unit id="ReportProblemDialog.Zipping" approved="yes">
         <source xml:lang="en">Zipping up book...</source>
         <target xml:lang="ar">جارٍ ضغط الكتاب…</target>
         <note>ID: ReportProblemDialog.Zipping</note>
         <note>This is shown while Bloom is creating the problem report. It's generally too fast to see, unless you include a large book.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.linkLabel1">
+      <trans-unit id="ReportProblemDialog.linkLabel1" approved="yes">
         <source xml:lang="en">Will not be private</source>
         <target xml:lang="ar">لن يكون خاصاً</target>
         <note>ID: ReportProblemDialog.linkLabel1</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.IGetIt">
+      <trans-unit id="SamplePrintNotification.IGetIt" approved="yes">
         <source xml:lang="en">I get it. Do not show this again.</source>
         <target xml:lang="ar">أحصل عليه. لا تعرض هذا مرة أخرى. </target>
         <note>ID: SamplePrintNotification.IGetIt</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.PleaseNotice">
+      <trans-unit id="SamplePrintNotification.PleaseNotice" approved="yes">
         <source xml:lang="en">Please notice the sample printer settings below. Use them as a guide while you set up the printer.</source>
         <target xml:lang="ar">يُرجى الاطلاع على نموذج إعدادات الطابعة أدناه. يمكنك الاسترشاد بها أثناء إعداد الطابعة. </target>
         <note>ID: SamplePrintNotification.PleaseNotice</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Arithmetic</source>
         <target xml:lang="ar">الحساب</target>
         <note>ID: TemplateBooks.BookName.Arithmetic</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="ar">الكتاب الأساسي</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="ar">الكتاب الكبير</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="ar">قارئ إمكانية التفكيك</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="ar">قارئ المستوى المحدد</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="ar">القاموس المصور</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vaccinations</source>
         <target xml:lang="ar">اللقاحات</target>
         <note>ID: TemplateBooks.BookName.Vaccinations</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="ar">تقويم الحائط</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A blank page that allows you to add items.</source>
         <target xml:lang="ar">صفحة فارغة تتيح لك إمكانية إضافة عناصر.</target>
         <note>ID: TemplateBooks.PageDescription.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page with a picture on top and a large, centered word below.</source>
         <target xml:lang="ar">صفحة تحتوي على صورة في الأعلى وكلمة كبيرة تتوسط أسفلها.</target>
         <note>ID: TemplateBooks.PageDescription.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="ar">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1 Problem</source>
         <target xml:lang="ar">مشكلة واحدة</target>
         <note>ID: TemplateBooks.PageLabel.1 Problem</note>
         <note>This label indicates a page with one arithmetic problem on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true" approved="yes">
         <source xml:lang="en">10</source>
         <target xml:lang="ar">10</target>
         <note>ID: TemplateBooks.PageLabel.10</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true" approved="yes">
         <source xml:lang="en">11</source>
         <target xml:lang="ar">11</target>
         <note>ID: TemplateBooks.PageLabel.11</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true" approved="yes">
         <source xml:lang="en">12</source>
         <target xml:lang="ar">12</target>
         <note>ID: TemplateBooks.PageLabel.12</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true" approved="yes">
         <source xml:lang="en">13</source>
         <target xml:lang="ar">13</target>
         <note>ID: TemplateBooks.PageLabel.13</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true" approved="yes">
         <source xml:lang="en">14</source>
         <target xml:lang="ar">14</target>
         <note>ID: TemplateBooks.PageLabel.14</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true" approved="yes">
         <source xml:lang="en">15</source>
         <target xml:lang="ar">15</target>
         <note>ID: TemplateBooks.PageLabel.15</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true" approved="yes">
         <source xml:lang="en">16</source>
         <target xml:lang="ar">16</target>
         <note>ID: TemplateBooks.PageLabel.16</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true" approved="yes">
         <source xml:lang="en">17</source>
         <target xml:lang="ar">17</target>
         <note>ID: TemplateBooks.PageLabel.17</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true" approved="yes">
         <source xml:lang="en">18</source>
         <target xml:lang="ar">18</target>
         <note>ID: TemplateBooks.PageLabel.18</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true" approved="yes">
         <source xml:lang="en">19</source>
         <target xml:lang="ar">19</target>
         <note>ID: TemplateBooks.PageLabel.19</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="ar">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2 Problems</source>
         <target xml:lang="ar">مشكلتان</target>
         <note>ID: TemplateBooks.PageLabel.2 Problems</note>
         <note>This label indicates a page with two arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true" approved="yes">
         <source xml:lang="en">20</source>
         <target xml:lang="ar">20</target>
         <note>ID: TemplateBooks.PageLabel.20</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true" approved="yes">
         <source xml:lang="en">21</source>
         <target xml:lang="ar">21</target>
         <note>ID: TemplateBooks.PageLabel.21</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="ar">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3 Problems</source>
         <target xml:lang="ar">3 مشكلات</target>
         <note>ID: TemplateBooks.PageLabel.3 Problems</note>
         <note>This label indicates a page with three arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="ar">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4 Problems</source>
         <target xml:lang="ar">4 مشكلات</target>
         <note>ID: TemplateBooks.PageLabel.4 Problems</note>
         <note>This label indicates a page with four arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="ar">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="ar">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="ar">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="ar">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="ar">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="ar">الأبجدية</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="ar">النص الأساسي والصورة</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="ar">النص الأساسي والصورة</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="ar">صفحة المساهمين في العمل</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="ar">مخصص</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="ar">اليوم 1</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="ar">اليوم 2</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="ar">اليوم 3</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="ar">اليوم 4</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="ar">اليوم 5a</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="ar">اليوم 5b</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Factory</source>
         <target xml:lang="ar">المصنع</target>
         <note>ID: TemplateBooks.PageLabel.Factory</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="ar">الغلاف الأمامي</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front/Back Matter</source>
         <target xml:lang="ar">المحتوى الأمامي/الخلفي</target>
         <note>ID: TemplateBooks.PageLabel.FrontBackMatter</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="ar">صورة في الأسفل</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="ar">صورة في المنتصف</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="ar">داخل الغلاف الخلفي</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="ar">داخل الغلاف الأمامي</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="ar">الإرشادات</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="ar">نص فقط</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="ar">صورة فقط</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="ar">صورة فقط</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="ar">خارج الغلاف الخلفي</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="ar">توفير الورق</target>
         <note>ID: TemplateBooks.PageLabel.Paper Saver</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="ar">صورة وكلمة</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="ar">صورة في المنتصف</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="ar">صورة في الأسفل</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SIL-Cameroon</source>
         <target xml:lang="ar">SIL-كاميرون</target>
         <note>ID: TemplateBooks.PageLabel.SIL-Cameroon</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Super Paper Saver</source>
         <target xml:lang="ar">التوفير الفائق للورق</target>
         <note>ID: TemplateBooks.PageLabel.Super Paper Saver</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="ar">هذه الصفحة فارغة عمداً</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="ar">صفحة العنوان</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="ar">تقليدي</target>
         <note>ID: TemplateBooks.PageLabel.Traditional</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="ar">إعداد</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="ar">الزراعة</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="ar">قصص الحيوان</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="ar">أعمال</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="ar">حياة المجتمع</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="ar">الثقافة</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="ar">قاموس</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="ar">البيئة</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="ar">الخيال</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="ar">الصحة</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="ar">شرح مهام عملية</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="ar">الرياضيات</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.NoTopic" sil:dynamic="true">
+      <trans-unit id="Topics.NoTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">No Topic</source>
         <target xml:lang="ar">بدون موضوع</target>
         <note>ID: Topics.NoTopic</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="ar">قصص واقعية</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="ar">تنمية الشخصية</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="ar">تمهيدي</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="ar">علوم</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="ar">روحانيات</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Story Book" sil:dynamic="true">
+      <trans-unit id="Topics.Story Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Story Book</source>
         <target xml:lang="ar">كتاب قصص</target>
         <note>ID: Topics.Story Book</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="ar">تقاليد</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="ar">قصة تقليدية</target>
         <note>ID: Topics.Traditional Story</note>

--- a/DistFiles/localization/ar/IntegrityFailureAdvice.xlf
+++ b/DistFiles/localization/ar/IntegrityFailureAdvice.xlf
@@ -2,72 +2,72 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="IntegrityFailureAdvice-en.md" datatype="html" source-language="en" target-language="ar">
     <body>
-      <trans-unit id="integrity.title">
+      <trans-unit id="integrity.title" approved="yes">
         <source xml:lang="en">Bloom cannot find some of its own files, and cannot continue</source>
         <target xml:lang="ar">يتعذر على Bloom العثور على بعض الملفات الخاصة به، ولا يمكنه المتابعة</target>
         <note>ID: integrity.title</note>
       </trans-unit>
-      <trans-unit id="integrity.causes">
+      <trans-unit id="integrity.causes" approved="yes">
         <source xml:lang="en">Possible Causes</source>
         <target xml:lang="ar">الأسباب الممكنة</target>
         <note>ID: integrity.causes</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.1">
+      <trans-unit id="integrity.causes.1" approved="yes">
         <source xml:lang="en">Your antivirus may have "quarantined" one or more Bloom files.</source>
         <target xml:lang="ar">ربما قام مكافح الفيروسات بعزل ملف واحد أو أكثر من ملفات Bloom.</target>
         <note>ID: integrity.causes.1</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.2">
+      <trans-unit id="integrity.causes.2" approved="yes">
         <source xml:lang="en">Your computer administrator may have your computer "locked down" to prevent bad things, but in such a way that Bloom could not place these files where they belong. </source>
         <target xml:lang="ar">ربما قام مشرف الكمبيوتر بقفل الكمبيوتر لمنع القيام بأنشطة سيئة، وأدى ذلك إلى تعذر Bloom عن وضع الملفات في المكان المناسب.</target>
         <note>ID: integrity.causes.2</note>
       </trans-unit>
-      <trans-unit id="integrity.todo">
+      <trans-unit id="integrity.todo" approved="yes">
         <source xml:lang="en">What To Do</source>
         <target xml:lang="ar">الإجراء اللازم</target>
         <note>ID: integrity.todo</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas">
+      <trans-unit id="integrity.todo.ideas" approved="yes">
         <source xml:lang="en">After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas:</source>
         <target xml:lang="ar">بعد إرسال هذا التقرير، سنتصل بك ونساعدك في حل هذه المشكلة. إلى أن يتم ذلك، فيما يلي بعض الأفكار:</target>
         <note>ID: integrity.todo.ideas</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Reinstall">
+      <trans-unit id="integrity.todo.ideas.Reinstall" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="ar">يمكنك تشغيل أداة تثبيت Bloom مرة أخرى، لمعرفة ما إذا كانت تعمل على نحو جيد هذه المرة أم لا.</target>
         <note>ID: integrity.todo.ideas.Reinstall</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Antivirus">
+      <trans-unit id="integrity.todo.ideas.Antivirus" approved="yes">
         <source xml:lang="en">If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>.</source>
         <target xml:lang="ar">إذا لم يساعد هذا في حل المشكلة، فيجب طرح الأمر على برنامج مكافحة الفيروسات. إذا كان قسم "الملفات المفقودة" أدناه يعرض أي ملفات تنتهي بالامتداد "exe."، فجرِّب وضع مجلد برنامج Bloom في "القائمة البيضاء" التي تتوفر في <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>.</target>
         <note>ID: integrity.todo.ideas.Antivirus</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVAST">
+      <trans-unit id="integrity.todo.ideas.AVAST" approved="yes">
         <source xml:lang="en">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">Instructions</g>.</source>
         <target xml:lang="ar">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">الإرشادات</g>.</target>
         <note>ID: integrity.todo.ideas.AVAST</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Norton">
+      <trans-unit id="integrity.todo.ideas.Norton" approved="yes">
         <target xml:lang="ar">Norton Antivirus: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">الإرشادات من Symantec</g>.</target>
         <note>ID: integrity.todo.ideas.Norton</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVG">
+      <trans-unit id="integrity.todo.ideas.AVG" approved="yes">
         <target xml:lang="ar">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">الإرشادات من AVG</g>.</target>
         <note>ID: integrity.todo.ideas.AVG</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Others">
+      <trans-unit id="integrity.todo.ideas.Others" approved="yes">
         <target xml:lang="ar">أخرى: ابحث في Google عن "سجل القائمة البيضاء وضع اسم مكافح الفيروسات الخاص بك"</target>
         <note>ID: integrity.todo.ideas.Others</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Restart">
+      <trans-unit id="integrity.todo.ideas.Restart" approved="yes">
         <target xml:lang="ar">يمكنك تشغيل أداة تثبيت Bloom مرة أخرى، لمعرفة ما إذا كانت تعمل على نحو جيد هذه المرة أم لا.</target>
         <note>ID: integrity.todo.ideas.Restart</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Retrieve">
+      <trans-unit id="integrity.todo.ideas.Retrieve" approved="yes">
         <target xml:lang="ar">ويمكنك أيضًا محاولة استرداد الجزء الذي أخذه مكافح الفيروسات من Bloom. بالنسبة إلى AVG، عليك البحث عن قائمة "الخيارات" في AVG، والنقر على "مخزن الفيروسات"، والنقر على ملف Bloom في المخزن، والنقر بعد ذلك على "استرداد". للحصول على دليل مرئي، يمكنك الاطلاع على <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">هذه الصورة</g>.</target>
         <note>ID: integrity.todo.ideas.Retrieve</note>
       </trans-unit>
-      <trans-unit id="integrity.missing">
+      <trans-unit id="integrity.missing" approved="yes">
         <target xml:lang="ar">الملفات المفقودة</target>
         <note>ID: integrity.missing</note>
       </trans-unit>

--- a/DistFiles/localization/ar/MissingLameModule.xlf
+++ b/DistFiles/localization/ar/MissingLameModule.xlf
@@ -2,19 +2,19 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="MissingLameModule-en.html" datatype="html" source-language="en" target-language="ar">
     <body>
-      <trans-unit id="missing.lame.please.install">
+      <trans-unit id="missing.lame.please.install" approved="yes">
         <source xml:lang="en">Please Install LAME</source>
         <target xml:lang="ar">الرجاء تثبيت LAME</target>
         <note>ID: missing.lame.please.install</note>
       </trans-unit>
-      <trans-unit id="missing.lame.bloom.needs.lame">
+      <trans-unit id="missing.lame.bloom.needs.lame" approved="yes">
         <source xml:lang="en">This book has audio recordings. Bloom can use these to make a "Talking Book" e-book. However, Bloom needs a program called "LAME for Audacity" in order to create the mp3 files that the book will use. Setting it up is easy. First download and run <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>. Next, restart Bloom.
       </source>
         <target xml:lang="ar">يحتوي هذا الكتاب على تسجيلات صوتية. بإمكان Bloom استخدام هذه التسجيلات لإعداد كتاب إلكتروني "ناطق". ولكن سيحتاج Bloom إلى توفر برنامج اسمه "LAME for Audacity" لإنشاء ملفات MP3 يستخدمها الكتاب. يمكنك إعداد ذلك بسهولة. قم أولاً بتنزيله وتشغيله <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>. بعد ذلك أعد تشغيله Bloom
       </target>
         <note>ID: missing.lame.bloom.needs.lame</note>
       </trans-unit>
-      <trans-unit id="missing.lame.audio.optional">
+      <trans-unit id="missing.lame.audio.optional" approved="yes">
         <source xml:lang="en">If you prefer to go ahead and publish your book without audio, click <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">here</g>.
       </source>
         <target xml:lang="ar">إذا كنت تفضل المتابعة ونشر كتابك بدون صوت، فانقر <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">هنا</g>.

--- a/DistFiles/localization/ar/Palaso.xlf
+++ b/DistFiles/localization/ar/Palaso.xlf
@@ -2,595 +2,595 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Palaso.dll" source-language="en" target-language="ar" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="AboutDialog.BuiltOnDate">
+      <trans-unit id="AboutDialog.BuiltOnDate" approved="yes">
         <source xml:lang="en">Built on {0}</source>
         <target xml:lang="ar">تصميم يعتمد على {0}</target>
         <note>ID: AboutDialog.BuiltOnDate</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.NoUpdates">
+      <trans-unit id="AboutDialog.NoUpdates" approved="yes">
         <source xml:lang="en">No Updates</source>
         <target xml:lang="ar">لا توجد تحديثات</target>
         <note>ID: AboutDialog.NoUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.WindowTitle">
+      <trans-unit id="AboutDialog.WindowTitle" approved="yes">
         <source xml:lang="en">About {0}</source>
         <target xml:lang="ar">معلومات حول {0}</target>
         <note>ID: AboutDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._checkForUpdates">
+      <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
         <source xml:lang="en">Check For Updates</source>
         <target xml:lang="ar">التحقق من وجود تحديثات</target>
         <note>ID: AboutDialog._checkForUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._releaseNotesLabel">
+      <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="ar">ملاحظات الإصدار</target>
         <note>ID: AboutDialog._releaseNotesLabel</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.General">
+      <trans-unit id="Application.AlreadyRunning.General" approved="yes">
         <source xml:lang="en">Another copy of the application is already running. If you cannot find it, restart your computer.</source>
         <target xml:lang="ar">جارٍ تشغيل نسخة أخرى من التطبيق الآن. إذا لم تتمكن من العثور عليها، أعِد تشغيل الكمبيوتر.</target>
         <note>ID: Application.AlreadyRunning.General</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.Specific">
+      <trans-unit id="Application.AlreadyRunning.Specific" approved="yes">
         <source xml:lang="en">Another copy of {0} is already running. If you cannot find that copy of {0}, restart your computer.</source>
         <target xml:lang="ar">جارٍ تشغيل نسخة أخرى من {0} الآن. إذا لم تتمكن من العثور على نسخة من {0}، أعِد تشغيل الكمبيوتر.</target>
         <note>ID: Application.AlreadyRunning.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.General">
+      <trans-unit id="Application.ProblemStarting.General" approved="yes">
         <source xml:lang="en">There was a problem starting the application which might require that you restart your computer.</source>
         <target xml:lang="ar">حدثت مشكلة أثناء تشغيل التطبيق وقد تحتاج إلى إعادة تشغيل الكمبيوتر.</target>
         <note>ID: Application.ProblemStarting.General</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.Specific">
+      <trans-unit id="Application.ProblemStarting.Specific" approved="yes">
         <source xml:lang="en">There was a problem starting {0} which might require that you restart your computer.</source>
         <target xml:lang="ar">حدثت مشكلة أثناء تشغيل {0} وقد تحتاج إلى إعادة تشغيل الكمبيوتر.</target>
         <note>ID: Application.ProblemStarting.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.General">
+      <trans-unit id="Application.WaitingFinish.General" approved="yes">
         <source xml:lang="en">Waiting for other application to finish...</source>
         <target xml:lang="ar">في انتظار انتهاء تطبيق آخر...</target>
         <note>ID: Application.WaitingFinish.General</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.Specific">
+      <trans-unit id="Application.WaitingFinish.Specific" approved="yes">
         <source xml:lang="en">Waiting for other {0} to finish...</source>
         <target xml:lang="ar">في انتظار انتهاء {0} آخر...</target>
         <note>ID: Application.WaitingFinish.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="ar">&amp;إلغاء</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.No">
+      <trans-unit id="Common.No" approved="yes">
         <source xml:lang="en">No</source>
         <target xml:lang="ar">لا</target>
         <note>ID: Common.No</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="ar">&amp;موافق</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Yes">
+      <trans-unit id="Common.Yes" approved="yes">
         <source xml:lang="en">Yes</source>
         <target xml:lang="ar">نعم</target>
         <note>ID: Common.Yes</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="ar">سيتم نقل {0} إلى "سلة المحذوفات".</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
         <note>Parameter {0} is a description of the things being deleted (e.g., "The selected files")</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="ar">سيتم نقل {0} إلى "سلة المحذوفات".</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
         <note>Parameter {0} is a file name</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Confirm Delete</source>
         <target xml:lang="ar">تأكيد حذف</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="ar">إل&amp;غاء</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="ar">&amp;حذف</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.AlmostMatchingImages">
+      <trans-unit id="ImageToolbox.AlmostMatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images with names close to {1}</source>
         <target xml:lang="ar">تم العثور على صور {0}&gt; تحمل أسماءً قريبة من {1}</target>
         <note>ID: ImageToolbox.AlmostMatchingImages</note>
         <note>The {0} will be replaced by the number of images found.  The {1} will be replaced with the search string.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ArtOfReading">
+      <trans-unit id="ImageToolbox.ArtOfReading" approved="yes">
         <source xml:lang="en">Art Of Reading</source>
         <target xml:lang="ar">فن القراءة</target>
         <note>ID: ImageToolbox.ArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Camera">
+      <trans-unit id="ImageToolbox.Camera" approved="yes">
         <source xml:lang="en">Camera</source>
         <target xml:lang="ar">الكاميرا</target>
         <note>ID: ImageToolbox.Camera</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
         <source xml:lang="en">Use {0}</source>
         <target xml:lang="ar">استخدام {0}</target>
         <note>ID: ImageToolbox.CopyExemplarMetadata</note>
         <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Crop">
+      <trans-unit id="ImageToolbox.Crop" approved="yes">
         <source xml:lang="en">Crop</source>
         <target xml:lang="ar">اقتصاص</target>
         <note>ID: ImageToolbox.Crop</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.DownloadArtOfReading">
+      <trans-unit id="ImageToolbox.DownloadArtOfReading" approved="yes">
         <source xml:lang="en">Download Art Of Reading Installer</source>
         <target xml:lang="ar">تنزيل أداة تثبيت فن القراءة</target>
         <note>ID: ImageToolbox.DownloadArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EditMetadataLink">
+      <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
         <source xml:lang="en">Edit...</source>
         <target xml:lang="ar">تحرير...</target>
         <note>ID: ImageToolbox.EditMetadataLink</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EnterSearchTerms">
+      <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
         <source xml:lang="en">This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.</source>
         <target xml:lang="ar">هذا معرض "فن القراءة".في المربع أعلاه، اكتب ما تريد البحث عنه، ثم اضغط على ENTER.يمكنك كتابة كلمات باللغتين الإنجليزية والإندونيسية.</target>
         <note>ID: ImageToolbox.EnterSearchTerms</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.FileButton">
+      <trans-unit id="ImageToolbox.FileButton" approved="yes">
         <source xml:lang="en">File</source>
         <target xml:lang="ar">الملف</target>
         <note>ID: ImageToolbox.FileButton</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
         <target xml:lang="ar">عذراً، حدث خطأ أثناء الحصول على الصورة.</target>
         <note>ID: ImageToolbox.GenericGettingImageProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericProblem">
+      <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
         <target xml:lang="ar">عذراً، حدث خطأ في صندوق أدوات الصور</target>
         <note>ID: ImageToolbox.GenericProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GetPicture">
+      <trans-unit id="ImageToolbox.GetPicture" approved="yes">
         <source xml:lang="en">Get Picture</source>
         <target xml:lang="ar">الحصول على الصورة</target>
         <note>ID: ImageToolbox.GetPicture</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
         <source xml:lang="en">Image Toolbox</source>
         <target xml:lang="ar">صندوق أدوات الصور</target>
         <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.InstallArtOfReading">
+      <trans-unit id="ImageToolbox.InstallArtOfReading" approved="yes">
         <source xml:lang="en">Install the Art Of Reading package (this may be very slow)</source>
         <target xml:lang="ar">تثبيت حزمة "فن القراءة" (قد يتم ذلك ببطء شديد)</target>
         <note>ID: ImageToolbox.InstallArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.MatchingImages">
+      <trans-unit id="ImageToolbox.MatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images</source>
         <target xml:lang="ar">تم العثور على {0} صور</target>
         <note>ID: ImageToolbox.MatchingImages</note>
         <note>The {0} will be replaced by the number of matching images</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NewMultilingual">
+      <trans-unit id="ImageToolbox.NewMultilingual" approved="yes">
         <source xml:lang="en">Did you know that there is a new version of this collection which lets you search in Arabic, Bengali, Chinese, English, French, Indonesian, Hindi, Portuguese, Spanish, Thai, or Swahili? It is free and available for downloading.</source>
         <target xml:lang="ar">هل تعرف أن هناك إصداراً جديداً من هذه المجموعة يتيح لك إمكانية البحث بالعربية والبنغالية والصينية والإنجليزية والفرنسية والإندونيسية والهندية والبرتغالية والإسبانية والتايلاندية والسواحلية؟ إنه إصدار مجاني ومتاح للتنزيل.</target>
         <note>ID: ImageToolbox.NewMultilingual</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoArtOfReading">
+      <trans-unit id="ImageToolbox.NoArtOfReading" approved="yes">
         <source xml:lang="en">This computer doesn't appear to have the 'Art Of Reading' gallery installed yet.</source>
         <target xml:lang="ar">يبدو أنه لم يتم تثبيت معرض "فن القراءة" على هذا الكمبيوتر حتى الآن.</target>
         <note>ID: ImageToolbox.NoArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoMatchingImages">
+      <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
         <source xml:lang="en">Found no matching images</source>
         <target xml:lang="ar">لم يتم العثور على أي صور مطابقة</target>
         <note>ID: ImageToolbox.NoMatchingImages</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PictureFiles">
+      <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
         <source xml:lang="en">picture files</source>
         <target xml:lang="ar">ملفات الصور</target>
         <note>ID: ImageToolbox.PictureFiles</note>
         <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice" approved="yes">
         <source xml:lang="en">Problem Getting Image</source>
         <target xml:lang="ar">هناك مشكلة في الحصول على الصورة</target>
         <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemLoadingImage">
+      <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
         <source xml:lang="en">Sorry, there was a problem loading that image.</source>
         <target xml:lang="ar">عذراً، هناك مشكلة في تحميل هذه الصورة.</target>
         <note>ID: ImageToolbox.ProblemLoadingImage</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
         <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
         <target xml:lang="ar">لا تحدد هذه الصورة:\n\nمن أنشأها؟\nمن يمكنه استخدامها؟</target>
         <note>ID: ImageToolbox.PromptForMissingMetadata</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Scanner">
+      <trans-unit id="ImageToolbox.Scanner" approved="yes">
         <source xml:lang="en">Scanner</source>
         <target xml:lang="ar">الماسح الضوئي</target>
         <note>ID: ImageToolbox.Scanner</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchArtOfReading">
+      <trans-unit id="ImageToolbox.SearchArtOfReading" approved="yes">
         <source xml:lang="en">Search the Art of Reading Gallery</source>
         <target xml:lang="ar">البحث في معرض "فن القراءة"</target>
         <note>ID: ImageToolbox.SearchArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchLanguage">
+      <trans-unit id="ImageToolbox.SearchLanguage" approved="yes">
         <source xml:lang="en">The search box is currently set to {0}</source>
         <target xml:lang="ar">تم تعيين مربع البحث في الوقت الحالي على {0}</target>
         <note>ID: ImageToolbox.SearchLanguage</note>
         <note>The {0} will be replaced by the name of the language used in the searches.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SetUpMetadataLink">
+      <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
         <source xml:lang="en">Set up metadata...</source>
         <target xml:lang="ar">قم بإعداد البيانات الوصفية...</target>
         <note>ID: ImageToolbox.SetUpMetadataLink</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.AlternateNamesHeader">
+      <trans-unit id="LanguageLookup.AlternateNamesHeader" approved="yes">
         <source xml:lang="en">Other Names</source>
         <target xml:lang="ar">أسماء أخرى</target>
         <note>ID: LanguageLookup.AlternateNamesHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2" approved="yes">
         <source xml:lang="en">This list should include all the ISO-639 languages, including all the alternative names known to ethnologue.com.\n\nIf necessary, use the "Unlisted Language" option, which will be selected for you now.</source>
         <target xml:lang="ar">يجب أن تتضمن هذه القائمة جميع لغات ISO-639، بما في ذلك جميع الأسماء البديلة المعروفة في ethnologue.com.\n\nعند اللزوم، يمكنك استخدام خيار "لغة غير مدرجة"، الذي سيتم تحديده لك الآن.</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue" approved="yes">
         <source xml:lang="en">Ethnologue.com</source>
         <target xml:lang="ar">Ethnologue.com</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
         <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
         <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
         <target xml:lang="ar">معلومات حول رموز لغات 639-3 وكيفية طلب الحصول على رموز جديدة</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
         <source xml:lang="en">About The ISO Language Registry</source>
         <target xml:lang="ar">معلومات حول سجل لغات ISO</target>
         <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CodeHeader">
+      <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
         <source xml:lang="en">Code</source>
         <target xml:lang="ar">الرمز</target>
         <note>ID: LanguageLookup.CodeHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryCount">
+      <trans-unit id="LanguageLookup.CountryCount" approved="yes">
         <source xml:lang="en">{0} Countries</source>
         <target xml:lang="ar">{0} بلاد</target>
         <note>ID: LanguageLookup.CountryCount</note>
         <note>Shown when there are multiple countries and it is just confusing to list them all. {0} is a count of countries.</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryHeader">
+      <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="ar">البلد</target>
         <note>ID: LanguageLookup.CountryHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
         <source xml:lang="en">You can change how the language name will be displayed here:</source>
         <target xml:lang="ar">يمكنك تغيير كيفية عرض اسم اللغة هنا:</target>
         <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
         <source xml:lang="en">Lookup Language Code...</source>
         <target xml:lang="ar">البحث عن رموز اللغة…</target>
         <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.PrimaryNameHeader">
+      <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="ar">الاسم</target>
         <note>ID: LanguageLookup.PrimaryNameHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel">
+      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel" approved="yes">
         <source xml:lang="en">Show regional dialects</source>
         <target xml:lang="ar">عرض اللهجات الإقليمية</target>
         <note>ID: LanguageLookup.ShowRegionalDialectsLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.UnlistedLanguage">
+      <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
         <source xml:lang="en">Unlisted Language</source>
         <target xml:lang="ar">اللغة غير مدرجة</target>
         <note>ID: LanguageLookup.UnlistedLanguage</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
         <source xml:lang="en">Can't find your language?</source>
         <target xml:lang="ar">لا يمكن العثور على لغتك؟</target>
         <note>ID: LanguageLookup._cannotFindLanguageLink</note>
       </trans-unit>
-      <trans-unit id="MemoryWarning">
+      <trans-unit id="MemoryWarning" approved="yes">
         <source xml:lang="en">Unfortunately, {0} is starting to get short of memory, and may soon slow down or experience other problems. We recommend that you quit and restart it when convenient.</source>
         <target xml:lang="ar">للأسف، ذاكرة {0} على وشك الانتهاء، وقد يحدث تباطؤ عن قريب أو تظهر مشاكل أخرى. نوصي بالخروج وإعادة التشغيل في وقت مناسب لك.</target>
         <note>ID: MemoryWarning</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Creator">
+      <trans-unit id="MetadataDisplay.Creator" approved="yes">
         <source xml:lang="en">Creator: {0}</source>
         <target xml:lang="ar">المؤلف: {0}</target>
         <note>ID: MetadataDisplay.Creator</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.CreatorLabel">
+      <trans-unit id="MetadataDisplay.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="ar">المؤلف</target>
         <note>ID: MetadataDisplay.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.LicenseInfo">
+      <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
         <source xml:lang="en">License Info</source>
         <target xml:lang="ar">معلومات الترخيص</target>
         <note>ID: MetadataDisplay.LicenseInfo</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You must keep the copyright and credits for authors, illustrators, etc.</source>
         <target xml:lang="ar">يجب الحفاظ على حقوق الطبع والنشر ووضع المساهمين في العمل من مؤلفين ورسامين وما إلى ذلك.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.AttributionRequired</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You are free to make commercial use of this work.</source>
         <target xml:lang="ar">يمكنك استخدام هذا العمل لأغراض تجارية.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work.</source>
         <target xml:lang="ar">يمكنك إدخال تعديلات وإضافات إلى هذا العمل.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.Derivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work, but you may distribute the resulting work only under the same or similar license to this one.</source>
         <target xml:lang="ar">يمكنك إدخال تعديلات وإضافات إلى هذا العمل، ولكن لا يجوز لك نشر العمل الناتج عن ذلك إلا بموجب ترخيص هذا العمل نفسه أو ترخيص شبيه.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not make changes or build upon this work without permission.</source>
         <target xml:lang="ar">لا يجوز لك إجراء تغييرات على هذا العمل أو التصميم عليه بدون إذن.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NoDerivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not use this work for commercial purposes.</source>
         <target xml:lang="ar">لا يجوز لك استخدام هذا العمل لأغراض تجارية.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NonCommercial</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For permission to reuse, contact the copyright holder.</source>
         <target xml:lang="ar">للحصول على إذن إعادة استخدام، عليك الاتصال بمالك حقوق الطبع والنشر.</target>
         <note>ID: MetadataDisplay.Licenses.NullLicense</note>
         <note>This is used when all we have is a copyright, no other license.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.NoLicense">
+      <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
         <source xml:lang="en">No license specified</source>
         <target xml:lang="ar">لم يتم تحديد ترخيص</target>
         <note>ID: MetadataDisplay.NoLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowCommercialUse">
+      <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
         <source xml:lang="en">Allow commercial uses of your work?</source>
         <target xml:lang="ar">هل تسمح باستخدام العمل لأغراض تجارية؟</target>
         <note>ID: MetadataEditor.AllowCommercialUse</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowDerivatives">
+      <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
         <source xml:lang="en">Allow modifications of your work?</source>
         <target xml:lang="ar">هل تسمح بإدخال تعديلات على عملك؟</target>
         <note>ID: MetadataEditor.AllowDerivatives</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CopyrightHolder">
+      <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
         <source xml:lang="en">Copyright Holder</source>
         <target xml:lang="ar">مالك حقوق الطبع والنشر</target>
         <note>ID: MetadataEditor.CopyrightHolder</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons">
+      <trans-unit id="MetadataEditor.CreativeCommons" approved="yes">
         <source xml:lang="en">Creative Commons</source>
         <target xml:lang="ar">المشاع الإبداعي</target>
         <note>ID: MetadataEditor.CreativeCommons</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental">
+      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental" approved="yes">
         <source xml:lang="en">Intergovernmental Version</source>
         <target xml:lang="ar">إصدار مشترك بين الحكومات</target>
         <note>ID: MetadataEditor.CreativeCommons.Intergovernmental</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreatorLabel">
+      <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="ar">المؤلف</target>
         <note>ID: MetadataEditor.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CustomLicense">
+      <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="ar">مخصص</target>
         <note>ID: MetadataEditor.CustomLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleNoCredit">
+      <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
         <source xml:lang="en">Copyright and License</source>
         <target xml:lang="ar">حقوق الطبع والنشر والترخيص</target>
         <note>ID: MetadataEditor.TitleNoCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleWithCredit">
+      <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
         <source xml:lang="en">Credit, Copyright, and License</source>
         <target xml:lang="ar">المساهمون في العمل وحقوق الطبع والنشر والترخيص</target>
         <note>ID: MetadataEditor.TitleWithCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.UnknownLicense">
+      <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <target xml:lang="ar">اتصل بمالك حقوق الطبع والنشر للحصول على أي أذونات</target>
         <note>ID: MetadataEditor.UnknownLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.YesShareAlike">
+      <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
         <source xml:lang="en">Yes, as long as others share alike</source>
         <target xml:lang="ar">نعم، ما دامت الحصة مساوية لحصة الآخرين</target>
         <note>ID: MetadataEditor.YesShareAlike</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.additionalRequestsLabel">
+      <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
         <source xml:lang="en">Additional Requests</source>
         <target xml:lang="ar">طلبات إضافية</target>
         <note>ID: MetadataEditor.additionalRequestsLabel</note>
         <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.betterLinkLabel1">
+      <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
         <source xml:lang="en">more info</source>
         <target xml:lang="ar">مزيد من المعلومات</target>
         <note>ID: MetadataEditor.betterLinkLabel1</note>
         <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere that defines it.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
         <source xml:lang="en">Not Enforceable</source>
         <target xml:lang="ar">غير قابل للتنفيذ</target>
         <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
         <note>While this screen allows it, legally you can't enforce any additions to a creative commons license. This link takes you to the clause that says that. This link is visible only if you choose Creative Commons but then type in  the "Additional Request" box.</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <target xml:lang="ar">قد يؤدي هذا أيضاً إلى إخفاء الأزرار الأخرى التي لا يحتاج إليها المستخدم غير المتقدم.</target>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.CtrlShiftHint">
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
         <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
         <target xml:lang="ar">سيظهر الزر عند الضغط باستمرار على مفتاحي Ctrl وShift معاً.</target>
         <note>ID: SettingsProtection.CtrlShiftHint</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+      <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
         <source xml:lang="en">Settings...</source>
         <target xml:lang="ar">الإعدادات…</target>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
         <source xml:lang="en">Hide the button that opens settings.</source>
         <target xml:lang="ar">إخفاء الزر الذي يفتح الإعدادات.</target>
         <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
         <source xml:lang="en">Factory Password</source>
         <target xml:lang="ar">كلمة مرور المصنع</target>
         <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
         <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
         <target xml:lang="ar">لمنع التغييرات غير المقصودة التي يمكن أن تتسبب في توقف هذه الأداة عن العمل، تم قفل هذه الإعدادات.</target>
         <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
         <source xml:lang="en">Settings Protection Password</source>
         <target xml:lang="ar">كلمة مرور حماية الإعدادات</target>
         <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox">
+      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
         <source xml:lang="en">Show Characters</source>
         <target xml:lang="ar">إظهار الأحرف</target>
         <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordNotice">
+      <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
         <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always google for "{1}" and "{2}".</source>
         <target xml:lang="ar">كلمة مرور المصنع لهذه الإعدادات هي "{0}". إذا نسيتها، فيمكنك دائمًا البحث عن "{1}" و"{2}" في Google</target>
         <note>ID: SettingsProtection.PasswordNotice</note>
         <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
         <source xml:lang="en">Require the factory password to get into settings.</source>
         <target xml:lang="ar">يلزم كتابة كلمة مرور المصنع للوصول إلى الإعدادات.</target>
         <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
         <source xml:lang="en">Settings Protection</source>
         <target xml:lang="ar">حماية الإعدادات</target>
         <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
       </trans-unit>
-      <trans-unit id="ShowReleaseNotesDialog.WindowTitle">
+      <trans-unit id="ShowReleaseNotesDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="ar">ملاحظات الإصدار</target>
         <note>ID: ShowReleaseNotesDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Font">
+      <trans-unit id="WSFontControl.Font" approved="yes">
         <source xml:lang="en">&amp;Font:</source>
         <target xml:lang="ar">ال&amp;خط:</target>
         <note>ID: WSFontControl.Font</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.FontNotAvailable">
+      <trans-unit id="WSFontControl.FontNotAvailable" approved="yes">
         <source xml:lang="en">(The selected font is not available on this machine. Using default.)</source>
         <target xml:lang="ar">(الخط المحدد غير متوفر على هذا الجهاز. يتم استخدام الخط الافتراضي.)</target>
         <note>ID: WSFontControl.FontNotAvailable</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.RightToLeftWS">
+      <trans-unit id="WSFontControl.RightToLeftWS" approved="yes">
         <source xml:lang="en">This is a &amp;right to left writing system.</source>
         <target xml:lang="ar">هذا نظام كتابة من &amp;اليمين إلى اليسار.</target>
         <note>ID: WSFontControl.RightToLeftWS</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Size">
+      <trans-unit id="WSFontControl.Size" approved="yes">
         <source xml:lang="en">&amp;Size:</source>
         <target xml:lang="ar">ال&amp;حجم:</target>
         <note>ID: WSFontControl.Size</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.TestArea">
+      <trans-unit id="WSFontControl.TestArea" approved="yes">
         <source xml:lang="en">&amp;Test Area:</source>
         <target xml:lang="ar">&amp;منطقة الاختبار:</target>
         <note>ID: WSFontControl.TestArea</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
         <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
         <target xml:lang="ar">إذا لم تكن لوحة المفاتيح التي تحتاج إليها مُدرجة، فانقر على الرابط المناسب أدناه لإعدادها</target>
         <note>ID: WSKeyboardControl.KeyboardNotListed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
         <source xml:lang="en">Windows keyboard settings</source>
         <target xml:lang="ar">إعدادات لوحة المفاتيح في Windows</target>
         <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
         <source xml:lang="en">Available keyboards</source>
         <target xml:lang="ar">لوحات المفاتيح المتوفرة</target>
         <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
         <source xml:lang="en">Previously used keyboards</source>
         <target xml:lang="ar">لوحات المفاتيح المستخدمة من قبل</target>
         <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
         <source xml:lang="en">Keyman Configuration</source>
         <target xml:lang="ar">تكوين Keyman</target>
         <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
         <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
         <target xml:lang="ar">لم يتم تثبيت Keyman 5.0 أو أي إصدار أحدث.</target>
         <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
         <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
         <target xml:lang="ar">حدد &amp;لوحة المفاتيح التي تريد كتابة نص {0} بها</target>
         <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.TestAreaCaption">
+      <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
         <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
         <target xml:lang="ar">&amp;منطقة الاختبار (يمكنك استخدام هذه المنطقة لكتابة شيء تختبر به لوحة المفاتيح.)</target>
         <note>ID: WSKeyboardControl.TestAreaCaption</note>
       </trans-unit>
-      <trans-unit id="Warning">
+      <trans-unit id="Warning" approved="yes">
         <source xml:lang="en">Warning</source>
         <target xml:lang="ar">تحذير</target>
         <note>ID: Warning</note>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption" approved="yes">
         <source xml:lang="en">Unable to connect to SLDR</source>
         <target xml:lang="ar">يتعذر الاتصال بـ SLDR</target>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrCaption</note>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText" approved="yes">
         <source xml:lang="en">The application is unable to connect to the SIL Locale Data Repository to retrieve the latest information about this language. If you create this writing system, the default settings might be incorrect or out of date. Are you sure you want to create a new writing system?</source>
         <target xml:lang="ar">يتعذر على التطبيق الاتصال بمستودع بيانات لغة SIL لاستقدام أحدث المعلومات حول هذه اللغة. عند إنشاء نظام الكتابة هذا، قد تكون الإعدادات الافتراضية غير صحيحة أو قديمة. هل انت متأكد من انك تريد إنشاء نظام كتابة جديد؟</target>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrText</note>

--- a/DistFiles/localization/ar/TrainingVideos.xlf
+++ b/DistFiles/localization/ar/TrainingVideos.xlf
@@ -2,17 +2,17 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="TrainingVideos-en.md" datatype="html" source-language="en" target-language="ar">
     <body>
-      <trans-unit id="training.videos">
+      <trans-unit id="training.videos" approved="yes">
         <source xml:lang="en">Bloom Training Videos</source>
         <target xml:lang="ar">مقطع فيديو للتدريب على Bloom</target>
         <note>ID: training.videos</note>
       </trans-unit>
-      <trans-unit id="training.videos.watch">
+      <trans-unit id="training.videos.watch" approved="yes">
         <source xml:lang="en">If you are connected to the internet now, you can watch videos in your web browser:</source>
         <target xml:lang="ar">إذا كان يتوفر لديك اتصال بالإنترنت، فيمكنك مشاهدة مقاطع فيديو في متصفح الويب الخاص بك:</target>
         <note>ID: training.videos.watch</note>
       </trans-unit>
-      <trans-unit id="training.videos.all">
+      <trans-unit id="training.videos.all" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-a" html:href="http://tiny.cc/bloomVimeo">All videos</g>
         </source>
@@ -21,12 +21,12 @@
         </target>
         <note>ID: training.videos.all</note>
       </trans-unit>
-      <trans-unit id="training.videos.intro">
+      <trans-unit id="training.videos.intro" approved="yes">
         <source xml:lang="en">Introductory Videos</source>
         <target xml:lang="ar">مقاطع الفيديو التعريفية</target>
         <note>ID: training.videos.intro</note>
       </trans-unit>
-      <trans-unit id="training.videos.whofor">
+      <trans-unit id="training.videos.whofor" approved="yes">
         <source xml:lang="en">
           <g id="genid-2" ctype="x-html-a" html:href="https://vimeo.com/114043219">Bloom: Who is it for</g>
         </source>
@@ -35,7 +35,7 @@
         </target>
         <note>ID: training.videos.whofor</note>
       </trans-unit>
-      <trans-unit id="training.videos.templates">
+      <trans-unit id="training.videos.templates" approved="yes">
         <source xml:lang="en">
           <g id="genid-3" ctype="x-html-a" html:href="https://vimeo.com/114024308">Understanding Templates and Shell Books</g>
         </source>
@@ -44,7 +44,7 @@
         </target>
         <note>ID: training.videos.templates</note>
       </trans-unit>
-      <trans-unit id="training.videos.basicbook">
+      <trans-unit id="training.videos.basicbook" approved="yes">
         <source xml:lang="en">
           <g id="genid-4" ctype="x-html-a" html:href="https://vimeo.com/112825489">Using the Basic Book template</g>
         </source>
@@ -53,7 +53,7 @@
         </target>
         <note>ID: training.videos.basicbook</note>
       </trans-unit>
-      <trans-unit id="training.videos.readers">
+      <trans-unit id="training.videos.readers" approved="yes">
         <source xml:lang="en">
           <g id="genid-5" ctype="x-html-a" html:href="http://tiny.cc/usingBloomReaderTemplates">Using Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -62,12 +62,12 @@
         </target>
         <note>ID: training.videos.readers</note>
       </trans-unit>
-      <trans-unit id="training.videos.advanced">
+      <trans-unit id="training.videos.advanced" approved="yes">
         <source xml:lang="en">Advanced Topics</source>
         <target xml:lang="ar">موضوعات متقدمة</target>
         <note>ID: training.videos.advanced</note>
       </trans-unit>
-      <trans-unit id="training.videos.formatting">
+      <trans-unit id="training.videos.formatting" approved="yes">
         <source xml:lang="en">
           <g id="genid-6" ctype="x-html-a" html:href="https://vimeo.com/117820891">Changing the format of text</g>
         </source>
@@ -76,7 +76,7 @@
         </target>
         <note>ID: training.videos.formatting</note>
       </trans-unit>
-      <trans-unit id="training.videos.custompage">
+      <trans-unit id="training.videos.custompage" approved="yes">
         <source xml:lang="en">
           <g id="genid-7" ctype="x-html-a" html:href="https://vimeo.com/116868148">Using the Custom Page template</g>
         </source>
@@ -85,7 +85,7 @@
         </target>
         <note>ID: training.videos.custompage</note>
       </trans-unit>
-      <trans-unit id="training.videos.specialcharacters">
+      <trans-unit id="training.videos.specialcharacters" approved="yes">
         <source xml:lang="en">
           <g id="genid-8" ctype="x-html-a" html:href="https://vimeo.com/117927599">Inserting special characters</g>
         </source>
@@ -94,7 +94,7 @@
         </target>
         <note>ID: training.videos.specialcharacters</note>
       </trans-unit>
-      <trans-unit id="training.videos.readertemplates">
+      <trans-unit id="training.videos.readertemplates" approved="yes">
         <source xml:lang="en">
           <g id="genid-9" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">Making a set of Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -103,24 +103,24 @@
         </target>
         <note>ID: training.videos.readertemplates</note>
       </trans-unit>
-      <trans-unit id="training.videos.offline">
+      <trans-unit id="training.videos.offline" approved="yes">
         <source xml:lang="en">Offline Viewing</source>
         <target xml:lang="ar">العرض بدون اتصال</target>
         <note>ID: training.videos.offline</note>
       </trans-unit>
-      <trans-unit id="training.videos.download">
+      <trans-unit id="training.videos.download" approved="yes">
         <source xml:lang="en">If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer:</source>
         <target xml:lang="ar">يمكنك تنزيل مقاطع الفيديو هذه على جهاز الكومبيوتر الخاص بك إذا كنت تريد الاطلاع عليها ومشاركتها أثناء عدم توفر اتصال بالإنترنت:</target>
         <note>ID: training.videos.download</note>
       </trans-unit>
-      <trans-unit id="training.videos.hires">
+      <trans-unit id="training.videos.hires" approved="yes">
         <source xml:lang="en">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">High Resolution</g> (Large files)</source>
         <target xml:lang="ar">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">دقة عالية</g> (ملفات كبيرة)</target>
         <note>ID: training.videos.hires</note>
       </trans-unit>
-      <trans-unit id="training.videos.lores">
+      <trans-unit id="training.videos.lores" approved="yes">
         <source xml:lang="en">
           <g id="genid-11" ctype="x-html-a" html:href="http://tiny.cc/bloomSDVideos">Low Resolution</g> (Smaller files)</source>
         <target xml:lang="ar">

--- a/DistFiles/localization/ar/bloomEpubPreview.xlf
+++ b/DistFiles/localization/ar/bloomEpubPreview.xlf
@@ -2,29 +2,29 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="bloomEpubPreview-en.html" datatype="html" source-language="en" target-language="ar">
     <body>
-      <trans-unit id="epubpreview.describe">
+      <trans-unit id="epubpreview.describe" approved="yes">
         <source xml:lang="en">This is an <g id="genid-1" ctype="x-html-a" html:href="https://en.wikipedia.org/wiki/ePUB">ePUB</g> (e-book) version of your book. <g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">It contains audio, so that new readers can listen as they read.</g>
       </source>
         <target xml:lang="ar">هذا إصدار  <g id="genid-1" ctype="x-html-a" html:href="https://en.wikipedia.org/wiki/ePUB">ePUB</g> (كتاب إلكتروني) من كتابك. <g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">يحتوي الكتاب على ملف صوتي، حتى يتمكن القراء الجدد من الاستماع أثناء القراءة.</g>
       </target>
         <note>ID: epubpreview.describe</note>
       </trans-unit>
-      <trans-unit id="epubpreview.recording.butnotalk">
+      <trans-unit id="epubpreview.recording.butnotalk" approved="yes">
         <source xml:lang="en">This book has some recordings, but this audio is not included in the ePUB.</source>
         <target xml:lang="ar">يحتوي هذا الكتاب على بعض التسجيلات، إلا أنه لا يتم تضمين ملف صوتي في ePUB.</target>
         <note>ID: epubpreview.recording.butnotalk</note>
       </trans-unit>
-      <trans-unit id="epubpreview.preview">
+      <trans-unit id="epubpreview.preview" approved="yes">
         <source xml:lang="en">Preview</source>
         <target xml:lang="ar">المعاينة</target>
         <note>ID: epubpreview.preview</note>
       </trans-unit>
-      <trans-unit id="epubpreview.resizing">
+      <trans-unit id="epubpreview.resizing" approved="yes">
         <source xml:lang="en">You can resize the preview by dragging the lower right corner of this simulated device. See how your book will look on screens of various sizes.</source>
         <target xml:lang="ar">يمكنك تغيير حجم المعاينة من خلال سحب الزاوية أسفل يمين جهاز المحاكاة هذا. انظر كيف سيظهر كتابك على شاشات ذات أحجام مختلفة.</target>
         <note>ID: epubpreview.resizing</note>
       </trans-unit>
-      <trans-unit id="epubpreview.readium">
+      <trans-unit id="epubpreview.readium" approved="yes">
         <source xml:lang="en">This page uses the <g id="genid-3" ctype="x-html-a" html:href="http://readium.org/">Readium</g> ePUB reader. Books will likely look different on different readers.
       </source>
         <target xml:lang="ar">
@@ -32,7 +32,7 @@
       </target>
         <note>ID: epubpreview.readium</note>
       </trans-unit>
-      <trans-unit id="epubpreview.talkingbookpreview">
+      <trans-unit id="epubpreview.talkingbookpreview" approved="yes">
         <source xml:lang="en">The preview here cannot yet play Talking Books. You can listen to it using Adobe's Free <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html">Digital Editions</g> e-book reader.
       </source>
         <target xml:lang="ar">لا يمكن للمعاينة تشغيل الكتب الناطقة في الوقت الحالي. يمكنك الاستماع إليها باستخدام  <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html"> الإصدارات الرقمية</g> من قارئ الكتب الإلكترونية المجاني Adobe 
@@ -40,53 +40,53 @@
       </target>
         <note>ID: epubpreview.talkingbookpreview</note>
       </trans-unit>
-      <trans-unit id="epubpreview.ontodevice">
+      <trans-unit id="epubpreview.ontodevice" approved="yes">
         <source xml:lang="en">Getting this book onto your Device</source>
         <target xml:lang="ar">وضع هذا الكتاب على جهازك</target>
         <note>ID: epubpreview.ontodevice</note>
       </trans-unit>
-      <trans-unit id="epubpreview.usingdropbox">
+      <trans-unit id="epubpreview.usingdropbox" approved="yes">
         <source xml:lang="en">A handy way to get books to your phone is to set up Dropbox or similar service on both your computer and your phone/tablet. Just click Save ePUB and then choose your Dropbox folder. On your phone, open the Dropbox app and select your book. If you are using a laptop, you can also try the free <g id="genid-5" ctype="x-html-a" html:href="http://www.ushareit.com/">ShareIt</g> program to send files from your laptop to a phone or tablet.
       </source>
         <target xml:lang="ar">هناك وسيلة سهلة لوضع الكتب على هاتفك، وهي إعداد Dropbox أو خدمة شبيهة لها على جهاز الكمبيوتر والهاتف/الجهاز اللوحي. لن يلزمك سوى النقر على "حفظ ePUB" واختيار مجلد Dropbox بعد ذلك. على الهاتف، افتح تطبيق Dropbox واختر كتابك. إذا كنت تستخدم جهاز كمبيوتر محمولاً، فيمكنك أيضًا تجربة برنامج  <g id="genid-5" ctype="x-html-a" html:href="http://shareit.lenovo.com/">ShareIt</g> المجاني لإرسال الملفات من الكمبيوتر المحمول إلى هاتف أو جهاز لوحي.
       </target>
         <note>ID: epubpreview.usingdropbox</note>
       </trans-unit>
-      <trans-unit id="epubpreview.recommended.reader">
+      <trans-unit id="epubpreview.recommended.reader" approved="yes">
         <source xml:lang="en">Recommended Reader</source>
         <target xml:lang="ar">القارئ الموصى به</target>
         <note>ID: epubpreview.recommended.reader</note>
       </trans-unit>
-      <trans-unit id="epubpreview.gitden.okay">
+      <trans-unit id="epubpreview.gitden.okay" approved="yes">
         <source xml:lang="en">Our testing has shown <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Gitden Reader</g> to be a good choice for Android and IOS (IPhone &amp; IPad) devices.
       </source>
         <target xml:lang="ar">أثبتت التجارب التي أجريناها أن  <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Gitden Reader</g> خياراً جيداً على أجهزة Android وiOS (سواء iPhone أو iPad).
       </target>
         <note>ID: epubpreview.gitden.okay</note>
       </trans-unit>
-      <trans-unit id="epubpreview.gitden.limits">
+      <trans-unit id="epubpreview.gitden.limits" approved="yes">
         <source xml:lang="en">To listen to this Talking Book using Gitden on a phone or tablet, you will need to disable Gitden's "Text To Speech" feature. Then it will show you the audio controls.</source>
         <target xml:lang="ar">للاستماع إلى هذا الكتاب الناطق باستخدام Gitden على هاتف أو جهاز لوحي، يلزمك تعطيل ميزة "تحويل النص إلى كلام" في Gitden. بعد ذلك سيعرض لك عناصر التحكم في الصوت.</target>
         <note>ID: epubpreview.gitden.limits</note>
       </trans-unit>
-      <trans-unit id="epubpreview.make.it.talk">
+      <trans-unit id="epubpreview.make.it.talk" approved="yes">
         <source xml:lang="en">Make it Talk</source>
         <target xml:lang="ar">إنشاء كتاب ناطق</target>
         <note>ID: epubpreview.make.it.talk</note>
       </trans-unit>
-      <trans-unit id="epubpreview.talking.book.tool">
+      <trans-unit id="epubpreview.talking.book.tool" approved="yes">
         <source xml:lang="en">If you want to make a "Talking Book" that new readers can read-along with, use Bloom's <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">Talking Book Tool</g> to add voice recordings.
       </source>
         <target xml:lang="ar">إذا كنت تريد إعداد "كتاب ناطق" يمكن للقراء الجدد القراءة معه، فيمكنك استخدام  <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">أداة الكتاب الناطق من Bloom </g> لإضافة تسجيلات صوتية.
       </target>
         <note>ID: epubpreview.talking.book.tool</note>
       </trans-unit>
-      <trans-unit id="epubpreview.write.us">
+      <trans-unit id="epubpreview.write.us" approved="yes">
         <source xml:lang="en">Write to us!</source>
         <target xml:lang="ar">راسلنا</target>
         <note>ID: epubpreview.write.us</note>
       </trans-unit>
-      <trans-unit id="epubpreview.use.help.report">
+      <trans-unit id="epubpreview.use.help.report" approved="yes">
         <source xml:lang="en">Are you interested in distributing Bloom books for use on phones and other ebook readers? Is there something you would need us to do before it is useful for you? Please use the Help:Report A Problem command to send us feedback. Thanks!</source>
         <target xml:lang="ar">هل لديك اهتمام بنشر كتب Bloom لاستخدامها على الهواتف الذكية وأجهزة القراءة الإلكترونية الأخرى؟ هل تحتاج منا القيام بشيء لتحقيق استفادة لديك؟ يمكنك استخدام أمر "مساعدة: الإبلاغ عن مشكلة" لإرسال ملاحظاتك إلينا. شكراً لك</target>
         <note>ID: epubpreview.use.help.report</note>

--- a/DistFiles/localization/ar/leveledReaderInfo.xlf
+++ b/DistFiles/localization/ar/leveledReaderInfo.xlf
@@ -2,58 +2,58 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="leveledReaderInfo-en.html" datatype="html" source-language="en" target-language="ar">
     <body>
-      <trans-unit id="leveled.reader.vocabulary">
+      <trans-unit id="leveled.reader.vocabulary" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="ar">المفردات</target>
         <note>ID: leveled.reader.vocabulary</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.simple">
+      <trans-unit id="leveled.reader.start.simple" approved="yes">
         <source xml:lang="en">At beginning levels, use simple words that are familiar to children. If it is possible in your language, use words with only one syllable. As children move up to higher levels, you can begin to use words with more syllables. You can begin to use less familiar words. Children should be able to guess the meaning of these less familiar words from the context of the surrounding words and sentences, as well as from the illustrations.</source>
         <target xml:lang="ar">في المستويات الأولى، احرص على استخدام كلمات بسيطة وشائعة لدى الأطفال. واحرص أيضاً على استخدام كلمات ذات مقطع واحد، إذا كانت لغتك تسمح بذلك. ومع تقدم مستويات الأطفال، سيكون بإمكانك بدء استخدام كلمات تحتوي على عدد مقاطع أكبر. ويمكنك بدء استخدام كلمات أقل شيوعاً. من المفترض أن يتمكن الأطفال من تخمين معاني هذه الكلمات الأقل شيوعاً من سياق الكلمات والجمل المحيطة، ومن الرسوم التوضيحية أيضاً. </target>
         <note>ID: leveled.reader.start.simple</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.formatting">
+      <trans-unit id="leveled.reader.formatting" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="ar">التنسيق</target>
         <note>ID: leveled.reader.formatting</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.large">
+      <trans-unit id="leveled.reader.start.large" approved="yes">
         <source xml:lang="en">Beginner readers will benefit from a larger font with clear spacing between words. Having the words or sentences in the same location on each page is also helpful. As readers progress to higher levels, font size and spacing will decrease and sentences can appear in different locations on the page.</source>
         <target xml:lang="ar">يستفيد القُرّاء المبتدئون من حجم الخط الكبير الذي يتميز بمسافات واضحة بين الكلمات. ومن المفيد لهم أيضاً وضع الكلمات أو الجمل في المكان نفسه على كل صفحة. ومع تقدم القراء و ارتقائهم إلى مستويات أعلى، يمكن تصغير حجم الخط والمسافات ويمكن أن تظهر الجمل في أماكن مختلفة على الصفحة.</target>
         <note>ID: leveled.reader.start.large</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.increase.sizes">
+      <trans-unit id="leveled.reader.increase.sizes" approved="yes">
         <source xml:lang="en">To increase the font size, line-spacing, and word-spacing in Bloom, click in a text box and then on the grey "cog" icon in the lower left-hand corner. If you do this and then make a template book, books made with that template will also use those font settings.</source>
         <target xml:lang="ar">لزيادة حجم الخط والمسافات بين الأسطر والمسافات بين الكلمات في Bloom، انقر داخل مربع النص وعلى الرمز الرمادي "cog" أسفل الجانب الأيسر. وإذا قمت بذلك ثم أنشأت نموذج لكتاب، ستتبع الكتب التي تُنشأ باستخدام هذا النموذج إعدادات الخط نفسها. </target>
         <note>ID: leveled.reader.increase.sizes</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.predictability">
+      <trans-unit id="leveled.reader.predictability" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="ar">إمكانية التنبؤ</target>
         <note>ID: leveled.reader.predictability</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repeat.patterns">
+      <trans-unit id="leveled.reader.repeat.patterns" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-em">Predictability</g> in a text means that the reader can guess what would come next. You can increase predictability by using repeated patterns. Here are some patterns you can use:</source>
         <target xml:lang="ar"> <g id="genid-1" ctype="x-html-em">إمكانية التنبؤ</g> في النص تعني أنه يمكن للقارئ تخمين ما سيظهر بعد ذلك. ويمكنك زيادة مستوى إمكانية التنبؤ باستخدام أنماط متكررة. وفيما يلي بعض الأنماط التي يمكنك استخدامها:</target>
         <note>ID: leveled.reader.repeat.patterns</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repetition">
+      <trans-unit id="leveled.reader.repetition" approved="yes">
         <source xml:lang="en">Repetition - repeating parts of the text, for example, using the same sentence with each page and just changing one word in the sentence</source>
         <target xml:lang="ar">التكرار - تكرار أجزاء من النص، مثل استخدام الجملة ذاتها في عدة صفحات والاكتفاء بتغيير كلمة واحدة من الجملة فقط.</target>
         <note>ID: leveled.reader.repetition</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.sequencing">
+      <trans-unit id="leveled.reader.sequencing" approved="yes">
         <source xml:lang="en">Sequencing - a story with a known sequence such as the days of the week or that uses numbers in a pattern</source>
         <target xml:lang="ar">التسلسل - خلق قصة تحتوي على تسلسل معروف مثل أيام الأسبوع أو تحتوي على أرقام تأخذ نمطًا معيَّنًا.</target>
         <note>ID: leveled.reader.sequencing</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.building.sequence">
+      <trans-unit id="leveled.reader.building.sequence" approved="yes">
         <source xml:lang="en">Building Sequence - a story with a pattern that is repeated and added to with each new page</source>
         <target xml:lang="ar">بناء تسلسل - خلق قصة تحتوي على نمط يتكرر وتتم الإضافة إليه في كل صفحة جديدة</target>
         <note>ID: leveled.reader.building.sequence</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.rhyme">
+      <trans-unit id="leveled.reader.rhyme" approved="yes">
         <source xml:lang="en">Rhyme - a story with a pattern or sequence that also includes rhyme. For example:
         <g id="genid-2" ctype="x-html-blockquote" html:class="poetry">
           <g id="genid-3" ctype="x-html-pre">Brown Bear, Brown Bear, What do you see?
@@ -76,64 +76,64 @@ Yellow Duck, Yellow Duck, What do you see?</g>
       </target>
         <note>ID: leveled.reader.rhyme</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations">
+      <trans-unit id="leveled.reader.illustrations" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="ar">استخدام الرسوم</target>
         <note>ID: leveled.reader.illustrations</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.help">
+      <trans-unit id="leveled.reader.illustrations.help" approved="yes">
         <source xml:lang="en">Illustrations provide support to the story. Illustrations relate to the story in different ways at different <g id="genid-5" ctype="x-html-em">levels</g> and for different types of readers (see below). Remember that in many cultures that don't have a lot of printed material around, complex pictures may be difficult to understand.
     </source>
         <target xml:lang="ar">تشكل الرسوم أهمية كبيرة في دعم القصة. ويجب أن تكون الرسوم ذات صلة بالقصة بطرق مختلفة <g id="genid-5" ctype="x-html-em">ومستويات مختلفة</g> وأنواع مختلفة من القراء (راجع أدناه). لا تنس أنه في الكثير من الثقافات التي لم تعتاد على توافر مواد مطبوعة، قد يصعب استيعاب الصور المعقَّدة.
     </target>
         <note>ID: leveled.reader.illustrations.help</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.emergent.reader">
+      <trans-unit id="leveled.reader.illustrations.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-6" ctype="x-html-strong">Emergent Readers</g> the pictures should closely match the storyline. The reader should be able to predict the story line just by looking at the pictures. The illustrations at this level should be simple.
       </source>
         <target xml:lang="ar">بالنسبة إلى <g id="genid-6" ctype="x-html-strong">القارئ الناشئ</g> يجب أن تتطابق الصور تماماً مع حبكة القصة. يجب أن يتمكن القارئ من التنبؤ بمسار القصة من خلال النظر إلى الصور فقط. ولذلك يجب أن تكون الرسوم في هذا المستوى بسيطة.
       </target>
         <note>ID: leveled.reader.illustrations.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.early.reader">
+      <trans-unit id="leveled.reader.illustrations.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-7" ctype="x-html-strong">Early Readers</g> the pictures should offer some support to the story line. As the amount of text increases, the reader is less reliant on the pictures and gets more meaning from the text. The illustrations can be more complex.
       </source>
         <target xml:lang="ar">بالنسبة إلى <g id="genid-7" ctype="x-html-strong">القارئ المبتدئ</g> يجب أن تكون الصور مفيدة لدعم واستيعاب حبكة القصة. عندما يزيد حجم النص، يقل اعتماد القارئ على الصور ويزيد اعتماده على النص لاستيعاب المعنى. يمكن أن تكون الرسوم أكثر تعقيداً.
       </target>
         <note>ID: leveled.reader.illustrations.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.fluent.reader">
+      <trans-unit id="leveled.reader.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-8" ctype="x-html-strong">Fluent Readers</g> the pictures should offer little or no support to the story line. The reader relies more on the text than the pictures for meaning. The illustrations can be even more complex.
       </source>
         <target xml:lang="ar">بالنسبة إلى <g id="genid-8" ctype="x-html-strong">القارئ الفصيح</g> يجب ألا تدعم الصور حبكة القصة كثيرا أو حتى تنعدم إضافتها. يعتمد القارئ في الاستيعاب على النص بشكل أكبر من اعتماده على الصور. يمكن أن تكون الرسوم أكثر تعقيدًا من نمط القارئ المبتدئ.
       </target>
         <note>ID: leveled.reader.fluent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice">
+      <trans-unit id="leveled.reader.topic.choice" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="ar">اختيار الموضوع</target>
         <note>ID: leveled.reader.topic.choice</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.discussion">
+      <trans-unit id="leveled.reader.topic.choice.discussion" approved="yes">
         <source xml:lang="en">Books can be on many topics. When developing books for beginning readers, choose topics that are familiar to them. Readers will be eager to read and will read more if they are reading about things they find interesting and familiar. For more experienced readers, topics can include information that the reader is not already familiar with.</source>
         <target xml:lang="ar">يمكن أن تتناول الكتب عدة موضوعات. عند إعداد كتب للقراء المبتدئين، اختر موضوعات مألوفة إليهم. ذلك لأنه عندما يكون لدى القراء فكرة عن محتوى الموضوع و يشعرون أنه يثير اهتمامهم سيزيد شغفهم للقراءة. بالنسبة إلى القراء المتمرسين، يمكن أن تتضمن الموضوعات معلومات ليس لدى القارئ خلفية عنها.</target>
         <note>ID: leveled.reader.topic.choice.discussion</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.emergent.reader">
+      <trans-unit id="leveled.reader.topic.choice.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-9" ctype="x-html-strong">Emergent Readers</g> the book should be concrete, should focus on one idea/theme, and should be familiar and easy to understand.
       </source>
         <target xml:lang="ar">بالنسبة إلى <g id="genid-9" ctype="x-html-strong">القارئ الناشئ</g> يجب أن يكون المحتوى ملموساً في الواقع، وأن يركز على فكرة واحدة أو موضوع واحد، وأن تكون لدى القارئ خلفية عن هذه الفكرة لبسهل عليهم استيعابها.
       </target>
         <note>ID: leveled.reader.topic.choice.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.early.reader">
+      <trans-unit id="leveled.reader.topic.choice.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-10" ctype="x-html-strong">Early Readers</g>, develop a story around a familiar concept but in greater depth.
       </source>
         <target xml:lang="ar">بالنسبة إلى <g id="genid-10" ctype="x-html-strong">القارئ المبتدئ</g>، ابتكر قصة تتمحور حول موضوع شائع، ولكن مع تناول تفاصيل بعمق أكبر.
       </target>
         <note>ID: leveled.reader.topic.choice.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.fluent.reader">
+      <trans-unit id="leveled.reader.topic.choice.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-11" ctype="x-html-strong">Fluent Readers</g> the concepts can expand beyond what is familiar, be more varied, and be abstract.
       </source>
         <target xml:lang="ar">بالنسبة إلى <g id="genid-11" ctype="x-html-strong">القارئ الفصيح</g> يمكن أن تمتد المفاهيم إلى ما دون الشائع، حاول أن تتسم هذه المفاهيم بالتنوع ، وأن تكون مجرَّدة.

--- a/DistFiles/localization/bn/Bloom.xlf
+++ b/DistFiles/localization/bn/Bloom.xlf
@@ -2,1968 +2,1968 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="bn" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="BloomIntegrity.WindowTitle">
+      <trans-unit id="BloomIntegrity.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom Problem</source>
         <target xml:lang="bn">ব্লুম সমস্যা</target>
         <note>ID: BloomIntegrity.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="BloomIntegrityDialog.ReportProblem">
+      <trans-unit id="BloomIntegrityDialog.ReportProblem" approved="yes">
         <source xml:lang="en">Report Problem</source>
         <target xml:lang="bn">সমস্যার বিবরণী দিন</target>
         <note>ID: BloomIntegrityDialog.ReportProblem</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName">
+      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName" approved="yes">
         <source xml:lang="en">Possibly this is an old Bloom Pack created before Bloom Packs could handle special characters in file names. You may be able to get the author to re-create it using a current version. If that's not possible a technical expert may be able to repair things.</source>
         <target xml:lang="bn">সম্ভবত ব্লুম দল নথিপত্রের নামের বিশেষ অক্ষর সঠিকভাবে পরিচালনা করার পূর্বেই এই পুরাতন ব্লুম দলটি তৈরি করা হয়েছিল। আপনি বর্তমান সংস্করণ ব্যবহার করে পুনরায় এটি তৈরি করতে লেখকের সাথে যোগাযোগ করতে পারেন। যদি সেটি সম্ভব না হয় তাহলে একজন কারিগরিভাবে দক্ষ ব্যক্তি এটি সংস্কার করতে পারেন।</target>
         <note>ID: BloomPackInstallDialog.BadCharsInFileName</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="bn">ব্লুম দল প্রতিষ্ঠা </target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="bn">{0} সংগ্রহটি এখন এই কম্পিউটারে ব্যবহারের জন্য প্রস্তুত।</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller" approved="yes">
         <source xml:lang="en">Bloom Pack Installer</source>
         <target xml:lang="bn">ব্লুম দল প্রতিষ্ঠা</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstaller</note>
         <note>Displayed as the message box title</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack">
+      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack" approved="yes">
         <source xml:lang="en">This BloomPack appears to be incomplete or corrupt.</source>
         <target xml:lang="bn">এই ব্লুমদলটি অসম্পূর্ণ অথবা নষ্ট হতে পারে।</target>
         <note>ID: BloomPackInstallDialog.CorruptBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.DoesNotExist">
+      <trans-unit id="BloomPackInstallDialog.DoesNotExist" approved="yes">
         <source xml:lang="en">{0} does not exist</source>
         <target xml:lang="bn">{0} বিদ্যমান নেই</target>
         <note>ID: BloomPackInstallDialog.DoesNotExist</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="bn">ব্লুম ঐ ব্লুম দলটি ইনস্টল করতে সমর্থ ছিল না।</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="bn">বের করা হচ্ছে...</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while Bloom Packs are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="bn">ব্লুম ইতোমধ্যে চলছে, কিন্তু আপনি পরবর্তী সময়ে ব্লুম না চালানো পর্যন্ত বিষয়বস্তু দেখা যাবে না</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.NotInstalled">
+      <trans-unit id="BloomPackInstallDialog.NotInstalled" approved="yes">
         <source xml:lang="en">The Bloom collection will not be installed.</source>
         <target xml:lang="bn">ব্লুম সংগ্রহ ইনইস্ট হবে না।</target>
         <note>ID: BloomPackInstallDialog.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="bn">খুলছে {0}...</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Replace">
+      <trans-unit id="BloomPackInstallDialog.Replace" approved="yes">
         <source xml:lang="en">This computer already has a Bloom collection named '{0}'. Do you want to replace it with the one from this Bloom Pack?</source>
         <target xml:lang="bn">এই কম্পিউটারে ইতোমধ্যে একটি ব্লুম সংগ্রহ আছে '{0}'। আপনি কি ব্লুম দলটির একটি দিয়ে এটি প্রতিস্থাপন করতে চান?</target>
         <note>ID: BloomPackInstallDialog.Replace</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder">
+      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder" approved="yes">
         <source xml:lang="en">Bloom Packs should have only a single collection folder at the top level of the .ZIP file.</source>
         <target xml:lang="bn">ব্লুম দলের কেবল সর্বোচ্চ পর্যায়ের জিপ (.ZIP) ফাইলে একক সংগ্রহের ফোল্ডার থাকবে।</target>
         <note>ID: BloomPackInstallDialog.SingleCollectionFolder</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.UnableToReplace">
+      <trans-unit id="BloomPackInstallDialog.UnableToReplace" approved="yes">
         <source xml:lang="en">Bloom was not able to remove the existing copy of '{0}'. Quit Bloom if it is running &amp; try again. Otherwise, try again after restarting your computer.</source>
         <target xml:lang="bn">ব্লুম '{0}' এর বিদ্যমান কপিটি মুছে ফেলতে পারেনি। যদি এটি চলতে থাকে তবে ব্লুম থেকে বের হয়ে আসুন এবং আবার চেষ্টা করুন। অন্যথা, কম্পিউটার পুনরায় চালু করার পর আবার চেষ্টা করুন।</target>
         <note>ID: BloomPackInstallDialog.UnableToReplace</note>
       </trans-unit>
-      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true">
+      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To select, use your mouse wheel or point at what you want, then release the key.</source>
         <target xml:lang="bn">আপনি যা চান তা নির্বাচন করতে, আপনার মাউসের হুইল বা পয়েন্ট ব্যবহার করুন, তারপর কী টি উন্মুক্ত করুন।</target>
         <note>ID: BookEditor.CharacterMap.Instructions</note>
         <note>When you hold down a key, a popup appears that lets you choose a related character. These instructions are shown in that popup.</note>
       </trans-unit>
-      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is the default for all text boxes with '{0}' style.</source>
         <target xml:lang="bn">এই পদ্ধতিটিটি সকল '{0}' প্রকারের বার্তা বক্স সহ রীতির জন্য অক্ষম ।</target>
         <note>ID: BookEditor.DefaultForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all text boxes with '{0}' style.</source>
         <target xml:lang="bn">এই পদ্ধতিটি সকল '{0}' রীতির বার্তা বক্সের জন্য</target>
         <note>ID: BookEditor.ForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text boxes with '{1}' style.</source>
         <target xml:lang="bn">এই পদ্ধতিটি সকল '{0}' রীতির বার্তা বক্সের জন্য</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true">
+      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sorry, Reader Templates do not allow changes to formatting.</source>
         <target xml:lang="bn">দুঃখিত, পাঠক নমুনাসমূহ পদ্ধতি পরিবর্তনের অনুমতি দেয় না।</target>
         <note>ID: BookEditor.FormattingDisabled</note>
       </trans-unit>
-      <trans-unit id="BookStorage.FolderMoved">
+      <trans-unit id="BookStorage.FolderMoved" approved="yes">
         <source xml:lang="en">It appears that some part of the folder path to this book has been moved or renamed. As a result, Bloom cannot save your changes to this page, and will need to exit now. If you haven't been renaming or moving things, please click Details below and report the problem to the developers.</source>
         <target xml:lang="bn">দেখে মনে হচ্ছে যে এই বইয়ের ফোল্ডারের পাথের কিছু অংশ সরানো হয়েছে অথবা পুনরায় নামকরণ করা হয়েছে। ফলশ্রুতিতে, ব্লুম এই পৃষ্ঠায় আপনার পরিবর্তন সংরক্ষণ করতে পারছে না, এবং বের হয়ে যেতে হবে। যদি আপনি জিনিসপত্রের পুনরায় নামকরণ না করেন অথবা না সরান, অনুগ্রহ করে বিস্তারিত তথ্যের জন্য নীচে ক্লিক করুন এবং ডেভলাপারের নিকট সমস্যাটি জানান।</target>
         <note>ID: BookStorage.FolderMoved</note>
       </trans-unit>
-      <trans-unit id="Browser.CopyTroubleshootingInfo">
+      <trans-unit id="Browser.CopyTroubleshootingInfo" approved="yes">
         <source xml:lang="en">Copy Troubleshooting Information</source>
         <target xml:lang="bn">টট্রাবলশ্যুটিং ইনিফরমেশন কপি করুন</target>
         <note>ID: Browser.CopyTroubleshootingInfo</note>
       </trans-unit>
-      <trans-unit id="Browser.OpenPageInFirefox">
+      <trans-unit id="Browser.OpenPageInFirefox" approved="yes">
         <source xml:lang="en">Open Page in Firefox (which must be in the PATH environment variable).</source>
         <target xml:lang="bn">ফায়ারফক্সে পেজ খুলুন (যা PATH environment এ পরিবর্তন করা যায়)।</target>
         <note>ID: Browser.OpenPageInFirefox</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="bn">উচ্চতর প্রোগ্রাম সেটিংস</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate" approved="yes">
         <source xml:lang="en">Automatically update Bloom</source>
         <target xml:lang="bn">স্বয়ংক্রিয়ভাবে ব্লুম আপডেট</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AutoUpdate</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="bn">পরীক্ষামূলক কমান্ডগুলো দেখান (উদাহরণস্বরূপ ইনডিজাইনের জন্য এক্সএমএল এক্সপোর্ট করা)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="bn">পরীক্ষামূলক টেমপ্লেটগুলো দেখান (উদাহরণস্বরূপ ছবির ডিরেক্টরি)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="bn">(পরীক্ষামূলক) পাঠান/গ্রহণ নিয়ন্ত্রণসমূহ দেখান</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="bn">বড় ছবির জন্য মেমরি সংকোচন করতে ইমেজ সার্ভার ব্যবহার করুন।</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom is switching the default font for "{0}" to the new "Andika New Basic".</source>
         <target xml:lang="bn">ব্লুম ডিফল্ট ফন্ট "{0}" থেকে নতুন "Andika New Basic" এ পরিবর্তীত হচ্ছে।</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate1</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This will improve the printed output for most languages. If your language is one of the few that need "Andika", you can switch it back in Settings:Book Making.</source>
         <target xml:lang="bn">এটি অধিকাংশ ভাষার ক্ষেত্রে প্রিন্ট সংস্করণকে উন্নত করবে। যদি কিছু ভাষার মধ্যে আপনার একটি ভাষার "Andika" প্রয়োজন হয়, আপনি এটি সেটিংস:বই তৈরি এ ফিরিয়ে নিতে পারেন।</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate2</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="bn">বই তৈরি</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="bn">{0} এর জন্য ডিফল্ট ফন্ট </target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="bn">সামনের/পিছনের ম্যাটার প্যাক</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="bn">কাগজ সংরক্ষক</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver</note>
         <note>Name of a Front/Back Matter Pack that puts credits on the inside of the front cover</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="bn">ঐতিহ্যবাহী</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional</note>
         <note>Name of the default Front/Back Matter Pack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="bn">ডান হতে বামে লিখন পদ্ধতি</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink" approved="yes">
         <source xml:lang="en">Special Script Settings</source>
         <target xml:lang="bn">বিশেষ স্ক্রিপ্ট সেটিংস</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="bn">সেটিংস</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="bn">পরিবর্তন...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="bn">ভাষা ১</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="bn">ভাষা ২</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="bn">ভাষা ৩</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="bn">ভাষাসমূহ</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="bn">মুছে ফেলুন</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="bn">সেট...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="bn">স্বদেশীয় ভাষা</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="bn">ভাষা ২ (উদাহরণস্বরূপ জাতীয় ভাষা)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="bn">ভাষা 3 (উদাহরণস্বরূপ আঞ্চলিক ভাষা) (ঐচ্ছিক)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="bn">ব্লুম সংগ্রহের নাম</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="bn">দেশ</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="bn">জেলা</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="bn">প্রকল্পের তথ্য</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="bn">প্রদেশ</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="bn">রিস্টার্ট</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="bn">ব্লুম বন্ধ হয়ে যাবে এবং নতুন সেটিংস এর সাথে পুনরায় প্রজেক্টটি খুলবে।</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <target xml:lang="bn">রিডার টেমপ্লেট ব্লুম প্যাক প্রস্তুত করুন...</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdminManagesUpdates">
+      <trans-unit id="CollectionTab.AdminManagesUpdates" approved="yes">
         <source xml:lang="en">Your system administrator manages Bloom updates for this computer.</source>
         <target xml:lang="bn">আপনার সিস্টেম প্রশাসক এই কম্পিউটারে ব্লুম আপডেট ব্যবস্থাপনা করেন।</target>
         <note>ID: CollectionTab.AdminManagesUpdates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="bn">উচ্চতর</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Applying">
+      <trans-unit id="CollectionTab.Applying" approved="yes">
         <source xml:lang="en">Applying updates</source>
         <target xml:lang="bn">আপডেট প্রয়োগ করা হচ্ছে</target>
         <note>ID: CollectionTab.Applying</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="bn">BloomLibrary.org এ আরো উৎস বইসমূহ নিন</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="bn">উৎস সংগ্রহ</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DuplicateBook">
+      <trans-unit id="CollectionTab.BookMenu.DuplicateBook" approved="yes">
         <source xml:lang="en">Duplicate Book</source>
         <target xml:lang="bn">বই কপি করুন</target>
         <note>ID: CollectionTab.BookMenu.DuplicateBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="bn">বই মুছে ফেলুন</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book. These programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="bn">ব্লুম এখন এই এইচটিএমএল ডকুমেন্টটি আপনার ওয়ার্ড প্রসেসিং প্রোগ্রামে খুলবে (সাধারণত ওয়ার্ড অথবা লিব্রাঅফিস)আপনি এই বইয়ের লেখা এবং ছবি নিয়ে কাজ করতে পারেন।এই প্রোগ্রামগুলো সাধারণত লেআউট সংরক্ষণ করতে পারে না, তাই অনেক বেশি আশা করবেন না।</target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="bn">ওয়ার্ড অথবা লিব্রাঅফিসে এক্সপোর্ট করুন...</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="bn">ইনডিজাইনের জন্য এক্সএমএলে এক্সপোর্ট করুন...</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="bn">আপডেট বই</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="bn">আপডেট থাম্বনেইল</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="bn">নতুন বইসমূহের উৎসসমূহ</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="bn">এই সংগ্রহটি বন্ধ করে দেওয়া হয়েছে, তাই নতুন বইসমূহ যুক্ত/মুছে ফেলা যাবে না।</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="bn">BloomLibrary.org হতে বইসমূহ</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="bn">বইসমূহ আপডেট করুন</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="bn">বইসমূহ চেক করুন</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="bn">হারানো ছবিসমূহ উদ্ধার করুন...</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="bn">ইতিহাস সংগ্রহ...</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="bn">নোটসমূহ সংগ্রহ...</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="bn">সংগ্রহসমূহ</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="bn">সংগ্রহসমূহ</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="bn">তৈরি হচ্ছে...</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="bn">বইটি '{0}' </target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="bn">ডিস্কে ফোল্ডারটি খুলুন</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="bn">এই বইটি সম্পাদন করুন</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="bn">স্বাস্থ্য</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="bn">কারণ এটি উৎসের সংগ্রহ, ব্লুম নতুন শেলের জন্য কোন বিদ্যমান শেল অফার করছে না।যদি আপনি শেলে একটি ভাষা যুক্ত করতে চান, শেলটির সংগ্রহ সম্পাদন করার চেয়ে একটি কপি তৈরি করুন।এছাড়াও, বর্তমানে দেওয়াল ক্যালেন্ডার নতুন শেল তৈরি করতে পারছে না।</target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="bn">ব্লুম প্যাক তৈরি করুন</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source.</source>
         <target xml:lang="bn">এই উৎস ব্যবহার করে একটি বই তৈরি করুন</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_" approved="yes">
         <source xml:lang="en">Create a book in my language using this source book.</source>
         <target xml:lang="bn">এই উৎস বই ব্যবহার করে আমার ভাষায় একটি বই তৈরি করুন।</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate_ToolTip_</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="bn">আরো...</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="bn">অন্যান্য সংগ্রহ</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_" approved="yes">
         <source xml:lang="en">Open/Create/Get Collection</source>
         <target xml:lang="bn">খুলুন/তৈরি করুন/সংগ্রহ করুন</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton_ToolTip_</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem">
+      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem" approved="yes">
         <source xml:lang="en">Open or Create Another Collection</source>
         <target xml:lang="bn">খুলুন অথবা অন্য সংগ্রহ তৈরি করুন</target>
         <note>ID: CollectionTab.OpenCreateCollectionMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="bn">নমুনা শেলসমূহ</target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="bn">পাঠান/গ্রহণ</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="bn">সেটিংস</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="bn">উৎস সংগ্রহ</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="bn">অতিরিক্ত সংগ্রহ ফোল্ডার খুলুন</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="bn">নতুন শেলসমূহের উৎসসমূহ</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="bn">টেমপ্লেটসমূহ</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.TitleMissing">
+      <trans-unit id="CollectionTab.TitleMissing" approved="yes">
         <source xml:lang="en">Title Missing</source>
         <target xml:lang="bn">শিরোনাম পাওয়া যায়নি</target>
         <note>ID: CollectionTab.TitleMissing</note>
         <note>Shown as the thumbnail caption when the book doesn't have a title</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UnableToCheckForUpdate">
+      <trans-unit id="CollectionTab.UnableToCheckForUpdate" approved="yes">
         <source xml:lang="en">Could not connect to the server to check for an update. Are you connected to the internet?</source>
         <target xml:lang="bn">আপডেটের জন্য সার্ভারের সাথে সংযোগ করা যায়নি। আপনি কি ইন্টারনেটের সাথে যুক্ত?</target>
         <note>ID: CollectionTab.UnableToCheckForUpdate</note>
         <note>Shown when Bloom tries to check for an update but can't, for example because it can't connect to the internet, or a problems with our server, etc.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpToDate">
+      <trans-unit id="CollectionTab.UpToDate" approved="yes">
         <source xml:lang="en">Your Bloom is up to date.</source>
         <target xml:lang="bn">আপনার ব্লুম সর্ব সাম্প্রতিক।</target>
         <note>ID: CollectionTab.UpToDate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateCheckInProgress">
+      <trans-unit id="CollectionTab.UpdateCheckInProgress" approved="yes">
         <source xml:lang="en">Bloom is already working on checking for updates.</source>
         <target xml:lang="bn">ব্লুম ইতোমধ্যে আপডেট চেক করার জন্য কাজ করা শুরু করেছে।</target>
         <note>ID: CollectionTab.UpdateCheckInProgress</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateFailed">
+      <trans-unit id="CollectionTab.UpdateFailed" approved="yes">
         <source xml:lang="en">A new version appears to be available, but Bloom could not install it.</source>
         <target xml:lang="bn">একটি নতুন সংস্করণ পাওয়া যাচ্ছে, কিন্তু ব্লুম এটি ইনস্টল করতে পারছে না।</target>
         <note>ID: CollectionTab.UpdateFailed</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateInstalled">
+      <trans-unit id="CollectionTab.UpdateInstalled" approved="yes">
         <source xml:lang="en">Update for {0} is ready.</source>
         <target xml:lang="bn">{0} এর জন্য আপডেট প্রস্তুত।</target>
         <note>ID: CollectionTab.UpdateInstalled</note>
         <note>Appears after Bloom has downloaded a program update in the background and is ready to switch the user to it the next time they run Bloom.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateNow">
+      <trans-unit id="CollectionTab.UpdateNow" approved="yes">
         <source xml:lang="en">Update Now</source>
         <target xml:lang="bn">এখুনি আপডেট করুন</target>
         <note>ID: CollectionTab.UpdateNow</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdatesAvailable">
+      <trans-unit id="CollectionTab.UpdatesAvailable" approved="yes">
         <source xml:lang="en">A new version of Bloom is available.</source>
         <target xml:lang="bn">ব্লুমের একটি নতুন সংস্করণ পাওয়া যাচ্ছে।</target>
         <note>ID: CollectionTab.UpdatesAvailable</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Updating">
+      <trans-unit id="CollectionTab.Updating" approved="yes">
         <source xml:lang="en">Downloading update to {0} ({1}kb).</source>
         <target xml:lang="bn">{0} ({1}কিলোবাইট) এ আপডেট ডাউনলোড।</target>
         <note>ID: CollectionTab.Updating</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="bn">পিছনে</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="bn">বাতিল</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="bn">&amp;বাতিল</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="bn">&amp;শেষ</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.Help" sil:dynamic="true">
+      <trans-unit id="Common.Help" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="bn">সহায়তা</target>
         <note>ID: Common.Help</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="bn">&amp;সহায়তা</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Loading" sil:dynamic="true">
+      <trans-unit id="Common.Loading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Loading...</source>
         <target xml:lang="bn">লোড হচ্ছে...</target>
         <note>ID: Common.Loading</note>
         <note>This is shown when Bloom is slowly loading something, so the user doesn't worry about why they don't see the result immediately.</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="bn">&amp;পরবর্তী</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="bn">পরবর্তী</target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="bn">ঠিক আছে</target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="bn">&amp;ঠিক আছে</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="bn">ঐচ্ছিক</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections.</source>
         <target xml:lang="bn">আপনার ({0}) ডাউনলোড সম্পন্ন হয়েছে।আপনি এটি 'BloomLibrary.org এর বইসমূহ' এর মধ্যে আপনার সংগ্রহশালার বিভাগে দেখতে পারেন।</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="bn">ডাউনলোড সম্পন্ন হয়েছে</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.CopyFailed">
+      <trans-unit id="Download.CopyFailed" approved="yes">
         <source xml:lang="en">Bloom downloaded the book but had problems making it available in Bloom. Please restart your computer and try again. If you get this message again, please click the 'Details' button and report the problem to the Bloom developers.</source>
         <target xml:lang="bn">ব্লুম বইটি ডাউনলোড করেছে কিন্তু এটি ব্লুমে নিয়ে আসতে সমস্যায় পড়ছে। অনুগ্রহপূর্বক আপনার কম্পিউটার রিস্টার্ট দিন এবং পুনরায় চেষ্টা করুন। যদি আপনি এই বার্তাটি পুনরায় পান, অনুগ্রহ করে 'বিস্তারিত' বোতামটি ক্লিক করুন এবং সমস্যাটি ব্লুম ডেভেলাপারদের জানান।</target>
         <note>ID: Download.CopyFailed</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="bn">বই ডাউনলোড</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="bn">আপনার বই ডাউনলোড করতে সমস্যা হচ্ছে।</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="bn">আপনার বই ডাউনলোড করতে সমস্যা হচ্ছে।আপনার ব্লুম রিস্টার্ট অথবা কারিগরি সহায়তা নেওয়ার প্রয়োজন হতে পারে।</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.TimeoutProblemNotice">
+      <trans-unit id="Download.TimeoutProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading the book: something took too long. You can try again at a different time, or write to us at issues@BloomLibrary.org if you cannot get the download to work from your location.</source>
         <target xml:lang="bn">এই বইটি ডাউনলোড করতে সমস্যা হয়েছিল: কোন কিছু খুব সময় নিয়েছিল।আপনি অন্য সময় আবার চেষ্টা করতে পারেন, অথবা যদি আপনার অবস্থান থেকে ডাউনলোডটি না পেয়ে থাকেন তাহলে আমাদেরকে issues@BloomLibrary.org এ লিখতে পারেন।</target>
         <note>ID: Download.TimeoutProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddPageButton">
+      <trans-unit id="EditTab.AddPageDialog.AddPageButton" approved="yes">
         <source xml:lang="en">Add Page</source>
         <target xml:lang="bn">পাতা যুক্ত করুন</target>
         <note>ID: EditTab.AddPageDialog.AddPageButton</note>
         <note>This is for the button that LAUNCHES the dialog, not the "Add this page" button that is IN the dialog.</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add This Page</source>
         <target xml:lang="bn">এই পাতা যুক্ত করুন</target>
         <note>ID: EditTab.AddPageDialog.AddThisPageButton</note>
         <note>This is for the button inside the dialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use This Layout</source>
         <target xml:lang="bn">এই লেআউটটি ব্যবহার করুন</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Continue anyway</source>
         <target xml:lang="bn">যেকোনো ভাবে চালিয়ে যান</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutContinueCheckbox</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose Different Layout...</source>
         <target xml:lang="bn">বিভিন্ন লেআউট নির্বাচন করুন...</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Converting to this layout will cause some content to be lost.</source>
         <target xml:lang="bn">এই লেআউটে রূপান্তর করা হলে কিছু জিনিস হারিয়ে যেতে পারে।</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutWillLoseData</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Page...</source>
         <target xml:lang="bn">পাতা যুক্ত করুন...</target>
         <note>ID: EditTab.AddPageDialog.Title</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="bn">যদি এই বইটি সম্পর্কে আপনার আরো তথ্য রাখার প্রয়োজন হয়, তাহলে আপনি পিছনের কভারের ভিতরের পাতাটি ব্যবহার করতে পারেন।</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="bn">যদি এই বইটি সম্পর্কে আপনার আরো তথ্য রাখার প্রয়োজন হয়, তাহলে আপনি পিছনের কভারের বাইরের পাতাটি ব্যবহার করতে পারেন।</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Background</source>
         <target xml:lang="bn">পটভূমি</target>
         <note>ID: EditTab.TextBoxProperties.Background</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="bn">দুইটি ভাষা</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the HTML used to make this PDF, in Firefox (must be on path)</source>
         <target xml:lang="bn">পিডিএফ তৈরি করার জন্য ফায়ারফক্সে (অবশ্যই পাথে থাকতে হবে) এইচটিএমএলটি খুলুন</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="bn">দুঃখিত, এই বইটির কপিরাইট এবং লাইসেন্স পরিবর্তন করা যাবে না।</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="bn">দুঃখিত, এই বইটি লক ডাউন হয়েছে তাই ছবিগুলো পরিবর্তন করা যাবে না।</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ChooseLayoutButton">
+      <trans-unit id="EditTab.ChooseLayoutButton" approved="yes">
         <source xml:lang="en">Choose Different Layout</source>
         <target xml:lang="bn">ভিন্ন লেআউট নির্বাচন করুন</target>
         <note>ID: EditTab.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="bn">সত্যিই পেজ মুছে ফেলতে চান?</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="bn">&amp;মুছে ফেলুন</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="bn">এই পেজটি স্থায়ীভাবে মুছে ফেলা হবে।</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="bn">বহুভাষিক সেটিংস</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip">
+      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip" approved="yes">
         <source xml:lang="en">Choose language to make this a bilingual or trilingual book</source>
         <target xml:lang="bn">দ্বিভাষিক অথবা ত্রিভাষিক বই তৈরি করতে ভাষা নির্বাচন করুন।</target>
         <note>ID: EditTab.ContentLanguagesDropdown.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="bn">কপি</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTip">
+      <trans-unit id="EditTab.CopyButton.ToolTip" approved="yes">
         <source xml:lang="en">Copy (Ctrl+C)</source>
         <target xml:lang="bn">কপি (Ctrl+C)</target>
         <note>ID: EditTab.CopyButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can copy it</source>
         <target xml:lang="bn">কপি করার পূর্বে আপনার কিছু লেখা নির্বাচন করা প্রয়োজন</target>
         <note>ID: EditTab.CopyButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="bn">এই বইয়ের অন্য সকল ছবিতে কি এই তথ্যটি কপি করবেন?</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="bn">লেআউট পরিবর্তন</target>
         <note>ID: EditTab.CustomPage.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true" approved="yes">
         <source xml:lang="en">or</source>
         <target xml:lang="bn">অথবা</target>
         <note>ID: EditTab.CustomPage.Or</note>
         <note>Shown between 'Picture' and 'Text' when Custom Page is in Layout mode</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture</source>
         <target xml:lang="bn">ছবি</target>
         <note>ID: EditTab.CustomPage.Picture</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <target xml:lang="bn">লেখা</target>
         <note>ID: EditTab.CustomPage.Text</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <target xml:lang="bn">লেখার বাক্স</target>
         <note>ID: EditTab.CustomPage.TextBox</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="bn">কাট</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTip">
+      <trans-unit id="EditTab.CutButton.ToolTip" approved="yes">
         <source xml:lang="en">Cut (Ctrl+X)</source>
         <target xml:lang="bn">কাট (Ctrl+X)</target>
         <note>ID: EditTab.CutButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can cut it</source>
         <target xml:lang="bn">কাট করার পূর্বে আপনার কিছু লেখা নির্বাচন করা প্রয়োজন</target>
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="bn">পৃষ্ঠা অপসারণ\n করুন</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTip">
+      <trans-unit id="EditTab.DeletePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Remove this page from the book</source>
         <target xml:lang="bn">বইটি থেকে পৃষ্ঠাটি অপসারণ করুন</target>
         <note>ID: EditTab.DeletePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be removed</source>
         <target xml:lang="bn">এই পৃষ্ঠাটি অপসারণ করা যাবে না</target>
         <note>ID: EditTab.DeletePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="bn">সদৃশ\n পৃষ্ঠা</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
         <target xml:lang="bn">এই পৃষ্ঠার সদৃশ একটি নতুন পৃষ্ঠা ঢোকান</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be duplicated</source>
         <target xml:lang="bn">এই পৃষ্ঠাটি সদৃশ করা যাবে না</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="bn">সম্পাদন</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true">
+      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot change these because this is not the original copy.</source>
         <target xml:lang="bn">আপনি এগুলো পরিবর্তন করতে পারবেন না কারণ এটি মূল কপি নয়।</target>
         <note>ID: EditTab.EditNotAllowed</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord" approved="yes">
         <source xml:lang="en">Sight Word</source>
         <target xml:lang="bn">সাইট শব্দ</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable" approved="yes">
         <source xml:lang="en">This word is not decodable in this stage.</source>
         <target xml:lang="bn">এই শব্দটি এই স্তরে ডিকোডেবল নয়।</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true">
+      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This sentence is too long for this level.</source>
         <target xml:lang="bn">এই বাক্যটি এই লেভের জন্য খুবই দীর্ঘ।</target>
         <note>ID: EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong</note>
       </trans-unit>
-      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true">
+      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This page is an experimental prototype which may have many problems, for which we apologize.</source>
         <target xml:lang="bn">এই পৃষ্ঠাটি একটি পরীক্ষামূলক প্রোটোটাইপ যার অনেকগুলো সমস্যা থাকতে পারে, সে জন্য আমরা ক্ষমাপ্রার্থী।</target>
         <note>ID: EditTab.ExperimentalNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="bn">বর্তমান নির্বাচিত ফন্টটি হল '{0}', কিন্তু এটি এই কম্পিউটারে ইনস্টল করা নেই। কিছু অন্যান্য ফন্ট ব্যবহার করা হবে।</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true" approved="yes">
         <source xml:lang="en">That style already exists. Please choose another name.</source>
         <target xml:lang="bn">এই স্টাইলটি ইতোমধ্যেই আছে।অনুগ্রহ করে অন্য একটি নাম নির্বাচন করুন।</target>
         <note>ID: EditTab.FormatDialog.AlreadyExists</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="bn">সীমানা এবং ব্যাকগ্রাউন্ড পরিবর্তন করুন</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <target xml:lang="bn">অক্ষর</target>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <target xml:lang="bn">তৈরি</target>
         <note>ID: EditTab.FormatDialog.Create</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create a new style</source>
         <target xml:lang="bn">নতুন স্টাইল তৈরি করুন</target>
         <note>ID: EditTab.FormatDialog.CreateStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Don't see what you need?</source>
         <target xml:lang="bn">যা প্রয়োজন তা কি দেখতে পাচ্ছেন না?</target>
         <note>ID: EditTab.FormatDialog.DontSeeNeed</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Emphasis</source>
         <target xml:lang="bn">গুরুত্ব দিন</target>
         <note>ID: EditTab.FormatDialog.Emphasis</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <target xml:lang="bn">ফন্ট</target>
         <note>ID: EditTab.FormatDialog.Font</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="bn">ফন্টের রূপ পরিবর্তন করুন</target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="bn">{0} ধরণ এবং ভাষা '{1}' বহনকারী সকল প্রকারের বক্সের লেখার আকার পরিবর্তন করতে পারে।\nবর্তমান আকার {2}pt.</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="bn">ফন্টের আকার পরিবর্তন করুন</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Format</source>
         <target xml:lang="bn">বিন্যাস</target>
         <note>ID: EditTab.FormatDialog.Format</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="bn">লেখার সারির মধ্যকার ফাঁকা জায়গা পরিবর্তন করুন</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New style</source>
         <target xml:lang="bn">নতুন স্টাইল</target>
         <note>ID: EditTab.FormatDialog.NewStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please use only alphabetical characters. Numbers at the end are ok, as in "part2".</source>
         <target xml:lang="bn">অনুগ্রহ করে শুধুমাত্র বর্ণানুক্রমিক অক্ষরসমূহ ব্যবহার করুন।"পার্ট২" এর মত, শেষাংশে নম্বর ঠিক আছে।</target>
         <note>ID: EditTab.FormatDialog.PleaseUseAlpha</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <target xml:lang="bn">ফাঁকাকরণ</target>
         <note>ID: EditTab.FormatDialog.Spacing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <target xml:lang="bn">স্টাইল</target>
         <note>ID: EditTab.FormatDialog.Style</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <target xml:lang="bn">স্টাইলের নাম</target>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="bn">অতিরিক্ত প্রস্থ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="bn">সাধারণ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="bn">শব্দগুলোর মধ্যে ফাঁকা জায়গা পরিবর্তন করুন</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="bn">প্রস্থ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="bn">স্টাইলের জন্য বিন্যাস ঠিক করুন</target>
         <note>ID: EditTab.FormatDialogTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="bn">আপনি এই জায়গাটি লেখক/শিল্পী, অথবা অন্য কোন কিছুর জন্য ব্যবহার করতে পারেন।</target>
         <note>ID: EditTab.FrontMatter.AuthorIllustratorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="bn">যখন আপনি মূল বই তৈরি করবেন, লেখক, শিল্পী, সম্পাদকবৃন্দ, ইত্যাদির অবদান রেকর্ড করতে এই বাক্সটি ব্যবহার করুন।</target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="bn">যখন আপনি শেল থেকে একটি বই তৈরি করবেন, কে এই অনুবাদটি করেছে তা জানাতে এই বাক্সটি ব্যবহার করুন।</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="bn">{lang} ভাষায় বইয়ের শিরোনাম</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright and License</source>
         <target xml:lang="bn">কৃতজ্ঞতা, কপিরাইট, এবং লাইসেন্স সম্পাদন করতে ক্লিক করুন</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="bn">কোন দাতা সংস্থার কৃতজ্ঞতা স্বীকারের জন্য এটি ব্যবহার করুন।</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="bn">আন্তর্জাতিক মান পুস্তক নম্বর।আপনার কাছে এগুলোর একটিও না থাকলে ফাঁকা রাখুন।</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.</source>
         <target xml:lang="bn">যদি এই বইটি সম্পর্কে আপনার আরো তথ্য রাখার প্রয়োজন হয়, তাহলে আপনি সামনের কভারের ভিতরের পাতাটি ব্যবহার করতে পারেন।</target>
         <note>ID: EditTab.FrontMatter.InsideFrontCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Name of Translator, in {lang}</source>
         <target xml:lang="bn">অনুবাদকের নাম, {lang} তে </target>
         <note>ID: EditTab.FrontMatter.NameofTranslatorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="bn">{lang} ভাষায় মূল (অথবা শেল) কৃতজ্ঞতা স্বীকার</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="bn">{lang} ভাষায় লেখক, শিল্পী, সম্পাদক, ইত্যাদি দ্বারা অবদান</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="bn">বিষয় নির্বাচন করতে ক্লিক করুন</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="bn">{lang} ভাষায় অনূদিত সংস্করণের কৃতজ্ঞতা স্বীকার</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.HowToUnlockBook">
+      <trans-unit id="EditTab.HowToUnlockBook" approved="yes">
         <source xml:lang="en">To unlock this shellbook, go into the toolbox on the right, find the gear icon, and click 'Allow changes to this shellbook'.</source>
         <target xml:lang="bn">এই শেলবইটি আনলক করতে ডানে টুলবক্সে যান, গিয়ার আইকন খুঁজুন, এবং 'এই শেলবুকটিতে পরিবর্তনের সম্মতি দিন' এ ক্লিক করুন।</target>
         <note>ID: EditTab.HowToUnlockBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="bn">ইমেজ পরিবর্তন করুন</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Copy Image</source>
         <target xml:lang="bn">ইমেজ কপি করুন</target>
         <note>ID: EditTab.Image.CopyImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cut Image</source>
         <target xml:lang="bn">ইমেজ কাট</target>
         <note>ID: EditTab.Image.CutImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, and License</source>
         <target xml:lang="bn">ইমেজের কৃতজ্ঞতা, কপিরাইট, ও লাইসেন্স সম্পাদন</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="bn">ইমেজ পেস্ট করুন</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse">
+      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse" approved="yes">
         <source xml:lang="en">Cancel this import</source>
         <target xml:lang="bn">এই ইম্পোর্টটি বাতিল করুন</target>
         <note>ID: EditTab.JpegWarningDialog.DoNotUse</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.Photograph">
+      <trans-unit id="EditTab.JpegWarningDialog.Photograph" approved="yes">
         <source xml:lang="en">Use the JPEG file</source>
         <target xml:lang="bn">জেপিইজি ফাইলটি ব্যবহার করুন</target>
         <note>ID: EditTab.JpegWarningDialog.Photograph</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WarningText">
+      <trans-unit id="EditTab.JpegWarningDialog.WarningText" approved="yes">
         <source xml:lang="en">The file you’ve chosen is a “JPEG” file. JPEGfiles are perfect for photographs and color artwork. However, JPEG files are a big problem for black and white line art. Problems include:\n• Fuzziness and grey dots.\n• Large file sizes, making the book hard to share.\n• If there are many large JPEGs, Bloom may not have enough memory to make PDF files.\n\nNote: Because JPEG is “lossy”, converting a JPEG to PNG, TIFF, or BMP actually makes things even worse. If this is black and white line art, you want to get an original scan in one of those formats.\n\nPlease select from one of the following, then click “OK”:</source>
         <target xml:lang="bn">আপনার নির্বাচিত ফাইলটি একটি "জেপিইজি" ফাইল। জেপিইজি ফাইলগুলো ফটোগ্রাফ ও রঙ্গীন আর্টওয়ার্কের জন্য উপযুক্ত। যাইহোক, জেপিইজি ফাইলগুলো কালো ও সাদা সারির শিল্পের জন্য বড় সমস্যা।অন্তর্ভুক্ত সমস্যাসমূহ:\n• ফাজি এবং ধূসর ডটসমূহ।\n• বড় আকারের ফাইলসমূহ, বইটি শেয়ার করা কঠিন হবে।\n• যদি অনেকগুলো বড় জেপিইজি থাকে, পিডিএফ তৈরি করতে ব্লুমের পর্যাপ্ত মেমরি নাও থাকতে পারে।\n\nলক্ষণীয়: কারণ জেপিইজি হল “লজি”, জেপিইজি থেকে পিএনজি, টিআইএফএফ, অথবা বিএমপিতে রূপান্তরিত করলে প্রকৃতপক্ষে জিনিসটি আরো খারাপ হবে।যদি এটি কালো এবং সাদা শিল্পের আর্ট হয়, আপনি ঐ বিন্যাসগুলোর একটির মূল স্ক্যান কপি চান।\n\nঅনুগ্রহ করে নিম্নের যেকোনো একটি নির্বাচন করুন, তারপর "ঠিক আছে" ক্লিক করুন:</target>
         <note>ID: EditTab.JpegWarningDialog.WarningText</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle">
+      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle" approved="yes">
         <source xml:lang="en">JPEG Warning</source>
         <target xml:lang="bn">জেপিইজি সতর্কতা</target>
         <note>ID: EditTab.JpegWarningDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="bn">এই অপশনটি শুধুমাত্র প্রকাশনা ট্যাবে পাওয়া যাবে।</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="bn">লেআউট পরিবর্তন</target>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="bn">একটি ভাষা</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NewBookName">
+      <trans-unit id="EditTab.NewBookName" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="bn">বই</target>
         <note>ID: EditTab.NewBookName</note>
         <note>Default file and folder name when you make a new book, but haven't give it a title yet.</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="bn">আপনি একটি ছবি পেস্ট করার পূর্বে, অন্য প্রোগ্রাম থেকে আপনার 'ক্লিপবোর্ডে' একটি কপি করুন।</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="bn">এই টেমপ্লেটের জন্য অন্য কোন লেআউট অপশন নেই।</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Overflow" sil:dynamic="true">
+      <trans-unit id="EditTab.Overflow" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This box has more text than will fit</source>
         <target xml:lang="bn">এই বাক্সে যা মানানসই তার চেয়ে অনেক বেশি লেখা আছে</target>
         <note>ID: EditTab.Overflow</note>
       </trans-unit>
-      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true">
+      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A container on this page is overflowing</source>
         <target xml:lang="bn">এই পৃষ্ঠায় একটি কন্টেইনার উঁপচে পড়ছে</target>
         <note>ID: EditTab.OverflowContainer</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are.</source>
         <target xml:lang="bn">ঐ পরিবর্তনটি অনুমোদিত নয়।ফ্রন্ট মেটার এবং বেক মেটার পৃষ্ঠাসমূহ অবশ্যই তারা যেখানে আছে সেখানে থাকবে। </target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="bn">অকার্যকর স্থানান্তর</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="bn">পৃষ্ঠাসমূহ</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="bn">পৃষ্ঠার আকার ও অভিমুখ পছন্দ করুন</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="bn">পেস্ট</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTip">
+      <trans-unit id="EditTab.PasteButton.ToolTip" approved="yes">
         <source xml:lang="en">Paste (Ctrl+V)</source>
         <target xml:lang="bn">পেস্ট (Ctrl+V)</target>
         <note>ID: EditTab.PasteButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing on the Clipboard that you can paste here.</source>
         <target xml:lang="bn">ক্লিপবোর্ডে কিছু নেই যা এখানে পেস্ট করতে পারেন।</target>
         <note>ID: EditTab.PasteButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Position" sil:dynamic="true">
+      <trans-unit id="EditTab.Position" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Position</source>
         <target xml:lang="bn">অবস্থান</target>
         <note>ID: EditTab.Position</note>
       </trans-unit>
-      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true">
+      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot put anything in there while making an original book.</source>
         <target xml:lang="bn">আপনি মূল বই তৈরির সময় সেখানে কোনকিছু রাখতে পারবেন না।</target>
         <note>ID: EditTab.ReadOnlyInAuthorMode</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="bn">সীমানা এবং ব্যাকগ্রাউন্ড পরিবর্তন করুন</target>
         <note>ID: EditTab.StyleEditor.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="bn">ফন্টের রূপ পরিবর্তন করুন</target>
         <note>ID: EditTab.StyleEditor.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="bn">ফন্টের আকার পরিবর্তন করুন</target>
         <note>ID: EditTab.StyleEditor.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="bn">লেখার সারির মধ্যকার ফাঁকা জায়গা পরিবর্তন করুন</target>
         <note>ID: EditTab.StyleEditor.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="bn">অতিরিক্ত প্রস্থ</target>
         <note>ID: EditTab.StyleEditor.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="bn">সাধারণ</target>
         <note>ID: EditTab.StyleEditor.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="bn">শব্দগুলোর মধ্যে ফাঁকা জায়গা পরিবর্তন করুন</target>
         <note>ID: EditTab.StyleEditor.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="bn">প্রস্থ </target>
         <note>ID: EditTab.StyleEditor.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="bn">স্টাইলের জন্য বিন্যাস ঠিক করুন</target>
         <note>ID: EditTab.StyleEditorTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="bn">টেমপ্লেট পৃষ্ঠাসমূহ</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom">
+      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom" approved="yes">
         <source xml:lang="en">Picture On Bottom</source>
         <target xml:lang="bn">নীচে ছবি</target>
         <note>ID: EditTab.ThumbnailCaptions.Picture On Bottom</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="bn">ছবির মেধাসত্ব অধিকার তথ্য</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="bn">ডিকোডেবল পাঠক কার্যসম্পাদন</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom can handle only the first {0} words.</source>
         <target xml:lang="bn">ব্লুম শুধুমাত্র প্রথম {0} শব্দসমূহ নিয়ন্ত্রণ করতে পারে।</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed words in this stage</source>
         <target xml:lang="bn">এই স্তরে অনুমোদিত শব্দসমূহ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles" approved="yes">
         <source xml:lang="en">Text files</source>
         <target xml:lang="bn">লিখিত ফাইলসমূহ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters" approved="yes">
         <source xml:lang="en">Letters: {0}</source>
         <target xml:lang="bn">অক্ষরসমূহ: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage" approved="yes">
         <source xml:lang="en">The following is a generated report of the decodable stages for {0}. You can make any changes you want to this file, but Bloom will not notice your changes. It is just a report.</source>
         <target xml:lang="bn">নিম্নোক্ত ডিকোডেবল স্তরসমূহ {0} এর জন্য একটি উৎপন্ন রিপোর্ট।আপনি এই ফাইলে ইচ্ছেমত যেকোনো পরিবর্তন করতে পারেন, কিন্তু ব্লুম আপনার কোনো পরিবর্তন পরিলক্ষিত করবে না।এটি শুধুমাত্র একটি রিপোর্ট।</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords" approved="yes">
         <source xml:lang="en">New Decodable Words: {0}</source>
         <target xml:lang="bn">নতুন ডিকোডেবল শব্দসমূহ: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords" approved="yes">
         <source xml:lang="en">New Sight Words: {0}</source>
         <target xml:lang="bn">নতুন সাইট শব্দসমূহ: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage" approved="yes">
         <source xml:lang="en">Stage {0}</source>
         <target xml:lang="bn">স্তর {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList" approved="yes">
         <source xml:lang="en">Complete Word List</source>
         <target xml:lang="bn">সম্পূর্ণ শব্দের তালিকা</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="bn">এই স্তরের অক্ষরসমূহ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="bn">একটি অক্ষর এবং বা শব্দের তালিকা খুলুন</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Generate a letter and word list report</source>
         <target xml:lang="bn">অক্ষর ও শব্দ তালিকার একটি রিপোর্ট তৈরি কর</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample words in this stage</source>
         <target xml:lang="bn">এই স্তরে নমুনা শব্দসমূহ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="bn">স্তরসমূহ সাজান</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="bn">স্তর</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="bn">এর</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="bn">এই স্তরে শব্দসমূহ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="bn">পর্যায়ভিত্তিক পাঠক কার্যসম্পাদন</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="bn">প্রকৃত</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true" approved="yes">
         <source xml:lang="en">avg per sentence</source>
         <target xml:lang="bn">গড়ে প্রতিটি বাক্য</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Average</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="bn">একটি বিষয় নির্বাচন করুন</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="bn">এই লেভেলের জন্য</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="bn">বিন্যাস</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="bn">চিত্রণ সহায়তা</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="bn">মনে রাখবেন</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="bn">পর্যায়</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
         <note>Used to create string "Level # of #". The space after this word is added programmatically.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="bn">এর </target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
         <note>Used to create string "Level # of #". The spaces on each side of this word are added programmatically.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="bn">সর্বোচ্চ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="bn">প্রতি পৃষ্ঠায়</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="bn">সবচেয়ে লম্বা বাক্য</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="bn">প্রিডেকটিবিলিটি</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="bn">লেভেলসমূহ সেট আপ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="bn">এই বই</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="bn">এই পৃষ্ঠা</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="bn">সর্বমোট</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="bn">অনন্য</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="bn">শব্দকোষ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="bn">শব্দ সংখ্যা</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="bn">আরো...</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allow changes to this shellbook</source>
         <target xml:lang="bn">এই শেলবুকে পরিবর্তন করার অনুমতি দিন</target>
         <note>ID: EditTab.Toolbox.Settings.Unlock</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom normally prevents most changes to shellbooks. If you need to add pages, change images, etc., tick the box below.</source>
         <target xml:lang="bn">ব্লুম সাধারণত শেলবুকে বেশি পরিবর্তন করতে বাধা দেয়।যদি আপনার পেজ যুক্ত, ছবি পরিবর্তন, ইত্যাদির প্রয়োজন হয়, নীচের বাক্সে টিক চিহ্ন দিন।</target>
         <note>ID: EditTab.Toolbox.Settings.UnlockShellBookIntroductionText</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState" approved="yes">
         <source xml:lang="en">Bloom recording is in an unusual state, possibly caused by unplugging a microphone. You will need to restart.</source>
         <target xml:lang="bn">ব্লুম রেকর্ডিং একটি অপ্রত্যাশিত ঘটনা, মাইক্রোফোন প্লাগ থেকে বিচ্ছিন্ন হলে এটি হতে পারে।আপনার পুনরায় চালু করতে হবে।</target>
         <note>ID: EditTab.Toolbox.TalkingBook.BadState</note>
         <note>This is very low priority for translation.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput" approved="yes">
         <source xml:lang="en">No input device</source>
         <target xml:lang="bn">কোন ইনপুট ডিভাইস নেই</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoInput</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic" approved="yes">
         <source xml:lang="en">This computer appears to have no sound recording device available. You will need one to record audio for a talking book.</source>
         <target xml:lang="bn">দেখে মনে হচ্ছে এই কম্পিউটারে কোন সাউন্ড রেকর্ডিং ডিভাইস নেই।আপনার কথা বইটির জন্য অডিও রেকর্ড করার ক্ষেত্রে একটি প্রয়োজন।</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoMic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage" approved="yes">
         <source xml:lang="en">Please hold the button down until you have finished recording</source>
         <target xml:lang="bn">অনুগ্রহ করে রেকর্ড শেষ না হওয়া পর্যন্ত বোতামটি নীচের দিকে চেপে ধরুন।</target>
         <note>ID: EditTab.Toolbox.TalkingBook.PleaseHoldMessage</note>
         <note>Appears when the speak/record button is pressed very briefly</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="bn">পিছনে</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Back</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4) Check</source>
         <target xml:lang="bn">৪) চেক করুন</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Check</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Check that you are recording into the correct device and that these levels are showing blue:</source>
         <target xml:lang="bn">১) পরীক্ষা করুন যে আপনি ঠিক ডিভাইসটিতে রেকডিং করছেন এবং এই লেভেলগুলি নীল দেখাচ্ছে:</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.CheckSettings</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Clear</source>
         <target xml:lang="bn">পরিষ্কার</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Clear</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Talking Book Tool</source>
         <target xml:lang="bn">টকিং বুক টুল</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Listen to the whole page</source>
         <target xml:lang="bn">সম্পূর্ণ পেজটি শুনুন</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Listen</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Look at the highlighted sentence</source>
         <target xml:lang="bn">২) হাইলাইট করা বাক্য দেখুন</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.LookAtSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5) Next</source>
         <target xml:lang="bn">৫) পরবর্তী</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Next</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3) Speak</source>
         <target xml:lang="bn">৩) কথা বলুন</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Speak</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an e-book that can play recordings while highlighting sentences.</source>
         <target xml:lang="bn">একটি ই-বুক তৈরি করুন যা কোন বাক্য হাইলাইট করা হলে তার রেকর্ড পড়ে শোনাবে।</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.ToolPurpose</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="bn">সবচেয়ে বড় বাক্য</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="bn">তিনটি ভাষা</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="bn">পূর্বাবস্থা</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTip">
+      <trans-unit id="EditTab.UndoButton.ToolTip" approved="yes">
         <source xml:lang="en">Undo (Ctrl+Z)</source>
         <target xml:lang="bn">পূর্বাবস্থা (Ctrl+Z)</target>
         <note>ID: EditTab.UndoButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing to undo</source>
         <target xml:lang="bn">এখানে পূর্বাবস্থায় নিয়ে যাওয়ার মত কিছু নেই</target>
         <note>ID: EditTab.UndoButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="Errors.BookProblem">
+      <trans-unit id="Errors.BookProblem" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.</source>
         <target xml:lang="bn">এই বইটি দেখাতে ব্লুমের সমস্যা হচ্ছে।এর অর্থ এই না যে আপনার কাজ নষ্ট হয়ে গেছে, কিন্তু এর অর্থ এটি যে কোন কিছু মেয়াদত্তীর্ণ হয়েছে, হারিয়েছে অথবা ভুল হয়েছে।</target>
         <note>ID: Errors.BookProblem</note>
       </trans-unit>
-      <trans-unit id="Errors.BrokenBook">
+      <trans-unit id="Errors.BrokenBook" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong. Consider using the 'Report a Problem' command under the 'Help' menu.</source>
         <target xml:lang="bn">এই বইটি দেখাতে ব্লুমের সমস্যা হচ্ছে।এর অর্থ এই না যে আপনার কাজ নষ্ট হয়ে গেছে, কিন্তু এর অর্থ এটি যে কোন কিছু মেয়াদত্তীর্ণ হয়েছে, হারিয়েছে অথবা ভুল হয়েছে।'সাহায্য' মেনুর নীচে 'সমস্যা রিপোর্ট করুন' কমান্ডটি ব্যবহারের বিবেচনা করুন।</target>
         <note>ID: Errors.BrokenBook</note>
       </trans-unit>
-      <trans-unit id="Errors.CannotConnectToBloomServer">
+      <trans-unit id="Errors.CannotConnectToBloomServer" approved="yes">
         <source xml:lang="en">Bloom was unable to start its own HTTP listener that it uses to talk to its embedded Firefox browser. If this happens even if you just restarted your computer, ask someone to investigate if you have an aggressive firewall product installed. The agressive firewall product may need to be uninstalled before you can use Bloom.</source>
         <target xml:lang="bn">ব্লুম তার নিজস্ব এইচটিটিপি শ্রোতা চালু করতে অসমর্থ যা এটি এমবেডেড ফায়ারফক্স ব্রাউজার ব্যবহার করে কথা বলতে পারে।যদি এটি ঘটে যদিও আপনি কেবল আপনার কম্পিউটার রিস্টার্ট দিয়েছেন, কাউকে তদন্ত করার জন্য দেখান যদি আপনার কোন আক্রমনাত্মক ফায়ারওয়াল পণ্য ইনস্টল হয়ে আছে।আপনি ব্লুম ব্যবহারের পূর্বে আক্রমনাত্মক ফায়ারওয়াল পণ্য আনইনস্টল করার প্রয়োজন হতে পারে।</target>
         <note>ID: Errors.CannotConnectToBloomServer</note>
       </trans-unit>
-      <trans-unit id="Errors.DeniedAccess">
+      <trans-unit id="Errors.DeniedAccess" approved="yes">
         <source xml:lang="en">Your computer denied Bloom access to the book. You may need technical help in setting the operating system permissions for this file.</source>
         <target xml:lang="bn">আপনার কম্পিউটার ব্লুমকে বইটিতে প্রবেশাধিকার দিতে অস্বীকৃতি জানায়।আপনার এই ফাইলটির অনুমতির জন্য অপারেটিং সিস্টেমের সেটিংয়ের কারিগরি সহায়তার প্রয়োজন হতে পারে।</target>
         <note>ID: Errors.DeniedAccess</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorSelecting">
+      <trans-unit id="Errors.ErrorSelecting" approved="yes">
         <source xml:lang="en">There was a problem selecting the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="bn">বইটি নির্বাচন করতে একটি সমস্যা হয়েছিল।ব্লুম রিস্টার্ট করলে সমস্যাটির সমাধান হতে পারে।যদি না হয়, অনুগ্রহ করে 'বিস্তারিত' বোতামটি ক্লিক করুন এবং সমস্যাটি ব্লুম ডেভেলাপারদের জানান।</target>
         <note>ID: Errors.ErrorSelecting</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorUpdating">
+      <trans-unit id="Errors.ErrorUpdating" approved="yes">
         <source xml:lang="en">There was a problem updating the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="bn">বইটি আপডেট করতে সমস্যা হচ্ছিল।ব্লুম রিস্টার্ট করলে সমস্যাটির সমাধান হতে পারে।যদি না হয়, অনুগ্রহ করে 'বিস্তারিত' বোতামটি ক্লিক করুন এবং সমস্যাটি ব্লুম ডেভেলাপারদের জানান।</target>
         <note>ID: Errors.ErrorUpdating</note>
       </trans-unit>
-      <trans-unit id="Errors.NeedNewerVersion">
+      <trans-unit id="Errors.NeedNewerVersion" approved="yes">
         <source xml:lang="en">{0} requires a newer version of Bloom. Download the latest version of Bloom from {1}.</source>
         <target xml:lang="bn">{0} এর জন্য ব্লুমের নতুন সংস্করণ প্রয়োজন। {1} থেকে ব্লুমের সর্বশেষ সংস্করণ ডাউনলোড করুন।</target>
         <note>ID: Errors.NeedNewerVersion</note>
         <note>{0} will get the name of the book, {1} will give a link to open the Bloom Library Web page.</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemDeletingFile">
+      <trans-unit id="Errors.ProblemDeletingFile" approved="yes">
         <source xml:lang="en">Bloom had a problem deleting this file: {0}</source>
         <target xml:lang="bn">এই ফাইলটি মুছে ফেলতে ব্লুমের সমস্যা হচ্ছে: {0}</target>
         <note>ID: Errors.ProblemDeletingFile</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemImportingPicture">
+      <trans-unit id="Errors.ProblemImportingPicture" approved="yes">
         <source xml:lang="en">Bloom had a problem importing this picture.</source>
         <target xml:lang="bn">এই ছবিটি ইম্পোর্ট করতে ব্লুমের সমস্যা হচ্ছে।</target>
         <note>ID: Errors.ProblemImportingPicture</note>
       </trans-unit>
-      <trans-unit id="Errors.ReportThisProblemButton">
+      <trans-unit id="Errors.ReportThisProblemButton" approved="yes">
         <source xml:lang="en">Report this problem to Bloom Support</source>
         <target xml:lang="bn">এই সমস্যাটি ব্লুমের সহায়তায় রিপোর্ট করুন</target>
         <note>ID: Errors.ReportThisProblemButton</note>
       </trans-unit>
-      <trans-unit id="Errors.SomethingWentWrong">
+      <trans-unit id="Errors.SomethingWentWrong" approved="yes">
         <source xml:lang="en">Sorry, something went wrong.</source>
         <target xml:lang="bn">দুঃখিত, কোনকিছুর ক্রটি হয়েছে।</target>
         <note>ID: Errors.SomethingWentWrong</note>
       </trans-unit>
-      <trans-unit id="Errors.XMatterNotFound">
+      <trans-unit id="Errors.XMatterNotFound" approved="yes">
         <source xml:lang="en">This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a Bloom Pack that will give you '{0}', or go to Settings:Book Making and change to another Front/Back Matter Pack.</source>
         <target xml:lang="bn">এই বইটি '{0}' নামের সামনের/পিছনের মেটার প্যাকের জন্য, কিন্তু ব্লুম এই কম্পিউটারে সেটি খুঁজে পায়নি।আপনি ব্লুম প্যাক ইনস্টল করতে পারেন যা আপনাকে '{0}' দিবে, অথবা যান  সেটিং:বই তৈরি এবং অন্য একটি সামনের/পিছনের মেটার প্যাকে পরিবর্তন করুন।</target>
         <note>ID: Errors.XMatterNotFound</note>
       </trans-unit>
-      <trans-unit id="Errors.ZoneAlarm">
+      <trans-unit id="Errors.ZoneAlarm" approved="yes">
         <source xml:lang="en">Bloom cannot start properly, and this symptom has been observed on machines with ZoneAlarm installed. Note: disabling ZoneAlarm does not help. Nor does restarting with it turned off. Something about the installation of ZoneAlarm causes the problem, and so far only uninstalling ZoneAlarm has been shown to fix the problem.</source>
         <target xml:lang="bn">ব্লুম ঠিকমত চালু হতে পারছে না, এবং এই লক্ষণটি জোনএল্যার্ম ইনস্টলকৃত মেশিনে দেখা দিয়েছে।লক্ষণীয়: জোনএল্যার্ম নিষ্ক্রিয় করেও কাজ করছে না।বন্ধ করেও কোন কাজ হয়নি।জোনএল্যার্ম ইনস্টলেশনের কিছু একটি হয়েছে যা সমস্যা সৃষ্টি করেছে, এবং তাই জোনএল্যার্ম আনইনস্টল করে সমস্যাটির সমাধান হতে পারে।</target>
         <note>ID: Errors.ZoneAlarm</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="bn">রিডার টেম্পলেটসমূহ তৈরি</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="bn">নতুন সংস্করণের জন্য চেক করুন</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="bn">ব্লুম সম্পর্কে</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <target xml:lang="bn">ডকুমেন্টেশন</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="bn">সাহায্য</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Get Help</source>
         <target xml:lang="bn">সাহায্য নিন</target>
         <note>ID: HelpMenu.Help Menu_ToolTip_</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem">
+      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem" approved="yes">
         <source xml:lang="en">Key Bloom Concepts</source>
         <target xml:lang="bn">ব্লুমের মূল ধারণাসমূহ</target>
         <note>ID: HelpMenu.KeyBloomConceptsToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="bn">একটি পরামর্শ দিন</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="bn">নিবন্ধন</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="bn">রিলিজ নোট...</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem">
+      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem" approved="yes">
         <source xml:lang="en">Report a Problem...</source>
         <target xml:lang="bn">সমস্যা রিপোর্ট করুন...</target>
         <note>ID: HelpMenu.ReportAProblemToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="bn">ইভেন্ট লগ দেখান</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="bn">রিডার টেম্পলেটসমূহ ব্যবহার</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="bn">ওয়েব সাইট</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.trainingVideos">
+      <trans-unit id="HelpMenu.trainingVideos" approved="yes">
         <source xml:lang="en">Training Videos</source>
         <target xml:lang="bn">প্রশিক্ষণ ভিডিওসমূহ</target>
         <note>ID: HelpMenu.trainingVideos</note>
       </trans-unit>
-      <trans-unit id="InstallProblem.BloomPdfMaker">
+      <trans-unit id="InstallProblem.BloomPdfMaker" approved="yes">
         <source xml:lang="en">A component of Bloom, BloomPdfMaker.exe, seems to be missing. This prevents previews and printing. Antivirus software sometimes does this. You may need technical help to repair the Bloom installation and protect this file from being deleted again.</source>
         <target xml:lang="bn">ব্লুমের একটি উপাদান BloomPdfMaker.exe, দেখে মনে হচ্ছে অনুপস্থিত।এটি প্রিভিউ এবং প্রিন্টিংকে বাধা দেয়।কখনও কখনও এন্টিভাইরাস সফটওয়্যার এটি করে।ব্লুম ইনস্টলেশন মেরামত করতে এবং পুনরায় ফাইলটি মুছে যাওয়া থেকে সুরক্ষা দিতে আপনার কারিগরি সহায়তার প্রয়োজন হতে পারে।</target>
         <note>ID: InstallProblem.BloomPdfMaker</note>
       </trans-unit>
-      <trans-unit id="LameEncoder.Progress">
+      <trans-unit id="LameEncoder.Progress" approved="yes">
         <source xml:lang="en">Converting to mp3</source>
         <target xml:lang="bn">এমপিথ্রি-তে রূপান্তরিত হচ্ছে</target>
         <note>ID: LameEncoder.Progress</note>
         <note>Appears in progress indicator</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.RightToLeftCheck">
+      <trans-unit id="LanguageFontDetails.RightToLeftCheck" approved="yes">
         <source xml:lang="en">This script is right to left</source>
         <target xml:lang="bn">এই স্ক্রিপ্টটি ডান থেকে বামে</target>
         <note>ID: LanguageFontDetails.RightToLeftCheck</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.TallerLinesCheck">
+      <trans-unit id="LanguageFontDetails.TallerLinesCheck" approved="yes">
         <source xml:lang="en">This script requires taller lines</source>
         <target xml:lang="bn">এই স্ক্রিপ্টটির দীর্ঘ সারি প্রয়োজন</target>
         <note>ID: LanguageFontDetails.TallerLinesCheck</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="bn">এ৪আনুভূমিক</target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="bn">এ৪আনুভূমিক পাশাপাশি</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="bn">এ৪আনুভূমিক পৃষ্ঠাগুলোর মধ্যে বিভক্ত</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="bn">এ৪উলম্ব</target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="bn">এ৫আনুভূমিক</target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="bn">এ৫উলম্ব</target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="bn">এ৫উলম্ব নীচে সারিকরণ করুন</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Landscape</source>
         <target xml:lang="bn">এ৬আনুভূমিক</target>
         <note>ID: LayoutChoices.A6Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Portrait</source>
         <target xml:lang="bn">এ৬উলম্ব</target>
         <note>ID: LayoutChoices.A6Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="bn">বি৫উলম্ব</target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">HalfLetterPortrait</source>
         <target xml:lang="bn">অর্ধেকঅক্ষরউলম্ব</target>
         <note>ID: LayoutChoices.HalfLetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterLandscape</source>
         <target xml:lang="bn">আনুভূমিকঅক্ষর</target>
         <note>ID: LayoutChoices.LetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterPortrait</source>
         <target xml:lang="bn">উলম্বঅক্ষর</target>
         <note>ID: LayoutChoices.LetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">QuarterLetterLandscape</source>
         <target xml:lang="bn">কোয়ার্টারআনুভূমিকঅক্ষর</target>
         <note>ID: LayoutChoices.QuarterLetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog.WindowTitle">
+      <trans-unit id="LicenseDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom {0}</source>
         <target xml:lang="bn">ব্লুম {0}</target>
         <note>ID: LicenseDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog._acceptButton">
+      <trans-unit id="LicenseDialog._acceptButton" approved="yes">
         <source xml:lang="en">I accept the terms of the license agreement</source>
         <target xml:lang="bn">আমি লাইসেন্স চুক্তির শর্তসমূহ মেনে নিচ্ছি</target>
         <note>ID: LicenseDialog._acceptButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="bn">আমি ব্লুম লাইব্রেরির ব্যবহারের শর্তাবলী মেনে নিচ্ছি</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="bn">ইমেইল ঠিকানা</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="bn">পাসওয়ার্ড ভুলে গেছেন</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="bn">&amp;লগইন</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="bn">পাসওয়ার্ড</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="bn">&amp;পাসওয়ার্ড দেখান</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="bn">ব্যবহারের শর্তাবলী দেখান</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="bn">BloomLibrary.org এ লগইন করুন</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="bn">সেখানে ঐ নামে ইতোমধ্যেই একটি সংগ্রহ আছে, এখানে &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;।\nঅনুগ্রহ করে একটি অনন্য নাম নির্বাচন করুন।</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="bn">এই সংগ্রহের জন্য মূল ভাষা নির্বাচন করুন</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="bn">উদাহরণস্বরূপ: "স্বাস্থ্য বই", "পিএনজি প্রাণী গল্পসমূহ" </target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="bn">আপনি এই সংগ্রহকে কি নামে ডাকতে চান?</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="bn">সংগ্রহ নামে সমস্যা</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="bn">সংগ্রহ তৈরি হবে এখানে: {0}</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="bn">নতুন সংগ্রহ তৈরি করতে প্রস্তুত</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FontAndScriptPage">
+      <trans-unit id="NewCollectionWizard.FontAndScriptPage" approved="yes">
         <source xml:lang="en">Font and Script</source>
         <target xml:lang="bn">ফন্ট এবং স্ক্রিপ্ট</target>
         <note>ID: NewCollectionWizard.FontAndScriptPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="bn">সংগ্রহের ধরন পছন্দ করুন</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions" approved="yes">
         <source xml:lang="en">If you already have a collection you want to open, click  the 'Cancel' button.</source>
         <target xml:lang="bn">যদি আপনার ইতোমধ্যেই থাকা সংগ্রহ খুলতে চান, 'বাতিল' বোতামে ক্লিক করুন।</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="bn">উৎস সংগ্রহ</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org. You may also make a Bloom Pack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="bn">বিস্তৃত যোগাযোগের জন্য এক বা ততোধিক ভাষায় একটি সংগ্রহের শেল অথবা টেমপ্লেট বইসমূহ।আপনি BloomLibrary.org - এ এই শেলগুলি আপলোড করতে পারবেন।আপনি অন্যদেরকে দেওয়ার জন্য একটি ব্লুম প্যাকও বানাতে পারেন তাহলে তারা আপনার শেলগুলো দিয়ে স্বদেশীয় বই বানাতে পারবেন।</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="bn">স্বদেশীয়/স্থানীয় ভাষা সংগ্রহ</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="bn">একটি স্থানীয় ভাষার সংগ্রহের বইসমূহ।</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="bn">ভাষার অবস্থান জানান</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="bn">দেশ</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="bn">জেলা</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="bn">এইগুলো ঐচ্ছিক। ব্লুম আপনার তৈরি করা বইয়ের শিরোনাম পৃষ্ঠায় সেগুলোকে সঠিক স্থানে রাখবে।</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="bn">প্রদেশ</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">
           {0} Books
         </source>
@@ -1971,1524 +1971,1524 @@
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="bn">নতুন ব্লুম সংগ্রহ তৈরি করুন</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="bn">প্রকল্পের নাম</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="bn">সেই নাম ব্যবহার করে নতুন সংগ্রহ তৈরি করতে ব্যর্থ।</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="bn">ব্লুমে স্বাগতম!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="bn">আপনি বই তৈরি করতে প্রায় প্রস্তুত।</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. The first thing we need to do is make one for you.</source>
         <target xml:lang="bn">জিনিসগুলো সাধারণ এবং সাজানো রাখতে, ব্লুম আপনার তৈরি করা সকল বইসমূহ এক বা ততোধিক &lt;i&gt;সংগ্রহশালায়&lt;/i&gt; রাখে। প্রথমে আমাদের যে কাজটি করতে হবে তা হল আপনার জন্য একটি তৈরি করতে হবে।</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="bn">শুরু করতে 'পরবর্তী' ক্লিক করুন।</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InDropboxMessage">
+      <trans-unit id="OpenCreateCloneControl.InDropboxMessage" approved="yes">
         <source xml:lang="en">Bloom detected that this collection is located in your Dropbox folder. This can cause problems as Dropbox sometimes locks Bloom out of its own files. If you have problems, we recommend that you move your collection somewhere else or disable Dropbox while using Bloom.</source>
         <target xml:lang="bn">ব্লুম শনাক্ত করেছে যে এই সংগ্রহশালাটি আপনার ড্রপবক্সের ফোল্ডারে রয়েছে।এটি একটি সমস্যার কারণ হতে পারে যেহেতু ড্রপবক্স কখনও কখনও ব্লুমকে তার নিজের ফাইল থেকে লক করে।যদি কোন সমস্যার সম্মুখীন হন, আমরা পরামর্শ দিচ্ছি যে আপনার সংগ্রহ অন্যত্র সরিয়ে রাখুন অথবা ব্লুম ব্যবহারের সময় ড্রপবক্স নিষ্ক্রিয় রাখুন।</target>
         <note>ID: OpenCreateCloneControl.InDropboxMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage">
+      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage" approved="yes">
         <source xml:lang="en">This collection is part of your 'Sources for new books' which you can see in the bottom left of the Collections tab. It cannot be opened for editing.</source>
         <target xml:lang="bn">এই সংগ্রহটি 'নতুন বইসমূহের উৎস' এর অংশ যা বামে সংগ্রহশালা ট্যাবের নীচে দেখতে পাবেন।এটি সম্পাদন করার জন্য খোলা যাবে না।</target>
         <note>ID: OpenCreateCloneControl.InSourceCollectionMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="bn">ব্লুম সংগ্রহশালা</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="bn">অন্য সংগ্রহের জন্য এই কম্পিউটারে ব্রাউজ করুন</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="bn">কোরাস হাব থেকে লোকাল নেটওয়ার্কে কপি</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="bn">ইন্টারনেট থেকে কপি</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="bn">ইউএসবি ড্রাইভ থেকে কপি</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="bn">নতুন সংগ্রহ তৈরি</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="bn">খুলুন/তৈরি করুন/সংগ্রহ করুন</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="bn">আরো পড়ুন</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="bn">অন্য কেউ কি আপনার সাথে সংগ্রহ শেয়ার করার জন্য পাঠান/গ্রহণ ব্যবহার করেছিল?\nআপনার কম্পিউটারে তাদের সংগ্রহ কপি করার জন্য এই লাল বোতামগুলোর যে কোন একটি ব্যবহার করুন।\nপরে, তাদের সাথে আপনার কাজ শেয়ার করার জন্য পাঠান/গ্রহণ ব্যবহার করুন।</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PageList.CantMoveWhenTranslating">
+      <trans-unit id="PageList.CantMoveWhenTranslating" approved="yes">
         <source xml:lang="en">Pages can not be re-ordered when you are translating a book.</source>
         <target xml:lang="bn">যখন আপনি একটি বই অনুবাদ করছেন তখন পৃষ্ঠাগুলো পুনর্বিন্যাস করা যাবে না।</target>
         <note>ID: PageList.CantMoveWhenTranslating</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="bn">অনুগ্রহ করে এডোবি রিডার ইনস্টল করুন তাহলে ব্লুম আপনার সম্পূর্ণ বইটি দেখাতে পারবে। তখন পর্যন্ত, আপনি তখনও পিডিএফ বইটি সংরক্ষণ করতে পারবেন এবং অন্যান্য প্রোগ্রামে এটি খুলতে পারবেন।</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="bn">সেটি অদ্ভুত...এডোবি রিডার এই পিডিএফটি দেখানোর চেষ্টা করার সময় ত্রুটি দেখিয়েছিল। আপনি এখনও পিডিএফ বইটি সংরক্ষণ করার জন্য চেষ্টা করতে পারেন।</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="bn">দুঃখের খবর। ব্লুম এখানে এডোবি রিডারে দেখানোর জন্য সমর্থ ছিল না, তাই ব্লুম আপনার সম্পূর্ণ বইটি দেখাতে পারছে না।\nঅনুগ্রহ করে 'এডোবি রিডার' এর বিদ্যমান সংস্করণ আনইনস্টল করুন এবং 'এডোবি রিডার' (পুনরায়) ইনস্টল করুন।\nআপনি সেটি সমাধান না করা পর্যন্ত, আপনি তখনও পিডিএফ বইটি সংরক্ষণ করতে পারেন এবং অন্যান্য প্রোগ্রামে এটি খুলতে পারবেন।</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="bn">বুকলেটের ভিতরে</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book. Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="bn">এই বইটির ভিতরের পৃষ্ঠাগুলো দিয়ে একটি বুকলেট তৈরি করুন। পৃষ্ঠাগুলো পরিপূর্ণ এবং পুনর্বিন্যস্ত সুতরাং যখন আপনি এটি ভাঁজ করবেন, তখন আপনি একটি বুকলেট পাবেন।\n</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="bn">আপলোড</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="bn">BloomLibrary.org এ আপলোড করুন, যেখানে অন্যরা ডাউনলোড করতে এবং তাদের নিজের ভাষায় অনূদিত করতে পারেন।</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="bn">বুকলেট কভার</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="bn">শুধুমাত্র সামনের এবং পিছনের (দুই পাশের) একটি পিডিএফ তৈরি করুন, তাহলে আপনি রঙ্গীন কাগজে প্রিন্ট করতে পারেন।</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubButton">
+      <trans-unit id="PublishTab.EpubButton" approved="yes">
         <source xml:lang="en">ePUB</source>
         <target xml:lang="bn">ইপাব</target>
         <note>ID: PublishTab.EpubButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an ePUB (electronic book) out of this book, allowing it to be read on various electronic reading devices.</source>
         <target xml:lang="bn">এটি বিভিন্ন ইলেকট্রনিক পড়া ডিভাইসের পড়তে হবে, যার ফলে এই কিতাব থেকে একটি EPUB (ইলেকট্রনিক বই) কর।</target>
         <note>ID: PublishTab.EpubRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="bn">এটি পুনরায় দেখাবেন না</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="bn">ইনডিজাইন এক্সএমএল তথ্য</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation">
+      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation" approved="yes">
         <source xml:lang="en">This PDF viewer can be improved by installing the free Adobe Reader on this computer.</source>
         <target xml:lang="bn">এই কম্পিউটারে বিনামূল্যে এডোবি রিডার ইনস্টল করে এই পিডিএফ ভিউয়ারটি উন্নত করা যেতে পারে।</target>
         <note>ID: PublishTab.Notifications.AdobeReaderRecommendation</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="bn">সাধারণ</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="bn">এই বইটির প্রতিটি পৃষ্ঠার পিডিএফ তৈরি করুন, প্রতিটি কাগজের টুকরা দিয়ে একটি পৃষ্ঠা।</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system PDF viewer</source>
         <target xml:lang="bn">সিস্টেমের ডিফল্ট পিডিএফ ভিউয়ারে পিডিএফটি খুলুন।</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="bn">বিদ্যমান প্রতিস্থাপন</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="bn">নোটিশ</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.BadPdf">
+      <trans-unit id="PublishTab.PdfMaker.BadPdf" approved="yes">
         <source xml:lang="en">Bloom had a problem making a PDF of this book. You may need technical help or to contact the developers. But here are some things you can try:</source>
         <target xml:lang="bn">এই বইটির পিডিএফ তৈরিতে ব্লুম সমস্যায় পড়েছিল। আপনার কারিগরি সহায়তার প্রয়োজন হতে পারে অথবা ডেভলাপারদের সাথে যোগাযোগ করতে হতে পারে। কিন্তু এখানে আপনি ব্যবহার করতে পারেন এমন কিছু আছে:</target>
         <note>ID: PublishTab.PdfMaker.BadPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory">
+      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory" approved="yes">
         <source xml:lang="en">Try doing this on a computer with more memory</source>
         <target xml:lang="bn">আরো মেমরির সাথে একটি কম্পিউটারে এটি চেষ্টা করুন</target>
         <note>ID: PublishTab.PdfMaker.TryMoreMemory</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryRestart">
+      <trans-unit id="PublishTab.PdfMaker.TryRestart" approved="yes">
         <source xml:lang="en">Restart your computer and try this again right away</source>
         <target xml:lang="bn">আপনার কম্পিউটার রিস্টার্ট করুন এবং সঠিক উপায়ে আবার চেষ্টা করুন</target>
         <note>ID: PublishTab.PdfMaker.TryRestart</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages">
+      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages" approved="yes">
         <source xml:lang="en">Replace large, high-resolution images in your document with lower-resolution ones</source>
         <target xml:lang="bn">আপনার নথিতে নিম্ন রেজল্যুশনের একটি দিয়ে বড়, উচ্চ-রেজল্যুশন ছবি স্থানান্তর</target>
         <note>ID: PublishTab.PdfMaker.TrySmallerImages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="bn">&amp;প্রিন্ট...</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="bn">প্রকাশ</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="bn">&amp;পিডিএফ সংরক্ষণ...</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveEpub">
+      <trans-unit id="PublishTab.SaveEpub" approved="yes">
         <source xml:lang="en">&amp;Save ePUB...</source>
         <target xml:lang="bn">&amp;ইপাব সংরক্ষণ...</target>
         <note>ID: PublishTab.SaveEpub</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="bn">চিহ্ন ক্রপ করুন</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="bn">কৃতজ্ঞতা স্বীকার</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">Additional Requests: </source>
         <target xml:lang="bn">অতিরিক্ত অনুরোধসমূহ:</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="bn">যেকোনো অনুমতির জন্য কপিরাইট ধারণকারীর সাথে যোগাযোগ করুন</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="bn">সিসি-বাই-এনসি</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you. If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="bn">BloomLibrary.org এ ইতোমধ্যে আপনার এই বইয়ের পূর্বের সংস্করণ আছে।যদি আপনি এটি পুনরায় আপলোড করেন, এটি আপনার বর্তমান সংস্করণের সাথে প্রতিস্থাপিত হবে।</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="bn">কপিরাইট</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="bn">কৃতজ্ঞতা</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="bn">দুঃখিত, {0} আপলোড করতে সমস্যা হচ্ছিল। নিম্নে কিছু বিস্তারিত দেওয়া হল। আপনার কারিগরি সহায়তার প্রয়োজন হতে পারে।</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading.</source>
         <target xml:lang="bn">আপলোড করার পূর্বে উপরের একটি অথবা আরো বেশি ক্ষেত্রে আপনার মনোযোগ প্রয়োজন।</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded. Sometimes this is caused by temporary problems with the servers we use. It's worth trying again in an hour or two. If you regularly get this problem please report it to us.</source>
         <target xml:lang="bn">দুঃখিত, "{0}" সফলতার সাথে আপলোড হয়নি। আমরা যে সার্ভার ব্যবহার করি তার জন্য কখনও কখনও এই সাময়িক সমস্যার সৃষ্টি হতে পারে। এটা এক বা দুই ঘন্টার মধ্যে আবার চেষ্টা করুন। আপনি যদি নিয়মিত এই সমস্যায় পড়েন তাহলে আমাদের জানান। </target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes.</source>
         <target xml:lang="bn">আপলোডের মাধ্যমে ব্লুম লাইব্রেরি ব্যবহারের নীতি এবং অনুমতির বিস্তারিত অধিকারের সাথে আপনি আপনার চুক্তি নিশ্চিত করেন। </target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="bn">আপনার বই আপলোড করতে সমস্যা হচ্ছে।</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="bn">ভাষাসমূহ</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="bn">ব্যবহার/লাইসেন্স</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="bn">একাউন্ট ইতোমধ্যে বিদ্যমান</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address. Would you like to log in instead?</source>
         <target xml:lang="bn">আমরা ঐ ঠিকানা দিয়ে আপনার সাইন আপ করাতে পারছি না, কারণ ঐ ঠিকানা দিয়ে ইতোমধ্যেই আমাদের একটি একাউন্ট আছে।আপনি কি পরিবর্তে লগ ইন করতে চান?</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="bn">আপনার লগইন যাচাই করতে ব্লুম সার্ভারের সাথে সংযুক্ত হতে পারছে না।অনুগ্রহ করে আপনার নেটওয়ার্ক সংযোগ পরীক্ষা করুন।</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="bn">লগইন ব্যর্থ হয়েছে</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="bn">আপনার লগইন অথবা সাইনআপ সম্পন্ন করতে ব্লুম সার্ভারের সাথে সংযুক্ত হতে পারছে না।এটি আপনার ইন্টারনেট সংযোগ, আমাদের সার্ভার অথবা এর মধ্যে কিছু সরঞ্জামের সমস্যা হতে পারে।</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="bn">একটি BloomLibrary.org একাউন্টের জন্য সাইনআপ করতে, আপনাকে অবশ্যই ব্লুমলাইব্রেরি ব্যবহার নীতি বাক্সটিতে টিক দিতে হবে।</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="bn">ইমেইল প্রয়োজন</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="bn">আমাদের রেকর্ডে ঐ ইমেইলের কোন ব্যবহারকারী নেই।আপনি কি সাইন আপ করতে চান?</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="bn">পাসওয়ার্ড এবং ব্যবহারকারীর আইডি মিলেনি</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="bn">অনুগ্রহ করে ব্যবহারকারীর নীতির সাথে সম্মতি জ্ঞাপন করুন</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="bn">অনুগ্রহ করে একটি বৈধ ইমেইল ঠিকানা প্রবেশ করান।আমরা এই ঠিকানায় একটি ইমেইল পাঠাব তাহলে আপনি আপনার পাসওয়ার্ড রিসেট করতে পারবেন।</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="bn">আপনার পাসওয়ার্ড রিসেট করতে ব্লুম সার্ভারের সাথে সংযুক্ত হতে পারছে না।অনুগ্রহ করে আপনার নেটওয়ার্ক সংযোগ পরীক্ষা করুন।</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="bn">পাসওয়ার্ড রিসেট ব্যর্থ হয়েছে</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="bn">পাসওয়ার্ড রিসেট করা হচ্ছে</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password.</source>
         <target xml:lang="bn">কিভাবে পাসওয়ার্ড রিসেট করতে হবে তার নির্দেশনাসহ আমরা {0} কে একটি ইমেইল পাঠাচ্ছি। </target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="bn">ব্লুম লাইব্রেরির জন্য সাইন আপন করুন।</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="bn">অপরিচিত ব্যবহারকারী</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="bn">ব্লুম আপনার সংরক্ষিত পরিচয়পত্র দিয়ে BloomLibrary.org লগইন করতে পারছে না।অনুগ্রহ করে আপনার নেটওয়ার্ক সংযোগ পরীক্ষা করুন।</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="bn">BloomLibrary.org এ লগইন করুন</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="bn">BloomLibrary.org হতে লগ আউট হন</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="bn">পিডিএফ এর প্রিভিউ তৈরি হচ্ছে...</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="bn">থাম্বেনাইল ছবি তৈরি হচ্ছে...</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.NoLangsFound">
+      <trans-unit id="PublishTab.Upload.NoLangsFound" approved="yes">
         <source xml:lang="en">(None found)</source>
         <target xml:lang="bn">(কোনকিছু পাওয়া যায়নি)</target>
         <note>ID: PublishTab.Upload.NoLangsFound</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="bn">দুঃখিত, ব্লুম ডেস্কটপের এই সংস্করণ BloomLibrary.org এর বর্তমান সংস্করণের সাথে উপযুক্ত নয়।অনুগ্রহ করে নতুন সংস্করণে আপগ্রেড করুন।</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.IncompleteTranslation">
+      <trans-unit id="PublishTab.Upload.IncompleteTranslation" approved="yes">
         <source xml:lang="en">(incomplete translation)</source>
         <target xml:lang="bn">(আংশিক)</target>
         <note>ID: PublishTab.Upload.IncompleteTranslation</note>
         <note>This is added after the language name, in order to indicate that some parts of the book have not been translated into this language yet.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="bn">অনুগ্রহ করে আপলোডের পূর্বে BloomLibrary.org এ লগইন করুন (অথবা সাইন আপ করুন)</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="bn">অনুগ্রহ করে সম্পাদন ট্যাব থেকে এটি সেট করুন</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="bn">BloomLibrary.org এর জন্য সাইন আপন করুন।</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="bn">ধাপ ১: মেটাডাটা নিশ্চিত করুন</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="bn">ধাপ ২: আপলোড</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="bn">পরামর্শ: ক্রিয়েটিভ কমনস লাইসেন্স ধার্য করে সকলকে আপনার কাজ পরিষ্কারভাবে কিছু অনুমতি দিতে সহজ করে দেয়।</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="bn">পরামর্শ: ক্রিয়েটিভ কমনস লাইসেন্স আপনার বইটি অন্যদের ব্যবহার করতে সহজ করে দেয়, যদিও তারা আপনার পছন্দের লাইসেন্সের ভাষায় দক্ষ না।</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="bn">সারাংশ</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="bn">ব্যবহারের শর্তাবলী দেখান</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TimeProblem">
+      <trans-unit id="PublishTab.Upload.TimeProblem" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. This is probably because your computer is set to use the wrong timezone or your system time is badly wrong. See http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html for how to fix this.</source>
         <target xml:lang="bn">আপনার বই আপলোড করতে সমস্যা হচ্ছে।এর কারণ সম্ভবত আপনার কম্পিউটার ভুল টাইমজোন ব্যবহার করছে অথবা আপনার সিস্টেমের সময় খুবই ভুল।কিভাবে সমস্যাটির সমাধান করতে হয় সেজন্য দেখুন http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html।</target>
         <note>ID: PublishTab.Upload.TimeProblem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="bn">শিরোনাম</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="bn">বই আপলোড করুন</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1}) </source>
         <target xml:lang="bn">অভিনন্দন, "{0}" এখন BloomLibrary.org ({1}) এ পাওয়া যাচ্ছে </target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="bn">আপলোড অনুমোদিত নয়</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="bn">আপনার বই আপলোড করতে সমস্যা হচ্ছে।আপনার ব্লুম রিস্টার্ট অথবা কারিগরি সহায়তা নেওয়ার প্রয়োজন হতে পারে।</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="bn">আপলোডের অগ্রগতি</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="bn">বই আপলোড (স্যান্ডবক্সে)</target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="bn">বইয়ের মেটাডাটা আপলোড হচ্ছে</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, and topic tags to the BloomLibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0} </source>
         <target xml:lang="bn">আপলোড হচ্ছে {0} </target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishView._saveButton">
+      <trans-unit id="PublishView._saveButton" approved="yes">
         <source xml:lang="en">Save stub</source>
         <target xml:lang="bn">স্টাব সংরক্ষণ করুন</target>
         <note>ID: PublishView._saveButton</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="bn">লেভেল যুক্ত করুন</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="bn">স্তর যুক্ত করুন</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <target xml:lang="bn">অনুগ্রহ করে নমুনা লেখার ফোল্ডারে লেখা যুক্ত করুন।</target>
         <note>ID: ReaderSetup.AddTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">allowed words</source>
         <target xml:lang="bn">অনুমোদিত শব্দ</target>
         <note>ID: ReaderSetup.AllowedWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <target xml:lang="bn">অনুমোদিত শব্দের ফাইল</target>
         <note>ID: ReaderSetup.AllowedWordsFile</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <target xml:lang="bn">অনুমতি শব্দ ফাইল</target>
         <note>ID: ReaderSetup.AllowedWordsFileHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Avg</source>
         <target xml:lang="bn">গড়</target>
         <note>ID: ReaderSetup.AverageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="bn">বই</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="bn">প্রতি বইয়ে সর্বোচ্চ শব্দের সংখ্যা</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose...</source>
         <target xml:lang="bn">পছন্দ ...</target>
         <note>ID: ReaderSetup.ChooseAllowedWordsFile</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="bn">এই স্তরে যুক্ত করতে অক্ষরগুলোতে ক্লিক করুন।</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="bn">ম্পেস দিয়ে পৃথক করুন</target>
         <note>ID: ReaderSetup.CombinationHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <target xml:lang="bn">উদাহরণস্বরূপ "এই স কল জি নিস"</target>
         <note>ID: ReaderSetup.CombinationHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <target xml:lang="bn">অক্ষরের সমন্বয় (গ্রাফিম)</target>
         <note>ID: ReaderSetup.Combinations</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="bn">ডিকোডেবল স্তরসমূহ</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true" approved="yes">
         <source xml:lang="en">File needs .TXT extension</source>
         <target xml:lang="bn">ফাইলের .TXT বর্ধিতাংশ প্রয়োজন</target>
         <note>ID: ReaderSetup.FileNeedsTxtExtension</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="bn">প্রথমে,</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="bn">এই বিন্যাসটি পড়া যায়নি</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="bn">নমুনা লেখা হিসেবে ব্যবহার করতে ফাইলগুলো এক্সপোর্ট এবং রূপান্তর করতে সহায়তা</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="bn">ভাষা</target>
         <note>ID: ReaderSetup.Language</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <target xml:lang="bn">বর্ণানুক্রমে অক্ষরের শব্দ-বিন্যাস ও তালিকা।</target>
         <note>ID: ReaderSetup.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="bn">ম্পেস দিয়ে পৃথক করুন</target>
         <note>ID: ReaderSetup.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <target xml:lang="bn">উদাহরণস্বরূপ "ক খ গ ঘ"</target>
         <note>ID: ReaderSetup.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="bn">অক্ষরসমূহ</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="bn">অক্ষরসমূহ এবং অক্ষরের সমন্বয়সূহ</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="bn">ডিকোডেবল রিডার তৈরিতে আপনাকে সাহায্য করতে, আপনি যা শেখাবেন সেই অক্ষর ও অক্ষরের সমন্বয়সমূহ ব্লুমের জানা প্রয়োজন।</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="bn">প্রতিটি অক্ষর অথবা অক্ষর সমন্বয় একটি ফাঁকা স্থান দিয়ে পৃথক করুন।উদাহরণস্বরূপ, ইংরেজি ভাষার জন্য আমরা যা ব্যবহার করতে পারি তা নীচে দেওয়া হল:</target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="bn">লক্ষ করুন যে শব্দ তৈরিতে যে সব প্রতীক ব্যবহার করা হয় যেমন '   এর মধ্যে, সেগুলো ইংরেজি তালিকায় অন্তর্ভুক্ত রয়েছে</target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="bn">এটি</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="bn">।</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="bn">পর্যায়</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level&amp;nbsp;</source>
         <target xml:lang="bn">পর্যায়&amp;nbsp;</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="bn">পাঠক পর্যায় সমূহ</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="bn">সাদৃশ্য রয়েছে এমন শব্দসমূহ</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Average Length of Sentences in Book</source>
         <target xml:lang="bn">বইয়ের বাক্যগুলোর সর্বোচ্চ গড় দৈর্ঘ্য</target>
         <note>ID: ReaderSetup.MaxAverageWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="bn">প্রতি বইয়ে সর্বোচ্চ শব্দের সংখ্যা</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <target xml:lang="bn">আরো শব্দসমূহ</target>
         <note>ID: ReaderSetup.MoreWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <target xml:lang="bn">এই ভাষার জন্য নমুনা লেখার ফোল্ডার খুলুন।</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="bn">পৃষ্ঠা</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="bn">প্রতিটি পৃষ্ঠায় সর্বোচ্চ শব্দ</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="bn">  এর দ্বারা চালিত</target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="bn">পাঠক পর্যায় সমূহ</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="bn">লেভেল মুছে ফেলুন {0}</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="bn">স্তর মুছে ফেলুন {0}</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove from this stage</source>
         <target xml:lang="bn">এই স্তর থেকে মুছে ফেলুন</target>
         <note>ID: ReaderSetup.RemoveWordList</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="bn">পুনর্বিন্যাস লেভেলে সারিগুলো টানুন।</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="bn">পুনর্বিন্যাস স্তরে সারিগুলো টানুন।</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <target xml:lang="bn">শব্দের তালিকা এবং নমুনা লেখাসমূহ</target>
         <note>ID: ReaderSetup.SampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Words</source>
         <target xml:lang="bn">নমুনা শব্দাবলি</target>
         <note>ID: ReaderSetup.SampleWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="bn">, সাক্ষরতার জন্য সার্চ ইঞ্জিন। </target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="bn">পূর্বের এবং নতুন অক্ষরসমূহ</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="bn">বাক্য</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="bn">প্রতিটি বাক্যে সর্বোচ্চ শব্দ</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="bn">ডিকোডেবল রিডার টুল সেট আপ</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="bn">লেভেলড রিডার টুল</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up the alphabet for this language.</source>
         <target xml:lang="bn">এই ভাষার জন্য বর্ণমালা সেট আপ করুন।</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <target xml:lang="bn">সাইট শব্দ কি?</target>
         <note>ID: ReaderSetup.SightWordHelp</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="bn">নতুন সাইট শব্দসমূহ: {0}</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="bn">সাইট শব্দসমূহ</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="bn">স্তর</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="bn">স্তর</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="bn">স্তরসমূহ</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="bn">সাইনফোনি</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="bn">এই লেভেলের জন্য যে সব জিনিস স্মরণ করতে হবে:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="bn">অনন্য</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="bn">বাক্যসমূহ</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage. There are two ways to give words to Bloom:</source>
         <target xml:lang="bn">ডিকোডেবল রিডারসমূহ তৈরি করতে, ব্লুম আপনাকে শব্দের পরামর্শ দিতে পারে যা বর্তমান স্তরের সাথে উপযুক্ত।দুইটি উপায়ে ব্লুমে শব্দসমূহ দেওয়া যায়:</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="bn">২) নমুনা ফাইলসমূহ রাখুন আপনার</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <target xml:lang="bn">নমুনা লেখার ফোল্ডারে</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="bn">১) এখানে শব্দসমূহ টাইপ করুন</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using lists of allowed words to define stages</source>
         <target xml:lang="bn">পর্যায় নির্ধারণ করার জন্য আমরা অনুমোদিত শব্দের তালিকা ব্যবহার করছি</target>
         <note>ID: ReaderSetup.Words.UseAllowedWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using letters with sight words to define stages</source>
         <target xml:lang="bn">পর্যায় নির্ধারণ করার জন্য আমরা সাইট শব্দ সম্বলিত অক্ষর ব্যবহার করছি</target>
         <note>ID: ReaderSetup.Words.UseLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="bn">অক্ষরসমূহ</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this Bloom Pack will carry your latest decodable and leveled reader settings for the \"{0}\" language. Anyone opening this Bloom Pack, who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this Bloom Pack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="bn">এছাড়াও, এই ব্লুম প্যাক \"{0}\" ভাষার জন্য আপনার সর্বশেষ ডিকোডেবল এবং লেভেল করা রিডার সেটিংসমূহ বহন করবে। যে কেউ এই ব্লুম প্যাক খুললে, যে \"{0}\" সংগ্রহশালা খুলবে, তারা তাদের বর্তমান ডিকোডেবল ও লেভেলড রিডার সেটিংস এই ব্লুম প্যাকের সেটিং দিয়ে পরিবর্তন করবে। ডিকোডেবল রিডারে ব্যবহারের জন্য তারা বর্তমান শব্দের সেটও পাবে।</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="bn">নিম্নোক্ত বইগুলো টেমপ্লেটসমূহের মধ্যে তৈরি হবে:</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <target xml:lang="bn">ব্লুম প্যাক সংরক্ষণ করুন</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <target xml:lang="bn">রিডার টেমপ্লেট ব্লুম প্যাক তৈরি করুন</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="bn">ইমেইল ঠিকানা</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="bn">নামের প্রথম অংশ</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="bn">অনুগ্রহ করে {0} নিবন্ধন করতে এক মিনিট সময় নিন।</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="bn">আপনি কিভাবে {0} ব্যবহার করছেন? </target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="bn">আমি আটকে গেছি, আমি এটি পরে শেষ করব।</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="bn">প্রতিষ্ঠান</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="bn">&amp;নিবন্ধন {0}</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="bn">ভাল নাম</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="bn">নিবন্ধন {0}</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <target xml:lang="bn">বন্ধ করুন</target>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.CouldNotSendToServer">
+      <trans-unit id="ReportProblemDialog.CouldNotSendToServer" approved="yes">
         <source xml:lang="en">Bloom was not able to submit your report directly to our server. Please retry or email {0} to {1}.</source>
         <target xml:lang="bn">ব্লুম আমাদের সার্ভারে সরাসরি রিপোর্ট পাঠাতে অসমর্থ।অনুগ্রহ করে পুনরায় চেষ্টা করুন অথবা {0} হতে {1} ইমেইল করুন।</target>
         <note>ID: ReportProblemDialog.CouldNotSendToServer</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Email">
+      <trans-unit id="ReportProblemDialog.Email" approved="yes">
         <source xml:lang="en">Email</source>
         <target xml:lang="bn">ইমেইল</target>
         <note>ID: ReportProblemDialog.Email</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeBookButton">
+      <trans-unit id="ReportProblemDialog.IncludeBookButton" approved="yes">
         <source xml:lang="en">Include Book '{0}'</source>
         <target xml:lang="bn">'{0}' বই অন্তর্ভুক্ত করুন</target>
         <note>ID: ReportProblemDialog.IncludeBookButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton">
+      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton" approved="yes">
         <source xml:lang="en">Include this screenshot</source>
         <target xml:lang="bn">এই স্ক্রীনশটটি অন্তর্ভুক্ত করুন</target>
         <note>ID: ReportProblemDialog.IncludeScreenshotButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Name">
+      <trans-unit id="ReportProblemDialog.Name" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="bn">নাম</target>
         <note>ID: ReportProblemDialog.Name</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Retry">
+      <trans-unit id="ReportProblemDialog.Retry" approved="yes">
         <source xml:lang="en">Retry</source>
         <target xml:lang="bn">পুনরায় চেষ্টা করুন</target>
         <note>ID: ReportProblemDialog.Retry</note>
         <note>Shown if there was an error submitting the report. Lets the user try submitting it again.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SeeDetails">
+      <trans-unit id="ReportProblemDialog.SeeDetails" approved="yes">
         <source xml:lang="en">See what else will be submitted</source>
         <target xml:lang="bn">দেখুন আর কি কি জমা হতে পারে</target>
         <note>ID: ReportProblemDialog.SeeDetails</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SubmitButton">
+      <trans-unit id="ReportProblemDialog.SubmitButton" approved="yes">
         <source xml:lang="en">&amp;Submit</source>
         <target xml:lang="bn">&amp;জমা করুন</target>
         <note>ID: ReportProblemDialog.SubmitButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Submitting">
+      <trans-unit id="ReportProblemDialog.Submitting" approved="yes">
         <source xml:lang="en">Submitting to server...</source>
         <target xml:lang="bn">সার্ভারে সাবমিট করা হচ্ছে...</target>
         <note>ID: ReportProblemDialog.Submitting</note>
         <note>This is shown while Bloom is sending the problem report to our server.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Success">
+      <trans-unit id="ReportProblemDialog.Success" approved="yes">
         <source xml:lang="en">We received your report, thanks for taking the time to help make Bloom better!</source>
         <target xml:lang="bn">আমরা আপনার রিপোর্ট পেয়েছি, সময় নিয়ে ব্লুমকে ভালো করতে সাহায্যের জন্য ধন্যবাদ!</target>
         <note>ID: ReportProblemDialog.Success</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WhatsTheProblem">
+      <trans-unit id="ReportProblemDialog.WhatsTheProblem" approved="yes">
         <source xml:lang="en">What seems to be the problem?</source>
         <target xml:lang="bn">কি সমস্যা হবে বলে মনে হয়?</target>
         <note>ID: ReportProblemDialog.WhatsTheProblem</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WindowTitle">
+      <trans-unit id="ReportProblemDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Report A Problem</source>
         <target xml:lang="bn">সমস্যা রিপোর্ট করুন</target>
         <note>ID: ReportProblemDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Zipping">
+      <trans-unit id="ReportProblemDialog.Zipping" approved="yes">
         <source xml:lang="en">Zipping up book...</source>
         <target xml:lang="bn">বই জিপ করা হচ্ছে ...</target>
         <note>ID: ReportProblemDialog.Zipping</note>
         <note>This is shown while Bloom is creating the problem report. It's generally too fast to see, unless you include a large book.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.linkLabel1">
+      <trans-unit id="ReportProblemDialog.linkLabel1" approved="yes">
         <source xml:lang="en">Will not be private</source>
         <target xml:lang="bn">ব্যক্তিগত হবে না</target>
         <note>ID: ReportProblemDialog.linkLabel1</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.IGetIt">
+      <trans-unit id="SamplePrintNotification.IGetIt" approved="yes">
         <source xml:lang="en">I get it. Do not show this again.</source>
         <target xml:lang="bn">আমি এটা বুঝতে পেরেছি।এটি পুনরায় দেখাবেন না।</target>
         <note>ID: SamplePrintNotification.IGetIt</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.PleaseNotice">
+      <trans-unit id="SamplePrintNotification.PleaseNotice" approved="yes">
         <source xml:lang="en">Please notice the sample printer settings below. Use them as a guide while you set up the printer.</source>
         <target xml:lang="bn">অনুগ্রহ করে নীচে নমুনা প্রিন্টার সেটিংস লক্ষ্য করুন।সেগুলো একটি নির্দেশিকা হিসেবে ব্যবহার করুন আপনি যখন প্রিন্টার সেটআপ করবেন।</target>
         <note>ID: SamplePrintNotification.PleaseNotice</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Arithmetic</source>
         <target xml:lang="bn">পাটীগণিত</target>
         <note>ID: TemplateBooks.BookName.Arithmetic</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="bn">প্রাথমিক বই</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="bn">বড় বই</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="bn">ডিকোডেবল রিডার</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="bn">লেভেলড রিডার</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="bn">ছবির অভিধান</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vaccinations</source>
         <target xml:lang="bn">টিকাসমূহ</target>
         <note>ID: TemplateBooks.BookName.Vaccinations</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="bn">দেওয়াল ক্যালেন্ডার</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A blank page that allows you to add items.</source>
         <target xml:lang="bn">একটি ফাঁকা পৃষ্ঠা যা আপনাকে নতুন কিছু যুক্ত করতে অনুমোদন দেয়।</target>
         <note>ID: TemplateBooks.PageDescription.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page with a picture on top and a large, centered word below.</source>
         <target xml:lang="bn">উপরে ছবি এবং বড় নীচে মধ্যবর্তী শব্দসহ পৃষ্ঠা।</target>
         <note>ID: TemplateBooks.PageDescription.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="bn">১</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1 Problem</source>
         <target xml:lang="bn">১ সমস্যা</target>
         <note>ID: TemplateBooks.PageLabel.1 Problem</note>
         <note>This label indicates a page with one arithmetic problem on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true" approved="yes">
         <source xml:lang="en">10</source>
         <target xml:lang="bn">১০</target>
         <note>ID: TemplateBooks.PageLabel.10</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true" approved="yes">
         <source xml:lang="en">11</source>
         <target xml:lang="bn">১১</target>
         <note>ID: TemplateBooks.PageLabel.11</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true" approved="yes">
         <source xml:lang="en">12</source>
         <target xml:lang="bn">১২</target>
         <note>ID: TemplateBooks.PageLabel.12</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true" approved="yes">
         <source xml:lang="en">13</source>
         <target xml:lang="bn">১৩</target>
         <note>ID: TemplateBooks.PageLabel.13</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true" approved="yes">
         <source xml:lang="en">14</source>
         <target xml:lang="bn">১৪</target>
         <note>ID: TemplateBooks.PageLabel.14</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true" approved="yes">
         <source xml:lang="en">15</source>
         <target xml:lang="bn">১৫</target>
         <note>ID: TemplateBooks.PageLabel.15</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true" approved="yes">
         <source xml:lang="en">16</source>
         <target xml:lang="bn">১৬</target>
         <note>ID: TemplateBooks.PageLabel.16</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true" approved="yes">
         <source xml:lang="en">17</source>
         <target xml:lang="bn">১৭</target>
         <note>ID: TemplateBooks.PageLabel.17</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true" approved="yes">
         <source xml:lang="en">18</source>
         <target xml:lang="bn">১৮</target>
         <note>ID: TemplateBooks.PageLabel.18</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true" approved="yes">
         <source xml:lang="en">19</source>
         <target xml:lang="bn">১৯</target>
         <note>ID: TemplateBooks.PageLabel.19</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="bn">২</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2 Problems</source>
         <target xml:lang="bn">২ সমস্যাসমূহ</target>
         <note>ID: TemplateBooks.PageLabel.2 Problems</note>
         <note>This label indicates a page with two arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true" approved="yes">
         <source xml:lang="en">20</source>
         <target xml:lang="bn">২০</target>
         <note>ID: TemplateBooks.PageLabel.20</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true" approved="yes">
         <source xml:lang="en">21</source>
         <target xml:lang="bn">২১</target>
         <note>ID: TemplateBooks.PageLabel.21</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="bn">৩</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3 Problems</source>
         <target xml:lang="bn">৩ সমস্যাসমূহ</target>
         <note>ID: TemplateBooks.PageLabel.3 Problems</note>
         <note>This label indicates a page with three arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="bn">৪</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4 Problems</source>
         <target xml:lang="bn">৪ সমস্যাসমূহ</target>
         <note>ID: TemplateBooks.PageLabel.4 Problems</note>
         <note>This label indicates a page with four arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="bn">৫</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="bn">৬</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="bn">৭</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="bn">৮</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="bn">৯</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="bn">বর্ণমালা</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="bn">মৌলিক লেখা ও ইমেজ</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="bn">মৌলিক লেখা ও ছবি</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="bn">কৃতজ্ঞতার পৃষ্ঠা</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="bn">কাস্টম</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="bn">দিন ১</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="bn">দিন ২</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="bn">দিন ৩</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="bn">দিন ৪</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="bn">দিন ৫এ</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="bn">দিন ৫বি</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Factory</source>
         <target xml:lang="bn">কারখানা</target>
         <note>ID: TemplateBooks.PageLabel.Factory</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="bn">সামনের কভার</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front/Back Matter</source>
         <target xml:lang="bn">প্রচ্ছদের সামনের/পিছনের বিষয়াবলি</target>
         <note>ID: TemplateBooks.PageLabel.FrontBackMatter</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="bn">নীচের ইমেজ</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="bn">মধ্যবর্তী ইমেজ</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="bn">পিছনের কভারের ভিতরে</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="bn">সামনের কভারের ভিতরে</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="bn">নির্দেশনা</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="bn">শুধু লেখা</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="bn">শুধু একটি ছবি</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="bn">শুধু একটি ইমেজ</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="bn">পিছনের কভারের বাহিরে</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="bn">কাগজ সাশ্রয়ী</target>
         <note>ID: TemplateBooks.PageLabel.Paper Saver</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="bn">ছবি ও শব্দ</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="bn">মধ্যবর্তী ছবি</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="bn">নীচের ছবি</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SIL-Cameroon</source>
         <target xml:lang="bn">SIL-ক্যামেরুন</target>
         <note>ID: TemplateBooks.PageLabel.SIL-Cameroon</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Super Paper Saver</source>
         <target xml:lang="bn">সর্বোচ্চ কাগজ সাশ্রয়ী</target>
         <note>ID: TemplateBooks.PageLabel.Super Paper Saver</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="bn">এই পৃষ্ঠাটি ইচ্ছাকৃতভাবে ফাঁকা রাখা হয়েছে</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="bn">শিরোনাম পৃষ্ঠা</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="bn">ঐতিহ্যবাহী</target>
         <note>ID: TemplateBooks.PageLabel.Traditional</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="bn">সেটআপ</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="bn">কৃষি</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="bn">প্রাণীর গল্পসমূহ</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="bn">ব্যবসা</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="bn">কমিউনিটি লিভিং</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="bn">সংস্কৃতি</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="bn">অভিধান</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="bn">পরিবেশ</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="bn">কাল্পনিক</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="bn">স্বাস্থ্য</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="bn">কিভাবে</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="bn">গণিত</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.NoTopic" sil:dynamic="true">
+      <trans-unit id="Topics.NoTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">No Topic</source>
         <target xml:lang="bn">কোন বিষয় না</target>
         <note>ID: Topics.NoTopic</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="bn">অকাল্পনিক</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="bn">ব্যক্তিগত উন্নয়ন</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="bn">প্রাইমার</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="bn">বিজ্ঞান</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="bn">আধ্যাত্মিক</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Story Book" sil:dynamic="true">
+      <trans-unit id="Topics.Story Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Story Book</source>
         <target xml:lang="bn">গল্পের বই</target>
         <note>ID: Topics.Story Book</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="bn">ঐতিহ্য</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="bn">ঐতিহাসিক গল্প</target>
         <note>ID: Topics.Traditional Story</note>

--- a/DistFiles/localization/bn/IntegrityFailureAdvice.xlf
+++ b/DistFiles/localization/bn/IntegrityFailureAdvice.xlf
@@ -2,77 +2,77 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="IntegrityFailureAdvice-en.md" datatype="html" source-language="en" target-language="bn">
     <body>
-      <trans-unit id="integrity.title">
+      <trans-unit id="integrity.title" approved="yes">
         <source xml:lang="en">Bloom cannot find some of its own files, and cannot continue</source>
         <target xml:lang="bn">ব্লুম তার  নিজস্ব কিছু ফাইল খুঁজে পায়নি, তাই আর চলবে না</target>
         <note>ID: integrity.title</note>
       </trans-unit>
-      <trans-unit id="integrity.causes">
+      <trans-unit id="integrity.causes" approved="yes">
         <source xml:lang="en">Possible Causes</source>
         <target xml:lang="bn">সম্ভাব্য কারণসমূহ</target>
         <note>ID: integrity.causes</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.1">
+      <trans-unit id="integrity.causes.1" approved="yes">
         <source xml:lang="en">Your antivirus may have "quarantined" one or more Bloom files.</source>
         <target xml:lang="bn">১)  আপনার এন্টিভাইরাস ব্লুমের এক বা একাধিক ফাইল "পৃথক করে রাখতে" পারে।</target>
         <note>ID: integrity.causes.1</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.2">
+      <trans-unit id="integrity.causes.2" approved="yes">
         <source xml:lang="en">Your computer administrator may have your computer "locked down" to prevent bad things, but in such a way that Bloom could not place these files where they belong. </source>
         <target xml:lang="bn">২)  আপনার কম্পিউটার প্রশাসক খারাপ জিনিস থেকে আপনার কম্পিউটারকে রক্ষা করার জন্য তালাবদ্ধ করে রাখতে পারে, কিন্তু এইভাবে ব্লুম কোন ফাইল যেখানে থাকা উচিত সেখানে রাখতে পারে না।</target>
         <note>ID: integrity.causes.2</note>
       </trans-unit>
-      <trans-unit id="integrity.todo">
+      <trans-unit id="integrity.todo" approved="yes">
         <source xml:lang="en">What To Do</source>
         <target xml:lang="bn">কী করতে হবে</target>
         <note>ID: integrity.todo</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas">
+      <trans-unit id="integrity.todo.ideas" approved="yes">
         <source xml:lang="en">After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas:</source>
         <target xml:lang="bn">আপনি এই রিপোর্ট জমা দেওয়ার পর, আমরা আপনার সাথে যোগাযোগ করব এবং কাজটি করতে আপনাকে সাহায্য করব।ইতোমধ্যে, এখানে কিছু ধারণা দেওয়া হল:</target>
         <note>ID: integrity.todo.ideas</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Reinstall">
+      <trans-unit id="integrity.todo.ideas.Reinstall" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="bn">ব্লুম ইনস্টলারটি পুনরায় চালু করুন, এবং দেখুন এইবার এটি ঠিকমত চালু হয় কিনা।</target>
         <note>ID: integrity.todo.ideas.Reinstall</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Antivirus">
+      <trans-unit id="integrity.todo.ideas.Antivirus" approved="yes">
         <source xml:lang="en">If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>.</source>
         <target xml:lang="bn">যদি এটি ঠিক না করতে পারে, তাহলে আপনার এন্টিভাইরাস কার্যক্রম সম্পর্কে আলোচনা করতে হবে।যদি "হারিয়ে যাওয়া ফাইলসমূহ" বিভাগেরর নীচে যেকোনো ফাইল দেখায় যার শেষে ".exe" রয়েছে, তা  ব্লুম কার্যক্রম ফোল্ডার "পরিচ্ছন্নতালিকা" হিসেবে,  <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g> এ বিদ্যমান।</target>
         <note>ID: integrity.todo.ideas.Antivirus</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVAST">
+      <trans-unit id="integrity.todo.ideas.AVAST" approved="yes">
         <source xml:lang="en">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">Instructions</g>.</source>
         <target xml:lang="bn">এভাস্ট: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">নির্দেশনাসমূহ</g>।</target>
         <note>ID: integrity.todo.ideas.AVAST</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Norton">
+      <trans-unit id="integrity.todo.ideas.Norton" approved="yes">
         <source xml:lang="en">Norton Antivirus: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">Instructions from Symantec</g>.</source>
         <target xml:lang="bn">নরটন এন্টিভাইরাস: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">সিম্যানটেক এর নির্দেশনাসমূহ</g>।</target>
         <note>ID: integrity.todo.ideas.Norton</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVG">
+      <trans-unit id="integrity.todo.ideas.AVG" approved="yes">
         <source xml:lang="en">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">Instructions from AVG</g>.</source>
         <target xml:lang="bn">এভিজি: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">এভিজি এর নির্দেশনাসমূহ</g>।</target>
         <note>ID: integrity.todo.ideas.AVG</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Others">
+      <trans-unit id="integrity.todo.ideas.Others" approved="yes">
         <source xml:lang="en">Others: Google for "whitelist directory name-of-your-antivirus"</source>
         <target xml:lang="bn">অন্যান্যসমূহ: "whitelist directory name-of-your-antivirus" জন্য গুগলে খুঁজুন।</target>
         <note>ID: integrity.todo.ideas.Others</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Restart">
+      <trans-unit id="integrity.todo.ideas.Restart" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="bn">ব্লুম ইনস্টলারটি পুনরায় চালু করুন, এবং দেখুন এইবার এটি ঠিকমত চালু হয় কিনা।</target>
         <note>ID: integrity.todo.ideas.Restart</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Retrieve">
+      <trans-unit id="integrity.todo.ideas.Retrieve" approved="yes">
         <source xml:lang="en">You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">this image</g>.</source>
         <target xml:lang="bn">এছাড়াও আপনার এন্টিভাইরাস ব্লুমের যে অংশটি নিয়ে নিয়েছিল তা পুনরুদ্ধার করার চেষ্টা করতে পারেন। AVG-র জন্য, আপনার AVG বিকল্প তালিকা খুঁজতে হবে, "ভাইরাস ভল্ট" এ ক্লিক করুন, ভল্টে ব্লুম ফাইলটিতে ক্লিক করুন, এবং "পুনরুদ্ধার করুন" এ ক্লিক করুন।দৃশ্যমান নির্দেশিকার জন্য, দেখুন <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">এই ছবি</g>।</target>
         <note>ID: integrity.todo.ideas.Retrieve</note>
       </trans-unit>
-      <trans-unit id="integrity.missing">
+      <trans-unit id="integrity.missing" approved="yes">
         <source xml:lang="en">Missing Files</source>
         <target xml:lang="bn">হারিয়ে যাওয়া ফাইলসমূহ</target>
         <note>ID: integrity.missing</note>

--- a/DistFiles/localization/bn/MissingLameModule.xlf
+++ b/DistFiles/localization/bn/MissingLameModule.xlf
@@ -2,19 +2,19 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="MissingLameModule-en.html" datatype="html" source-language="en" target-language="bn">
     <body>
-      <trans-unit id="missing.lame.please.install">
+      <trans-unit id="missing.lame.please.install" approved="yes">
         <source xml:lang="en">Please Install LAME</source>
         <target xml:lang="bn">অনুগ্রহ করে LAME ইনস্টল করুন</target>
         <note>ID: missing.lame.please.install</note>
       </trans-unit>
-      <trans-unit id="missing.lame.bloom.needs.lame">
+      <trans-unit id="missing.lame.bloom.needs.lame" approved="yes">
         <source xml:lang="en">This book has audio recordings. Bloom can use these to make a "Talking Book" e-book. However, Bloom needs a program called "LAME for Audacity" in order to create the mp3 files that the book will use. Setting it up is easy. First download and run <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>. Next, restart Bloom.
       </source>
         <target xml:lang="bn">এই বইতে অডিও রেকর্ডিং রয়েছে। ব্লুম এটি ব্যবহার করে "কথা বলার" ই-বুক তৈরী করতে পারে। যাইহোক, MP3 ফাইলগুলো তৈরী করার জন্য ব্লুমের "LAME for Audacity" প্রোগ্রামটির দরকার যা বইটি ব্যবহার করবে। এটা বিন্যাস করা সহজ। প্রথম ডাউনলোড করে চালু/ রান করা <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>। পরবর্তীতে, পুনরায় ব্লুম চালু করুন।
       </target>
         <note>ID: missing.lame.bloom.needs.lame</note>
       </trans-unit>
-      <trans-unit id="missing.lame.audio.optional">
+      <trans-unit id="missing.lame.audio.optional" approved="yes">
         <source xml:lang="en">If you prefer to go ahead and publish your book without audio, click <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">here</g>.
       </source>
         <target xml:lang="bn">যদি আপনি চালিয়ে যেতে চান এবং অডিও ছাড়া আপনার বই প্রকাশ করতে চান, <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">এখানে চাপুন</g>।

--- a/DistFiles/localization/bn/Palaso.xlf
+++ b/DistFiles/localization/bn/Palaso.xlf
@@ -2,595 +2,595 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Palaso.dll" source-language="en" target-language="bn" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="AboutDialog.BuiltOnDate">
+      <trans-unit id="AboutDialog.BuiltOnDate" approved="yes">
         <source xml:lang="en">Built on {0}</source>
         <target xml:lang="bn"> {0} নির্মিত</target>
         <note>ID: AboutDialog.BuiltOnDate</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.NoUpdates">
+      <trans-unit id="AboutDialog.NoUpdates" approved="yes">
         <source xml:lang="en">No Updates</source>
         <target xml:lang="bn">কোন আপডেট নেই</target>
         <note>ID: AboutDialog.NoUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.WindowTitle">
+      <trans-unit id="AboutDialog.WindowTitle" approved="yes">
         <source xml:lang="en">About {0}</source>
         <target xml:lang="bn">সম্পর্কে {0}</target>
         <note>ID: AboutDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._checkForUpdates">
+      <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
         <source xml:lang="en">Check For Updates</source>
         <target xml:lang="bn">আপডেটের জন্য চেক করুন</target>
         <note>ID: AboutDialog._checkForUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._releaseNotesLabel">
+      <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="bn">রিলিজ নোট</target>
         <note>ID: AboutDialog._releaseNotesLabel</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.General">
+      <trans-unit id="Application.AlreadyRunning.General" approved="yes">
         <source xml:lang="en">Another copy of the application is already running. If you cannot find it, restart your computer.</source>
         <target xml:lang="bn">অ্যাপ্লিকেশনের অন্য একটি কপি ইতোমধ্যে চলছে।যদি আপনি এটি খুঁজে না পান, আপনার কম্পিউটার রিস্টার্ট দিন।</target>
         <note>ID: Application.AlreadyRunning.General</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.Specific">
+      <trans-unit id="Application.AlreadyRunning.Specific" approved="yes">
         <source xml:lang="en">Another copy of {0} is already running. If you cannot find that copy of {0}, restart your computer.</source>
         <target xml:lang="bn">{0} এর অন্য একটি কপি ইতোমধ্যে চলছে।যদি আপনি {0} এর ঐ কপিটি খুঁজে না পান, আপনার কম্পিউটার রিস্টার্ট দিন।</target>
         <note>ID: Application.AlreadyRunning.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.General">
+      <trans-unit id="Application.ProblemStarting.General" approved="yes">
         <source xml:lang="en">There was a problem starting the application which might require that you restart your computer.</source>
         <target xml:lang="bn">অ্যাপ্লিকেশনটি চালু হতে সমস্যা হয়েছিল সে জন্য আপনার কম্পিউটারটি রিস্টার্ট দেওয়ার প্রয়োজন হতে পারে।</target>
         <note>ID: Application.ProblemStarting.General</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.Specific">
+      <trans-unit id="Application.ProblemStarting.Specific" approved="yes">
         <source xml:lang="en">There was a problem starting {0} which might require that you restart your computer.</source>
         <target xml:lang="bn">{0} চালু হতে সমস্যা হয়েছিল সে জন্য আপনার কম্পিউটারটি রিস্টার্ট দেওয়ার প্রয়োজন হতে পারে।</target>
         <note>ID: Application.ProblemStarting.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.General">
+      <trans-unit id="Application.WaitingFinish.General" approved="yes">
         <source xml:lang="en">Waiting for other application to finish...</source>
         <target xml:lang="bn">অন্যান্য অ্যাপ্লিকেশন শেষ হতে অপেক্ষা...</target>
         <note>ID: Application.WaitingFinish.General</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.Specific">
+      <trans-unit id="Application.WaitingFinish.Specific" approved="yes">
         <source xml:lang="en">Waiting for other {0} to finish...</source>
         <target xml:lang="bn">অন্যান্য {0} শেষ হতে অপেক্ষা...</target>
         <note>ID: Application.WaitingFinish.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="bn">এবং বাতিল</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.No">
+      <trans-unit id="Common.No" approved="yes">
         <source xml:lang="en">No</source>
         <target xml:lang="bn">না</target>
         <note>ID: Common.No</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="bn">&amp;ঠিক আছে</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Yes">
+      <trans-unit id="Common.Yes" approved="yes">
         <source xml:lang="en">Yes</source>
         <target xml:lang="bn">হ্যাঁ</target>
         <note>ID: Common.Yes</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="bn">{0} রিসাইকেল বিনে স্থানান্তরিত হবে।</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
         <note>Parameter {0} is a description of the things being deleted (e.g., "The selected files")</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="bn">{0} রিসাইকেল বিনে স্থানান্তরিত হবে।</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
         <note>Parameter {0} is a file name</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Confirm Delete</source>
         <target xml:lang="bn">মুছে দেওয়া নিশ্চিত করুন</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="bn">এবং বাতিল</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="bn">&amp;মুছে দিন</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.AlmostMatchingImages">
+      <trans-unit id="ImageToolbox.AlmostMatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images with names close to {1}</source>
         <target xml:lang="bn">{1} এর কাছাকাছি মানের {0} ছবি পাওয়া গিয়েছে </target>
         <note>ID: ImageToolbox.AlmostMatchingImages</note>
         <note>The {0} will be replaced by the number of images found.  The {1} will be replaced with the search string.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ArtOfReading">
+      <trans-unit id="ImageToolbox.ArtOfReading" approved="yes">
         <source xml:lang="en">Art Of Reading</source>
         <target xml:lang="bn">আর্ট অফ রিডিং</target>
         <note>ID: ImageToolbox.ArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Camera">
+      <trans-unit id="ImageToolbox.Camera" approved="yes">
         <source xml:lang="en">Camera</source>
         <target xml:lang="bn">ক্যামেরা</target>
         <note>ID: ImageToolbox.Camera</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
         <source xml:lang="en">Use {0}</source>
         <target xml:lang="bn">{0} ব্যবহার করুন</target>
         <note>ID: ImageToolbox.CopyExemplarMetadata</note>
         <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Crop">
+      <trans-unit id="ImageToolbox.Crop" approved="yes">
         <source xml:lang="en">Crop</source>
         <target xml:lang="bn">ক্রপ</target>
         <note>ID: ImageToolbox.Crop</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.DownloadArtOfReading">
+      <trans-unit id="ImageToolbox.DownloadArtOfReading" approved="yes">
         <source xml:lang="en">Download Art Of Reading Installer</source>
         <target xml:lang="bn">আর্ট অফ রিডিং ইনস্টলার ডাউনলোড করুন</target>
         <note>ID: ImageToolbox.DownloadArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EditMetadataLink">
+      <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
         <source xml:lang="en">Edit...</source>
         <target xml:lang="bn">সম্পাদন...</target>
         <note>ID: ImageToolbox.EditMetadataLink</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EnterSearchTerms">
+      <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
         <source xml:lang="en">This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.</source>
         <target xml:lang="bn">এটি হচ্ছে 'আর্ট অফ রিডিং' গ্যালারিআপনি যা খুঁজছেন তা উপরের বাক্সে টাইপ করুন, তারপর ইন্টার চাপুনআপনি ইংরেজি এবং ইন্দোনেশীয় শব্দ টাইপ করতে পারেন।</target>
         <note>ID: ImageToolbox.EnterSearchTerms</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.FileButton">
+      <trans-unit id="ImageToolbox.FileButton" approved="yes">
         <source xml:lang="en">File</source>
         <target xml:lang="bn">ফাইল</target>
         <note>ID: ImageToolbox.FileButton</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
         <target xml:lang="bn">দুঃখিত, ইমেজটি পাওয়ার সময় কোনকিছুর ত্রুটি হয়েছিল।</target>
         <note>ID: ImageToolbox.GenericGettingImageProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericProblem">
+      <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
         <target xml:lang="bn">দুঃখিত, ইমেজটুলবক্সের সাথে কোনকিছুর ত্রুটি হয়েছিল।</target>
         <note>ID: ImageToolbox.GenericProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GetPicture">
+      <trans-unit id="ImageToolbox.GetPicture" approved="yes">
         <source xml:lang="en">Get Picture</source>
         <target xml:lang="bn">ছবি নিন</target>
         <note>ID: ImageToolbox.GetPicture</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
         <source xml:lang="en">Image Toolbox</source>
         <target xml:lang="bn">ইমেজ টুলবক্স</target>
         <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.InstallArtOfReading">
+      <trans-unit id="ImageToolbox.InstallArtOfReading" approved="yes">
         <source xml:lang="en">Install the Art Of Reading package (this may be very slow)</source>
         <target xml:lang="bn">আর্ট অফ রিডিং প্যাকেজ ইনস্টল করুন (এটি খুব ধীর গতির হতে পারে)</target>
         <note>ID: ImageToolbox.InstallArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.MatchingImages">
+      <trans-unit id="ImageToolbox.MatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images</source>
         <target xml:lang="bn">{0} ইমেজ পাওয়া গিয়েছে</target>
         <note>ID: ImageToolbox.MatchingImages</note>
         <note>The {0} will be replaced by the number of matching images</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NewMultilingual">
+      <trans-unit id="ImageToolbox.NewMultilingual" approved="yes">
         <source xml:lang="en">Did you know that there is a new version of this collection which lets you search in Arabic, Bengali, Chinese, English, French, Indonesian, Hindi, Portuguese, Spanish, Thai, or Swahili? It is free and available for downloading.</source>
         <target xml:lang="bn">আপনি জানেন কি এই সংগ্রহের একটি নতুন সংস্করন এসেছে যা আপনাকে আরবী, বাংলা, চীনা, ইংরেজি, ফ্রেঞ্চ, ইন্দোনেশীয়, হিন্দি, পর্তুগীজ, স্প্যানিশ, থাই, অথবা সোয়াহিলি ভাষায় খুঁজতে সাহায্য করবে? এটি ফ্রী এবং ডাউনলোডের জন্য পাওয়া যাচ্ছে।</target>
         <note>ID: ImageToolbox.NewMultilingual</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoArtOfReading">
+      <trans-unit id="ImageToolbox.NoArtOfReading" approved="yes">
         <source xml:lang="en">This computer doesn't appear to have the 'Art Of Reading' gallery installed yet.</source>
         <target xml:lang="bn">এখন পর্যন্ত এই কম্পিউটারে 'আর্ট অফ রিডিং' গ্যালারি ইনস্টল দেওয়া হয়নি বলে মনে হচ্ছে।</target>
         <note>ID: ImageToolbox.NoArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoMatchingImages">
+      <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
         <source xml:lang="en">Found no matching images</source>
         <target xml:lang="bn">কোন ম্যাচ করা ইমেজ পাওয়া যায়নি</target>
         <note>ID: ImageToolbox.NoMatchingImages</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PictureFiles">
+      <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
         <source xml:lang="en">picture files</source>
         <target xml:lang="bn">ছবির ফাইলসমূহ</target>
         <note>ID: ImageToolbox.PictureFiles</note>
         <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice" approved="yes">
         <source xml:lang="en">Problem Getting Image</source>
         <target xml:lang="bn">ইমেজ পেতে সমস্যা</target>
         <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemLoadingImage">
+      <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
         <source xml:lang="en">Sorry, there was a problem loading that image.</source>
         <target xml:lang="bn">দুঃখিত, ইমেজ লোড হতে সমস্যা হচ্ছিল।</target>
         <note>ID: ImageToolbox.ProblemLoadingImage</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
         <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
         <target xml:lang="bn">এই ইমেজটি জানে না:\n\nকে এটি তৈরি করেছিল?\nকে এটি ব্যবহার করতে পারবে?</target>
         <note>ID: ImageToolbox.PromptForMissingMetadata</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Scanner">
+      <trans-unit id="ImageToolbox.Scanner" approved="yes">
         <source xml:lang="en">Scanner</source>
         <target xml:lang="bn">স্ক্যানার</target>
         <note>ID: ImageToolbox.Scanner</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchArtOfReading">
+      <trans-unit id="ImageToolbox.SearchArtOfReading" approved="yes">
         <source xml:lang="en">Search the Art of Reading Gallery</source>
         <target xml:lang="bn">আর্ট অফ রিডিং গ্যালারিটি অনুসন্ধান করুন</target>
         <note>ID: ImageToolbox.SearchArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchLanguage">
+      <trans-unit id="ImageToolbox.SearchLanguage" approved="yes">
         <source xml:lang="en">The search box is currently set to {0}</source>
         <target xml:lang="bn">অনুসন্ধান বাক্সটি বর্তমানে {0} তে সেট করা আছে</target>
         <note>ID: ImageToolbox.SearchLanguage</note>
         <note>The {0} will be replaced by the name of the language used in the searches.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SetUpMetadataLink">
+      <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
         <source xml:lang="en">Set up metadata...</source>
         <target xml:lang="bn">মেটাডাটা সেট আপ...</target>
         <note>ID: ImageToolbox.SetUpMetadataLink</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.AlternateNamesHeader">
+      <trans-unit id="LanguageLookup.AlternateNamesHeader" approved="yes">
         <source xml:lang="en">Other Names</source>
         <target xml:lang="bn">অন্যান্য নামসমূহ</target>
         <note>ID: LanguageLookup.AlternateNamesHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2" approved="yes">
         <source xml:lang="en">This list should include all the ISO-639 languages, including all the alternative names known to ethnologue.com.\n\nIf necessary, use the "Unlisted Language" option, which will be selected for you now.</source>
         <target xml:lang="bn">এই তালিকায় আইএসও-৬৩৯ ভাষাসমূহ অন্তর্ভুক্ত থাকতে হবে, যাতে অন্তর্ভুক্ত থাকবে সকল বিকল্প নামসমূহ যা ethnologue.com এর পরিচিত।\n\nপ্রয়োজন হলে, "অতালিকাভুক্ত ভাষা" অপশন ব্যবহার করুন, যা আপনার জন্য এখন নির্বাচন করা হবে।</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue" approved="yes">
         <source xml:lang="en">Ethnologue.com</source>
         <target xml:lang="bn">Ethnologue.com</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
         <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
         <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
         <target xml:lang="bn">ভাষা ৬৩৯-৩ কোড সম্পর্কে এবং কিভাবে নতুনটির জন্য তা প্রয়োগ করা যায়</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
         <source xml:lang="en">About The ISO Language Registry</source>
         <target xml:lang="bn">আইএসও ভাষা রেজিস্ট্রি সম্পর্কে</target>
         <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CodeHeader">
+      <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
         <source xml:lang="en">Code</source>
         <target xml:lang="bn">কোড</target>
         <note>ID: LanguageLookup.CodeHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryCount">
+      <trans-unit id="LanguageLookup.CountryCount" approved="yes">
         <source xml:lang="en">{0} Countries</source>
         <target xml:lang="bn">{0} দেশসমূহ</target>
         <note>ID: LanguageLookup.CountryCount</note>
         <note>Shown when there are multiple countries and it is just confusing to list them all. {0} is a count of countries.</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryHeader">
+      <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="bn">দেশ</target>
         <note>ID: LanguageLookup.CountryHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
         <source xml:lang="en">You can change how the language name will be displayed here:</source>
         <target xml:lang="bn">কিভাবে এখানে ভাষার নামসমূহ প্রদর্শিত হবে তা আপনি পরিবর্তন করতে পারবেন:</target>
         <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
         <source xml:lang="en">Lookup Language Code...</source>
         <target xml:lang="bn">ভাষা কোড খুঁজে দেখুন...</target>
         <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.PrimaryNameHeader">
+      <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="bn">নাম</target>
         <note>ID: LanguageLookup.PrimaryNameHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel">
+      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel" approved="yes">
         <source xml:lang="en">Show regional dialects</source>
         <target xml:lang="bn">আঞ্চলিক উপভাষা প্রদর্শন</target>
         <note>ID: LanguageLookup.ShowRegionalDialectsLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.UnlistedLanguage">
+      <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
         <source xml:lang="en">Unlisted Language</source>
         <target xml:lang="bn">অতালিকাভুক্ত ভাষা</target>
         <note>ID: LanguageLookup.UnlistedLanguage</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
         <source xml:lang="en">Can't find your language?</source>
         <target xml:lang="bn">আপনার ভাষা খুঁজে পাচ্ছেন না?</target>
         <note>ID: LanguageLookup._cannotFindLanguageLink</note>
       </trans-unit>
-      <trans-unit id="MemoryWarning">
+      <trans-unit id="MemoryWarning" approved="yes">
         <source xml:lang="en">Unfortunately, {0} is starting to get short of memory, and may soon slow down or experience other problems. We recommend that you quit and restart it when convenient.</source>
         <target xml:lang="bn">অপ্রত্যাশিত, {0} শুরু হতে মেমরি স্বল্পতা দেখা দিয়েছে, এবং খুব শীঘ্র ধীর গতির হতে পারে অথবা অন্যান্য সমস্যার সম্মুখীন হতে পারেন।  আমরা পরামর্শ দেই যে যখন আপনার সুবিধা হবে আপনি এটি বন্ধ করুন এবং রিস্টার্ট দিন।</target>
         <note>ID: MemoryWarning</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Creator">
+      <trans-unit id="MetadataDisplay.Creator" approved="yes">
         <source xml:lang="en">Creator: {0}</source>
         <target xml:lang="bn">প্রস্তুতকারী: {0}</target>
         <note>ID: MetadataDisplay.Creator</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.CreatorLabel">
+      <trans-unit id="MetadataDisplay.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="bn">প্রস্তুতকারী</target>
         <note>ID: MetadataDisplay.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.LicenseInfo">
+      <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
         <source xml:lang="en">License Info</source>
         <target xml:lang="bn">লাইসেন্সের তথ্য</target>
         <note>ID: MetadataDisplay.LicenseInfo</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You must keep the copyright and credits for authors, illustrators, etc.</source>
         <target xml:lang="bn">আপনাকে অবশ্যই লেখক, শিল্পী, ইত্যাদির কপিরাইট এবং কৃতজ্ঞতা প্রকাশ করতে হবে।</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.AttributionRequired</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You are free to make commercial use of this work.</source>
         <target xml:lang="bn">এই কাজটির বাণিজ্যিক ব্যবহারে আপনি অনুমতিপ্রাপ্ত।</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work.</source>
         <target xml:lang="bn">আপনি এই কাজটি পরিবর্তন এবং যুক্ত করতে পারবেন। </target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.Derivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work, but you may distribute the resulting work only under the same or similar license to this one.</source>
         <target xml:lang="bn">আপনি এই কাজটি পরিবর্তন এবং যুক্ত করতে পারবেন, কিন্তু আপনি শুধুমাত্র এটির সাথে একই অথবা অনুরূপ লাইসেন্সের অধীনে ফলাফলের কাজ বিতরণ করতে পারবেন।</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not make changes or build upon this work without permission.</source>
         <target xml:lang="bn">অনুমতি ব্যতীত আপনি হয়তো এই কাজটি পরিবর্তন অথবা তৈরি করতে পারবেন না।</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NoDerivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not use this work for commercial purposes.</source>
         <target xml:lang="bn">আপনি হয়তো এই কাজটি বাণিজ্যিক উদ্দেশ্যে ব্যবহার করতে পারবেন না।</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NonCommercial</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For permission to reuse, contact the copyright holder.</source>
         <target xml:lang="bn">পুনর্ব্যবহারের অনুমতির জন্য, কপিরাইট ধারণকারীর সাথে যোগাযোগ করুন।</target>
         <note>ID: MetadataDisplay.Licenses.NullLicense</note>
         <note>This is used when all we have is a copyright, no other license.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.NoLicense">
+      <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
         <source xml:lang="en">No license specified</source>
         <target xml:lang="bn">কোন লাইসেন্স নির্ধারিত নয়</target>
         <note>ID: MetadataDisplay.NoLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowCommercialUse">
+      <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
         <source xml:lang="en">Allow commercial uses of your work?</source>
         <target xml:lang="bn">আপনার কাজের বাণিজ্যিক ব্যবহারের অনুমতি দিচ্ছেন কি?</target>
         <note>ID: MetadataEditor.AllowCommercialUse</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowDerivatives">
+      <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
         <source xml:lang="en">Allow modifications of your work?</source>
         <target xml:lang="bn">আপনার কাজের পরিবর্তনের অনুমতি দিচ্ছেন কি?</target>
         <note>ID: MetadataEditor.AllowDerivatives</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CopyrightHolder">
+      <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
         <source xml:lang="en">Copyright Holder</source>
         <target xml:lang="bn">কপিরাইট ধারণকারী</target>
         <note>ID: MetadataEditor.CopyrightHolder</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons">
+      <trans-unit id="MetadataEditor.CreativeCommons" approved="yes">
         <source xml:lang="en">Creative Commons</source>
         <target xml:lang="bn">ক্রিয়েটিভ কমন্স</target>
         <note>ID: MetadataEditor.CreativeCommons</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental">
+      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental" approved="yes">
         <source xml:lang="en">Intergovernmental Version</source>
         <target xml:lang="bn">আন্তঃসরকারী সংস্করণ</target>
         <note>ID: MetadataEditor.CreativeCommons.Intergovernmental</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreatorLabel">
+      <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="bn">প্রস্তুতকারী</target>
         <note>ID: MetadataEditor.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CustomLicense">
+      <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="bn">কাস্টম</target>
         <note>ID: MetadataEditor.CustomLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleNoCredit">
+      <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
         <source xml:lang="en">Copyright and License</source>
         <target xml:lang="bn">কপিরাইট এবং লাইসেন্স</target>
         <note>ID: MetadataEditor.TitleNoCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleWithCredit">
+      <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
         <source xml:lang="en">Credit, Copyright, and License</source>
         <target xml:lang="bn">কৃতজ্ঞতা, কপিরাইট, এবং লাইসেন্স</target>
         <note>ID: MetadataEditor.TitleWithCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.UnknownLicense">
+      <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <target xml:lang="bn">যেকোনো অনুমতির জন্য কপিরাইট ধারণকারীর সাথে যোগাযোগ করুন</target>
         <note>ID: MetadataEditor.UnknownLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.YesShareAlike">
+      <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
         <source xml:lang="en">Yes, as long as others share alike</source>
         <target xml:lang="bn">হ্যাঁ, যতক্ষণ পর্যন্ত অন্যরা একই রকম শেয়ার করে</target>
         <note>ID: MetadataEditor.YesShareAlike</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.additionalRequestsLabel">
+      <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
         <source xml:lang="en">Additional Requests</source>
         <target xml:lang="bn">অতিরিক্ত অনুরোধসমূহ</target>
         <note>ID: MetadataEditor.additionalRequestsLabel</note>
         <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.betterLinkLabel1">
+      <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
         <source xml:lang="en">more info</source>
         <target xml:lang="bn">আরো তথ্য</target>
         <note>ID: MetadataEditor.betterLinkLabel1</note>
         <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere that defines it.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
         <source xml:lang="en">Not Enforceable</source>
         <target xml:lang="bn">প্রয়োগযোগ্য নয়</target>
         <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
         <note>While this screen allows it, legally you can't enforce any additions to a creative commons license. This link takes you to the clause that says that. This link is visible only if you choose Creative Commons but then type in  the "Additional Request" box.</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <target xml:lang="bn">অদক্ষ ব্যবহারকারীদের প্রয়োজন নয় এমন বোতামসমূহ এটি লুকিয়ে রাখতে পারে।</target>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.CtrlShiftHint">
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
         <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
         <target xml:lang="bn">কন্ট্রোল এবং শিফট কী একসাথে চেপে ধরলে বোতামটি দৃশ্যমান হবে।</target>
         <note>ID: SettingsProtection.CtrlShiftHint</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+      <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
         <source xml:lang="en">Settings...</source>
         <target xml:lang="bn">সেটিংস...</target>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
         <source xml:lang="en">Hide the button that opens settings.</source>
         <target xml:lang="bn">সেটিংস উন্মুক্তকারী বোতামটি লুকিয়ে রাখুন।</target>
         <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
         <source xml:lang="en">Factory Password</source>
         <target xml:lang="bn">ফ্যাক্টরি পাসওয়ার্ড</target>
         <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
         <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
         <target xml:lang="bn">দুর্ঘটনাবশত পরিবর্তন রোধে যা এই টুলটি আপনার জন্য কাজ করা বন্ধ করে দিতে পারে, এই সেটিংসসমূহ বদ্ধ করে রাখা হয়েছে।</target>
         <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
         <source xml:lang="en">Settings Protection Password</source>
         <target xml:lang="bn">সেটিংস সুরক্ষা পাসওয়ার্ড</target>
         <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox">
+      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
         <source xml:lang="en">Show Characters</source>
         <target xml:lang="bn">অক্ষর প্রদর্শন</target>
         <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordNotice">
+      <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
         <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always google for "{1}" and "{2}".</source>
         <target xml:lang="bn">এই সেটিংসসমূহের জন্য ফ্যাক্টরি পাসওয়ার্ডটি হল "{0}"।যদি আপনি এটি ভুলে যান, আপনি সবসময় "{1}" এবং "{2}" ব্যবহার করে খুঁজতে পারেন।</target>
         <note>ID: SettingsProtection.PasswordNotice</note>
         <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
         <source xml:lang="en">Require the factory password to get into settings.</source>
         <target xml:lang="bn">সেটিংসে প্রবেশের জন্য ফ্যাক্টরি পাসওয়ার্ডটি প্রয়োজন।</target>
         <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
         <source xml:lang="en">Settings Protection</source>
         <target xml:lang="bn">সেটিংস সুরক্ষা</target>
         <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
       </trans-unit>
-      <trans-unit id="ShowReleaseNotesDialog.WindowTitle">
+      <trans-unit id="ShowReleaseNotesDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="bn">অব্যাহতি পত্র</target>
         <note>ID: ShowReleaseNotesDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Font">
+      <trans-unit id="WSFontControl.Font" approved="yes">
         <source xml:lang="en">&amp;Font:</source>
         <target xml:lang="bn">&amp;ফন্ট:</target>
         <note>ID: WSFontControl.Font</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.FontNotAvailable">
+      <trans-unit id="WSFontControl.FontNotAvailable" approved="yes">
         <source xml:lang="en">(The selected font is not available on this machine. Using default.)</source>
         <target xml:lang="bn">(নির্বাচিত ফন্টটি এই যন্ত্রে বিদ্যমান নেই। ডিফল্ট ব্যবহার করুন।)</target>
         <note>ID: WSFontControl.FontNotAvailable</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.RightToLeftWS">
+      <trans-unit id="WSFontControl.RightToLeftWS" approved="yes">
         <source xml:lang="en">This is a &amp;right to left writing system.</source>
         <target xml:lang="bn">এটি একটি ডান হতে বামে লিখন পদ্ধতি।</target>
         <note>ID: WSFontControl.RightToLeftWS</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Size">
+      <trans-unit id="WSFontControl.Size" approved="yes">
         <source xml:lang="en">&amp;Size:</source>
         <target xml:lang="bn">এবং আকার:</target>
         <note>ID: WSFontControl.Size</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.TestArea">
+      <trans-unit id="WSFontControl.TestArea" approved="yes">
         <source xml:lang="en">&amp;Test Area:</source>
         <target xml:lang="bn">&amp; পরীক্ষা এলাকা:</target>
         <note>ID: WSFontControl.TestArea</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
         <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
         <target xml:lang="bn">আপনার যে কীবোর্ডটি প্রয়োজন তা যদি তালিকায় না থাকে, তাহলে সেট আপ করতে নীচের যথাযথ লিংকে ক্লিক করুন</target>
         <note>ID: WSKeyboardControl.KeyboardNotListed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
         <source xml:lang="en">Windows keyboard settings</source>
         <target xml:lang="bn">উইন্ডোজের কীবোর্ড সেটিংস</target>
         <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
         <source xml:lang="en">Available keyboards</source>
         <target xml:lang="bn">বিদ্যমান কীবোর্ডসমূহ</target>
         <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
         <source xml:lang="en">Previously used keyboards</source>
         <target xml:lang="bn">পূর্বে ব্যবহৃত কীবোর্ডসমূহ</target>
         <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
         <source xml:lang="en">Keyman Configuration</source>
         <target xml:lang="bn">কিম্যান কনফিগারেশন</target>
         <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
         <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
         <target xml:lang="bn">কিম্যান ৫.০ অথবা পরবর্তী সংস্করণ ইনস্টল নেই।</target>
         <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
         <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
         <target xml:lang="bn">{0} লেখা টাইপ করার জন্য &amp;কীবোর্ডটি নির্বাচন করুন</target>
         <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.TestAreaCaption">
+      <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
         <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
         <target xml:lang="bn">&amp;পরীক্ষা এলাকা (আপনার কীবোর্ডটি পরীক্ষা করার জন্য এই এলাকাটি ব্যবহার করুন)</target>
         <note>ID: WSKeyboardControl.TestAreaCaption</note>
       </trans-unit>
-      <trans-unit id="Warning">
+      <trans-unit id="Warning" approved="yes">
         <source xml:lang="en">Warning</source>
         <target xml:lang="bn">সতর্কতা</target>
         <note>ID: Warning</note>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption" approved="yes">
         <source xml:lang="en">Unable to connect to SLDR</source>
         <target xml:lang="bn">এসএলডিআর এর সাথে সংযুক্ত হতে পারছে না</target>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrCaption</note>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText" approved="yes">
         <source xml:lang="en">The application is unable to connect to the SIL Locale Data Repository to retrieve the latest information about this language. If you create this writing system, the default settings might be incorrect or out of date. Are you sure you want to create a new writing system?</source>
         <target xml:lang="bn">এই ভাষা সম্পর্কে সাম্প্রতিক তথ্য পুনরুদ্ধার করতে অ্যাপ্লিকেশনটি এসআইএল লোকাল ডাটা রিপোজিটরির সাথে সংযুক্ত হতে পারছে না।  যদি আপনি এই লেখার প্রক্রিয়াটি তৈরি করেন, ডিফল্ট সেটিংসটি ভুল হতে পারে অথবা মেয়াদ উত্তীর্ণ হতে পারে। আপনি কি নিশ্চিত যে আপনি একটি লেখার নতুন প্রক্রিয়া তৈরি করতে চান?</target>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrText</note>

--- a/DistFiles/localization/bn/TrainingVideos.xlf
+++ b/DistFiles/localization/bn/TrainingVideos.xlf
@@ -2,17 +2,17 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="TrainingVideos-en.md" datatype="html" source-language="en" target-language="bn">
     <body>
-      <trans-unit id="training.videos">
+      <trans-unit id="training.videos" approved="yes">
         <source xml:lang="en">Bloom Training Videos</source>
         <target xml:lang="bn">ব্লুম প্রশিক্ষণ ভিডিও</target>
         <note>ID: training.videos</note>
       </trans-unit>
-      <trans-unit id="training.videos.watch">
+      <trans-unit id="training.videos.watch" approved="yes">
         <source xml:lang="en">If you are connected to the internet now, you can watch videos in your web browser:</source>
         <target xml:lang="bn">যদি আপনি এখন ইন্টারনেটের সাথে সংযুক্ত থাকেন, ওয়েব ব্রাউজারে আপনি ভিডিও দেখতে পারেন:</target>
         <note>ID: training.videos.watch</note>
       </trans-unit>
-      <trans-unit id="training.videos.all">
+      <trans-unit id="training.videos.all" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-a" html:href="http://tiny.cc/bloomVimeo">All videos</g>
         </source>
@@ -21,12 +21,12 @@
         </target>
         <note>ID: training.videos.all</note>
       </trans-unit>
-      <trans-unit id="training.videos.intro">
+      <trans-unit id="training.videos.intro" approved="yes">
         <source xml:lang="en">Introductory Videos</source>
         <target xml:lang="bn">প্রারম্ভিক ভিডিওসমূহ</target>
         <note>ID: training.videos.intro</note>
       </trans-unit>
-      <trans-unit id="training.videos.whofor">
+      <trans-unit id="training.videos.whofor" approved="yes">
         <source xml:lang="en">
           <g id="genid-2" ctype="x-html-a" html:href="https://vimeo.com/114043219">Bloom: Who is it for</g>
         </source>
@@ -35,7 +35,7 @@
         </target>
         <note>ID: training.videos.whofor</note>
       </trans-unit>
-      <trans-unit id="training.videos.templates">
+      <trans-unit id="training.videos.templates" approved="yes">
         <source xml:lang="en">
           <g id="genid-3" ctype="x-html-a" html:href="https://vimeo.com/114024308">Understanding Templates and Shell Books</g>
         </source>
@@ -44,7 +44,7 @@
         </target>
         <note>ID: training.videos.templates</note>
       </trans-unit>
-      <trans-unit id="training.videos.basicbook">
+      <trans-unit id="training.videos.basicbook" approved="yes">
         <source xml:lang="en">
           <g id="genid-4" ctype="x-html-a" html:href="https://vimeo.com/112825489">Using the Basic Book template</g>
         </source>
@@ -53,7 +53,7 @@
         </target>
         <note>ID: training.videos.basicbook</note>
       </trans-unit>
-      <trans-unit id="training.videos.readers">
+      <trans-unit id="training.videos.readers" approved="yes">
         <source xml:lang="en">
           <g id="genid-5" ctype="x-html-a" html:href="http://tiny.cc/usingBloomReaderTemplates">Using Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -62,12 +62,12 @@
         </target>
         <note>ID: training.videos.readers</note>
       </trans-unit>
-      <trans-unit id="training.videos.advanced">
+      <trans-unit id="training.videos.advanced" approved="yes">
         <source xml:lang="en">Advanced Topics</source>
         <target xml:lang="bn">উচ্চতর বিষয়সমূহ</target>
         <note>ID: training.videos.advanced</note>
       </trans-unit>
-      <trans-unit id="training.videos.formatting">
+      <trans-unit id="training.videos.formatting" approved="yes">
         <source xml:lang="en">
           <g id="genid-6" ctype="x-html-a" html:href="https://vimeo.com/117820891">Changing the format of text</g>
         </source>
@@ -76,7 +76,7 @@
         </target>
         <note>ID: training.videos.formatting</note>
       </trans-unit>
-      <trans-unit id="training.videos.custompage">
+      <trans-unit id="training.videos.custompage" approved="yes">
         <source xml:lang="en">
           <g id="genid-7" ctype="x-html-a" html:href="https://vimeo.com/116868148">Using the Custom Page template</g>
         </source>
@@ -85,7 +85,7 @@
         </target>
         <note>ID: training.videos.custompage</note>
       </trans-unit>
-      <trans-unit id="training.videos.specialcharacters">
+      <trans-unit id="training.videos.specialcharacters" approved="yes">
         <source xml:lang="en">
           <g id="genid-8" ctype="x-html-a" html:href="https://vimeo.com/117927599">Inserting special characters</g>
         </source>
@@ -94,7 +94,7 @@
         </target>
         <note>ID: training.videos.specialcharacters</note>
       </trans-unit>
-      <trans-unit id="training.videos.readertemplates">
+      <trans-unit id="training.videos.readertemplates" approved="yes">
         <source xml:lang="en">
           <g id="genid-9" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">Making a set of Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -103,24 +103,24 @@
         </target>
         <note>ID: training.videos.readertemplates</note>
       </trans-unit>
-      <trans-unit id="training.videos.offline">
+      <trans-unit id="training.videos.offline" approved="yes">
         <source xml:lang="en">Offline Viewing</source>
         <target xml:lang="bn">অফলাইনে দেখা</target>
         <note>ID: training.videos.offline</note>
       </trans-unit>
-      <trans-unit id="training.videos.download">
+      <trans-unit id="training.videos.download" approved="yes">
         <source xml:lang="en">If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer:</source>
         <target xml:lang="bn">যদি আপনি ইন্টারনেট সংযোগ না থাকা অবস্থায় ভিডিওগুলোর যে কোন একটি কাউকে দেখাতে ও শেয়ার করতে চান তবে আপনি আপনার কম্পিউটারে ভিডিওগুলো ডাউনলোড করতে পারেন:</target>
         <note>ID: training.videos.download</note>
       </trans-unit>
-      <trans-unit id="training.videos.hires">
+      <trans-unit id="training.videos.hires" approved="yes">
         <source xml:lang="en">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">High Resolution</g> (Large files)</source>
         <target xml:lang="bn">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">উচ্চ রেজল্যুশন</g> (বড় ফাইলসমূহ)</target>
         <note>ID: training.videos.hires</note>
       </trans-unit>
-      <trans-unit id="training.videos.lores">
+      <trans-unit id="training.videos.lores" approved="yes">
         <source xml:lang="en">
           <g id="genid-11" ctype="x-html-a" html:href="http://tiny.cc/bloomSDVideos">Low Resolution</g> (Smaller files)</source>
         <target xml:lang="bn">

--- a/DistFiles/localization/bn/bloomEpubPreview.xlf
+++ b/DistFiles/localization/bn/bloomEpubPreview.xlf
@@ -2,89 +2,89 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="bloomEpubPreview-en.html" datatype="html" source-language="en" target-language="bn">
     <body>
-      <trans-unit id="epubpreview.describe">
+      <trans-unit id="epubpreview.describe" approved="yes">
         <source xml:lang="en">This is an <g id="genid-1" ctype="x-html-a" html:href="https://en.wikipedia.org/wiki/ePUB">ePUB</g> (e-book) version of your book. <g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">It contains audio, so that new readers can listen as they read.</g>
       </source>
         <target xml:lang="bn">এটি হল আপনার বইটির <g id="genid-1" ctype="x-html-a" html:href="https://bn.wikipedia.org/wiki/ePUB">ePUB</g> (ই-বুক) সংস্করণ <g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">এটিতে অডিও রয়েছে, যেন নতুন পাঠকরা পড়ার সাথে সাথে তা শুনতেও পারে।</g>
       </target>
         <note>ID: epubpreview.describe</note>
       </trans-unit>
-      <trans-unit id="epubpreview.recording.butnotalk">
+      <trans-unit id="epubpreview.recording.butnotalk" approved="yes">
         <source xml:lang="en">This book has some recordings, but this audio is not included in the ePUB.</source>
         <target xml:lang="bn">এই বইটিতে কিছু কিছু রেকর্ডিং রয়েছে, কিন্তু এই অডিওটি ePUB এর মধ্যে অন্তর্ভুক্ত নয়।</target>
         <note>ID: epubpreview.recording.butnotalk</note>
       </trans-unit>
-      <trans-unit id="epubpreview.preview">
+      <trans-unit id="epubpreview.preview" approved="yes">
         <source xml:lang="en">Preview</source>
         <target xml:lang="bn">প্রিভিউ/ পুনরায় দেখা</target>
         <note>ID: epubpreview.preview</note>
       </trans-unit>
-      <trans-unit id="epubpreview.resizing">
+      <trans-unit id="epubpreview.resizing" approved="yes">
         <source xml:lang="en">You can resize the preview by dragging the lower right corner of this simulated device. See how your book will look on screens of various sizes.</source>
         <target xml:lang="bn">আপনি এই কৃত্রিম যন্ত্রের পর্দার নীচের অংশে ডানদিকে কোণাটি টেনে প্রিভিউয়ের মাপ পরিবর্তন করতে পারেন। দেখুন, আপনার বইটি বিভিন্ন আকারে পর্দায় কেমন দেখাবে। </target>
         <note>ID: epubpreview.resizing</note>
       </trans-unit>
-      <trans-unit id="epubpreview.readium">
+      <trans-unit id="epubpreview.readium" approved="yes">
         <source xml:lang="en">This page uses the <g id="genid-3" ctype="x-html-a" html:href="http://readium.org/">Readium</g> ePUB reader. Books will likely look different on different readers.
       </source>
         <target xml:lang="bn">এই পৃষ্ঠাটিতে  <g id="genid-3" ctype="x-html-a" html:href="http://readium.org/">Readium</g> ePUB পাঠক রয়েছে। বইগুলো সম্ভবত ভিন্ন পাঠকের কাছে ভিন্নভাবে দেখাবে। 
       </target>
         <note>ID: epubpreview.readium</note>
       </trans-unit>
-      <trans-unit id="epubpreview.talkingbookpreview">
+      <trans-unit id="epubpreview.talkingbookpreview" approved="yes">
         <source xml:lang="en">The preview here cannot yet play Talking Books. You can listen to it using Adobe's Free <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html">Digital Editions</g> e-book reader.
       </source>
         <target xml:lang="bn">প্রিভিউ এখানে তখনও কথা বলা বইয়ের ভূমিকা পালন করবে না। আপনি এটি Adobe ফ্রি ডিজিটাল এডিশন ব্যবহার করে শুনতে পারেন  <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html">Digital Editions</g> ই-বুক পাঠক। 
       </target>
         <note>ID: epubpreview.talkingbookpreview</note>
       </trans-unit>
-      <trans-unit id="epubpreview.ontodevice">
+      <trans-unit id="epubpreview.ontodevice" approved="yes">
         <source xml:lang="en">Getting this book onto your Device</source>
         <target xml:lang="bn">এই বইটি আপনার ডিভাইসে নিন। </target>
         <note>ID: epubpreview.ontodevice</note>
       </trans-unit>
-      <trans-unit id="epubpreview.usingdropbox">
+      <trans-unit id="epubpreview.usingdropbox" approved="yes">
         <source xml:lang="en">A handy way to get books to your phone is to set up Dropbox or similar service on both your computer and your phone/tablet. Just click Save ePUB and then choose your Dropbox folder. On your phone, open the Dropbox app and select your book. If you are using a laptop, you can also try the free <g id="genid-5" ctype="x-html-a" html:href="http://www.ushareit.com/">ShareIt</g> program to send files from your laptop to a phone or tablet.
       </source>
         <target xml:lang="bn">হাতের নাগালে বইগুলো পেতে আপনার ফোনে পেতে ড্রপবক্স বা অনুরূপ সেবাটি আপনার কম্পিউটার এবং আপনার ফোন/ট্যাবলেট উভয়ে সেট আপ করুন। শুধু ePUB সংরক্ষণে ক্লিক করে এবং তারপর আপনার ড্রপবক্স ফোল্ডারটি নির্বাচন করুন। আপনার ফোনে, ড্রপবক্স অ্যাপ্লিকেশনটি খুলুন এবং আপনার বই নির্বাচন করুন। যদি আপনি ল্যাপটপ ব্যবহার করেন, তাহলে আপনি বিনামূল্যে প্রোগ্রামটি থেকে ফাইলগুলো  আপনার ল্যাপটপ থেকে ফোন বা ট্যাবলেটে পাঠানোর জন্য চেষ্টা করতে পারেন।  <g id="genid-5" ctype="x-html-a" html:href="http://shareit.lenovo.com/">ShareIt</g> 
       </target>
         <note>ID: epubpreview.usingdropbox</note>
       </trans-unit>
-      <trans-unit id="epubpreview.recommended.reader">
+      <trans-unit id="epubpreview.recommended.reader" approved="yes">
         <source xml:lang="en">Recommended Reader</source>
         <target xml:lang="bn">পপ্রস্তাবিত রিডার</target>
         <note>ID: epubpreview.recommended.reader</note>
       </trans-unit>
-      <trans-unit id="epubpreview.gitden.okay">
+      <trans-unit id="epubpreview.gitden.okay" approved="yes">
         <source xml:lang="en">Our testing has shown <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Gitden Reader</g> to be a good choice for Android and IOS (IPhone &amp; IPad) devices.
       </source>
         <target xml:lang="bn">আমাদের পরীক্ষায় দেখা গেছে যে  <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Gitden Reader</g> অ্যান্ড্রয়েড ও IOS (আইফোন &amp; iPad) ডিভাইসগুলো বেশ ভাল। 
       </target>
         <note>ID: epubpreview.gitden.okay</note>
       </trans-unit>
-      <trans-unit id="epubpreview.gitden.limits">
+      <trans-unit id="epubpreview.gitden.limits" approved="yes">
         <source xml:lang="en">To listen to this Talking Book using Gitden on a phone or tablet, you will need to disable Gitden's "Text To Speech" feature. Then it will show you the audio controls.</source>
         <target xml:lang="bn">Gitden ব্যবহার করে ফোন বা ট্যাবলেটে কথা বলা বইটি শোনার জন্য, আপনার Gitden এর "বার্তা থেকে উক্তি” ফিচারটি নিষ্ক্রিয় করতে হবে। তারপর এটি আপনাকে অডিও নিয়ন্ত্রণগুলি দেখাবে। </target>
         <note>ID: epubpreview.gitden.limits</note>
       </trans-unit>
-      <trans-unit id="epubpreview.make.it.talk">
+      <trans-unit id="epubpreview.make.it.talk" approved="yes">
         <source xml:lang="en">Make it Talk</source>
         <target xml:lang="bn">এটিকে কথা বলাতে</target>
         <note>ID: epubpreview.make.it.talk</note>
       </trans-unit>
-      <trans-unit id="epubpreview.talking.book.tool">
+      <trans-unit id="epubpreview.talking.book.tool" approved="yes">
         <source xml:lang="en">If you want to make a "Talking Book" that new readers can read-along with, use Bloom's <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">Talking Book Tool</g> to add voice recordings.
       </source>
         <target xml:lang="bn">যদি আপনি একটি “কথা বলার বই” তৈরী করতে চান, যা নতুন পাঠকরাও সাথে সাথে   পড়তে পারে, তাহলে ব্লুমের <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">ব্যবহার করুন।</g> ভয়েস রেকর্ডিং যুক্ত করার জন্য।
       </target>
         <note>ID: epubpreview.talking.book.tool</note>
       </trans-unit>
-      <trans-unit id="epubpreview.write.us">
+      <trans-unit id="epubpreview.write.us" approved="yes">
         <source xml:lang="en">Write to us!</source>
         <target xml:lang="bn">আমাদের কাছে লিখুন!</target>
         <note>ID: epubpreview.write.us</note>
       </trans-unit>
-      <trans-unit id="epubpreview.use.help.report">
+      <trans-unit id="epubpreview.use.help.report" approved="yes">
         <source xml:lang="en">Are you interested in distributing Bloom books for use on phones and other ebook readers? Is there something you would need us to do before it is useful for you? Please use the Help:Report A Problem command to send us feedback. Thanks!</source>
         <target xml:lang="bn">আপনি কি ফোনে এবং অন্যান্য ইবুক পাঠকদের ব্যবহারের জন্য ব্লুম বই বিতরনে আগ্রহী? আমরা কি এমন কিছু করতে পারি যা এটি ব্যবহার করার পূর্বে আপনার জন্য দরকারী হতে পারে?  দয়া করে সাহায্য ব্যবহার করুন: আমাদের প্রতিক্রিয়া পাঠাতে একটি সমস্যা নির্দেশিত প্রতিবেদন  লিখুন । ধন্যবাদ!</target>
         <note>ID: epubpreview.use.help.report</note>

--- a/DistFiles/localization/bn/leveledReaderInfo.xlf
+++ b/DistFiles/localization/bn/leveledReaderInfo.xlf
@@ -2,59 +2,59 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="leveledReaderInfo-en.html" datatype="html" source-language="en" target-language="bn">
     <body>
-      <trans-unit id="leveled.reader.vocabulary">
+      <trans-unit id="leveled.reader.vocabulary" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="bn">শব্দকোষ</target>
         <note>ID: leveled.reader.vocabulary</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.simple">
+      <trans-unit id="leveled.reader.start.simple" approved="yes">
         <source xml:lang="en">At beginning levels, use simple words that are familiar to children. If it is possible in your language, use words with only one syllable. As children move up to higher levels, you can begin to use words with more syllables. You can begin to use less familiar words. Children should be able to guess the meaning of these less familiar words from the context of the surrounding words and sentences, as well as from the illustrations.</source>
         <target xml:lang="bn">প্রারম্ভিক পর্যায়ে, খুব সাধারণ শব্দ ব্যবহার করুন যা শিশুদের পরিচিত।যদি সম্ভব হয়, আপনার ভাষার এক অক্ষর বিশিষ্ট শব্দ ব্যবহার করুন।শিশুরা উচ্চতর পর্যায়ে গেলে, আপনি একাধিক অক্ষর বিশিষ্ট শব্দ ব্যবহার করা শুরু করতে পারেন।তখন আপনি কম পরিচিত শব্দও ব্যবহার করা শুরু করতে পারেন।শিশুরা গল্পের বিষয়বস্তু, পারিপার্শ্বিক শব্দ ও বাক্যসমূহ, সেই সাথে ছবি থেকে এইসব কম পরিচিত শব্দসমূহের অর্থ অনুমান করতে পারবে।</target>
         <note>ID: leveled.reader.start.simple</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.formatting">
+      <trans-unit id="leveled.reader.formatting" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="bn">বিন্যাস</target>
         <note>ID: leveled.reader.formatting</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.large">
+      <trans-unit id="leveled.reader.start.large" approved="yes">
         <source xml:lang="en">Beginner readers will benefit from a larger font with clear spacing between words. Having the words or sentences in the same location on each page is also helpful. As readers progress to higher levels, font size and spacing will decrease and sentences can appear in different locations on the page.</source>
         <target xml:lang="bn">যারা প্রথমবার পড়তে শিখছে তাদের জন্য বড় ফন্ট ও শব্দের সাথে বেশ ফাঁকা স্থান রাখলে ভাল হয়। প্রতি পৃষ্ঠায় শব্দসমূহ ও বাক্যসমূহ একই স্থানে থাকলে ভাল হয়।পাঠকদের অগ্রগতি উচ্চ লেভেলে, ফন্ট সাইজ এবং ফাঁকাকরণ কমানো হবে এবং বাক্যসমূহ পৃষ্ঠার বিভিন্ন স্থানে দেখা যাবে।</target>
         <note>ID: leveled.reader.start.large</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.increase.sizes">
+      <trans-unit id="leveled.reader.increase.sizes" approved="yes">
         <source xml:lang="en">To increase the font size, line-spacing, and word-spacing in Bloom, click in a text box and then on the grey "cog" icon in the lower left-hand corner. If you do this and then make a template book, books made with that template will also use those font settings.</source>
         <target xml:lang="bn">ব্লুমে ফন্টের আকার, সারি-ফাঁকাকরণ এবং শব্দ-ফাঁকাকরণ বৃদ্ধি করতে, লেখার বাক্সে ক্লিক করুন এবং তারপর নীচের বাম দিকের কোণায় ধূসর "কগ" আইকনে।আপনি যদি এটি করেন এবং তারপর একটি টেমপ্লেট বই তৈরি করেন, ঐ টেমপ্লেট দিয়ে তৈরিকৃত বইটি ফন্টের ঐ সেটিংস ব্যবহার করবে।</target>
         <note>ID: leveled.reader.increase.sizes</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.predictability">
+      <trans-unit id="leveled.reader.predictability" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="bn">অনুমেয়/ অনুমানযোগ্য</target>
         <note>ID: leveled.reader.predictability</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repeat.patterns">
+      <trans-unit id="leveled.reader.repeat.patterns" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-em">Predictability</g> in a text means that the reader can guess what would come next. You can increase predictability by using repeated patterns. Here are some patterns you can use:</source>
         <target xml:lang="bn">
           <g id="genid-1" ctype="x-html-em">অনুমেয়/ অনুমানযোগ্য</g> লেখার বেলায় এর অর্থ হল পাঠক অনুমান করতে পারে পরবর্তীতে কি হতে যাচ্ছে।অনুমান দক্ষতা বৃদ্ধির জন্য আপনি একই ধরন  পুনরাবৃত্তি করতে পারেন।এখানে কয়েকটি ধরন দেওয়া হল যা আপনি ব্যবহার করতে পারেন:</target>
         <note>ID: leveled.reader.repeat.patterns</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repetition">
+      <trans-unit id="leveled.reader.repetition" approved="yes">
         <source xml:lang="en">Repetition - repeating parts of the text, for example, using the same sentence with each page and just changing one word in the sentence</source>
         <target xml:lang="bn">পুনরাবৃত্তি - লেখার অাংশিক পুনরাবৃত্তি, উদারণস্বরূপ, প্রতি পৃষ্ঠায় একই বাক্যের ব্যবহার এবং শুধুমাত্র বাক্যটিতে একটি শব্দ পরিবর্তন করা</target>
         <note>ID: leveled.reader.repetition</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.sequencing">
+      <trans-unit id="leveled.reader.sequencing" approved="yes">
         <source xml:lang="en">Sequencing - a story with a known sequence such as the days of the week or that uses numbers in a pattern</source>
         <target xml:lang="bn">পর্যায়ক্রম - একটি পরিচিত পর্যায়ক্রমের গল্প যেমন সপ্তাহের দিনসমূহ অথবা এমন ধরনের গল্প যেখোনে সংখ্যার ব্যবহার আছে</target>
         <note>ID: leveled.reader.sequencing</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.building.sequence">
+      <trans-unit id="leveled.reader.building.sequence" approved="yes">
         <source xml:lang="en">Building Sequence - a story with a pattern that is repeated and added to with each new page</source>
         <target xml:lang="bn">পর্যায়ক্রম তৈরি - একটি ধরনের সাথে একটি গল্প যা পুনরাবৃত্তি ঘটেছে এবং প্রতি পৃষ্ঠার সাথে এর মিল রয়েছে</target>
         <note>ID: leveled.reader.building.sequence</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.rhyme">
+      <trans-unit id="leveled.reader.rhyme" approved="yes">
         <source xml:lang="en">Rhyme - a story with a pattern or sequence that also includes rhyme. For example:
         <g id="genid-2" ctype="x-html-blockquote" html:class="poetry">
           <g id="genid-3" ctype="x-html-pre">Brown Bear, Brown Bear, What do you see?
@@ -77,64 +77,64 @@ Yellow Duck, Yellow Duck, What do you see?</g>
       </target>
         <note>ID: leveled.reader.rhyme</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations">
+      <trans-unit id="leveled.reader.illustrations" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="bn">চিত্রণ/ ছবি সহায়তা</target>
         <note>ID: leveled.reader.illustrations</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.help">
+      <trans-unit id="leveled.reader.illustrations.help" approved="yes">
         <source xml:lang="en">Illustrations provide support to the story. Illustrations relate to the story in different ways at different <g id="genid-5" ctype="x-html-em">levels</g> and for different types of readers (see below). Remember that in many cultures that don't have a lot of printed material around, complex pictures may be difficult to understand.
     </source>
         <target xml:lang="bn">ছবি গল্পকে সহায়তা প্রদান করে।ছবি বিভিন্নভাবে বিভিন্ন উপায়ে গল্পকে বর্ণনা করে <g id="genid-5" ctype="x-html-em">পর্যায়সমূহ</g> এবং বিভিন্ন ধরনের পাঠকদের জন্য (নীচে দেখুন)মনে রাখতে হবে যে অনেক সংস্কৃতিতে পর্যাপ্ত পরিমাণ ছাপানো উপকরণ নেই, জটিল ছবিগুলো বোঝা কঠিন হতে পারে।
     </target>
         <note>ID: leveled.reader.illustrations.help</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.emergent.reader">
+      <trans-unit id="leveled.reader.illustrations.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-6" ctype="x-html-strong">Emergent Readers</g> the pictures should closely match the storyline. The reader should be able to predict the story line just by looking at the pictures. The illustrations at this level should be simple.
       </source>
         <target xml:lang="bn">অত্যাবশ্যক <g id="genid-6" ctype="x-html-strong">পাঠকের জন্য</g> ছবিগুলো কাহিনী সূত্রের সাথে মিল থাকা উচিত।যেন পাঠক শুধুমাত্র ছবিগুলো দেখেই গল্পের মূলভাব অনুমান করতে পারে।এই পর্যায়ে ছবি খুব সাধারণ হতে হবে।
       </target>
         <note>ID: leveled.reader.illustrations.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.early.reader">
+      <trans-unit id="leveled.reader.illustrations.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-7" ctype="x-html-strong">Early Readers</g> the pictures should offer some support to the story line. As the amount of text increases, the reader is less reliant on the pictures and gets more meaning from the text. The illustrations can be more complex.
       </source>
         <target xml:lang="bn">প্রথম দিকের <g id="genid-7" ctype="x-html-strong">নব্য পাঠকদের জন্য</g> ছবিগুলোর উচিত গল্পের মূলভাবে কিছু সহায়তা প্রদান করা।যেহেতু লেখার পরিমাণ বৃদ্ধি হয়েছে, পাঠকরা ছবির দিকে কম নির্ভরশীল হবে এবং লেখা থেকে বেশি পাবে।চিত্রণটি আরো জটিল হতে পারে।
       </target>
         <note>ID: leveled.reader.illustrations.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.fluent.reader">
+      <trans-unit id="leveled.reader.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-8" ctype="x-html-strong">Fluent Readers</g> the pictures should offer little or no support to the story line. The reader relies more on the text than the pictures for meaning. The illustrations can be even more complex.
       </source>
         <target xml:lang="bn">দক্ষ <g id="genid-8" ctype="x-html-strong">সাবলীল পাঠকদের জন্য</g> ছবিগুলোর উচিত গল্পের মূলভাবে কম সহায়তা প্রদান অথবা কোন সহায়তা প্রদান না করা।পাঠকরা অর্থের জন্য ছবির চেয়ে লেখার উপর বেশি নির্ভর করে।চিত্রণটি আরো জটিল হতে পারে।
       </target>
         <note>ID: leveled.reader.fluent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice">
+      <trans-unit id="leveled.reader.topic.choice" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="bn">একটি বিষয় নির্বাচন করুন</target>
         <note>ID: leveled.reader.topic.choice</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.discussion">
+      <trans-unit id="leveled.reader.topic.choice.discussion" approved="yes">
         <source xml:lang="en">Books can be on many topics. When developing books for beginning readers, choose topics that are familiar to them. Readers will be eager to read and will read more if they are reading about things they find interesting and familiar. For more experienced readers, topics can include information that the reader is not already familiar with.</source>
         <target xml:lang="bn">বইসমূহ অনেক বিষয়ের হতে পারে।প্রারম্ভিক পাঠকদের জন্য বই তৈরির সময়, তাদের পরিচিত বিষয়সমূহ নির্বাচন করুন।পাঠকরা আগ্রহের সাথে পড়বে এবং আরো পড়তে থাকবে যদি তারা তাদের আগ্রহের এবং পরিচিতি বিষয় সম্পর্কে পড়ে।আরো অভিজ্ঞ পাঠকদের জন্য, বিষয়টিতে তথ্য অন্তর্ভুক্ত থাকতে পারে যার সাথে পাঠক পরিচিত নয়।</target>
         <note>ID: leveled.reader.topic.choice.discussion</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.emergent.reader">
+      <trans-unit id="leveled.reader.topic.choice.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-9" ctype="x-html-strong">Emergent Readers</g> the book should be concrete, should focus on one idea/theme, and should be familiar and easy to understand.
       </source>
         <target xml:lang="bn">অত্যাবশ্যক <g id="genid-9" ctype="x-html-strong">পাঠকদের জন্য</g> বইটি বাস্তব সম্মত হতে হবে, ধারণা/মূলভাবে আলোকপাত করা উচিত, এবং পরিচিত হওয়া উচিত এবং সহজে বোঝা যাওয়া উচিত।
       </target>
         <note>ID: leveled.reader.topic.choice.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.early.reader">
+      <trans-unit id="leveled.reader.topic.choice.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-10" ctype="x-html-strong">Early Readers</g>, develop a story around a familiar concept but in greater depth.
       </source>
         <target xml:lang="bn">প্রথম দিকের <g id="genid-10" ctype="x-html-strong">নব্য পাঠকদের জন্য</g>, পরিচিত ধারণার উপর কিন্তু খুবই গভীরতার সাথে একটি গল্প তৈরি করুন।
       </target>
         <note>ID: leveled.reader.topic.choice.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.fluent.reader">
+      <trans-unit id="leveled.reader.topic.choice.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-11" ctype="x-html-strong">Fluent Readers</g> the concepts can expand beyond what is familiar, be more varied, and be abstract.
       </source>
         <target xml:lang="bn">দক্ষ <g id="genid-11" ctype="x-html-strong">সাবলীল পাঠকদের জন্য</g> যা পরিচিত তার ভিত্তিতে ধারণাটি বিস্তৃত হতে পারে, আরো বৈচিত্রপূর্ণ এবং আনমনা হন।

--- a/DistFiles/localization/ha/Bloom.xlf
+++ b/DistFiles/localization/ha/Bloom.xlf
@@ -2,2940 +2,2940 @@
 <xliff xmlns:sil="http://sil.org/software/XLiff" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="Bloom.exe" source-language="en" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n" target-language="ha">
     <body>
-      <trans-unit id="BloomIntegrity.WindowTitle" approved="yes">
+      <trans-unit id="BloomIntegrity.WindowTitle" approved="yes" approved="yes">
         <source xml:lang="en">Bloom Problem</source>
         <note>ID: BloomIntegrity.WindowTitle</note>
         <target xml:lang="ha">Matsalar Bloom</target>
         <note>ID: BloomIntegrity.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="BloomIntegrityDialog.ReportProblem">
+      <trans-unit id="BloomIntegrityDialog.ReportProblem" approved="yes">
         <source xml:lang="en">Report Problem</source>
         <note>ID: BloomIntegrityDialog.ReportProblem</note>
         <target xml:lang="ha" state="translated">Kai Rahoton Matsalar</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName">
+      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName" approved="yes">
         <source xml:lang="en">Possibly this is an old Bloom Pack created before Bloom Packs could handle special characters in file names. You may be able to get the author to re-create it using a current version. If that's not possible a technical expert may be able to repair things.</source>
         <note>ID: BloomPackInstallDialog.BadCharsInFileName</note>
         <target xml:lang="ha" state="translated">Mai yiwuwa wannan tsohon shirin Bloom ne wanda aka ƙirƙiro kafin shirin Bloom ya fara amfani da mai Haruffa na musamman a cikin sunayen kundin ajiye bayani. Za ka iya samun marubucin don sake ƘirƘiro maka shi ta hanyar amfani da wannan sabon shirin. Idan hakan bai samu ba, Ƙwararre kan irin wannan harkar zai iya gyara abubuwan.</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
         <target xml:lang="ha" state="translated">Sa Shirin Bloom a cikin na'ura mai ƙwaƙwalwa</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
         <target xml:lang="ha" state="translated">Yanzu {0} za'a iya amfani da shirye shiryen a cikin wannan na'ura.</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller" approved="yes">
         <source xml:lang="en">Bloom Pack Installer</source>
         <note>ID: BloomPackInstallDialog.BloomPackInstaller</note>
         <note>Displayed as the message box title</note>
         <target xml:lang="ha" state="translated">Abu mai saka shirye-shirye a cikin na'ura mai ƙwaƙwalwa.</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack">
+      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack" approved="yes">
         <source xml:lang="en">This BloomPack appears to be incomplete or corrupt.</source>
         <note>ID: BloomPackInstallDialog.CorruptBloomPack</note>
         <target xml:lang="ha" state="translated">Wannan ƙunshin shirye-shirye na Bloom kamar ba cikakakke ba ne ko kuma gurɓatacce ne.</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.DoesNotExist">
+      <trans-unit id="BloomPackInstallDialog.DoesNotExist" approved="yes">
         <source xml:lang="en">{0} does not exist</source>
         <note>ID: BloomPackInstallDialog.DoesNotExist</note>
         <target xml:lang="ha" state="translated">{0} babu shi</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
         <target xml:lang="ha" state="translated">Bloom ya kasa saka wancan Ƙunshin shire-shire na Bloom</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while Bloom Packs are being installed</note>
         <target xml:lang="ha" state="translated">Ɗiba...</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
         <target xml:lang="ha" state="translated">Bloom yana gudana, amma abubuwan da ke cikinsa ba za su bayyana ba har sai lokaci na gaba sa'adda ka sake gudanar da Bloom</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.NotInstalled">
+      <trans-unit id="BloomPackInstallDialog.NotInstalled" approved="yes">
         <source xml:lang="en">The Bloom collection will not be installed.</source>
         <note>ID: BloomPackInstallDialog.NotInstalled</note>
         <target xml:lang="ha" state="translated">Ba za'a sanya maka ƙunshin shirye-shirye na Bloom ba.</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <note>ID: BloomPackInstallDialog.Opening</note>
         <target xml:lang="ha" state="translated">Buɗewa {0}...</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Replace">
+      <trans-unit id="BloomPackInstallDialog.Replace" approved="yes">
         <source xml:lang="en">This computer already has a Bloom collection named '{0}'. Do you want to replace it with the one from this Bloom Pack?</source>
         <note>ID: BloomPackInstallDialog.Replace</note>
         <target xml:lang="ha" state="translated">Wannan na'ura mai ƙwaƙwalwa dama tana da abubuwan da Bloom ya ƙunsa mai suna '{0}'. Ko kana son ka maye gurbinsa da wanda ke cikin wannan Ƙunshin shirin Bloom?</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder">
+      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder" approved="yes">
         <source xml:lang="en">Bloom Packs should have only a single collection folder at the top level of the .ZIP file.</source>
         <note>ID: BloomPackInstallDialog.SingleCollectionFolder</note>
         <target xml:lang="ha" state="translated">Kamata ya yi kowane Ƙunshin shirin Bloom su kasance sun haɗa tarin abubuwa a wuri ɗaya a saman kundin .ZIP.</target>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.UnableToReplace">
+      <trans-unit id="BloomPackInstallDialog.UnableToReplace" approved="yes">
         <source xml:lang="en">Bloom was not able to remove the existing copy of '{0}'. Quit Bloom if it is running &amp; try again. Otherwise, try again after restarting your computer.</source>
         <note>ID: BloomPackInstallDialog.UnableToReplace</note>
         <target xml:lang="ha" state="translated">Bloom bai iya cire kofin da yake ciki yanzu  '{0}'. Fita daga Bloom in baya yi sannan ka sake gwadawa kuma. Ko kuma, ka sake gwadawa bayan ka kashe, ka sake kunna na'urar.</target>
       </trans-unit>
-      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true">
+      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To select, use your mouse wheel or point at what you want, then release the key.</source>
         <note>ID: BookEditor.CharacterMap.Instructions</note>
         <note>When you hold down a key, a popup appears that lets you choose a related character. These instructions are shown in that popup.</note>
         <target xml:lang="ha" state="translated">Don zaɓe, ka yi amfani da kusun na'urarka ko ka nuna abinda kake so, sannan ka saki abinda ka danna.</target>
       </trans-unit>
-      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is the default for all text boxes with '{0}' style.</source>
         <note>ID: BookEditor.DefaultForText</note>
         <target xml:lang="ha" state="translated">Wannan tsarin shine wanda ya fito tun daga kamfani ga dukkan akwatunan rubutu '{0}' irin salon ke nan</target>
       </trans-unit>
-      <trans-unit id="BookEditor.ForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all text boxes with '{0}' style.</source>
         <note>ID: BookEditor.ForText</note>
         <target xml:lang="ha" state="translated">Wannan shirin na kowane akwatin rubutu ne mai tsarin '{0}'</target>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text boxes with '{1}' style.</source>
         <note>ID: BookEditor.ForTextInLang</note>
         <target xml:lang="ha" state="translated">Wannan shirin na kowane akwatin rubutun {0} mai tsarin '{1}'</target>
       </trans-unit>
-      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true">
+      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sorry, Reader Templates do not allow changes to formatting.</source>
         <note>ID: BookEditor.FormattingDisabled</note>
         <target xml:lang="ha" state="translated">Yi haƙuri, Muhallin Maikaratu ba ya bayar da damar yin canje-canje don shirin ba.</target>
       </trans-unit>
-      <trans-unit id="BookStorage.CorruptBook">
+      <trans-unit id="BookStorage.CorruptBook" approved="yes">
         <source xml:lang="en">Bloom had a problem reading this book and recovered by restoring a recent backup. Please check recent changes to this book. If this happens for no obvious reason, please click Details below and report it to us.</source>
         <note>ID: BookStorage.CorruptBook</note>
         <target xml:lang="ha" state="needs-translation">Bloom had a problem reading this book and recovered by restoring a recent backup. Please check recent changes to this book. If this happens for no obvious reason, please click Details below and report it to us.</target>
       </trans-unit>
-      <trans-unit id="BookStorage.FolderMoved">
+      <trans-unit id="BookStorage.FolderMoved" approved="yes">
         <source xml:lang="en">It appears that some part of the folder path to this book has been moved or renamed. As a result, Bloom cannot save your changes to this page, and will need to exit now. If you haven't been renaming or moving things, please click Details below and report the problem to the developers.</source>
         <note>ID: BookStorage.FolderMoved</note>
         <target xml:lang="ha" state="translated">Da alamar wani ɓangaren turbar akwatin shiga wannan littafin an cire shi ko canja mashi suna. A sakamakon haka, Bloom ba zai iya ajiye canje-canjen wannan shafin da ka yi ba, buƙatar yanzu itace fita. Idan ba ka cire ko tura abubuwa ba, idan ka yarda ka dangwala akan Bayanan da ke ƙasa kuma ka aika da rahoton matsalar zuwa ga waɗanda suka ƙirƙiro manhajar.</target>
       </trans-unit>
-      <trans-unit id="Browser.CopyTroubleshootingInfo">
+      <trans-unit id="Browser.CopyTroubleshootingInfo" approved="yes">
         <source xml:lang="en">Copy Troubleshooting Information</source>
         <note>ID: Browser.CopyTroubleshootingInfo</note>
         <target xml:lang="ha" state="needs-translation">Copy Troubleshooting Information</target>
       </trans-unit>
-      <trans-unit id="Browser.OpenPageInFirefox">
+      <trans-unit id="Browser.OpenPageInFirefox" approved="yes">
         <source xml:lang="en">Open Page in Firefox (which must be in the PATH environment variable)</source>
         <note>ID: Browser.OpenPageInFirefox</note>
         <target xml:lang="ha" state="needs-translation">Open Page in Firefox (which must be in the PATH environment variable)</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
         <target xml:lang="ha" state="translated">Saice-saicen shirye shirye na gaba</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate" approved="yes">
         <source xml:lang="en">Automatically update Bloom</source>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AutoUpdate</note>
         <target xml:lang="ha" state="translated">Da kanshi zai sanya sabbin shiSrye-shirye na Bloom</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
         <target xml:lang="ha" state="translated">Nuna Umarnan Gwaji (misali, Fitar da XML domin Zayyani na ciki)</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
         <target xml:lang="ha" state="translated">Nuna Muhallan Gwaji (misali, ƙamus din hotuna)</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
         <target xml:lang="ha" state="translated">(Gwaji) Nuna Wurin gudanarwa, Aikawa/Karba</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
         <target xml:lang="ha" state="translated">Yi amfani da Rumbun Surorori na yanar gizo don rage yin amfani da sashen ajiyar bayanai da ke da manyan surori.</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom is switching the default font for "{0}" to the new "Andika New Basic".</source>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate1</note>
         <target xml:lang="ha" state="translated">Bloom na juyar da tsarin da ya fito daga kamfani na haruffa "{0}" zuwa sabon "Andika New Basic".</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This will improve the printed output for most languages. If your language is one of the few that need "Andika", you can switch it back in Settings:Book Making.</source>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate2</note>
         <target xml:lang="ha" state="translated">Wannan zai inganta abubuwan da aka wallafa na yawancin harsuna. Idan harshenka na ɗaya daga cikin wasu harsunan da ke buƙatar "Andika", kana iya komawa baya a cikin wurin yin Saiti: Yin Littafi.</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
         <target xml:lang="ha" state="translated">Yin Littafi</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Branding">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Branding" approved="yes">
         <source xml:lang="en">Branding</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Branding</note>
         <target xml:lang="ha" state="needs-translation">Branding</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
         <target xml:lang="ha" state="translated">Harafn da kamfani ya tsaro ne {0}</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
         <target xml:lang="ha" state="translated">Ƙunshin Rubutaccen Aiki na Gaba/Baya</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver</note>
         <note>Name of a Front/Back Matter Pack that puts credits on the inside of the front cover</note>
         <target xml:lang="ha" state="translated">Mai ajiye Takarda</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional</note>
         <note>Name of the default Front/Back Matter Pack</note>
         <target xml:lang="ha" state="translated">Na'al'ada</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Arabic-Indic">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Arabic-Indic" approved="yes">
         <source xml:lang="en">Arabic-Indic</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Arabic-Indic</note>
         <target xml:lang="ha" state="needs-translation">Arabic-Indic</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Armenian">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Armenian" approved="yes">
         <source xml:lang="en">Armenian</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Armenian</note>
         <target xml:lang="ha" state="needs-translation">Armenian</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Bengali">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Bengali" approved="yes">
         <source xml:lang="en">Bengali</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Bengali</note>
         <target xml:lang="ha" state="needs-translation">Bengali</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Cambodian">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Cambodian" approved="yes">
         <source xml:lang="en">Cambodian</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Cambodian</note>
         <target xml:lang="ha" state="needs-translation">Cambodian</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Cjk-Decimal">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Cjk-Decimal" approved="yes">
         <source xml:lang="en">Cjk-Decimal</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Cjk-Decimal</note>
         <target xml:lang="ha" state="needs-translation">Cjk-Decimal</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Decimal">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Decimal" approved="yes">
         <source xml:lang="en">Decimal</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Decimal</note>
         <target xml:lang="ha" state="needs-translation">Decimal</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Devanagari">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Devanagari" approved="yes">
         <source xml:lang="en">Devanagari</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Devanagari</note>
         <target xml:lang="ha" state="needs-translation">Devanagari</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Georgian">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Georgian" approved="yes">
         <source xml:lang="en">Georgian</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Georgian</note>
         <target xml:lang="ha" state="needs-translation">Georgian</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Gujarati">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Gujarati" approved="yes">
         <source xml:lang="en">Gujarati</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Gujarati</note>
         <target xml:lang="ha" state="needs-translation">Gujarati</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Gurmukhi">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Gurmukhi" approved="yes">
         <source xml:lang="en">Gurmukhi</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Gurmukhi</note>
         <target xml:lang="ha" state="needs-translation">Gurmukhi</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Hebrew">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Hebrew" approved="yes">
         <source xml:lang="en">Hebrew</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Hebrew</note>
         <target xml:lang="ha" state="needs-translation">Hebrew</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Kannada">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Kannada" approved="yes">
         <source xml:lang="en">Kannada</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Kannada</note>
         <target xml:lang="ha" state="needs-translation">Kannada</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Khmer">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Khmer" approved="yes">
         <source xml:lang="en">Khmer</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Khmer</note>
         <target xml:lang="ha" state="needs-translation">Khmer</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Lao">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Lao" approved="yes">
         <source xml:lang="en">Lao</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Lao</note>
         <target xml:lang="ha" state="needs-translation">Lao</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Lower-Armenian">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Lower-Armenian" approved="yes">
         <source xml:lang="en">Lower-Armenian</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Lower-Armenian</note>
         <target xml:lang="ha" state="needs-translation">Lower-Armenian</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Malayalam">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Malayalam" approved="yes">
         <source xml:lang="en">Malayalam</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Malayalam</note>
         <target xml:lang="ha" state="needs-translation">Malayalam</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Mongolian">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Mongolian" approved="yes">
         <source xml:lang="en">Mongolian</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Mongolian</note>
         <target xml:lang="ha" state="needs-translation">Mongolian</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Myanmar">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Myanmar" approved="yes">
         <source xml:lang="en">Myanmar</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Myanmar</note>
         <target xml:lang="ha" state="needs-translation">Myanmar</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Oriya">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Oriya" approved="yes">
         <source xml:lang="en">Oriya</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Oriya</note>
         <target xml:lang="ha" state="needs-translation">Oriya</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.PageNumberingStyleLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.PageNumberingStyleLabel" approved="yes">
         <source xml:lang="en">Page Numbering Style</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.PageNumberingStyleLabel</note>
         <target xml:lang="ha" state="needs-translation">Page Numbering Style</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Persian">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Persian" approved="yes">
         <source xml:lang="en">Persian</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Persian</note>
         <target xml:lang="ha" state="needs-translation">Persian</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Tamil">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Tamil" approved="yes">
         <source xml:lang="en">Tamil</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Tamil</note>
         <target xml:lang="ha" state="needs-translation">Tamil</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Telugu">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Telugu" approved="yes">
         <source xml:lang="en">Telugu</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Telugu</note>
         <target xml:lang="ha" state="needs-translation">Telugu</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Thai">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Thai" approved="yes">
         <source xml:lang="en">Thai</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Thai</note>
         <target xml:lang="ha" state="needs-translation">Thai</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Tibetan">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Tibetan" approved="yes">
         <source xml:lang="en">Tibetan</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Tibetan</note>
         <target xml:lang="ha" state="needs-translation">Tibetan</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Upper-Armenian">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Upper-Armenian" approved="yes">
         <source xml:lang="en">Upper-Armenian</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Upper-Armenian</note>
         <target xml:lang="ha" state="needs-translation">Upper-Armenian</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
         <target xml:lang="ha" state="translated">Tsarin Rubutun Dama zuwa Hagu</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink" approved="yes">
         <source xml:lang="en">Special Script Settings</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink</note>
         <target xml:lang="ha" state="translated">Saitin Rubutu na Musamman</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
         <target xml:lang="ha" state="translated">Tsaruka...</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
         <target xml:lang="ha" state="translated">Canji...</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a vernacular collection, we say 'Vernacular Language', but in a source collection, Vernacular has no relevance, so we use this different label</note>
         <target xml:lang="ha" state="translated">Harshe 1</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a vernacular collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
         <target xml:lang="ha" state="translated">Harshe 2</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a vernacular collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
         <target xml:lang="ha" state="translated">Harshe 3</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
         <target xml:lang="ha" state="translated">Harsuna</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
         <target xml:lang="ha" state="translated">Cire</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
         <target xml:lang="ha" state="translated">Saita...</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Vernacular Language</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
         <target xml:lang="ha" state="translated">Yaren da ba turanci ba</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
         <target xml:lang="ha" state="translated">Harshe 2 (Misali Harshen Ƙasa)</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)  (Optional)</source>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
         <target xml:lang="ha" state="translated">Harshe 3 (Misali Harshen Lardi) (San kana so)</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
         <target xml:lang="ha" state="translated">Sunan Tarin Bayanan Bloom</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
         <target xml:lang="ha" state="translated">Ƙasa</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
         <target xml:lang="ha" state="translated">Gunduma</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
         <target xml:lang="ha" state="translated">Bayanin Aiki</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
         <target xml:lang="ha" state="translated">Lardi</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
         <target xml:lang="ha" state="translated">Kashe ka sake Kunnawa</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
         <target xml:lang="ha" state="translated">Bloom zai rufe ya kuma sake buɗe wannan aikin da sabon saiti.</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
         <target xml:lang="ha" state="translated">Ka yi Muhallin Maikaratu na manhajar Bloom...</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdminManagesUpdates">
+      <trans-unit id="CollectionTab.AdminManagesUpdates" approved="yes">
         <source xml:lang="en">Your system administrator manages Bloom updates for this computer.</source>
         <note>ID: CollectionTab.AdminManagesUpdates</note>
         <target xml:lang="ha" state="translated">Mai kula da na'urarka mai aiki da ƙwaƙwalwa yana sarrafa sabunta Bloom ga wannan na'urar.</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
         <target xml:lang="ha" state="translated">Na gaba</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Applying">
+      <trans-unit id="CollectionTab.Applying" approved="yes">
         <source xml:lang="en">Applying updates</source>
         <note>ID: CollectionTab.Applying</note>
         <target xml:lang="ha" state="translated">Saka sabuntawa</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
         <target xml:lang="ha" state="translated">Samu ƙarin littafai daga ɗakin karatun Bloom na yanar gizo a BloomLibrary.org</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
         <target xml:lang="ha" state="translated">Asalin Tari</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DuplicateBook">
+      <trans-unit id="CollectionTab.BookMenu.DuplicateBook" approved="yes">
         <source xml:lang="en">Duplicate Book</source>
         <note>ID: CollectionTab.BookMenu.DuplicateBook</note>
         <target xml:lang="ha" state="translated">Kwafe Littafi</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
         <target xml:lang="ha" state="translated">Share Littafi</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book. These programs normally don't do well with preserving the layout, so don't expect much.</source>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
         <target xml:lang="ha" state="translated">Yanzu Bloom zai buɗe wadannan takardun HTLM a cikin manhajar rubuta kalmominka (wanda ake kira Word ko LibreOffice). Za ka iya yin aiki da rubutu da hotunan wannan littafin. Akasari waɗannan manhajojin ba sukan yi aiki da kyau ba a wurin ajiye shimfiɗar littafi, don haka kar ka za ci abinda ya fi haka.</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
         <target xml:lang="ha" state="translated">Kai zuwa Word ko LibreOffice...</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
         <target xml:lang="ha" state="translated">Kai zuwa XML don yin Zayyana...</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.MakeBloomPack">
+      <trans-unit id="CollectionTab.BookMenu.MakeBloomPack" approved="yes">
         <source xml:lang="en">Make Bloom Pack...</source>
         <note>ID: CollectionTab.BookMenu.MakeBloomPack</note>
         <target xml:lang="ha" state="needs-translation">Make Bloom Pack...</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
         <target xml:lang="ha" state="translated">Sabunta bayanan Littafi</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
         <target xml:lang="ha" state="translated">Sabunta bayanan Siga</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <note>ID: CollectionTab.BookSourceHeading</note>
         <target xml:lang="ha" state="translated">Wurin da za a samu Sabbin Littafai</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
         <target xml:lang="ha" state="translated">An rufe wannan tarin bayanai, saboda haka ba a iya ƙara ko cire sabbin littafai.</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
         <target xml:lang="ha" state="translated">Litattafai daga ɗakin karatun yanar gizo na BloomLibrary.org</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
         <target xml:lang="ha" state="translated">Sake sabunta bayanan dukkan Litattafai</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
         <target xml:lang="ha" state="translated">Binciki Dukkan Litattafan</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
         <target xml:lang="ha" state="translated">Ceto hotunan da suka Ɓace...</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
         <target xml:lang="ha" state="translated">Tarihin Haɗawa...</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
         <target xml:lang="ha" state="translated">Bayanin abubuwan da aka tara...</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <note>ID: CollectionTab.CollectionTabLabel</note>
         <target xml:lang="ha" state="translated">Tarawa</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <note>ID: CollectionTab.Collections</note>
         <target xml:lang="ha" state="translated">Tarawa</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
         <target xml:lang="ha" state="translated">Gini...</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
         <target xml:lang="ha" state="translated">Littafin '{0}'</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
         <target xml:lang="ha" state="translated">Buɗe wurin ajiye bayani akan Faifai</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <note>ID: CollectionTab.EditBookButton</note>
         <target xml:lang="ha" state="translated">Yi gyare-gyare a wannan littafin</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <note>ID: CollectionTab.Health</note>
         <target xml:lang="ha" state="translated">Lafiya</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
         <target xml:lang="ha" state="translated">Saboda wannan asalin tari ne, Bloom ba ya bayar da kowace irin kumba a matsayin tushen sabuwar kumba.Idan kana son ƙara wani harshe ga wata kumba, kana buƙatar yin gyare-gyaren tarin bayanan da ke ƙunshe a kumba, ba yin kwafin sa ba.  Haka kuma, ba za a iya amfani da Kalandar Bango ba  a halin yanzu don yin wata sabuwar kumba.</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
         <target xml:lang="ha" state="translated">Yi Kundin Bloom</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
         <target xml:lang="ha" state="translated">Yi littafi ta hanyar amfani da wannan tushen</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_" approved="yes">
         <source xml:lang="en">Create a book in my language using this source book</source>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate_ToolTip_</note>
         <target xml:lang="ha" state="translated">Ƙirƙiro littafi a cikin harshena ta hanyar amfani da wannan littafin tushe</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
         <target xml:lang="ha" state="translated">Ƙari...</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
         <target xml:lang="ha" state="translated">Sauran Tarin Bayanai</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_" approved="yes">
         <source xml:lang="en">Open/Create/Get Collection</source>
         <note>ID: CollectionTab.Open/CreateCollectionButton_ToolTip_</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
         <target xml:lang="ha" state="translated">Buɗe/Ƙirƙira/Samu Tarin Bayanai</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem">
+      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem" approved="yes">
         <source xml:lang="en">Open or Create Another Collection</source>
         <note>ID: CollectionTab.OpenCreateCollectionMenuItem</note>
         <target xml:lang="ha" state="translated">Buɗe ko ka Ƙirƙiri Wani tarin bayanai</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <note>ID: CollectionTab.Sample Shells</note>
         <target xml:lang="ha" state="translated">Kumbunan Samfur</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <note>ID: CollectionTab.SendReceive</note>
         <target xml:lang="ha" state="translated">Aika/Karɓa</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <note>ID: CollectionTab.SettingsButton</note>
         <target xml:lang="ha" state="translated">Tsaruka</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <note>ID: CollectionTab.Source Collection</note>
         <target xml:lang="ha" state="translated">Asalin Tari</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
         <target xml:lang="ha" state="translated">Buɗe Karin Akwatin Tarin Bayanai</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
         <target xml:lang="ha" state="translated">Wurin da za a samu Sabbin Kumbuna</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <note>ID: CollectionTab.Templates</note>
         <target xml:lang="ha" state="translated">Muhalli</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.TitleMissing">
+      <trans-unit id="CollectionTab.TitleMissing" approved="yes">
         <source xml:lang="en">Title Missing</source>
         <note>ID: CollectionTab.TitleMissing</note>
         <note>Shown as the thumbnail caption when the book doesn't have a title.</note>
         <target xml:lang="ha" state="translated">Ɓacewar Suna</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.UnableToCheckForUpdate">
+      <trans-unit id="CollectionTab.UnableToCheckForUpdate" approved="yes">
         <source xml:lang="en">Could not connect to the server to check for an update. Are you connected to the internet?</source>
         <note>ID: CollectionTab.UnableToCheckForUpdate</note>
         <note>Shown when Bloom tries to check for an update but can't, for example because it can't connect to the internet, or a problems with our server, etc.</note>
         <target xml:lang="ha" state="translated">Ba a iya sada ka da yanar gizo don bincikawa ko akwai sabuntawa. Ko ka na haɗe da layin sadarwar yanar gizo?</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpToDate">
+      <trans-unit id="CollectionTab.UpToDate" approved="yes">
         <source xml:lang="en">Your Bloom is up to date.</source>
         <note>ID: CollectionTab.UpToDate</note>
         <target xml:lang="ha" state="translated">Bloom ɗinka baya buƙatar sabuntawa.</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateCheckInProgress">
+      <trans-unit id="CollectionTab.UpdateCheckInProgress" approved="yes">
         <source xml:lang="en">Bloom is already working on checking for updates.</source>
         <note>ID: CollectionTab.UpdateCheckInProgress</note>
         <target xml:lang="ha" state="translated">Bloom na kan aikin binciken sabunta bayanai.</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateFailed">
+      <trans-unit id="CollectionTab.UpdateFailed" approved="yes">
         <source xml:lang="en">A new version appears to be available, but Bloom could not install it.</source>
         <note>ID: CollectionTab.UpdateFailed</note>
         <target xml:lang="ha" state="translated">An nuna cewa akwai wata sabuwar manhaja, amma Bloom ba ya iya sa ta.</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateInstalled">
+      <trans-unit id="CollectionTab.UpdateInstalled" approved="yes">
         <source xml:lang="en">Update for {0} is ready.</source>
         <note>ID: CollectionTab.UpdateInstalled</note>
         <note>Appears after Bloom has downloaded a program update in the background and is ready to switch the user to it the next time they run Bloom.</note>
         <target xml:lang="ha" state="translated">Sabuntawa domin {0} ya shirya</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateNow">
+      <trans-unit id="CollectionTab.UpdateNow" approved="yes">
         <source xml:lang="en">Update Now</source>
         <note>ID: CollectionTab.UpdateNow</note>
         <target xml:lang="ha" state="translated">Sabunta Yanzu</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdatesAvailable">
+      <trans-unit id="CollectionTab.UpdatesAvailable" approved="yes">
         <source xml:lang="en">A new version of Bloom is available.</source>
         <note>ID: CollectionTab.UpdatesAvailable</note>
         <target xml:lang="ha" state="translated">Akwai sabuwar manhajar Bloom.</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Updating">
+      <trans-unit id="CollectionTab.Updating" approved="yes">
         <source xml:lang="en">Downloading update to {0} ({1}kb).</source>
         <note>ID: CollectionTab.Updating</note>
         <target xml:lang="ha" state="translated">Sauke Sabuntawa zuwa ga {0} ({1}kb)</target>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
         <target xml:lang="ha" state="translated">Baya</target>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <note>ID: Common.Cancel</note>
         <target xml:lang="ha" state="translated">Soke</target>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <note>ID: Common.CancelButton</note>
         <target xml:lang="ha" state="translated">&amp;Soke</target>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
         <target xml:lang="ha" state="translated">&amp;Ƙare</target>
       </trans-unit>
-      <trans-unit id="Common.Help" sil:dynamic="true">
+      <trans-unit id="Common.Help" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <note>ID: Common.Help</note>
         <target xml:lang="ha" state="needs-translation">Help</target>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <note>ID: Common.HelpButton</note>
         <target xml:lang="ha" state="translated">&amp;Taimako</target>
       </trans-unit>
-      <trans-unit id="Common.Loading" sil:dynamic="true">
+      <trans-unit id="Common.Loading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Loading...</source>
         <note>ID: Common.Loading</note>
         <note>This is shown when Bloom is slowly loading something, so the user doesn't worry about why they don't see the result immediately.</note>
         <target xml:lang="ha" state="translated">Saukewa...</target>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
         <target xml:lang="ha" state="translated">&amp;Gaba</target>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
         <target xml:lang="ha" state="translated">Gaba</target>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <note>ID: Common.OK</note>
         <target xml:lang="ha" state="translated">Ya yi</target>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <note>ID: Common.OKButton</note>
         <target xml:lang="ha" state="translated">&amp;Ya yi</target>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <note>ID: Common.Optional</note>
         <target xml:lang="ha" state="translated">Zaɓi</target>
       </trans-unit>
-      <trans-unit id="Common.SeeWebPage">
+      <trans-unit id="Common.SeeWebPage" approved="yes">
         <source xml:lang="en">See {0}.</source>
         <note>ID: Common.SeeWebPage</note>
         <note>Used to point the user to a web page. Put the '{0}' where the web page URL will go.</note>
         <target xml:lang="ha" state="needs-translation">See {0}.</target>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections.</source>
         <note>ID: Download.Completed</note>
         <target xml:lang="ha" state="translated">An kammala sauke maka {0}.Zaka iya ganin shi a cikin Littafai daga Ɗakin Karatun Blom na yanar gizo BloomLibrary.org a bangaren Tarin bayanai.</target>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <note>ID: Download.CompletedCaption</note>
         <target xml:lang="ha" state="translated">An kammala saukewa</target>
       </trans-unit>
-      <trans-unit id="Download.CopyFailed">
+      <trans-unit id="Download.CopyFailed" approved="yes">
         <source xml:lang="en">Bloom downloaded the book but had problems making it available in Bloom. Please restart your computer and try again. If you get this message again, please click the 'Details' button and report the problem to the Bloom developers.</source>
         <note>ID: Download.CopyFailed</note>
         <target xml:lang="ha" state="translated">Bloom ya sauke littafin amma ya haɗu da matsalar kawo shi a Bloom. Don Allah ka kashe na'urarka ka sake kunnata.Idan ka sake samun wannan saƙon, don Allah ka dangwala malatsin 'Details' ka aika da rahoton matsalar ga waɗanda suka gina Bloom</target>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <note>ID: Download.DownloadingDialogTitle</note>
         <target xml:lang="ha" state="translated">Sauke littafi</target>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <note>ID: Download.GenericNetworkProblemNotice</note>
         <target xml:lang="ha" state="translated">An samu wata matsala a lokacin saukar da littafinka</target>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <note>ID: Download.ProblemNotice</note>
         <target xml:lang="ha" state="translated">An samu wata matsalar a lokacin saukar da littafinka.Ka kashe da sake kunna Bloom ko kuma ka nemi taimakon ƙwararre.</target>
       </trans-unit>
-      <trans-unit id="Download.TimeoutProblemNotice">
+      <trans-unit id="Download.TimeoutProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading the book: something took too long. You can try again at a different time, or write to us at issues@BloomLibrary.org if you cannot get the download to work from your location.</source>
         <note>ID: Download.TimeoutProblemNotice</note>
         <target xml:lang="ha" state="translated">An sami wata matsala a wurin saukar da littafin: Wani abu ya ɗauki lokaci mai tsawo. Za ka iya sake jarraba yin hakan a wani lokaci na daban, ko ka rubuto mana zuwa ga issues@bloomlibrary.org idan ba ka iya samun saukarwa da zaka iya amfani da shi daga wurin da kake ba.</target>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddPageButton">
+      <trans-unit id="EditTab.AddPageDialog.AddPageButton" approved="yes">
         <source xml:lang="en">Add Page</source>
         <note>ID: EditTab.AddPageDialog.AddPageButton</note>
         <note>This is for the button that LAUNCHES the dialog, not the "Add this page" button that is IN the dialog.</note>
         <target xml:lang="ha" state="translated">Ƙarin Shafi</target>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add This Page</source>
         <note>ID: EditTab.AddPageDialog.AddThisPageButton</note>
         <note>This is for the button inside the dialog</note>
         <target xml:lang="ha" state="translated">Ƙara Wannan Shafin</target>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use This Layout</source>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutButton</note>
         <target xml:lang="ha" state="translated">Yi Amfani da Wannan Shimfidar</target>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Continue anyway</source>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutContinueCheckbox</note>
         <target xml:lang="ha" state="translated">Cigaba kawai</target>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose Different Layout...</source>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutTitle</note>
         <target xml:lang="ha" state="translated">Zabi wata shimfidar littafi ta daban...</target>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Converting to this layout will cause some content to be lost.</source>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutWillLoseData</note>
         <target xml:lang="ha" state="translated">Mayarwa zuwa wannan shimfidar zai iya sa a yi asarar wasu abubuwa .</target>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.NoTemplate" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.NoTemplate" sil:dynamic="true" approved="yes">
         <source xml:lang="en">(no template file found)</source>
         <note>ID: EditTab.AddPageDialog.NoTemplate</note>
         <note>Seen when the book's main template page file is missing.</note>
         <target xml:lang="ha" state="needs-translation">(no template file found)</target>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Page...</source>
         <note>ID: EditTab.AddPageDialog.Title</note>
         <target xml:lang="ha" state="translated">Ƙarin shafi...</target>
       </trans-unit>
-      <trans-unit id="EditTab.AddTextBoxToImage" sil:dynamic="true">
+      <trans-unit id="EditTab.AddTextBoxToImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Text Box To Image</source>
         <note>ID: EditTab.AddTextBoxToImage</note>
         <target xml:lang="ha" state="needs-translation">Add Text Box To Image</target>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
         <target xml:lang="ha" state="translated">Idan kana son ka sa ƙarin bayani game da littafin a wani wuri, kana iya amfani da wannan shafin, wanda yake a cikin marfin baya.</target>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
         <target xml:lang="ha" state="translated">Idan kana son ka sa ƙarin bayani game da littafin a wani wuri, kana iya amfani da wannan shafin, wanda yake a cikin marfin baya.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
         <target xml:lang="ha" state="translated">Harsuna biyu</target>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the HTML used to make this PDF, in Firefox (must be on path)</source>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
         <target xml:lang="ha" state="translated">Bude HTML ɗin da aka yi amfani da shi wurin wannan PDF, a cikin manhajar Firefox (dole ya kasance kan turba)</target>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <note>ID: EditTab.CannotChangeCopyright</note>
         <target xml:lang="ha" state="translated">Yi hanƙuri, haƙƙin mallaka da izinin wannan littafin ba su canzuwa.</target>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <note>ID: EditTab.CantPasteImageLocked</note>
         <target xml:lang="ha" state="translated">Yi hankuri, an kulle wannan littafin ta yadda ba za a iya canja surori ba.</target>
       </trans-unit>
-      <trans-unit id="EditTab.ChooseLayoutButton">
+      <trans-unit id="EditTab.ChooseLayoutButton" approved="yes">
         <source xml:lang="en">Choose Different Layout</source>
         <note>ID: EditTab.ChooseLayoutButton</note>
         <target xml:lang="ha" state="translated">Zaɓi wani tsarin littafi na daban</target>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
         <target xml:lang="ha" state="translated">Ka tabbata za ka share shafi?</target>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
         <target xml:lang="ha" state="translated">&amp;Share</target>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
         <target xml:lang="ha" state="translated">Za a cire wannan har abada.</target>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
         <target xml:lang="ha" state="translated">Saitin harsuna da yawa</target>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip">
+      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip" approved="yes">
         <source xml:lang="en">Choose language to make this a bilingual or trilingual book</source>
         <note>ID: EditTab.ContentLanguagesDropdown.ToolTip</note>
         <target xml:lang="ha" state="translated">Zaɓi harshe don mayar da wannan littafin a cikin harshe biyu ko uku</target>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <note>ID: EditTab.CopyButton</note>
         <target xml:lang="ha" state="translated">Kwafi</target>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTip">
+      <trans-unit id="EditTab.CopyButton.ToolTip" approved="yes">
         <source xml:lang="en">Copy (Ctrl+C)</source>
         <note>ID: EditTab.CopyButton.ToolTip</note>
         <target xml:lang="ha" state="translated">Kwafii (Ctrl+C)</target>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can copy it</source>
         <note>ID: EditTab.CopyButton.ToolTipWhenDisabled</note>
         <target xml:lang="ha" state="translated">Kana buƙatar zaɓen wani rubutu kafin ka yi kwafin shi</target>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
         <target xml:lang="ha" state="translated">A yi kwafin wannan bayanin kan dukkan hotunan da ke cikin wannan littafin?</target>
       </trans-unit>
-      <trans-unit id="EditTab.CopyPage">
+      <trans-unit id="EditTab.CopyPage" approved="yes">
         <source xml:lang="en">Copy Page</source>
         <note>ID: EditTab.CopyPage</note>
         <target xml:lang="ha" state="needs-translation">Copy Page</target>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <note>ID: EditTab.CustomPage.ChangeLayout</note>
         <target xml:lang="ha" state="translated">Canja tsarin shimfiƙar littafi</target>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> or </source>
         <note>ID: EditTab.CustomPage.Or</note>
         <note>Shown between 'Picture' and 'Text' when Custom Page is in Layout mode</note>
         <target xml:lang="ha" state="translated"> ko </target>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture</source>
         <note>ID: EditTab.CustomPage.Picture</note>
         <target xml:lang="ha" state="translated">Hoto</target>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <note>ID: EditTab.CustomPage.Text</note>
         <target xml:lang="ha" state="translated">Rubutu</target>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <note>ID: EditTab.CustomPage.TextBox</note>
         <target xml:lang="ha" state="translated">Akwatin Rubutu</target>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <note>ID: EditTab.CutButton</note>
         <target xml:lang="ha" state="translated">Yanke</target>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTip">
+      <trans-unit id="EditTab.CutButton.ToolTip" approved="yes">
         <source xml:lang="en">Cut (Ctrl+X)</source>
         <note>ID: EditTab.CutButton.ToolTip</note>
         <target xml:lang="ha" state="translated">Yanke (Ctrl+X)</target>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can cut it</source>
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
         <target xml:lang="ha" state="translated">Kana buƙatar zaɓen wani rubutu kafin ka yanke shi</target>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <note>ID: EditTab.DeletePageButton</note>
         <target xml:lang="ha" state="translated">Cire\n Shafix</target>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTip">
+      <trans-unit id="EditTab.DeletePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Remove this page from the book</source>
         <note>ID: EditTab.DeletePageButton.ToolTip</note>
         <target xml:lang="ha" state="translated">Cire wannan shafin daga cikin littafin</target>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be removed</source>
         <note>ID: EditTab.DeletePageButton.ToolTipWhenDisabled</note>
         <target xml:lang="ha" state="translated">Wannan shafin ba ya ciruwa</target>
       </trans-unit>
-      <trans-unit id="EditTab.DeleteTextBoxFromImage" sil:dynamic="true">
+      <trans-unit id="EditTab.DeleteTextBoxFromImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Delete Text Box From Image</source>
         <note>ID: EditTab.DeleteTextBoxFromImage</note>
         <target xml:lang="ha" state="needs-translation">Delete Text Box From Image</target>
       </trans-unit>
-      <trans-unit id="EditTab.DirectFormatting.Bold" sil:dynamic="true">
+      <trans-unit id="EditTab.DirectFormatting.Bold" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bold</source>
         <note>ID: EditTab.DirectFormatting.Bold</note>
         <note>This is for the 4-button panel that pops up when the user selects more than one character in a textbox.</note>
         <target xml:lang="ha" state="needs-translation">Bold</target>
       </trans-unit>
-      <trans-unit id="EditTab.DirectFormatting.Italic" sil:dynamic="true">
+      <trans-unit id="EditTab.DirectFormatting.Italic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Italic</source>
         <note>ID: EditTab.DirectFormatting.Italic</note>
         <note>This is for the 4-button panel that pops up when the user selects more than one character in a textbox.</note>
         <target xml:lang="ha" state="needs-translation">Italic</target>
       </trans-unit>
-      <trans-unit id="EditTab.DirectFormatting.Superscript" sil:dynamic="true">
+      <trans-unit id="EditTab.DirectFormatting.Superscript" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Superscript</source>
         <note>ID: EditTab.DirectFormatting.Superscript</note>
         <note>This is for the 4-button panel that pops up when the user selects more than one character in a textbox.</note>
         <target xml:lang="ha" state="needs-translation">Superscript</target>
       </trans-unit>
-      <trans-unit id="EditTab.DirectFormatting.Underline" sil:dynamic="true">
+      <trans-unit id="EditTab.DirectFormatting.Underline" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Underline</source>
         <note>ID: EditTab.DirectFormatting.Underline</note>
         <note>This is for the 4-button panel that pops up when the user selects more than one character in a textbox.</note>
         <target xml:lang="ha" state="needs-translation">Underline</target>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n  Page</source>
         <note>ID: EditTab.DuplicatePageButton</note>
         <target xml:lang="ha" state="translated">Maimata\n Shafi</target>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
         <note>ID: EditTab.DuplicatePageButton.ToolTip</note>
         <target xml:lang="ha" state="translated">Sa wani sabon shafi wanda ya ke maimaicin wannan ne</target>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be duplicated</source>
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
         <target xml:lang="ha" state="translated">Wannan shafin ba ya maimaituwa</target>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <note>ID: EditTab.Edit</note>
         <target xml:lang="ha" state="translated">Tace</target>
       </trans-unit>
-      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true">
+      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot change these because this is not the original copy.</source>
         <note>ID: EditTab.EditNotAllowed</note>
         <target xml:lang="ha" state="translated">Ba ka iya canja wannan saboda ba littafin asali ba ne.</target>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord" approved="yes">
         <source xml:lang="en">Sight Word</source>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord</note>
         <target xml:lang="ha" state="translated">Kalmomin da ake Gani</target>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable" approved="yes">
         <source xml:lang="en">This word is not decodable in this stage.</source>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable</note>
         <target xml:lang="ha" state="translated">Wannan kalmar ba karbau ba ce a wannan matakin.</target>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true">
+      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This sentence is too long for this level.</source>
         <note>ID: EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong</note>
         <target xml:lang="ha" state="translated">Wannan jimlar ta yi tsawo ga wannan matakin.</target>
       </trans-unit>
-      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true">
+      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This page is an experimental prototype which may have many problems, for which we apologize.</source>
         <note>ID: EditTab.ExperimentalNotice</note>
         <target xml:lang="ha" state="translated">Wannan shafin na gwaji ne wanda ka iya samun matsaloli da dama, kuma muna neman afuwa kan wannan.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <note>ID: EditTab.FontMissing</note>
         <target xml:lang="ha" state="translated">Girman harafin da aka zaɓa yanzu shine '{0}' amma ba a sa shi a ƙwaƙwalwar wannan na'ura mai aiki da ƙwaƙwalwa ba. Za a yi amfani da girman wasu harufa.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Alignment" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Alignment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alignment</source>
         <note>ID: EditTab.FormatDialog.Alignment</note>
         <target xml:lang="ha" state="needs-translation">Alignment</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true" approved="yes">
         <source xml:lang="en">That style already exists. Please choose another name.</source>
         <note>ID: EditTab.FormatDialog.AlreadyExists</note>
         <target xml:lang="ha" state="translated">Wannan tsarin da ma akwai shi. Don Allah ka zabi wani suna.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
         <target xml:lang="ha" state="translated">Canja iyaka da tsarin ciki</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
         <target xml:lang="ha" state="translated">Nuna Alamu</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <note>ID: EditTab.FormatDialog.Create</note>
         <target xml:lang="ha" state="translated">Ƙirƙira</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create a new style</source>
         <note>ID: EditTab.FormatDialog.CreateStyle</note>
         <target xml:lang="ha" state="translated">Ƙirƙiri wani sabon tsari</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Don't see what you need?</source>
         <note>ID: EditTab.FormatDialog.DontSeeNeed</note>
         <target xml:lang="ha" state="translated">Ba ka ganin abin da kake bukata?</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Emphasis</source>
         <note>ID: EditTab.FormatDialog.Emphasis</note>
         <target xml:lang="ha" state="translated">Jaddadawa</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <note>ID: EditTab.FormatDialog.Font</note>
         <target xml:lang="ha" state="translated">Girman Haruffa</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
         <target xml:lang="ha" state="translated">Canja fuskar girman harafi</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
         <target xml:lang="ha" state="translated">Chanjin yanayin girman rubutun ga dukan akwatuna da ke ɗauke da tsarin '{0}' da yare '{1}'.\nGirman rubutun yanzu shine {2}pt.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
         <target xml:lang="ha" state="translated">Canja yanayin girman rubutu</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Format</source>
         <note>ID: EditTab.FormatDialog.Format</note>
         <target xml:lang="ha" state="translated">Tsari</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Indent" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Indent" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Indent</source>
         <note>ID: EditTab.FormatDialog.Indent</note>
         <target xml:lang="ha" state="needs-translation">Indent</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
         <target xml:lang="ha" state="translated">Canja girman filin da ke tsakanin layukan rubutu</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New style</source>
         <note>ID: EditTab.FormatDialog.NewStyle</note>
         <target xml:lang="ha" state="translated">Sabon tsari</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.ParagraphSpacing">
+      <trans-unit id="EditTab.FormatDialog.ParagraphSpacing" approved="yes">
         <source xml:lang="en">Space Between Paragraphs</source>
         <note>ID: EditTab.FormatDialog.ParagraphSpacing</note>
         <target xml:lang="ha" state="needs-translation">Space Between Paragraphs</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.ParagraphTab">
+      <trans-unit id="EditTab.FormatDialog.ParagraphTab" approved="yes">
         <source xml:lang="en">Paragraph</source>
         <note>ID: EditTab.FormatDialog.ParagraphTab</note>
         <target xml:lang="ha" state="needs-translation">Paragraph</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please use only alphabetical characters. Numbers at the end are ok, as in "part2".</source>
         <note>ID: EditTab.FormatDialog.PleaseUseAlpha</note>
         <target xml:lang="ha" state="translated">Don Allah ka yi amfani da haruffa bakake kawai. Sa lambobi a ƙarshe ya yi daidai, kamar a cikin"kashi na 2".</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.ResetStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.ResetStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reset this style to default settings</source>
         <note>ID: EditTab.FormatDialog.ResetStyle</note>
         <target xml:lang="ha" state="needs-translation">Reset this style to default settings</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <note>ID: EditTab.FormatDialog.Spacing</note>
         <target xml:lang="ha" state="translated">Faɗaɗawa</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <note>ID: EditTab.FormatDialog.Style</note>
         <target xml:lang="ha" state="translated">Tsari</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
         <target xml:lang="ha" state="translated">Sunan Tsari</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
         <target xml:lang="ha" state="translated">Mafi Faɗi</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
         <target xml:lang="ha" state="translated">Daidai</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
         <target xml:lang="ha" state="translated">Canja girman filin da ke tsakanin kalmomi</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
         <target xml:lang="ha" state="translated">Faɗi</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <note>ID: EditTab.FormatDialogTip</note>
         <target xml:lang="ha" state="translated">Daidata shirin tsarawa</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <note>ID: EditTab.FrontMatter.AuthorIllustratorPrompt</note>
         <target xml:lang="ha" state="translated">Kana iya amfani da wannan filin don marubuci/mai zayyana, ko wani abu na daban.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
         <target xml:lang="ha" state="translated">A lokacin da kake yin littafin asali, ka yi amfani da wannan akwatin don ɗaukar gudunmawa da wasu marubuta suka bayar, masu zayyana da kuma masu tace bayanai da sauransu.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
         <target xml:lang="ha" state="translated">A lokacin da kake yin littafi daga cikin kumba, ka yi amfani da wannan akwatin ka faɗi wanda ya yi fassarar.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
         <target xml:lang="ha" state="translated">Taken Littafi a cikin {lang}</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CreditTranslator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CreditTranslator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Name of the translator, in {lang}</source>
         <note>ID: EditTab.FrontMatter.CreditTranslator</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
         <target xml:lang="ha" state="needs-translation">Name of the translator, in {lang}</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright &amp; License</source>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
         <target xml:lang="ha" state="translated">Dangwala ka yi gyara ga Haƙƙin Mallaka da Izini</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
         <target xml:lang="ha" state="translated">Ka yi amfani da wannan domin godiya ga duk wata gudunmawar kudi daga kungiyoyi.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
         <target xml:lang="ha" state="translated">Lambar Ingancin Littafi ta ƙasa da kasa. Kabar fili idan ba ka da ɗaya daga waɗannan.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.</source>
         <note>ID: EditTab.FrontMatter.InsideFrontCoverTextPrompt</note>
         <target xml:lang="ha" state="translated">Idan kana son ka sa ƙarin bayani game da littafin a wani wuri, kana iya amfani da wannan shafin, wanda yake a cikin marfin gaba.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ListSeparator">
+      <trans-unit id="EditTab.FrontMatter.ListSeparator" approved="yes">
         <source xml:lang="en">, </source>
         <note>ID: EditTab.FrontMatter.ListSeparator</note>
         <note>This is used to separate items in a list, such as 'Province, District, Country' on the Title Page. For English, that means comma followed by a space. Don't forget the space if your script uses them.</note>
         <target xml:lang="ha" state="needs-translation">, </target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Name of Translator, in {lang}</source>
         <note>ID: EditTab.FrontMatter.NameofTranslatorPrompt</note>
         <target xml:lang="ha" state="translated">Sunan Mai fassara, cikin {lang}</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
         <target xml:lang="ha" state="translated">Godiya (ko kumba) ta asali cikin {lang}</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
         <target xml:lang="ha" state="translated">Taimakon da marubuta, masu zayyana, masu gyaran rubutu da sauran su suka bayar cikin {lang}</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalHadNoCopyrightSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalHadNoCopyrightSentence" approved="yes">
         <source xml:lang="en">Adapted from original without a copyright notice.</source>
         <note>ID: EditTab.FrontMatter.OriginalHadNoCopyrightSentence</note>
         <note>On the Credits page of a book being translated, Bloom shows this if the original book did not have a copyright notice.</note>
         <target xml:lang="ha" state="needs-translation">Adapted from original without a copyright notice.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalLicenseSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalLicenseSentence" approved="yes">
         <source xml:lang="en">Licensed under {0}.</source>
         <note>ID: EditTab.FrontMatter.OriginalLicenseSentence</note>
         <note>On the Credits page of a book being translated, Bloom puts texts like 'Licensed under CC-BY', so that we have a record of what the license was for the original book. Put {0} in the translation, where the license should go in the sentence.</note>
         <target xml:lang="ha" state="needs-translation">Licensed under {0}.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalCopyrightSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalCopyrightSentence" approved="yes">
         <source xml:lang="en">Adapted from original, {0}.</source>
         <note>ID: EditTab.FrontMatter.OriginalCopyrightSentence</note>
         <note>On the Credits page of a book being translated, Bloom shows the original copyright. Put {0} in the translation where the copyright notice should go. For example in English, 'Adapted from original, {0}.' comes out like 'Adapted from original, Copyright 2011 SIL'.</note>
         <target xml:lang="ha" state="needs-translation">Adapted from original, {0}.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.PasteImageCreditsLink" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.PasteImageCreditsLink" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image Credits</source>
         <note>ID: EditTab.FrontMatter.PasteImageCreditsLink</note>
         <target xml:lang="ha" state="needs-translation">Paste Image Credits</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.PasteMissingCredits" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.PasteMissingCredits" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Missing credits:</source>
         <note>ID: EditTab.FrontMatter.PasteMissingCredits</note>
         <target xml:lang="ha" state="needs-translation">Missing credits:</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.SimpleLineDrawings" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.SimpleLineDrawings" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Simple line drawings look best. Instead of using this page, you can also make your own thumbnail.png file and set it to Read-only so Bloom doesn't write over it.</source>
         <note>ID: EditTab.FrontMatter.SimpleLineDrawings</note>
         <target xml:lang="ha" state="needs-translation">Simple line drawings look best. Instead of using this page, you can also make your own thumbnail.png file and set it to Read-only so Bloom doesn't write over it.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
         <target xml:lang="ha" state="translated">Dangwala don zaɓen darasi</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
         <target xml:lang="ha" state="translated">Godiya don fassarar da aka yi cikin {lang}</target>
       </trans-unit>
-      <trans-unit id="EditTab.HowToUnlockBook">
+      <trans-unit id="EditTab.HowToUnlockBook" approved="yes">
         <source xml:lang="en">To unlock this shellbook, go into the toolbox on the right, find the gear icon, and click 'Allow changes to this shellbook'.</source>
         <note>ID: EditTab.HowToUnlockBook</note>
         <target xml:lang="ha" state="translated">Don buɗe wannan littafin kumba, ka shiga akwati a hannunka na dama, ka duba alamar gear, sai ka dangwala 'Allow changes to this shellbook'.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <note>ID: EditTab.Image.ChangeImage</note>
         <target xml:lang="ha" state="translated">Canja Sura</target>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Copy Image</source>
         <note>ID: EditTab.Image.CopyImage</note>
         <target xml:lang="ha" state="translated">Yi Kofin Sura</target>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CopyImageFailed" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CopyImageFailed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom had problems using your computer's clipboard. Some other program may be interfering.</source>
         <note>ID: EditTab.Image.CopyImageFailed</note>
         <target xml:lang="ha" state="needs-translation">Bloom had problems using your computer's clipboard. Some other program may be interfering.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cut Image</source>
         <note>ID: EditTab.Image.CutImage</note>
         <target xml:lang="ha" state="translated">Yanke Sura</target>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, and License</source>
         <note>ID: EditTab.Image.EditMetadata</note>
         <target xml:lang="ha" state="translated">Gyara Ta'allaƙar Sura, Haƙƙin Mallaka da kuma Izini</target>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <note>ID: EditTab.Image.PasteImage</note>
         <target xml:lang="ha" state="translated">Shimfida Sura</target>
       </trans-unit>
-      <trans-unit id="EditTab.Image.TryRestart" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.TryRestart" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Try closing other programs and restart your computer if necessary.</source>
         <note>ID: EditTab.Image.TryRestart</note>
         <target xml:lang="ha" state="needs-translation">Try closing other programs and restart your computer if necessary.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Instructions.DeleteAllowed">
+      <trans-unit id="EditTab.Instructions.DeleteAllowed" approved="yes">
         <source xml:lang="en">Feel free to modify or delete this page.</source>
         <note>ID: EditTab.Instructions.DeleteAllowed</note>
         <target xml:lang="ha" state="needs-translation">Feel free to modify or delete this page.</target>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse">
+      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse" approved="yes">
         <source xml:lang="en">Cancel this import</source>
         <note>ID: EditTab.JpegWarningDialog.DoNotUse</note>
         <target xml:lang="ha" state="translated">Soke Ɗaukowa</target>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.Photograph">
+      <trans-unit id="EditTab.JpegWarningDialog.Photograph" approved="yes">
         <source xml:lang="en">Use the JPEG file</source>
         <note>ID: EditTab.JpegWarningDialog.Photograph</note>
         <target xml:lang="ha" state="translated">Yi amfani da Kundin Ajiya na JPEG</target>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WarningText">
+      <trans-unit id="EditTab.JpegWarningDialog.WarningText" approved="yes">
         <source xml:lang="en">The file you’ve chosen is a “JPEG” file. JPEG files are perfect for photographs and color artwork. However, JPEG files are a big problem for black and white line art. Problems include:\n• Fuzziness and grey dots.\n• Large file sizes, making the book hard to share.\n• If there are many large JPEGs, Bloom may not have enough memory to make PDF files.\n\nNote: Because JPEG is “lossy”, converting a JPEG to PNG, TIFF, or BMP actually makes things even worse. If this is black and white line art, you want to get an original scan in one of those formats.\n\nPlease select from one of the following, then click “OK”:</source>
         <note>ID: EditTab.JpegWarningDialog.WarningText</note>
         <target xml:lang="ha" state="translated">Kundin ajiyar da ka zaɓa na "JPEG" ne.Kundayen JPEG na da kyau a wurin aikin hotuna da fasahar sarrafa kaloli.Duk da haka, kundayen JPEG wata babbar matsala ce ga aikin fasahar layin baki da fari.Matsalolin sun haɗa da:\n • Dushi-dushi da ɗige ɗige ruwan toka.\n • Girman manyan kundaye, su sa littafin ya yi wahalar rarrabawa.\n• Idan akwai JPEG manya da yawa, me yiwuwa Bloom ba zai samu wurin yin kundayen PDF yalwatacce ba.\n\n Kula: Saboda JPEG mai "kabarniya" ne, mayar da JPEG ɗin zuwa PNG, TIFF ko BMP haƙiƙa na kara munana abubuwa Idan wannan aikin fasahar yin layi baki da fari ne, ka na son samun majarrabin asali na waɗancan tsarukan.\n\n  Don Allah ka zaɓa daga waɗannan abubuwan da ke biyowa, sannan ka dangwala "OK":</target>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle">
+      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle" approved="yes">
         <source xml:lang="en">JPEG Warning</source>
         <note>ID: EditTab.JpegWarningDialog.WindowTitle</note>
         <target xml:lang="ha" state="translated">Gargaɗin JPEG</target>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
         <target xml:lang="ha" state="translated">Ana iya samun wannan zaɓin a sashen Wallafa kawai.</target>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
         <target xml:lang="ha" state="translated">Canja tsarin shimfiɗar littafi</target>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
         <target xml:lang="ha" state="translated">Harshe Ɗaya</target>
       </trans-unit>
-      <trans-unit id="EditTab.NewBookName">
+      <trans-unit id="EditTab.NewBookName" approved="yes">
         <source xml:lang="en">Book</source>
         <note>ID: EditTab.NewBookName</note>
         <note>Default file and folder name when you make a new book, but haven't give it a title yet.</note>
         <target xml:lang="ha" state="translated">Littafi</target>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
         <target xml:lang="ha" state="translated">Kafin ka iya shimfiɗa wata sura, ka yi kofin ta a allon kofinka 'clipboard', daga wata manhaja.</target>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
         <target xml:lang="ha" state="translated">Babu wasu zaɓe-zaɓen tsarin shimfidar littafi ga wannan muhallin.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Overflow" sil:dynamic="true">
+      <trans-unit id="EditTab.Overflow" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This box has more text than will fit</source>
         <note>ID: EditTab.Overflow</note>
         <target xml:lang="ha" state="translated">Wannan akwatin na da rubutu fiye da yadda ya kamata ya ɗauka</target>
       </trans-unit>
-      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true">
+      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A container on this page is overflowing</source>
         <note>ID: EditTab.OverflowContainer</note>
         <note>This shows up in pages like the cover where sizing is very flexible. No one thing is too big, but not everything on the page will fit. To see it, put a lot of text on a cover page, until a red bar appears at the bottom; then hover over the bar. </note>
         <target xml:lang="ha" state="translated">Abinda ke ɗauke da abubuwa akan wannan shafin yana malala</target>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are.</source>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
         <target xml:lang="ha" state="translated">Ba a yarda da wancan canjin ba.Abinda ke ƙunshe a shafukan Gaba da na Baya dole ne sukasance a wurin da suke.</target>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
         <target xml:lang="ha" state="translated">Haramtaccen Motsi</target>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <note>ID: EditTab.PageList.Heading</note>
         <target xml:lang="ha" state="translated">Shafuka</target>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
         <target xml:lang="ha" state="translated">Ka zaɓi girman shafi da tsari</target>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <note>ID: EditTab.PasteButton</note>
         <target xml:lang="ha" state="translated">Shimfiɗa</target>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTip">
+      <trans-unit id="EditTab.PasteButton.ToolTip" approved="yes">
         <source xml:lang="en">Paste (Ctrl+V)</source>
         <note>ID: EditTab.PasteButton.ToolTip</note>
         <target xml:lang="ha" state="translated">Shimfida (Ctrl+V)</target>
       </trans-unit>
-      <trans-unit id="EditTab.PastePage">
+      <trans-unit id="EditTab.PastePage" approved="yes">
         <source xml:lang="en">Paste Page</source>
         <note>ID: EditTab.PastePage</note>
         <target xml:lang="ha" state="needs-translation">Paste Page</target>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing on the Clipboard that you can paste here.</source>
         <note>ID: EditTab.PasteButton.ToolTipWhenDisabled</note>
         <target xml:lang="ha" state="translated">Babu wani abu akan allon kwafi da zaka iya shimfidawa a nan.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Position" sil:dynamic="true">
+      <trans-unit id="EditTab.Position" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Position</source>
         <note>ID: EditTab.Position</note>
         <target xml:lang="ha" state="translated">Mataki</target>
       </trans-unit>
-      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true">
+      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot put anything in there while making an original book.</source>
         <note>ID: EditTab.ReadOnlyInAuthorMode</note>
         <target xml:lang="ha" state="translated">Ba ka iya sa komai a can ciki idan kana yin littafin asali.</target>
       </trans-unit>
-      <trans-unit id="EditTab.SavingNotification" sil:dynamic="true">
+      <trans-unit id="EditTab.SavingNotification" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Saving...</source>
         <note>ID: EditTab.SavingNotification</note>
         <target xml:lang="ha" state="needs-translation">Saving...</target>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <note>ID: EditTab.StyleEditor.BorderToolTip</note>
         <target xml:lang="ha" state="translated">Canja iyaka da tsarin ciki</target>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <note>ID: EditTab.StyleEditor.FontFaceToolTip</note>
         <target xml:lang="ha" state="translated">Canja fuskar girman harafi</target>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <note>ID: EditTab.StyleEditor.FontSizeToolTip</note>
         <target xml:lang="ha" state="translated">Canja yanayin girman rubutu</target>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <note>ID: EditTab.StyleEditor.LineSpacingToolTip</note>
         <target xml:lang="ha" state="translated">Canja girman filin da ke tsakanin layukan rubutu</target>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <note>ID: EditTab.StyleEditor.WordSpacingExtraWide</note>
         <target xml:lang="ha" state="translated">Mafi Faɗi</target>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <note>ID: EditTab.StyleEditor.WordSpacingNormal</note>
         <target xml:lang="ha" state="translated">Daidai</target>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <note>ID: EditTab.StyleEditor.WordSpacingToolTip</note>
         <target xml:lang="ha" state="translated">Canja girman filin da ke tsakanin layukan rubutu</target>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <note>ID: EditTab.StyleEditor.WordSpacingWide</note>
         <target xml:lang="ha" state="translated">Faɗi</target>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <note>ID: EditTab.StyleEditorTip</note>
         <target xml:lang="ha" state="translated">Daidata shirin tsarawa</target>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
         <target xml:lang="ha" state="translated">Shafukan Muhalli</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.HintBubbles">
+      <trans-unit id="EditTab.TextBoxProperties.HintBubbles" approved="yes">
         <source xml:lang="en">Hint Bubbles</source>
         <note>ID: EditTab.TextBoxProperties.HintBubbles</note>
         <note>This is the label of a tab in the text properties dialog that appears when you click a cog icon in a text box while changing the layout of a page</note>
         <target xml:lang="ha" state="needs-translation">Hint Bubbles</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.LanguageTab">
+      <trans-unit id="EditTab.TextBoxProperties.LanguageTab" approved="yes">
         <source xml:lang="en">Language</source>
         <note>ID: EditTab.TextBoxProperties.LanguageTab</note>
         <target xml:lang="ha" state="needs-translation">Language</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Alignment" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.Alignment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alignment</source>
         <note>ID: EditTab.TextBoxProperties.Alignment</note>
         <target xml:lang="ha" state="needs-translation">Alignment</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Background</source>
         <note>ID: EditTab.TextBoxProperties.Background</note>
         <target xml:lang="ha" state="translated">Adon ciki</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.BordersAndBackground" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.BordersAndBackground" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Borders &amp; Background</source>
         <note>ID: EditTab.TextBoxProperties.BordersAndBackground</note>
         <target xml:lang="ha" state="needs-translation">Borders &amp; Background</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.BorderSides" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.BorderSides" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Border Sides</source>
         <note>ID: EditTab.TextBoxProperties.BorderSides</note>
         <target xml:lang="ha" state="needs-translation">Border Sides</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.BorderStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.BorderStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Border Style</source>
         <note>ID: EditTab.TextBoxProperties.BorderStyle</note>
         <target xml:lang="ha" state="needs-translation">Border Style</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.IncludeLang">
+      <trans-unit id="EditTab.TextBoxProperties.IncludeLang" approved="yes">
         <source xml:lang="en">Include the name of the language using {lang}. For example: "Enter color in {lang}".</source>
         <note>ID: EditTab.TextBoxProperties.IncludeLang</note>
         <note>Becomes visible when "Show on each" option is chosen in combo. Do NOT translate {lang}.</note>
         <target xml:lang="ha" state="needs-translation">Include the name of the language using {lang}. For example: "Enter color in {lang}".</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.LocalLanguage">
+      <trans-unit id="EditTab.TextBoxProperties.LocalLanguage" approved="yes">
         <source xml:lang="en">Local Language</source>
         <note>ID: EditTab.TextBoxProperties.LocalLanguage</note>
         <target xml:lang="ha" state="needs-translation">Local Language</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.NationalLanguage">
+      <trans-unit id="EditTab.TextBoxProperties.NationalLanguage" approved="yes">
         <source xml:lang="en">National Language</source>
         <note>ID: EditTab.TextBoxProperties.NationalLanguage</note>
         <target xml:lang="ha" state="needs-translation">National Language</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Normal">
+      <trans-unit id="EditTab.TextBoxProperties.Normal" approved="yes">
         <source xml:lang="en">Normal</source>
         <note>ID: EditTab.TextBoxProperties.Normal</note>
         <target xml:lang="ha" state="needs-translation">Normal</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.NormalLabel">
+      <trans-unit id="EditTab.TextBoxProperties.NormalLabel" approved="yes">
         <source xml:lang="en">"Normal" will show local language, and potentially regional or national, depending on the multilingual settings of the book. Use this for most content.</source>
         <note>ID: EditTab.TextBoxProperties.NormalLabel</note>
         <target xml:lang="ha" state="needs-translation">"Normal" will show local language, and potentially regional or national, depending on the multilingual settings of the book. Use this for most content.</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.OtherLanguagesLabel">
+      <trans-unit id="EditTab.TextBoxProperties.OtherLanguagesLabel" approved="yes">
         <source xml:lang="en">Use one of these for simple text boxes that are always in only one language.</source>
         <note>ID: EditTab.TextBoxProperties.OtherLanguagesLabel</note>
         <target xml:lang="ha" state="needs-translation">Use one of these for simple text boxes that are always in only one language.</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.RegionalLanguage">
+      <trans-unit id="EditTab.TextBoxProperties.RegionalLanguage" approved="yes">
         <source xml:lang="en">Regional Language</source>
         <note>ID: EditTab.TextBoxProperties.RegionalLanguage</note>
         <target xml:lang="ha" state="needs-translation">Regional Language</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.WhatToPut">
+      <trans-unit id="EditTab.TextBoxProperties.WhatToPut" approved="yes">
         <source xml:lang="en">What should authors put in this box?</source>
         <note>ID: EditTab.TextBoxProperties.WhatToPut</note>
         <target xml:lang="ha" state="needs-translation">What should authors put in this box?</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.ShowHintBubble">
+      <trans-unit id="EditTab.TextBoxProperties.ShowHintBubble" approved="yes">
         <source xml:lang="en">Show the hint bubble</source>
         <note>ID: EditTab.TextBoxProperties.ShowHintBubble</note>
         <note>Label above pull-down menu with options, ShowOnGroup/ShowOnEach</note>
         <target xml:lang="ha" state="needs-translation">Show the hint bubble</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.ShowOnGroup">
+      <trans-unit id="EditTab.TextBoxProperties.ShowOnGroup" approved="yes">
         <source xml:lang="en">Just once on the whole group</source>
         <note>ID: EditTab.TextBoxProperties.ShowOnGroup</note>
         <target xml:lang="ha" state="needs-translation">Just once on the whole group</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.ShowOnEach">
+      <trans-unit id="EditTab.TextBoxProperties.ShowOnEach" approved="yes">
         <source xml:lang="en">On each language-field in the group</source>
         <note>ID: EditTab.TextBoxProperties.ShowOnEach</note>
         <target xml:lang="ha" state="needs-translation">On each language-field in the group</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Title">
+      <trans-unit id="EditTab.TextBoxProperties.Title" approved="yes">
         <source xml:lang="en">Text Box Properties</source>
         <note>ID: EditTab.TextBoxProperties.Title</note>
         <target xml:lang="ha" state="needs-translation">Text Box Properties</target>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.VerticalAlignment">
+      <trans-unit id="EditTab.TextBoxProperties.VerticalAlignment" approved="yes">
         <source xml:lang="en">Vertical Alignment</source>
         <note>ID: EditTab.TextBoxProperties.VerticalAlignment</note>
         <note>Label above the set of options, Top/Center/Bottom</note>
         <target xml:lang="ha" state="needs-translation">Vertical Alignment</target>
       </trans-unit>
-      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom">
+      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom" approved="yes">
         <source xml:lang="en">Picture On Bottom</source>
         <note>ID: EditTab.ThumbnailCaptions.Picture On Bottom</note>
         <target xml:lang="ha" state="translated">Hoto a Kasa</target>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
         <target xml:lang="ha" state="translated">Yi hoton Bayanin Mallakakkar fasaha</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
         <target xml:lang="ha" state="translated">Kayan aikin Mai karatu</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom can handle only the first {0} words.</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated</note>
         <target xml:lang="ha" state="translated">Bloom zai iya kula da kalmomin farko na {0}</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed words in this stage</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage</note>
         <target xml:lang="ha" state="translated">A bar kalmomi a cikin wannan matakin</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles" approved="yes">
         <source xml:lang="en">Text files</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles</note>
         <target xml:lang="ha" state="translated">Kundin matani</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters" approved="yes">
         <source xml:lang="en">Letters: {0}</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters</note>
         <target xml:lang="ha" state="translated">Haruffa: {0}</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage" approved="yes">
         <source xml:lang="en">The following is a generated report of the decodable stages for {0}. You can make any changes you want to this file, but Bloom will not notice your changes. It is just a report.</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage</note>
         <target xml:lang="ha" state="translated">Abin da ke biye rahoton da aka haɗa ne na matakan karɓau na {0}. Kana iya yin duk wani canjin da kake buƙata ga wannan kundin ajiye bayanan, amma Bloom ba zai kula da canje-canjenka ba. Rahoto ne kawai.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords" approved="yes">
         <source xml:lang="en">New Decodable Words: {0}</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords</note>
         <target xml:lang="ha" state="translated">Sabbin Kalmomin Karɓau: {0}</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords" approved="yes">
         <source xml:lang="en">New Sight Words: {0}</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords</note>
         <target xml:lang="ha" state="translated">Sabbin Kalmomin da ake gani</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage" approved="yes">
         <source xml:lang="en">Stage {0}</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage</note>
         <target xml:lang="ha" state="translated">Matakin {0}</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList" approved="yes">
         <source xml:lang="en">Complete Word List</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList</note>
         <target xml:lang="ha" state="translated">Cikakken jerin Kalma</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
         <target xml:lang="ha" state="translated">Haruffa a cikin wannan matakin</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
         <target xml:lang="ha" state="translated">Buɗe Kundin jerin Harafi da Kalma</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Generate a letter and word list report</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport</note>
         <target xml:lang="ha" state="translated">Tara wani rahoton jerin harafi da kalma</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample words in this stage</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage</note>
         <target xml:lang="ha" state="translated">Samfurin kalmomi a wannan matakin</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
         <target xml:lang="ha" state="translated">Matakan Saiti</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SortAlphabetically">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SortAlphabetically" approved="yes">
         <source xml:lang="en">Sort alphabetically</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SortAlphabetically</note>
         <target xml:lang="ha" state="needs-translation">Sort alphabetically</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SortByFrequency">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SortByFrequency" approved="yes">
         <source xml:lang="en">Sort by frequency</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SortByFrequency</note>
         <target xml:lang="ha" state="needs-translation">Sort by frequency</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SortByWordLength">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SortByWordLength" approved="yes">
         <source xml:lang="en">Sort by word length</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SortByWordLength</note>
         <target xml:lang="ha" state="needs-translation">Sort by word length</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
         <target xml:lang="ha" state="translated">Mataki</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
         <target xml:lang="ha" state="translated">na</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
         <target xml:lang="ha" state="translated">Kalmomi a wannan matakin</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
         <target xml:lang="ha" state="translated">Ayyanannen Kayan aikin Maikaratu</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
         <target xml:lang="ha" state="translated">Na haƙiƙa</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true" approved="yes">
         <source xml:lang="en">avg per sentence</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Average</note>
         <target xml:lang="ha" state="needs-translation">avg per sentence</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
         <target xml:lang="ha" state="translated">Zaɓen Darasi</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
         <target xml:lang="ha" state="translated">Don wannan matakin</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
         <target xml:lang="ha" state="translated">Tsara bayani</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
         <target xml:lang="ha" state="translated">Tallafin Zayyana</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
         <target xml:lang="ha" state="translated">Ajiye a zuci</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
         <note>Used to create string "Level # of #". The space after this word is added programmatically.</note>
         <target xml:lang="ha" state="translated">Mataki</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
         <note>Used to create string "Level # of #". The spaces on each side of this word are added programmatically.</note>
         <target xml:lang="ha" state="translated"> na </target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
         <target xml:lang="ha" state="translated">Na ƙarshe</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
         <target xml:lang="ha" state="translated">A shafi ɗaya</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerSentence</note>
         <target xml:lang="ha" state="needs-translation">longest sentence</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
         <target xml:lang="ha" state="translated">Hasashe</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
         <target xml:lang="ha" state="translated">Matakan da aka tsara</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
         <target xml:lang="ha" state="translated">Wannan Littafi</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
         <target xml:lang="ha" state="translated">Wannan Shafi</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
         <target xml:lang="ha" state="translated">Jimla</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
         <target xml:lang="ha" state="translated">wanda babu irinsa</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
         <target xml:lang="ha" state="translated">Baƙin kalmomi</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
         <target xml:lang="ha" state="translated">Ƙidayar Kalmomi</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <note>ID: EditTab.Toolbox.More</note>
         <target xml:lang="ha" state="translated">Ƙari...</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.IsTemplateBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.IsTemplateBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This is a template book.</source>
         <note>ID: EditTab.Toolbox.Settings.IsTemplateBook</note>
         <target xml:lang="ha" state="needs-translation">This is a template book.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.IsTemplateBookIntroductionText" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.IsTemplateBookIntroductionText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you click "Add Page", you can choose from pages contained in template books. To make this a template book, tick this checkbox.</source>
         <note>ID: EditTab.Toolbox.Settings.IsTemplateBookIntroductionText</note>
         <target xml:lang="ha" state="needs-translation">When you click "Add Page", you can choose from pages contained in template books. To make this a template book, tick this checkbox.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allow changes to this shellbook</source>
         <note>ID: EditTab.Toolbox.Settings.Unlock</note>
         <target xml:lang="ha" state="translated">Bar damar yin canje-canje a cikin gidan wannan littafin</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom normally prevents most changes to shellbooks. If you need to add pages, change images, etc., tick the box below.</source>
         <note>ID: EditTab.Toolbox.Settings.UnlockShellBookIntroductionText</note>
         <target xml:lang="ha" state="translated">Dama dai Bloom ya hana canje-canje a cikin gidan litattafai.Idan kana son Ƙara shafi ɗaya ko fiye, ko sanya wasu hotuna, da sauran su, sai ka sa alama a cikin akwatin da ke Ƙasa.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState" approved="yes">
         <source xml:lang="en">Bloom recording is in an unusual state, possibly caused by unplugging a microphone. You will need to restart.</source>
         <note>ID: EditTab.Toolbox.TalkingBook.BadState</note>
         <note>This is very low priority for translation.</note>
         <target xml:lang="ha" state="translated">Ɗaukar sautin Bloom na fuskantar matsala, mai yiwuwa wannan ya faru ne ta sanadiyyar cire bututun magana. Zaka buƙaci Ka kashe ka sake kunnawa.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput" approved="yes">
         <source xml:lang="en">No input device</source>
         <note>ID: EditTab.Toolbox.TalkingBook.NoInput</note>
         <target xml:lang="ha" state="translated">Babu abin haɗawa zuwa cikin na'ura</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic" approved="yes">
         <source xml:lang="en">This computer appears to have no sound recording device available. You will need one to record audio for a talking book.</source>
         <note>ID: EditTab.Toolbox.TalkingBook.NoMic</note>
         <target xml:lang="ha" state="translated">Da alama wannan na'ura mai aiki da ƙwaƙwalwa ba ta da kayan ɗaukar murya. Za ka buƙaci ɓuƙaci guda domin ɗaukar murya saboda littafi mai magana.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage" approved="yes">
         <source xml:lang="en">Please hold the button down until you have finished recording</source>
         <note>ID: EditTab.Toolbox.TalkingBook.PleaseHoldMessage</note>
         <note>Appears when the speak/record button is pressed very briefly</note>
         <target xml:lang="ha" state="translated">Idan ka yarda ka danna abin dannawa ƙasa har sai ka gama ɗaukar muryar</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Back</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Back</note>
         <target xml:lang="ha" state="translated">Baya</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4) Check</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Check</note>
         <target xml:lang="ha" state="translated">4) Bincika</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Check that you are recording into the correct device and that these levels are showing blue:</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.CheckSettings</note>
         <target xml:lang="ha" state="translated">1) Ka tabbatar da kana ɗaukar sauti a cikin na'urar da ta dace kuma waɗannan matakan suna nuna shuɗiyar kala:</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Clear</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Clear</note>
         <target xml:lang="ha" state="translated">Tangaram</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Talking Book Tool</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Heading</note>
         <target xml:lang="ha" state="translated">Kayan Litatafin Magana</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Listen to the whole page</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Listen</note>
         <target xml:lang="ha" state="translated">Saurari dukkan shafi</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Look at the highlighted sentence</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.LookAtSentence</note>
         <target xml:lang="ha" state="translated">2) Ka dubi jimlar da aka yi ma alama</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5) Next</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Next</note>
         <target xml:lang="ha" state="translated">5) Gaba</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3) Speak</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Speak</note>
         <target xml:lang="ha" state="translated">3) Yi magana</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an e-book that can play recordings while highlighting sentences.</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.ToolPurpose</note>
         <target xml:lang="ha" state="needs-translation">Make an e-book that can play recordings while highlighting sentences.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
         <target xml:lang="ha" state="translated">Jimla mafi tsawo</target>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
         <target xml:lang="ha" state="translated">Harsuna Uku</target>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <note>ID: EditTab.UndoButton</note>
         <target xml:lang="ha" state="translated">Cire</target>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTip">
+      <trans-unit id="EditTab.UndoButton.ToolTip" approved="yes">
         <source xml:lang="en">Undo (Ctrl+Z)</source>
         <note>ID: EditTab.UndoButton.ToolTip</note>
         <target xml:lang="ha" state="translated">Cire (Ctrl+Z)</target>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing to undo</source>
         <note>ID: EditTab.UndoButton.ToolTipWhenDisabled</note>
         <target xml:lang="ha" state="translated">Babu wani abun da za a cire</target>
       </trans-unit>
-      <trans-unit id="Errors.BookProblem">
+      <trans-unit id="Errors.BookProblem" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.</source>
         <note>ID: Errors.BookProblem</note>
         <target xml:lang="ha" state="translated">Bloom ya samu matsalar nuna wannan littafin.Wannan ba ya na nufin cewa ka rasa aikinka ba, amma yana nufin wani abu ya tsufa, ko ya ɓata, ko kuma ya samu matsala.</target>
       </trans-unit>
-      <trans-unit id="Errors.BrokenBook">
+      <trans-unit id="Errors.BrokenBook" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong. Consider using the 'Report a Problem' command under the 'Help' menu.</source>
         <note>ID: Errors.BrokenBook</note>
         <target xml:lang="ha" state="translated">Bloom ya samu matsalar nuna wannan littafin. Wannan ba ya na nufin cewa ka rasa aikinka ba, amma yana nufin wani abu ya tsufa, ko ya ɓata ko kuma ya samu matsala. Yi amfani da umurnin 'Kai Rahoton Matsala' a karkashin jerin 'Taimako'.</target>
       </trans-unit>
-      <trans-unit id="Errors.CannotAccessFile">
+      <trans-unit id="Errors.CannotAccessFile" approved="yes">
         <source xml:lang="en">Cannot access {0}</source>
         <note>ID: Errors.CannotAccessFile</note>
         <note>displays as a "toast", {0} is the URL/filename</note>
         <target xml:lang="ha" state="needs-translation">Cannot access {0}</target>
       </trans-unit>
-      <trans-unit id="Errors.CannotConnectToBloomServer">
+      <trans-unit id="Errors.CannotConnectToBloomServer" approved="yes">
         <source xml:lang="en">Bloom was unable to start its own HTTP listener that it uses to talk to its embedded Firefox browser. If this happens even if you just restarted your computer, ask someone to investigate if you have an aggressive firewall product installed. The agressive firewall product may need to be uninstalled before you can use Bloom.</source>
         <note>ID: Errors.CannotConnectToBloomServer</note>
         <target xml:lang="ha" state="translated">Bloom ya kasa kunna masaurarin HTTP da ta ke amfani da shi a wurin sadarwa da yanar gizon Firefox da ta ke amfani da shi.Idan wannan na faruwa ko da ka kashe kuma ka sake kunna na'urarka mai ƙwaƙwalwa, ka nemi wani ya bincika ko ka saka wata garkuwan kariya mai kai farmaki a cikin na'urarrka. Akwai bukatar cire garkuwan kariya mai kai farmaki daga cikin na'urarka kafin ka iya amfani da Bloom.</target>
       </trans-unit>
-      <trans-unit id="Errors.DeniedAccess">
+      <trans-unit id="Errors.DeniedAccess" approved="yes">
         <source xml:lang="en">Your computer denied Bloom access to the book. You may need technical help in setting the operating system permissions for this file.</source>
         <note>ID: Errors.DeniedAccess</note>
         <target xml:lang="ha" state="translated">Na'urarka mai aiki da ƙwaƙwalwa ta hana Bloom ya kai ga littafin. Kana buƙatar taimakon ƙwararre don saitin neman yardar na'urar don wannan kundin ajiye bayanan.</target>
       </trans-unit>
-      <trans-unit id="Errors.ErrorSelecting">
+      <trans-unit id="Errors.ErrorSelecting" approved="yes">
         <source xml:lang="en">There was a problem selecting the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <note>ID: Errors.ErrorSelecting</note>
         <target xml:lang="ha" state="translated">An sami matsala a wurin zaɓen littafin. Kashewa da sake kunna Bloom zai iya magance wannan matasalar.Idan bai yi ba, don Allah ka dangwala malatsin 'Details' ka aika da rahoton matsalar ga wadanda suka gina Bloom.</target>
       </trans-unit>
-      <trans-unit id="Errors.ErrorUpdating">
+      <trans-unit id="Errors.ErrorUpdating" approved="yes">
         <source xml:lang="en">There was a problem updating the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <note>ID: Errors.ErrorUpdating</note>
         <target xml:lang="ha" state="translated">An sami matsala a wurin sabunta bayanan littafin. Kashewa da sake kunna Bloom zai iya magance wannan matasalar.Idan bai yi ba, don Allah ka dangwala malatsin 'Details' ka aika da rahoton matsalar ga wadanda suka gina Bloom.</target>
       </trans-unit>
-      <trans-unit id="Errors.NeedNewerVersion">
+      <trans-unit id="Errors.NeedNewerVersion" approved="yes">
         <source xml:lang="en">{0} requires a newer version of Bloom. Download the latest version of Bloom from {1}.</source>
         <note>ID: Errors.NeedNewerVersion</note>
         <note>{0} will get the name of the book, {1} will give a link to open the Bloom Library Web page.</note>
         <target xml:lang="ha" state="translated">{0} na buƙatar sabon Bloom. Ka sauke sabon Bloom daga {1}</target>
       </trans-unit>
-      <trans-unit id="Errors.ProblemDeletingFile">
+      <trans-unit id="Errors.ProblemDeletingFile" approved="yes">
         <source xml:lang="en">Bloom had a problem deleting this file: {0}</source>
         <note>ID: Errors.ProblemDeletingFile</note>
         <target xml:lang="ha" state="translated">Bloom ya samu matsalar share wannan kundin: {0}</target>
       </trans-unit>
-      <trans-unit id="Errors.ProblemImportingPicture">
+      <trans-unit id="Errors.ProblemImportingPicture" approved="yes">
         <source xml:lang="en">Bloom had a problem importing this picture.</source>
         <note>ID: Errors.ProblemImportingPicture</note>
         <target xml:lang="ha" state="translated">Bloom ya samu matsalar kawo wannan hoton.</target>
       </trans-unit>
-      <trans-unit id="Errors.ReportThisProblemButton">
+      <trans-unit id="Errors.ReportThisProblemButton" approved="yes">
         <source xml:lang="en">Report this problem to Bloom Support</source>
         <note>ID: Errors.ReportThisProblemButton</note>
         <target xml:lang="ha" state="translated">Kai rahoton wannan matsalar a wurin Agajin Bloom</target>
       </trans-unit>
-      <trans-unit id="Errors.SomethingWentWrong">
+      <trans-unit id="Errors.SomethingWentWrong" approved="yes">
         <source xml:lang="en">Sorry, something went wrong.</source>
         <note>ID: Errors.SomethingWentWrong</note>
         <target xml:lang="ha" state="translated">Yi hakuri, an ɗan sami matsala.</target>
       </trans-unit>
-      <trans-unit id="Errors.SpecifiedXMatterNotFound">
+      <trans-unit id="Errors.SpecifiedXMatterNotFound" approved="yes">
         <source xml:lang="en">This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a Bloom Pack that will give you '{0}', or change the book's Front/Back Matter pack setting.</source>
         <note>ID: Errors.SpecifiedXMatterNotFound</note>
         <target xml:lang="ha" state="needs-translation">This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a Bloom Pack that will give you '{0}', or change the book's Front/Back Matter pack setting.</target>
       </trans-unit>
-      <trans-unit id="Errors.XMatterNotFound">
+      <trans-unit id="Errors.XMatterNotFound" approved="yes">
         <source xml:lang="en">This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a Bloom Pack that will give you '{0}', or go to Settings:Book Making and change to another Front/Back Matter Pack.</source>
         <note>ID: Errors.XMatterNotFound</note>
         <target xml:lang="ha" state="translated">Wannan Littafin ya nemi Makunshin Aikin Rubutun Gaba/Baya mai suna '{0}'. amma Bloom ya kasa samun shi a wannan na'ura mai aiki da ƙwaƙwalwa. Ko dai ka sa Makunshin Bloom a na'urarka wanda zai baka '{0}', ko kuma ka je wurin saitin:Yin Littafi ka canja zuwa wani Makunshin Aikin Rubutu na Gaba/Baya.</target>
       </trans-unit>
-      <trans-unit id="Errors.XMatterProblemLabel">
+      <trans-unit id="Errors.XMatterProblemLabel" approved="yes">
         <source xml:lang="en">Front/Back Matter Problem</source>
         <note>ID: Errors.XMatterProblemLabel</note>
         <note>This shows in the 'toast' that pops up to notify the user of a non-fatal problem.</note>
         <target xml:lang="ha" state="needs-translation">Front/Back Matter Problem</target>
       </trans-unit>
-      <trans-unit id="Errors.XMatterSpecifiedByBookNotFound">
+      <trans-unit id="Errors.XMatterSpecifiedByBookNotFound" approved="yes">
         <source xml:lang="en">This book called for a Front/Back Matter pack named '{0}', but this version of Bloom does not have it, and Bloom could not find it on this computer. The book has been changed to use the Front/Back Matter pages from the Collection Settings.</source>
         <note>ID: Errors.XMatterSpecifiedByBookNotFound</note>
         <target xml:lang="ha" state="needs-translation">This book called for a Front/Back Matter pack named '{0}', but this version of Bloom does not have it, and Bloom could not find it on this computer. The book has been changed to use the Front/Back Matter pages from the Collection Settings.</target>
       </trans-unit>
-      <trans-unit id="Errors.ZoneAlarm">
+      <trans-unit id="Errors.ZoneAlarm" approved="yes">
         <source xml:lang="en">Bloom cannot start properly, and this symptom has been observed on machines with ZoneAlarm installed. Note: disabling ZoneAlarm does not help. Nor does restarting with it turned off. Something about the installation of ZoneAlarm causes the problem, and so far only uninstalling ZoneAlarm has been shown to fix the problem.</source>
         <note>ID: Errors.ZoneAlarm</note>
         <target xml:lang="ha" state="translated">Bloom ba ya kunnawa yadda ya kamata, kuma wannan alamar an shaida ta a na'urori da aka sa ma ZoneAlarm.Kula: Hana ZoneAlarm ba zai taimaka ba.Haka ma kashewa da sake kunnata. Wani abu game da saka ZoneAlarm na haddasa matsaloli, don haka cire shi daga na'urarka mai aiki da ƙwaƙwalwa ne kawai aka nuna zai magance matsalar.</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
         <target xml:lang="ha" state="translated">Ginin Muhallan Mai karatu</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
         <target xml:lang="ha" state="translated">Bincika don samun sabuwar manhaja</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <note>ID: HelpMenu.CreditsMenuItem</note>
         <target xml:lang="ha" state="translated">Game da Bloom</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
         <target xml:lang="ha" state="translated">Tara bayanai</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <note>ID: HelpMenu.Help Menu</note>
         <target xml:lang="ha" state="translated">Taimako</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Get Help</source>
         <note>ID: HelpMenu.Help Menu_ToolTip_</note>
         <target xml:lang="ha" state="translated">Samu Taimako</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem">
+      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem" approved="yes">
         <source xml:lang="en">Key Bloom Concepts</source>
         <note>ID: HelpMenu.KeyBloomConceptsToolStripMenuItem</note>
         <target xml:lang="ha" state="translated">Manyan Hikimomin Bloom</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.AskAQuestionMenuItem">
+      <trans-unit id="HelpMenu.AskAQuestionMenuItem" approved="yes">
         <source xml:lang="en">Ask a Question (web)</source>
         <note>ID: HelpMenu.AskAQuestionMenuItem</note>
         <target xml:lang="ha" state="needs-translation">Ask a Question (web)</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Request a Feature (web)</source>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
         <target xml:lang="ha" state="translated">Bayar da shawara</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
         <target xml:lang="ha" state="translated">Rijista</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
         <target xml:lang="ha" state="translated">Bayanan fitarwa</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem">
+      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem" approved="yes">
         <source xml:lang="en">Report a Problem...</source>
         <note>ID: HelpMenu.ReportAProblemToolStripMenuItem</note>
         <target xml:lang="ha" state="translated">Kai Rahoton Matsala</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
         <target xml:lang="ha" state="translated">Nuna Jerin Ayyuka</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
         <target xml:lang="ha" state="translated">Amfani da Muhallan Mai karatu </target>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
         <target xml:lang="ha" state="translated">Dandalin yanar gizo</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.trainingVideos">
+      <trans-unit id="HelpMenu.trainingVideos" approved="yes">
         <source xml:lang="en">Training Videos</source>
         <note>ID: HelpMenu.trainingVideos</note>
         <target xml:lang="ha" state="translated">Hoton bidiyo na Koyarwa</target>
       </trans-unit>
-      <trans-unit id="InstallProblem.BloomPdfMaker">
+      <trans-unit id="InstallProblem.BloomPdfMaker" approved="yes">
         <source xml:lang="en">A component of Bloom, BloomPdfMaker.exe, seems to be missing. This prevents previews and printing. Antivirus software sometimes does this. You may need technical help to repair the Bloom installation and protect this file from being deleted again.</source>
         <note>ID: InstallProblem.BloomPdfMaker</note>
         <target xml:lang="ha" state="translated">Wani ɓangaren Bloom mai suna BloompdfMaker.exe, ga alama ya ɓata. Wannan na hana kallon aikin da akayi da kuma wallafawa. Manhajar garkuwa mafi yawancin lokaci yana aikata hakan.Kana iya neman taimakon ƙwararre don gyara sa Bloom da kuma kare wannan kundin bayanai daga ƙara sharewa.</target>
       </trans-unit>
-      <trans-unit id="LameEncoder.Progress">
+      <trans-unit id="LameEncoder.Progress" approved="yes">
         <source xml:lang="en">Converting to mp3</source>
         <note>ID: LameEncoder.Progress</note>
         <note>Appears in progress indicator</note>
         <target xml:lang="ha" state="translated">Mayarwa zuwa sautin mp3</target>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.RightToLeftCheck">
+      <trans-unit id="LanguageFontDetails.RightToLeftCheck" approved="yes">
         <source xml:lang="en">This script is right to left</source>
         <note>ID: LanguageFontDetails.RightToLeftCheck</note>
         <target xml:lang="ha" state="translated">Wannan rubutun an yi shi ne da tsarin rubutun dama zuwa hagu</target>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.TallerLinesCheck">
+      <trans-unit id="LanguageFontDetails.TallerLinesCheck" approved="yes">
         <source xml:lang="en">This script requires taller lines</source>
         <note>ID: LanguageFontDetails.TallerLinesCheck</note>
         <target xml:lang="ha" state="translated">Wannan rubutun na buƙatar dogayen layuka</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A3Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A3Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A3Landscape</source>
         <note>ID: LayoutChoices.A3Landscape</note>
         <target xml:lang="ha" state="needs-translation">A3Landscape</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <note>ID: LayoutChoices.A4Landscape</note>
         <target xml:lang="ha" state="translated">Faɗin A4</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
         <target xml:lang="ha" state="translated">Faɗin A4 gefe da gefe</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
         <target xml:lang="ha" state="translated">Faɗin A4  da raba shafuka</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <note>ID: LayoutChoices.A4Portrait</note>
         <target xml:lang="ha" state="translated">Tsawon A4</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <note>ID: LayoutChoices.A5Landscape</note>
         <target xml:lang="ha" state="translated">Faɗin A5</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <note>ID: LayoutChoices.A5Portrait</note>
         <target xml:lang="ha" state="translated">Tsawon A5</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
         <target xml:lang="ha" state="translated">Tsawon A5 Layin ƙasa</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Landscape</source>
         <note>ID: LayoutChoices.A6Landscape</note>
         <target xml:lang="ha" state="translated">Faɗin A6</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Portrait</source>
         <note>ID: LayoutChoices.A6Portrait</note>
         <target xml:lang="ha" state="translated">Tsawon A6</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <note>ID: LayoutChoices.B5Portrait</note>
         <target xml:lang="ha" state="translated">Tsawon B5</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.Device16x9Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.Device16x9Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Device16x9Landscape</source>
         <note>ID: LayoutChoices.Device16x9Landscape</note>
         <target xml:lang="ha" state="needs-translation">Device16x9Landscape</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.Device16x9Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.Device16x9Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Device16x9Portrait</source>
         <note>ID: LayoutChoices.Device16x9Portrait</note>
         <target xml:lang="ha" state="needs-translation">Device16x9Portrait</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">HalfLetterPortrait</source>
         <note>ID: LayoutChoices.HalfLetterPortrait</note>
         <target xml:lang="ha" state="translated">Tsawon Rabin Wasiƙa</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterLandscape</source>
         <note>ID: LayoutChoices.LetterLandscape</note>
         <target xml:lang="ha" state="translated">Faɗin Wasiƙa</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterPortrait</source>
         <note>ID: LayoutChoices.LetterPortrait</note>
         <target xml:lang="ha" state="translated">Tsawon Wasiƙa</target>
       </trans-unit>
-      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">QuarterLetterLandscape</source>
         <note>ID: LayoutChoices.QuarterLetterLandscape</note>
         <target xml:lang="ha" state="translated">Faɗin Kashi ɗaya bisa huɗu na Wasiƙa</target>
       </trans-unit>
-      <trans-unit id="LicenseDialog.WindowTitle">
+      <trans-unit id="LicenseDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom {0}</source>
         <note>ID: LicenseDialog.WindowTitle</note>
         <target xml:lang="ha" state="needs-translation">Bloom {0}</target>
       </trans-unit>
-      <trans-unit id="LicenseDialog._acceptButton">
+      <trans-unit id="LicenseDialog._acceptButton" approved="yes">
         <source xml:lang="en">I accept the terms of the license agreement</source>
         <note>ID: LicenseDialog._acceptButton</note>
         <target xml:lang="ha" state="translated">Na yarda da sharuɗɗan yarjejeniyar izini</target>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <note>ID: LoginDialog.AgreeToTerms</note>
         <target xml:lang="ha" state="translated">Na yarda da sharuɗɗan amfani da Ɗakin karatu na Bloom Library</target>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <note>ID: LoginDialog.Email</note>
         <target xml:lang="ha" state="translated">Adireshin Wasikar Yanar Gizo</target>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <note>ID: LoginDialog.ForgotPassword</note>
         <target xml:lang="ha" state="translated">Na manta kalmar izinin shiga</target>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <note>ID: LoginDialog.LoginButton</note>
         <target xml:lang="ha" state="translated">Shiga</target>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <note>ID: LoginDialog.Password</note>
         <target xml:lang="ha" state="translated">Kalmar Iznin Shiga</target>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <note>ID: LoginDialog.ShowPassword</note>
         <target xml:lang="ha" state="translated">Kuma a Nuna Kalmar neman Izinin Shiga</target>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <note>ID: LoginDialog.ShowTerms</note>
         <target xml:lang="ha" state="translated">Nuna sharuɗɗan amfani</target>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <note>ID: LoginDialog.WindowTitle</note>
         <target xml:lang="ha" state="translated">Ka shiga zauren yanar gizo na ɗakin karatu na BloomLibrary.org</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
         <target xml:lang="ha" state="translated">Akwai wani tarin bayanan da ke da wannan sunan, a &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\n Don Allah ka ɗauki sunan da babu irinsa.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
         <target xml:lang="ha" state="translated">Ka zaɓi jigon harshe don wannan tarin bayanai</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
         <target xml:lang="ha" state="translated">Misali: "Littafan lafiya", 'PNG Labaran Dabbobi"</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
         <target xml:lang="ha" state="translated">Me kake buƙatar kiran wannan tarin bayanai?</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
         <target xml:lang="ha" state="translated">Matsalar Sunan Tarin Bayanai</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
         <target xml:lang="ha" state="translated">Za a ƙirƙiri tarin bayanai a: {0}</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <note>ID: NewCollectionWizard.FinishPage</note>
         <target xml:lang="ha" state="translated">An shirya Ƙirƙirar Sabon Tarin Bayanai</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPageContent">
+      <trans-unit id="NewCollectionWizard.FinishPageContent" approved="yes">
         <source xml:lang="en">OK, that's all we need to get started with your new '{0}' collection.\nClick on the 'Finish' button.</source>
         <note>ID: NewCollectionWizard.FinishPageContent</note>
         <note>{0} is the name of the new collection</note>
         <target xml:lang="ha" state="needs-translation">OK, that's all we need to get started with your new '{0}' collection.\nClick on the 'Finish' button.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FontAndScriptPage">
+      <trans-unit id="NewCollectionWizard.FontAndScriptPage" approved="yes">
         <source xml:lang="en">Font and Script</source>
         <note>ID: NewCollectionWizard.FontAndScriptPage</note>
         <target xml:lang="ha" state="translated">Girman Harafi da rubutu</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
         <target xml:lang="ha" state="translated">Zaɓi irin tarin bayanai</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions" approved="yes">
         <source xml:lang="en">If you already have a collection you want to open, click  the 'Cancel' button.</source>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions</note>
         <target xml:lang="ha" state="translated">Idan kana da wani tarin bayanan da kake son ka buɗe, dangwala malatsin 'Soke'.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
         <target xml:lang="ha" state="translated">Asalin Tari</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org. You may also make a Bloom Pack to give to others so that they can make vernacular books with your shells.</source>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
         <target xml:lang="ha" state="translated">Tarin bayanan kumba ko littafan muhalli a cikin harshe ɗaya ko fiye na gamammiyar sadarwa. Za ka iya ɗora wadannan kumbunan ɗakin karatun Bloom na yanar gizo zuwa BloomLibrary.org.Kuma kana iya yin Ƙunshin Bloom ka ba wasu don su rubuta littafai a cikin wasu harsuna da kumbunan littafanka.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Vernacular/Local Language Collection</source>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
         <target xml:lang="ha" state="translated">Wani Harshe/Tarin Bayanan Harshen Gida</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
         <target xml:lang="ha" state="translated">Tarin Littafa a cikin harshen gida.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <note>ID: NewCollectionWizard.LocationPage</note>
         <target xml:lang="ha" state="translated">Ka ba Harshe Wuri</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
         <target xml:lang="ha" state="translated">Ƙasa</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
         <target xml:lang="ha" state="translated">Gunduma</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
         <target xml:lang="ha" state="translated">Waɗannan zaɓi ne.Bloom zai ajiye su wuraren da ya dace akan shafin taken littafan da ka ƙirƙira.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
         <target xml:lang="ha" state="translated">Lardi</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
         <target xml:lang="ha" state="translated">Littafai {0}</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
         <target xml:lang="ha" state="translated">Ƙirƙiri Wani Sabon Tarin Bayanan Bloom</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <note>ID: NewCollectionWizard.ProjectName</note>
         <target xml:lang="ha" state="translated">Sunan Aiki</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
         <target xml:lang="ha" state="translated">An kasa ƙirƙiro wani sabon tarin bayanai ta hanyar amfani da wancan sunan.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <note>ID: NewCollectionWizard.WelcomePage</note>
         <target xml:lang="ha" state="translated">Barka da shigowa Bloom!</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
         <target xml:lang="ha" state="translated">Ka kusa fara yin littafai.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. The first thing we need to do is make one for you.</source>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
         <target xml:lang="ha" state="translated">Don ka aje abu cikin sauƙi kuma a shirye, Bloom zai aje dukkan littafan da ka yi a cikin ɗaya ko fiye na &lt;i&gt;Tarin Bayanai&lt;/i&gt;. Abinda mu ke son mu yi shine mu yi maka ɗaya.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
         <target xml:lang="ha" state="translated">Dangwala 'Gaba' don farawa.</target>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InDropboxMessage">
+      <trans-unit id="OpenCreateCloneControl.InDropboxMessage" approved="yes">
         <source xml:lang="en">Bloom detected that this collection is located in your Dropbox folder. This can cause problems as Dropbox sometimes locks Bloom out of its own files. If you have problems, we recommend that you move your collection somewhere else or disable Dropbox while using Bloom.</source>
         <note>ID: OpenCreateCloneControl.InDropboxMessage</note>
         <target xml:lang="ha" state="translated">Bloom ya gano wannan tarin bayanai na cikin Akwatin Ajiyarka na DropBox a yanar gizo. Wannan na iya haddasa matsaloli saboda akwatin ajiyar Dropbox na yanar gizo a wasu lokuta da dama yakan rufe Bloom daga kundayen bayanansa. Idan kana da matsaloli, muna baka shawarar ka tura tarin bayananka zuwa wani wuri ko kuma ka rufe akwatin ajiyar Dropbox a lokacin da kake amfani da Bloom.</target>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage">
+      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage" approved="yes">
         <source xml:lang="en">This collection is part of your 'Sources for new books' which you can see in the bottom left of the Collections tab. It cannot be opened for editing.</source>
         <note>ID: OpenCreateCloneControl.InSourceCollectionMessage</note>
         <target xml:lang="ha" state="translated">Wannan tarin bayanan wnai ɓangare ne na 'Tushen sabbin littafai' waɗanda za ka iya gani daga ƙasa ɓangaren hagu na madannin Tari. Ba a iya buɗe ta don tace bayanai.</target>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
         <target xml:lang="ha" state="translated">Tarin Bayanan Bloom</target>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
         <target xml:lang="ha" state="translated">Bincika don samun wani tarin bayanai a cikin wannan na'ura mai ƙwaƙwalwa</target>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
         <target xml:lang="ha" state="translated">Yi kwafi daga Chorus Hup akan Sadarwar da ke Tsakanin Na'urori masu aiki da ƙwaƙwalwa</target>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
         <target xml:lang="ha" state="translated">Yi kwafi daga yanar gizo</target>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
         <target xml:lang="ha" state="translated">Yi kwafi daga na'urar USB</target>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
         <target xml:lang="ha" state="translated">Ƙirƙiri Wani Sabon Tarin Bayanan</target>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
         <target xml:lang="ha" state="translated">Buɗe/Ƙirƙiri Tarin Bayanai</target>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
         <target xml:lang="ha" state="translated">Karanta da yawa</target>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
         <target xml:lang="ha" state="translated">Ko wani ya taɓa amfani da Aika/Karɓa don raba tarin bayanai tare da kai?\n Yi amfani da ɗaya daga waɗannan jajayen abin latsawar don kwafe tarin bayanansu a cikin na'urarka mai aiki da ƙwaƙwalwa.\n Daga ƙarshe, yi amani da aika/karɓa don rarraba aikinka da su.</target>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.UILanguageMenu_ToolTip_">
+      <trans-unit id="OpenCreateNewCollectionsDialog.UILanguageMenu_ToolTip_" approved="yes">
         <source xml:lang="en">Change user interface language</source>
         <note>ID: OpenCreateNewCollectionsDialog.UILanguageMenu_ToolTip_</note>
         <target xml:lang="ha" state="needs-translation">Change user interface language</target>
       </trans-unit>
-      <trans-unit id="PageList.CantMoveWhenTranslating">
+      <trans-unit id="PageList.CantMoveWhenTranslating" approved="yes">
         <source xml:lang="en">Pages can not be re-ordered when you are translating a book.</source>
         <note>ID: PageList.CantMoveWhenTranslating</note>
         <target xml:lang="ha" state="translated">Ba a iya sake tsarin shafuka a lokacin da kake fassara littatfi.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeEulaTitle">
+      <trans-unit id="PublishTab.AdobeEulaTitle" approved="yes">
         <source xml:lang="en">Adobe Color Profile License Agreement</source>
         <note>ID: PublishTab.AdobeEulaTitle</note>
         <note>dialog title for license agreement</note>
         <target xml:lang="ha" state="needs-translation">Adobe Color Profile License Agreement</target>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
         <target xml:lang="ha" state="translated">Don Allah ka sa manhajar Adobe saboda Bloom ya iya nuna littafinka da ka kammala.Kafin sannan, za ka iya aje Littafin da aka yi a PDF ka kuma buɗe shi a cikin wata manhajar.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
         <target xml:lang="ha" state="translated">Wannan sabon abu ne...Manhajar buɗe aikin da aka yi a Adobe ta bayar da matsala a lokacin da aka yi ƙoƙarin nuna wancan PDF ɗin.Har yanzu za ka iya ƙoƙarin jarraba Littafin PDF ɗin.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
         <target xml:lang="ha" state="translated">Mugun Labari. Bloom ya kasa samun manhajar Adobe da za ya nuna anan, saboda haka Bloom ba ya iya nuna littafinka da ka kammala.\n Don Allah ka cire manhajar 'Adobe Reader' sannan ka sake sa manhajar 'Adobe Reader' din.\n Kafin ka gyara wannan matsalar,  har yanzu za ka iya aje Littafin PDF ka kuma buɗe shi a cikin wata manhajar.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <note>ID: PublishTab.BodyOnlyRadio</note>
         <target xml:lang="ha" state="translated">Cikin Ɗan Ƙaramin Littafi</target>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book. Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
         <target xml:lang="ha" state="translated">Yi ɗan karamin littafi daga cikin shafukan littafin.Za a shimfida shafuka a sake tsara su saboda idan ka lankwasa su za ka samu dan karamin littafi.\n</target>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
         <target xml:lang="ha" state="translated">Ɗora</target>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
         <target xml:lang="ha" state="translated">Ɗora akan ɗakin karatun yanar gizon BloomLibrary.org, inda wurin da sauran mutane za su iya saukarwa kuma su mayar da shi a cikin harshensu.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <note>ID: PublishTab.CoverOnlyRadio</note>
         <target xml:lang="ha" state="translated">Murfin Ɗan Ƙaramin Littafi</target>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
         <target xml:lang="ha" state="translated">Yi PDF na gaba da baya kawai (kowane ɓangare), don ka iya wallafawa akan takarda mai kala.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubButton">
+      <trans-unit id="PublishTab.EpubButton" approved="yes">
         <source xml:lang="en">ePUB</source>
         <note>ID: PublishTab.EpubButton</note>
         <target xml:lang="ha" state="needs-translation">ePUB</target>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an ePUB (electronic book) out of this book, allowing it to be read on various electronic reading devices.</source>
         <note>ID: PublishTab.EpubRadio-tooltip</note>
         <target xml:lang="ha" state="needs-translation">Make an ePUB (electronic book) out of this book, allowing it to be read on various electronic reading devices.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
         <target xml:lang="ha" state="translated">Kar a Ƙara nuna wannan.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
         <target xml:lang="ha" state="translated">Bayanin Zayyanar InDesign XML</target>
       </trans-unit>
-      <trans-unit id="PublishTab.LessMemoryPdfMode">
+      <trans-unit id="PublishTab.LessMemoryPdfMode" approved="yes">
         <source xml:lang="en">Use less memory (slower)</source>
         <note>ID: PublishTab.LessMemoryPdfMode</note>
         <note>The parenthesized word indicates the negative effect of using this option. This text is for a menu item.</note>
         <target xml:lang="ha" state="needs-translation">Use less memory (slower)</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation">
+      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation" approved="yes">
         <source xml:lang="en">This PDF viewer can be improved by installing the free Adobe Reader on this computer.</source>
         <note>ID: PublishTab.Notifications.AdobeReaderRecommendation</note>
         <target xml:lang="ha" state="translated">Ana iya inganta wannan mahangin PDF ta hanyar sa manhajar Adobe Reader ta kyauta a cikin wannan na'urar</target>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
         <target xml:lang="ha" state="translated">A sauƙaƙe</target>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
         <target xml:lang="ha" state="translated">Ka yi PDF na kowane shafin littafin, shafi ɗaya a kowace takarda.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Options">
+      <trans-unit id="PublishTab.Options" approved="yes">
         <source xml:lang="en">Options</source>
         <note>ID: PublishTab.Options</note>
         <note>menu header in the Publish tab</note>
         <target xml:lang="ha" state="needs-translation">Options</target>
       </trans-unit>
-      <trans-unit id="PublishTab.OptionsMenu.SizeLayout">
+      <trans-unit id="PublishTab.OptionsMenu.SizeLayout" approved="yes">
         <source xml:lang="en">Size/Layout</source>
         <note>ID: PublishTab.OptionsMenu.SizeLayout</note>
         <note>Header for a region of the menu which lists various standard page layout sizes</note>
         <target xml:lang="ha" state="needs-translation">Size/Layout</target>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system PDF viewer</source>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
         <target xml:lang="ha" state="translated">Ka buɗe PDF a cikin tsarin madubin PDF na asali</target>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
         <target xml:lang="ha" state="translated">Maye gurbin Wanda ake da shi</target>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
         <target xml:lang="ha" state="translated">Sanarwa</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.BadPdf">
+      <trans-unit id="PublishTab.PdfMaker.BadPdf" approved="yes">
         <source xml:lang="en">Bloom had a problem making a PDF of this book. You may need technical help or to contact the developers. But here are some things you can try:</source>
         <note>ID: PublishTab.PdfMaker.BadPdf</note>
         <target xml:lang="ha" state="translated">Bloom ya samu matsala a wurin yin PDF na wannan littafin.Me yiwuwa kana buƙatar taimakon ƙwararei ko ka tuntuɓi waɗanda su ka yi manhajar.Amma ga waɗansu abubuwan da za ka jarraba yi:</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.Compress">
+      <trans-unit id="PublishTab.PdfMaker.Compress" approved="yes">
         <source xml:lang="en">Compressing PDF</source>
         <note>ID: PublishTab.PdfMaker.Compress</note>
         <note>Message displayed in a progress report dialog box</note>
         <target xml:lang="ha" state="needs-translation">Compressing PDF</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.CompressConvertColor">
+      <trans-unit id="PublishTab.PdfMaker.CompressConvertColor" approved="yes">
         <source xml:lang="en">Compressing PDF &amp; Converting Color to CMYK</source>
         <note>ID: PublishTab.PdfMaker.CompressConvertColor</note>
         <note>Message displayed in a progress report dialog box</note>
         <target xml:lang="ha" state="needs-translation">Compressing PDF &amp; Converting Color to CMYK</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.Creating">
+      <trans-unit id="PublishTab.PdfMaker.Creating" approved="yes">
         <source xml:lang="en">Creating PDF ...</source>
         <note>ID: PublishTab.PdfMaker.Creating</note>
         <note>Message displayed in a progress report dialog box</note>
         <target xml:lang="ha" state="needs-translation">Creating PDF ...</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.DesktopPrinting">
+      <trans-unit id="PublishTab.PdfMaker.DesktopPrinting" approved="yes">
         <source xml:lang="en">PDF for Desktop Printing</source>
         <note>ID: PublishTab.PdfMaker.DesktopPrinting</note>
         <note>displayed as file type for Save File dialog.  Don't use vertical bar (|) in this string!</note>
         <target xml:lang="ha" state="needs-translation">PDF for Desktop Printing</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.ErrorProcessing">
+      <trans-unit id="PublishTab.PdfMaker.ErrorProcessing" approved="yes">
         <source xml:lang="en">Error creating, compressing, or recoloring the PDF file</source>
         <note>ID: PublishTab.PdfMaker.ErrorProcessing</note>
         <note>Message briefly displayed to the user in a toast</note>
         <target xml:lang="ha" state="needs-translation">Error creating, compressing, or recoloring the PDF file</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.Finished">
+      <trans-unit id="PublishTab.PdfMaker.Finished" approved="yes">
         <source xml:lang="en">Finished making PDF from HTML</source>
         <note>ID: PublishTab.PdfMaker.Finished</note>
         <note>Message displayed in a progress report dialog box</note>
         <target xml:lang="ha" state="needs-translation">Finished making PDF from HTML</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.MakingFromHtml">
+      <trans-unit id="PublishTab.PdfMaker.MakingFromHtml" approved="yes">
         <source xml:lang="en">Making PDF from HTML</source>
         <note>ID: PublishTab.PdfMaker.MakingFromHtml</note>
         <note>Message displayed in a progress report dialog box, a partial step of "Creating PDF"</note>
         <target xml:lang="ha" state="needs-translation">Making PDF from HTML</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.MakingPageOfPdf">
+      <trans-unit id="PublishTab.PdfMaker.MakingPageOfPdf" approved="yes">
         <source xml:lang="en">Making Page {0} of the PDF</source>
         <note>ID: PublishTab.PdfMaker.MakingPageOfPdf</note>
         <note>Message displayed in a progress report dialog box, {0} is replaced by the page number</note>
         <target xml:lang="ha" state="needs-translation">Making Page {0} of the PDF</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.Printshop">
+      <trans-unit id="PublishTab.PdfMaker.Printshop" approved="yes">
         <source xml:lang="en">PDF for Printshop (CMYK - U.S. Web Coated (SWOP) v2)</source>
         <note>ID: PublishTab.PdfMaker.Printshop</note>
         <note>displayed as file type for Save File dialog, the content in parentheses may not be translatable.  Don't use vertical bar (|) in this string!</note>
         <target xml:lang="ha" state="needs-translation">PDF for Printshop (CMYK - U.S. Web Coated (SWOP) v2)</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory">
+      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory" approved="yes">
         <source xml:lang="en">Try doing this on a computer with more memory</source>
         <note>ID: PublishTab.PdfMaker.TryMoreMemory</note>
         <target xml:lang="ha" state="translated">Ka yi ƙoƙarin yin wannan a cikin na'ura mai aiki da ƙwaƙwalwar da ta ke da isasshen wurin aje bayanai</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryRestart">
+      <trans-unit id="PublishTab.PdfMaker.TryRestart" approved="yes">
         <source xml:lang="en">Restart your computer and try this again right away</source>
         <note>ID: PublishTab.PdfMaker.TryRestart</note>
         <target xml:lang="ha" state="translated">Ka kashe da sake kunna na'urarka a wannan lokacin</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages">
+      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages" approved="yes">
         <source xml:lang="en">Replace large, high-resolution images in your document with lower-resolution ones</source>
         <note>ID: PublishTab.PdfMaker.TrySmallerImages</note>
         <target xml:lang="ha" state="translated">Ka maye gurbin manya da surorin da ke karau-karau a cikin abuwanda kake da su a na'urarka da wadanda ba su kai su zama karau-karau ba</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfNotSaved">
+      <trans-unit id="PublishTab.PdfNotSaved" approved="yes">
         <source xml:lang="en">PDF Not Saved</source>
         <note>ID: PublishTab.PdfNotSaved</note>
         <note>title for the message box</note>
         <target xml:lang="ha" state="needs-translation">PDF Not Saved</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfNotSavedWhy">
+      <trans-unit id="PublishTab.PdfNotSavedWhy" approved="yes">
         <source xml:lang="en">The PDF file has not been saved because you chose not to allow producing a "PDF for Printshop".</source>
         <note>ID: PublishTab.PdfNotSavedWhy</note>
         <note>explanation that file was not saved displayed in a message box</note>
         <target xml:lang="ha" state="needs-translation">The PDF file has not been saved because you chose not to allow producing a "PDF for Printshop".</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <note>ID: PublishTab.PrintButton</note>
         <target xml:lang="ha" state="translated">&amp;Wallafa...</target>
       </trans-unit>
-      <trans-unit id="PublishTab.PrologToAdobeEula">
+      <trans-unit id="PublishTab.PrologToAdobeEula" approved="yes">
         <source xml:lang="en">Bloom uses Adobe color profiles to convert PDF files from using RGB color to using CMYK color.  This is part of preparing a "PDF for Printshop".  You must agree to the following license in order to perform this task in Bloom.</source>
         <note>ID: PublishTab.PrologToAdobeEula</note>
         <note>Brief explanation of what this license is and why the user needs to agree to it</note>
         <target xml:lang="ha" state="needs-translation">Bloom uses Adobe color profiles to convert PDF files from using RGB color to using CMYK color.  This is part of preparing a "PDF for Printshop".  You must agree to the following license in order to perform this task in Bloom.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <note>ID: PublishTab.Publish</note>
         <target xml:lang="ha" state="translated">Ɗababa'a</target>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <note>ID: PublishTab.SaveButton</note>
         <target xml:lang="ha" state="translated">&amp;Aje PDF...</target>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveEpub">
+      <trans-unit id="PublishTab.SaveEpub" approved="yes">
         <source xml:lang="en">&amp;Save ePUB...</source>
         <note>ID: PublishTab.SaveEpub</note>
         <target xml:lang="ha" state="translated">&amp;Aje ePUB...</target>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <note>ID: PublishTab.ShowCropMarks</note>
         <target xml:lang="ha" state="translated">Alamun Yanka</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
         <target xml:lang="ha" state="translated">Godiya</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">Additional Requests: </source>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
         <target xml:lang="ha" state="translated">Ƙarin Roƙo: </target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <note>ID: PublishTab.Upload.AllReserved</note>
         <target xml:lang="ha" state="translated">Ba a yarda a yi aiki da wannan ba tare da izini ba  (Tuntubi Mai haƙƙin Mallaka don neman izini.)</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <note>ID: PublishTab.Upload.CcLink</note>
         <target xml:lang="ha" state="needs-translation">CC-BY-NC</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you. If you upload it again, it will be replaced with your current version.</source>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
         <target xml:lang="ha" state="translated">Dama can ɗakin Karatun yanar gizo na BloomLibrary.org na da wannan littafin domin kai. Idan ka sake ɗora shi, zai maye gurbn wanda ke akwai.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <note>ID: PublishTab.Upload.Copyright</note>
         <target xml:lang="ha" state="translated">Haƙƙin Mallaka</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <note>ID: PublishTab.Upload.Credits</note>
         <target xml:lang="ha" state="translated">ta'allaƙawa</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
         <target xml:lang="ha" state="translated">Yi haƙuri, an sami matsala a wurin ɗora {0}. Wasu bayanai za su biyo. Kana iya neman taimakon ƙwararre</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading.</source>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
         <target xml:lang="ha" state="translated">Fili ɗaya ko fiye da hakan na neman kulawarka kafin ɗorawa</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded. Sometimes this is caused by temporary problems with the servers we use. It's worth trying again in an hour or two. If you regularly get this problem please report it to us.</source>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
         <target xml:lang="ha" state="translated">Yi haƙuri, ba a yi nasarar ɗora "{0}" ba</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes.</source>
         <note>ID: PublishTab.Upload.Gaurantee</note>
         <target xml:lang="ha" state="translated">Ta hanyar ɗorawa, ka tabbatar da amincewarka da sharuɗɗan Ɗakin karatun Bloom kuma ka bayar da damar da ya bayyana</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
         <target xml:lang="ha" state="translated">An sami wata matsala a lokacin ɗora littafinka.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GiveBack">
+      <trans-unit id="PublishTab.Upload.GiveBack" approved="yes">
         <source xml:lang="en">It’s easy to “give back”</source>
         <note>ID: PublishTab.Upload.GiveBack</note>
         <target xml:lang="ha" state="needs-translation">It’s easy to “give back”</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.IncompleteTranslation">
+      <trans-unit id="PublishTab.Upload.IncompleteTranslation" approved="yes">
         <source xml:lang="en">(incomplete translation)</source>
         <note>ID: PublishTab.Upload.IncompleteTranslation</note>
         <note>This is added after the language name, in order to indicate that some parts of the book have not been translated into this language yet.</note>
         <target xml:lang="ha" state="translated">(rabi da rabi)</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <note>ID: PublishTab.Upload.Languages</note>
         <target xml:lang="ha" state="translated">Harsuna</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <note>ID: PublishTab.Upload.License</note>
         <target xml:lang="ha" state="translated">Izinin/Amfani</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
         <target xml:lang="ha" state="translated">Akwai irin wannan Asusun</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address. Would you like to log in instead?</source>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
         <target xml:lang="ha" state="translated">Ba mu iya buɗa maka hanya da wannan adireshin, saboda muna da wani asusu da irin wannan adireshin.Ko za ka so ka dai shiga ɗin?</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
         <target xml:lang="ha" state="translated">Bloom ba ya shiga rumbun yanar gizo don tantance shigar da kake son yi.Don Allah ka binciki haɗin sadawar yanar gizonka.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
         <target xml:lang="ha" state="translated">Ba a yi nasarar shiga ba</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
         <target xml:lang="ha" state="translated">Bloom ya kasa haɗuwa da rubun sadarwa na yanar gizo don kammala shigarka ko yin rijistar shigarka.Wannan na iya kasancewa matsala ce daga layin sadawarka na yanar gizo, ko rumbun sadarwar yanar gizonmu ko kuma wasu kayan aikin da ke tsakani.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
         <target xml:lang="ha" state="translated">Don yin rijistar shiga ɗakin karatu na yanar gizo (BloomLibrary.org), dole ne ka bincika akwatin da ke nuna cewa ka yarda da sharuɗɗan amfani da ɗakin karatun Bloom na yanar gizo.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
         <target xml:lang="ha" state="translated">Ana buƙatar Adireshin wasiƙar Yanar gizo</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
         <target xml:lang="ha" state="translated">Ba mu da bayanin wani mai amfani da ke da irin wannan adireshin wasikar yanar gizo.Ko kana buƙatar yin rijistar shiga?</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
         <target xml:lang="ha" state="translated">Kalmar Izinin shiga da Shaidar mai amfani ba su zo daidai ba</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
         <target xml:lang="ha" state="translated">Don Allah ka amince da sharuɗɗan amfani</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
         <target xml:lang="ha" state="translated">Don Allah ka sa adireshin wasiƙar yanar gizo mai aiki.Za mu aika maka da wasiƙar yanar gizo zuwa wannan adireshin, don ka sake saitin kalmar izinni shigarka.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
         <target xml:lang="ha" state="translated">Bloom ya kasa haɗuwa da rumbun sadarwa na yanar gizo don sake saitin kalmar neman izinin shigarka.Don Allah ka binciki haɗin sadarwar yanar gizonka.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
         <target xml:lang="ha" state="translated">Ba a yi nasarar sake saitin kalmar neman izinin shigarka ba</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
         <target xml:lang="ha" state="translated">Ana sake saitin kalmar neman izin shiga</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password.</source>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
         <target xml:lang="ha" state="translated">Muna kan aikawa da wasiƙar yanar gizo zuwa ga {0} da ka'idoji kan yadda za ka sake saitin kalmar neman izinin shigarka</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <note>ID: PublishTab.Upload.Login.Signup</note>
         <target xml:lang="ha" state="translated">Yi ristar shiga Dakin karatun Bloom.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Template">
+      <trans-unit id="PublishTab.Upload.Template" approved="yes">
         <source xml:lang="en">This book seems to be a template, that is, it contains blank pages for authoring a new book rather than content to translate into other languages. If that is not what you intended, you should get expert help before uploading this book.
 
 Do you want to go ahead?</source>
@@ -2944,1188 +2944,1188 @@ Do you want to go ahead?</source>
 
 Do you want to go ahead?</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
         <target xml:lang="ha" state="translated">Ba a san wannan mai amfanin ba</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <note>ID: PublishTab.Upload.LoginFailure</note>
         <target xml:lang="ha" state="translated">Bloom ya kasa buɗe ɗakin karatun yanar gizon Bloom (BloomLibrary.org) ta hanyar amfani da bayananka da ka bayar. Don Allah ka binciki haɗin sadawar yanar gizonka.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <note>ID: PublishTab.Upload.LoginLink</note>
         <target xml:lang="ha" state="translated">Ka shiga zauren karatu na BloomLibrary.org</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <note>ID: PublishTab.Upload.Logout</note>
         <target xml:lang="ha" state="translated">Fita daga zauren yanar gizo na karatun Bloom.org</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <note>ID: PublishTab.Upload.MakingPdf</note>
         <target xml:lang="ha" state="translated">Yin duban kwankwancewar PDF...</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
         <target xml:lang="ha" state="translated">Yin surar bayyanawa...</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.NoLangsFound">
+      <trans-unit id="PublishTab.Upload.NoLangsFound" approved="yes">
         <source xml:lang="en">(None found)</source>
         <note>ID: PublishTab.Upload.NoLangsFound</note>
         <target xml:lang="ha" state="translated">(Ba abinda aka samu)</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <note>ID: PublishTab.Upload.OldVersion</note>
         <target xml:lang="ha" state="translated">Yi haƙuri, wannan tsarin Bloom na na'ura mai aiki da ƙwaƙwalwa ta tebur bai dace da sabon tsarin zauren karatun yanar gizo na BloomLibrary.org baDon Allah ka ɗaga darajar manhajar zuwa sabon tsari</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
         <target xml:lang="ha" state="translated">Don Allah ka shiga zauren karatu na yanar gizon BloomLibrary.org (ko ka yi rista) kafin ka ɗora</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
         <target xml:lang="ha" state="translated">Don Allah ka yi saitin wannan a cikin wurin tacewa na edit tab</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <note>ID: PublishTab.Upload.SignupLink</note>
         <target xml:lang="ha" state="translated">Yi ristar shiga Ɗakin karatu na BloomLibrary.org</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <note>ID: PublishTab.Upload.Step1</note>
         <target xml:lang="ha" state="translated">Mataki na 1:Tabbatar da kundin bayanai</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <note>ID: PublishTab.Upload.Step2</note>
         <target xml:lang="ha" state="translated">Mataki na 2: Ɗora</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
         <target xml:lang="ha" state="translated">Shawara: Sa Buɗaɗɗen Izinin Aikin Fasaha na sauƙaƙa maka wurin bayar da izini ga kowa da kowa ƙarara</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
         <target xml:lang="ha" state="translated">Shawara: Budaɗɗen Izinin Aikin Fasaha na ƙara sauƙaƙa ma wasu yin amfani da littafinka, koda ba su ƙware ba a harshen da ka yi aiki na izini wanda aka saba.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <note>ID: PublishTab.Upload.Summary</note>
         <target xml:lang="ha" state="translated">Taƙaitawa</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <note>ID: PublishTab.Upload.TermsLink</note>
         <target xml:lang="ha" state="translated">Nuna Sharuɗɗan Amfani</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TimeProblem">
+      <trans-unit id="PublishTab.Upload.TimeProblem" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. This is probably because your computer is set to use the wrong timezone or your system time is badly wrong. See http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html for how to fix this.</source>
         <note>ID: PublishTab.Upload.TimeProblem</note>
         <target xml:lang="ha" state="translated">An sami wata matsala a lokacin ɗora littafinka.Wataƙila don an yi saitin na'urarka ta yi amfani da lokacin wani yankin da ba daidai ba ko saitn agogon na'urarka ba ya da kyau.Duba http://www.di-mgt.com.au/wclo/help/wclo_setsysclock.html don ganin yadda za ka saita wannan.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <note>ID: PublishTab.Upload.Title</note>
         <target xml:lang="ha" state="translated">Take</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <note>ID: PublishTab.Upload.UploadButton</note>
         <target xml:lang="ha" state="translated">Ɗora Littafi</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
         <target xml:lang="ha" state="translated">Muna taya ka murna, "{0}' yanzu yana kan ɗakin karatun Bloom na yanar gizo BloomLibrary.org ({1})</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
         <target xml:lang="ha" state="translated">Ba a yarda da a ɗorawa ba</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
         <target xml:lang="ha" state="translated">An sami wata matsala a lokacin ɗora littafinka.Ka kashe da sake kunna Bloom ko kuma ka nemi taimakon ƙwararre.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <note>ID: PublishTab.Upload.UploadProgress</note>
         <target xml:lang="ha" state="translated">Ci gaban Ɗorawa</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
         <target xml:lang="ha" state="translated">Ɗora Littafi zuwa akwatin (Sandbox)</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, and topic tags to the BloomLibrary.org database.</note>
         <target xml:lang="ha" state="translated">Ɗora bayanin littafi</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
         <target xml:lang="ha" state="translated">Ɗorawa {0}</target>
       </trans-unit>
-      <trans-unit id="PublishView._saveButton">
+      <trans-unit id="PublishView._saveButton" approved="yes">
         <source xml:lang="en">Save stub</source>
         <note>ID: PublishView._saveButton</note>
         <target xml:lang="ha" state="translated">Aje ƙaramin aiki</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <note>ID: ReaderSetup.AddLevel</note>
         <target xml:lang="ha" state="translated">Ƙara Mataki</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <note>ID: ReaderSetup.AddStage</note>
         <target xml:lang="ha" state="translated">Ƙara mataki</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <note>ID: ReaderSetup.AddTexts</note>
         <target xml:lang="ha" state="translated">Don Allahh sa rubutu a cikin akwatin samfurin rubutu.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">allowed words</source>
         <note>ID: ReaderSetup.AllowedWords</note>
         <target xml:lang="ha" state="needs-translation">allowed words</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <note>ID: ReaderSetup.AllowedWordsFile</note>
         <target xml:lang="ha" state="needs-translation">Allowed Words File</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <note>ID: ReaderSetup.AllowedWordsFileHeader</note>
         <target xml:lang="ha" state="needs-translation">Allowed Words File</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Avg</source>
         <note>ID: ReaderSetup.AverageHeader</note>
         <target xml:lang="ha" state="needs-translation">Avg</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <note>ID: ReaderSetup.BookHeader</note>
         <target xml:lang="ha" state="translated">Littafi</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <note>ID: ReaderSetup.BookMaxWords</note>
         <target xml:lang="ha" state="translated">Yawan Kalmomin Littafi</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose...</source>
         <note>ID: ReaderSetup.ChooseAllowedWordsFile</note>
         <target xml:lang="ha" state="needs-translation">Choose...</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <note>ID: ReaderSetup.ClickLetter</note>
         <target xml:lang="ha" state="translated">Dangwala haruffa don ka sa su a cikin wannan matakin.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <note>ID: ReaderSetup.CombinationHelp1</note>
         <target xml:lang="ha" state="translated">Karaba ta hanyar sakin filaye</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <note>ID: ReaderSetup.CombinationHelp2</note>
         <target xml:lang="ha" state="translated">Misali "ai oo sh ng th ing"</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <note>ID: ReaderSetup.Combinations</note>
         <target xml:lang="ha" state="translated">Harhaɗa Haruffa (Graphemes)</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <note>ID: ReaderSetup.DecodableStages</note>
         <target xml:lang="ha" state="translated">Matakan karɓa</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true" approved="yes">
         <source xml:lang="en">File needs .TXT extension</source>
         <note>ID: ReaderSetup.FileNeedsTxtExtension</note>
         <target xml:lang="ha" state="translated">Kundi aje bayani na bukatar ƙarin .TXT</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
         <target xml:lang="ha" state="translated">Farko,</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <note>ID: ReaderSetup.FormatNotSupported</note>
         <target xml:lang="ha" state="translated">Ba a iya karanta wannan tsarin</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <note>ID: ReaderSetup.HowToExport</note>
         <target xml:lang="ha" state="translated">Ka taimaka wurin kawo da mayar da kundayen aje bayanan da za a yi amfani da su a amtsayin samfurin matannai</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <note>ID: ReaderSetup.Language</note>
         <target xml:lang="ha" state="translated">Harshe</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <note>ID: ReaderSetup.LetterHelp1</note>
         <target xml:lang="ha" state="translated">Ka jera haruffa da haɗa kalmomi a cikin tsarin baƙaƙe.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <note>ID: ReaderSetup.LetterHelp2</note>
         <target xml:lang="ha" state="translated">Ka raba ta hanyar sakin filaye</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <note>ID: ReaderSetup.LetterHelp3</note>
         <target xml:lang="ha" state="translated">Misali "a b c d"</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <note>ID: ReaderSetup.Letters</note>
         <target xml:lang="ha" state="translated">Haruffa</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <note>ID: ReaderSetup.Letters.Header</note>
         <target xml:lang="ha" state="translated">Haruffa da Haɗe-Haɗen Haruffa</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <note>ID: ReaderSetup.Letters.Intro</note>
         <target xml:lang="ha" state="translated">Don taimaka yin masu karatu karɓau, Bloom na bukatar sanin haruffa da hade-haden haruffan da za ka rika koyarwa.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
         <target xml:lang="ha" state="translated">Raba kowane harafi ko haɗin harafi da fili.Misali, ga abinda me yiwuwa za mu yi amfani da shi a harshen Turanci:</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
         <target xml:lang="ha" state="translated">Kula cewa jerin Turanci ya haɗa da alamomin da ake amfani da su ayi kalma, kamar 'a cikin </target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
         <target xml:lang="ha" state="translated">Na ta</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
         <target xml:lang="ha" state="needs-translation">.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <note>ID: ReaderSetup.LevelHeader</note>
         <target xml:lang="ha" state="translated">Mataki</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level&amp;nbsp;</source>
         <note>ID: ReaderSetup.LevelLabel</note>
         <target xml:lang="ha" state="translated">Mataki  </target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <note>ID: ReaderSetup.Levels</note>
         <target xml:lang="ha" state="translated">Matakan Mai karatu</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <note>ID: ReaderSetup.MatchingWords</note>
         <target xml:lang="ha" state="translated">Kalma madaidaiciya</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Average Length of Sentences in Book</source>
         <note>ID: ReaderSetup.MaxAverageWords</note>
         <target xml:lang="ha" state="needs-translation">Maximum Average Length of Sentences in Book</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
         <target xml:lang="ha" state="translated">Yawan Kalmomin Littafi</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <note>ID: ReaderSetup.MoreWords</note>
         <target xml:lang="ha" state="translated">Ƙarin kalmomi</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
         <target xml:lang="ha" state="translated">Buɗe akwatin samfurin rubutu don wannan harshe.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <note>ID: ReaderSetup.PageHeader</note>
         <target xml:lang="ha" state="translated">Shafi</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <note>ID: ReaderSetup.PageMaxWords</note>
         <target xml:lang="ha" state="translated">Iyakar yawan kalmomin kowane Shafi</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <note>ID: ReaderSetup.PoweredBy</note>
         <target xml:lang="ha" state="translated">Ƙarfafawar  </target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Punctuation" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Punctuation" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Punctuation</source>
         <note>ID: ReaderSetup.Punctuation</note>
         <target xml:lang="ha" state="needs-translation">Punctuation</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <note>ID: ReaderSetup.ReaderLevels</note>
         <target xml:lang="ha" state="translated">Matakan Mai karatu</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <note>ID: ReaderSetup.RemoveLevel</note>
         <target xml:lang="ha" state="translated">Cire Mataki {0}</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <note>ID: ReaderSetup.RemoveStage</note>
         <target xml:lang="ha" state="translated">Cire Mataki {0}</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove from this stage</source>
         <note>ID: ReaderSetup.RemoveWordList</note>
         <target xml:lang="ha" state="translated">Cire daga wannan matakin</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <note>ID: ReaderSetup.ReorderLevels</note>
         <target xml:lang="ha" state="translated">Jawo jerukan don sake tsara matakai.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <note>ID: ReaderSetup.ReorderStages</note>
         <target xml:lang="ha" state="translated">Jawo jerukan don sake tsara matakai.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <note>ID: ReaderSetup.SampleTexts</note>
         <target xml:lang="ha" state="translated">Jerin Kalmomi da Samfurin rubutu</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Words</source>
         <note>ID: ReaderSetup.SampleWords</note>
         <target xml:lang="ha" state="needs-translation">Sample Words</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <note>ID: ReaderSetup.SearchEngine</note>
         <target xml:lang="ha" state="translated">, Na'urar bincike don Koyarwa.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <note>ID: ReaderSetup.SelectedLetters</note>
         <target xml:lang="ha" state="translated">Tsoffin Haruffa da Sabbi</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <note>ID: ReaderSetup.SentenceHeader</note>
         <target xml:lang="ha" state="translated">Jimla</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
         <target xml:lang="ha" state="translated">Iyakar yawan Kalmomi a cikin kowace Jimla</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentencePunctuation.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentencePunctuation.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Special Sentence-Ending Punctuation</source>
         <note>ID: ReaderSetup.SentencePunctuation.Header</note>
         <target xml:lang="ha" state="needs-translation">Special Sentence-Ending Punctuation</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentencePunctuation.Help" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentencePunctuation.Help" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom already knows which characters in the world's languages always mark the end of sentences. To add others, enter the Unicode character escapes here. For example for Thai script languages, enter \U0020 to tell Bloom that normal spaces are used to break sentences.</source>
         <note>ID: ReaderSetup.SentencePunctuation.Help</note>
         <target xml:lang="ha" state="needs-translation">Bloom already knows which characters in the world's languages always mark the end of sentences. To add others, enter the Unicode character escapes here. For example for Thai script languages, enter \U0020 to tell Bloom that normal spaces are used to break sentences.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
         <target xml:lang="ha" state="translated">Saita Kayan aikin Mai karatu Karɓau</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
         <target xml:lang="ha" state="translated">Saita Kayan Aikin Matakin Ayyanannen Maikaratu</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <note>ID: ReaderSetup.SetupAlphabet</note>
         <target xml:lang="ha" state="translated">Saita baƙaƙe don wannan harshe</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <note>ID: ReaderSetup.SightWordHelp</note>
         <target xml:lang="ha" state="translated">Mene ne kalmomin da ake gani?</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <note>ID: ReaderSetup.SightWordLabel</note>
         <target xml:lang="ha" state="translated">Sabbin Kalmomin da ake gani</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <note>ID: ReaderSetup.SightWordsHeader</note>
         <target xml:lang="ha" state="translated">Kalmomin da ake Gani</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <note>ID: ReaderSetup.StageHeader</note>
         <target xml:lang="ha" state="translated">Mataki</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <note>ID: ReaderSetup.StageLabel</note>
         <target xml:lang="ha" state="translated">Matakin </target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <note>ID: ReaderSetup.Stages</note>
         <target xml:lang="ha" state="translated">Matakai</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <note>ID: ReaderSetup.Synphony</note>
         <target xml:lang="ha" state="needs-translation">SynPhony</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <note>ID: ReaderSetup.ToRemember</note>
         <target xml:lang="ha" state="translated">Abubuwan da ya kamata a tuna da su a wannan matakin:</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <note>ID: ReaderSetup.UniqueHeader</note>
         <target xml:lang="ha" state="translated">Wanda babu irinsa</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <note>ID: ReaderSetup.Words</note>
         <target xml:lang="ha" state="translated">Kalmomi</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage. There are two ways to give words to Bloom:</source>
         <note>ID: ReaderSetup.Words.Intro</note>
         <target xml:lang="ha" state="translated">Don taimka ka yi Karɓaɓɓun masu karatu, Bllom na iya bayar da shawarar kalmomin da za su dace da wannan matakin da ake ciki.Akwai hanyoyi biyu na ba Bllom kalmomi:</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
         <target xml:lang="ha" state="translated">2) Aje Kundin Rubutu a cikin</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
         <target xml:lang="ha" state="translated">Akwatin Samfurin Rubutunka</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
         <target xml:lang="ha" state="translated">1) Rubuta Kalmomi a Nan</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using lists of allowed words to define stages</source>
         <note>ID: ReaderSetup.Words.UseAllowedWords</note>
         <target xml:lang="ha" state="needs-translation">We are using lists of allowed words to define stages</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using letters with sight words to define stages</source>
         <note>ID: ReaderSetup.Words.UseLetters</note>
         <target xml:lang="ha" state="needs-translation">We are using letters with sight words to define stages</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <note>ID: ReaderSetup.lettersHeader</note>
         <target xml:lang="ha" state="translated">Haruffa</target>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this Bloom Pack will carry your latest decodable and leveled reader settings for the \"{0}\" language. Anyone opening this Bloom Pack, who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this Bloom Pack. They will also get the current set of words for use in decodable readers.</source>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
         <target xml:lang="ha" state="translated">Ƙari kan hakan, wannan Ƙunshin Bloom ɗin zai ɗauki sabon saitin karɓau da ayyanannen maikaratunka don \"{0}\" harshe.Duk wanda zai buɗe wannan Ƙunshin Bloom, wanda ya buɗe tarin bayanan \:{0}"\  za su sami saitinsu na karɓau da ayyanannen mai karatu na yanzu a cikin wannan Ƙunshin Blom ɗin.Kuma za su sami saitin kalmomi na yanzu da ake amfani da su a cikin masu karatu karɓau.</target>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
         <target xml:lang="ha" state="translated">Waɗannan littafan da ke biye za a yi su a cikin muhallan:</target>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
         <target xml:lang="ha" state="translated">Aje Ƙunshin Bloom</target>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
         <target xml:lang="ha" state="translated">Ka yi Muhallin Maikaratu na Manhajar Bloom</target>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <note>ID: RegisterDialog.Email</note>
         <target xml:lang="ha" state="translated">Adireshin Wasikar Yanar Gizo</target>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <note>ID: RegisterDialog.FirstName</note>
         <target xml:lang="ha" state="translated">Sunan Farko</target>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
         <target xml:lang="ha" state="translated">Don Allah ka sadaukar da ɗan lokaci don yin ristar {0}</target>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
         <target xml:lang="ha" state="translated">Ya kake amfani da {0}?</target>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
         <target xml:lang="ha" state="translated">Aiki ya sha man kai, zan ƙare wannan a nan gaba.</target>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <note>ID: RegisterDialog.Organization</note>
         <target xml:lang="ha" state="translated">Ƙungiya</target>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <note>ID: RegisterDialog.RegisterButton</note>
         <target xml:lang="ha" state="translated">Yi &amp;Risjita</target>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <note>ID: RegisterDialog.Surname</note>
         <target xml:lang="ha" state="translated">Sunan Mahaifi</target>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
         <target xml:lang="ha" state="translated">Yi rijista {0}</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
         <target xml:lang="ha" state="translated">Rufe</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.CouldNotSendToServer">
+      <trans-unit id="ReportProblemDialog.CouldNotSendToServer" approved="yes">
         <source xml:lang="en">Bloom was not able to submit your report directly to our server. Please retry or email {0} to {1}.</source>
         <note>ID: ReportProblemDialog.CouldNotSendToServer</note>
         <target xml:lang="ha" state="translated">Bloom ya kasa aika rahoto kai tsaye zuwa ga rumbun aje bayanan mu na yanar gizo. Don Allah ka ƙara jarraba aikawa ko ka aika saƙo ta adirshin yanar gizo {0} zuwa {1}.</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Email">
+      <trans-unit id="ReportProblemDialog.Email" approved="yes">
         <source xml:lang="en">Email</source>
         <note>ID: ReportProblemDialog.Email</note>
         <target xml:lang="ha" state="translated">Adireshin wasikar Yanar Gizo</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeBookButton">
+      <trans-unit id="ReportProblemDialog.IncludeBookButton" approved="yes">
         <source xml:lang="en">Include Book '{0}'</source>
         <note>ID: ReportProblemDialog.IncludeBookButton</note>
         <target xml:lang="ha" state="translated">Haɗa da Littafi '{0}'</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton">
+      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton" approved="yes">
         <source xml:lang="en">Include this screenshot</source>
         <note>ID: ReportProblemDialog.IncludeScreenshotButton</note>
         <target xml:lang="ha" state="translated">Haɗa da wannan hoton abubuwan da na'urarka mai aiki da ƙwaƙwalwa ta nuna</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Name">
+      <trans-unit id="ReportProblemDialog.Name" approved="yes">
         <source xml:lang="en">Name</source>
         <note>ID: ReportProblemDialog.Name</note>
         <target xml:lang="ha" state="translated">Suna</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Retry">
+      <trans-unit id="ReportProblemDialog.Retry" approved="yes">
         <source xml:lang="en">Retry</source>
         <note>ID: ReportProblemDialog.Retry</note>
         <note>Shown if there was an error submitting the report. Lets the user try submitting it again.</note>
         <target xml:lang="ha" state="translated">Ƙara jarrabawa</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SeeDetails">
+      <trans-unit id="ReportProblemDialog.SeeDetails" approved="yes">
         <source xml:lang="en">See what else will be submitted</source>
         <note>ID: ReportProblemDialog.SeeDetails</note>
         <target xml:lang="ha" state="translated">Duba kuma abinda za a sake aikawa</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SubmitButton">
+      <trans-unit id="ReportProblemDialog.SubmitButton" approved="yes">
         <source xml:lang="en">&amp;Submit</source>
         <note>ID: ReportProblemDialog.SubmitButton</note>
         <target xml:lang="ha" state="translated">Aikawa</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Submitting">
+      <trans-unit id="ReportProblemDialog.Submitting" approved="yes">
         <source xml:lang="en">Submitting to server...</source>
         <note>ID: ReportProblemDialog.Submitting</note>
         <note>This is shown while Bloom is sending the problem report to our server.</note>
         <target xml:lang="ha" state="translated">Aikawa zuwa ga rumbun ajiya na yanar gizo...</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Success">
+      <trans-unit id="ReportProblemDialog.Success" approved="yes">
         <source xml:lang="en">We received your report, thanks for taking the time to help make Bloom better!</source>
         <note>ID: ReportProblemDialog.Success</note>
         <target xml:lang="ha" state="translated">Mun karɓi rahotonka, muna godiya da lokacin da ka ɗauka don taimakawa wurin kyautata Bloom!</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WhatsTheProblem">
+      <trans-unit id="ReportProblemDialog.WhatsTheProblem" approved="yes">
         <source xml:lang="en">What seems to be the problem?</source>
         <note>ID: ReportProblemDialog.WhatsTheProblem</note>
         <target xml:lang="ha" state="translated">Mecece matsalar?</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WindowTitle">
+      <trans-unit id="ReportProblemDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Report A Problem</source>
         <note>ID: ReportProblemDialog.WindowTitle</note>
         <target xml:lang="ha" state="translated">Kai Rahoton Matsala</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Zipping">
+      <trans-unit id="ReportProblemDialog.Zipping" approved="yes">
         <source xml:lang="en">Zipping up book...</source>
         <note>ID: ReportProblemDialog.Zipping</note>
         <note>This is shown while Bloom is creating the problem report. It's generally too fast to see, unless you include a large book.</note>
         <target xml:lang="ha" state="translated">Rufe littafi...</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.linkLabel1">
+      <trans-unit id="ReportProblemDialog.linkLabel1" approved="yes">
         <source xml:lang="en">Will not be private</source>
         <note>ID: ReportProblemDialog.linkLabel1</note>
         <target xml:lang="ha" state="translated">Ba zai zama abin sirri ba</target>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.IGetIt">
+      <trans-unit id="SamplePrintNotification.IGetIt" approved="yes">
         <source xml:lang="en">I get it. Do not show this again.</source>
         <note>ID: SamplePrintNotification.IGetIt</note>
         <target xml:lang="ha" state="translated">Na same shi.Kar a ƙara nuna wannan.</target>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.PleaseNotice">
+      <trans-unit id="SamplePrintNotification.PleaseNotice" approved="yes">
         <source xml:lang="en">Please notice the sample printer settings below. Use them as a guide while you set up the printer.</source>
         <note>ID: SamplePrintNotification.PleaseNotice</note>
         <target xml:lang="ha" state="translated">Don Allah ka lura da samfurin saitin na'urar wallafawa da ke ƙasa. Ka yi amfani da su a matsayin jagora a lokacin da kake saitin na'urar wallafawa.</target>
       </trans-unit>
-      <trans-unit id="ScriptSettingsDialog.DefaultLineSpacing">
+      <trans-unit id="ScriptSettingsDialog.DefaultLineSpacing" approved="yes">
         <source xml:lang="en">Default line spacing</source>
         <note>ID: ScriptSettingsDialog.DefaultLineSpacing</note>
         <target xml:lang="ha" state="needs-translation">Default line spacing</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Arithmetic</source>
         <note>ID: TemplateBooks.BookName.Arithmetic</note>
         <target xml:lang="ha" state="translated">Lissafi</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
         <target xml:lang="ha" state="translated">Littafin farko</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <note>ID: TemplateBooks.BookName.Big Book</note>
         <target xml:lang="ha" state="translated">Babban littafi</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
         <target xml:lang="ha" state="translated">Mai karatu karɓau</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
         <target xml:lang="ha" state="translated">Matakin Ayyanannen Maikaratu</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
         <target xml:lang="ha" state="translated">Ƙamus na hotuna</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vaccinations</source>
         <note>ID: TemplateBooks.BookName.Vaccinations</note>
         <target xml:lang="ha" state="translated">Rigakafi</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Template Starter" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Template Starter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Template Starter</source>
         <note>ID: TemplateBooks.BookName.Template Starter</note>
         <target xml:lang="ha" state="needs-translation">Template Starter</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
         <target xml:lang="ha" state="translated">Kalandar Bango</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A blank page that allows you to add items.</source>
         <note>ID: TemplateBooks.PageDescription.Custom</note>
         <target xml:lang="ha" state="translated">Shafin da ba kome a cikinsa wanda zai baka damar kara wani abu.</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Flyleaf" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Flyleaf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This page was automatically inserted because the following page is marked as part of a two page spread.</source>
         <note>ID: TemplateBooks.PageDescription.Flyleaf</note>
         <target xml:lang="ha" state="needs-translation">This page was automatically inserted because the following page is marked as part of a two page spread.</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page with a picture on top and a large, centered word below.</source>
         <note>ID: TemplateBooks.PageDescription.Picture &amp; Word</note>
         <target xml:lang="ha" state="translated">Shafi da hoto a sama, da ƙatuwar kalma a tsakiya daga ƙasa.</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <note>ID: TemplateBooks.PageLabel.1</note>
         <target xml:lang="ha" state="needs-translation">1</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1 Problem</source>
         <note>ID: TemplateBooks.PageLabel.1 Problem</note>
         <note>This label indicates a page with one arithmetic problem on it.</note>
         <target xml:lang="ha" state="translated">Matsala 1</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true" approved="yes">
         <source xml:lang="en">10</source>
         <note>ID: TemplateBooks.PageLabel.10</note>
         <target xml:lang="ha" state="needs-translation">10</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true" approved="yes">
         <source xml:lang="en">11</source>
         <note>ID: TemplateBooks.PageLabel.11</note>
         <target xml:lang="ha" state="needs-translation">11</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true" approved="yes">
         <source xml:lang="en">12</source>
         <note>ID: TemplateBooks.PageLabel.12</note>
         <target xml:lang="ha" state="needs-translation">12</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true" approved="yes">
         <source xml:lang="en">13</source>
         <note>ID: TemplateBooks.PageLabel.13</note>
         <target xml:lang="ha" state="needs-translation">13</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true" approved="yes">
         <source xml:lang="en">14</source>
         <note>ID: TemplateBooks.PageLabel.14</note>
         <target xml:lang="ha" state="needs-translation">14</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true" approved="yes">
         <source xml:lang="en">15</source>
         <note>ID: TemplateBooks.PageLabel.15</note>
         <target xml:lang="ha" state="needs-translation">15</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true" approved="yes">
         <source xml:lang="en">16</source>
         <note>ID: TemplateBooks.PageLabel.16</note>
         <target xml:lang="ha" state="needs-translation">16</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true" approved="yes">
         <source xml:lang="en">17</source>
         <note>ID: TemplateBooks.PageLabel.17</note>
         <target xml:lang="ha" state="needs-translation">17</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true" approved="yes">
         <source xml:lang="en">18</source>
         <note>ID: TemplateBooks.PageLabel.18</note>
         <target xml:lang="ha" state="needs-translation">18</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true" approved="yes">
         <source xml:lang="en">19</source>
         <note>ID: TemplateBooks.PageLabel.19</note>
         <target xml:lang="ha" state="needs-translation">19</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <note>ID: TemplateBooks.PageLabel.2</note>
         <target xml:lang="ha" state="needs-translation">2</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2 Problems</source>
         <note>ID: TemplateBooks.PageLabel.2 Problems</note>
         <note>This label indicates a page with two arithmetic problems on it.</note>
         <target xml:lang="ha" state="translated">Matsaloli 2</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true" approved="yes">
         <source xml:lang="en">20</source>
         <note>ID: TemplateBooks.PageLabel.20</note>
         <target xml:lang="ha" state="needs-translation">20</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true" approved="yes">
         <source xml:lang="en">21</source>
         <note>ID: TemplateBooks.PageLabel.21</note>
         <target xml:lang="ha" state="needs-translation">21</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <note>ID: TemplateBooks.PageLabel.3</note>
         <target xml:lang="ha" state="needs-translation">3</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3 Problems</source>
         <note>ID: TemplateBooks.PageLabel.3 Problems</note>
         <note>This label indicates a page with three arithmetic problems on it.</note>
         <target xml:lang="ha" state="translated">Matsaloli 3</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <note>ID: TemplateBooks.PageLabel.4</note>
         <target xml:lang="ha" state="needs-translation">4</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4 Problems</source>
         <note>ID: TemplateBooks.PageLabel.4 Problems</note>
         <note>This label indicates a page with four arithmetic problems on it.</note>
         <target xml:lang="ha" state="translated">Matsaloli 4</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <note>ID: TemplateBooks.PageLabel.5</note>
         <target xml:lang="ha" state="needs-translation">5</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <note>ID: TemplateBooks.PageLabel.6</note>
         <target xml:lang="ha" state="needs-translation">6</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <note>ID: TemplateBooks.PageLabel.7</note>
         <target xml:lang="ha" state="needs-translation">7</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <note>ID: TemplateBooks.PageLabel.8</note>
         <target xml:lang="ha" state="needs-translation">8</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <note>ID: TemplateBooks.PageLabel.9</note>
         <target xml:lang="ha" state="needs-translation">9</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.About" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.About" sil:dynamic="true" approved="yes">
         <source xml:lang="en">About</source>
         <note>ID: TemplateBooks.PageLabel.About</note>
         <note>Caption of 2nd page in books made from Template Starter</note>
         <target xml:lang="ha" state="needs-translation">About</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
         <target xml:lang="ha" state="translated">Baƙi</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
         <target xml:lang="ha" state="translated">Matani da Sura Matakin Fako</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
         <target xml:lang="ha" state="translated">Matani da Hoto Matakin</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
         <target xml:lang="ha" state="translated">Shafin Ta'allaƙawa</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
         <target xml:lang="ha" state="translated">Al'ada</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
         <target xml:lang="ha" state="translated">Rana ta 1</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
         <target xml:lang="ha" state="translated">Rana ta 2</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
         <target xml:lang="ha" state="translated">Rana ta 3</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
         <target xml:lang="ha" state="translated">Rana ta 4</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
         <target xml:lang="ha" state="translated">Rana ta 5a</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
         <target xml:lang="ha" state="translated">Rana ta 5b</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Factory</source>
         <note>ID: TemplateBooks.PageLabel.Factory</note>
         <target xml:lang="ha" state="needs-translation">Factory</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Flyleaf" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Flyleaf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Flyleaf</source>
         <note>ID: TemplateBooks.PageLabel.Flyleaf</note>
         <target xml:lang="ha" state="needs-translation">Flyleaf</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
         <target xml:lang="ha" state="translated">Marfin Littafi</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front/Back Matter</source>
         <note>ID: TemplateBooks.PageLabel.FrontBackMatter</note>
         <target xml:lang="ha" state="needs-translation">Front/Back Matter</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image For Thumbnail" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image For Thumbnail" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image For Thumbnail</source>
         <note>ID: TemplateBooks.PageLabel.Image For Thumbnail</note>
         <note>Caption of first page in books made from Template Starter</note>
         <target xml:lang="ha" state="needs-translation">Image For Thumbnail</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
         <target xml:lang="ha" state="translated">Sura a ƙasa</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
         <target xml:lang="ha" state="translated">Sura a Tsakiya</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
         <target xml:lang="ha" state="translated">Cikin Marfin Baya</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
         <target xml:lang="ha" state="translated">Cikin Marfin Gaba</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
         <target xml:lang="ha" state="translated">Sharuɗɗa</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
         <target xml:lang="ha" state="translated">Matani Kawai</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
         <target xml:lang="ha" state="translated">Hoto Kawai</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
         <target xml:lang="ha" state="translated">Sura Kawai</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
         <target xml:lang="ha" state="translated">Bayan Marfin Baya</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <note>ID: TemplateBooks.PageLabel.Paper Saver</note>
         <target xml:lang="ha" state="needs-translation">Paper Saver</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
         <target xml:lang="ha" state="translated">Hoto da Kalma</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
         <target xml:lang="ha" state="translated">Hoto a Tsakiya</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
         <target xml:lang="ha" state="translated">Hoto a Ƙasa</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SIL-Cameroon</source>
         <note>ID: TemplateBooks.PageLabel.SIL-Cameroon</note>
         <target xml:lang="ha" state="needs-translation">SIL-Cameroon</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Super Paper Saver</source>
         <note>ID: TemplateBooks.PageLabel.Super Paper Saver</note>
         <target xml:lang="ha" state="needs-translation">Super Paper Saver</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
         <target xml:lang="ha" state="translated">Wannan Shafin ba Kome A cikinsa</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
         <target xml:lang="ha" state="translated">Shafin Take</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <note>ID: TemplateBooks.PageLabel.Traditional</note>
         <target xml:lang="ha" state="needs-translation">Traditional</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
         <target xml:lang="ha" state="translated">Tsari</target>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Harkar Noma</target>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Labaran Dabbobi</target>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Kasuwanci</target>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Rayuwar al'umma</target>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Al'ada</target>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Ƙamus</target>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Muhalli</target>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Almara</target>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Lafiya</target>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Yadda Za a yi</target>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Lissafi</target>
       </trans-unit>
-      <trans-unit id="Topics.NoTopic" sil:dynamic="true">
+      <trans-unit id="Topics.NoTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">No Topic</source>
         <note>ID: Topics.NoTopic</note>
         <target xml:lang="ha" state="translated">Babu Darasi</target>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Wanda ba Almara ba</target>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Bunƙasar Kai</target>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Littafin gabatarwa</target>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Kimiya</target>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Na Addini</target>
       </trans-unit>
-      <trans-unit id="Topics.Story Book" sil:dynamic="true">
+      <trans-unit id="Topics.Story Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Story Book</source>
         <note>ID: Topics.Story Book</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Littafin Labari</target>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Al'ada</target>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <note>ID: Topics.Traditional Story</note>
         <note>shows in the topics chooser in the edit tab</note>
         <target xml:lang="ha" state="translated">Labarin Al'ada</target>
       </trans-unit>
-      <trans-unit id="WebServer.Warning.NoImageFile">
+      <trans-unit id="WebServer.Warning.NoImageFile" approved="yes">
         <source xml:lang="en">Cannot Find Image File</source>
         <note>ID: WebServer.Warning.NoImageFile</note>
         <note>displays as a "toast"</note>
         <target xml:lang="ha" state="needs-translation">Cannot Find Image File</target>
       </trans-unit>
-      <trans-unit id="WebServer.Warning.NoFile">
+      <trans-unit id="WebServer.Warning.NoFile" approved="yes">
         <source xml:lang="en">Cannot Find File</source>
         <note>ID: WebServer.Warning.NoFile</note>
         <note>displays as a "toast"</note>

--- a/DistFiles/localization/ha/IntegrityFailureAdvice.xlf
+++ b/DistFiles/localization/ha/IntegrityFailureAdvice.xlf
@@ -2,77 +2,77 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="IntegrityFailureAdvice-en.md" datatype="html" source-language="en" target-language="ha">
     <body>
-      <trans-unit id="integrity.title">
+      <trans-unit id="integrity.title" approved="yes">
         <source xml:lang="en">Bloom cannot find some of its own files, and cannot continue</source>
         <target xml:lang="ha">Bloom bai iya samun wasu kundayen ajiyar bayanan shi ba, kuma ba zai iya ci gaba ba</target>
         <note>ID: integrity.title</note>
       </trans-unit>
-      <trans-unit id="integrity.causes">
+      <trans-unit id="integrity.causes" approved="yes">
         <source xml:lang="en">Possible Causes</source>
         <target xml:lang="ha">Kila abubuwan da suka haddasa haka ne</target>
         <note>ID: integrity.causes</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.1">
+      <trans-unit id="integrity.causes.1" approved="yes">
         <source xml:lang="en">Your antivirus may have "quarantined" one or more Bloom files.</source>
         <target xml:lang="ha">Manhajar kariyar na'urarka ta "share" kundin ajiye bayanan Bloom ɗaya ko fiye da ɗaya</target>
         <note>ID: integrity.causes.1</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.2">
+      <trans-unit id="integrity.causes.2" approved="yes">
         <source xml:lang="en">Your computer administrator may have your computer "locked down" to prevent bad things, but in such a way that Bloom could not place these files where they belong. </source>
         <target xml:lang="ha">Mai yiwuwa masu sha'anin kula da na'urarka "ya kulle" don hana faruwar wasu miyagun matsaloli ta hanyar da Bloom ba zai iya ajiye waɗannan kundayen ajiyar bayanai wurin da ya kamata ba 2)</target>
         <note>ID: integrity.causes.2</note>
       </trans-unit>
-      <trans-unit id="integrity.todo">
+      <trans-unit id="integrity.todo" approved="yes">
         <source xml:lang="en">What To Do</source>
         <target xml:lang="ha">Abin yi</target>
         <note>ID: integrity.todo</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas">
+      <trans-unit id="integrity.todo.ideas" approved="yes">
         <source xml:lang="en">After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas:</source>
         <target xml:lang="ha">Bayan ka aika da wannan rahoton, za mu tuntuɓe ka mu taimaka maka wurin magance wannan matsalar. A halin yanzu dai, ga abinda za'a gwada yi a gani:</target>
         <note>ID: integrity.todo.ideas</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Reinstall">
+      <trans-unit id="integrity.todo.ideas.Reinstall" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="ha">*Ka sake gudanar da yadda ake sa manhajar Bloom, don ka ga ko za ta gudana ba tare da wata matsala ba a wannan lokacin.</target>
         <note>ID: integrity.todo.ideas.Reinstall</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Antivirus">
+      <trans-unit id="integrity.todo.ideas.Antivirus" approved="yes">
         <source xml:lang="en">If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>.</source>
         <target xml:lang="ha">Idan matsalar ba ta gyaru ba, to yanzu sai ka tuntuɓi manhajar bayar da kariya ga na'ura mai ƙwaƙwalwa. Idan sashen "Ɓatattun Kundayen Ajiyar Bayanai" da ke biye a ƙasa na nuna kowaɗanne irin kundayen ajiyar bayanan da suka shiga cikin ".exe" duba "jerin amintattu" a cikin akwatin Bloom wanda yake a <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>.</target>
         <note>ID: integrity.todo.ideas.Antivirus</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVAST">
+      <trans-unit id="integrity.todo.ideas.AVAST" approved="yes">
         <source xml:lang="en">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">Instructions</g>.</source>
         <target xml:lang="ha">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">Sharudda</g>.</target>
         <note>ID: integrity.todo.ideas.AVAST</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Norton">
+      <trans-unit id="integrity.todo.ideas.Norton" approved="yes">
         <source xml:lang="en">Norton Antivirus: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">Instructions from Symantec</g>.</source>
         <target xml:lang="ha">Garkuwar Norton: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920html">Sharudda daga Symantec</g>.</target>
         <note>ID: integrity.todo.ideas.Norton</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVG">
+      <trans-unit id="integrity.todo.ideas.AVG" approved="yes">
         <source xml:lang="en">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">Instructions from AVG</g>.</source>
         <target xml:lang="ha">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?I=en_US&amp;amp;name=How-to-exclude-file-folder-or-website-from-AVG-scanning">Sharudda daga AVG</g>.</target>
         <note>ID: integrity.todo.ideas.AVG</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Others">
+      <trans-unit id="integrity.todo.ideas.Others" approved="yes">
         <source xml:lang="en">Others: Google for "whitelist directory name-of-your-antivirus"</source>
         <target xml:lang="ha">Wasu: Google don "tsarin jerin amintattun sunan-garkuwar-na'urarka mai aiki da ƙwaƙwalwa".</target>
         <note>ID: integrity.todo.ideas.Others</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Restart">
+      <trans-unit id="integrity.todo.ideas.Restart" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="ha">Ka sake sa Bloom, ka gani idan zai fara da kyau a wannan karon.</target>
         <note>ID: integrity.todo.ideas.Restart</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Retrieve">
+      <trans-unit id="integrity.todo.ideas.Retrieve" approved="yes">
         <source xml:lang="en">You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">this image</g>.</source>
         <target xml:lang="ha">Kuma za ka iya ƙoƙarin sake dawowa da wani ɓangaren Bloom da garkuwar kariyar na'urarka mai aiki da ƙwaƙwalwa ta ɗauke daga cikinsa. Domin aik da AVG, kana buƙatar samun tsarin "zaɓi" na AVG, ka dangwala "virus vault", akan kundin ajiyar bayanai na Bloom sannan ka dangwala "restore". Domin jagora cikin hoto, sai ka ga <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dIRrsSN.png">wannan hoton</g>.</target>
         <note>ID: integrity.todo.ideas.Retrieve</note>
       </trans-unit>
-      <trans-unit id="integrity.missing">
+      <trans-unit id="integrity.missing" approved="yes">
         <source xml:lang="en">Missing Files</source>
         <target xml:lang="ha">Batattun Kundayen Ajiyar Bayanai</target>
         <note>ID: integrity.missing</note>

--- a/DistFiles/localization/ha/Palaso.xlf
+++ b/DistFiles/localization/ha/Palaso.xlf
@@ -2,595 +2,595 @@
 <xliff xmlns:sil="http://sil.org/software/XLiff" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file original="Palaso.dll" source-language="en" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n" target-language="ha">
     <body>
-      <trans-unit id="AboutDialog.BuiltOnDate">
+      <trans-unit id="AboutDialog.BuiltOnDate" approved="yes">
         <source xml:lang="en">Built on {0}</source>
         <note>ID: AboutDialog.BuiltOnDate</note>
         <target xml:lang="ha" state="needs-translation">Built on {0}</target>
       </trans-unit>
-      <trans-unit id="AboutDialog.NoUpdates">
+      <trans-unit id="AboutDialog.NoUpdates" approved="yes">
         <source xml:lang="en">No Updates</source>
         <note>ID: AboutDialog.NoUpdates</note>
         <target xml:lang="ha" state="translated">Ba sababbin abubuwa</target>
       </trans-unit>
-      <trans-unit id="AboutDialog.WindowTitle">
+      <trans-unit id="AboutDialog.WindowTitle" approved="yes">
         <source xml:lang="en">About {0}</source>
         <note>ID: AboutDialog.WindowTitle</note>
         <target xml:lang="ha" state="needs-translation">About {0}</target>
       </trans-unit>
-      <trans-unit id="AboutDialog._checkForUpdates">
+      <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
         <source xml:lang="en">Check For Updates</source>
         <note>ID: AboutDialog._checkForUpdates</note>
         <target xml:lang="ha" state="translated">Ka bincika ko akwai sababbin abubuwa</target>
       </trans-unit>
-      <trans-unit id="AboutDialog._releaseNotesLabel">
+      <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <note>ID: AboutDialog._releaseNotesLabel</note>
         <target xml:lang="ha" state="translated">Bayanin fitarwa</target>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.General">
+      <trans-unit id="Application.AlreadyRunning.General" approved="yes">
         <source xml:lang="en">Another copy of the application is already running. If you cannot find it, restart your computer.</source>
         <note>ID: Application.AlreadyRunning.General</note>
         <target xml:lang="ha" state="translated">Wani kofin wannan manhajar na kan gudana. Idan ba za ka iya samun shi ba, sai ka kashe sannan ka sake kunna na'urarka mai ƙwaƙwalwa.</target>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.Specific">
+      <trans-unit id="Application.AlreadyRunning.Specific" approved="yes">
         <source xml:lang="en">Another copy of {0} is already running. If you cannot find that copy of {0}, restart your computer.</source>
         <note>ID: Application.AlreadyRunning.Specific</note>
         <note>{0} is the application name</note>
         <target xml:lang="ha" state="translated">Wani kofin na {0} na kan gudana. Idan ba za ka iya samun kofin ba, sai ka kashe sannan ka sake kunna na'urarka mai ƙwaƙwalwa.</target>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.General">
+      <trans-unit id="Application.ProblemStarting.General" approved="yes">
         <source xml:lang="en">There was a problem starting the application which might require that you restart your computer.</source>
         <note>ID: Application.ProblemStarting.General</note>
         <target xml:lang="ha" state="translated">Akwai wata 'yar matsala a wurin buɗe manhajar wadda mai yiwuwa za ka buƙaci ka kashe, sannan ka sake kunna na'urar ta ka.</target>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.Specific">
+      <trans-unit id="Application.ProblemStarting.Specific" approved="yes">
         <source xml:lang="en">There was a problem starting {0} which might require that you restart your computer.</source>
         <note>ID: Application.ProblemStarting.Specific</note>
         <note>{0} is the application name</note>
         <target xml:lang="ha" state="translated">A kwai wata 'yar matsala a wurin buɗewa {0} wadda me yiwuwu za ka buƙaci ka kashe na'urar ta ka sannan ka sake kunnawa.</target>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.General">
+      <trans-unit id="Application.WaitingFinish.General" approved="yes">
         <source xml:lang="en">Waiting for other application to finish...</source>
         <note>ID: Application.WaitingFinish.General</note>
         <target xml:lang="ha" state="translated">Ana jiran sauran manhajar su gama...</target>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.Specific">
+      <trans-unit id="Application.WaitingFinish.Specific" approved="yes">
         <source xml:lang="en">Waiting for other {0} to finish...</source>
         <note>ID: Application.WaitingFinish.Specific</note>
         <note>{0} is the application name</note>
         <target xml:lang="ha" state="translated">Ana jiran sauran su gama...</target>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <note>ID: Common.CancelButton</note>
         <target xml:lang="ha" state="translated">&amp;Soke</target>
       </trans-unit>
-      <trans-unit id="Common.No">
+      <trans-unit id="Common.No" approved="yes">
         <source xml:lang="en">No</source>
         <note>ID: Common.No</note>
         <target xml:lang="ha" state="translated">A'a</target>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <note>ID: Common.OKButton</note>
         <target xml:lang="ha" state="translated">&amp;Ya yi</target>
       </trans-unit>
-      <trans-unit id="Common.Yes">
+      <trans-unit id="Common.Yes" approved="yes">
         <source xml:lang="en">Yes</source>
         <note>ID: Common.Yes</note>
         <target xml:lang="ha" state="translated">I</target>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
         <note>Parameter {0} is a description of the things being deleted (e.g., "The selected files")</note>
         <target xml:lang="ha" state="translated">{0} za a jefa kwandon shara.</target>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
         <note>Parameter {0} is a file name</note>
         <target xml:lang="ha" state="translated">{0} za a jefa a kwandon shara.</target>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Confirm Delete</source>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
         <target xml:lang="ha" state="translated">Ka Tabbata kana so a share</target>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
         <target xml:lang="ha" state="translated">&amp;Soke</target>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
         <target xml:lang="ha" state="translated">&amp;Share</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.AlmostMatchingImages">
+      <trans-unit id="ImageToolbox.AlmostMatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images with names close to {1}</source>
         <note>ID: ImageToolbox.AlmostMatchingImages</note>
         <note>The {0} will be replaced by the number of images found.  The {1} will be replaced with the search string.</note>
         <target xml:lang="ha" state="translated">An sami {0} hotuna masu sunaye kusa da {1}</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ArtOfReading">
+      <trans-unit id="ImageToolbox.ArtOfReading" approved="yes">
         <source xml:lang="en">Art Of Reading</source>
         <note>ID: ImageToolbox.ArtOfReading</note>
         <target xml:lang="ha" state="translated">Fasahar Karatu</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Camera">
+      <trans-unit id="ImageToolbox.Camera" approved="yes">
         <source xml:lang="en">Camera</source>
         <note>ID: ImageToolbox.Camera</note>
         <target xml:lang="ha" state="translated">Na'urar ɗaukar hoto</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
         <source xml:lang="en">Use {0}</source>
         <note>ID: ImageToolbox.CopyExemplarMetadata</note>
         <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
         <target xml:lang="ha" state="translated">Yi amfani da {0}</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Crop">
+      <trans-unit id="ImageToolbox.Crop" approved="yes">
         <source xml:lang="en">Crop</source>
         <note>ID: ImageToolbox.Crop</note>
         <target xml:lang="ha" state="translated">Datse</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.DownloadArtOfReading">
+      <trans-unit id="ImageToolbox.DownloadArtOfReading" approved="yes">
         <source xml:lang="en">Download Art Of Reading Installer</source>
         <note>ID: ImageToolbox.DownloadArtOfReading</note>
         <target xml:lang="ha" state="translated">Saukar da Manhajar Fasahar Karatu</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EditMetadataLink">
+      <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
         <source xml:lang="en">Edit...</source>
         <note>ID: ImageToolbox.EditMetadataLink</note>
         <target xml:lang="ha" state="translated">Tace rubutu...</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EnterSearchTerms">
+      <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
         <source xml:lang="en">This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.</source>
         <note>ID: ImageToolbox.EnterSearchTerms</note>
         <target xml:lang="ha" state="translated">Wannan shine zauren 'Fasahar Karatu'. A cikin akwatin da ke sama, ka rubuta abinda kake nema, sannan ka dangwala ENTER. Kana iya rubuta kalmomi a cikin harshen Ingilishi ko Indonisiya.</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.FileButton">
+      <trans-unit id="ImageToolbox.FileButton" approved="yes">
         <source xml:lang="en">File</source>
         <note>ID: ImageToolbox.FileButton</note>
         <target xml:lang="ha" state="translated">Kundi</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
         <note>ID: ImageToolbox.GenericGettingImageProblem</note>
         <target xml:lang="ha" state="translated">Gafara dai, an ɗan sami 'yar matsala a lokacin da ake ƙoƙarin samun hoton.</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericProblem">
+      <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
         <note>ID: ImageToolbox.GenericProblem</note>
         <target xml:lang="ha" state="translated">Yi haƙuri, wani abu ya sami akwatin da hoton ya ke ciki</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GetPicture">
+      <trans-unit id="ImageToolbox.GetPicture" approved="yes">
         <source xml:lang="en">Get Picture</source>
         <note>ID: ImageToolbox.GetPicture</note>
         <target xml:lang="ha" state="translated">Samu hoto</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
         <source xml:lang="en">Image Toolbox</source>
         <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
         <target xml:lang="ha" state="translated">Akwati mai ɗauke da hoto</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.InstallArtOfReading">
+      <trans-unit id="ImageToolbox.InstallArtOfReading" approved="yes">
         <source xml:lang="en">Install the Art Of Reading package (this may be very slow)</source>
         <note>ID: ImageToolbox.InstallArtOfReading</note>
         <target xml:lang="ha" state="translated">A Saka manhajar Fasahar Karatu (mai yiwuwa ya ɗan ɗauki lokaci)</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.MatchingImages">
+      <trans-unit id="ImageToolbox.MatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images</source>
         <note>ID: ImageToolbox.MatchingImages</note>
         <note>The {0} will be replaced by the number of matching images</note>
         <target xml:lang="ha" state="translated">An sami {0} hotuna</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NewMultilingual">
+      <trans-unit id="ImageToolbox.NewMultilingual" approved="yes">
         <source xml:lang="en">Did you know that there is a new version of this collection which lets you search in Arabic, Bengali, Chinese, English, French, Indonesian, Hindi, Portuguese, Spanish, Thai, or Swahili? It is free and available for downloading.</source>
         <note>ID: ImageToolbox.NewMultilingual</note>
         <target xml:lang="ha" state="translated">Ko ka san akwai wani sabon manhajar wanda zai ba ka damar bincike a cikin harshen Larabci, Bengali, Sinanci, Ingilishi, Farasanci, Indonsiyanci, Hindu, Potugis, Spaniyanci, Thai ko Suwahili? A kyauta, kuma zaka iya saukar da shi zuwa cikin taka na'urar.</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoArtOfReading">
+      <trans-unit id="ImageToolbox.NoArtOfReading" approved="yes">
         <source xml:lang="en">This computer doesn't appear to have the 'Art Of Reading' gallery installed yet.</source>
         <note>ID: ImageToolbox.NoArtOfReading</note>
         <target xml:lang="ha" state="translated">Da alama wannan na'urar ba ta da manhajar zauren Fasahar karatu tukunna.</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoMatchingImages">
+      <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
         <source xml:lang="en">Found no matching images</source>
         <note>ID: ImageToolbox.NoMatchingImages</note>
         <target xml:lang="ha" state="translated">Ba a samu hotunan da suka dace ba</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PictureFiles">
+      <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
         <source xml:lang="en">picture files</source>
         <note>ID: ImageToolbox.PictureFiles</note>
         <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
         <target xml:lang="ha" state="translated">Kundayen hoto</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice" approved="yes">
         <source xml:lang="en">Problem Getting Image</source>
         <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
         <target xml:lang="ha" state="translated">Matsala ta Samun Hoto</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemLoadingImage">
+      <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
         <source xml:lang="en">Sorry, there was a problem loading that image.</source>
         <note>ID: ImageToolbox.ProblemLoadingImage</note>
         <target xml:lang="ha" state="translated">Gafara dai, an samu matsala wajen jawo wancen hoton.</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
         <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
         <note>ID: ImageToolbox.PromptForMissingMetadata</note>
         <target xml:lang="ha" state="translated">Wannan hoton bai san shi ba:\n\n ba Wa ya ƙirƙiro shi?\nWa zai iya amfani da shi?</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Scanner">
+      <trans-unit id="ImageToolbox.Scanner" approved="yes">
         <source xml:lang="en">Scanner</source>
         <note>ID: ImageToolbox.Scanner</note>
         <target xml:lang="ha" state="translated">Mai ɗaukar hoton cikin abu</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchArtOfReading">
+      <trans-unit id="ImageToolbox.SearchArtOfReading" approved="yes">
         <source xml:lang="en">Search the Art of Reading Gallery</source>
         <note>ID: ImageToolbox.SearchArtOfReading</note>
         <target xml:lang="ha" state="translated">Binciki Zauren Fasahar Karatu</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchLanguage">
+      <trans-unit id="ImageToolbox.SearchLanguage" approved="yes">
         <source xml:lang="en">The search box is currently set to {0}</source>
         <note>ID: ImageToolbox.SearchLanguage</note>
         <note>The {0} will be replaced by the name of the language used in the searches.</note>
         <target xml:lang="ha" state="translated">A halin yanzu an saita akwatin binciken ya {0}</target>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SetUpMetadataLink">
+      <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
         <source xml:lang="en">Set up metadata...</source>
         <note>ID: ImageToolbox.SetUpMetadataLink</note>
         <target xml:lang="ha" state="translated">Yi saitin matattarar bayanai...</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.AlternateNamesHeader">
+      <trans-unit id="LanguageLookup.AlternateNamesHeader" approved="yes">
         <source xml:lang="en">Other Names</source>
         <note>ID: LanguageLookup.AlternateNamesHeader</note>
         <target xml:lang="ha" state="translated">Wasu Sunaye</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2" approved="yes">
         <source xml:lang="en">This list should include all the ISO-639 languages, including all the alternative names known to ethnologue.com.\n\nIf necessary, use the "Unlisted Language" option, which will be selected for you now.</source>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2</note>
         <target xml:lang="ha" state="translated">Wannan jerin zai ƙunshi dukkan yarukan  ISO-369, haɗe da dukkan sunayen da ethnologue.com ya sani.\n\n Idan ya zama dole, yi amfani da zaɓin "Yarurrukan da basu cikin jeri" waɗanda za a zaɓa maka yanzu.</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue" approved="yes">
         <source xml:lang="en">Ethnologue.com</source>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
         <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
         <target xml:lang="ha" state="needs-translation">Ethnologue.com</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
         <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
         <target xml:lang="ha" state="translated">Game da Yaren 639-3 Codes da Yadda Za Ka Nemi Wasu Sabbi</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
         <source xml:lang="en">About The ISO Language Registry</source>
         <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
         <target xml:lang="ha" state="translated">Game da wurin yin Rajistar Yaren ISO</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CodeHeader">
+      <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
         <source xml:lang="en">Code</source>
         <note>ID: LanguageLookup.CodeHeader</note>
         <target xml:lang="ha" state="translated">Lamba ta musamman</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryCount">
+      <trans-unit id="LanguageLookup.CountryCount" approved="yes">
         <source xml:lang="en">{0} Countries</source>
         <note>ID: LanguageLookup.CountryCount</note>
         <note>Shown when there are multiple countries and it is just confusing to list them all. {0} is a count of countries.</note>
         <target xml:lang="ha" state="translated">Ƙasashe {0}</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryHeader">
+      <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
         <source xml:lang="en">Country</source>
         <note>ID: LanguageLookup.CountryHeader</note>
         <target xml:lang="ha" state="translated">Ƙasa</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
         <source xml:lang="en">You can change how the language name will be displayed here:</source>
         <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
         <target xml:lang="ha" state="translated">Ka na iya canza yadda za a nuna sunan yaren a nan:</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
         <source xml:lang="en">Lookup Language Code...</source>
         <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
         <target xml:lang="ha" state="translated">Duba Lamba ta Yaren...</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.PrimaryNameHeader">
+      <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
         <source xml:lang="en">Name</source>
         <note>ID: LanguageLookup.PrimaryNameHeader</note>
         <target xml:lang="ha" state="translated">Suna</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel">
+      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel" approved="yes">
         <source xml:lang="en">Show regional dialects</source>
         <note>ID: LanguageLookup.ShowRegionalDialectsLabel</note>
         <target xml:lang="ha" state="translated">Nuna ƙarin harsunan lardi</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup.UnlistedLanguage">
+      <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
         <source xml:lang="en">Unlisted Language</source>
         <note>ID: LanguageLookup.UnlistedLanguage</note>
         <target xml:lang="ha" state="translated">Yaren da ba shi a cikin jeri</target>
       </trans-unit>
-      <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
         <source xml:lang="en">Can't find your language?</source>
         <note>ID: LanguageLookup._cannotFindLanguageLink</note>
         <target xml:lang="ha" state="translated">Ba ka sami yarenka ba?</target>
       </trans-unit>
-      <trans-unit id="MemoryWarning">
+      <trans-unit id="MemoryWarning" approved="yes">
         <source xml:lang="en">Unfortunately, {0} is starting to get short of memory, and may soon slow down or experience other problems. We recommend that you quit and restart it when convenient.</source>
         <note>ID: MemoryWarning</note>
         <target xml:lang="ha" state="translated">Amma kash, {0} wurin ajiyar bayanai na na'urarka ya ragu sosai, kuma saurin ta na iya raguwa, haɗi da wasu    matsaloli. Muna ba ka shawarar ka fita sannan ka kuma sake kunna ta a lokacin da ya dace.</target>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Creator">
+      <trans-unit id="MetadataDisplay.Creator" approved="yes">
         <source xml:lang="en">Creator: {0}</source>
         <note>ID: MetadataDisplay.Creator</note>
         <target xml:lang="ha" state="translated">Maiƙirƙirowa: {0}</target>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.CreatorLabel">
+      <trans-unit id="MetadataDisplay.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <note>ID: MetadataDisplay.CreatorLabel</note>
         <target xml:lang="ha" state="translated">Maiƙirƙirowa</target>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.LicenseInfo">
+      <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
         <source xml:lang="en">License Info</source>
         <note>ID: MetadataDisplay.LicenseInfo</note>
         <target xml:lang="ha" state="translated">Bayanin izini</target>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You must keep the copyright and credits for authors, illustrators, etc.</source>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.AttributionRequired</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
         <target xml:lang="ha" state="translated">Dole ne ka ajiye haƙƙin mallaka da kuma alaƙanta aiki ga marubuta, masu zayyana da sauran su.</target>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You are free to make commercial use of this work.</source>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
         <target xml:lang="ha" state="translated">An yarda ka yi amfani da wannan aikin ta wajen harkar kasuwanci.</target>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work.</source>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.Derivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
         <target xml:lang="ha" state="translated">Kana iya ɗaukar aikin nan a yadda ya ke ko ka yi ƙari akai.</target>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work, but you may distribute the resulting work only under the same or similar license to this one.</source>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
         <target xml:lang="ha" state="translated">Kana iya ɗaukar aikin nan a yadda ya ke, amma za ka iya rarraba sakamakonsa ta ƙarƙashin wannan izinin ne ko wani makamancinsa kawai.</target>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not make changes or build upon this work without permission.</source>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NoDerivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
         <target xml:lang="ha" state="translated">Ba zai yiwu ka yi canje-canje ko ka yi ɗori akan wannan aikin ba tare da izini ba.</target>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not use this work for commercial purposes.</source>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NonCommercial</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
         <target xml:lang="ha" state="translated">Wannan aiki ba domin a yi amfani da shi domin kasuwanci ba ne.</target>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For permission to reuse, contact the copyright holder.</source>
         <note>ID: MetadataDisplay.Licenses.NullLicense</note>
         <note>This is used when all we have is a copyright, no other license.</note>
         <target xml:lang="ha" state="translated">Don izinin sake amfani da shi, ka tuntuɓi mai haƙƙin mallaka.</target>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.NoLicense">
+      <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
         <source xml:lang="en">No license specified</source>
         <note>ID: MetadataDisplay.NoLicense</note>
         <target xml:lang="ha" state="translated">Ba wani izinin da aka bayyana</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowCommercialUse">
+      <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
         <source xml:lang="en">Allow commercial uses of your work?</source>
         <note>ID: MetadataEditor.AllowCommercialUse</note>
         <target xml:lang="ha" state="translated">An ba da izinin yin amfanin da shi domin kasuwanci?</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowDerivatives">
+      <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
         <source xml:lang="en">Allow modifications of your work?</source>
         <note>ID: MetadataEditor.AllowDerivatives</note>
         <target xml:lang="ha" state="translated">Am bayar da izinin yin gyare-gyare a cikin aikinka?</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CopyrightHolder">
+      <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
         <source xml:lang="en">Copyright Holder</source>
         <note>ID: MetadataEditor.CopyrightHolder</note>
         <target xml:lang="ha" state="translated">Mai haƙƙin Mallaka</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons">
+      <trans-unit id="MetadataEditor.CreativeCommons" approved="yes">
         <source xml:lang="en">Creative Commons</source>
         <note>ID: MetadataEditor.CreativeCommons</note>
         <target xml:lang="ha" state="translated">Sanayyar Fasaha</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental">
+      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental" approved="yes">
         <source xml:lang="en">Intergovernmental Version</source>
         <note>ID: MetadataEditor.CreativeCommons.Intergovernmental</note>
         <target xml:lang="ha" state="needs-translation">Intergovernmental Version</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreatorLabel">
+      <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <note>ID: MetadataEditor.CreatorLabel</note>
         <target xml:lang="ha" state="translated">Maiƙirƙirowa</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CustomLicense">
+      <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
         <source xml:lang="en">Custom</source>
         <note>ID: MetadataEditor.CustomLicense</note>
         <target xml:lang="ha" state="translated">al'ada</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleNoCredit">
+      <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
         <source xml:lang="en">Copyright and License</source>
         <note>ID: MetadataEditor.TitleNoCredit</note>
         <target xml:lang="ha" state="translated">Haƙƙin Mallaka da bayar da izini</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleWithCredit">
+      <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
         <source xml:lang="en">Credit, Copyright, and License</source>
         <note>ID: MetadataEditor.TitleWithCredit</note>
         <target xml:lang="ha" state="translated">Ta'allaƙawa, Haƙƙin Mallaka da Izini</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.UnknownLicense">
+      <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <note>ID: MetadataEditor.UnknownLicense</note>
         <target xml:lang="ha" state="translated">Ka tuntuɓi Mai haƙƙin Mallaka don neman izini</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.YesShareAlike">
+      <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
         <source xml:lang="en">Yes, as long as others share alike</source>
         <note>ID: MetadataEditor.YesShareAlike</note>
         <target xml:lang="ha" state="translated">I, muddin manufarmu ta zama iri ɗaya ce</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.additionalRequestsLabel">
+      <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
         <source xml:lang="en">Additional Requests</source>
         <note>ID: MetadataEditor.additionalRequestsLabel</note>
         <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
         <target xml:lang="ha" state="translated">Ƙarin roko</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.betterLinkLabel1">
+      <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
         <source xml:lang="en">more info</source>
         <note>ID: MetadataEditor.betterLinkLabel1</note>
         <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere that defines it.</note>
         <target xml:lang="ha" state="translated">Ƙarin bayani</target>
       </trans-unit>
-      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
         <source xml:lang="en">Not Enforceable</source>
         <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
         <note>While this screen allows it, legally you can't enforce any additions to a creative commons license. This link takes you to the clause that says that. This link is visible only if you choose Creative Commons but then type in  the "Additional Request" box.</note>
         <target xml:lang="ha" state="translated">Ba tilastawa</target>
       </trans-unit>
-      <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
         <target xml:lang="ha" state="translated">Wannan zai iya ɓoye wasu madannai ma waɗanda basu ƙware ba domin ba su buƙatarsu.</target>
       </trans-unit>
-      <trans-unit id="SettingsProtection.CtrlShiftHint">
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
         <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
         <note>ID: SettingsProtection.CtrlShiftHint</note>
         <target xml:lang="ha" state="translated">Madannai za su ta fito idan ka danna Ctrl da Shift tare.</target>
       </trans-unit>
-      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+      <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
         <source xml:lang="en">Settings...</source>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
         <target xml:lang="ha" state="translated">Tsaruka...</target>
       </trans-unit>
-      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
         <source xml:lang="en">Hide the button that opens settings.</source>
         <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
         <target xml:lang="ha" state="translated">Ɓoye madanni da ya ke bude wurin saitin tsare-tsare.</target>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
         <source xml:lang="en">Factory Password</source>
         <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
         <target xml:lang="ha" state="translated">Kalmar izinin shiga daga kamfani</target>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
         <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
         <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
         <target xml:lang="ha" state="translated">Don kiyaye faruwar canje-canjen da ba a buƙata waɗanda za su iya sa wannan manhajar da kake aiki da ita ta dena, an rufe wannan saitin.</target>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
         <source xml:lang="en">Settings Protection Password</source>
         <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
         <target xml:lang="ha" state="translated">Kalma ta Kariyar shiga Tsarin saiti</target>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox">
+      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
         <source xml:lang="en">Show Characters</source>
         <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
         <target xml:lang="ha" state="translated">Nuna Baƙaƙe</target>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordNotice">
+      <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
         <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always google for "{1}" and "{2}".</source>
         <note>ID: SettingsProtection.PasswordNotice</note>
         <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
         <target xml:lang="ha" state="translated">Kalmar Izinin Shiga ta Kamfani don yin wannan saitin ita ce "{0}". Idan ka manta ta, a kodayaushe za ka iya shiga yanar gizon matambayi ba ya bata don "{1}" da "{2}"</target>
       </trans-unit>
-      <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
         <source xml:lang="en">Require the factory password to get into settings.</source>
         <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
         <target xml:lang="ha" state="translated">Nemi Kalmar Izinin Shiga ta Kamfani don yin saiti.</target>
       </trans-unit>
-      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
         <source xml:lang="en">Settings Protection</source>
         <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
         <target xml:lang="ha" state="translated">Tsarin saitin Kalmar Izinin Shiga ta Kariya</target>
       </trans-unit>
-      <trans-unit id="ShowReleaseNotesDialog.WindowTitle">
+      <trans-unit id="ShowReleaseNotesDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <note>ID: ShowReleaseNotesDialog.WindowTitle</note>
         <target xml:lang="ha" state="needs-translation">Release Notes</target>
       </trans-unit>
-      <trans-unit id="WSFontControl.Font">
+      <trans-unit id="WSFontControl.Font" approved="yes">
         <source xml:lang="en">&amp;Font:</source>
         <note>ID: WSFontControl.Font</note>
         <target xml:lang="ha" state="translated">&amp;Girman Haruffa:</target>
       </trans-unit>
-      <trans-unit id="WSFontControl.FontNotAvailable">
+      <trans-unit id="WSFontControl.FontNotAvailable" approved="yes">
         <source xml:lang="en">(The selected font is not available on this machine. Using default.)</source>
         <note>ID: WSFontControl.FontNotAvailable</note>
         <target xml:lang="ha" state="translated">(Ba harafin da ka zaba akan wannan na'urar, ta yin amfanida abun ta fito da shi tun asali.)</target>
       </trans-unit>
-      <trans-unit id="WSFontControl.RightToLeftWS">
+      <trans-unit id="WSFontControl.RightToLeftWS" approved="yes">
         <source xml:lang="en">This is a &amp;right to left writing system.</source>
         <note>ID: WSFontControl.RightToLeftWS</note>
         <target xml:lang="ha" state="translated">Wannan tsarin rubutun da ake farawa ne daga hannun dama zuwa hagu.</target>
       </trans-unit>
-      <trans-unit id="WSFontControl.Size">
+      <trans-unit id="WSFontControl.Size" approved="yes">
         <source xml:lang="en">&amp;Size:</source>
         <note>ID: WSFontControl.Size</note>
         <target xml:lang="ha" state="translated">&amp;Yanayin Girma:</target>
       </trans-unit>
-      <trans-unit id="WSFontControl.TestArea">
+      <trans-unit id="WSFontControl.TestArea" approved="yes">
         <source xml:lang="en">&amp;Test Area:</source>
         <note>ID: WSFontControl.TestArea</note>
         <target xml:lang="ha" state="translated">&amp;Wurin Jarrabawa:</target>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
         <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
         <note>ID: WSKeyboardControl.KeyboardNotListed</note>
         <target xml:lang="ha" state="translated">Idan ba a sa irin wurin latsa kalmomin rubutun da kake bukata ba, ka dangwala hanyar da tafi dacewa a ƙasa don yin saitin</target>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
         <source xml:lang="en">Windows keyboard settings</source>
         <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
         <target xml:lang="ha" state="translated">Tsarin allon madannai na Windows</target>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
         <source xml:lang="en">Available keyboards</source>
         <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
         <target xml:lang="ha" state="translated">Allon maddannan da ke akwai</target>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
         <source xml:lang="en">Previously used keyboards</source>
         <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
         <target xml:lang="ha" state="translated">Allon madannan da aka yi amfani da su</target>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
         <source xml:lang="en">Keyman Configuration</source>
         <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
         <target xml:lang="ha" state="translated">Saitin Keyman.</target>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
         <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
         <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
         <target xml:lang="ha" state="translated">Ba a riga an sa Keyman 5.0 ko na gaba ba.</target>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
         <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
         <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
         <target xml:lang="ha" state="translated">Zaɓi Wurin kalmomin rubutu da za ka rubuta {0}</target>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.TestAreaCaption">
+      <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
         <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
         <note>ID: WSKeyboardControl.TestAreaCaption</note>
         <target xml:lang="ha" state="translated">&amp;Wurin Jarrabawa (Ka yi amfani da wannan wurin don rubuta wani abin da za ka jarraba allon madannanka.)</target>
       </trans-unit>
-      <trans-unit id="Warning">
+      <trans-unit id="Warning" approved="yes">
         <source xml:lang="en">Warning</source>
         <note>ID: Warning</note>
         <target xml:lang="ha" state="translated">Gargaɗi</target>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption" approved="yes">
         <source xml:lang="en">Unable to connect to SLDR</source>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrCaption</note>
         <target xml:lang="ha" state="translated">An kasa haɗawa zuwa SLDR</target>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText" approved="yes">
         <source xml:lang="en">The application is unable to connect to the SIL Locale Data Repository to retrieve the latest information about this language. If you create this writing system, the default settings might be incorrect or out of date. Are you sure you want to create a new writing system?</source>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrText</note>
         <target xml:lang="ha" state="translated">Manhajar ta kasa haɗawa da gidan yanar gizon na ma'adanar SIL don samun sabon bayani game da wannan harshen.  Idan ka ƙirƙiri wannan tsarin rubutu, saitin da na'ura ta fito da shi me yiwuwa ba daidai yake ba ko kuma ya ƙare aiki. Ka tabbata zaka sake ƙirƙirar wani tsarin rubutun?</target>

--- a/DistFiles/localization/ha/TrainingVideos.xlf
+++ b/DistFiles/localization/ha/TrainingVideos.xlf
@@ -2,17 +2,17 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="TrainingVideos-en.md" datatype="html" source-language="en" target-language="ar">
     <body>
-      <trans-unit id="training.videos">
+      <trans-unit id="training.videos" approved="yes">
         <source xml:lang="en">Bloom Training Videos</source>
         <target xml:lang="ha">Hoton bidiyon koyarwa na Bloom</target>
         <note>ID: training.videos</note>
       </trans-unit>
-      <trans-unit id="training.videos.watch">
+      <trans-unit id="training.videos.watch" approved="yes">
         <source xml:lang="en">If you are connected to the internet now, you can watch videos in your web browser:</source>
         <target xml:lang="ha">Idan yanzu kana kan yanar gizo-gizo, za ka iya kallon hotunan bidiyo a kan gidan shigar yanar gizo-gizonka:</target>
         <note>ID: training.videos.watch</note>
       </trans-unit>
-      <trans-unit id="training.videos.all">
+      <trans-unit id="training.videos.all" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-a" html:href="http://tiny.cc/bloomVimeo">All videos</g>
         </source>
@@ -21,12 +21,12 @@
         </target>
         <note>ID: training.videos.all</note>
       </trans-unit>
-      <trans-unit id="training.videos.intro">
+      <trans-unit id="training.videos.intro" approved="yes">
         <source xml:lang="en">Introductory Videos</source>
         <target xml:lang="ha">Hotunan gabatarwa na bidiyon</target>
         <note>ID: training.videos.intro</note>
       </trans-unit>
-      <trans-unit id="training.videos.whofor">
+      <trans-unit id="training.videos.whofor" approved="yes">
         <source xml:lang="en">
           <g id="genid-2" ctype="x-html-a" html:href="https://vimeo.com/114043219">Bloom: Who is it for</g>
         </source>
@@ -35,7 +35,7 @@
         </target>
         <note>ID: training.videos.whofor</note>
       </trans-unit>
-      <trans-unit id="training.videos.templates">
+      <trans-unit id="training.videos.templates" approved="yes">
         <source xml:lang="en">
           <g id="genid-3" ctype="x-html-a" html:href="https://vimeo.com/114024308">Understanding Templates and Shell Books</g>
         </source>
@@ -44,7 +44,7 @@
         </target>
         <note>ID: training.videos.templates</note>
       </trans-unit>
-      <trans-unit id="training.videos.basicbook">
+      <trans-unit id="training.videos.basicbook" approved="yes">
         <source xml:lang="en">
           <g id="genid-4" ctype="x-html-a" html:href="https://vimeo.com/112825489">Using the Basic Book template</g>
         </source>
@@ -53,7 +53,7 @@
         </target>
         <note>ID: training.videos.basicbook</note>
       </trans-unit>
-      <trans-unit id="training.videos.readers">
+      <trans-unit id="training.videos.readers" approved="yes">
         <source xml:lang="en">
           <g id="genid-5" ctype="x-html-a" html:href="http://tiny.cc/usingBloomReaderTemplates">Using Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -62,12 +62,12 @@
         </target>
         <note>ID: training.videos.readers</note>
       </trans-unit>
-      <trans-unit id="training.videos.advanced">
+      <trans-unit id="training.videos.advanced" approved="yes">
         <source xml:lang="en">Advanced Topics</source>
         <target xml:lang="ha">Darussa na Gaba</target>
         <note>ID: training.videos.advanced</note>
       </trans-unit>
-      <trans-unit id="training.videos.formatting">
+      <trans-unit id="training.videos.formatting" approved="yes">
         <source xml:lang="en">
           <g id="genid-6" ctype="x-html-a" html:href="https://vimeo.com/117820891">Changing the format of text</g>
         </source>
@@ -76,7 +76,7 @@
         </target>
         <note>ID: training.videos.formatting</note>
       </trans-unit>
-      <trans-unit id="training.videos.custompage">
+      <trans-unit id="training.videos.custompage" approved="yes">
         <source xml:lang="en">
           <g id="genid-7" ctype="x-html-a" html:href="https://vimeo.com/116868148">Using the Custom Page template</g>
         </source>
@@ -85,7 +85,7 @@
         </target>
         <note>ID: training.videos.custompage</note>
       </trans-unit>
-      <trans-unit id="training.videos.specialcharacters">
+      <trans-unit id="training.videos.specialcharacters" approved="yes">
         <source xml:lang="en">
           <g id="genid-8" ctype="x-html-a" html:href="https://vimeo.com/117927599">Inserting special characters</g>
         </source>
@@ -94,7 +94,7 @@
         </target>
         <note>ID: training.videos.specialcharacters</note>
       </trans-unit>
-      <trans-unit id="training.videos.readertemplates">
+      <trans-unit id="training.videos.readertemplates" approved="yes">
         <source xml:lang="en">
           <g id="genid-9" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">Making a set of Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -103,24 +103,24 @@
         </target>
         <note>ID: training.videos.readertemplates</note>
       </trans-unit>
-      <trans-unit id="training.videos.offline">
+      <trans-unit id="training.videos.offline" approved="yes">
         <source xml:lang="en">Offline Viewing</source>
         <target xml:lang="ha">Kallon da ba akan yanar gizo-gizo ba</target>
         <note>ID: training.videos.offline</note>
       </trans-unit>
-      <trans-unit id="training.videos.download">
+      <trans-unit id="training.videos.download" approved="yes">
         <source xml:lang="en">If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer:</source>
         <target xml:lang="ha">Idan kana son ka sami wani daga cikin waɗannan hotunan bidiyo don nunawa da rabawa a lokacin da babu sadarwar a yanar gizo-gizo, zaka iya samun hotunan bidiyon akan na'urarka mai ƙwaƙwalwa:</target>
         <note>ID: training.videos.download</note>
       </trans-unit>
-      <trans-unit id="training.videos.hires">
+      <trans-unit id="training.videos.hires" approved="yes">
         <source xml:lang="en">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">High Resolution</g> (Large files)</source>
         <target xml:lang="ha">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">Hotuna Masu Inganci</g> (Manyan kundayen ajiya)</target>
         <note>ID: training.videos.hires</note>
       </trans-unit>
-      <trans-unit id="training.videos.lores">
+      <trans-unit id="training.videos.lores" approved="yes">
         <source xml:lang="en">
           <g id="genid-11" ctype="x-html-a" html:href="http://tiny.cc/bloomSDVideos">Low Resolution</g> (Smaller files)</source>
         <target xml:lang="ha">

--- a/DistFiles/localization/ha/leveledReaderInfo.xlf
+++ b/DistFiles/localization/ha/leveledReaderInfo.xlf
@@ -2,59 +2,59 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="leveledReaderInfo-en.html" datatype="html" source-language="en" target-language="ha">
     <body>
-      <trans-unit id="leveled.reader.vocabulary">
+      <trans-unit id="leveled.reader.vocabulary" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="ha">Kalmomi</target>
         <note>ID: leveled.reader.vocabulary</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.simple">
+      <trans-unit id="leveled.reader.start.simple" approved="yes">
         <source xml:lang="en">At beginning levels, use simple words that are familiar to children. If it is possible in your language, use words with only one syllable. As children move up to higher levels, you can begin to use words with more syllables. You can begin to use less familiar words. Children should be able to guess the meaning of these less familiar words from the context of the surrounding words and sentences, as well as from the illustrations.</source>
         <target xml:lang="ha">A matakan farko, yi amfani da kalmomi masu sauƙi da yara za su gane. Idan zai yiwu a cikin harshenka, yi amfani da kalmomi masu gaɓa ɗaya. A lokacin da yara ke ƙarawa gaba, kana iya fara amfani da kalmomi masu gaɓa fiye da ɗaya. Kana iya fara amfani da wasu baƙin kalmomi. Kamata ya yi yara su fara da neman ma'anar waɗannan baƙin kalmomin daga matanin da ke ƙunshe da kalmomin ko jimloli da kuma misalai.</target>
         <note>ID: leveled.reader.start.simple</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.formatting">
+      <trans-unit id="leveled.reader.formatting" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="ha">Tsara bayani</target>
         <note>ID: leveled.reader.formatting</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.large">
+      <trans-unit id="leveled.reader.start.large" approved="yes">
         <source xml:lang="en">Beginner readers will benefit from a larger font with clear spacing between words. Having the words or sentences in the same location on each page is also helpful. As readers progress to higher levels, font size and spacing will decrease and sentences can appear in different locations on the page.</source>
         <target xml:lang="ha">Masu karatu a mataki na farko zasu amfana da rubutun da aka yi da girma tare da sakin fili a tsakanin kalmomi. Samun kalmomi ko jimloli a wuri ɗaya akan kowane shafi shima zai taimaka. A lokacin da fahimtar masu karatu ta ƙaru, girman rubutu da barin 'yar tazara tsakanin kalmomi zai ragu sannan jimloli na iya kasancewa wurare daban-daban a shafi.</target>
         <note>ID: leveled.reader.start.large</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.increase.sizes">
+      <trans-unit id="leveled.reader.increase.sizes" approved="yes">
         <source xml:lang="en">To increase the font size, line-spacing, and word-spacing in Bloom, click in a text box and then on the grey "cog" icon in the lower left-hand corner. If you do this and then make a template book, books made with that template will also use those font settings.</source>
         <target xml:lang="ha">Don kara girman rubutu, sakin layi, da layi tsakanin a kan Bloom, ka dangwala rubutun da aka yi a cikin akwati, sannan ka dangwala alamar da aka yi mai kalar ruwan toka a kwanar da ke ƙasan hannunka na hagu. Idan ka yi haka sai ka yi littafi akan filin da ke bambantawa, litattafan da aka yi a cikin irin waɗannan alamu suma za su iya amfani da waɗancan tsarin yanayin girman rubutu.</target>
         <note>ID: leveled.reader.increase.sizes</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.predictability">
+      <trans-unit id="leveled.reader.predictability" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="ha">Hasashe</target>
         <note>ID: leveled.reader.predictability</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repeat.patterns">
+      <trans-unit id="leveled.reader.repeat.patterns" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-em">Predictability</g> in a text means that the reader can guess what would come next. You can increase predictability by using repeated patterns. Here are some patterns you can use:</source>
         <target xml:lang="ha">
           <g id="genid-1" ctype="x-html-em">Hasashe</g>A cikin matani wannan na nufin mai karatu na iya hasashen abin da zai biyo baya. Za ka iya ƙara taimakawa wajen sanin mai zai faru ta hanyar maimata abubuwa. Ga wasu abubuwan da za ka iya amfani da su:</target>
         <note>ID: leveled.reader.repeat.patterns</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repetition">
+      <trans-unit id="leveled.reader.repetition" approved="yes">
         <source xml:lang="en">Repetition - repeating parts of the text, for example, using the same sentence with each page and just changing one word in the sentence</source>
         <target xml:lang="ha">Maimatawa - maimata wani ɓangaren matani, misali, yin amfani da jimla iri ɗaya a shafi ɗaya ta hanyar canja kalma ɗaya kawai a cikin jimlar</target>
         <note>ID: leveled.reader.repetition</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.sequencing">
+      <trans-unit id="leveled.reader.sequencing" approved="yes">
         <source xml:lang="en">Sequencing - a story with a known sequence such as the days of the week or that uses numbers in a pattern</source>
         <target xml:lang="ha">Tsari - Labarin da aka yi da sanannen tsari kamar ranakun mako ko waɗanda ke amfani da tsarin lambobi</target>
         <note>ID: leveled.reader.sequencing</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.building.sequence">
+      <trans-unit id="leveled.reader.building.sequence" approved="yes">
         <source xml:lang="en">Building Sequence - a story with a pattern that is repeated and added to with each new page</source>
         <target xml:lang="ha">Gina Tsari - Labarin da ke da tsarin da aka maimata kuma aka sa a kowane sabon shafi</target>
         <note>ID: leveled.reader.building.sequence</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.rhyme">
+      <trans-unit id="leveled.reader.rhyme" approved="yes">
         <source xml:lang="en">Rhyme - a story with a pattern or sequence that also includes rhyme. For example:
         <g id="genid-2" ctype="x-html-blockquote" html:class="poetry">
           <g id="genid-3" ctype="x-html-pre">Brown Bear, Brown Bear, What do you see?
@@ -77,64 +77,64 @@ Rawayar Agwagwa, Rawayar Agwagwa, Me Kike gani?</g>
       </target>
         <note>ID: leveled.reader.rhyme</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations">
+      <trans-unit id="leveled.reader.illustrations" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="ha">Tallafin Zayyana</target>
         <note>ID: leveled.reader.illustrations</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.help">
+      <trans-unit id="leveled.reader.illustrations.help" approved="yes">
         <source xml:lang="en">Illustrations provide support to the story. Illustrations relate to the story in different ways at different <g id="genid-5" ctype="x-html-em">levels</g> and for different types of readers (see below). Remember that in many cultures that don't have a lot of printed material around, complex pictures may be difficult to understand.
     </source>
         <target xml:lang="ha">Zayyana na taimakawa don gane labari. Bayani da kwatanci na da alaƙa da labari ta hanyoyi daban-daban a kowane <g id="genid-5" ctype="x-html-em">mataki</g>kuma don amfanin masu karatu ir-daban (duba ƙasa). Ka tuna akwai al'adu da yawa da ba su da rubutatttun abubuwa, hotuna masu sarƙaƙiya na iya zama da wuyar fahimta.
     </target>
         <note>ID: leveled.reader.illustrations.help</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.emergent.reader">
+      <trans-unit id="leveled.reader.illustrations.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-6" ctype="x-html-strong">Emergent Readers</g> the pictures should closely match the storyline. The reader should be able to predict the story line just by looking at the pictures. The illustrations at this level should be simple.
       </source>
         <target xml:lang="ha">Domin <g id="genid-6" ctype="x-html-strong">Masu karatu da ke tasowa</g>Ya kasance hotunan sun yi daidai da labarin. Ya zamanto cewa mai karatun zai sanin inda labarin ya nufa daga hotunan. Zayyanannun misalai a wannan matakin su kasance masu sauƙi.
       </target>
         <note>ID: leveled.reader.illustrations.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.early.reader">
+      <trans-unit id="leveled.reader.illustrations.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-7" ctype="x-html-strong">Early Readers</g> the pictures should offer some support to the story line. As the amount of text increases, the reader is less reliant on the pictures and gets more meaning from the text. The illustrations can be more complex.
       </source>
         <target xml:lang="ha">Domin <g id="genid-7" ctype="x-html-strong">Masu karatu a mataki na fari</g>hotunan su kasance masu goyon bayan labarin. A lokacin da yawan matani ke ƙaruwa, mai karatu zai rage dogaro ga hotuna kuma ya samu ma'ana da dama daga matanin. Zayyanannun misalai na iya zama sun sarƙaƙe
       </target>
         <note>ID: leveled.reader.illustrations.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.fluent.reader">
+      <trans-unit id="leveled.reader.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-8" ctype="x-html-strong">Fluent Readers</g> the pictures should offer little or no support to the story line. The reader relies more on the text than the pictures for meaning. The illustrations can be even more complex.
       </source>
         <target xml:lang="ha">Domin <g id="genid-8" ctype="x-html-strong">Ƙwararrun masu karatu</g>a nan hotunan na iya kasancewa suna taimakawa kaɗan yadda ko basu za'a iya gane inda labarin ya nufa. Ya kasance maikaratu ya dogara ga matani fiye da hotuna a wurin samun ma'ana. Zayyanannun misalai na iya zama sarƙaƙƙu.
       </target>
         <note>ID: leveled.reader.fluent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice">
+      <trans-unit id="leveled.reader.topic.choice" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="ha">Zaɓen Kan Magana</target>
         <note>ID: leveled.reader.topic.choice</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.discussion">
+      <trans-unit id="leveled.reader.topic.choice.discussion" approved="yes">
         <source xml:lang="en">Books can be on many topics. When developing books for beginning readers, choose topics that are familiar to them. Readers will be eager to read and will read more if they are reading about things they find interesting and familiar. For more experienced readers, topics can include information that the reader is not already familiar with.</source>
         <target xml:lang="ha">Litattafai na iya zama akan kawunan magana da yawa. Lokacin shirya littafi domin masu koyon karatu, a zaɓi kan magana da suka saba da ita. Masu karautu za su samu sauƙin karatu kuma su yi karatu da yawa idan suna karanta abinda suke sha'awa kuma wanda suka sani. Ga masu karatu da suka saba, kawunan magana na iya haɗawa da labarin da mai karatu bai saba da shi ba.</target>
         <note>ID: leveled.reader.topic.choice.discussion</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.emergent.reader">
+      <trans-unit id="leveled.reader.topic.choice.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-9" ctype="x-html-strong">Emergent Readers</g> the book should be concrete, should focus on one idea/theme, and should be familiar and easy to understand.
       </source>
         <target xml:lang="ha">Domin <g id="genid-9" ctype="x-html-strong">Masu Karatu da ke ɓullowa</g>litattafan su kasance masu inganci, su kasance suna cikin manufa/take ɗaya, kuma su kasance sanannu masu sauƙin fahimta.
       </target>
         <note>ID: leveled.reader.topic.choice.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.early.reader">
+      <trans-unit id="leveled.reader.topic.choice.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-10" ctype="x-html-strong">Early Readers</g>, develop a story around a familiar concept but in greater depth.
       </source>
         <target xml:lang="ha">Domin <g id="genid-10" ctype="x-html-strong">Masu Karatu da fari-fari</g>a haɗa labari akan sanannen abu amma mai zurfi.
       </target>
         <note>ID: leveled.reader.topic.choice.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.fluent.reader">
+      <trans-unit id="leveled.reader.topic.choice.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-11" ctype="x-html-strong">Fluent Readers</g> the concepts can expand beyond what is familiar, be more varied, and be abstract.
       </source>
         <target xml:lang="ha">Domin <g id="genid-11" ctype="x-html-strong">Waɗanda suka karatu sosai</g>abubuwan da aka gina littafi da su na iya zurfafawa fiye da yadda aka sansu, su bambanta kuma su kasance game gari.

--- a/DistFiles/localization/hi/Bloom.xlf
+++ b/DistFiles/localization/hi/Bloom.xlf
@@ -2,2300 +2,2300 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="hi" datatype="plaintext" product-version="3.0.53.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="hi">डेकोदाबाल रीडर उपकरण</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="hi">लगाया रीडर उपकरण</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="hi">और अधिक...</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="hi">ब्लूम पैक स्थापना</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="hi">{0} संग्रह अब इस कंप्यूटर पर उपयोग के लिए तैयार है।</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="hi">खिले उस ब्लूम पैक को स्थापित करने में सक्षम नहीं था</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="hi">एक्स्ट्रेक्टिंग...</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while BloomPacks are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="hi">ब्लूम पहले से चल रहा है, लेकिन अगली बार तुम खिले चलाएँ जब तक ऊपर सामग्री दिखाएँ नहीं करेंगे</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="hi">{0} खोलने...</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text in boxes with '{1}' style</source>
         <target xml:lang="hi">इस स्वरूपण सभी {0} पाठ बक्सों में '{1}' शैली के साथ के लिए है</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="hi">उन्नत प्रोग्राम सेटिंग्स</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="hi">शो प्रयोगात्मक आदेशों (उदाहरण के लिए xml निर्यात करें इन डिज़ाइन   के लिए)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="hi">प्रयोगात्मक टेम्पलेट्स (उदाहरण के लिए चित्र शब्दकोश) दिखाएँ</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="hi">बड़ी छवियाँ के साथ स्मृति के उपयोग को कम करने के लिए छवि सर्वर का उपयोग करें।</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="hi">(प्रयोगात्मक) भेजें/प्राप्त करें नियंत्रण दिखाएँ</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="hi">पुस्तक बनाना</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="hi">{0} के लिए डिफ़ॉल्ट फ़ॉन्ट</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="hi">बात के सामने/वापस पैक</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="hi">बाईं करने के लिए सही लेखन प्रणाली</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="hi">सेटिंग्स</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="hi">बदलें...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="hi">1 भाषा</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="hi">2 भाषा</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="hi">3 भाषा</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="hi">भाषाएँ</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="hi">सेट करें...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="hi">जातीय भाषा</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="hi">भाषा 2 (उदाहरण के लिए राष्ट्रीय भाषा)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="hi">3 (उदाहरण के लिए क्षेत्रीय भाषा) भाषा (वैकल्पिक)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="hi">निकालें</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="hi">ब्लूम संग्रह नाम</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="hi">देश</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="hi">जिला</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="hi">परियोजना की जानकारी</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="hi">प्रांत</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="hi">पुनरारंभ करें</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="hi">ब्लूम को बंद करें और नई सेटिंग्स के साथ इस परियोजना को पुनः खोलने जाएगा।</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book, but these programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="hi">ब्लूम अब अपने शब्द संसाधन प्रोग्राम (सामान्य रूप से शब्द या लिब्रे कार्यालय) में इस HTML दस्तावेज़ खुलेगा। आप पाठ और इस पुस्तक की छवियों के साथ काम करने में सक्षम हो जाएगा, लेकिन इन कार्यक्रमों के साथ बहुत अच्छी तरह से लेआउट, इतनी ज्यादा उम्मीद नहीं बनाए सामान्य रूप से नहीं है।</target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="hi">पुस्तक का अद्यतन</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="hi">थम्बनेल अद्यतन करें</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="hi">पुस्तक को हटाना</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="hi">शब्द या लिब्रे  कार्यालय को निर्यात करें...</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="hi">एक्स एम एल को निर्यात के लिए इन डिज़ाइन ...</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="hi">खिले पुस्तकालय ऑर्ग से किताबें</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="hi">सभी पुस्तकों का अद्यतन करते हैं</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="hi">सभी पुस्तकों की जाँच करें</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="hi">लापता छवियों बचाव...</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="hi">संग्रह इतिहास...</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="hi">संग्रह नोट्स...</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="hi">संग्रह</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="hi">संग्रह</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="hi">पुस्तक '{0}'</target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="hi">डिस्क पर फ़ोल्डर खोलें</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="hi">स्वास्थ्य</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <target xml:lang="hi">एक किताब इस स्रोत का उपयोग करें</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="hi">अन्य संग्रह</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="hi">नमूना गोले</target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="hi">भेजें/प्राप्त करें</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="hi">सेटिंग्स</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="hi">स्रोत संग्रह</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="hi">खुला अतिरिक्त संग्रह फ़ोल्डर</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="hi">टेम्पलेट्स</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="hi">इस किताब को संपादित करें</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="hi">ब्लूम पैक बनाने</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template BloomPack...</source>
         <target xml:lang="hi">पाठक टेम्पलेट BloomPack बनाओ...</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="hi">उन्नत</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="hi">अधिक स्रोत पुस्तकें जाओ पर खिले पुस्तकालय ऑर्ग</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="hi">स्रोत संग्रह</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="hi">नई पुस्तकों के लिए सूत्रों</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="hi">इस संग्रह, लॉक ताकि नई किताबें जोड़ा गया/हटाया जा नहीं कर सकता है।</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="hi">क्योंकि यह एक स्रोत संग्रह है, खिले नई गोले के लिए स्रोतों के रूप में किसी भी मौजूदा गोले की पेशकश नहीं है। यदि आप एक भाषा एक खोल करने के लिए जोड़ने के लिए चाहते हैं, तो इसके बजाय आप संपादित संग्रह खोल से युक्त, बजाय इसे की एक प्रतिलिपि बनाने के लिए की जरूरत है। इसके अलावा, वॉल कैलेंडर वर्तमान में एक नया खोल करने के लिए उपयोग किया जा सकता।</target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="hi">और अधिक...</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="hi">नई गोले के लिए स्रोतों</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="hi">पीठ</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="hi">रद्द करें</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="hi">रद्द करें</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="hi">समाप्त करें</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="hi">मदद</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="hi">अगले</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="hi">अगले</target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="hi">ठीक है</target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="hi">ठीक है</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="hi">वैकल्पिक</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="hi">इमारत...</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="hi">इस अवस्था में पत्र</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="hi">एक अक्षर और शब्द सूची फ़ाइल खोलें</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="hi">चरणों को सेट करें</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="hi">स्टेज</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="hi">की</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="hi">इस अवस्था में शब्द</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections. If you don't seem to be in the middle of doing something, Bloom will select it for you.</source>
         <target xml:lang="hi">आपका डाउनलोड ({0}) पूरा हो गया है। आप इसे अपने संग्रह में से 'ब्लूम लाइब्रेरी से किताबें' अनुभाग में देख सकते हैं। अगर आप कुछ कर के बीच में होना करने के लिए प्रतीत नहीं, ब्लूम यह आप के लिए का चयन करेंगे।</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="hi">डाउनलोड पूरा हो गया</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="hi">पुस्तक डाउनलोड करना</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="hi">आपकी पुस्तक को डाउनलोड करने में कोई समस्या थी।</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="hi">अगर आप की जरूरत है कहीं डाल पुस्तक के बारे में अधिक जानकारी के लिए, आप इस पृष्ठ, जो िपछला कवर के अंदर है का उपयोग कर सकते हैं।</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="hi">अगर आप की जरूरत है कहीं डाल पुस्तक के बारे में अधिक जानकारी के लिए, आप इस पृष्ठ, जो िपछला कवर के बाहर है का उपयोग कर सकते हैं।</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the Html used to make this PDF, in Firefox (must be on path)</source>
         <target xml:lang="hi">खुला Html (पथ पर होना चाहिए) क्रोम में इस पीडीएफ बनाने के लिए इस्तेमाल किया</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="hi">माफ करना, कॉपीराइट और लाइसेंस के इस पुस्तक के लिए बदला नहीं जा सकता।</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="hi">इसलिए कि छवियाँ परिवर्तित नहीं किया जा सकता खेद है, इस पुस्तक नीचे बंद है।</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="hi">वास्तव में पृष्ठ हटाएँ?</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="hi">हटाएँ</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="hi">यह पृष्ठ स्थायी रूप से निकाल दिया जाएगा।</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="hi">संपादित करें</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="hi">वर्तमान चयनित फ़ॉन्ट '{0}' है, लेकिन यह इस कंप्यूटर पर स्थापित नहीं है। कुछ अन्य फ़ॉन्ट उपयोग किया जाएगा।</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="hi">जब आप किसी मूल किताब बना रही हैं, लेखकों, स्‍पष्‍टकर्ता, संपादकों, आदि द्वारा किए गए योगदान को रिकॉर्ड करने के लिए इस बॉक्स का उपयोग करें।</target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="hi">जब आप एक किताब एक शैल से बना, जो अनुवाद किया था बताने के लिए इस बॉक्स का उपयोग करें।</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="hi">{भाषा} में पुस्तक शीर्षक</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright &amp; License</source>
         <target xml:lang="hi">कॉपीराइट &amp; लायसेंस को संपादित करने के लिए क्लिक करें</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="hi">इस प्रयोग के लिए किसी भी प्रदाता एजेन्सीस स्वीकार करते हैं।</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="hi">अंतर्राष्ट्रीय मानक पुस्तक संख्या। यदि आप इन में से एक है नहीं रिक्त छोड़ दें।</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="hi">मूल (या शैल) स्वीकृतियां {भाषा} में</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="hi">लेखकों, चित्रकारों, संपादकों, आदि, {भाषा} में द्वारा किए गए योगदान</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="hi">विषय चुनने के लिए क्लिक करें</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="hi">स्वीकृतियां {भाषा} में अनुवादित संस्करण के लिए</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="hi">छवि बदलने के लिए</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, &amp; License</source>
         <target xml:lang="hi">छवि क्रेडिट, कॉपीराइट, &amp; लाइसेंस संपादित करें</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="hi">छवि चिपकाएँ</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="hi">लेआउट बदलें</target>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="hi">इससे पहले कि आप एक छवि चिपकाएँ कर सकते हैं, अपने 'क्लिपबोर्ड', पर एक अन्य प्रोग्राम से प्रतिलिपि बनाएँ।</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="hi">पृष्ठों</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="hi">एक पृष्ठ आकार और ओरिएंटेशन का चयन</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="hi">बॉर्डर और पृष्ठभूमि परिवर्तित करें</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="hi">फ़ॉन्ट चेहरा बदल</target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="hi">सभी बक्से की शैली '{0}' और भाषा '{1}' को ले जाने के लिए पाठ का आकार बदलता है।\nवर्तमान आकार {2} पीटी है।</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="hi">फ़ॉन्ट आकार बदलें</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="hi">पाठ की पंक्तियों के बीच की रिक्ति परिवर्तित करें</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="hi">अतिरिक्त व्यापक</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="hi">सामान्य</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="hi">शब्दों के बीच की रिक्ति परिवर्तित करें</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="hi">विस्तृत</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="hi">शैली के लिए स्वरूपण समायोजित करें</target>
         <note>ID: EditTab.FormatDialogTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="hi">टेम्पलेट पृष्ठों</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="hi">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="hi">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="hi">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="hi">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="hi">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="hi">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="hi">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="hi">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="hi">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="hi">वर्णमाला</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="hi">बुनियादी पाठ &amp; छवि</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="hi">बुनियादी पाठ &amp; चित्र</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="hi">क्रेडिट पृष्ठ</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="hi">कस्टम</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="hi">1 दिन</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="hi">2 दिन</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="hi">3 दिन</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="hi">दिन 4</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="hi">दिन 5a</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="hi">दिन 5 ब</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="hi">फ्रंट कवर</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="hi">तल पर छवि</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="hi">बीच में छवि</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="hi">पीछे के कवर के अंदर</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="hi">अंदर सामने कवर</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="hi">निर्देश</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="hi">बस पाठ</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="hi">बस एक चित्र</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="hi">बस एक छवि</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="hi">पीछे के कवर बाहर</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="hi">चित्र &amp; शब्द</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="hi">तल पर चित्र</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="hi">मध्य में चित्र</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="hi">यह पृष्ठ जानबूझकर रिक्त है</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="hi">शीर्षक पृष्ठ</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="hi">बहुभाषी सेटिंग्स</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="hi">प्रतिलिपि बनाएँ</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="hi">कट</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTip">
+      <trans-unit id="EditTab.CutButton.ToolTip" approved="yes">
         <source xml:lang="en">Cut (Ctrl-x)</source>
         <target xml:lang="hi">(कंट्रोल -x) में कटौती</target>
         <note>ID: EditTab.CutButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can cut it</source>
         <target xml:lang="hi">आप की जरूरत है इससे पहले कि आप उसे काट कर सकते हैं कुछ पाठ का चयन करने के लिए</target>
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="hi">हटाने\nपृष्ठ</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTip">
+      <trans-unit id="EditTab.DeletePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Remove this page from the book</source>
         <target xml:lang="hi">यह पृष्ठ किताब से निकालें</target>
         <note>ID: EditTab.DeletePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be removed</source>
         <target xml:lang="hi">यह पृष्ठ नहीं निकाला जा सकता</target>
         <note>ID: EditTab.DeletePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="hi">नकल\nपृष्ठ</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
         <target xml:lang="hi">जो इस एक की नकल है एक नया पृष्ठ सम्मिलित करें</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be duplicated</source>
         <target xml:lang="hi">यह पृष्ठ दोहराया नहीं जा सकता</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="hi">चिपकाएँ</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTip">
+      <trans-unit id="EditTab.PasteButton.ToolTip" approved="yes">
         <source xml:lang="en">Paste (Ctrl+v)</source>
         <target xml:lang="hi">पेस्ट (कंट्रोल  + v)</target>
         <note>ID: EditTab.PasteButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing on the Clipboard that you can paste here.</source>
         <target xml:lang="hi">वहाँ कुछ भी नहीं है कि तुम यहाँ पेस्ट कर सकते हैं क्लिपबोर्ड पर।</target>
         <note>ID: EditTab.PasteButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="hi">पूर्ववत् करें</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTip">
+      <trans-unit id="EditTab.UndoButton.ToolTip" approved="yes">
         <source xml:lang="en">Undo (Ctrl+z)</source>
         <target xml:lang="hi">पूर्ववत् करें (कंट्रोल  + z)</target>
         <note>ID: EditTab.UndoButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="hi">दो भाषाएँ</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="hi">इस पुस्तक में अन्य सभी चित्रों के लिए इस जानकारी की प्रतिलिपि बनाएँ?</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="hi">यह विकल्प केवल प्रकाशित करें टैब में उपलब्ध है।</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="hi">एक भाषा</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="hi">इस टेम्पलेट के लिए कोई अन्य लेआउट विकल्प हैं।</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="hi">चित्र बौद्धिक गुण जानकारी</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="hi">तीन भाषाओं</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="hi">इमारत पाठक टेम्पलेट्स</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu">
+      <trans-unit id="HelpMenu.Help Menu" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="hi">मदद</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="hi">पाठक टेम्पलेट्स का उपयोग करना</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="hi">एक सुझाव है</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="hi">वेब साइट</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="hi">नए संस्करण के लिए जाँच करें</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="hi">खिल के बारे में</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <target xml:lang="hi">प्रलेखन</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="hi">पंजीकरण</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="hi">रिलीज नोट्स...</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="hi">इवेंट लॉग दिखाएँ</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="hi">इन डिज़ाइन  एक्स एम एल  सूचना</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="hi">यह फिर से न दिखाएँ</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="hi">A4लैंडस्केप</target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="hi">A4लैंडस्केप कंधे से कंधा मिलाकर</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="hi">A4लैंडस्केप विभाजन पार पन्ने</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="hi">A4चित्र</target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="hi">A5लैंडस्केप </target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="hi">A5चित्र</target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="hi">A5चित्र नीचेसंरेखित</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="hi">B5चित्र</target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="hi">वास्तविक</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="hi">विषय के विकल्प</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="hi">इस स्तर के लिए</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="hi">स्वरूपण</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration support</source>
         <target xml:lang="hi">चित्रण समर्थन</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="hi">ध्यान में रखें</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="hi">स्तर</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> of </source>
         <target xml:lang="hi">की</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="hi">मैक्स</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="hi">प्रति पृष्ठ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="hi">प्रति वाक्य</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="hi">पूर्वानुमान</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="hi">ऊपर के स्तर सेट करें</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="hi">इस पुस्तक</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="hi">यह पृष्ठ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="hi">कुल</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="hi">अद्वितीय</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="hi">शब्दावली</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="hi">शब्द मायने रखता है</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="hi">मैं उपयोग के खिले लाइब्रेरी की शर्तों से सहमत</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="hi">ईमेल पता</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="hi">पासवर्ड भूल गया</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="hi">लॉगिन</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="hi">पासवर्ड</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="hi">दिखाने के उपयोग की शर्तें</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="hi">खिले पुस्तकालय ऑर्ग करने के लिए लॉग इन करें</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="hi">पासवर्ड दिखाएँ</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="hi">&lt;a href='file://{0}'&gt;{0}&lt;/a&gt;पर उस नाम के साथ एक संग्रह पहले से ही है।\nकृपया एक अद्वितीय नाम चुनें।</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="hi">इस संग्रह के लिए मुख्य भाषा चुनें</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="hi">उदाहरण: "स्वास्थ्य किताबें", "PNG पशु कहानियां"</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="hi">आप क्या कहते हैं इस संग्रह के लिए चाहते हैं?</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="hi">संग्रह नाम समस्या</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="hi">संग्रह पर बनाया जाएगा: {0}</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="hi">नया संग्रह बनाएँ करने के लिए तैयार</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="hi">संग्रह के प्रकार का चयन</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="hi">स्रोत संग्रह</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org and optionally make a BloomPack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="hi">शेल या टेम्पलेट का एक संग्रह है व्यापक संचार के एक या एक से अधिक भाषाओं में किताबें। आप ये गोले BloomLibrary.org करने के लिए अपलोड करें और वैकल्पिक रूप से इतना है कि वे स्थानीय भाषा की पुस्तकों के साथ अपने गोले बना कर सकते हैं दूसरों को देने के लिए एक BloomPack बनाने के लिए सक्षम हो जाएगा।</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="hi">स्थानीय भाषा/स्थानीय भाषा संग्रह</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="hi">एक स्थानीय भाषा में पुस्तकों का एक संग्रह है।</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="hi">भाषा स्थान दे</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="hi">देश</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="hi">जिला</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="hi">ये वैकल्पिक हैं। ब्लूम उन्हें आप बना पुस्तकों के शीर्षक पृष्ठ पर सही स्थानों में जगह होगी।</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="hi">प्रांत</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="hi">{0} पुस्तकें</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="hi">नई ब्लूम संग्रह बनाएँ</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="hi">प्रोजेक्ट का नाम</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="hi">उस नाम का उपयोग कर एक नया संग्रह बनाने में असमर्थ।</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="hi">ब्लूम में आपका स्वागत है!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="hi">तुम लगभग किताबें बनाने शुरू के लिए तैयार कर रहे हैं।</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. So the first thing we need to do is make one for you.</source>
         <target xml:lang="hi">आदेश में चीजों को सरल और संगठित रखने के लिए, सभी किताबें आप बनाने के एक या अधिक &lt;i&gt;संग्रहों&lt;/i&gt;में खिले रखता है। तो हम करने की ज़रूरत पहली बात आप के लिए एक बना है।</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="hi">आरंभ करने के लिए 'अगला' क्लिक करें।</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="hi">ब्लूम संग्रह</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="hi">इस कंप्यूटर पर किसी अन्य संग्रह के लिए ब्राउज़ करें</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="hi">स्थानीय नेटवर्क पर कोरस हब से प्रतिलिपि बनाएँ</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="hi">इंटरनेट से प्रतिलिपि बनाएँ</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="hi">यूएसबी ड्राइव से प्रतिलिपि बनाएँ</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="hi">नया संग्रह बनाएँ</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="hi">ओपन/संग्रह बनाएँ</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="hi">और अधिक पढ़ें</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="hi">किसी और के एक संग्रह को आप के साथ साझा करने के लिए भेजें/प्राप्त करें इस्तेमाल किया है?\nये लाल बटन में से एक उनके संग्रह करने के लिए आपके कंप्यूटर की प्रतिलिपि का उपयोग करें।\nबाद में, वापस उन लोगों के साथ अपने काम साझा करने के लिए भेजें/प्राप्त करें का उपयोग करें।</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="hi">मौजूदा एक की जगह</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="hi">नोटिस</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are</source>
         <target xml:lang="hi">कि बदलाव की अनुमति नहीं है। बात के सामने और पीछे की बात पृष्ठों रहना चाहिए जहाँ वे हैं</target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="hi">अमान्य चाल</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="hi">ताकि खिल अपनी पूरी किताब दिखा सकते हैं अडोब रीडर स्थापित कृपया। तब तक, तुम अब भी पीडीएफ किताब बचाने कर सकते हैं और इसे कुछ अन्य प्रोग्राम में खुला।</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="hi">अजीब बात है कि... एडोब रीडर दिखाने का प्रयास करते समय एक त्रुटि दिया था कि पीडीएफ। आप अभी भी PDF पुस्तक सहेजने का प्रयास करें कर सकते हैं।</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="hi">दुखद खबर। खिले तो ब्लूम अपनी पूरी किताब दिखा सकता एडोब रीडर यहाँ, दिखाने के लिए प्राप्त करने में सक्षम नहीं था।\nकृपया 'एडोब रीडर' के अपने मौजूदा संस्करण की स्थापना रद्द करें और 'एडोब रीडर' (पुनः) स्थापित करें।\nजब तक आप कि तय हो, तुम अभी भी पीडीएफ किताब बचाने कर सकते हैं और इसे कुछ अन्य प्रोग्राम में खोलें।</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="hi">बुकलेट अंदर</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book.
  Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="hi">अंदर से एक बुकलेट बना पुस्तक के पन्नों।
  पृष्ठों बाहर रखा जाएगा और इतना है कि जब आप इसे गुना है, आप एक पुस्तिका होगा reordered.(-999)</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="hi">अपलोड करें</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="hi">खिले पुस्तकालय ऑर्ग, जहां दूसरों के डाउनलोड कर सकते हैं और अपनी भाषा में मुख्य स्थान में स्थिर करने के लिए अपलोड करें।</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="hi">बुकलेट आवरण</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="hi">बस सामने की एक पीडीएफ बनाने के लिए और वापस (दोनों पक्षों), तो तुम रंग का कागज पर मुद्रित कर सकते हैं।</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="hi">सरल</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="hi">एक पीडीएफ किताब, एक कागज का टुकड़ा प्रति पृष्ठ के प्रत्येक पृष्ठ के बनाने के।</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system pdf viewer</source>
         <target xml:lang="hi">पीडीएफ डिफ़ॉल्ट सिस्टम पीडीएफ व्यूअर में खोलें</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="hi">प्रिंट...</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="hi">प्रकाशित करें</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="hi">पीडीएफ सहेजें...</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="hi">फसल के निशान</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="hi">पावती</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">AdditionalRequests: </source>
         <target xml:lang="hi">अतिरिक्त अनुरोध</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="hi">सभी अधिकार आरक्षित (संपर्क करें कॉपीराइट धारक किसी भी अनुमतियों के लिए.)</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you.  If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="hi">खिले पुस्तकालय ऑर्ग पहले से ही तुम से इस पुस्तक का एक पिछला संस्करण है।  यदि आप इसे फिर से अपलोड करें, यह अपने वर्तमान संस्करण के साथ प्रतिस्थापित किया जाएगा।</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="hi">कॉपीराइट</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="hi">क्रेडिट्स</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="hi">आपकी पुस्तक को डाउनलोड करने में कोई समस्या थी। तुम खिले पुनरारंभ करें या तकनीकी सहायता प्राप्त करने के लिए पड़ सकता है।</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="hi">माफ करना, {0} अपलोड करने में कोई समस्या थी। कुछ विवरण का पालन करें। आप तकनीकी सहायता की आवश्यकता हो सकती।</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading</source>
         <target xml:lang="hi">एक या अधिक फ़ील्ड्स उपरोक्त अपलोड करने से पहले अपना ध्यान देने की जरूरत</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded</source>
         <target xml:lang="hi">क्षमा करें, "{0}" अपलोड नहीं सफलतापूर्वक किया गया था</target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes</source>
         <target xml:lang="hi">अपलोड करने, द्वारा आप ब्लूम लाइब्रेरी उपयोग की शर्तों के साथ अपने समझौते की पुष्टि करें और यह बताता है कि अधिकार अनुदान</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="hi">अपनी पुस्तक अपलोड करने में कोई समस्या थी।</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="hi">भाषाएँ</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="hi">उपयोग/लाइसेंस</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="hi">खाता पहले से मौजूद है</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address.  Would you like to log in instead?</source>
         <target xml:lang="hi">क्योंकि हम उस पते के साथ एक खाता पहले से ही है हम आपको उस पते के साथ, नहीं कर सकता साइन अप करें।  तुम बदले लॉग ऑन करना चाहेंगे?</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="hi">ब्लूम आपके लॉगिन को सत्यापित करने के लिए सर्वर से कनेक्ट नहीं हो सका। कृपया अपने नेटवर्क कनेक्शन की जाँच करें।</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="hi">लॉगिन विफल रहा</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="hi">ब्लूम आपके लॉगिन या पंजीकरण पूर्ण करने के लिए सर्वर से कनेक्ट नहीं हो सका। इस बीच में अपने इंटरनेट कनेक्शन, हमारे सर्वर या कुछ उपकरणों के साथ एक समस्या हो सकता है।</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="hi">एक खिले पुस्तकालय ऑर्ग  खाते के लिए साइन अप करने के लिए, आप चेक बॉक्स यह दर्शाता है कि आप BloomLibrary उपयोग की शर्तों से सहमत होना चाहिए।</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="hi">ईमेल की जरूरत</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="hi">हम एक उपयोगकर्ता है कि ईमेल के साथ रिकॉर्ड पर नहीं। आप साइन अप करने के लिए चाहते हैं?</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="hi">पासवर्ड और उपयोगकर्ता आईडी से मेल नहीं खाती</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="hi">कृपया उपयोग की शर्तों से सहमत हूँ</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="hi">कृपया एक मान्य ईमेल पता दर्ज करें। हम इस पते पर एक ईमेल भेज देंगे ताकि आप अपने पासवर्ड को रीसेट कर सकते हैं।</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="hi">ब्लूम अपने पासवर्ड को रीसेट करने के लिए सर्वर से कनेक्ट नहीं हो सका। कृपया अपने नेटवर्क कनेक्शन की जाँच करें।</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="hi">पासवर्ड रीसेट करें विफल रहा</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="hi">पासवर्ड रीसेट करना</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password</source>
         <target xml:lang="hi">हम कैसे अपना पासवर्ड रीसेट करने के लिए निर्देश के साथ {0} के लिए एक ईमेल भेज रहे हैं</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="hi">ब्लूम पुस्तकालय के लिए साइन अप करें।</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="hi">अज्ञात उपयोगकर्ता</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="hi">ब्लूम खिले पुस्तकालय ऑर्ग अपने सहेजे गए क्रेडेंशियल का उपयोग करने के लिए लॉग नहीं कर सका। कृपया अपने नेटवर्क कनेक्शन की जाँच करें।</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="hi">खिले पुस्तकालय ऑर्ग से बाहर लॉग इन करें</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="hi">पी डी एफ़ पूर्वावलोकन बनाने के...</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="hi">थंबनेल छवि बनाने के...</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="hi">क्षमा करें, ब्लूम डेस्कटॉप का यह संस्करण BloomLibrary.org के वर्तमान संस्करण के साथ संगत नहीं है। कृपया एक नए संस्करण के लिए उन्नयन।</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="hi">कृपया लॉग इन करने के लिए BloomLibrary.org (या साइन अप) अपलोड करने से पहले</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="hi">कृपया इस संपादन टैब से सेट करें</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="hi">चरण 1: मेटाडेटा की पुष्टि करें</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="hi">चरण 2: अपलोड करें</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="hi">सुझाव: एक क्रिएटिव सामान्य लाइसेंस असाइन करना यह आप स्पष्ट रूप से निश्चित अनुमति देना करने के लिए हर किसी के लिए आसान बनाता है।</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="hi">सुझाव: भले ही वे अपने कस्टम लाइसेंस की भाषा में धाराप्रवाह नहीं कर रहे हैं क्रिएटिव कॉमन्स लाइसेंस यह अपनी पुस्तक का उपयोग करने के लिए दूसरों के लिए ज्यादा आसान बनाने के।</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="hi">सारांश</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="hi">दिखाने के उपयोग की शर्तें</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="hi">शीर्षक</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="hi">बुक अपलोड करें</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <target xml:lang="hi">"बधाई हो, {0}" अब पर खिले पुस्तकालय ऑर्ग ({1}) उपलब्ध है</target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="hi">अपलोड करने की अनुमति नहीं है</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="hi">अपनी पुस्तक अपलोड करने में कोई समस्या थी। तुम खिले पुनरारंभ करें या तकनीकी सहायता प्राप्त करने के लिए पड़ सकता है।</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="hi">अपलोड प्रगति</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="hi">पुस्तक (करने के लिए बालूदानी) अपलोड करें</target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="hi">पुस्तक मेटाडेटा को अपलोड</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, &amp; topic tags to the bloomlibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="hi">{0} को अपलोड</target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="hi">प्रतिलिपि द्वारा नेकां</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="hi">खिले पुस्तकालय ऑर्ग करने के लिए लॉग इन करें</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="hi">खिले पुस्तकालय ऑर्ग के लिए साइन अप करें</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="hi">स्तर जोड़ें</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="hi">चरण जोड़ें</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <target xml:lang="hi">कृपया ग्रंथों के लिए नमूना ग्रंथों फ़ोल्डर जोड़ें।</target>
         <note>ID: ReaderSetup.AddTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="hi">पुस्तक</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="hi">पुस्तक प्रति अधिकतम शब्द</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="hi">उन्हें इस अवस्था को जोड़ने के लिए अक्षरों पर क्लिक करें।</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="hi">रिक्त स्थान से अलग</target>
         <note>ID: ReaderSetup.CombinationHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <target xml:lang="hi">उदाहरण के लिए "ऐ ऊ श एनजी गु आईएनजी"</target>
         <note>ID: ReaderSetup.CombinationHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <target xml:lang="hi">अक्षरों के संयोजन (ग्रॅफेमेस )</target>
         <note>ID: ReaderSetup.Combinations</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="hi">डेकोडाबाल अवस्था</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="hi">प्रथम,</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="hi">इस प्रारूप पढ़ा नहीं कर सकता</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="hi">निर्यात और नमूना ग्रंथों के रूप में उपयोग करने के लिए फ़ाइलों को परिवर्तित करने में मदद</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="hi">भाषा</target>
         <note>ID: ReaderSetup.Language</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <target xml:lang="hi">अक्षर और शब्द-गठन अकारादि क्रम में अक्षरों की सूची।</target>
         <note>ID: ReaderSetup.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="hi">रिक्त स्थान से अलग</target>
         <note>ID: ReaderSetup.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <target xml:lang="hi">उदाहरण के लिए "एक ख ग घ"</target>
         <note>ID: ReaderSetup.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="hi">पत्र</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="hi">पत्र और पत्र संयोजन</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="hi">आप पाठकों के decodable बनाने में मदद करने के लिए, पत्र और पत्र संयोजन कि आप शिक्षण हो जाएगा पता करने के लिए ब्लूम की जरूरत।</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="hi">प्रत्येक पत्र या पत्र संयोजन एक स्थान के साथ अलग करें। उदाहरण के लिए, यहाँ है क्या हम के लिए अंग्रेजी भाषा का प्रयोग हो सकता है:</target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="hi">सूचना है कि अंग्रेजी सूची भी शामिल है जैसे शब्दों में, करने के लिए उपयोग किए गए प्रतीक ' में</target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="hi">यह है</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="hi">.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="hi">स्तर</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="hi">स्तर</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="hi">पाठक का स्तर</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="hi">शब्दों से मेल खाते</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="hi">पुस्तक प्रति अधिकतम अद्वितीय शब्दों</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <target xml:lang="hi">और शब्द</target>
         <note>ID: ReaderSetup.MoreWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <target xml:lang="hi">इस भाषा के लिए नमूना ग्रंथों फ़ोल्डर खोलें।</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="hi">पृष्ठ</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="hi">प्रत्येक पृष्ठ पर अधिकतम शब्द</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="hi">इसके द्वारा संचालित</target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="hi">पाठक का स्तर</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="hi">तर {0} निकालें</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="hi">स्टेज {0} निकालें</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="hi">पंक्तियों के स्तर को पुन: क्रमांकित करने के लिए खींचें।</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="hi">चरणों को पुन: क्रमांकित करने के लिए पंक्तियों को खींचें।</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <target xml:lang="hi">शब्द सूचियों और नमूना ग्रंथों</target>
         <note>ID: ReaderSetup.SampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="hi">, साक्षरता के लिए खोज इंजन।</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="hi">पिछले और नए पत्र</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="hi">वाक्य</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="hi">प्रत्येक वाक्य में अधिकतम शब्द</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="hi">Decodable रीडर उपकरण अप सेट करें</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="hi">समतल पाठक उपकरण अप सेट करें</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <target xml:lang="hi">वर्णमाला इस भाषा के लिए सेट करें।</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <target xml:lang="hi">क्या दृष्टि शब्दों रहे हैं?</target>
         <note>ID: ReaderSetup.SightWordHelp</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="hi">नई दृष्टि शब्दों</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="hi">दृष्टि शब्दों</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="hi">स्टेज</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="hi">स्टेज</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="hi">चरणों</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="hi">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="hi">इस स्तर के लिए याद करने के लिए चीजें:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="hi">अद्वितीय</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="hi">शब्दों के</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage.  There are two ways to give words to Bloom:</source>
         <target xml:lang="hi">आप पाठकों के decodable बनाने में मदद करने के लिए, ब्लूम शब्दों है कि वर्तमान मंच के भीतर फिट का सुझाव कर सकते हैं।  खिलने को शब्द देने के लिए दो तरीके हैं:</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="hi">2) जगह पाठ फ़ाइलों में अपने</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Text Folder</source>
         <target xml:lang="hi">नमूना पाठ फ़ोल्डर</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="hi">1) यहाँ शब्द लिखें</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="hi">पत्र</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this BloomPack will carry your latest decodable and leveled reader settings for the "{0}" language. Anyone opening this BloomPack , who then opens a "{0}" collection, will have their current decodable and leveled reader settings replaced by the settings in this BloomPack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="hi">इसके अलावा, इस BloomPack अपनी नवीनतम decodable और लगाया रीडर सेटिंग्स "{0}" भाषा के लिए ले जाएगा। किसी को खोलने के इस BloomPack, जो फिर एक "{0}" संग्रह खोलता है, उनकी वर्तमान पाठक decodable और लगाया सेटिंग्स द्वारा इस BloomPack में सेटिंग्स बदल दिया होगा। वे भी पाठकों के decodable में उपयोग के लिए शब्दों के मौजूदा सेट मिल जाएगा।</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="hi">निम्नलिखित पुस्तकों टेम्पलेट्स में किया जाएगा:</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save BloomPack</source>
         <target xml:lang="hi">BloomPack सहेजें</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template BloomPack</source>
         <target xml:lang="hi">पाठक टेम्पलेट BloomPack बनाना</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="hi">ईमेल पता</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="hi">प्रथम नाम</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="hi">कृपया {0} रजिस्टर करने के लिए एक मिनट ले लो</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="hi">कैसे आप {0} का उपयोग कर रहे हैं?</target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="hi">मैं फँस गया हूँ, मैं यह बाद में पूरा करेंगे।</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="hi">संगठन</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="hi">पंजीकृत करें</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="hi">कुलनाम</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="hi">{0} रजिस्टर</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="hi">बुनियादी पुस्तिका</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="hi">बिग बुक</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="hi">डेकोदाबाल पाठक</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="hi">लगाया पाठक</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="hi">चित्र शब्दकोश</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="hi">दीवार कैलेंडर</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="hi">कृषि</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="hi">पशु कहानियां</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="hi">व्यापार</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="hi">सामुदायिक जीवन</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="hi">संस्कृति</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="hi">शब्दकोश</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="hi">पर्यावरण</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="hi">कथा</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="hi">स्वास्थ्य</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="hi">कैसे करना है</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="hi">गणित</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="hi">गैर गल्प</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="hi">व्यक्तिगत विकास</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="hi">भजन की पुस्तक</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="hi">विज्ञान</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="hi">आध्यात्मिक</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="hi">परंपरा</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="hi">पारंपरिक कहानी</target>
         <note>ID: Topics.Traditional Story</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="hi">सेटअप</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
       </trans-unit>
-      <trans-unit id="You may use this space for author/illustrator, or anything else." sil:dynamic="true">
+      <trans-unit id="You may use this space for author/illustrator, or anything else." sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="hi">लेखक/स्‍पष्‍टकर्ता, या कुछ और के लिए आप इस स्थान का उपयोग हो सकता।</target>
         <note>ID: You may use this space for author/illustrator, or anything else.</note>

--- a/DistFiles/localization/hi/Palaso.xlf
+++ b/DistFiles/localization/hi/Palaso.xlf
@@ -2,395 +2,395 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Palaso.dll" source-language="en" target-language="hi" datatype="plaintext" product-version="3.0.53.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="AboutDialog.AboutDialogWindowTitle">
+      <trans-unit id="AboutDialog.AboutDialogWindowTitle" approved="yes">
         <source xml:lang="en">About</source>
         <target xml:lang="hi">के बारे में</target>
         <note>ID: AboutDialog.AboutDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.NoUpdates">
+      <trans-unit id="AboutDialog.NoUpdates" approved="yes">
         <source xml:lang="en">No Updates</source>
         <target xml:lang="hi">कोई अद्यतन</target>
         <note>ID: AboutDialog.NoUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._checkForUpdates">
+      <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
         <source xml:lang="en">Check For Updates</source>
         <target xml:lang="hi">अद्यतनों के लिए जाँच करें</target>
         <note>ID: AboutDialog._checkForUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._releaseNotesLabel">
+      <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="hi">रिलीज नोट्स</target>
         <note>ID: AboutDialog._releaseNotesLabel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="hi">रद्द करें</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.No">
+      <trans-unit id="Common.No" approved="yes">
         <source xml:lang="en">No</source>
         <target xml:lang="hi">नहीं</target>
         <note>ID: Common.No</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="hi">ठीक है</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Yes">
+      <trans-unit id="Common.Yes" approved="yes">
         <source xml:lang="en">Yes</source>
         <target xml:lang="hi">हाँ</target>
         <note>ID: Common.Yes</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="hi">{0} को रीसायकल बिन में ले जाई जाएगी।</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
         <note>Param 0 is a description of the things being deleted (e.g., "The selected files"</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="hi">{0} को रीसायकल बिन में ले जाई जाएगी।</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
         <note>Param 0 is a file name</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Confirm Delete</source>
         <target xml:lang="hi">हटाने की पुष्टि करें</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="hi">रद्द करें</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="hi">हटाएँ</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ArtOfReading">
+      <trans-unit id="ImageToolbox.ArtOfReading" approved="yes">
         <source xml:lang="en">Art Of Reading</source>
         <target xml:lang="hi">पढ़ने की कला</target>
         <note>ID: ImageToolbox.ArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Camera">
+      <trans-unit id="ImageToolbox.Camera" approved="yes">
         <source xml:lang="en">Camera</source>
         <target xml:lang="hi">कैमरा</target>
         <note>ID: ImageToolbox.Camera</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
         <source xml:lang="en">Use {0}</source>
         <target xml:lang="hi">{0} का उपयोग करें</target>
         <note>ID: ImageToolbox.CopyExemplarMetadata</note>
         <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Crop">
+      <trans-unit id="ImageToolbox.Crop" approved="yes">
         <source xml:lang="en">Crop</source>
         <target xml:lang="hi">फसल</target>
         <note>ID: ImageToolbox.Crop</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EditMetadataLink">
+      <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
         <source xml:lang="en">Edit...</source>
         <target xml:lang="hi">संपादित करें...</target>
         <note>ID: ImageToolbox.EditMetadataLink</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EnterSearchTerms">
+      <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
         <source xml:lang="en">This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.</source>
         <target xml:lang="hi">इस 'पढ़ने की कला' गैलरी है। उपरोक्त बॉक्स, में लिखें क्या आप के लिए खोज रहे हैं, तो दर्ज दबाएँ। आप शब्दों के अंग्रेजी और इंडोनेशिया में टाइप कर सकते हैं।</target>
         <note>ID: ImageToolbox.EnterSearchTerms</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.FileButton">
+      <trans-unit id="ImageToolbox.FileButton" approved="yes">
         <source xml:lang="en">File</source>
         <target xml:lang="hi">फ़ाइल</target>
         <note>ID: ImageToolbox.FileButton</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
         <target xml:lang="hi">क्षमा करें, कुछ छवि हो रही है जबकि गलत हो गया था।</target>
         <note>ID: ImageToolbox.GenericGettingImageProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericProblem">
+      <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
         <target xml:lang="hi">क्षमा करें, कुछ छवि उपकरण बॉक्स के साथ गलत हो गया था</target>
         <note>ID: ImageToolbox.GenericProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GetPicture">
+      <trans-unit id="ImageToolbox.GetPicture" approved="yes">
         <source xml:lang="en">Get Picture</source>
         <target xml:lang="hi">चित्र प्राप्त करें</target>
         <note>ID: ImageToolbox.GetPicture</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
         <source xml:lang="en">Image Toolbox</source>
         <target xml:lang="hi">छवि उपकरण बॉक्स</target>
         <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoMatchingImages">
+      <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
         <source xml:lang="en">Found no matching images</source>
         <target xml:lang="hi">कोई मेल खाने वाला चित्र पाया</target>
         <note>ID: ImageToolbox.NoMatchingImages</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PictureFiles">
+      <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
         <source xml:lang="en">picture files</source>
         <target xml:lang="hi">चित्र फ़ाइलें</target>
         <note>ID: ImageToolbox.PictureFiles</note>
         <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice" approved="yes">
         <source xml:lang="en">Problem Getting Image</source>
         <target xml:lang="hi">समस्या हो रही छवि</target>
         <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemLoadingImage">
+      <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
         <source xml:lang="en">Sorry, there was a problem loading that image.</source>
         <target xml:lang="hi">क्षमा करें, कि छवि लोड करने में कोई समस्या थी।</target>
         <note>ID: ImageToolbox.ProblemLoadingImage</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
         <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
         <target xml:lang="hi">इस छवि जिसने इसे बनाया नहीं know:\n\nकरता है?\nकौन इसे का उपयोग कर सकते हैं?</target>
         <note>ID: ImageToolbox.PromptForMissingMetadata</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Scanner">
+      <trans-unit id="ImageToolbox.Scanner" approved="yes">
         <source xml:lang="en">Scanner</source>
         <target xml:lang="hi">स्कैनर</target>
         <note>ID: ImageToolbox.Scanner</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SetUpMetadataLink">
+      <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
         <source xml:lang="en">Set up metadata...</source>
         <target xml:lang="hi">मेटाडेटा को सेट करें...</target>
         <note>ID: ImageToolbox.SetUpMetadataLink</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.AlternateNamesHeader">
+      <trans-unit id="LanguageLookup.AlternateNamesHeader" approved="yes">
         <source xml:lang="en">Other Names</source>
         <target xml:lang="hi">अन्य नाम</target>
         <note>ID: LanguageLookup.AlternateNamesHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue" approved="yes">
         <source xml:lang="en">Ethnologue.com</source>
         <target xml:lang="hi">एन्थोनोलोग .काम</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
         <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
         <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
         <target xml:lang="hi">भाषा 639-3 कोड्स &amp; नए लोगों के लिए आवेदन कैसे करें के बारे में</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
         <source xml:lang="en">About The ISO Language Registry</source>
         <target xml:lang="hi">आईएसओ भाषा रजिस्ट्री के बारे में</target>
         <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CodeHeader">
+      <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
         <source xml:lang="en">Code</source>
         <target xml:lang="hi">कोड</target>
         <note>ID: LanguageLookup.CodeHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryHeader">
+      <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="hi">देश</target>
         <note>ID: LanguageLookup.CountryHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
         <source xml:lang="en">You can change how the language name will be displayed here:</source>
         <target xml:lang="hi">आप बदल सकते हैं कैसे भाषा नाम यहाँ प्रदर्शित किया जाएगा:</target>
         <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
         <source xml:lang="en">Lookup Language Code...</source>
         <target xml:lang="hi">लुकअप भाषा कोड...</target>
         <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.PrimaryNameHeader">
+      <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="hi">नाम</target>
         <note>ID: LanguageLookup.PrimaryNameHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.UnlistedLanguage">
+      <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
         <source xml:lang="en">Unlisted Language</source>
         <target xml:lang="hi">असूचीबद्ध भाषा</target>
         <note>ID: LanguageLookup.UnlistedLanguage</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
         <source xml:lang="en">Can't find your language?</source>
         <target xml:lang="hi">आपकी भाषा नहीं ढूँढ सकता?</target>
         <note>ID: LanguageLookup._cannotFindLanguageLink</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Creator">
+      <trans-unit id="MetadataDisplay.Creator" approved="yes">
         <source xml:lang="en">Creator: {0}</source>
         <target xml:lang="hi">निर्माता: {0}</target>
         <note>ID: MetadataDisplay.Creator</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.LicenseInfo">
+      <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
         <source xml:lang="en">License Info</source>
         <target xml:lang="hi">लाइसेंस जानकारी</target>
         <note>ID: MetadataDisplay.LicenseInfo</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.NoLicense">
+      <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
         <source xml:lang="en">No license specified</source>
         <target xml:lang="hi">निर्दिष्ट कोई लाइसेंस</target>
         <note>ID: MetadataDisplay.NoLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowCommercialUse">
+      <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
         <source xml:lang="en">Allow commercial uses of your work?</source>
         <target xml:lang="hi">अपने काम के वाणिज्यिक उपयोग करता है की अनुमति दें?</target>
         <note>ID: MetadataEditor.AllowCommercialUse</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowDerivatives">
+      <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
         <source xml:lang="en">Allow modifications of your work?</source>
         <target xml:lang="hi">संशोधनों के अपने काम की अनुमति दें?</target>
         <note>ID: MetadataEditor.AllowDerivatives</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CopyrightHolder">
+      <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
         <source xml:lang="en">Copyright Holder</source>
         <target xml:lang="hi">कॉपीराइट धारक</target>
         <note>ID: MetadataEditor.CopyrightHolder</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons">
+      <trans-unit id="MetadataEditor.CreativeCommons" approved="yes">
         <source xml:lang="en">Creative Commons</source>
         <target xml:lang="hi">क्रिएटिव कॉमन्स</target>
         <note>ID: MetadataEditor.CreativeCommons</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreatorLabel">
+      <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="hi">निर्माता</target>
         <note>ID: MetadataEditor.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CustomLicense">
+      <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="hi">कस्टम</target>
         <note>ID: MetadataEditor.CustomLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleNoCredit">
+      <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
         <source xml:lang="en">Copyright &amp; License</source>
         <target xml:lang="hi">कॉपीराइट &amp; लाइसेंस</target>
         <note>ID: MetadataEditor.TitleNoCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleWithCredit">
+      <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
         <source xml:lang="en">Credit, Copyright, &amp; License</source>
         <target xml:lang="hi">क्रेडिट, कॉपीराइट, &amp; लाइसेंस</target>
         <note>ID: MetadataEditor.TitleWithCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.UnknownLicense">
+      <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <target xml:lang="hi">कॉपीराइट धारक के लिए किसी भी अनुमतियों से संपर्क करें</target>
         <note>ID: MetadataEditor.UnknownLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.YesShareAlike">
+      <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
         <source xml:lang="en">Yes, as long as others share alike</source>
         <target xml:lang="hi">हाँ, लंबे समय के रूप में दूसरों के एक जैसे साझा करें</target>
         <note>ID: MetadataEditor.YesShareAlike</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.additionalRequestsLabel">
+      <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
         <source xml:lang="en">Additional Requests</source>
         <target xml:lang="hi">अतिरिक्त अनुरोध</target>
         <note>ID: MetadataEditor.additionalRequestsLabel</note>
         <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.betterLinkLabel1">
+      <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
         <source xml:lang="en">more info</source>
         <target xml:lang="hi">और अधिक जानकारी</target>
         <note>ID: MetadataEditor.betterLinkLabel1</note>
         <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere tha defines it.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
         <source xml:lang="en">Not Enforceable</source>
         <target xml:lang="hi">प्रवर्तनीय नहीं</target>
         <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <target xml:lang="hi">यह अन्य बटन जो गैर-उन्नत उपयोगकर्ता द्वारा जरूरी नहीं हैं छुपा भी सकते हैं।</target>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.CtrlShiftHint">
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
         <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
         <target xml:lang="hi">जब आप संयम और पाली कुंजियाँ एक साथ पकड़ बटन दिखाई देंगे।</target>
         <note>ID: SettingsProtection.CtrlShiftHint</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+      <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
         <source xml:lang="en">Settings Protection...</source>
         <target xml:lang="hi">सेटिंग्स संरक्षण...</target>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
         <source xml:lang="en">Hide the button that opens settings.</source>
         <target xml:lang="hi">छुपाएँ बटन कि सेटिंग्स को खोलता है।</target>
         <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
         <source xml:lang="en">Factory Password</source>
         <target xml:lang="hi">फैक्टरी पासवर्ड</target>
         <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
         <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
         <target xml:lang="hi">आकस्मिक परिवर्तन जो आप के लिए काम करना बंद करने के लिए इस उपकरण का कारण बन सकता है को रोकने के लिए, ये सेटिंग अवरोधित किया गया है।</target>
         <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
         <source xml:lang="en">Settings Protection Password</source>
         <target xml:lang="hi">सेटिंग्स सुरक्षा पासवर्ड</target>
         <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox">
+      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
         <source xml:lang="en">Show Characters</source>
         <target xml:lang="hi">वर्ण दिखाएँ</target>
         <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordNotice">
+      <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
         <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always google for "{1}" and "{2}".</source>
         <target xml:lang="hi">इन सेटिंग्स के लिए कारखाने पासवर्ड "{0}" है।  अगर तुम इसे भूल जाओ, तुम हमेशा "{1}" और "{2}" के लिए गूगल कर सकते हैं</target>
         <note>ID: SettingsProtection.PasswordNotice</note>
         <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
         <source xml:lang="en">Require the factory password to get into settings.</source>
         <target xml:lang="hi">कारखाना सेटिंग्स को प्राप्त करने के लिए पासवर्ड की आवश्यकता होती है।</target>
         <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
         <source xml:lang="en">Settings Protection</source>
         <target xml:lang="hi">सेटिंग्स संरक्षण</target>
         <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
         <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
         <target xml:lang="hi">अगर आप की जरूरत कुंजीपटल सूचीबद्ध नहीं है, यह सेट अप करने के लिए नीचे उपयुक्त लिंक पर क्लिक करें</target>
         <note>ID: WSKeyboardControl.KeyboardNotListed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
         <source xml:lang="en">Windows keyboard settings</source>
         <target xml:lang="hi">विंडोज़  कुंजीपटल सेटिंग्स</target>
         <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
         <source xml:lang="en">Available keyboards</source>
         <target xml:lang="hi">उपलब्ध कीबोर्ड</target>
         <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
         <source xml:lang="en">Previously used keyboards</source>
         <target xml:lang="hi">पहले इस्तेमाल कीबोर्ड</target>
         <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
         <source xml:lang="en">Keyman Configuration</source>
         <target xml:lang="hi">कीमेन विन्यास</target>
         <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
         <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
         <target xml:lang="hi">कीमेन 5.0 या बाद के संस्करण स्थापित नहीं है।</target>
         <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
         <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
         <target xml:lang="hi">{0} पाठ टाइप करने के लिए जो के साथ कुंजीपटल का चयन करें</target>
         <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.TestAreaCaption">
+      <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
         <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
         <target xml:lang="hi">परीक्षण क्षेत्र (अपने कुंजीपटल बाहर का परीक्षण करने के लिए कुछ टाइप करने के लिए उपयोग इस क्षेत्र.)</target>
         <note>ID: WSKeyboardControl.TestAreaCaption</note>

--- a/DistFiles/localization/id/Bloom.xlf
+++ b/DistFiles/localization/id/Bloom.xlf
@@ -2,3509 +2,3509 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="id" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="BloomIntegrity.WindowTitle">
+      <trans-unit id="BloomIntegrity.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom Problem</source>
         <target xml:lang="id">Masalah Bloom</target>
         <note>ID: BloomIntegrity.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="BloomIntegrityDialog.ReportProblem">
+      <trans-unit id="BloomIntegrityDialog.ReportProblem" approved="yes">
         <source xml:lang="en">Report Problem</source>
         <target xml:lang="id">Laporkan Masalah</target>
         <note>ID: BloomIntegrityDialog.ReportProblem</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName">
+      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName" approved="yes">
         <source xml:lang="en">Possibly this is an old Bloom Pack created before Bloom Packs could handle special characters in file names. You may be able to get the author to re-create it using a current version. If that's not possible a technical expert may be able to repair things.</source>
         <target xml:lang="id">Kemungkinan ini adalah Paket Bloom lawas yang dibuat sebelum Paket Bloom mampu menangani karakter khusus dalam nama berkas.Anda dapat menghubungi penulis untuk membuat ulang dengan memakai versi saat ini.Jika itu tidak mungkin, ada seorang ahli teknik yang mungkin dapat memperbaiki berbagai hal.</target>
         <note>ID: BloomPackInstallDialog.BadCharsInFileName</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="id">Pemasangan Paket Bloom</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="id">Koleksi {0} sekarang siap digunakan pada komputer ini.</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller" approved="yes">
         <source xml:lang="en">Bloom Pack Installer</source>
         <target xml:lang="id">Pemasang Paket Bloom</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstaller</note>
         <note>Displayed as the message box title</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack">
+      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack" approved="yes">
         <source xml:lang="en">This BloomPack appears to be incomplete or corrupt.</source>
         <target xml:lang="id">BloomPack tampaknya tidak lengkap atau rusak.</target>
         <note>ID: BloomPackInstallDialog.CorruptBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.DoesNotExist">
+      <trans-unit id="BloomPackInstallDialog.DoesNotExist" approved="yes">
         <source xml:lang="en">{0} does not exist</source>
         <target xml:lang="id"> {0} tidak ada</target>
         <note>ID: BloomPackInstallDialog.DoesNotExist</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="id">Bloom tidak dapat memasang Paket Bloom tersebut</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="id">Mengekstraksi...</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while Bloom Packs are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="id">Bloom sudah berjalan, namun isinya tidak akan tampil sampai Anda menjalankan Bloom di kesempatan berikutnya</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.NotInstalled">
+      <trans-unit id="BloomPackInstallDialog.NotInstalled" approved="yes">
         <source xml:lang="en">The Bloom collection will not be installed.</source>
         <target xml:lang="id">Koleksi Bloom tidak akan dipasang.</target>
         <note>ID: BloomPackInstallDialog.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="id"> Membuka {0}... </target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Replace">
+      <trans-unit id="BloomPackInstallDialog.Replace" approved="yes">
         <source xml:lang="en">This computer already has a Bloom collection named '{0}'. Do you want to replace it with the one from this Bloom Pack?</source>
         <target xml:lang="id">Komputer ini sudah memiliki koleksi Bloom bernama '{0}'. Apakah Anda ingin menggantinya dengan koleksi dari Paket Bloom ini?</target>
         <note>ID: BloomPackInstallDialog.Replace</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder">
+      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder" approved="yes">
         <source xml:lang="en">Bloom Packs should have only a single collection folder at the top level of the .ZIP file.</source>
         <target xml:lang="id">Paket Bloom semestinya hanya memiliki satu folder koleksi di tingkat teratas dari berkas .ZIP.</target>
         <note>ID: BloomPackInstallDialog.SingleCollectionFolder</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.UnableToReplace">
+      <trans-unit id="BloomPackInstallDialog.UnableToReplace" approved="yes">
         <source xml:lang="en">Bloom was not able to remove the existing copy of '{0}'. Quit Bloom if it is running &amp; try again. Otherwise, try again after restarting your computer.</source>
         <target xml:lang="id"> Bloom tidak dapat menghapus salinan '{0}' yang ada saat ini. Keluar dari Bloom jika sedang berjalan &amp; coba lagi.Jika tidak, coba lagi setelah Anda nyalakan ulang komputer,</target>
         <note>ID: BloomPackInstallDialog.UnableToReplace</note>
       </trans-unit>
-      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true">
+      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To select, use your mouse wheel or point at what you want, then release the key.</source>
         <target xml:lang="id">Untuk memilih, gunakan mouse atau arahkan pada yang diinginkan, lalu lepaskan tombol.</target>
         <note>ID: BookEditor.CharacterMap.Instructions</note>
         <note>When you hold down a key, a popup appears that lets you choose a related character. These instructions are shown in that popup.</note>
       </trans-unit>
-      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is the default for all text boxes with '{0}' style.</source>
         <target xml:lang="id"> Pemformatan ini adalah default untuk semua kotak teks bergaya '{0}'.</target>
         <note>ID: BookEditor.DefaultForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all text boxes with '{0}' style.</source>
         <target xml:lang="id">Pemformatan ini adalah untuk semua kotak teks bergaya '{0}'.</target>
         <note>ID: BookEditor.ForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text boxes with '{1}' style.</source>
         <target xml:lang="id">Pemformatan ini adalah untuk semua kotak teks {0} bergaya '{1}'</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true">
+      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sorry, Reader Templates do not allow changes to formatting.</source>
         <target xml:lang="id">Maaf, Template Pembaca tidak mengizinkan perubahan pada format.</target>
         <note>ID: BookEditor.FormattingDisabled</note>
       </trans-unit>
-      <trans-unit id="BookStorage.FolderMoved">
+      <trans-unit id="BookStorage.FolderMoved" approved="yes">
         <source xml:lang="en">It appears that some part of the folder path to this book has been moved or renamed. As a result, Bloom cannot save your changes to this page, and will need to exit now. If you haven't been renaming or moving things, please click Details below and report the problem to the developers.</source>
         <target xml:lang="id">Tampaknya sebagian dari jalur folder ke buku ini telah dipindahkan atau diganti namanya.Akibatnya, Bloom tidak bisa menyimpan perubahan di halaman ini, dan harus keluar sekarang.Jika Anda belum mengganti nama atau memindahkan sesuatu, mohon klik Detail di bawah dan laporkan masalahnya ke pengembang.</target>
         <note>ID: BookStorage.FolderMoved</note>
       </trans-unit>
-      <trans-unit id="Browser.CopyTroubleshootingInfo">
+      <trans-unit id="Browser.CopyTroubleshootingInfo" approved="yes">
         <source xml:lang="en">Copy Troubleshooting Information</source>
         <target xml:lang="id">Copy Informasi Pemecahan Masalah</target>
         <note>ID: Browser.CopyTroubleshootingInfo</note>
       </trans-unit>
-      <trans-unit id="Browser.OpenPageInFirefox">
+      <trans-unit id="Browser.OpenPageInFirefox" approved="yes">
         <source xml:lang="en">Open Page in Firefox (which must be in the PATH environment variable)</source>
         <target xml:lang="id">Terbuka Halaman di Firefox (yang harus dalam variabel lingkungan PATH)</target>
         <note>ID: Browser.OpenPageInFirefox</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="id">Pengaturan Program Tingkat Lanjutan</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate" approved="yes">
         <source xml:lang="en">Automatically update Bloom</source>
         <target xml:lang="id">Otomatis memperbarui Bloom</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AutoUpdate</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="id">Tampilkan Perintah Eksperimental (mis. Ekspor XML untuk InDesign)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="id">Tampilkan Template Eksperimental (mis. Kamus Gambar)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="id">(Eksperimental) Tampilkan Kontrol Kirim/Terima</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="id">Gunakan Server Gambar untuk mengurangi pemakaian memori pada gambar berukuran besar.</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom is switching the default font for "{0}" to the new "Andika New Basic".</source>
         <target xml:lang="id"> Bloom mengganti bentuk huruf default untuk "{0}" ke "Andika Dasar Baru" terbaru. </target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate1</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This will improve the printed output for most languages. If your language is one of the few that need "Andika", you can switch it back in Settings:Book Making.</source>
         <target xml:lang="id">Ini akan menyempurnakah hasil cetak bagi sebagian besar bahasa.Jika bahasa Anda adalah salah satu dari beberapa yang memerlukan "Andika", Anda bisa menggantinya kembali dalam Pengaturan: Pembuatan Buku.</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate2</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="id">Pembuatan Buku</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="id">Bentuk Huruf Default untuk {0} </target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="id">Paket Materi Depan/Belakang</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="id">Penghemat Kertas</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver</note>
         <note>Name of a Front/Back Matter Pack that puts credits on the inside of the front cover</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="id">Tradisional</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional</note>
         <note>Name of the default Front/Back Matter Pack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="id">Sistem Penulisan Kanan ke Kiri</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink" approved="yes">
         <source xml:lang="en">Special Script Settings</source>
         <target xml:lang="id">Pengaturan Tulisan Khusus</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="id">Pengaturan</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="id">Ganti...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="id">Bahasa 1</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="id">Bahasa 2</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="id">Bahasa 3</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="id">Bahasa-bahasa</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="id">Menghapus</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="id">Atur...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="id">Bahasa Daerah</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="id">Bahasa 2 (mis. Bahasa Nasional)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="id">Bahasa 3 (mis. Bahasa Regional) (Tidak Wajib)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="id">Nama Koleksi Bloom</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="id">Negara</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="id">Distrik</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="id">Informasi Proyek</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="id">Provinsi</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="id">Nyalakan Ulang</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="id">Bloom akan menutup dan membuka kembali proyek ini dengan pengaturan baru.</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <target xml:lang="id">Buat Paket Template Pembaca Bloom...</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdminManagesUpdates">
+      <trans-unit id="CollectionTab.AdminManagesUpdates" approved="yes">
         <source xml:lang="en">Your system administrator manages Bloom updates for this computer.</source>
         <target xml:lang="id">Administrator sistem Anda mengelola pembaruan Bloom untuk komputer ini.</target>
         <note>ID: CollectionTab.AdminManagesUpdates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="id"> Tingkat Lanjutan</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Applying">
+      <trans-unit id="CollectionTab.Applying" approved="yes">
         <source xml:lang="en">Applying updates</source>
         <target xml:lang="id">Menerapkan pembaruan</target>
         <note>ID: CollectionTab.Applying</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="id">Dapatkan buku sumber yang lain di BloomLibrary.org</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="id">Koleksi Sumber</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DuplicateBook">
+      <trans-unit id="CollectionTab.BookMenu.DuplicateBook" approved="yes">
         <source xml:lang="en">Duplicate Book</source>
         <target xml:lang="id">Salin Buku</target>
         <note>ID: CollectionTab.BookMenu.DuplicateBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="id">Hapus Buku</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book. These programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="id">Bloom sekarang akan membuka dokumen HTML ini di program pengolah kata Anda (biasanya Word atau LibreOffice). Anda dapat mulai bekerja dengan teks dan gambar dari buku ini. Program ini biasanya tidak dapat bekerja dengan baik untuk mempertahankan layout, jadi jangan terlalu berharap banyak.</target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="id">Ekspor ke Word atau LibreOffice...</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="id">Ekspor ke XML untuk InDesign...</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="id">Perbarui Buku</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="id">Perbarui Gambar Mini</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="id">Sumber untuk Buku Baru</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="id">Koleksi ini terkunci, jadi buku baru tidak bisa ditambah/dihapus.</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="id">Buku dari BloomLibrary.org</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="id">Perbarui Semua Buku</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="id">Periksa Semua Buku</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="id">Amankan Gambar yang Hilang...</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="id">Riwayat Koleksi...</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="id">Catatan Koleksi...</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="id">Koleksi</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="id">Koleksi</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="id">Membangun...</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="id">Buku '{0}' </target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="id">Buka Folder di Disk</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="id">Edit buku ini</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="id">Kesehatan</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="id">Karena ini merupakan koleksi sumber, Bloom tidak menawarkan kerangka apa pun yang ada sebagai sumber untuk kerangka baru.Jika Anda ingin menambahkan bahasa ke suatu kerangka, Anda harus mengedit koleksi yang berisi kerangka, dan bukan membuat salinannya.Selain itu, Kalender Dinding saat ini tidak bisa dipakai untuk membuat Kerangka baru.</target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="id">Buat Paket Bloom</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <target xml:lang="id">Buat buku dengan menggunakan sumber ini</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_" approved="yes">
         <source xml:lang="en">Create a book in my language using this source book</source>
         <target xml:lang="id">Buat buku dalam bahasa saya dengan memakai buku sumber ini</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate_ToolTip_</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="id">Lainnya...</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="id">Koleksi Lain</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_" approved="yes">
         <source xml:lang="en">Open/Create/Get Collection</source>
         <target xml:lang="id">Buka/Buat/Dapatkan Koleksi</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton_ToolTip_</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem">
+      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem" approved="yes">
         <source xml:lang="en">Open or Create Another Collection</source>
         <target xml:lang="id">Buka atau Buat Koleksi Lain</target>
         <note>ID: CollectionTab.OpenCreateCollectionMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="id">Contoh Kerangka</target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="id">Kirim/Terima</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="id">Pengaturan</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="id">Koleksi Sumber</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="id">Buka Folder Koleksi Tambahan</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="id">Sumber untuk Kerangka Baru</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="id">Template</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.TitleMissing">
+      <trans-unit id="CollectionTab.TitleMissing" approved="yes">
         <source xml:lang="en">Title Missing</source>
         <target xml:lang="id">Tidak Ada Judul</target>
         <note>ID: CollectionTab.TitleMissing</note>
         <note>Shown as the thumbnail caption when the book doesn't have a title.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UnableToCheckForUpdate">
+      <trans-unit id="CollectionTab.UnableToCheckForUpdate" approved="yes">
         <source xml:lang="en">Could not connect to the server to check for an update. Are you connected to the internet?</source>
         <target xml:lang="id">Tidak bisa terhubung ke server untuk memperiksa yang terbaru. Apakah Anda sudah terhubung ke internet?</target>
         <note>ID: CollectionTab.UnableToCheckForUpdate</note>
         <note>Shown when Bloom tries to check for an update but can't, for example because it can't connect to the internet, or a problems with our server, etc.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpToDate">
+      <trans-unit id="CollectionTab.UpToDate" approved="yes">
         <source xml:lang="en">Your Bloom is up to date.</source>
         <target xml:lang="id">Bloom Anda sudah termutakhirkan.</target>
         <note>ID: CollectionTab.UpToDate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateCheckInProgress">
+      <trans-unit id="CollectionTab.UpdateCheckInProgress" approved="yes">
         <source xml:lang="en">Bloom is already working on checking for updates.</source>
         <target xml:lang="id">Bloom sudah melakukan pemeriksaan untuk yang terbaru.</target>
         <note>ID: CollectionTab.UpdateCheckInProgress</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateFailed">
+      <trans-unit id="CollectionTab.UpdateFailed" approved="yes">
         <source xml:lang="en">A new version appears to be available, but Bloom could not install it.</source>
         <target xml:lang="id">Versi baru sudah tersedia, namun Bloom tidak bisa memasangnya.</target>
         <note>ID: CollectionTab.UpdateFailed</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateInstalled">
+      <trans-unit id="CollectionTab.UpdateInstalled" approved="yes">
         <source xml:lang="en">Update for {0} is ready.</source>
         <target xml:lang="id">Pembaruan untuk {0} telah siap</target>
         <note>ID: CollectionTab.UpdateInstalled</note>
         <note>Appears after Bloom has downloaded a program update in the background and is ready to switch the user to it the next time they run Bloom.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateNow">
+      <trans-unit id="CollectionTab.UpdateNow" approved="yes">
         <source xml:lang="en">Update Now</source>
         <target xml:lang="id">Perbarui Sekarang</target>
         <note>ID: CollectionTab.UpdateNow</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdatesAvailable">
+      <trans-unit id="CollectionTab.UpdatesAvailable" approved="yes">
         <source xml:lang="en">A new version of Bloom is available.</source>
         <target xml:lang="id">Versi Bloom yang baru tersedia.</target>
         <note>ID: CollectionTab.UpdatesAvailable</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Updating">
+      <trans-unit id="CollectionTab.Updating" approved="yes">
         <source xml:lang="en">Downloading update to {0} ({1}kb).</source>
         <target xml:lang="id">Mengunduh yang terbaru ke {0} ({1}kb).</target>
         <note>ID: CollectionTab.Updating</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="id">Kembali</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="id">Batalkan</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="id">&amp;Batalkan</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="id">&amp;Selesaikan</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.Help" sil:dynamic="true">
+      <trans-unit id="Common.Help" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="id">Bantuan</target>
         <note>ID: Common.Help</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="id">&amp;Bantuan</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Loading" sil:dynamic="true">
+      <trans-unit id="Common.Loading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Loading...</source>
         <target xml:lang="id">Memuat...</target>
         <note>ID: Common.Loading</note>
         <note>This is shown when Bloom is slowly loading something, so the user doesn't worry about why they don't see the result immediately.</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="id">&amp;Berikutnya</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="id">Berikutnya</target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="id">Oke</target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="id">&amp;Oke</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="id">tidak wajib</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections.</source>
         <target xml:lang="id"> Unduhan Anda ({0}) selesai. Anda dapat melihatnya dalam bagian 'Buku dari BloomLibrary.org' dari Koleksi Anda.</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="id">Unduhan selesai.</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.CopyFailed">
+      <trans-unit id="Download.CopyFailed" approved="yes">
         <source xml:lang="en">Bloom downloaded the book but had problems making it available in Bloom. Please restart your computer and try again. If you get this message again, please click the 'Details' button and report the problem to the Bloom developers.</source>
         <target xml:lang="id">Bloom sudah mengunduh buku tersebut namun ada masalah saat menyediakannya di Bloom. Mohon nyalakan kembali komputer Anda dan coba lagi.Jika Anda menerima pesan ini lagi, klik tombol 'Detail' dan laporkan masalahnya ke pengembang Bloom.</target>
         <note>ID: Download.CopyFailed</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="id">Mengunduh buku</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="id">Ada masalah saat mengunduh buku Anda.</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="id">Ada masalah saat mengunduh buku Anda.Anda mungkin harus memulai ulang Bloom atau dapatkan bantuan teknis.</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.TimeoutProblemNotice">
+      <trans-unit id="Download.TimeoutProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading the book: something took too long. You can try again at a different time, or write to us at issues@BloomLibrary.org if you cannot get the download to work from your location.</source>
         <target xml:lang="id">Ada masalah saat mengunduh buku: sesuatu membuatnya menjadi lama.Anda bisa mencoba lagi di lain waktu, atau tulislah email kepada kami di issues@BloomLibrary.org jika Anda tidak bisa mendapatkan unduhan dari lokasi Anda.</target>
         <note>ID: Download.TimeoutProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddPageButton">
+      <trans-unit id="EditTab.AddPageDialog.AddPageButton" approved="yes">
         <source xml:lang="en">Add Page</source>
         <target xml:lang="id">Tambahkan Halaman</target>
         <note>ID: EditTab.AddPageDialog.AddPageButton</note>
         <note>This is for the button that LAUNCHES the dialog, not the "Add this page" button that is IN the dialog.</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add This Page</source>
         <target xml:lang="id">Tambahkan Halaman Ini</target>
         <note>ID: EditTab.AddPageDialog.AddThisPageButton</note>
         <note>This is for the button inside the dialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use This Layout</source>
         <target xml:lang="id">Gunakan Layout Ini</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Continue anyway</source>
         <target xml:lang="id">Tetap lanjutkan</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutContinueCheckbox</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose Different Layout...</source>
         <target xml:lang="id">Pilih Layout Berbeda...</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Converting to this layout will cause some content to be lost.</source>
         <target xml:lang="id">Mengubah layout ini akan menyebabkan sebagian isinya hilang.</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutWillLoseData</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Page...</source>
         <target xml:lang="id">Tambahkan Halaman...</target>
         <note>ID: EditTab.AddPageDialog.Title</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="id">Jika Anda perlu menempatkan informasi lebih lanjut mengenai buku tersebut, Anda bisa menggunakan halaman ini, yaitu di bagian dalam dari sampul belakang.</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="id">Jika Anda perlu menempatkan informasi lebih lanjut mengenai buku tersebut, Anda bisa menggunakan halaman ini, yaitu di bagian luar dari sampul belakang.</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Background</source>
         <target xml:lang="id">Latar belakang</target>
         <note>ID: EditTab.TextBoxProperties.Background</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="id">Dua Bahasa</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the HTML used to make this PDF, in Firefox (must be on path)</source>
         <target xml:lang="id">Buka HTML yang digunakan untuk membuat PDF ini, dalam Firefox (harus berada di jalurnya) </target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="id">Maaf, hak cipta dan lisensi untuk buku ini tidak bisa diubah.</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="id">Maaf, buku ini dikunci sehingga gambar tidak bisa diubah.</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ChooseLayoutButton">
+      <trans-unit id="EditTab.ChooseLayoutButton" approved="yes">
         <source xml:lang="en">Choose Different Layout</source>
         <target xml:lang="id">Pilih Layout Berbeda</target>
         <note>ID: EditTab.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="id">Yakin Ingin Menghapus Halaman?</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="id">&amp;Hapus</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="id">Halaman ini akan dihapus permanen.</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="id">Pengaturan Multibahasa</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip">
+      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip" approved="yes">
         <source xml:lang="en">Choose language to make this a bilingual or trilingual book</source>
         <target xml:lang="id">Pilih bahasa untuk membuat ini menjadi buku dwibahasa atau tribahasa</target>
         <note>ID: EditTab.ContentLanguagesDropdown.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="id">Salin</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTip">
+      <trans-unit id="EditTab.CopyButton.ToolTip" approved="yes">
         <source xml:lang="en">Copy (Ctrl+C)</source>
         <target xml:lang="id">Salin (Ctrl+C)</target>
         <note>ID: EditTab.CopyButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can copy it</source>
         <target xml:lang="id">Anda perlu memilih beberapa teks sebelum Anda dapat menyalinnya</target>
         <note>ID: EditTab.CopyButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="id">Salin informasi ini ke semua gambar lain di buku ini?</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="id">Ganti Layout</target>
         <note>ID: EditTab.CustomPage.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true" approved="yes">
         <source xml:lang="en">or</source>
         <target xml:lang="id">atau</target>
         <note>ID: EditTab.CustomPage.Or</note>
         <note>Shown between 'Picture' and 'Text' when Custom Page is in Layout mode</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture</source>
         <target xml:lang="id">Gambar</target>
         <note>ID: EditTab.CustomPage.Picture</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <target xml:lang="id">Teks</target>
         <note>ID: EditTab.CustomPage.Text</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <target xml:lang="id">Kotak Teks</target>
         <note>ID: EditTab.CustomPage.TextBox</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="id">Potong</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTip">
+      <trans-unit id="EditTab.CutButton.ToolTip" approved="yes">
         <source xml:lang="en">Cut (Ctrl+X)</source>
         <target xml:lang="id">Potong (Ctrl+X)</target>
         <note>ID: EditTab.CutButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can cut it</source>
         <target xml:lang="id">Anda perlu memilih beberapa teks sebelum Anda dapat memotongnya</target>
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="id">Hapus\n Halaman</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTip">
+      <trans-unit id="EditTab.DeletePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Remove this page from the book</source>
         <target xml:lang="id">Hapus halaman ini dari buku</target>
         <note>ID: EditTab.DeletePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be removed</source>
         <target xml:lang="id">Halaman ini tidak bisa dihapus</target>
         <note>ID: EditTab.DeletePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="id">Duplikasikan\n Halaman</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
         <target xml:lang="id">Sisipkan halaman baru yang merupakan duplikat dari halaman ini</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be duplicated</source>
         <target xml:lang="id">Halaman ini tidak bisa diduplikasikan</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="id">Edit</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true">
+      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot change these because this is not the original copy.</source>
         <target xml:lang="id">Anda tidak bisa mengubahnya karena ini bukan salinan asli.</target>
         <note>ID: EditTab.EditNotAllowed</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord" approved="yes">
         <source xml:lang="en">Sight Word</source>
         <target xml:lang="id">Kata untuk Melihat</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable" approved="yes">
         <source xml:lang="en">This word is not decodable in this stage.</source>
         <target xml:lang="id">Kata ini tidak dapat didekodekan pada tahap ini.</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true">
+      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This sentence is too long for this level.</source>
         <target xml:lang="id">Kalimat ini terlalu panjang untuk tingkat ini.</target>
         <note>ID: EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong</note>
       </trans-unit>
-      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true">
+      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This page is an experimental prototype which may have many problems, for which we apologize.</source>
         <target xml:lang="id">Halaman ini merupakan bentuk-uji-coba eksperimental yang mungkin memiliki banyak masalah, karena itu kami mohon maaf.</target>
         <note>ID: EditTab.ExperimentalNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="id">Bentuk huruf yang saat ini dipilih adalah '{0}', namun tidak terpasang di komputer ini.Sebagian bentuk huruf lainnya akan digunakan.</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true" approved="yes">
         <source xml:lang="en">That style already exists. Please choose another name.</source>
         <target xml:lang="id">Gaya itu sudah ada.Pilih nama lain.</target>
         <note>ID: EditTab.FormatDialog.AlreadyExists</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="id">Ganti bingkai dan latar belakang</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <target xml:lang="id">Karakter</target>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <target xml:lang="id">Buat</target>
         <note>ID: EditTab.FormatDialog.Create</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create a new style</source>
         <target xml:lang="id">Buat gaya baru</target>
         <note>ID: EditTab.FormatDialog.CreateStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Don't see what you need?</source>
         <target xml:lang="id">Yang dibutuhkan tidak ada?</target>
         <note>ID: EditTab.FormatDialog.DontSeeNeed</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Emphasis</source>
         <target xml:lang="id">Penekanan</target>
         <note>ID: EditTab.FormatDialog.Emphasis</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <target xml:lang="id">Bentuk Huruf</target>
         <note>ID: EditTab.FormatDialog.Font</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="id">Ganti tampilan bentuk huruf</target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="id">Ubah pada ukuran teks untuk semua kotak yang mempunyai gaya '{0}' dan bahasa '{1}'.\n Ukuran sekarang adalah {2}pt. </target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="id">Ganti ukuran bentuk huruf</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Format</source>
         <target xml:lang="id">Format</target>
         <note>ID: EditTab.FormatDialog.Format</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="id">Ganti jarak antar baris teks</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New style</source>
         <target xml:lang="id">Gaya baru</target>
         <note>ID: EditTab.FormatDialog.NewStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please use only alphabetical characters. Numbers at the end are ok, as in "part2".</source>
         <target xml:lang="id">Mohon gunakan karakter abjad saja. Nomor di akhir dibolehkan, seperti pada "bagian2".</target>
         <note>ID: EditTab.FormatDialog.PleaseUseAlpha</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <target xml:lang="id">Tempatkan</target>
         <note>ID: EditTab.FormatDialog.Spacing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <target xml:lang="id">Gaya</target>
         <note>ID: EditTab.FormatDialog.Style</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <target xml:lang="id">Nama Gaya</target>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="id">Ekstra Lebar</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="id">Normal</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="id">Ganti jarak antar kata</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="id">Lebar</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="id">Sesuaikan pemformatan untuk gaya</target>
         <note>ID: EditTab.FormatDialogTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="id">Anda dapat menggunakan ruang ini untuk penulis/ilustrator, atau apa saja.</target>
         <note>ID: EditTab.FrontMatter.AuthorIllustratorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="id">Saat Anda membuat buku asli, gunakan kotak ini untuk mencatat kontribusi yang dibuat oleh penulis, ilustrator, editor, dsb.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="id">Saat Anda menggunakan buku dari kerangka, gunakan kotak ini untuk memberi tahu penerjemahnya.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="id">Judul buku dalam {bahasa} </target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright and License</source>
         <target xml:lang="id">Klik untuk Mengedit Hak Cipta dan Lisensi</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="id">Gunakan ini untuk memberikan penghargaan kepada penyandang dana.</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="id">Nomor Buku Standar Internasional. Biarkan kosong jika Anda tidak memilikinya.</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.</source>
         <target xml:lang="id">Jika Anda perlu menempatkan informasi lebih lanjut mengenai buku tersebut, Anda bisa menggunakan halaman ini, yaitu di bagian dalam dari sampul depan.</target>
         <note>ID: EditTab.FrontMatter.InsideFrontCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Name of Translator, in {lang}</source>
         <target xml:lang="id">Nama Penerjemah, dalam {bahasa} </target>
         <note>ID: EditTab.FrontMatter.NameofTranslatorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="id">Penghargaan Asli (atau Kerangka) dalam {bahasa} </target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="id">Kontribusi dibuat oleh para penulis, ilustrator, editor, dsb., dalam {bahasa} </target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalCopyrightSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalCopyrightSentence" approved="yes">
         <source xml:lang="en">Adapted from original, {0}.</source>
         <target xml:lang="id">Berdasarkan karya asli, {0}.</target>
         <note>ID: EditTab.FrontMatter.OriginalCopyrightSentence</note>
         <note>On the Credits page of a book being translated, Bloom shows the original copyright. Put {0} in the translation where the copyright notice should go. For example in English, 'Adapted from original, {0}.' comes out like 'Adapted from original, Copyright 2011 SIL'.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalHadNoCopyrightSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalHadNoCopyrightSentence" approved="yes">
         <source xml:lang="en">Adapted from original without a copyright notice.</source>
         <target xml:lang="id">Berdasarkan karya asli yang tidak mempunyai pernyataan hak cipta.</target>
         <note>ID: EditTab.FrontMatter.OriginalHadNoCopyrightSentence</note>
         <note>On the Credits page of a book being translated, Bloom shows this if the original book did not have a copyright notice.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalLicenseSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalLicenseSentence" approved="yes">
         <source xml:lang="en">Licensed under {0}.</source>
         <target xml:lang="id">Diberi izin berdasarkan peraturan {0}.</target>
         <note>ID: EditTab.FrontMatter.OriginalLicenseSentence</note>
         <note>On the Credits page of a book being translated, Bloom puts texts like 'Licensed under CC-BY', so that we have a record of what the license was for the original book. Put {0} in the translation, where the license should go in the sentence.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="id">Klik untuk memilih topik</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="id">Penghargaan untuk versi terjemahan, dalam {bahasa} </target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.HowToUnlockBook">
+      <trans-unit id="EditTab.HowToUnlockBook" approved="yes">
         <source xml:lang="en">To unlock this shellbook, go into the toolbox on the right, find the gear icon, and click 'Allow changes to this shellbook'.</source>
         <target xml:lang="id">Untuk membuka buku kerangka, lihat kotak alat di sebelah kanan, temukan ikon roda gigi, dan klik 'Izinkan perubahan pada buku kerangka ini'.</target>
         <note>ID: EditTab.HowToUnlockBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="id">Ganti Gambar</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Copy Image</source>
         <target xml:lang="id">Salin Gambar</target>
         <note>ID: EditTab.Image.CopyImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cut Image</source>
         <target xml:lang="id">Potong Gambar</target>
         <note>ID: EditTab.Image.CutImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, and License</source>
         <target xml:lang="id">Edit Gambar untuk Pengakuan, Hak Cipta, dan Lisensi</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="id">Tempelkan Gambar</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse">
+      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse" approved="yes">
         <source xml:lang="en">Cancel this import</source>
         <target xml:lang="id">Batalkan impor ini</target>
         <note>ID: EditTab.JpegWarningDialog.DoNotUse</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.Photograph">
+      <trans-unit id="EditTab.JpegWarningDialog.Photograph" approved="yes">
         <source xml:lang="en">Use the JPEG file</source>
         <target xml:lang="id">Gunakan berkas JPEG</target>
         <note>ID: EditTab.JpegWarningDialog.Photograph</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WarningText">
+      <trans-unit id="EditTab.JpegWarningDialog.WarningText" approved="yes">
         <source xml:lang="en">The file you’ve chosen is a “JPEG” file. JPEG files are perfect for photographs and color artwork. However, JPEG files are a big problem for black and white line art. Problems include:\n• Fuzziness and grey dots.\n• Large file sizes, making the book hard to share.\n• If there are many large JPEGs, Bloom may not have enough memory to make PDF files.\n\nNote: Because JPEG is “lossy”, converting a JPEG to PNG, TIFF, or BMP actually makes things even worse. If this is black and white line art, you want to get an original scan in one of those formats.\n\nPlease select from one of the following, then click “OK”:</source>
         <target xml:lang="id">Berkas yang telah Anda pilih adalah berkas “JPEG”.Berkas JPEG cocok untuk foto dan seni gambar berwarna. Namun berkas JPEG memiliki masalah untuk gambar hitam dan putih. Masalah mencakup:\n • Gambar kabur dan titik-titik kelabu.\n • Ukuran berkas besar, sehingga buku sulit dibagikan.\n • Jika Ada banyak JPEG berukuran besar, Bloom mungkin tidak memiliki cukup memori untuk membuat berkas PDF.\n\n Perhatikan: Karena sifat JPEG yang “banyak yang terbuang”, mengonversikan JPEG ke PNG, TIFF, atau BMP malahan akan membuatnya lebih buruk. Jika ini adalah gambar hitam putih, Anda ingin mendapatkan pindaian asli dalam salah satu format tersebut.\n\n Pilih dari salah satu yang berikut, lalu klik “Oke”:</target>
         <note>ID: EditTab.JpegWarningDialog.WarningText</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle">
+      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle" approved="yes">
         <source xml:lang="en">JPEG Warning</source>
         <target xml:lang="id">Peringatan JPEG</target>
         <note>ID: EditTab.JpegWarningDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="id">Opsi ini hanya tersedia dalam label Terbitkan.</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="id">Ganti Layout</target>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="id">Satu Bahasa</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NewBookName">
+      <trans-unit id="EditTab.NewBookName" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="id">Buku</target>
         <note>ID: EditTab.NewBookName</note>
         <note>Default file and folder name when you make a new book, but haven't give it a title yet.</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="id">Sebelum Anda dapat menempelkan gambar, salin salah satunya ke 'clipboard', dari program lain.</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="id">Tidak ada opsi layout lain untuk template ini.</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Overflow" sil:dynamic="true">
+      <trans-unit id="EditTab.Overflow" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This box has more text than will fit</source>
         <target xml:lang="id">Kotak memiliki lebih banyak teks untuk dapat dimuati</target>
         <note>ID: EditTab.Overflow</note>
       </trans-unit>
-      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true">
+      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A container on this page is overflowing</source>
         <target xml:lang="id">Wadah dalam halaman ini kelebihan teks</target>
         <note>ID: EditTab.OverflowContainer</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are.</source>
         <target xml:lang="id">Perubahan itu tidak diizinkan. Halaman materi depan dan materi belakang harus tetap berada di tempatnya.</target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="id">Pemindahan Tidak Diperbolehkan</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="id">Halaman</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="id">Pilih ukuran halaman dan orientasi</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="id">Tempelkan</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTip">
+      <trans-unit id="EditTab.PasteButton.ToolTip" approved="yes">
         <source xml:lang="en">Paste (Ctrl+V)</source>
         <target xml:lang="id">Tempelkan (Ctrl+V)</target>
         <note>ID: EditTab.PasteButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing on the Clipboard that you can paste here.</source>
         <target xml:lang="id">Tidak ada apa pun di Clipboard yang bisa Anda tempelkan di sini.</target>
         <note>ID: EditTab.PasteButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Position" sil:dynamic="true">
+      <trans-unit id="EditTab.Position" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Position</source>
         <target xml:lang="id">Posisi</target>
         <note>ID: EditTab.Position</note>
       </trans-unit>
-      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true">
+      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot put anything in there while making an original book.</source>
         <target xml:lang="id">Anda tidak dapat menempatkan apa pun saat membuat buku asli.</target>
         <note>ID: EditTab.ReadOnlyInAuthorMode</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="id">Ganti bingkai dan latar belakang</target>
         <note>ID: EditTab.StyleEditor.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="id">Ganti tampilan bentuk huruf</target>
         <note>ID: EditTab.StyleEditor.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="id">Ganti ukuran bentuk huruf</target>
         <note>ID: EditTab.StyleEditor.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="id">Ganti jarak antar baris teks</target>
         <note>ID: EditTab.StyleEditor.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="id">Ekstra Lebar</target>
         <note>ID: EditTab.StyleEditor.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="id">Normal</target>
         <note>ID: EditTab.StyleEditor.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="id">Ganti jarak antar kata</target>
         <note>ID: EditTab.StyleEditor.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="id">Lebar</target>
         <note>ID: EditTab.StyleEditor.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="id">Sesuaikan pemformatan untuk gaya</target>
         <note>ID: EditTab.StyleEditorTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="id">Halaman Template</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom">
+      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom" approved="yes">
         <source xml:lang="en">Picture On Bottom</source>
         <target xml:lang="id">Gambar di Bawah</target>
         <note>ID: EditTab.ThumbnailCaptions.Picture On Bottom</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="id">Informasi Hak Kekayaan Intelektual Gambar</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="id">Alat Pembaca yang Dapat Didekodekan</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom can handle only the first {0} words.</source>
         <target xml:lang="id">Bloom hanya dapat menangani {0} kata pertama.</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed words in this stage</source>
         <target xml:lang="id">Izinkan penggunaan kata-kata dalam tahap ini</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles" approved="yes">
         <source xml:lang="en">Text files</source>
         <target xml:lang="id">Berkas teks</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters" approved="yes">
         <source xml:lang="en">Letters: {0}</source>
         <target xml:lang="id">Huruf: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage" approved="yes">
         <source xml:lang="en">The following is a generated report of the decodable stages for {0}. You can make any changes you want to this file, but Bloom will not notice your changes. It is just a report.</source>
         <target xml:lang="id">Berikut adalah laporan yang dibuat dari tahap yang dapat didekodekan untuk {0}. Anda dapat membuat perubahan apa pun yang Anda inginkan pada berkas ini, namun Bloom tidak akan mencatat perubahan Anda.Ini hanyalah sebuah laporan.</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords" approved="yes">
         <source xml:lang="en">New Decodable Words: {0}</source>
         <target xml:lang="id">Kata-Kata Baru yang Dapat Dikodekan: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords" approved="yes">
         <source xml:lang="en">New Sight Words: {0}</source>
         <target xml:lang="id">Kata-Kata untuk Melihat yang Baru: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage" approved="yes">
         <source xml:lang="en">Stage {0}</source>
         <target xml:lang="id">Tahap {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList" approved="yes">
         <source xml:lang="en">Complete Word List</source>
         <target xml:lang="id">Lengkapi Daftar Kata</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="id">Huruf dalam tahapan ini</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="id">Buka Daftar Berkas Huruf dan Kata</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Generate a letter and word list report</source>
         <target xml:lang="id">Buat laporan daftar huruf dan kata</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample words in this stage</source>
         <target xml:lang="id">Contoh kata dalam tahapan ini</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="id">Siapkan Tahapan</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="id">Tahap</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="id">dari</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="id">Kata-kata dalam tahap ini</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="id">Alat Pembaca Berlevel</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="id">Aktual</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true" approved="yes">
         <source xml:lang="en">avg per sentence</source>
         <target xml:lang="id">rata-rata per kalimat</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Average</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="id">Pilihan Topik</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="id">Untuk Tingkat ini</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="id">Pemformatan</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="id">Dukungan Ilustrasi</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="id">Ingatlah</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="id">Tingkat</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
         <note>Used to create string "Level # of #". The space after this word is added programmatically.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="id">dari</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
         <note>Used to create string "Level # of #". The spaces on each side of this word are added programmatically.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="id">Maks</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="id">per halaman</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="id">kalimat terpanjang</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="id">Keterprediksian</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="id">Atur Tingkat</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="id">Buku Ini</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="id">Halaman Ini</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="id">total</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="id">unik</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="id">Kosa Kata</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="id">Hitungan Kata</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="id">Lebih...</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allow changes to this shellbook</source>
         <target xml:lang="id">Memungkinkan perubahan buku kerangka ini</target>
         <note>ID: EditTab.Toolbox.Settings.Unlock</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom normally prevents most changes to shellbooks. If you need to add pages, change images, etc., tick the box below.</source>
         <target xml:lang="id">Bloom biasanya mencegah sebagian besar perubahan uku kerangka. Jika Anda perlu menambahkan halaman, mengubah gambar, dll, centang kotak di bawah.</target>
         <note>ID: EditTab.Toolbox.Settings.UnlockShellBookIntroductionText</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState" approved="yes">
         <source xml:lang="en">Bloom recording is in an unusual state, possibly caused by unplugging a microphone. You will need to restart.</source>
         <target xml:lang="id">Perekaman Bloom dalam keadaan yang tidak biasa, mungkin disebabkan oleh mencabut mikrofon. Anda akan perlu restart.</target>
         <note>ID: EditTab.Toolbox.TalkingBook.BadState</note>
         <note>This is very low priority for translation.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput" approved="yes">
         <source xml:lang="en">No input device</source>
         <target xml:lang="id">Tidak ada perangkat input</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoInput</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic" approved="yes">
         <source xml:lang="en">This computer appears to have no sound recording device available. You will need one to record audio for a talking book.</source>
         <target xml:lang="id">Komputer ini tampaknya tidak memiliki alat perekam suara yang tersedia. Anda akan membutuhkan satu untuk merekam audio untuk sebuah buku berbicara.</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoMic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage" approved="yes">
         <source xml:lang="en">Please hold the button down until you have finished recording</source>
         <target xml:lang="id">Harap tahan tombol bawah sampai Anda selesai merekam</target>
         <note>ID: EditTab.Toolbox.TalkingBook.PleaseHoldMessage</note>
         <note>Appears when the speak/record button is pressed very briefly</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="id">Kembali</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Back</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4) Check</source>
         <target xml:lang="id">4) Periksa</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Check</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Check that you are recording into the correct device and that these levels are showing blue:</source>
         <target xml:lang="id">1) Periksa apakah Anda merekam di perangkat yang benar dan bahwa tingkatan ini ditampilkan dalam warna biru:</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.CheckSettings</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Clear</source>
         <target xml:lang="id">Kosongkan</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Clear</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Talking Book Tool</source>
         <target xml:lang="id">Alat Bantu Buku Berbicara</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Listen to the whole page</source>
         <target xml:lang="id">Dengarkan seluruh halaman</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Listen</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Look at the highlighted sentence</source>
         <target xml:lang="id">2) Lihat kalimat yang disorot</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.LookAtSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5) Next</source>
         <target xml:lang="id">5) Berikutnya</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Next</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3) Speak</source>
         <target xml:lang="id">3) Bicara</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Speak</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an e-book that can play recordings while highlighting sentences.</source>
         <target xml:lang="id">Membuat e-book yang dapat memutar rekaman sementara menyoroti kalimat.</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.ToolPurpose</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="id">kalimat terpanjang</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="id">Tiga Bahasa</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="id">Urungkan</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTip">
+      <trans-unit id="EditTab.UndoButton.ToolTip" approved="yes">
         <source xml:lang="en">Undo (Ctrl+Z)</source>
         <target xml:lang="id">Urungkan (Ctrl+Z)</target>
         <note>ID: EditTab.UndoButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing to undo</source>
         <target xml:lang="id">Tidak ada yang dapat diurungkan</target>
         <note>ID: EditTab.UndoButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="Errors.BookProblem">
+      <trans-unit id="Errors.BookProblem" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.</source>
         <target xml:lang="id">Bloom mengalami masalah saat menampilkan buku ini.Ini tidak berarti bahwa pekerjaan Anda hilang, namun ada yang usang, tidak ada, atau bermasalah.</target>
         <note>ID: Errors.BookProblem</note>
       </trans-unit>
-      <trans-unit id="Errors.BrokenBook">
+      <trans-unit id="Errors.BrokenBook" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong. Consider using the 'Report a Problem' command under the 'Help' menu.</source>
         <target xml:lang="id">Bloom mengalami masalah saat menampilkan buku ini. Ini tidak berarti bahwa pekerjaan Anda hilang, namun ada yang usang, tidak ada, atau bermasalah. Pertimbangkan memakai perintah 'Laporkan Masalah' dalam menu 'Bantuan'.</target>
         <note>ID: Errors.BrokenBook</note>
       </trans-unit>
-      <trans-unit id="Errors.CannotConnectToBloomServer">
+      <trans-unit id="Errors.CannotConnectToBloomServer" approved="yes">
         <source xml:lang="en">Bloom was unable to start its own HTTP listener that it uses to talk to its embedded Firefox browser. If this happens even if you just restarted your computer, ask someone to investigate if you have an aggressive firewall product installed. The agressive firewall product may need to be uninstalled before you can use Bloom.</source>
         <target xml:lang="id">Bloom tidak dapat memulai pendengar HTTP-nya yang digunakan untuk berkomunikasi ke Firefox browser yang disematkannya. Jika ini pernah terjadi sebelum Anda menyalakan komputer, minta seseorang untuk menyeledikinya bilamana Anda memasang produk firewall yang agresif. Produk firewall yang agresif mungkin perlu dihapus sebelum Anda bisa menggunakan Bloom.</target>
         <note>ID: Errors.CannotConnectToBloomServer</note>
       </trans-unit>
-      <trans-unit id="Errors.DeniedAccess">
+      <trans-unit id="Errors.DeniedAccess" approved="yes">
         <source xml:lang="en">Your computer denied Bloom access to the book. You may need technical help in setting the operating system permissions for this file.</source>
         <target xml:lang="id">Komputer Anda menolak akses Bloom ke buku. Anda mungkin perlu bantuan teknis untuk mengatur izin sistem operasi untuk berkas ini.</target>
         <note>ID: Errors.DeniedAccess</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorSelecting">
+      <trans-unit id="Errors.ErrorSelecting" approved="yes">
         <source xml:lang="en">There was a problem selecting the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="id">Ada masalah saat memilih buku. Memulai kembali Bloom mungkin akan menyelesaikan masalahnya. Jika tidak, klik tombol 'Detail' dan laporkan masalahnya ke Pengembang Bloom.</target>
         <note>ID: Errors.ErrorSelecting</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorUpdating">
+      <trans-unit id="Errors.ErrorUpdating" approved="yes">
         <source xml:lang="en">There was a problem updating the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="id">Anda masalah saat memperbarui buku. Memulai kembali Bloom mungkin akan menyelesaikan masalahnya. Jika tidak, klik tombol 'Detail' dan laporkan masalahnya ke pengembang Bloom.</target>
         <note>ID: Errors.ErrorUpdating</note>
       </trans-unit>
-      <trans-unit id="Errors.NeedNewerVersion">
+      <trans-unit id="Errors.NeedNewerVersion" approved="yes">
         <source xml:lang="en">{0} requires a newer version of Bloom. Download the latest version of Bloom from {1}.</source>
         <target xml:lang="id">{0} memerlukan versi Bloom yang lebih baru. Unduh versi terakhir dari Bloom dari {1}.</target>
         <note>ID: Errors.NeedNewerVersion</note>
         <note>{0} will get the name of the book, {1} will give a link to open the Bloom Library Web page.</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemDeletingFile">
+      <trans-unit id="Errors.ProblemDeletingFile" approved="yes">
         <source xml:lang="en">Bloom had a problem deleting this file: {0}</source>
         <target xml:lang="id">Bloom mengalami masalah saat menghapus berkas ini: {0}</target>
         <note>ID: Errors.ProblemDeletingFile</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemImportingPicture">
+      <trans-unit id="Errors.ProblemImportingPicture" approved="yes">
         <source xml:lang="en">Bloom had a problem importing this picture.</source>
         <target xml:lang="id">Bloom mengalami masalah saat mengimpor gambar ini.</target>
         <note>ID: Errors.ProblemImportingPicture</note>
       </trans-unit>
-      <trans-unit id="Errors.ReportThisProblemButton">
+      <trans-unit id="Errors.ReportThisProblemButton" approved="yes">
         <source xml:lang="en">Report this problem to Bloom Support</source>
         <target xml:lang="id">Laporkan masalah ini ke bagian Dukungan Bloom.</target>
         <note>ID: Errors.ReportThisProblemButton</note>
       </trans-unit>
-      <trans-unit id="Errors.SomethingWentWrong">
+      <trans-unit id="Errors.SomethingWentWrong" approved="yes">
         <source xml:lang="en">Sorry, something went wrong.</source>
         <target xml:lang="id">Maaf, ada yang salah.</target>
         <note>ID: Errors.SomethingWentWrong</note>
       </trans-unit>
-      <trans-unit id="Errors.XMatterNotFound">
+      <trans-unit id="Errors.XMatterNotFound" approved="yes">
         <source xml:lang="en">This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a Bloom Pack that will give you '{0}', or go to Settings:Book Making and change to another Front/Back Matter Pack.</source>
         <target xml:lang="id">Buku ini meminta paket Materi Depan/Belakang bernama '{0}', namun Bloom tidak dapat menemukannya di komputer ini. Anda bisa memasang Paket Bloom yang akan memberi Anda '{0}', atau buka Pengaturan:Pembuatan Buku dan ganti ke Paket Materi Depan/Belakang.</target>
         <note>ID: Errors.XMatterNotFound</note>
       </trans-unit>
-      <trans-unit id="Errors.ZoneAlarm">
+      <trans-unit id="Errors.ZoneAlarm" approved="yes">
         <source xml:lang="en">Bloom cannot start properly, and this symptom has been observed on machines with ZoneAlarm installed. Note: disabling ZoneAlarm does not help. Nor does restarting with it turned off. Something about the installation of ZoneAlarm causes the problem, and so far only uninstalling ZoneAlarm has been shown to fix the problem.</source>
         <target xml:lang="id">Bloom tidak bisa memulai dengan benar, dan gejala ini terpantau pada mesin yang memasang ZoneAlarm. Catatan: menonaktifkan ZoneAlarm tidak akan membantu. Juga memulainya kembali dengan status dimatikan. Ada sesuatu pada pemasangan ZoneAlarm yang menyebabkan masalah, dan sejauh ini hanya dengan menghapus ZoneAlarm yang tampaknya bisa menyelesaikan masalah ini.</target>
         <note>ID: Errors.ZoneAlarm</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="id">Membangun Template Pembaca</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="id">Periksa Versi Terbaru</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="id">Tentang Bloom</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <target xml:lang="id">Dokumentasi</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="id">Bantuan</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Get Help</source>
         <target xml:lang="id">Dapatkan Bantuan</target>
         <note>ID: HelpMenu.Help Menu_ToolTip_</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem">
+      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem" approved="yes">
         <source xml:lang="en">Key Bloom Concepts</source>
         <target xml:lang="id">Konsep Utama Bloom</target>
         <note>ID: HelpMenu.KeyBloomConceptsToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="id">Beri Saran</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="id">Pendaftaran</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="id">Catatan Rilis...</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem">
+      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem" approved="yes">
         <source xml:lang="en">Report a Problem...</source>
         <target xml:lang="id">Laporkan Masalah...</target>
         <note>ID: HelpMenu.ReportAProblemToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="id">Tampilkan Catatan Peristiwa</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="id">Memakai Template Pembaca</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="id">Situs Web</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.trainingVideos">
+      <trans-unit id="HelpMenu.trainingVideos" approved="yes">
         <source xml:lang="en">Training Videos</source>
         <target xml:lang="id">Video Pelatihan</target>
         <note>ID: HelpMenu.trainingVideos</note>
       </trans-unit>
-      <trans-unit id="InstallProblem.BloomPdfMaker">
+      <trans-unit id="InstallProblem.BloomPdfMaker" approved="yes">
         <source xml:lang="en">A component of Bloom, BloomPdfMaker.exe, seems to be missing. This prevents previews and printing. Antivirus software sometimes does this. You may need technical help to repair the Bloom installation and protect this file from being deleted again.</source>
         <target xml:lang="id">Komponen dari Bloom, BloomPdfMaker.exe, tampaknya tidak ada.Ini mencegah pratinjau dan pencetakan.Perangkat lunak Antivirus terkadang menjadi penyebabnya.Anda mungkin perlu bantuan teknis untuk memperbaiki pemasangan Bloom dan melindungi berkas ini agar tidak lagi dihapus.</target>
         <note>ID: InstallProblem.BloomPdfMaker</note>
       </trans-unit>
-      <trans-unit id="LameEncoder.Progress">
+      <trans-unit id="LameEncoder.Progress" approved="yes">
         <source xml:lang="en">Converting to mp3</source>
         <target xml:lang="id">Mengonversi ke MP3</target>
         <note>ID: LameEncoder.Progress</note>
         <note>Appears in progress indicator</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.RightToLeftCheck">
+      <trans-unit id="LanguageFontDetails.RightToLeftCheck" approved="yes">
         <source xml:lang="en">This script is right to left</source>
         <target xml:lang="id">Naskah ini dari kanan ke kiri</target>
         <note>ID: LanguageFontDetails.RightToLeftCheck</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.TallerLinesCheck">
+      <trans-unit id="LanguageFontDetails.TallerLinesCheck" approved="yes">
         <source xml:lang="en">This script requires taller lines</source>
         <target xml:lang="id">Naskah ini membutuhkan baris yang lebih tinggi</target>
         <note>ID: LanguageFontDetails.TallerLinesCheck</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="id">LanskapA4</target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="id">LanskapA4 Berdampingan</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="id">LanskapA4 HalamanTerpisah</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="id">PotretA4</target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="id">LanskapA5</target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="id">PotretA5</target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="id">PotretA5 RataBawah</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Landscape</source>
         <target xml:lang="id">LanskapA6</target>
         <note>ID: LayoutChoices.A6Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Portrait</source>
         <target xml:lang="id">PotretA6</target>
         <note>ID: LayoutChoices.A6Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="id">PotretB5</target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">HalfLetterPortrait</source>
         <target xml:lang="id">PotretSetengahSurat</target>
         <note>ID: LayoutChoices.HalfLetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterLandscape</source>
         <target xml:lang="id">LandskapSurat</target>
         <note>ID: LayoutChoices.LetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterPortrait</source>
         <target xml:lang="id">PotretSurat</target>
         <note>ID: LayoutChoices.LetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">QuarterLetterLandscape</source>
         <target xml:lang="id">LanskapSuratrSeperempat</target>
         <note>ID: LayoutChoices.QuarterLetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog.WindowTitle">
+      <trans-unit id="LicenseDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom {0}</source>
         <target xml:lang="id">Bloom {0}</target>
         <note>ID: LicenseDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog._acceptButton">
+      <trans-unit id="LicenseDialog._acceptButton" approved="yes">
         <source xml:lang="en">I accept the terms of the license agreement</source>
         <target xml:lang="id">Saya setuju ketentuan perjanjian lisensi</target>
         <note>ID: LicenseDialog._acceptButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="id">Saya setuju Ketentuan Penggunaan Perpustakaan Bloom</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="id">Alamat Email</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="id">Lupa Kata Sandi</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="id">&amp;Masuk</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="id">Kata Sandi</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="id">&amp;Tampilkan Kata Sandi</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="id">Tampilkan Ketentuan Penggunaan</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="id">Masuk ke BloomLibrary.org</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="id">Koleksi dengan nama itu sudah ada, di &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\n Pilih nama yang unik.</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="id">Pilih Bahasa Utama untuk Koleksi Ini</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="id">Misalnya: "Buku Kesehatan", "Cerita Hewan PNG"</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="id">Koleksi ini akan diberi nama apa?</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="id">Masalah Nama Koleksi</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="id">Koleksi akan dibuat pada: {0} </target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="id">Siap Membuat Koleksi Baru</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FontAndScriptPage">
+      <trans-unit id="NewCollectionWizard.FontAndScriptPage" approved="yes">
         <source xml:lang="en">Font and Script</source>
         <target xml:lang="id">Huruf dan Tulisan</target>
         <note>ID: NewCollectionWizard.FontAndScriptPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="id">Pilih Jenis Koleksi</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions" approved="yes">
         <source xml:lang="en">If you already have a collection you want to open, click  the 'Cancel' button.</source>
         <target xml:lang="id">Jika Anda sudah memiliki koleksi untuk dibuka, klik tombol 'Batalkan'.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="id">Koleksi Sumber</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org. You may also make a Bloom Pack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="id">Koleksi kerangka atau template buku di satu atau beberapa bahasa pasaran.Anda dapat mengunggah kerangka ini ke BloomLibrary.org.Anda juga dapat membuat sebuah Paket Bloom untuk diberikan ke orang lain sehingga mereka bisa membuat buku berbahasa daerah dengan kerangka Anda.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="id">Koleksi Bahasa Daerah/Lokal</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="id">Koleksi buku dalam bahasa lokal.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="id">Berikan Lokasi Bahasa</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="id">Negara</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="id">Distrik</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="id">Ini opsional.Bloom akan menempatkannya di tempat yang benar pada halaman judul dari buku yang Anda buat</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="id">Provinsi</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="id">{0} Buku</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="id">Buat Koleksi Bloom Baru</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="id">Nama Proyek</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="id">Tidak dapat membuat koleksi baru menggunakan nama itu.</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="id">Selamat datang di Bloom!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="id">Anda hampir siap membuat buku.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. The first thing we need to do is make one for you.</source>
         <target xml:lang="id">Untuk membuat berbagai hal tetap simpel dan tertata, Bloom menyimpan semua buku yang Anda buat di satu atau beberapa &lt;i&gt;Koleksi&lt;/i&gt;. Hal pertama yang kita harus lakukan adalah membuat satu koleksi untuk Anda.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="id">Klik 'Berikutnya' untuk memulai.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InDropboxMessage">
+      <trans-unit id="OpenCreateCloneControl.InDropboxMessage" approved="yes">
         <source xml:lang="en">Bloom detected that this collection is located in your Dropbox folder. This can cause problems as Dropbox sometimes locks Bloom out of its own files. If you have problems, we recommend that you move your collection somewhere else or disable Dropbox while using Bloom.</source>
         <target xml:lang="id">Bloom mendeteksi bahwa koleksi ini ada di folder Dropbox Anda.Ini bisa bermasalah karena Dropbox terkadang mengunci Bloom dari berkasnya sendiri.Jika Anda menghadapi masalah, sebaiknya pindahkan koleksi ke tempat lain atau nonaktifkan Dropbox saat menggunakan Bloom.</target>
         <note>ID: OpenCreateCloneControl.InDropboxMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage">
+      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage" approved="yes">
         <source xml:lang="en">This collection is part of your 'Sources for new books' which you can see in the bottom left of the Collections tab. It cannot be opened for editing.</source>
         <target xml:lang="id">Koleksi adalah bagian dari 'Sumber untuk buku baru' yang Anda bisa lihat di bagian kiri bawah tab Koleksi.Koleksi ini tidak bisa dibuka untuk diedit.</target>
         <note>ID: OpenCreateCloneControl.InSourceCollectionMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="id">Koleksi Bloom</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="id">Jelajahi koleksi lain di komputer ini</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="id">Salin dari Chorus Hub di Jaringan Lokal</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="id">Salin dari Internet</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="id">Salin dari Drive USB</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="id">Buat Koleksi Baru</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="id">Buka/Buat Koleksi</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="id">Baca Lainnya</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="id">Apakah ada orang lain yang memakai Kirim/Terima untuk berbagi koleksi dengan Anda?\n Gunakan salah satu dari tombol merah ini utnuk menyalin koleksi mereka ke komputer Anda.\n Setelah itu, gunakan Kirim/Terima untuk membagikan kembali karya Anda kepada mereka.</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PageList.CantMoveWhenTranslating">
+      <trans-unit id="PageList.CantMoveWhenTranslating" approved="yes">
         <source xml:lang="en">Pages can not be re-ordered when you are translating a book.</source>
         <target xml:lang="id">Halaman tidak bisa diurutkan kembali saat Anda menerjemahkan buku.</target>
         <note>ID: PageList.CantMoveWhenTranslating</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="id">Pasang Adobe Reader agar Bloom bisa menampilkan buku Anda yang telah diselesaikan.Sebelum itu, Anda masih bisa menyimpan Buku PDF dan membukanya di program yang lain.</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="id">Ada keanehan... Adobe Reader mengalami masalah saat mencoba menampilkan PDF itu. Anda masih bisa menyimpan buku PDF.</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="id">Kabar Buruk. Bloom tidak bisa meminta Adobe Reader untuk ditampilkan di sini, jadi Bloom tidak bisa menampilkan buku Anda yang sudah selesai.\n Hapus versi 'Adobe Reader' saat ini dan pasang (kembali) 'Adobe Reader'.\n Sebelum Anda memperbaikinya, Anda masih bisa menyimpan Buku PDF dan membukanya di program yang lain.</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="id">Bagian Dalam buku kecil</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book. Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="id">Buat buku kecil dari halaman dalam buku.Halaman akan diletakkan dan diurutkan ulang sehingga saat Anda melipatnya, Anda akan memiliki buku kecil.\n </target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="id">Unggah</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="id">Unggah ke BloomLibrary.org, di mana orang lain bisa mengunduh dan menempatkan ke dalam bahasa mereka sendiri.</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="id">Sampul Buku kecil</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="id">Buat PDF dari bagian depan dan belakang saja (kedua sisi), agar Anda bisa mencetaknya pada kertas berwarna.</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubButton">
+      <trans-unit id="PublishTab.EpubButton" approved="yes">
         <source xml:lang="en">ePUB</source>
         <target xml:lang="id">ePUB</target>
         <note>ID: PublishTab.EpubButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an ePUB (electronic book) out of this book, allowing it to be read on various electronic reading devices.</source>
         <target xml:lang="id">Membuat ePUB (buku elektronik) dari buku ini, yang memungkinkan untuk dibaca di berbagai perangkat baca elektronik.</target>
         <note>ID: PublishTab.EpubRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="id">Jangan Tampilkan Lagi</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="id">Informasi XML InDesign</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation">
+      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation" approved="yes">
         <source xml:lang="en">This PDF viewer can be improved by installing the free Adobe Reader on this computer.</source>
         <target xml:lang="id">Penampil PDF ini bisa ditingkatkan dengan memasang Adobe Reader gratis pada komputer ini.</target>
         <note>ID: PublishTab.Notifications.AdobeReaderRecommendation</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="id">Sederhana</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="id">Buat PDF dari setiap halaman pada buku, satu halaman per lembar kertas.</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system PDF viewer</source>
         <target xml:lang="id">Buka PDF di sistem default dari penampil PDF</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="id">Ganti yang sudah Ada</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="id">Perhatikan</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.BadPdf">
+      <trans-unit id="PublishTab.PdfMaker.BadPdf" approved="yes">
         <source xml:lang="en">Bloom had a problem making a PDF of this book. You may need technical help or to contact the developers. But here are some things you can try:</source>
         <target xml:lang="id">Bloom mengalami masalah saat membuat PDF buku ini.Anda mungkin perlu bantuan teknis atau hubungi pengembang.Namun ada beberapa hal yang bisa Anda coba:</target>
         <note>ID: PublishTab.PdfMaker.BadPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory">
+      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory" approved="yes">
         <source xml:lang="en">Try doing this on a computer with more memory</source>
         <target xml:lang="id">Cobalah ini di komputer bermemori besar.</target>
         <note>ID: PublishTab.PdfMaker.TryMoreMemory</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryRestart">
+      <trans-unit id="PublishTab.PdfMaker.TryRestart" approved="yes">
         <source xml:lang="en">Restart your computer and try this again right away</source>
         <target xml:lang="id">Mulai kembali komputer Anda dan langsung coba lagi </target>
         <note>ID: PublishTab.PdfMaker.TryRestart</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages">
+      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages" approved="yes">
         <source xml:lang="en">Replace large, high-resolution images in your document with lower-resolution ones</source>
         <target xml:lang="id">Ganti gambar besar dan beresolusi tinggi di dokumen dengan gambar beresolusi lebih rendah</target>
         <note>ID: PublishTab.PdfMaker.TrySmallerImages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="id">&amp;Cetak...</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="id">Terbitkan</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="id">&amp;Simpan PDF... </target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveEpub">
+      <trans-unit id="PublishTab.SaveEpub" approved="yes">
         <source xml:lang="en">&amp;Save ePUB...</source>
         <target xml:lang="id">&amp;Simpan ePUB...</target>
         <note>ID: PublishTab.SaveEpub</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="id">Tanda Pangkas</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="id">Penghargaan</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">Additional Requests: </source>
         <target xml:lang="id">Permintaan Tambahan:</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="id">Semua hak dilindungi undang-undang (Hubungi pemilik Hak Cipta untuk memperoleh izin apa pun).</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="id">CC-BY-NC</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you. If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="id">BloomLibrary.org sudah memiliki versi sebelumnya dari buku ini dari Anda.Jika Anda mengunduhnya lagi, buku akan diganti dengan versi saat ini.</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="id">Hak Cipta</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="id">pengakuan</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="id">Maaf, ada masalah saat mengunggah {0}. Detail lainnya menyusul. Anda mungkin harus membutuhkan bantuan teknis.</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading.</source>
         <target xml:lang="id">Satu atau beberapa bidang di atas perlu perhatian Anda sebelum mengunggah.</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded. Sometimes this is caused by temporary problems with the servers we use. It's worth trying again in an hour or two. If you regularly get this problem please report it to us.</source>
         <target xml:lang="id"> Maaf, "{0}" gagal diunggahKadang-kadang hal ini disebabkan oleh masalah sementara dengan server yang kita gunakan. Ini perlu mencoba lagi di satu atau dua jam. Jika Anda secara teratur mendapatkan masalah ini silahkan laporkan kepada kami.</target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes.</source>
         <target xml:lang="id">Dengan mengunggah, Anda menyatakan persetujuan Anda dengan Ketentuan Penggunaan Perpustakaan Bloom dan memberikan hak-hak yang dijelaskannya.</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="id">Anda masalah saat mengunggah buku Anda.</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="id">Bahasa-bahasa</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="id">Penggunaan/Lisensi</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="id">Akun Sudah Ada</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address. Would you like to log in instead?</source>
         <target xml:lang="id">Kami tidak bisa mendaftarkan Anda dengan alamat itu, karena sudah ada akun yang memakai alamat itu. Apakah Anda ingin masuk?</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="id">Bloom tidak bisa terhubung ke server untuk memverifikasi info masuk Anda. Periksa koneksi internet Anda.</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="id">Gagal masuk</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="id">Bloom tidak bisa terhubung ke server untuk menyelesaikan info masuk atau pendaftaran Anda. Ini bisa jadi karena koneksi internet, server kami, atau beberapa peralatan di antaranya bermasalah.</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="id">Untuk mendaftar ke BloomLibrary.org, Anda harus mencentang kotak yang menunjukkan persetujuan Anda dengan Ketentuan Penggunaan BloomLibrary.</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="id">Email Harus Diisi</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="id">Tidak ada catatan kami yang terkait dengan email tersebut. Anda ingin mendaftar?</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="id">Kata sandi dan ID pengguna tidak cocok</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="id">Mohon setujui ketentuan penggunaan</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="id">Masukkan alamat email yang berlaku. Kami akan mengirim email ke alamat ini agar Anda bisa mengganti kata sandi.</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="id">Bloom tidak bisa terhubung ke server untuk mengganti kata sandi Anda. Periksa koneksi internet Anda.</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="id">Gagal Mengganti kata sandi</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="id">Mengganti Kata Sandi</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password.</source>
         <target xml:lang="id">Kami mengirim email ke {0} yang berisi petunjuk mengenai cara mengganti kata sandi</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="id">Daftar ke Perpustakaan Bloom.</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="id">Pengguna tidak dikenal</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="id">Bloom tidak bisa masuk ke BloomLibrary.org memakai izin masuk Anda yang disimpan. Periksa koneksi internet Anda.</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="id">Masuk ke BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="id">Keluar dari BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="id">Membuat Pratinjau PDF... </target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="id">Membuat gambar mini...</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.NoLangsFound">
+      <trans-unit id="PublishTab.Upload.NoLangsFound" approved="yes">
         <source xml:lang="en">(None found)</source>
         <target xml:lang="id">(tidak ada yang ditemukan)</target>
         <note>ID: PublishTab.Upload.NoLangsFound</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="id">Maaf, versi Desktop Bloom ini tidak kompatibel dengan versi BloomLibrary.org saat ini. Mohon tingkatkan ke versi yang lebih baru.</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.IncompleteTranslation">
+      <trans-unit id="PublishTab.Upload.IncompleteTranslation" approved="yes">
         <source xml:lang="en">(incomplete translation)</source>
         <target xml:lang="id">(sebagian)</target>
         <note>ID: PublishTab.Upload.IncompleteTranslation</note>
         <note>This is added after the language name, in order to indicate that some parts of the book have not been translated into this language yet.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="id">Masuklah ke BloomLibrary.org (atau daftar) sebelum mengunggah</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="id">Atur ini di label edit</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="id">Daftar ke BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="id">Langkah 1: Konfirmasikan Metadata</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="id">Langkah 2: Unggah</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="id">Saran: Menetapkan Lisensi Creative Commons memudahkan Anda untuk memberikan izin tertentu secara jelas kepada semua orang.</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="id">Saran: Lisensi Creative Commons memudahkan orang lain menggunakan buku Anda, meskipun mereka tidak memiliki bahasa yang sefasih dalam izin khusus Anda.</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="id">Rangkuman</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="id">Tampilkan Ketentuan Penggunaan</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TimeProblem">
+      <trans-unit id="PublishTab.Upload.TimeProblem" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. This is probably because your computer is set to use the wrong timezone or your system time is badly wrong. See http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html for how to fix this.</source>
         <target xml:lang="id">Anda masalah saat mengunggah buku Anda. Ini mungkin karena komputer Anda diatur ke zona waktu yang salah atau sistem Anda bermasalah. Lihat http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html untuk mengetahui cara memperbaikinya.</target>
         <note>ID: PublishTab.Upload.TimeProblem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="id">Judul</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="id">Unggah Buku</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <target xml:lang="id">Selamat, "{0}" sekarang tersedia di BloomLibrary.org ({1}) </target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="id">Tidak Diizinkan Mengunggah</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="id">Anda masalah saat mengunggah buku Anda. Anda mungkin harus memulai ulang Bloom atau dapatkan bantuan teknis.</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="id">Kemajuan Unggahan</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="id">Unggah Buku (ke Sandbox)</target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="id">Mengunggah metadata buku</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, and topic tags to the BloomLibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="id">Mengunggah {0} </target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishView._saveButton">
+      <trans-unit id="PublishView._saveButton" approved="yes">
         <source xml:lang="en">Save stub</source>
         <target xml:lang="id">Simpan stub</target>
         <note>ID: PublishView._saveButton</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="id">Tambahkan Tingkat</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="id">Tambahkan Tahap</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <target xml:lang="id">Tambahkan teks ke folder Teks Contoh</target>
         <note>ID: ReaderSetup.AddTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">allowed words</source>
         <target xml:lang="id">kata diperbolehkan</target>
         <note>ID: ReaderSetup.AllowedWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <target xml:lang="id">Diperbolehkan Berkas Kata</target>
         <note>ID: ReaderSetup.AllowedWordsFile</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <target xml:lang="id">Diizinkan Kata Berkas</target>
         <note>ID: ReaderSetup.AllowedWordsFileHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Avg</source>
         <target xml:lang="id">Rata-rata</target>
         <note>ID: ReaderSetup.AverageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="id">Buku</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="id">Maksimum Kata per Buku</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose...</source>
         <target xml:lang="id">Memilih...</target>
         <note>ID: ReaderSetup.ChooseAllowedWordsFile</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="id">Klik pada huruf untuk menambahkannya ke tahapan ini.</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="id">Pisahkan dengan spasi</target>
         <note>ID: ReaderSetup.CombinationHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <target xml:lang="id">Mis. "ai oo sh ng th ing"</target>
         <note>ID: ReaderSetup.CombinationHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <target xml:lang="id">Kombinasi Huruf (Grafem)</target>
         <note>ID: ReaderSetup.Combinations</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="id">Tahap Dapat Dikodekan</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true" approved="yes">
         <source xml:lang="en">File needs .TXT extension</source>
         <target xml:lang="id">File harus berekstensi .TXT</target>
         <note>ID: ReaderSetup.FileNeedsTxtExtension</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="id">Pertama-tama,</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="id">Format tidak terbaca</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="id">Bantu mengekspor dan mengonversikan file untuk digunakan sebagai teks contoh</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="id">Bahasa</target>
         <note>ID: ReaderSetup.Language</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <target xml:lang="id">Cantumkan huruf dan karakter pembentuk kata sesuai urutan abjad.</target>
         <note>ID: ReaderSetup.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="id">Pisahkan dengan spasi</target>
         <note>ID: ReaderSetup.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <target xml:lang="id">Mis. "a b c d"</target>
         <note>ID: ReaderSetup.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="id">Huruf</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="id">Huruf dan Kombinasi Huruf</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="id">Untuk membantu Anda membuat pembaca yang dapat dikodekan, Bloom perlu mengetahui huruf dan kombinasi huruf yang akan Anda ajarkan.</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="id">Pisahkan setiap huruf atau kombinasi huruf dengan spasi. Misalnya, berikut yang mungkin digunakan dalam bahasa Inggris:</target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="id">Perhatikan bahwa daftar dalam bahasa Inggris meliputi simbol yang digunakan untuk membentuk kata, seperti ' dalam </target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="id">ini</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="id">.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="id">Level</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level&amp;nbsp;</source>
         <target xml:lang="id">Level&amp;nbsp;</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="id">Level Pembaca</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="id">kata yang cocok</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Average Length of Sentences in Book</source>
         <target xml:lang="id">Maksimum rata-rata Panjang Kalimat dalam Buku</target>
         <note>ID: ReaderSetup.MaxAverageWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="id">Kata Unik Maksimum per Buku</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <target xml:lang="id">Kata-Kata Lainnya</target>
         <note>ID: ReaderSetup.MoreWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <target xml:lang="id">Buka folder teks contoh untuk bahasa ini.</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="id">Halaman</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="id">Maksimum Kata pada setiap Halaman</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="id">Diberdayakan oleh </target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="id">Level Pembaca</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="id">Hapus Level {0} </target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="id">Hapus Tahapan {0} </target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove from this stage</source>
         <target xml:lang="id">Hapus dari tahapan ini</target>
         <note>ID: ReaderSetup.RemoveWordList</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="id">Seret baris untuk mengurutkan ulang level</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="id">Seret baris untuk mengurutkan tahapan.</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <target xml:lang="id">Daftar kata dan Teks Contoh</target>
         <note>ID: ReaderSetup.SampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Words</source>
         <target xml:lang="id">Kata sampel</target>
         <note>ID: ReaderSetup.SampleWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="id">, Mesin Pencari untuk Keaksaraan.</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="id">Huruf Sebelumnya dan Baru</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="id">Kalimat</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="id">Maksimum Kata dalam setiap Kalimat</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="id">Siapkan Alat Pembaca yang Dapat Didekodekan</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="id">Siapkan Alat Pembaca Berlevel</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <target xml:lang="id">siapkan abjad untuk bahasa ini.</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <target xml:lang="id">Apa itu kata terlihat?</target>
         <note>ID: ReaderSetup.SightWordHelp</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="id">Kata-Kata yang Terlihat</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="id">Kata Terlihat</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="id">Tahap</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="id">Tahap </target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="id">Tahap</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="id">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="id">Yang harus diingat di level ini:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="id">Unik</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="id">Kata</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage. There are two ways to give words to Bloom:</source>
         <target xml:lang="id">Untuk membantu Anda membuat pembaca yang dapat didekodekan, Bloom dapat menyarankan kata yang cocok untuk tahap saat ini. Ada dua cara untuk memberikan kata-kata ke Bloom:</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="id">2) Tempatkan File Teks di</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <target xml:lang="id">Folder Teks Contoh</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="id">1) Ketik Kata-Kata di Sini</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using lists of allowed words to define stages</source>
         <target xml:lang="id">Kami menggunakan daftar kata diizinkan untuk menentukan tahap</target>
         <note>ID: ReaderSetup.Words.UseAllowedWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using letters with sight words to define stages</source>
         <target xml:lang="id">Kami menggunakan huruf dengan pemandangan kata-kata untuk mendefinisikan tahap</target>
         <note>ID: ReaderSetup.Words.UseLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="id">Huruf</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this Bloom Pack will carry your latest decodable and leveled reader settings for the \"{0}\" language. Anyone opening this Bloom Pack, who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this Bloom Pack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="id">Selain itu, Paket Bloom ini akan membawa pengaturan pembaca yang dapat didekodekan dan berlevel terakhir untuk bahasa\"{0}\". Siapa saja yang membuka Paket Bloom ini, yang kemudian membuka koleksi \"{0}\", akan menimpa pengaturan pembaca yang dapat didekodekan dan berlevel saat ini dengan pengaturan dalam Paket Bloom. Mereka juga akan mendapatkan seperangkat kata-kata untuk digunakan dalam pembaca yang dapat didekodekan.</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="id">Buku berikut akan dibuat ke dalam templat:</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <target xml:lang="id">Simpan Paket Bloom</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <target xml:lang="id">Buat Paket Templat Pembaca Bloom</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="id">Alamat Email</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="id">Nama Depan</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="id">Luangkan waktu sebentar untuk mendaftar {0} </target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="id">Bagaimana Anda menggunakan {0}? </target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="id">Saya mentok, saya akan menuntaskan ini belakangan.</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="id">Organisasi</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="id">&amp;Daftar</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="id">Nama Belakang</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="id">Daftar {0} </target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <target xml:lang="id">Tutup</target>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.CouldNotSendToServer">
+      <trans-unit id="ReportProblemDialog.CouldNotSendToServer" approved="yes">
         <source xml:lang="en">Bloom was not able to submit your report directly to our server. Please retry or email {0} to {1}.</source>
         <target xml:lang="id">Bloom tidak dapat menyerahkan laporan Anda secara langsung ke server kami. Coba lagi atau kirim email ke {0} untuk {1}. </target>
         <note>ID: ReportProblemDialog.CouldNotSendToServer</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Email">
+      <trans-unit id="ReportProblemDialog.Email" approved="yes">
         <source xml:lang="en">Email</source>
         <target xml:lang="id">Email</target>
         <note>ID: ReportProblemDialog.Email</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeBookButton">
+      <trans-unit id="ReportProblemDialog.IncludeBookButton" approved="yes">
         <source xml:lang="en">Include Book '{0}'</source>
         <target xml:lang="id">Sertakan Buku '{0}' </target>
         <note>ID: ReportProblemDialog.IncludeBookButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton">
+      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton" approved="yes">
         <source xml:lang="en">Include this screenshot</source>
         <target xml:lang="id">Sertakan tangkapan layar ini</target>
         <note>ID: ReportProblemDialog.IncludeScreenshotButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Name">
+      <trans-unit id="ReportProblemDialog.Name" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="id">Nama</target>
         <note>ID: ReportProblemDialog.Name</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Retry">
+      <trans-unit id="ReportProblemDialog.Retry" approved="yes">
         <source xml:lang="en">Retry</source>
         <target xml:lang="id">Coba lagi</target>
         <note>ID: ReportProblemDialog.Retry</note>
         <note>Shown if there was an error submitting the report. Lets the user try submitting it again.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SeeDetails">
+      <trans-unit id="ReportProblemDialog.SeeDetails" approved="yes">
         <source xml:lang="en">See what else will be submitted</source>
         <target xml:lang="id">Lihat apa lagi yang akan diserahkan</target>
         <note>ID: ReportProblemDialog.SeeDetails</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SubmitButton">
+      <trans-unit id="ReportProblemDialog.SubmitButton" approved="yes">
         <source xml:lang="en">&amp;Submit</source>
         <target xml:lang="id">&amp;Serahkan</target>
         <note>ID: ReportProblemDialog.SubmitButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Submitting">
+      <trans-unit id="ReportProblemDialog.Submitting" approved="yes">
         <source xml:lang="en">Submitting to server...</source>
         <target xml:lang="id">Menyerahkan ke server...</target>
         <note>ID: ReportProblemDialog.Submitting</note>
         <note>This is shown while Bloom is sending the problem report to our server.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Success">
+      <trans-unit id="ReportProblemDialog.Success" approved="yes">
         <source xml:lang="en">We received your report, thanks for taking the time to help make Bloom better!</source>
         <target xml:lang="id">Kami sudah menerima laporan Anda, terima kasih telah meluangkan waktu untuk membantu Bloom menjadi lebih baik!</target>
         <note>ID: ReportProblemDialog.Success</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WhatsTheProblem">
+      <trans-unit id="ReportProblemDialog.WhatsTheProblem" approved="yes">
         <source xml:lang="en">What seems to be the problem?</source>
         <target xml:lang="id">Apa kira-kira masalahnya?</target>
         <note>ID: ReportProblemDialog.WhatsTheProblem</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WindowTitle">
+      <trans-unit id="ReportProblemDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Report A Problem</source>
         <target xml:lang="id">Laporkan Masalah</target>
         <note>ID: ReportProblemDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Zipping">
+      <trans-unit id="ReportProblemDialog.Zipping" approved="yes">
         <source xml:lang="en">Zipping up book...</source>
         <target xml:lang="id">Meringkas buku...</target>
         <note>ID: ReportProblemDialog.Zipping</note>
         <note>This is shown while Bloom is creating the problem report. It's generally too fast to see, unless you include a large book.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.linkLabel1">
+      <trans-unit id="ReportProblemDialog.linkLabel1" approved="yes">
         <source xml:lang="en">Will not be private</source>
         <target xml:lang="id">Tidak akan bersifat pribadi</target>
         <note>ID: ReportProblemDialog.linkLabel1</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.IGetIt">
+      <trans-unit id="SamplePrintNotification.IGetIt" approved="yes">
         <source xml:lang="en">I get it. Do not show this again.</source>
         <target xml:lang="id">Paham.Jangan tampilkan ini lagi.</target>
         <note>ID: SamplePrintNotification.IGetIt</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.PleaseNotice">
+      <trans-unit id="SamplePrintNotification.PleaseNotice" approved="yes">
         <source xml:lang="en">Please notice the sample printer settings below. Use them as a guide while you set up the printer.</source>
         <target xml:lang="id">Perhatikan pengaturan printer contoh di bawah.Gunakan sebagai panduan saat Anda menyiapkan printer.</target>
         <note>ID: SamplePrintNotification.PleaseNotice</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Arithmetic</source>
         <target xml:lang="id">Aritmetika</target>
         <note>ID: TemplateBooks.BookName.Arithmetic</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="id">Buku Dasar</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="id">Buku Besar</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="id">Pembaca yang Dapat Didekodekan</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="id">Pembaca Berlevel</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="id">Kamus Gambar</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vaccinations</source>
         <target xml:lang="id">Vaksinasi</target>
         <note>ID: TemplateBooks.BookName.Vaccinations</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="id">Kalender Dinding</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A blank page that allows you to add items.</source>
         <target xml:lang="id">Halaman kosong yang memungkinkan Anda untuk menambahkan sesuatu.</target>
         <note>ID: TemplateBooks.PageDescription.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page with a picture on top and a large, centered word below.</source>
         <target xml:lang="id">Halaman dengan gambar di bagian atas dan sebuah kata berukuran besar di tengah-tengah di bawah ini.</target>
         <note>ID: TemplateBooks.PageDescription.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="id">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1 Problem</source>
         <target xml:lang="id">1 Masalah</target>
         <note>ID: TemplateBooks.PageLabel.1 Problem</note>
         <note>This label indicates a page with one arithmetic problem on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true" approved="yes">
         <source xml:lang="en">10</source>
         <target xml:lang="id">10</target>
         <note>ID: TemplateBooks.PageLabel.10</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true" approved="yes">
         <source xml:lang="en">11</source>
         <target xml:lang="id">11</target>
         <note>ID: TemplateBooks.PageLabel.11</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true" approved="yes">
         <source xml:lang="en">12</source>
         <target xml:lang="id">12</target>
         <note>ID: TemplateBooks.PageLabel.12</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true" approved="yes">
         <source xml:lang="en">13</source>
         <target xml:lang="id">13</target>
         <note>ID: TemplateBooks.PageLabel.13</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true" approved="yes">
         <source xml:lang="en">14</source>
         <target xml:lang="id">14</target>
         <note>ID: TemplateBooks.PageLabel.14</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true" approved="yes">
         <source xml:lang="en">15</source>
         <target xml:lang="id">15</target>
         <note>ID: TemplateBooks.PageLabel.15</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true" approved="yes">
         <source xml:lang="en">16</source>
         <target xml:lang="id">16</target>
         <note>ID: TemplateBooks.PageLabel.16</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true" approved="yes">
         <source xml:lang="en">17</source>
         <target xml:lang="id">17</target>
         <note>ID: TemplateBooks.PageLabel.17</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true" approved="yes">
         <source xml:lang="en">18</source>
         <target xml:lang="id">18</target>
         <note>ID: TemplateBooks.PageLabel.18</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true" approved="yes">
         <source xml:lang="en">19</source>
         <target xml:lang="id">19</target>
         <note>ID: TemplateBooks.PageLabel.19</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="id">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2 Problems</source>
         <target xml:lang="id">2 Masalah</target>
         <note>ID: TemplateBooks.PageLabel.2 Problems</note>
         <note>This label indicates a page with two arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true" approved="yes">
         <source xml:lang="en">20</source>
         <target xml:lang="id">20</target>
         <note>ID: TemplateBooks.PageLabel.20</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true" approved="yes">
         <source xml:lang="en">21</source>
         <target xml:lang="id">21</target>
         <note>ID: TemplateBooks.PageLabel.21</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="id">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3 Problems</source>
         <target xml:lang="id">3 Masalah</target>
         <note>ID: TemplateBooks.PageLabel.3 Problems</note>
         <note>This label indicates a page with three arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="id">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4 Problems</source>
         <target xml:lang="id">4 Masalah</target>
         <note>ID: TemplateBooks.PageLabel.4 Problems</note>
         <note>This label indicates a page with four arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="id">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="id">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="id">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="id">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="id">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="id">Abjad</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="id">Teks &amp; Gambar Dasar</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="id">Teks &amp; Gambar Dasar</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="id">Halaman Pengakuan</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="id">Khusus</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="id">Hari 1</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="id">Hari 2</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="id">Hari 3</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="id">Hari 4</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="id">Hari 5a</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="id">Hari 5b</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Factory</source>
         <target xml:lang="id">Pabrik</target>
         <note>ID: TemplateBooks.PageLabel.Factory</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="id">Sampul Depan</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front/Back Matter</source>
         <target xml:lang="id">Materi Depan/Belakang</target>
         <note>ID: TemplateBooks.PageLabel.FrontBackMatter</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="id">Gambar di Bawah</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="id">Gambar di Tengah</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="id">Dalam Sampul Belakang </target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="id">Dalam Sampul Depan</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="id">Perintah</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="id">Hanya Teks</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="id">Hanya Gambar</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="id">Hanya sebuah Gambar</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="id">Di Luar Sampul Belakang</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="id">Paper Saver</target>
         <note>ID: TemplateBooks.PageLabel.Paper Saver</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="id">Gambar &amp; Kata</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="id">Gambar di Tengah</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="id">Gambar di Bawah</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SIL-Cameroon</source>
         <target xml:lang="id">SIL-Kamerun</target>
         <note>ID: TemplateBooks.PageLabel.SIL-Cameroon</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Super Paper Saver</source>
         <target xml:lang="id">Super Paper Saver</target>
         <note>ID: TemplateBooks.PageLabel.Super Paper Saver</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="id">Halaman Ini Sengaja Dibiarkan Kosong</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="id">Halaman Judul</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="id">Tradisional</target>
         <note>ID: TemplateBooks.PageLabel.Traditional</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="id">Persiapan</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="id">Perhatian</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="id">Cerita Hewan</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="id">Bisnis</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="id">Kehidupan Bermasyarakat</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="id">Budaya</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="id">Kamus</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="id">Lingkungan</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="id">Fiksi</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="id">Kesehatan</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="id">Petunjuk</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="id">Matematika</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.NoTopic" sil:dynamic="true">
+      <trans-unit id="Topics.NoTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">No Topic</source>
         <target xml:lang="id">Tanpa Topik</target>
         <note>ID: Topics.NoTopic</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="id">Nonfiksi</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="id">Pengembangan Diri</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="id">Primer</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="id">Sains</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="id">Keagamaan</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Story Book" sil:dynamic="true">
+      <trans-unit id="Topics.Story Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Story Book</source>
         <target xml:lang="id">Buku Cerita</target>
         <note>ID: Topics.Story Book</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="id">Tradisi</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="id">Cerita Tradisional</target>
         <note>ID: Topics.Traditional Story</note>

--- a/DistFiles/localization/id/IntegrityFailureAdvice.xlf
+++ b/DistFiles/localization/id/IntegrityFailureAdvice.xlf
@@ -2,77 +2,77 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="IntegrityFailureAdvice-en.md" datatype="html" source-language="en" target-language="id">
     <body>
-      <trans-unit id="integrity.title">
+      <trans-unit id="integrity.title" approved="yes">
         <source xml:lang="en">Bloom cannot find some of its own files, and cannot continue</source>
         <target xml:lang="id">Bloom tidak dapat menemukan beberapa filenya sendiri, dan tidak dapat melanjutkan</target>
         <note>ID: integrity.title</note>
       </trans-unit>
-      <trans-unit id="integrity.causes">
+      <trans-unit id="integrity.causes" approved="yes">
         <source xml:lang="en">Possible Causes</source>
         <target xml:lang="id">Kemungkinan Penyebab</target>
         <note>ID: integrity.causes</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.1">
+      <trans-unit id="integrity.causes.1" approved="yes">
         <source xml:lang="en">Your antivirus may have "quarantined" one or more Bloom files.</source>
         <target xml:lang="id">Antivirus Anda mungkin telah "mengkarantina" salah satu atau beberapa file Bloom.</target>
         <note>ID: integrity.causes.1</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.2">
+      <trans-unit id="integrity.causes.2" approved="yes">
         <source xml:lang="en">Your computer administrator may have your computer "locked down" to prevent bad things, but in such a way that Bloom could not place these files where they belong. </source>
         <target xml:lang="id">Administrator komputer Anda mungkin telah "mengunci" komputer Anda untuk mencegah hal-hal buruk, namun sedemikian rupa sehingga Bloom tidak dapat menempatkan berkas ini di tempat yang sesuai</target>
         <note>ID: integrity.causes.2</note>
       </trans-unit>
-      <trans-unit id="integrity.todo">
+      <trans-unit id="integrity.todo" approved="yes">
         <source xml:lang="en">What To Do</source>
         <target xml:lang="id">Yang Harus Dilakukan</target>
         <note>ID: integrity.todo</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas">
+      <trans-unit id="integrity.todo.ideas" approved="yes">
         <source xml:lang="en">After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas:</source>
         <target xml:lang="id">Setelah Anda menyerahkan laporan ini, kami akan menghubungi Anda dan membantu Anda menyelesaikannya. Untuk sementara, ada beberapa ide:</target>
         <note>ID: integrity.todo.ideas</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Reinstall">
+      <trans-unit id="integrity.todo.ideas.Reinstall" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="id">Jalankan pemasang Bloom sekali lagi, dan periksa apakah kali ini pemasang bisa berjalan dengan baik.</target>
         <note>ID: integrity.todo.ideas.Reinstall</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Antivirus">
+      <trans-unit id="integrity.todo.ideas.Antivirus" approved="yes">
         <source xml:lang="en">If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>.</source>
         <target xml:lang="id">Jika hal itu tidak memperbaikinya, sebaiknya hubungi program antivirus Anda. Jika bagian "Berkas Tidak Ditemukan" di bawah menunjukkan berkas apa pun yang berakhir ".exe", pertimbangkan untuk "memasukkan dalam daftar putih" folder program Bloom, yang berada dalam <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>.</target>
         <note>ID: integrity.todo.ideas.Antivirus</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVAST">
+      <trans-unit id="integrity.todo.ideas.AVAST" approved="yes">
         <source xml:lang="en">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">Instructions</g>.</source>
         <target xml:lang="id">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">Petunjuk</g>.</target>
         <note>ID: integrity.todo.ideas.AVAST</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Norton">
+      <trans-unit id="integrity.todo.ideas.Norton" approved="yes">
         <source xml:lang="en">Norton Antivirus: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">Instructions from Symantec</g>.</source>
         <target xml:lang="id">Norton Antivirus: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">Petunjuk dari Symantec</g>.</target>
         <note>ID: integrity.todo.ideas.Norton</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVG">
+      <trans-unit id="integrity.todo.ideas.AVG" approved="yes">
         <source xml:lang="en">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">Instructions from AVG</g>.</source>
         <target xml:lang="id">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">Petunjuk dari AVG</g>.</target>
         <note>ID: integrity.todo.ideas.AVG</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Others">
+      <trans-unit id="integrity.todo.ideas.Others" approved="yes">
         <source xml:lang="en">Others: Google for "whitelist directory name-of-your-antivirus"</source>
         <target xml:lang="id">Lain-lain: Lakukan pencarian di Google untuk istilah "mendaftar putih direktori nama-dari antivirus- Anda".</target>
         <note>ID: integrity.todo.ideas.Others</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Restart">
+      <trans-unit id="integrity.todo.ideas.Restart" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="id">Jalankan pemasang Bloom sekali lagi, dan periksa apakah kali ini pemasang bisa berjalan dengan baik.</target>
         <note>ID: integrity.todo.ideas.Restart</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Retrieve">
+      <trans-unit id="integrity.todo.ideas.Retrieve" approved="yes">
         <source xml:lang="en">You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">this image</g>.</source>
         <target xml:lang="id">Anda juga dapat mencoba dan memperoleh kembali bagian dari Bloom yang diambil oleh program antivirus. Untuk AVG, Anda harus mencari menu "opsi" AVG, klik "kubah virus", klik berkas Bloom dalam kubah, dan klik "pulihkan". Untuk panduan visual, lihat <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">gambar ini</g>.</target>
         <note>ID: integrity.todo.ideas.Retrieve</note>
       </trans-unit>
-      <trans-unit id="integrity.missing">
+      <trans-unit id="integrity.missing" approved="yes">
         <source xml:lang="en">Missing Files</source>
         <target xml:lang="id">Berkas Tidak Ditemukan</target>
         <note>ID: integrity.missing</note>

--- a/DistFiles/localization/id/MissingLameModule.xlf
+++ b/DistFiles/localization/id/MissingLameModule.xlf
@@ -2,19 +2,19 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="MissingLameModule-en.html" datatype="html" source-language="en" target-language="id">
     <body>
-      <trans-unit id="missing.lame.please.install">
+      <trans-unit id="missing.lame.please.install" approved="yes">
         <source xml:lang="en">Please Install LAME</source>
         <target xml:lang="id">Silakan pasang LAME</target>
         <note>ID: missing.lame.please.install</note>
       </trans-unit>
-      <trans-unit id="missing.lame.bloom.needs.lame">
+      <trans-unit id="missing.lame.bloom.needs.lame" approved="yes">
         <source xml:lang="en">This book has audio recordings. Bloom can use these to make a "Talking Book" e-book. However, Bloom needs a program called "LAME for Audacity" in order to create the mp3 files that the book will use. Setting it up is easy. First download and run <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>. Next, restart Bloom.
       </source>
         <target xml:lang="id">Buku ini memiliki rekaman-rekaman audio. Bloom dapat menggunakan rekaman tersebut untuk membuat buku elektronik "Buku Berbicara" Namun, Bloom memerlukan suatu program yang disebut "LAME untuk Keberanian" supaya bisa membuat berkas MP3 yang akan dipakai buku tersebut. Pemasangannya mudah. Pertama unduh dan jalankan <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>. Berikutnya, mulai ulang Bloom.
       </target>
         <note>ID: missing.lame.bloom.needs.lame</note>
       </trans-unit>
-      <trans-unit id="missing.lame.audio.optional">
+      <trans-unit id="missing.lame.audio.optional" approved="yes">
         <source xml:lang="en">If you prefer to go ahead and publish your book without audio, click <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">here</g>.
       </source>
         <target xml:lang="id">Jika Anda ingin melanjutkan dan menerbitkan buku Anda tanpa audio, klik <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">sini</g>.

--- a/DistFiles/localization/id/Palaso.xlf
+++ b/DistFiles/localization/id/Palaso.xlf
@@ -2,595 +2,595 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Palaso.dll" source-language="en" target-language="id" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="AboutDialog.BuiltOnDate">
+      <trans-unit id="AboutDialog.BuiltOnDate" approved="yes">
         <source xml:lang="en">Built on {0}</source>
         <target xml:lang="id">Dibangun pada {0}</target>
         <note>ID: AboutDialog.BuiltOnDate</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.NoUpdates">
+      <trans-unit id="AboutDialog.NoUpdates" approved="yes">
         <source xml:lang="en">No Updates</source>
         <target xml:lang="id">Tidak Ada Pembaruan</target>
         <note>ID: AboutDialog.NoUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.WindowTitle">
+      <trans-unit id="AboutDialog.WindowTitle" approved="yes">
         <source xml:lang="en">About {0}</source>
         <target xml:lang="id">Tentang {0}</target>
         <note>ID: AboutDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._checkForUpdates">
+      <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
         <source xml:lang="en">Check For Updates</source>
         <target xml:lang="id">Periksa Pembaruan</target>
         <note>ID: AboutDialog._checkForUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._releaseNotesLabel">
+      <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="id">Catatan Rilis</target>
         <note>ID: AboutDialog._releaseNotesLabel</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.General">
+      <trans-unit id="Application.AlreadyRunning.General" approved="yes">
         <source xml:lang="en">Another copy of the application is already running. If you cannot find it, restart your computer.</source>
         <target xml:lang="id">Salinan aplikasi yang lain sudah berjalan.Jika Anda tidak menemukannya, mulai ulang komputer Anda.</target>
         <note>ID: Application.AlreadyRunning.General</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.Specific">
+      <trans-unit id="Application.AlreadyRunning.Specific" approved="yes">
         <source xml:lang="en">Another copy of {0} is already running. If you cannot find that copy of {0}, restart your computer.</source>
         <target xml:lang="id">Salinan aplikasi {0} yang lain sudah berjalan.Jika Anda tidak menemukan salinan {0}, mulai ulang komputer Anda.</target>
         <note>ID: Application.AlreadyRunning.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.General">
+      <trans-unit id="Application.ProblemStarting.General" approved="yes">
         <source xml:lang="en">There was a problem starting the application which might require that you restart your computer.</source>
         <target xml:lang="id">Ada masalah saat memulai aplikasi yang mungkin mengharuskan Anda untuk memulai ulang komputer.</target>
         <note>ID: Application.ProblemStarting.General</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.Specific">
+      <trans-unit id="Application.ProblemStarting.Specific" approved="yes">
         <source xml:lang="en">There was a problem starting {0} which might require that you restart your computer.</source>
         <target xml:lang="id">Ada masalah saat memulai {0} yang mungkin mengharuskan Anda untuk memulai ulang komputer.</target>
         <note>ID: Application.ProblemStarting.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.General">
+      <trans-unit id="Application.WaitingFinish.General" approved="yes">
         <source xml:lang="en">Waiting for other application to finish...</source>
         <target xml:lang="id">Menunggu aplikasi lain selesai...</target>
         <note>ID: Application.WaitingFinish.General</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.Specific">
+      <trans-unit id="Application.WaitingFinish.Specific" approved="yes">
         <source xml:lang="en">Waiting for other {0} to finish...</source>
         <target xml:lang="id">Menunggu {0} lain selesai...</target>
         <note>ID: Application.WaitingFinish.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="id">&amp;Batalkan</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.No">
+      <trans-unit id="Common.No" approved="yes">
         <source xml:lang="en">No</source>
         <target xml:lang="id">Tidak</target>
         <note>ID: Common.No</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="id">&amp;Oke</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Yes">
+      <trans-unit id="Common.Yes" approved="yes">
         <source xml:lang="en">Yes</source>
         <target xml:lang="id">Ya</target>
         <note>ID: Common.Yes</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="id">{0} akan dipindahkan ke Keranjang Sampah.</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
         <note>Parameter {0} is a description of the things being deleted (e.g., "The selected files"</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="id">{0} akan dipindahkan ke Keranjang Sampah.</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
         <note>Parameter {0} is a file name</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Confirm Delete</source>
         <target xml:lang="id">Konfirmasikan Penghapusan</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="id">&amp;Batalkan</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="id">&amp;Hapus</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.AlmostMatchingImages">
+      <trans-unit id="ImageToolbox.AlmostMatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images with names close to {1}</source>
         <target xml:lang="id">Ditemukan {0} gambar yang namanya mirip dengan {1}</target>
         <note>ID: ImageToolbox.AlmostMatchingImages</note>
         <note>The {0} will be replaced by the number of images found.  The {1} will be replaced with the search string.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ArtOfReading">
+      <trans-unit id="ImageToolbox.ArtOfReading" approved="yes">
         <source xml:lang="en">Art Of Reading</source>
         <target xml:lang="id">Seni Membaca</target>
         <note>ID: ImageToolbox.ArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Camera">
+      <trans-unit id="ImageToolbox.Camera" approved="yes">
         <source xml:lang="en">Camera</source>
         <target xml:lang="id">Kamera</target>
         <note>ID: ImageToolbox.Camera</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
         <source xml:lang="en">Use {0}</source>
         <target xml:lang="id">Gunakan {0}</target>
         <note>ID: ImageToolbox.CopyExemplarMetadata</note>
         <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Crop">
+      <trans-unit id="ImageToolbox.Crop" approved="yes">
         <source xml:lang="en">Crop</source>
         <target xml:lang="id">Pangkas</target>
         <note>ID: ImageToolbox.Crop</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.DownloadArtOfReading">
+      <trans-unit id="ImageToolbox.DownloadArtOfReading" approved="yes">
         <source xml:lang="en">Download Art Of Reading Installer</source>
         <target xml:lang="id">Unduh Pemasang Seni Membaca</target>
         <note>ID: ImageToolbox.DownloadArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EditMetadataLink">
+      <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
         <source xml:lang="en">Edit...</source>
         <target xml:lang="id">Edit...</target>
         <note>ID: ImageToolbox.EditMetadataLink</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EnterSearchTerms">
+      <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
         <source xml:lang="en">This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.</source>
         <target xml:lang="id">Ini adalah galeri 'Seni Membaca'.Dalam kotak di atas, ketik yang Anda cari, lalu tekan ENTER. Anda dapat mengetik kata-kata dalam bahasa Inggris dan bahasa Indonesia.</target>
         <note>ID: ImageToolbox.EnterSearchTerms</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.FileButton">
+      <trans-unit id="ImageToolbox.FileButton" approved="yes">
         <source xml:lang="en">File</source>
         <target xml:lang="id">Berkas</target>
         <note>ID: ImageToolbox.FileButton</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
         <target xml:lang="id">Maaf, ada masalah saat mengambil gambar.</target>
         <note>ID: ImageToolbox.GenericGettingImageProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericProblem">
+      <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
         <target xml:lang="id">Maaf, ada masalah dengan Kotak Alat Gambar</target>
         <note>ID: ImageToolbox.GenericProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GetPicture">
+      <trans-unit id="ImageToolbox.GetPicture" approved="yes">
         <source xml:lang="en">Get Picture</source>
         <target xml:lang="id">Ambil Gambar</target>
         <note>ID: ImageToolbox.GetPicture</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
         <source xml:lang="en">Image Toolbox</source>
         <target xml:lang="id">Kotak Alat Gambar</target>
         <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.InstallArtOfReading">
+      <trans-unit id="ImageToolbox.InstallArtOfReading" approved="yes">
         <source xml:lang="en">Install the Art Of Reading package (this may be very slow)</source>
         <target xml:lang="id">Pasang paket Seni Membaca (ini mungkin akan butuh waktu)</target>
         <note>ID: ImageToolbox.InstallArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.MatchingImages">
+      <trans-unit id="ImageToolbox.MatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images</source>
         <target xml:lang="id">{0} gambar ditemukan</target>
         <note>ID: ImageToolbox.MatchingImages</note>
         <note>The {0} will be replaced by the number of matching images</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NewMultilingual">
+      <trans-unit id="ImageToolbox.NewMultilingual" approved="yes">
         <source xml:lang="en">Did you know that there is a new version of this collection which lets you search in Arabic, Bengali, Chinese, English, French, Indonesian, Hindi, Portuguese, Spanish, Thai, or Swahili? It is free and available for downloading.</source>
         <target xml:lang="id">Tahukah Anda bahwa ada versi terbaru untuk koleksi ini yang memungkinkan Anda mencari dalam bahasa Arab, Bengal, Mandarin, Inggris, Prancis, Indonesia, Hindi, Portugis, Spanyol, Thailand, atau Swahili? Koleksi ini gratis dan tersedia untuk diunduh.</target>
         <note>ID: ImageToolbox.NewMultilingual</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoArtOfReading">
+      <trans-unit id="ImageToolbox.NoArtOfReading" approved="yes">
         <source xml:lang="en">This computer doesn't appear to have the 'Art Of Reading' gallery installed yet.</source>
         <target xml:lang="id">Komputer ini tampaknya belum memasang galeri 'Seni Membaca'.</target>
         <note>ID: ImageToolbox.NoArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoMatchingImages">
+      <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
         <source xml:lang="en">Found no matching images</source>
         <target xml:lang="id">Gambar yang cocok tidak ditemukan</target>
         <note>ID: ImageToolbox.NoMatchingImages</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PictureFiles">
+      <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
         <source xml:lang="en">picture files</source>
         <target xml:lang="id">berkas gambar</target>
         <note>ID: ImageToolbox.PictureFiles</note>
         <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice" approved="yes">
         <source xml:lang="en">Problem Getting Image</source>
         <target xml:lang="id">Masalah Mengambil Gambar</target>
         <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemLoadingImage">
+      <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
         <source xml:lang="en">Sorry, there was a problem loading that image.</source>
         <target xml:lang="id">Maaf, ada masalah saat mengambil gambar tersebut.</target>
         <note>ID: ImageToolbox.ProblemLoadingImage</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
         <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
         <target xml:lang="id">Gambar ini tidak mengetahui:\n\nSiapa yang membuatnya?\nSiapa yang dapat menggunakannya?</target>
         <note>ID: ImageToolbox.PromptForMissingMetadata</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Scanner">
+      <trans-unit id="ImageToolbox.Scanner" approved="yes">
         <source xml:lang="en">Scanner</source>
         <target xml:lang="id">Pemindai</target>
         <note>ID: ImageToolbox.Scanner</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchArtOfReading">
+      <trans-unit id="ImageToolbox.SearchArtOfReading" approved="yes">
         <source xml:lang="en">Search the Art of Reading Gallery</source>
         <target xml:lang="id">Cari Galeri Seni Membaca</target>
         <note>ID: ImageToolbox.SearchArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchLanguage">
+      <trans-unit id="ImageToolbox.SearchLanguage" approved="yes">
         <source xml:lang="en">The search box is currently set to {0}</source>
         <target xml:lang="id">Kotak pencarian saat ini diatur ke {0}</target>
         <note>ID: ImageToolbox.SearchLanguage</note>
         <note>The {0} will be replaced by the name of the language used in the searches.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SetUpMetadataLink">
+      <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
         <source xml:lang="en">Set up metadata...</source>
         <target xml:lang="id">Menyiapkan metadata...</target>
         <note>ID: ImageToolbox.SetUpMetadataLink</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.AlternateNamesHeader">
+      <trans-unit id="LanguageLookup.AlternateNamesHeader" approved="yes">
         <source xml:lang="en">Other Names</source>
         <target xml:lang="id">Nama Lain</target>
         <note>ID: LanguageLookup.AlternateNamesHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2" approved="yes">
         <source xml:lang="en">This list should include all the ISO-639 languages, including all the alternative names known to ethnologue.com.\n\nIf necessary, use the "Unlisted Language" option, which will be selected for you now.</source>
         <target xml:lang="id">Daftar ini harus menyertakan semua bahasa yang tercatat dalam ISO-639, termasuk semua nama alternatif yang dikenal oleh ethnologue.com.\n\nJika perlu, gunakan pilihan "Bahasa Tak Terdaftar", yang akan dipilih untuk Anda sekarang.</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue" approved="yes">
         <source xml:lang="en">Ethnologue.com</source>
         <target xml:lang="id">Ethnologue.com</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
         <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
         <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
         <target xml:lang="id">Tentang Kode Bahasa 639-3 &amp; Cara Menerapkannya untuk Bahasa-bahasa yang Baru</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
         <source xml:lang="en">About The ISO Language Registry</source>
         <target xml:lang="id">Tentang Pendaftaran Bahasa dengan Kode ISO</target>
         <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CodeHeader">
+      <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
         <source xml:lang="en">Code</source>
         <target xml:lang="id">Kode</target>
         <note>ID: LanguageLookup.CodeHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryCount">
+      <trans-unit id="LanguageLookup.CountryCount" approved="yes">
         <source xml:lang="en">{0} Countries</source>
         <target xml:lang="id">{0} Negara-negara</target>
         <note>ID: LanguageLookup.CountryCount</note>
         <note>Shown when there are multiple countries and it is just confusing to list them all. {0} is a count of countries.</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryHeader">
+      <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="id">Negara</target>
         <note>ID: LanguageLookup.CountryHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
         <source xml:lang="en">You can change how the language name will be displayed here:</source>
         <target xml:lang="id">Anda dapat mengubah cara nama bahasa ditampilkan di sini:</target>
         <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
         <source xml:lang="en">Lookup Language Code...</source>
         <target xml:lang="id">Mencari Kode Bahasa...</target>
         <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.PrimaryNameHeader">
+      <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="id">Nama</target>
         <note>ID: LanguageLookup.PrimaryNameHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel">
+      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel" approved="yes">
         <source xml:lang="en">Show regional dialects</source>
         <target xml:lang="id">Tampilkan dialek regional</target>
         <note>ID: LanguageLookup.ShowRegionalDialectsLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.UnlistedLanguage">
+      <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
         <source xml:lang="en">Unlisted Language</source>
         <target xml:lang="id">Bahasa Tak Terdaftar</target>
         <note>ID: LanguageLookup.UnlistedLanguage</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
         <source xml:lang="en">Can't find your language?</source>
         <target xml:lang="id">Tidak dapat menemukan bahasa Anda?</target>
         <note>ID: LanguageLookup._cannotFindLanguageLink</note>
       </trans-unit>
-      <trans-unit id="MemoryWarning">
+      <trans-unit id="MemoryWarning" approved="yes">
         <source xml:lang="en">Unfortunately, {0} is starting to get short of memory, and may soon slow down or experience other problems. We recommend that you quit and restart it when convenient.</source>
         <target xml:lang="id">Sayang sekali, {0} sedang kekurangan memori, dan sebentar lagi akan melambat atau mengalami masalah lain. Sebaiknya Anda keluar dari aplikasi dan mulai lagi pada waktu yang tepat.</target>
         <note>ID: MemoryWarning</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Creator">
+      <trans-unit id="MetadataDisplay.Creator" approved="yes">
         <source xml:lang="en">Creator: {0}</source>
         <target xml:lang="id">Pembuat: {0}</target>
         <note>ID: MetadataDisplay.Creator</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.CreatorLabel">
+      <trans-unit id="MetadataDisplay.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="id">Pembuat</target>
         <note>ID: MetadataDisplay.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.LicenseInfo">
+      <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
         <source xml:lang="en">License Info</source>
         <target xml:lang="id">Keterangan Lisensi</target>
         <note>ID: MetadataDisplay.LicenseInfo</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You must keep the copyright and credits for authors, illustrators, etc.</source>
         <target xml:lang="id">Anda harus menghargai hak cipta dan pengakuan untuk para penulis, ilustrator, dsb.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.AttributionRequired</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You are free to make commercial use of this work.</source>
         <target xml:lang="id">Anda bebas menggunakan karya ini untuk keperluan komersial.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work.</source>
         <target xml:lang="id">Anda dapat menyesuaikan dan menambahkan ke karya ini.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.Derivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work, but you may distribute the resulting work only under the same or similar license to this one.</source>
         <target xml:lang="id">Anda dapat menyesuaikan dan menambahkan ke karya ini, namun Anda hanya dapat mendistribusikan hasil karya tersebut di bawah lisensi yang sama atau serupa dengan yang ini.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not make changes or build upon this work without permission.</source>
         <target xml:lang="id">Anda tidak boleh mengubah atau membuat di atas karya ini tanpa izin.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NoDerivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not use this work for commercial purposes.</source>
         <target xml:lang="id">Anda tidak boleh menggunakan karya ini untuk keperluan komersial.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NonCommercial</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For permission to reuse, contact the copyright holder.</source>
         <target xml:lang="id">Untuk memperoleh izin penggunaan kembali, hubungi pemegang hak cipta.</target>
         <note>ID: MetadataDisplay.Licenses.NullLicense</note>
         <note>This is used when all we have is a copyright, no other license.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.NoLicense">
+      <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
         <source xml:lang="en">No license specified</source>
         <target xml:lang="id">Lisensi tidak ditetapkan</target>
         <note>ID: MetadataDisplay.NoLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowCommercialUse">
+      <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
         <source xml:lang="en">Allow commercial uses of your work?</source>
         <target xml:lang="id">Boleh menggunakan karya Anda untuk keperluan komersial?</target>
         <note>ID: MetadataEditor.AllowCommercialUse</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowDerivatives">
+      <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
         <source xml:lang="en">Allow modifications of your work?</source>
         <target xml:lang="id">Boleh memodifikasi karya Anda?</target>
         <note>ID: MetadataEditor.AllowDerivatives</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CopyrightHolder">
+      <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
         <source xml:lang="en">Copyright Holder</source>
         <target xml:lang="id">Pemegang Hak Cipta</target>
         <note>ID: MetadataEditor.CopyrightHolder</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons">
+      <trans-unit id="MetadataEditor.CreativeCommons" approved="yes">
         <source xml:lang="en">Creative Commons</source>
         <target xml:lang="id">Kesepakatan Umum dalam Pembuatan</target>
         <note>ID: MetadataEditor.CreativeCommons</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental">
+      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental" approved="yes">
         <source xml:lang="en">Intergovernmental Version</source>
         <target xml:lang="id">Intergovernmental Versi</target>
         <note>ID: MetadataEditor.CreativeCommons.Intergovernmental</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreatorLabel">
+      <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="id">Pembuat</target>
         <note>ID: MetadataEditor.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CustomLicense">
+      <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="id">Khusus</target>
         <note>ID: MetadataEditor.CustomLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleNoCredit">
+      <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
         <source xml:lang="en">Copyright and License</source>
         <target xml:lang="id">Hak Cipta dan Lisensi</target>
         <note>ID: MetadataEditor.TitleNoCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleWithCredit">
+      <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
         <source xml:lang="en">Credit, Copyright, and License</source>
         <target xml:lang="id">Penghargaan, Hak Cipta, dan Lisensi</target>
         <note>ID: MetadataEditor.TitleWithCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.UnknownLicense">
+      <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <target xml:lang="id">Hubungi pemegang hak cipta untuk setiap izin</target>
         <note>ID: MetadataEditor.UnknownLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.YesShareAlike">
+      <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
         <source xml:lang="en">Yes, as long as others share alike</source>
         <target xml:lang="id">Ya, asalkan orang lain berbagi hal yang sama</target>
         <note>ID: MetadataEditor.YesShareAlike</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.additionalRequestsLabel">
+      <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
         <source xml:lang="en">Additional Requests</source>
         <target xml:lang="id">Permintaan Tambahan</target>
         <note>ID: MetadataEditor.additionalRequestsLabel</note>
         <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.betterLinkLabel1">
+      <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
         <source xml:lang="en">more info</source>
         <target xml:lang="id">keterangan lebih lanjut</target>
         <note>ID: MetadataEditor.betterLinkLabel1</note>
         <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere that defines it.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
         <source xml:lang="en">Not Enforceable</source>
         <target xml:lang="id">Tidak Dapat Diterapkan</target>
         <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
         <note>While this screen allows it, legally you can't enforce any additions to a creative commons license. This link takes you to the clause that says that. This link is visible only if you choose Creative Commons but then type in  the "Additional Request" box.</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <target xml:lang="id">Ini juga akan menyembunyikan tombol lain yang tidak diperlukan oleh pengguna yang bukan tingkat mahir.</target>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.CtrlShiftHint">
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
         <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
         <target xml:lang="id">Tombol ini akan tampil ketika Anda menekan tombol Ctrl dan Shift pada saat yang sama.</target>
         <note>ID: SettingsProtection.CtrlShiftHint</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+      <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
         <source xml:lang="en">Settings...</source>
         <target xml:lang="id">Pengaturan...</target>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
         <source xml:lang="en">Hide the button that opens settings.</source>
         <target xml:lang="id">Sembunyikan tombol yang membuka pengaturan.</target>
         <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
         <source xml:lang="en">Factory Password</source>
         <target xml:lang="id">Kata Sandi default</target>
         <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
         <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
         <target xml:lang="id">Untuk mencegah perubahan yang tidak disengaja yang dapat membuat alat ini berhenti berfungsi untuk Anda, pengaturan ini telah dikunci.</target>
         <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
         <source xml:lang="en">Settings Protection Password</source>
         <target xml:lang="id">Kata Sandi Perlindungan Pengaturan</target>
         <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox">
+      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
         <source xml:lang="en">Show Characters</source>
         <target xml:lang="id">Tampilkan Karakter</target>
         <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordNotice">
+      <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
         <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always google for "{1}" and "{2}".</source>
         <target xml:lang="id">Kata sandi perusahaan untuk pengaturan ini adalah "{0}". Jika Anda lupa kata sandi, Anda bisa mencarinya di Google "{1}" dan "{2}"</target>
         <note>ID: SettingsProtection.PasswordNotice</note>
         <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
         <source xml:lang="en">Require the factory password to get into settings.</source>
         <target xml:lang="id">Wajibkan kata sandi default dimasukkan ke pengaturan.</target>
         <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
         <source xml:lang="en">Settings Protection</source>
         <target xml:lang="id">Perlindungan Pengaturan</target>
         <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
       </trans-unit>
-      <trans-unit id="ShowReleaseNotesDialog.WindowTitle">
+      <trans-unit id="ShowReleaseNotesDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="id">Catatan rilis</target>
         <note>ID: ShowReleaseNotesDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Font">
+      <trans-unit id="WSFontControl.Font" approved="yes">
         <source xml:lang="en">&amp;Font:</source>
         <target xml:lang="id">&amp;Bentuk huruf:</target>
         <note>ID: WSFontControl.Font</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.FontNotAvailable">
+      <trans-unit id="WSFontControl.FontNotAvailable" approved="yes">
         <source xml:lang="en">(The selected font is not available on this machine. Using default.)</source>
         <target xml:lang="id">(Bentuk huruf yang dipilih tidak tersedia pada mesin ini. Menggunakan default).</target>
         <note>ID: WSFontControl.FontNotAvailable</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.RightToLeftWS">
+      <trans-unit id="WSFontControl.RightToLeftWS" approved="yes">
         <source xml:lang="en">This is a &amp;right to left writing system.</source>
         <target xml:lang="id">Ini adalah sistem penulisan kanan ke kiri.</target>
         <note>ID: WSFontControl.RightToLeftWS</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Size">
+      <trans-unit id="WSFontControl.Size" approved="yes">
         <source xml:lang="en">&amp;Size:</source>
         <target xml:lang="id">&amp;Ukuran:</target>
         <note>ID: WSFontControl.Size</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.TestArea">
+      <trans-unit id="WSFontControl.TestArea" approved="yes">
         <source xml:lang="en">&amp;Test Area:</source>
         <target xml:lang="id">&amp;Area Pengujian:</target>
         <note>ID: WSFontControl.TestArea</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
         <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
         <target xml:lang="id">Jika keyboard yang Anda butuhkan tidak tercantum, klik tautan yang sesuai di bawah untuk mengaturnya</target>
         <note>ID: WSKeyboardControl.KeyboardNotListed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
         <source xml:lang="en">Windows keyboard settings</source>
         <target xml:lang="id">Pengaturan keyboard Windows</target>
         <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
         <source xml:lang="en">Available keyboards</source>
         <target xml:lang="id">Keyboard yang tersedia</target>
         <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
         <source xml:lang="en">Previously used keyboards</source>
         <target xml:lang="id">Keyboard yang sebelumnya dipakai</target>
         <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
         <source xml:lang="en">Keyman Configuration</source>
         <target xml:lang="id">Konfigurasi Keyman</target>
         <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
         <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
         <target xml:lang="id">Keyman 5.0 atau yang terbaru tidak dipasang.</target>
         <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
         <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
         <target xml:lang="id">Pilih &amp;keyboard yang akan digunakan untuk mengetik teks {0}</target>
         <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.TestAreaCaption">
+      <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
         <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
         <target xml:lang="id">&amp;Area Pengujian (Gunakan area ini untuk mengetik sesuatu untuk menguji keyboard Anda).</target>
         <note>ID: WSKeyboardControl.TestAreaCaption</note>
       </trans-unit>
-      <trans-unit id="Warning">
+      <trans-unit id="Warning" approved="yes">
         <source xml:lang="en">Warning</source>
         <target xml:lang="id">Peringatan</target>
         <note>ID: Warning</note>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption" approved="yes">
         <source xml:lang="en">Unable to connect to SLDR</source>
         <target xml:lang="id">Tidak dapat terhubung ke SLDR</target>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrCaption</note>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText" approved="yes">
         <source xml:lang="en">The application is unable to connect to the SIL Locale Data Repository to retrieve the latest information about this language. If you create this writing system, the default settings might be incorrect or out of date. Are you sure you want to create a new writing system?</source>
         <target xml:lang="id">Aplikasi tidak dapat terhubung ke Penyimpanan Data Lokal SIL untuk mengambil informasi terbaru mengenai bahasa ini. Jika Anda membuat sistem penulisan ini, pengaturan default-nya mungkin salah atau sudah usang. Yakin ingin membuat sistem penulisan yang baru?</target>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrText</note>

--- a/DistFiles/localization/id/TrainingVideos.xlf
+++ b/DistFiles/localization/id/TrainingVideos.xlf
@@ -2,17 +2,17 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="TrainingVideos-en.md" datatype="html" source-language="en" target-language="id">
     <body>
-      <trans-unit id="training.videos">
+      <trans-unit id="training.videos" approved="yes">
         <source xml:lang="en">Bloom Training Videos</source>
         <target xml:lang="id">Video Pelatihan Bloom</target>
         <note>ID: training.videos</note>
       </trans-unit>
-      <trans-unit id="training.videos.watch">
+      <trans-unit id="training.videos.watch" approved="yes">
         <source xml:lang="en">If you are connected to the internet now, you can watch videos in your web browser:</source>
         <target xml:lang="id">Jika Anda sedang terhubung ke internet, Anda dapat menonton video di browser web:</target>
         <note>ID: training.videos.watch</note>
       </trans-unit>
-      <trans-unit id="training.videos.all">
+      <trans-unit id="training.videos.all" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-a" html:href="http://tiny.cc/bloomVimeo">All videos</g>
         </source>
@@ -21,12 +21,12 @@
         </target>
         <note>ID: training.videos.all</note>
       </trans-unit>
-      <trans-unit id="training.videos.intro">
+      <trans-unit id="training.videos.intro" approved="yes">
         <source xml:lang="en">Introductory Videos</source>
         <target xml:lang="id">Video Pengantar</target>
         <note>ID: training.videos.intro</note>
       </trans-unit>
-      <trans-unit id="training.videos.whofor">
+      <trans-unit id="training.videos.whofor" approved="yes">
         <source xml:lang="en">
           <g id="genid-2" ctype="x-html-a" html:href="https://vimeo.com/114043219">Bloom: Who is it for</g>
         </source>
@@ -35,7 +35,7 @@
         </target>
         <note>ID: training.videos.whofor</note>
       </trans-unit>
-      <trans-unit id="training.videos.templates">
+      <trans-unit id="training.videos.templates" approved="yes">
         <source xml:lang="en">
           <g id="genid-3" ctype="x-html-a" html:href="https://vimeo.com/114024308">Understanding Templates and Shell Books</g>
         </source>
@@ -44,7 +44,7 @@
         </target>
         <note>ID: training.videos.templates</note>
       </trans-unit>
-      <trans-unit id="training.videos.basicbook">
+      <trans-unit id="training.videos.basicbook" approved="yes">
         <source xml:lang="en">
           <g id="genid-4" ctype="x-html-a" html:href="https://vimeo.com/112825489">Using the Basic Book template</g>
         </source>
@@ -53,7 +53,7 @@
         </target>
         <note>ID: training.videos.basicbook</note>
       </trans-unit>
-      <trans-unit id="training.videos.readers">
+      <trans-unit id="training.videos.readers" approved="yes">
         <source xml:lang="en">
           <g id="genid-5" ctype="x-html-a" html:href="http://tiny.cc/usingBloomReaderTemplates">Using Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -62,12 +62,12 @@
         </target>
         <note>ID: training.videos.readers</note>
       </trans-unit>
-      <trans-unit id="training.videos.advanced">
+      <trans-unit id="training.videos.advanced" approved="yes">
         <source xml:lang="en">Advanced Topics</source>
         <target xml:lang="id">Topik Tingkat Mahir</target>
         <note>ID: training.videos.advanced</note>
       </trans-unit>
-      <trans-unit id="training.videos.formatting">
+      <trans-unit id="training.videos.formatting" approved="yes">
         <source xml:lang="en">
           <g id="genid-6" ctype="x-html-a" html:href="https://vimeo.com/117820891">Changing the format of text</g>
         </source>
@@ -76,7 +76,7 @@
         </target>
         <note>ID: training.videos.formatting</note>
       </trans-unit>
-      <trans-unit id="training.videos.custompage">
+      <trans-unit id="training.videos.custompage" approved="yes">
         <source xml:lang="en">
           <g id="genid-7" ctype="x-html-a" html:href="https://vimeo.com/116868148">Using the Custom Page template</g>
         </source>
@@ -85,7 +85,7 @@
         </target>
         <note>ID: training.videos.custompage</note>
       </trans-unit>
-      <trans-unit id="training.videos.specialcharacters">
+      <trans-unit id="training.videos.specialcharacters" approved="yes">
         <source xml:lang="en">
           <g id="genid-8" ctype="x-html-a" html:href="https://vimeo.com/117927599">Inserting special characters</g>
         </source>
@@ -94,7 +94,7 @@
         </target>
         <note>ID: training.videos.specialcharacters</note>
       </trans-unit>
-      <trans-unit id="training.videos.readertemplates">
+      <trans-unit id="training.videos.readertemplates" approved="yes">
         <source xml:lang="en">
           <g id="genid-9" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">Making a set of Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -103,17 +103,17 @@
         </target>
         <note>ID: training.videos.readertemplates</note>
       </trans-unit>
-      <trans-unit id="training.videos.offline">
+      <trans-unit id="training.videos.offline" approved="yes">
         <source xml:lang="en">Offline Viewing</source>
         <target xml:lang="id">Menonton Secara Offline</target>
         <note>ID: training.videos.offline</note>
       </trans-unit>
-      <trans-unit id="training.videos.download">
+      <trans-unit id="training.videos.download" approved="yes">
         <source xml:lang="en">If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer:</source>
         <target xml:lang="id">Jika Anda ingin mengunduh salah satu video untuk ditampilkan dan dibagikan saat koneksi internet tidak tersedia, Anda bisa mengunduh video ke komputer Anda:</target>
         <note>ID: training.videos.download</note>
       </trans-unit>
-      <trans-unit id="training.videos.hires">
+      <trans-unit id="training.videos.hires" approved="yes">
         <source xml:lang="en">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">High Resolution</g> (Large files)</source>
         <target xml:lang="id">

--- a/DistFiles/localization/id/bloomEpubPreview.xlf
+++ b/DistFiles/localization/id/bloomEpubPreview.xlf
@@ -2,89 +2,89 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="bloomEpubPreview-en.html" datatype="html" source-language="en" target-language="id">
     <body>
-      <trans-unit id="epubpreview.describe">
+      <trans-unit id="epubpreview.describe" approved="yes">
         <source xml:lang="en">This is an <g id="genid-1" ctype="x-html-a" html:href="https://en.wikipedia.org/wiki/ePUB">ePUB</g> (e-book) version of your book. <g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">It contains audio, so that new readers can listen as they read.</g>
       </source>
         <target xml:lang="id">Ini adalah <g id="genid-1" ctype="x-html-a" html:href="https://en.wikipedia.org/wiki/ePUB">ePUB</g> versi buku Anda. <g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">Ini berisi audio, sehingga pembaca baru dapat mendengarkan ketika mereka membaca.</g>
       </target>
         <note>ID: epubpreview.describe</note>
       </trans-unit>
-      <trans-unit id="epubpreview.recording.butnotalk">
+      <trans-unit id="epubpreview.recording.butnotalk" approved="yes">
         <source xml:lang="en">This book has some recordings, but this audio is not included in the ePUB.</source>
         <target xml:lang="id">Buku ini memiliki beberapa rekaman, tapi audio ini tidak termasuk dalam ePUB.</target>
         <note>ID: epubpreview.recording.butnotalk</note>
       </trans-unit>
-      <trans-unit id="epubpreview.preview">
+      <trans-unit id="epubpreview.preview" approved="yes">
         <source xml:lang="en">Preview</source>
         <target xml:lang="id">Pratinjau</target>
         <note>ID: epubpreview.preview</note>
       </trans-unit>
-      <trans-unit id="epubpreview.resizing">
+      <trans-unit id="epubpreview.resizing" approved="yes">
         <source xml:lang="en">You can resize the preview by dragging the lower right corner of this simulated device. See how your book will look on screens of various sizes.</source>
         <target xml:lang="id">Anda dapat mengubah ukuran pratinjau dengan menyeret sudut kanan bawah dari perangkat simulasi ini. Lihat bagaimana buku Anda akan terlihat pada layar dengan berbagai ukuran.</target>
         <note>ID: epubpreview.resizing</note>
       </trans-unit>
-      <trans-unit id="epubpreview.readium">
+      <trans-unit id="epubpreview.readium" approved="yes">
         <source xml:lang="en">This page uses the <g id="genid-3" ctype="x-html-a" html:href="http://readium.org/">Readium</g> ePUB reader. Books will likely look different on different readers.
       </source>
         <target xml:lang="id">Halaman ini menggunakan <g id="genid-3" ctype="x-html-a" html:href="http://readium.org/">Readium</g> ePUB buku baca. Buku kemungkinan akan terlihat berbeda pada buku bacaan yang berbeda.
       </target>
         <note>ID: epubpreview.readium</note>
       </trans-unit>
-      <trans-unit id="epubpreview.talkingbookpreview">
+      <trans-unit id="epubpreview.talkingbookpreview" approved="yes">
         <source xml:lang="en">The preview here cannot yet play Talking Books. You can listen to it using Adobe's Free <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html">Digital Editions</g> e-book reader.
       </source>
         <target xml:lang="id">Pratinjau di sini belum bisa mengoperasikan Buku Berbicara. Anda dapat mendengarkannya dengan menggunakan Adobe Gratis <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html">Edisi Digital</g> buku bacaan buku elektronik.
       </target>
         <note>ID: epubpreview.talkingbookpreview</note>
       </trans-unit>
-      <trans-unit id="epubpreview.ontodevice">
+      <trans-unit id="epubpreview.ontodevice" approved="yes">
         <source xml:lang="en">Getting this book onto your Device</source>
         <target xml:lang="id">Mendapatkan Buku Ini Ke Perangkat Anda</target>
         <note>ID: epubpreview.ontodevice</note>
       </trans-unit>
-      <trans-unit id="epubpreview.usingdropbox">
+      <trans-unit id="epubpreview.usingdropbox" approved="yes">
         <source xml:lang="en">A handy way to get books to your phone is to set up Dropbox or similar service on both your computer and your phone/tablet. Just click Save ePUB and then choose your Dropbox folder. On your phone, open the Dropbox app and select your book. If you are using a laptop, you can also try the free <g id="genid-5" ctype="x-html-a" html:href="http://www.ushareit.com/">ShareIt</g> program to send files from your laptop to a phone or tablet.
       </source>
         <target xml:lang="id">Sebuah cara praktis untuk mendapatkan buku-buku ke ponsel Anda adalah memasang Dropbox atau layanan serupa pada baik komputer dan ponsel/tablet Anda. Cukup klik Simpan EPUB dan kemudian pilih folder Dropbox Anda. Di ponsel Anda, buka aplikasi Dropbox dan pilih buku Anda. Jika Anda menggunakan laptop, Anda juga dapat mencoba program gratis <g id="genid-5" ctype="x-html-a" html:href="http://www.ushareit.com/">ShareIt</g> untuk mengirim file dari laptop Anda ke ponsel atau tablet.
       </target>
         <note>ID: epubpreview.usingdropbox</note>
       </trans-unit>
-      <trans-unit id="epubpreview.recommended.reader">
+      <trans-unit id="epubpreview.recommended.reader" approved="yes">
         <source xml:lang="en">Recommended Reader</source>
         <target xml:lang="id">Buku baca yang direkomendasikan</target>
         <note>ID: epubpreview.recommended.reader</note>
       </trans-unit>
-      <trans-unit id="epubpreview.gitden.okay">
+      <trans-unit id="epubpreview.gitden.okay" approved="yes">
         <source xml:lang="en">Our testing has shown <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Gitden Reader</g> to be a good choice for Android and IOS (IPhone &amp; IPad) devices.
       </source>
         <target xml:lang="id">Pengujian kami menunjukkan <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Buku Baca Gitden</g> menjadi pilihan yang baik untuk perangkat Android dan iOS (iPhone &amp; IPad).
       </target>
         <note>ID: epubpreview.gitden.okay</note>
       </trans-unit>
-      <trans-unit id="epubpreview.gitden.limits">
+      <trans-unit id="epubpreview.gitden.limits" approved="yes">
         <source xml:lang="en">To listen to this Talking Book using Gitden on a phone or tablet, you will need to disable Gitden's "Text To Speech" feature. Then it will show you the audio controls.</source>
         <target xml:lang="id">Untuk mendengarkan Buku Berbicara ini yang menggunakan Gitden pada ponsel atau tablet, Anda perlu untuk menonaktifkan fitur "Text To Speech" Gitden. Maka ia akan menampilkan kontrol audio.</target>
         <note>ID: epubpreview.gitden.limits</note>
       </trans-unit>
-      <trans-unit id="epubpreview.make.it.talk">
+      <trans-unit id="epubpreview.make.it.talk" approved="yes">
         <source xml:lang="en">Make it Talk</source>
         <target xml:lang="id">Buatlah Berbicara</target>
         <note>ID: epubpreview.make.it.talk</note>
       </trans-unit>
-      <trans-unit id="epubpreview.talking.book.tool">
+      <trans-unit id="epubpreview.talking.book.tool" approved="yes">
         <source xml:lang="en">If you want to make a "Talking Book" that new readers can read-along with, use Bloom's <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">Talking Book Tool</g> to add voice recordings.
       </source>
         <target xml:lang="id">Jika Anda ingin membuat "Buku Berbicara" di mana pembaca baru bisa membaca sambil mendengarkan, gunakan Bloom <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">Talking Book Tool</g> untuk menambahkan rekaman suara.
       </target>
         <note>ID: epubpreview.talking.book.tool</note>
       </trans-unit>
-      <trans-unit id="epubpreview.write.us">
+      <trans-unit id="epubpreview.write.us" approved="yes">
         <source xml:lang="en">Write to us!</source>
         <target xml:lang="id">Tulislah kepada kami!</target>
         <note>ID: epubpreview.write.us</note>
       </trans-unit>
-      <trans-unit id="epubpreview.use.help.report">
+      <trans-unit id="epubpreview.use.help.report" approved="yes">
         <source xml:lang="en">Are you interested in distributing Bloom books for use on phones and other ebook readers? Is there something you would need us to do before it is useful for you? Please use the Help:Report A Problem command to send us feedback. Thanks!</source>
         <target xml:lang="id">Apakah Anda tertarik untuk mendistribusikan buku Bloom untuk digunakan pada ponsel dan buku bacaan ebook lainnya? Apakah ada sesuatu yang menurut Anda perlu kami lakukan supaya hal ini berguna untuk Anda? Silakan gunakan petunjuk Bantuan:Laporkan Suatu Masalah untuk mengirimkan kami masukan. Terima kasih!</target>
         <note>ID: epubpreview.use.help.report</note>

--- a/DistFiles/localization/id/leveledReaderInfo.xlf
+++ b/DistFiles/localization/id/leveledReaderInfo.xlf
@@ -2,59 +2,59 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="leveledReaderInfo-en.html" datatype="html" source-language="en" target-language="id">
     <body>
-      <trans-unit id="leveled.reader.vocabulary">
+      <trans-unit id="leveled.reader.vocabulary" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="id">Kosa Kata</target>
         <note>ID: leveled.reader.vocabulary</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.simple">
+      <trans-unit id="leveled.reader.start.simple" approved="yes">
         <source xml:lang="en">At beginning levels, use simple words that are familiar to children. If it is possible in your language, use words with only one syllable. As children move up to higher levels, you can begin to use words with more syllables. You can begin to use less familiar words. Children should be able to guess the meaning of these less familiar words from the context of the surrounding words and sentences, as well as from the illustrations.</source>
         <target xml:lang="id">Di tingkat pemula, gunakanlah kata-kata sederhana yang tidak asing bagi anak-anak. Jika memungkinkan dalam bahasa Indonesia, gunakan kata-kata dengan satu suku kata. Seiring dengan meningkatnya kemampuan anak-anak, Anda bisa mulai menggunakan kata-kata yang memiliki lebih banyak suku kata. Anda dapat mulai menggunakan kata-kata yang tidak umum. Anak-anak harus dapat menebak arti kata-kata yang tidak umum ini dari konteks kata dan kalimat di sekelilingnya, serta dari ilustrasi.</target>
         <note>ID: leveled.reader.start.simple</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.formatting">
+      <trans-unit id="leveled.reader.formatting" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="id">Pemformatan</target>
         <note>ID: leveled.reader.formatting</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.large">
+      <trans-unit id="leveled.reader.start.large" approved="yes">
         <source xml:lang="en">Beginner readers will benefit from a larger font with clear spacing between words. Having the words or sentences in the same location on each page is also helpful. As readers progress to higher levels, font size and spacing will decrease and sentences can appear in different locations on the page.</source>
         <target xml:lang="id">Pembaca pemula akan memperoleh manfaat dari bentuk huruf yang lebih besar dengan jarak yang jelas di antara kata-katanya. Memiliki kata-kata atau kalimat di lokasi yang sama pada setiap halaman juga akan membantu. Seiring kenaikan tingkat pembaca, ukuran bentuk huruf dan jarak akan berkurang dan kalimat dapat muncul di lokasi yang berbeda di halaman.</target>
         <note>ID: leveled.reader.start.large</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.increase.sizes">
+      <trans-unit id="leveled.reader.increase.sizes" approved="yes">
         <source xml:lang="en">To increase the font size, line-spacing, and word-spacing in Bloom, click in a text box and then on the grey "cog" icon in the lower left-hand corner. If you do this and then make a template book, books made with that template will also use those font settings.</source>
         <target xml:lang="id">Untuk meningkatkan ukuran fon, jarak baris, dan jarak kata dalam Bloom, klik dalam kotak teks, lalu pada ikon "roda gigi" abu-abu di sudut kiri bawah. Jika Anda melakukan ini lalu membuat buku templat, buku yang dibuat dengan templat itu juga menggunakan pengaturan fon tersebut.</target>
         <note>ID: leveled.reader.increase.sizes</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.predictability">
+      <trans-unit id="leveled.reader.predictability" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="id">Keterprediksian</target>
         <note>ID: leveled.reader.predictability</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repeat.patterns">
+      <trans-unit id="leveled.reader.repeat.patterns" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-em">Predictability</g> in a text means that the reader can guess what would come next. You can increase predictability by using repeated patterns. Here are some patterns you can use:</source>
         <target xml:lang="id">
           <g id="genid-1" ctype="x-html-em">Keterprediksian</g>dalam teks berarti pembaca dapat menebak apa yang akan datang sesudahnya. Anda dapat meningkatkan keterprediksian dengan menggunakan pola-pola berulang. Berikut sebagian pola yang bisa Anda gunakan:</target>
         <note>ID: leveled.reader.repeat.patterns</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repetition">
+      <trans-unit id="leveled.reader.repetition" approved="yes">
         <source xml:lang="en">Repetition - repeating parts of the text, for example, using the same sentence with each page and just changing one word in the sentence</source>
         <target xml:lang="id">Perulangan - mengulangi bagian dari teks, misalnya, memakai kalimat yang sama di setiap halaman dan hanya mengganti satu kata dalam kalimat.</target>
         <note>ID: leveled.reader.repetition</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.sequencing">
+      <trans-unit id="leveled.reader.sequencing" approved="yes">
         <source xml:lang="en">Sequencing - a story with a known sequence such as the days of the week or that uses numbers in a pattern</source>
         <target xml:lang="id">Pengurutan - sebuah kisah dengan urutan yang diketahui seperti hari dalam minggu atau yang menggunakan angka dalam sebuah pola</target>
         <note>ID: leveled.reader.sequencing</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.building.sequence">
+      <trans-unit id="leveled.reader.building.sequence" approved="yes">
         <source xml:lang="en">Building Sequence - a story with a pattern that is repeated and added to with each new page</source>
         <target xml:lang="id">Membangun Urutan - sebuah kisah dengan pola yang berulang dan ditambahkan pada setiap halaman</target>
         <note>ID: leveled.reader.building.sequence</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.rhyme">
+      <trans-unit id="leveled.reader.rhyme" approved="yes">
         <source xml:lang="en">Rhyme - a story with a pattern or sequence that also includes rhyme. For example:
         <g id="genid-2" ctype="x-html-blockquote" html:class="poetry">
           <g id="genid-3" ctype="x-html-pre">Brown Bear, Brown Bear, What do you see?
@@ -77,64 +77,64 @@ Komik apa, komik apa, komik apa sekarang?</g>
       </target>
         <note>ID: leveled.reader.rhyme</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations">
+      <trans-unit id="leveled.reader.illustrations" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="id">Dukungan Ilustrasi</target>
         <note>ID: leveled.reader.illustrations</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.help">
+      <trans-unit id="leveled.reader.illustrations.help" approved="yes">
         <source xml:lang="en">Illustrations provide support to the story. Illustrations relate to the story in different ways at different <g id="genid-5" ctype="x-html-em">levels</g> and for different types of readers (see below). Remember that in many cultures that don't have a lot of printed material around, complex pictures may be difficult to understand.
     </source>
         <target xml:lang="id">Ilustrasi memberikan dukungan pada sebuah kisah. Ilustrasi terkait dengan kisah dengan cara berbeda pada berbagai macam <g id="genid-5" ctype="x-html-em">tingkat</g>dan untuk berbagai jenis pembaca (lihat di bawah). Ingatlah bahwa pada banyak kebudayaan yang tidak memiliki banyak materi cetak, gambar yang kompleks mungkin sulit dipahami.
     </target>
         <note>ID: leveled.reader.illustrations.help</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.emergent.reader">
+      <trans-unit id="leveled.reader.illustrations.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-6" ctype="x-html-strong">Emergent Readers</g> the pictures should closely match the storyline. The reader should be able to predict the story line just by looking at the pictures. The illustrations at this level should be simple.
       </source>
         <target xml:lang="id">Bagi <g id="genid-6" ctype="x-html-strong">Pembaca Berkembang</g>gambar harus sesuai benar dengan alur cerita. Pembaca harus dapat menebak alur cerita hanya dengan melihat gambarnya. Ilustrasi pada tingkat ini harus sederhana.
       </target>
         <note>ID: leveled.reader.illustrations.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.early.reader">
+      <trans-unit id="leveled.reader.illustrations.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-7" ctype="x-html-strong">Early Readers</g> the pictures should offer some support to the story line. As the amount of text increases, the reader is less reliant on the pictures and gets more meaning from the text. The illustrations can be more complex.
       </source>
         <target xml:lang="id">Bagi <g id="genid-7" ctype="x-html-strong">Pembaca Pemula</g>gambar sebaiknya membantu untuk memahami alur cerita. Seiring bertambahnya jumlah teks, pembaca tidak begitu mengandalkan pada gambar dan memperoleh lebih banyak arti/pengertian/pemahaman dari teks. Ilustrasinya bisa lebih kompleks lagi.
       </target>
         <note>ID: leveled.reader.illustrations.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.fluent.reader">
+      <trans-unit id="leveled.reader.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-8" ctype="x-html-strong">Fluent Readers</g> the pictures should offer little or no support to the story line. The reader relies more on the text than the pictures for meaning. The illustrations can be even more complex.
       </source>
         <target xml:lang="id">Bagi <g id="genid-8" ctype="x-html-strong">Pembaca Mahir</g>gambar sebaiknya memberikan sedikit atau tidak bantuan untuk memahami alur cerita. Pembaca lebih mengandalkan teks daripada gambar untuk memahami arti. Ilustrasinya bahkan bisa lebih kompleks lagi.
       </target>
         <note>ID: leveled.reader.fluent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice">
+      <trans-unit id="leveled.reader.topic.choice" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="id">Pilihan Topik</target>
         <note>ID: leveled.reader.topic.choice</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.discussion">
+      <trans-unit id="leveled.reader.topic.choice.discussion" approved="yes">
         <source xml:lang="en">Books can be on many topics. When developing books for beginning readers, choose topics that are familiar to them. Readers will be eager to read and will read more if they are reading about things they find interesting and familiar. For more experienced readers, topics can include information that the reader is not already familiar with.</source>
         <target xml:lang="id">Buku dapat mengenai berbagai topik. Ketika mengembangkan buku untuk pembaca pemula, pilihlah topik yang tidak asing bagi mereka. Pembaca akan terdorong untuk membaca dan akan lebih banyak membaca jika mereka membaca tentang hal-hal yang dirasa menarik dan tidak asing bagi mereka. Untuk pembaca yang lebih berpengalaman, topik bisa meliputi informasi yang benar-benar baru bagi mereka.</target>
         <note>ID: leveled.reader.topic.choice.discussion</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.emergent.reader">
+      <trans-unit id="leveled.reader.topic.choice.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-9" ctype="x-html-strong">Emergent Readers</g> the book should be concrete, should focus on one idea/theme, and should be familiar and easy to understand.
       </source>
         <target xml:lang="id">Bagi <g id="genid-9" ctype="x-html-strong">Pembaca Berkembang</g>buku haruslah konkret, harus memfokuskan pada satu ide/tema, dan harus sudah tidak asing lagi serta mudah dipahami.
       </target>
         <note>ID: leveled.reader.topic.choice.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.early.reader">
+      <trans-unit id="leveled.reader.topic.choice.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-10" ctype="x-html-strong">Early Readers</g>, develop a story around a familiar concept but in greater depth.
       </source>
         <target xml:lang="id">Bagi <g id="genid-10" ctype="x-html-strong">Pembaca Pemula</g>, kembangkan kisah seputar konsep yang tidak asing lagi namun lebih mendalam.
       </target>
         <note>ID: leveled.reader.topic.choice.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.fluent.reader">
+      <trans-unit id="leveled.reader.topic.choice.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-11" ctype="x-html-strong">Fluent Readers</g> the concepts can expand beyond what is familiar, be more varied, and be abstract.
       </source>
         <target xml:lang="id">Bagi <g id="genid-11" ctype="x-html-strong">Pembaca Mahir</g>konsepnya bisa diperluas melampaui apa yang sudah tidak asing lagi, lebih bervariasi, dan abstrak.

--- a/DistFiles/localization/km/Bloom.xlf
+++ b/DistFiles/localization/km/Bloom.xlf
@@ -130,10 +130,10 @@
         <note>ID: Browser.OpenPageInFirefox</note>
         <target xml:lang="km" state="needs-translation">Open Page in Firefox (which must be in the PATH environment variable)</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
-        <target xml:lang="km" state="translated">ការកំណត់កម្មវិធីកម្រិតខ្ពស់</target>
+        <target xml:lang="km">ការកំណត់កម្មវិធីកម្រិតខ្ពស់</target>
       </trans-unit>
       <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate">
         <source xml:lang="en">Automatically update Bloom</source>
@@ -171,21 +171,21 @@
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate2</note>
         <target xml:lang="km" state="needs-translation">This will improve the printed output for most languages. If your language is one of the few that need "Andika", you can switch it back in Settings:Book Making.</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
-        <target xml:lang="km" state="translated">ការបង្កើតសៀវភៅ</target>
+        <target xml:lang="km">ការបង្កើតសៀវភៅ</target>
       </trans-unit>
       <trans-unit id="CollectionSettingsDialog.BookMakingTab.Branding">
         <source xml:lang="en">Branding</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Branding</note>
         <target xml:lang="km" state="needs-translation">Branding</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
-        <target xml:lang="km" state="translated">ហ្វុនដើមសម្រាប់ {0}</target>
+        <target xml:lang="km">ហ្វុនដើមសម្រាប់ {0}</target>
       </trans-unit>
       <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
         <source xml:lang="en">Front/Back Matter Pack</source>
@@ -334,53 +334,53 @@
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Upper-Armenian</note>
         <target xml:lang="km" state="needs-translation">Upper-Armenian</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
-        <target xml:lang="km" state="translated">ប្រព័ន្ធសរសេរពីស្តាំទៅឆ្វេង</target>
+        <target xml:lang="km">ប្រព័ន្ធសរសេរពីស្តាំទៅឆ្វេង</target>
       </trans-unit>
       <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink">
         <source xml:lang="en">Special Script Settings</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink</note>
         <target xml:lang="km" state="needs-translation">Special Script Settings</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
-        <target xml:lang="km" state="translated">ការកំណត់</target>
+        <target xml:lang="km">ការកំណត់</target>
       </trans-unit>
       <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
         <source xml:lang="en">Change...</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
         <target xml:lang="km" state="needs-translation">Change...</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a vernacular collection, we say 'Vernacular Language', but in a source collection, Vernacular has no relevance, so we use this different label</note>
-        <target xml:lang="km" state="translated">ភាសាទី 1</target>
+        <target xml:lang="km">ភាសាទី 1</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a vernacular collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
-        <target xml:lang="km" state="translated">ភាសាទី 2</target>
+        <target xml:lang="km">ភាសាទី 2</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a vernacular collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
-        <target xml:lang="km" state="translated">ភាសាទី 3</target>
+        <target xml:lang="km">ភាសាទី 3</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
-        <target xml:lang="km" state="translated">ភាសា</target>
+        <target xml:lang="km">ភាសា</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
-        <target xml:lang="km" state="translated">ដកចេញ</target>
+        <target xml:lang="km">ដកចេញ</target>
       </trans-unit>
       <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
         <source xml:lang="en">Set...</source>
@@ -388,10 +388,10 @@
         <note>If there is no third language specified, the link changes to this.</note>
         <target xml:lang="km" state="needs-translation">Set...</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Vernacular Language</source>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
-        <target xml:lang="km" state="translated">ភាសាត្រាប់</target>
+        <target xml:lang="km">ភាសាត្រាប់</target>
       </trans-unit>
       <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
@@ -403,46 +403,46 @@
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
         <target xml:lang="km" state="needs-translation">Language 3 (e.g. Regional Language)  (Optional)</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
-        <target xml:lang="km" state="translated">ឈ្មោះកូឡិកសិន Bloom</target>
+        <target xml:lang="km">ឈ្មោះកូឡិកសិន Bloom</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
-        <target xml:lang="km" state="translated">ប្រទេស</target>
+        <target xml:lang="km">ប្រទេស</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
-        <target xml:lang="km" state="translated">ឌីស្ទ្រីក</target>
+        <target xml:lang="km">ឌីស្ទ្រីក</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
-        <target xml:lang="km" state="translated">ព័ត៌មានគម្រោង</target>
+        <target xml:lang="km">ព័ត៌មានគម្រោង</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
-        <target xml:lang="km" state="translated">ខេត្ត</target>
+        <target xml:lang="km">ខេត្ត</target>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
-        <target xml:lang="km" state="translated">ចាប់ផ្តើមឡើងវិញ</target>
+        <target xml:lang="km">ចាប់ផ្តើមឡើងវិញ</target>
       </trans-unit>
       <trans-unit id="CollectionSettingsDialog.RestartMessage">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
         <target xml:lang="km" state="needs-translation">Bloom will close and re-open this project with the new settings.</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
-        <target xml:lang="km" state="translated">ធ្វើកញ្ចប់ Bloom ឯកសារគំរូសម្រាប់អ្នកអាន…</target>
+        <target xml:lang="km">ធ្វើកញ្ចប់ Bloom ឯកសារគំរូសម្រាប់អ្នកអាន…</target>
       </trans-unit>
       <trans-unit id="CollectionTab.AdminManagesUpdates">
         <source xml:lang="en">Your system administrator manages Bloom updates for this computer.</source>
@@ -465,11 +465,11 @@
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
         <target xml:lang="km" state="needs-translation">Get more source books at BloomLibrary.org</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
-        <target xml:lang="km" state="translated">បណ្តុំប្រភព</target>
+        <target xml:lang="km">បណ្តុំប្រភព</target>
       </trans-unit>
       <trans-unit id="CollectionTab.BookMenu.DuplicateBook">
         <source xml:lang="en">Duplicate Book</source>
@@ -511,10 +511,10 @@
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
         <target xml:lang="km" state="needs-translation">Update Thumbnail</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <note>ID: CollectionTab.BookSourceHeading</note>
-        <target xml:lang="km" state="translated">ប្រភពនានាសម្រាប់សៀវភៅថ្មី</target>
+        <target xml:lang="km">ប្រភពនានាសម្រាប់សៀវភៅថ្មី</target>
       </trans-unit>
       <trans-unit id="CollectionTab.BookSourcesLockNotice">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
@@ -551,15 +551,15 @@
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
         <target xml:lang="km" state="needs-translation">Collection Notes...</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <note>ID: CollectionTab.CollectionTabLabel</note>
-        <target xml:lang="km" state="translated">កូឡិកសិន</target>
+        <target xml:lang="km">កូឡិកសិន</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <note>ID: CollectionTab.Collections</note>
-        <target xml:lang="km" state="translated">កូឡិកសិន</target>
+        <target xml:lang="km">កូឡិកសិន</target>
       </trans-unit>
       <trans-unit id="CollectionTab.ConfiguringBookMessage">
         <source xml:lang="en">Building...</source>
@@ -576,10 +576,10 @@
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
         <target xml:lang="km" state="needs-translation">Open Folder on Disk</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <note>ID: CollectionTab.EditBookButton</note>
-        <target xml:lang="km" state="translated">កែសៀវភៅនេះ</target>
+        <target xml:lang="km">កែសៀវភៅនេះ</target>
       </trans-unit>
       <trans-unit id="CollectionTab.Health" sil:dynamic="true">
         <source xml:lang="en">Health</source>
@@ -596,27 +596,27 @@
         <note>ID: CollectionTab.MakeBloomPackButton</note>
         <target xml:lang="km" state="needs-translation">Make Bloom Pack</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
-        <target xml:lang="km" state="translated">ធ្វើសៀវភៅដោយប្រើប្រភពនេះ</target>
+        <target xml:lang="km">ធ្វើសៀវភៅដោយប្រើប្រភពនេះ</target>
       </trans-unit>
       <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_">
         <source xml:lang="en">Create a book in my language using this source book</source>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate_ToolTip_</note>
         <target xml:lang="km" state="needs-translation">Create a book in my language using this source book</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
-        <target xml:lang="km" state="translated">ថែមទៀត…</target>
+        <target xml:lang="km">ថែមទៀត…</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
-        <target xml:lang="km" state="translated">កូឡិកសិនដទៃទៀត</target>
+        <target xml:lang="km">កូឡិកសិនដទៃទៀត</target>
       </trans-unit>
       <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_">
         <source xml:lang="en">Open/Create/Get Collection</source>
@@ -629,40 +629,40 @@
         <note>ID: CollectionTab.OpenCreateCollectionMenuItem</note>
         <target xml:lang="km" state="needs-translation">Open or Create Another Collection</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <note>ID: CollectionTab.Sample Shells</note>
-        <target xml:lang="km" state="translated">Shells គំរូ</target>
+        <target xml:lang="km">Shells គំរូ</target>
       </trans-unit>
       <trans-unit id="CollectionTab.SendReceive">
         <source xml:lang="en">Send/Receive</source>
         <note>ID: CollectionTab.SendReceive</note>
         <target xml:lang="km" state="needs-translation">Send/Receive</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <note>ID: CollectionTab.SettingsButton</note>
-        <target xml:lang="km" state="translated">ការកំណត់</target>
+        <target xml:lang="km">ការកំណត់</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <note>ID: CollectionTab.Source Collection</note>
-        <target xml:lang="km" state="translated">បណ្តុំប្រភព</target>
+        <target xml:lang="km">បណ្តុំប្រភព</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
-        <target xml:lang="km" state="translated">បើកហ្វូលឌ័រកូឡិកសិនបន្ថែម</target>
+        <target xml:lang="km">បើកហ្វូលឌ័រកូឡិកសិនបន្ថែម</target>
       </trans-unit>
       <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
         <source xml:lang="en">Sources For New Shells</source>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
         <target xml:lang="km" state="needs-translation">Sources For New Shells</target>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <note>ID: CollectionTab.Templates</note>
-        <target xml:lang="km" state="translated">ឯកសារគំរូ</target>
+        <target xml:lang="km">ឯកសារគំរូ</target>
       </trans-unit>
       <trans-unit id="CollectionTab.TitleMissing">
         <source xml:lang="en">Title Missing</source>
@@ -718,15 +718,15 @@
         <note>In a wizard, this button takes you to the previous step.</note>
         <target xml:lang="km" state="needs-translation">Back</target>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <note>ID: Common.Cancel</note>
-        <target xml:lang="km" state="translated">លុបចោល</target>
+        <target xml:lang="km">លុបចោល</target>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <note>ID: Common.CancelButton</note>
-        <target xml:lang="km" state="translated">&amp;លុបចោល</target>
+        <target xml:lang="km">&amp;លុបចោល</target>
       </trans-unit>
       <trans-unit id="Common.Finish">
         <source xml:lang="en">&amp;Finish</source>
@@ -750,27 +750,27 @@
         <note>This is shown when Bloom is slowly loading something, so the user doesn't worry about why they don't see the result immediately.</note>
         <target xml:lang="km" state="needs-translation">Loading...</target>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
-        <target xml:lang="km" state="translated">&amp;បន្ទាប់</target>
+        <target xml:lang="km">&amp;បន្ទាប់</target>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
-        <target xml:lang="km" state="translated">បន្ទាប់</target>
+        <target xml:lang="km">បន្ទាប់</target>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <note>ID: Common.OK</note>
-        <target xml:lang="km" state="translated">អូខេ</target>
+        <target xml:lang="km">អូខេ</target>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <note>ID: Common.OKButton</note>
-        <target xml:lang="km" state="translated">&amp;អូខេ</target>
+        <target xml:lang="km">&amp;អូខេ</target>
       </trans-unit>
       <trans-unit id="Common.Optional">
         <source xml:lang="en">optional</source>
@@ -876,11 +876,11 @@
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
         <target xml:lang="km" state="needs-translation">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
-        <target xml:lang="km" state="translated">ពីរភាសា</target>
+        <target xml:lang="km">ពីរភាសា</target>
       </trans-unit>
       <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
         <source xml:lang="en">Open the HTML used to make this PDF, in Firefox (must be on path)</source>
@@ -912,10 +912,10 @@
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
         <target xml:lang="km" state="needs-translation">&amp;Delete</target>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
-        <target xml:lang="km" state="translated">ទំព័រនេះ នឹងត្រូវលុបចោលជាអចិន្ត្រៃយ៍</target>
+        <target xml:lang="km">ទំព័រនេះ នឹងត្រូវលុបចោលជាអចិន្ត្រៃយ៍</target>
       </trans-unit>
       <trans-unit id="EditTab.ContentLanguagesDropdown">
         <source xml:lang="en">Multilingual Settings</source>
@@ -927,10 +927,10 @@
         <note>ID: EditTab.ContentLanguagesDropdown.ToolTip</note>
         <target xml:lang="km" state="needs-translation">Choose language to make this a bilingual or trilingual book</target>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <note>ID: EditTab.CopyButton</note>
-        <target xml:lang="km" state="translated">ចម្លង</target>
+        <target xml:lang="km">ចម្លង</target>
       </trans-unit>
       <trans-unit id="EditTab.CopyButton.ToolTip">
         <source xml:lang="en">Copy (Ctrl+C)</source>
@@ -969,20 +969,20 @@
         <note>ID: EditTab.CustomPage.Picture</note>
         <target xml:lang="km" state="needs-translation">Picture</target>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <note>ID: EditTab.CustomPage.Text</note>
-        <target xml:lang="km" state="translated">អត្ថបទ</target>
+        <target xml:lang="km">អត្ថបទ</target>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <note>ID: EditTab.CustomPage.TextBox</note>
-        <target xml:lang="km" state="translated">ប្រអប់អត្ថបទ</target>
+        <target xml:lang="km">ប្រអប់អត្ថបទ</target>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <note>ID: EditTab.CutButton</note>
-        <target xml:lang="km" state="translated">កាត់</target>
+        <target xml:lang="km">កាត់</target>
       </trans-unit>
       <trans-unit id="EditTab.CutButton.ToolTip">
         <source xml:lang="en">Cut (Ctrl+X)</source>
@@ -994,10 +994,10 @@
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
         <target xml:lang="km" state="needs-translation">You need to select some text before you can cut it</target>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <note>ID: EditTab.DeletePageButton</note>
-        <target xml:lang="km" state="translated">ដកចេញទំព័រ</target>
+        <target xml:lang="km">ដកចេញទំព័រ</target>
       </trans-unit>
       <trans-unit id="EditTab.DeletePageButton.ToolTip">
         <source xml:lang="en">Remove this page from the book</source>
@@ -1038,10 +1038,10 @@
         <note>This is for the 4-button panel that pops up when the user selects more than one character in a textbox.</note>
         <target xml:lang="km" state="needs-translation">Underline</target>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n  Page</source>
         <note>ID: EditTab.DuplicatePageButton</note>
-        <target xml:lang="km" state="translated">ទំព័រជាន់គ្នា</target>
+        <target xml:lang="km">ទំព័រជាន់គ្នា</target>
       </trans-unit>
       <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
@@ -1053,10 +1053,10 @@
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
         <target xml:lang="km" state="needs-translation">This page cannot be duplicated</target>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <note>ID: EditTab.Edit</note>
-        <target xml:lang="km" state="translated">កែ</target>
+        <target xml:lang="km">កែ</target>
       </trans-unit>
       <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true">
         <source xml:lang="en">You cannot change these because this is not the original copy.</source>
@@ -1103,15 +1103,15 @@
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
         <target xml:lang="km" state="needs-translation">Change the border and background</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
-        <target xml:lang="km" state="translated">អក្សរ</target>
+        <target xml:lang="km">អក្សរ</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <note>ID: EditTab.FormatDialog.Create</note>
-        <target xml:lang="km" state="translated">បង្កើត</target>
+        <target xml:lang="km">បង្កើត</target>
       </trans-unit>
       <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true">
         <source xml:lang="en">Create a new style</source>
@@ -1128,10 +1128,10 @@
         <note>ID: EditTab.FormatDialog.Emphasis</note>
         <target xml:lang="km" state="needs-translation">Emphasis</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <note>ID: EditTab.FormatDialog.Font</note>
-        <target xml:lang="km" state="translated">ហ្វុន</target>
+        <target xml:lang="km">ហ្វុន</target>
       </trans-unit>
       <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
         <source xml:lang="en">Change the font face</source>
@@ -1188,40 +1188,40 @@
         <note>ID: EditTab.FormatDialog.ResetStyle</note>
         <target xml:lang="km" state="needs-translation">Reset this style to default settings</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <note>ID: EditTab.FormatDialog.Spacing</note>
-        <target xml:lang="km" state="translated">គម្លាត</target>
+        <target xml:lang="km">គម្លាត</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <note>ID: EditTab.FormatDialog.Style</note>
-        <target xml:lang="km" state="translated">ស្តាល</target>
+        <target xml:lang="km">ស្តាល</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
-        <target xml:lang="km" state="translated">ឈ្មោះស្តាល</target>
+        <target xml:lang="km">ឈ្មោះស្តាល</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
-        <target xml:lang="km" state="translated">ទូលាយខ្លាំង</target>
+        <target xml:lang="km">ទូលាយខ្លាំង</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
-        <target xml:lang="km" state="translated">ធម្មតា</target>
+        <target xml:lang="km">ធម្មតា</target>
       </trans-unit>
       <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
         <source xml:lang="en">Change the spacing between words</source>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
         <target xml:lang="km" state="needs-translation">Change the spacing between words</target>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
-        <target xml:lang="km" state="translated">ទូលាយ</target>
+        <target xml:lang="km">ទូលាយ</target>
       </trans-unit>
       <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
         <source xml:lang="en">Adjust formatting for style</source>
@@ -1243,11 +1243,11 @@
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
         <target xml:lang="km" state="needs-translation">When you make a book from a shell, use this box to tell who did the translation.</target>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
-        <target xml:lang="km" state="translated">ចំណងជើងសៀវភៅជាភាសា {lang}</target>
+        <target xml:lang="km">ចំណងជើងសៀវភៅជាភាសា {lang}</target>
       </trans-unit>
       <trans-unit id="EditTab.FrontMatter.CreditTranslator" sil:dynamic="true">
         <source xml:lang="en">Name of the translator, in {lang}</source>
@@ -1344,10 +1344,10 @@
         <note>ID: EditTab.HowToUnlockBook</note>
         <target xml:lang="km" state="needs-translation">To unlock this shellbook, go into the toolbox on the right, find the gear icon, and click 'Allow changes to this shellbook'.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <note>ID: EditTab.Image.ChangeImage</note>
-        <target xml:lang="km" state="translated">ប្តូររូបភាព</target>
+        <target xml:lang="km">ប្តូររូបភាព</target>
       </trans-unit>
       <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true">
         <source xml:lang="en">Copy Image</source>
@@ -1369,10 +1369,10 @@
         <note>ID: EditTab.Image.EditMetadata</note>
         <target xml:lang="km" state="needs-translation">Edit Image Credits, Copyright, and License</target>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <note>ID: EditTab.Image.PasteImage</note>
-        <target xml:lang="km" state="translated">រូបភាពបិត</target>
+        <target xml:lang="km">រូបភាពបិត</target>
       </trans-unit>
       <trans-unit id="EditTab.Image.TryRestart" sil:dynamic="true">
         <source xml:lang="en">Try closing other programs and restart your computer if necessary.</source>
@@ -1414,11 +1414,11 @@
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
         <target xml:lang="km" state="needs-translation">Change Layout</target>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
-        <target xml:lang="km" state="translated">ភាសាមួយ</target>
+        <target xml:lang="km">ភាសាមួយ</target>
       </trans-unit>
       <trans-unit id="EditTab.NewBookName">
         <source xml:lang="en">Book</source>
@@ -1458,20 +1458,20 @@
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
         <target xml:lang="km" state="needs-translation">Invalid Move</target>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <note>ID: EditTab.PageList.Heading</note>
-        <target xml:lang="km" state="translated">ទំព័រ</target>
+        <target xml:lang="km">ទំព័រ</target>
       </trans-unit>
       <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
         <source xml:lang="en">Choose a page size and orientation</source>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
         <target xml:lang="km" state="needs-translation">Choose a page size and orientation</target>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <note>ID: EditTab.PasteButton</note>
-        <target xml:lang="km" state="translated">បិត</target>
+        <target xml:lang="km">បិត</target>
       </trans-unit>
       <trans-unit id="EditTab.PasteButton.ToolTip">
         <source xml:lang="en">Paste (Ctrl+V)</source>
@@ -1548,10 +1548,10 @@
         <note>ID: EditTab.StyleEditorTip</note>
         <target xml:lang="km" state="needs-translation">Adjust formatting for style</target>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
-        <target xml:lang="km" state="translated">ទំព័រឯកសារគំរូ</target>
+        <target xml:lang="km">ទំព័រឯកសារគំរូ</target>
       </trans-unit>
       <trans-unit id="EditTab.TextBoxProperties.HintBubbles">
         <source xml:lang="en">Hint Bubbles</source>
@@ -1667,10 +1667,10 @@
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
         <target xml:lang="km" state="needs-translation">Picture Intellectual Property Information</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
-        <target xml:lang="km" state="translated">ឧបករណ៍អ្នកអានដែលអាចចាត់តាមអក្សរ</target>
+        <target xml:lang="km">ឧបករណ៍អ្នកអានដែលអាចចាត់តាមអក្សរ</target>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true">
         <source xml:lang="en">Bloom can handle only the first {0} words.</source>
@@ -1717,15 +1717,15 @@
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList</note>
         <target xml:lang="km" state="needs-translation">Complete Word List</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
-        <target xml:lang="km" state="translated">អក្សរក្នុងដំណាក់កាលនេះ</target>
+        <target xml:lang="km">អក្សរក្នុងដំណាក់កាលនេះ</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
-        <target xml:lang="km" state="translated">បើកឯកសារជាអក្សរ និងបញ្ជីពាក្យ</target>
+        <target xml:lang="km">បើកឯកសារជាអក្សរ និងបញ្ជីពាក្យ</target>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true">
         <source xml:lang="en">Generate a letter and word list report</source>
@@ -1737,10 +1737,10 @@
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage</note>
         <target xml:lang="km" state="needs-translation">Sample words in this stage</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
-        <target xml:lang="km" state="translated">បង្កើត ដំណាក់កាលផ្សេងៗ</target>
+        <target xml:lang="km">បង្កើត ដំណាក់កាលផ្សេងៗ</target>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SortAlphabetically">
         <source xml:lang="en">Sort alphabetically</source>
@@ -1757,30 +1757,30 @@
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SortByWordLength</note>
         <target xml:lang="km" state="needs-translation">Sort by word length</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
-        <target xml:lang="km" state="translated">ដំណាក់កាល</target>
+        <target xml:lang="km">ដំណាក់កាល</target>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
         <source xml:lang="en">of</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
         <target xml:lang="km" state="needs-translation">of</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
-        <target xml:lang="km" state="translated">ចំនួនពាក្យក្នុងដំណាក់កាលនេះ</target>
+        <target xml:lang="km">ចំនួនពាក្យក្នុងដំណាក់កាលនេះ</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
-        <target xml:lang="km" state="translated">ឧបករណ៍អ្នកអានតាមកម្រិត</target>
+        <target xml:lang="km">ឧបករណ៍អ្នកអានតាមកម្រិត</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
-        <target xml:lang="km" state="translated">ពិតប្រាកដ</target>
+        <target xml:lang="km">ពិតប្រាកដ</target>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true">
         <source xml:lang="en">avg per sentence</source>
@@ -1792,10 +1792,10 @@
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
         <target xml:lang="km" state="needs-translation">Choice of Topic</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
-        <target xml:lang="km" state="translated">សម្រាប់កម្រិតនេះ</target>
+        <target xml:lang="km">សម្រាប់កម្រិតនេះ</target>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
         <source xml:lang="en">Formatting</source>
@@ -1807,16 +1807,16 @@
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
         <target xml:lang="km" state="needs-translation">Illustration Support</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
-        <target xml:lang="km" state="translated">ទុកក្នុងចិត្ត</target>
+        <target xml:lang="km">ទុកក្នុងចិត្ត</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
         <note>Used to create string "Level # of #". The space after this word is added programmatically.</note>
-        <target xml:lang="km" state="translated">កម្រិត</target>
+        <target xml:lang="km">កម្រិត</target>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
         <source xml:lang="en">of</source>
@@ -1824,65 +1824,65 @@
         <note>Used to create string "Level # of #". The spaces on each side of this word are added programmatically.</note>
         <target xml:lang="km" state="needs-translation">of</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
-        <target xml:lang="km" state="translated">អតិ</target>
+        <target xml:lang="km">អតិ</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
-        <target xml:lang="km" state="translated">ក្នុងមួយទំព័រ</target>
+        <target xml:lang="km">ក្នុងមួយទំព័រ</target>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true">
         <source xml:lang="en">longest sentence</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerSentence</note>
         <target xml:lang="km" state="needs-translation">longest sentence</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
-        <target xml:lang="km" state="translated">ភាពព្យាករណ៍បាន</target>
+        <target xml:lang="km">ភាពព្យាករណ៍បាន</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
-        <target xml:lang="km" state="translated">បង្កើត កម្រិតផ្សេងៗ</target>
+        <target xml:lang="km">បង្កើត កម្រិតផ្សេងៗ</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
-        <target xml:lang="km" state="translated">សៀវភៅនេះ</target>
+        <target xml:lang="km">សៀវភៅនេះ</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
-        <target xml:lang="km" state="translated">ទំព័រនេះ</target>
+        <target xml:lang="km">ទំព័រនេះ</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
-        <target xml:lang="km" state="translated">សរុប</target>
+        <target xml:lang="km">សរុប</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
-        <target xml:lang="km" state="translated">មានតែមួយ</target>
+        <target xml:lang="km">មានតែមួយ</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
-        <target xml:lang="km" state="translated">វាក្យស័ព្ទ</target>
+        <target xml:lang="km">វាក្យស័ព្ទ</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
-        <target xml:lang="km" state="translated">ចំនួនពាក្យ</target>
+        <target xml:lang="km">ចំនួនពាក្យ</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <note>ID: EditTab.Toolbox.More</note>
-        <target xml:lang="km" state="translated">ថែមទៀត…</target>
+        <target xml:lang="km">ថែមទៀត…</target>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.Settings.IsTemplateBook" sil:dynamic="true">
         <source xml:lang="en">This is a template book.</source>
@@ -1976,21 +1976,21 @@
         <note>ID: EditTab.Toolbox.TalkingBookTool.ToolPurpose</note>
         <target xml:lang="km" state="needs-translation">Make an e-book that can play recordings while highlighting sentences.</target>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
-        <target xml:lang="km" state="translated">ក្នុងមួយប្រយោគ</target>
+        <target xml:lang="km">ក្នុងមួយប្រយោគ</target>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
-        <target xml:lang="km" state="translated">បីភាសា</target>
+        <target xml:lang="km">បីភាសា</target>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <note>ID: EditTab.UndoButton</note>
-        <target xml:lang="km" state="translated">បកក្រោយ</target>
+        <target xml:lang="km">បកក្រោយ</target>
       </trans-unit>
       <trans-unit id="EditTab.UndoButton.ToolTip">
         <source xml:lang="en">Undo (Ctrl+Z)</source>
@@ -2090,30 +2090,30 @@
         <note>ID: Errors.ZoneAlarm</note>
         <target xml:lang="km" state="needs-translation">Bloom cannot start properly, and this symptom has been observed on machines with ZoneAlarm installed. Note: disabling ZoneAlarm does not help. Nor does restarting with it turned off. Something about the installation of ZoneAlarm causes the problem, and so far only uninstalling ZoneAlarm has been shown to fix the problem.</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
-        <target xml:lang="km" state="translated">ការបង្កើតឯកសារគំរូសម្រាប់អ្នកអាន</target>
+        <target xml:lang="km">ការបង្កើតឯកសារគំរូសម្រាប់អ្នកអាន</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
-        <target xml:lang="km" state="translated">ពិនិត្យរកមើលកំណែថ្មី</target>
+        <target xml:lang="km">ពិនិត្យរកមើលកំណែថ្មី</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <note>ID: HelpMenu.CreditsMenuItem</note>
-        <target xml:lang="km" state="translated">អំពី Bloom</target>
+        <target xml:lang="km">អំពី Bloom</target>
       </trans-unit>
       <trans-unit id="HelpMenu.DocumentationMenuItem">
         <source xml:lang="en">Documentation</source>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
         <target xml:lang="km" state="needs-translation">Documentation</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <note>ID: HelpMenu.Help Menu</note>
-        <target xml:lang="km" state="translated">ជំនួយ</target>
+        <target xml:lang="km">ជំនួយ</target>
       </trans-unit>
       <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true">
         <source xml:lang="en">Get Help</source>
@@ -2155,10 +2155,10 @@
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
         <target xml:lang="km" state="needs-translation">Show Event Log</target>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
-        <target xml:lang="km" state="translated">ការប្រើឯកសារគំរូសម្រាប់អ្នកអាន </target>
+        <target xml:lang="km">ការប្រើឯកសារគំរូសម្រាប់អ្នកអាន </target>
       </trans-unit>
       <trans-unit id="HelpMenu.WebSiteMenuItem">
         <source xml:lang="en">Web Site</source>
@@ -2382,20 +2382,20 @@
         <note>ID: NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions</note>
         <target xml:lang="km" state="needs-translation">If you already have a collection you want to open, click  the 'Cancel' button.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
-        <target xml:lang="km" state="translated">បណ្តុំប្រភព</target>
+        <target xml:lang="km">បណ្តុំប្រភព</target>
       </trans-unit>
       <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org. You may also make a Bloom Pack to give to others so that they can make vernacular books with your shells.</source>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
         <target xml:lang="km" state="needs-translation">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org. You may also make a Bloom Pack to give to others so that they can make vernacular books with your shells.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Vernacular/Local Language Collection</source>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
-        <target xml:lang="km" state="translated">កូឡិកសិនត្រាប់ភាសា</target>
+        <target xml:lang="km">កូឡិកសិនត្រាប់ភាសា</target>
       </trans-unit>
       <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
         <source xml:lang="en">A collection of books in a local language.</source>
@@ -2407,25 +2407,25 @@
         <note>ID: NewCollectionWizard.LocationPage</note>
         <target xml:lang="km" state="needs-translation">Give Language Location</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
-        <target xml:lang="km" state="translated">ប្រទេស</target>
+        <target xml:lang="km">ប្រទេស</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
-        <target xml:lang="km" state="translated">ឌីស្ទ្រីក</target>
+        <target xml:lang="km">ឌីស្ទ្រីក</target>
       </trans-unit>
       <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
         <target xml:lang="km" state="needs-translation">These are optional. Bloom will place them in the right places on title page of books you create.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
-        <target xml:lang="km" state="translated">ខេត្ត</target>
+        <target xml:lang="km">ខេត្ត</target>
       </trans-unit>
       <trans-unit id="NewCollectionWizard.NewBookPattern">
         <source xml:lang="en">{0} Books</source>
@@ -2438,20 +2438,20 @@
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
         <target xml:lang="km" state="needs-translation">Create New Bloom Collection</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <note>ID: NewCollectionWizard.ProjectName</note>
-        <target xml:lang="km" state="translated">ឈ្មោះគម្រោង</target>
+        <target xml:lang="km">ឈ្មោះគម្រោង</target>
       </trans-unit>
       <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
         <target xml:lang="km" state="needs-translation">Unable to create a new collection using that name.</target>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <note>ID: NewCollectionWizard.WelcomePage</note>
-        <target xml:lang="km" state="translated">Bloom សូមស្វាគមន៍</target>
+        <target xml:lang="km">Bloom សូមស្វាគមន៍</target>
       </trans-unit>
       <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
         <source xml:lang="en">You are almost ready to start making books.</source>
@@ -2504,10 +2504,10 @@
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
         <target xml:lang="km" state="needs-translation">Copy from USB Drive</target>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
-        <target xml:lang="km" state="translated">បង្កើត កូឡិកសិនថ្មី</target>
+        <target xml:lang="km">បង្កើត កូឡិកសិនថ្មី</target>
       </trans-unit>
       <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
         <source xml:lang="en">Open/Create Collections</source>
@@ -2596,10 +2596,10 @@
         <note>ID: PublishTab.EpubRadio-tooltip</note>
         <target xml:lang="km" state="needs-translation">Make an ePUB (electronic book) out of this book, allowing it to be read on various electronic reading devices.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
-        <target xml:lang="km" state="translated">កុំបង្ហាញសារនេះម្តងទៀត</target>
+        <target xml:lang="km">កុំបង្ហាញសារនេះម្តងទៀត</target>
       </trans-unit>
       <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
         <source xml:lang="en">InDesign XML Information</source>
@@ -2753,10 +2753,10 @@
         <note>Brief explanation of what this license is and why the user needs to agree to it</note>
         <target xml:lang="km" state="needs-translation">Bloom uses Adobe color profiles to convert PDF files from using RGB color to using CMYK color.  This is part of preparing a "PDF for Printshop".  You must agree to the following license in order to perform this task in Bloom.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <note>ID: PublishTab.Publish</note>
-        <target xml:lang="km" state="translated">បោះពុម្ព</target>
+        <target xml:lang="km">បោះពុម្ព</target>
       </trans-unit>
       <trans-unit id="PublishTab.SaveButton">
         <source xml:lang="en">&amp;Save PDF...</source>
@@ -2844,10 +2844,10 @@
         <note>This is added after the language name, in order to indicate that some parts of the book have not been translated into this language yet.</note>
         <target xml:lang="km" state="needs-translation">(incomplete translation)</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <note>ID: PublishTab.Upload.Languages</note>
-        <target xml:lang="km" state="translated">ភាសា</target>
+        <target xml:lang="km">ភាសា</target>
       </trans-unit>
       <trans-unit id="PublishTab.Upload.License">
         <source xml:lang="en">Usage/License</source>
@@ -2899,10 +2899,10 @@
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
         <target xml:lang="km" state="needs-translation">Password and user ID did not match</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
-        <target xml:lang="km" state="translated">សូមយល់ស្របលក្ខខណ្ឌប្រើប្រាស់</target>
+        <target xml:lang="km">សូមយល់ស្របលក្ខខណ្ឌប្រើប្រាស់</target>
       </trans-unit>
       <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
@@ -3034,10 +3034,10 @@ Do you want to go ahead?</target>
         <note>ID: PublishTab.Upload.TimeProblem</note>
         <target xml:lang="km" state="needs-translation">There was a problem uploading your book. This is probably because your computer is set to use the wrong timezone or your system time is badly wrong. See http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html for how to fix this.</target>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <note>ID: PublishTab.Upload.Title</note>
-        <target xml:lang="km" state="translated">ចំណងជើង</target>
+        <target xml:lang="km">ចំណងជើង</target>
       </trans-unit>
       <trans-unit id="PublishTab.Upload.UploadButton">
         <source xml:lang="en">Upload Book</source>
@@ -3085,15 +3085,15 @@ Do you want to go ahead?</target>
         <note>ID: PublishView._saveButton</note>
         <target xml:lang="km" state="needs-translation">Save stub</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <note>ID: ReaderSetup.AddLevel</note>
-        <target xml:lang="km" state="translated">បន្ថែម កម្រិត</target>
+        <target xml:lang="km">បន្ថែម កម្រិត</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <note>ID: ReaderSetup.AddStage</note>
-        <target xml:lang="km" state="translated">បន្ថែម ដំណាក់កាល</target>
+        <target xml:lang="km">បន្ថែម ដំណាក់កាល</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
@@ -3120,10 +3120,10 @@ Do you want to go ahead?</target>
         <note>ID: ReaderSetup.AverageHeader</note>
         <target xml:lang="km" state="needs-translation">Avg</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <note>ID: ReaderSetup.BookHeader</note>
-        <target xml:lang="km" state="translated">សៀវភៅ</target>
+        <target xml:lang="km">សៀវភៅ</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
         <source xml:lang="en">Maximum Words per Book</source>
@@ -3155,10 +3155,10 @@ Do you want to go ahead?</target>
         <note>ID: ReaderSetup.Combinations</note>
         <target xml:lang="km" state="needs-translation">Letter Combinations (Graphemes)</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <note>ID: ReaderSetup.DecodableStages</note>
-        <target xml:lang="km" state="translated">ដំណាក់កាលដែលអាចចាត់តាមអក្សរ</target>
+        <target xml:lang="km">ដំណាក់កាលដែលអាចចាត់តាមអក្សរ</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true">
         <source xml:lang="en">File needs .TXT extension</source>
@@ -3200,15 +3200,15 @@ Do you want to go ahead?</target>
         <note>ID: ReaderSetup.LetterHelp3</note>
         <target xml:lang="km" state="needs-translation">E.g. "a b c d"</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <note>ID: ReaderSetup.Letters</note>
-        <target xml:lang="km" state="translated">អក្សរ</target>
+        <target xml:lang="km">អក្សរ</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <note>ID: ReaderSetup.Letters.Header</note>
-        <target xml:lang="km" state="translated">អក្សរ និងអក្សរផ្សំ</target>
+        <target xml:lang="km">អក្សរ និងអក្សរផ្សំ</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
@@ -3235,20 +3235,20 @@ Do you want to go ahead?</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
         <target xml:lang="km" state="needs-translation">.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <note>ID: ReaderSetup.LevelHeader</note>
-        <target xml:lang="km" state="translated">កម្រិត</target>
+        <target xml:lang="km">កម្រិត</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level&amp;nbsp;</source>
         <note>ID: ReaderSetup.LevelLabel</note>
-        <target xml:lang="km" state="translated">កម្រិត</target>
+        <target xml:lang="km">កម្រិត</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <note>ID: ReaderSetup.Levels</note>
-        <target xml:lang="km" state="translated">កម្រិតអ្នកអាន</target>
+        <target xml:lang="km">កម្រិតអ្នកអាន</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
         <source xml:lang="en">matching words</source>
@@ -3275,10 +3275,10 @@ Do you want to go ahead?</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
         <target xml:lang="km" state="needs-translation">Open the sample texts folder for this language.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <note>ID: ReaderSetup.PageHeader</note>
-        <target xml:lang="km" state="translated">ទំព័រ</target>
+        <target xml:lang="km">ទំព័រ</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
         <source xml:lang="en">Maximum Words on each Page</source>
@@ -3295,20 +3295,20 @@ Do you want to go ahead?</target>
         <note>ID: ReaderSetup.Punctuation</note>
         <target xml:lang="km" state="needs-translation">Punctuation</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <note>ID: ReaderSetup.ReaderLevels</note>
-        <target xml:lang="km" state="translated">កម្រិតអ្នកអាន</target>
+        <target xml:lang="km">កម្រិតអ្នកអាន</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <note>ID: ReaderSetup.RemoveLevel</note>
-        <target xml:lang="km" state="translated">ដកចេញកម្រិត {0}</target>
+        <target xml:lang="km">ដកចេញកម្រិត {0}</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <note>ID: ReaderSetup.RemoveStage</note>
-        <target xml:lang="km" state="translated">ដកចេញ ដំណាក់កាល {0}</target>
+        <target xml:lang="km">ដកចេញ ដំណាក់កាល {0}</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true">
         <source xml:lang="en">Remove from this stage</source>
@@ -3340,15 +3340,15 @@ Do you want to go ahead?</target>
         <note>ID: ReaderSetup.SearchEngine</note>
         <target xml:lang="km" state="needs-translation">, the Search Engine for Literacy.</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <note>ID: ReaderSetup.SelectedLetters</note>
-        <target xml:lang="km" state="translated">អក្សរមុន និងថ្មី</target>
+        <target xml:lang="km">អក្សរមុន និងថ្មី</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <note>ID: ReaderSetup.SentenceHeader</note>
-        <target xml:lang="km" state="translated">ប្រយោគ</target>
+        <target xml:lang="km">ប្រយោគ</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
         <source xml:lang="en">Maximum Words in each Sentence</source>
@@ -3375,55 +3375,55 @@ Do you want to go ahead?</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
         <target xml:lang="km" state="needs-translation">Set up Leveled Reader Tool</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <note>ID: ReaderSetup.SetupAlphabet</note>
-        <target xml:lang="km" state="translated">បង្កើតអក្ខក្រមសម្រាប់ភាសានេះ</target>
+        <target xml:lang="km">បង្កើតអក្ខក្រមសម្រាប់ភាសានេះ</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
         <source xml:lang="en">What are sight words?</source>
         <note>ID: ReaderSetup.SightWordHelp</note>
         <target xml:lang="km" state="needs-translation">What are sight words?</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <note>ID: ReaderSetup.SightWordLabel</note>
-        <target xml:lang="km" state="translated">ពាក្យជារូបថ្មី</target>
+        <target xml:lang="km">ពាក្យជារូបថ្មី</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <note>ID: ReaderSetup.SightWordsHeader</note>
-        <target xml:lang="km" state="translated">ពាក្យរូបភាព</target>
+        <target xml:lang="km">ពាក្យរូបភាព</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <note>ID: ReaderSetup.StageHeader</note>
-        <target xml:lang="km" state="translated">ដំណាក់កាល</target>
+        <target xml:lang="km">ដំណាក់កាល</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <note>ID: ReaderSetup.StageLabel</note>
-        <target xml:lang="km" state="translated">ដំណាក់កាល</target>
+        <target xml:lang="km">ដំណាក់កាល</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <note>ID: ReaderSetup.Stages</note>
-        <target xml:lang="km" state="translated">ដំណាក់កាលនានា</target>
+        <target xml:lang="km">ដំណាក់កាលនានា</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
         <source xml:lang="en">SynPhony</source>
         <note>ID: ReaderSetup.Synphony</note>
         <target xml:lang="km" state="needs-translation">SynPhony</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <note>ID: ReaderSetup.ToRemember</note>
-        <target xml:lang="km" state="translated">រឿងត្រូវចងចាំសម្រាប់កម្រិតនេះ</target>
+        <target xml:lang="km">រឿងត្រូវចងចាំសម្រាប់កម្រិតនេះ</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <note>ID: ReaderSetup.UniqueHeader</note>
-        <target xml:lang="km" state="translated">មានតែមួយ</target>
+        <target xml:lang="km">មានតែមួយ</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
         <source xml:lang="en">Words</source>
@@ -3440,10 +3440,10 @@ Do you want to go ahead?</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
         <target xml:lang="km" state="needs-translation">2) Place Text Files in Your</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
-        <target xml:lang="km" state="translated">ហ្វូលឌ័រអត្ថបទគំរូ</target>
+        <target xml:lang="km">ហ្វូលឌ័រអត្ថបទគំរូ</target>
       </trans-unit>
       <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
         <source xml:lang="en">1) Type Words Here</source>
@@ -3460,10 +3460,10 @@ Do you want to go ahead?</target>
         <note>ID: ReaderSetup.Words.UseLetters</note>
         <target xml:lang="km" state="needs-translation">We are using letters with sight words to define stages</target>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <note>ID: ReaderSetup.lettersHeader</note>
-        <target xml:lang="km" state="translated">អក្សរ</target>
+        <target xml:lang="km">អក្សរ</target>
       </trans-unit>
       <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
         <source xml:lang="en">In addition, this Bloom Pack will carry your latest decodable and leveled reader settings for the \"{0}\" language. Anyone opening this Bloom Pack, who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this Bloom Pack. They will also get the current set of words for use in decodable readers.</source>
@@ -3475,15 +3475,15 @@ Do you want to go ahead?</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
         <target xml:lang="km" state="needs-translation">The following books will be made into templates:</target>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
-        <target xml:lang="km" state="translated">រក្សាទុកកញ្ចប់ Bloom</target>
+        <target xml:lang="km">រក្សាទុកកញ្ចប់ Bloom</target>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
-        <target xml:lang="km" state="translated">ធ្វើកញ្ចប់ Bloom ឯកសារគំរូសម្រាប់អ្នកអាន</target>
+        <target xml:lang="km">ធ្វើកញ្ចប់ Bloom ឯកសារគំរូសម្រាប់អ្នកអាន</target>
       </trans-unit>
       <trans-unit id="RegisterDialog.Email">
         <source xml:lang="en">Email Address</source>
@@ -3533,11 +3533,11 @@ Do you want to go ahead?</target>
         <note>Place a {0} where the name of the program goes.</note>
         <target xml:lang="km" state="needs-translation">Register {0}</target>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
-        <target xml:lang="km" state="translated">បិទ</target>
+        <target xml:lang="km">បិទ</target>
       </trans-unit>
       <trans-unit id="ReportProblemDialog.CouldNotSendToServer">
         <source xml:lang="en">Bloom was not able to submit your report directly to our server. Please retry or email {0} to {1}.</source>
@@ -3632,25 +3632,25 @@ Do you want to go ahead?</target>
         <note>ID: TemplateBooks.BookName.Arithmetic</note>
         <target xml:lang="km" state="needs-translation">Arithmetic</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
-        <target xml:lang="km" state="translated">សៀវភៅមូលដ្ឋាន</target>
+        <target xml:lang="km">សៀវភៅមូលដ្ឋាន</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <note>ID: TemplateBooks.BookName.Big Book</note>
-        <target xml:lang="km" state="translated">សៀវភៅធំ</target>
+        <target xml:lang="km">សៀវភៅធំ</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
-        <target xml:lang="km" state="translated">អ្នកអានដែលអាចចាត់តាមអក្សរ</target>
+        <target xml:lang="km">អ្នកអានដែលអាចចាត់តាមអក្សរ</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
-        <target xml:lang="km" state="translated">អ្នកអានតាមកម្រិត</target>
+        <target xml:lang="km">អ្នកអានតាមកម្រិត</target>
       </trans-unit>
       <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
         <source xml:lang="en">Picture Dictionary</source>
@@ -3822,30 +3822,30 @@ Do you want to go ahead?</target>
         <note>Caption of 2nd page in books made from Template Starter</note>
         <target xml:lang="km" state="needs-translation">About</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
-        <target xml:lang="km" state="translated">អក្ខក្រម</target>
+        <target xml:lang="km">អក្ខក្រម</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
-        <target xml:lang="km" state="translated">អត្ថបទ និងរូបភាពមូលដ្ឋាន</target>
+        <target xml:lang="km">អត្ថបទ និងរូបភាពមូលដ្ឋាន</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
-        <target xml:lang="km" state="translated">អត្ថបទ និងរូបភាពមូលដ្ឋាន</target>
+        <target xml:lang="km">អត្ថបទ និងរូបភាពមូលដ្ឋាន</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
-        <target xml:lang="km" state="translated">ទំព័រ ក្រេឌីត</target>
+        <target xml:lang="km">ទំព័រ ក្រេឌីត</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
-        <target xml:lang="km" state="translated">បង្កើត</target>
+        <target xml:lang="km">បង្កើត</target>
       </trans-unit>
       <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
         <source xml:lang="en">Day 1</source>
@@ -3887,10 +3887,10 @@ Do you want to go ahead?</target>
         <note>ID: TemplateBooks.PageLabel.Flyleaf</note>
         <target xml:lang="km" state="needs-translation">Flyleaf</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
-        <target xml:lang="km" state="translated">គម្របមុខ</target>
+        <target xml:lang="km">គម្របមុខ</target>
       </trans-unit>
       <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true">
         <source xml:lang="en">Front/Back Matter</source>
@@ -3903,20 +3903,20 @@ Do you want to go ahead?</target>
         <note>Caption of first page in books made from Template Starter</note>
         <target xml:lang="km" state="needs-translation">Image For Thumbnail</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
-        <target xml:lang="km" state="translated">រូបភាពខាងក្រោម</target>
+        <target xml:lang="km">រូបភាពខាងក្រោម</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
-        <target xml:lang="km" state="translated">រូបភាពចំកណ្តាល</target>
+        <target xml:lang="km">រូបភាពចំកណ្តាល</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
-        <target xml:lang="km" state="translated">គម្របក្រោយខាងក្នុង</target>
+        <target xml:lang="km">គម្របក្រោយខាងក្នុង</target>
       </trans-unit>
       <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
         <source xml:lang="en">Inside Front Cover</source>
@@ -3928,25 +3928,25 @@ Do you want to go ahead?</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
         <target xml:lang="km" state="needs-translation">Instructions</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
-        <target xml:lang="km" state="translated">គ្រាន់តែអត្ថបទ</target>
+        <target xml:lang="km">គ្រាន់តែអត្ថបទ</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
-        <target xml:lang="km" state="translated">គ្រាន់តែជារូបភាព</target>
+        <target xml:lang="km">គ្រាន់តែជារូបភាព</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
-        <target xml:lang="km" state="translated">គ្រាន់តែជារូបភាព</target>
+        <target xml:lang="km">គ្រាន់តែជារូបភាព</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
-        <target xml:lang="km" state="translated">គម្របក្រោយខាងក្រៅ</target>
+        <target xml:lang="km">គម្របក្រោយខាងក្រៅ</target>
       </trans-unit>
       <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true">
         <source xml:lang="en">Paper Saver</source>
@@ -3958,15 +3958,15 @@ Do you want to go ahead?</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
         <target xml:lang="km" state="needs-translation">Picture &amp; Word</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
-        <target xml:lang="km" state="translated">រូបភាពចំកណ្តាល</target>
+        <target xml:lang="km">រូបភាពចំកណ្តាល</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
-        <target xml:lang="km" state="translated">រូបភាពខាងក្រោម</target>
+        <target xml:lang="km">រូបភាពខាងក្រោម</target>
       </trans-unit>
       <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true">
         <source xml:lang="en">SIL-Cameroon</source>
@@ -3983,10 +3983,10 @@ Do you want to go ahead?</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
         <target xml:lang="km" state="needs-translation">This Page Is Intentionally Blank</target>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
-        <target xml:lang="km" state="translated">ទំព័រចំណងជើង</target>
+        <target xml:lang="km">ទំព័រចំណងជើង</target>
       </trans-unit>
       <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true">
         <source xml:lang="en">Traditional</source>

--- a/DistFiles/localization/lo/Bloom.xlf
+++ b/DistFiles/localization/lo/Bloom.xlf
@@ -2,2496 +2,2496 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="lo" datatype="plaintext" product-version="3.0.100.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="lo">ເຄື່ອງມື  Decodable Reader  </target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="lo">ເຄື່ອງມື Leveled Reader</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="lo">ເພີ່ມເຕີມ …</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName">
+      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName" approved="yes">
         <source xml:lang="en">Possibly this is an old BloomPack created before BloomPacks could handle special characters in file names. You may be able to get the author to re-create it using a current version. If that's not possible a technical expert may be able to repair things.</source>
         <target xml:lang="lo">ຖ້າເປັນໄປໄດ້ນີ້ແມ່ນມີBloomPackອາຍຸ ສ້າງຂຶ້ນກ່ອນ BloomPacks ສາມາດຈັດຮູບແບບຕົວຫນັງສື ພິເສດໃນຊື່ໄຟລ໌. ທ່ານອາດຈະສາມາດໄດ້ຮັບການນັກປະພັນໄດ້ເພື່ອສ້າງໃຫມ່ການນໍາໃຊ້ສະບັບປະຈຸບັນ. ຖ້າຫາກວ່າເປັນໄປບໍ່ໄດ້ຜູ້ຊ່ຽວຊານດ້ານວິຊາການອາດຈະສາມາດທີ່ຈະສ້ອມແປງສິ່ງ.</target>
         <note>ID: BloomPackInstallDialog.BadCharsInFileName</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="lo">ການຕິດຕັ້ງ Bloom Pack</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="lo">ໃນປັດຈຸບັນ{0} Collectionຄວາມພ້ອມທີ່ຈະນໍາໃຊ້ໃນຄອມພິວເຕີນີ້.</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller" approved="yes">
         <source xml:lang="en">Bloom Pack Installer</source>
         <target xml:lang="lo">Bloom Pack Installer</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstaller</note>
         <note>Displayed as the message box title</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.DoesNotExist">
+      <trans-unit id="BloomPackInstallDialog.DoesNotExist" approved="yes">
         <source xml:lang="en">{0} does not exist</source>
         <target xml:lang="lo">{0} ບໍ່ມີ</target>
         <note>ID: BloomPackInstallDialog.DoesNotExist</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="lo">Bloomບໍ່ສາມາດທີ່ຈະຕິດຕັ້ງທີ່BloomPack</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="lo">ພາວະຖົດຖອຍ….</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while BloomPacks are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="lo">Bloom ຍັງແລ່ນ, ແຕ່ວ່າເນື້ອໃນຈະບໍ່ປາກົດຈົນກ່ວາທີ່ໃຊ້ເວລາຕໍ່ໄປທ່ານແລ່ນBloom </target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.NotInstalled">
+      <trans-unit id="BloomPackInstallDialog.NotInstalled" approved="yes">
         <source xml:lang="en">The Bloom collection will not be installed.</source>
         <target xml:lang="lo">Bloom Collectionຈະບໍ່ໄດ້ຮັບການຕິດຕັ້ງ</target>
         <note>ID: BloomPackInstallDialog.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="lo">ເປີດ {0}….</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Replace">
+      <trans-unit id="BloomPackInstallDialog.Replace" approved="yes">
         <source xml:lang="en">This computer already has a Bloom collection named '{0}'. Do you want to replace it with the one from this Bloom Pack?</source>
         <target xml:lang="lo">ຄອມພິວເຕີນີ້ມີ Bloom Collection ແລ້ວ '{0}'. ທ່ານຕ້ອງການເພື່ອທົດແທນການມັນມີຫນຶ່ງຈາBloom Pack ນີ້ບໍ່?</target>
         <note>ID: BloomPackInstallDialog.Replace</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder">
+      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder" approved="yes">
         <source xml:lang="en">Bloom Packs should have only a single collection folder at the top level of the zip file.</source>
         <target xml:lang="lo">Bloom Packs ຄວນຈະມີພຽງແຕ່ເປັນການເກັບກໍາຂໍ້ມູນໂຟເດີດຽວຢູ່ໃນລະດັບດ້ານເທິງຂອງໄຟຫັດໄປສະນີ.</target>
         <note>ID: BloomPackInstallDialog.SingleCollectionFolder</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.UnableToReplace">
+      <trans-unit id="BloomPackInstallDialog.UnableToReplace" approved="yes">
         <source xml:lang="en">Bloom was not able to remove the existing copy of '{0}'. Quit Bloom if it is running &amp; try again. Otherwise, try again after restarting your computer.</source>
         <target xml:lang="lo">"Bloom ແມ່ນບໍ່ສາມາດທີ່ຈະເອົາສໍາເນົາຂອງທີ່ມີຢູ່ '{0}'. \nອອກຈາກ Bloom ວ່າມັນແມ່ນແລ່ນແລະພະຍາຍາມອີກເທື່ອຫນຶ່ງ. ຖ້າບໍ່ດັ່ງນັ້ນ, ພະຍາຍາມອີກເທື່ອຫນຶ່ງຫລັງຈາກທີ່ຄອມພິວເຕີຂອງທ່ານ."</target>
         <note>ID: BloomPackInstallDialog.UnableToReplace</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all text boxes with '{0}' style</source>
         <target xml:lang="lo">ຕົວແບບນີ້ແມ່ນມີຈຸດປະສົງສໍາລັບການທີ່ທັງຫມົດກ່ອງຂໍ້ຄວາມທີ່ມີ '{0}' ແບບ</target>
         <note>ID: BookEditor.ForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text in boxes with '{1}' style</source>
         <target xml:lang="lo">ຮູບແບບການແມ່ນສໍາລັບຂໍ້ຄວາມທັງຫມົດໃນປ່ອງທີ່ມີ {0} {1} 'ແບບ</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="lo">ການຕັ້ງຄ່າຄໍາຮ້ອງສະຫມັກຂັ້ນສູງ</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="lo">ໃນຄໍາສັ່ງເພື່ອທົດສອບ (ຕົວຢ່າງເຊັ່ນສົ່ງອອກໄປ InDesign ໃນ XML).</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="lo">ຜົນການທົດລອງສະແດງໃຫ້ເຫັນແມ່ແບບ (ຕົວຢ່າງເຊັ່ນ: ປະທານຸກົມຮູບພາບ).</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="lo">ກະລຸນາໃຊ້ Image Serverປະຕິບັດການຮູບພາບຂະຫນາດໃຫຍ່, ນີ້ສາມາດຫຼຸດຜ່ອນຄວາມຈໍາໄດ້.</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="lo">(ທົດສອບ) ສະແດງໃຫ້ເຫັນການສົ່ງ / ຮັບການຄວບຄຸມ.</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="lo">ການຜະລິດປື້ມບັນ</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="lo">ຕົວອັກສອນໄວ້ໃນຕອນຕົ້ນສໍາລັບ {0}.</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="lo">ຫນ້າ / ກັບຄືນໄປບ່ອນ Matter Pack</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="lo">ຂວາຫາຊ້າຍລະບົບການຂຽນ</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="lo">ການຕັ້ງຄ່າ</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="lo">ການປ່ຽນແປງ ...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="lo">ພາສາ 1</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="lo">ພາສາ 2 </target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="lo">ພາສາ 3</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="lo">ພາສາ</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="lo">ການສ້າງຕັ້ງຂອງ ...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="lo">ພາສາທ້ອງຖິ່ນ</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="lo">ພາສາ 2 (ຕົວຢ່າງ: ພາສາແຫ່ງຊາດ).</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="lo">ພາສາ 3 (ສໍາລັບການຍົກຕົວຢ່າງ, ພາສາຂອງພູມິພາກ) (ຖ້າມີ).</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="lo">ລົບ</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="lo">ຊື່ຂອງ Bloom Collection</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="lo">ປະເທດ</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="lo">District</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="lo">ຂໍ້ມູນໂຄງການ</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="lo">ຈັງຫວັດ</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="lo">ເປັນການເລີ່ມຕົ້ນໃຫມ່</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="lo">Bloom ຖືກປິດ, ຫຼັງຈາກນັ້ນເປີດໂຄງການເພື່ອການຕັ້ງຄ່າໃຫມ່.</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book, but these programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="lo">Bloom ແມ່ນ HTML ທີ່ເປີດແປນ (Word ຫຼື LibreOffice) ໃນໂຮງງານຜະລິດຄໍາຂອງທ່ານ. ສັງເກດວ່າທ່ານສາມາດຈັດການກັບການທັງຫມົດຂອງຫນັງສືຫຼືຮູບພາບ. ແຕ່ບໍ່ຈໍາເປັນຈະສາມາດເພື່ອຊ່ວຍປະຢັດຮູບແບບ.</target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="lo">ປັບຂໍ້ມູນຫຼ້າສຸດ ປື້ມບັນ</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="lo">ປັບຂໍ້ມູນຫຼ້າສຸດ Thumbnail</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="lo">ລົບປື້ມບັນ</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="lo">ການສົ່ງອອກໄປ Word ຫຼື LibreOffice ...</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="lo">ການສົ່ງອອກໃນຮູບແບບ XML ສໍາລັບ InDesign ...</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="lo">ປື້ມບັນທຶກຂອງ BloomLibrary.org</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="lo">ການປັບປຸງປື້ມບັນ</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="lo">ກວດສອບປື້ມບັນທັງຫມົດ</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="lo">ປົກປັກຮັກສາການສູນເສຍ ...</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="lo">ການເກັບປະຫວັດສາດ</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="lo">ການບັນທຶກການເກັບ</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="lo">Collections</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="lo">Collections</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="lo">{0} ປື້ມບັນ</target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="lo">ເປີດໂຟເດີໃນ Disk</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="lo">ສຸຂະພາບ</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <target xml:lang="lo">ເຮັດປື້ມບັນໄດ້ນໍາໃຊ້ແຫລ່ງນີ້</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="lo">Collection ອື່ນ ໆ</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="lo">Shells ຕົວຢ່າງ </target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="lo">ສົ່ງ / ຮັບ</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="lo">ການຕັ້ງຄ່າ</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="lo">ແຫຼ່ງCollection </target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="lo">ເປີດໂຟນເດີ Collection ອື່ນ ໆ</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="lo">ແມ່ແບບ</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="lo">ເພື່ອແກ້ໄຂບັນຫານີ້</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="lo">ເຮັດ Bloom Pack</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <target xml:lang="lo">ເຮັດສັງລວມຕົ້ນແບບ  Bloom Pack …</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="lo">ຄວາມຄືບຫນ້າ</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="lo">ໄດ້ຮັບຫນັງສືອື່ນໆ. ທີ່ BloomLibrary.org</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="lo">Source Collection</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="lo">ແຫຼ່ງສໍາລັບການປື້ມບັນໃຫມ່</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="lo">ການເກັບກໍານີ້ແມ່ນມີຊາຍແດນຕິດ, ທ່ານບໍ່ສາມາດເພີ່ມຫຼືເອົາຫນັງສື.</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="lo">ເນື່ອງຈາກວ່ານີ້ແມ່ນແຫຼ່ງຂໍ້ມູນທີ່ collection, Bloom ບໍ່ໄດ້ສະເຫນີໄຍທີ່ມີຢູ່ເປັນແຫລ່ງສໍາລັບ Shell ໃຫມ່ເປັນຢ່າງໃດ. ຖ້າຫາກທ່ານຕ້ອງການທີ່ຈະເພີ່ມພາສາເພື່ອ shell, collection ແທນທີ່ຈະທ່ານຈໍາເປັນຕ້ອງໄດ້ແກ້ໄຂຫອຍໄດ້, ແທນທີ່ຈະກ່ວາການເຮັດສໍາເນົາຂອງມັນ. ນອກຈາກນີ້ຍັງ Wall calendar ແມ່ນບໍ່ໄດ້ປະຈຸບັນຈະຖືກນໍາໃຊ້ເພື່ອເຮັດShell ໃຫມ່.</target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="lo">ອື່ນ ໆ</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem">
+      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem" approved="yes">
         <source xml:lang="en">Open or Create Another Collection</source>
         <target xml:lang="lo">ເປີດຫລື ສ້າງCollection ອີກປະການຫນຶ່ງ</target>
         <note>ID: CollectionTab.OpenCreateCollectionMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="lo">ແຫຼ່ງຂໍ້ມູນສໍາລັບ Shells ໃຫມ່</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="lo">ຄືນ</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="lo">ຍົກເລີກ</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="lo">&amp;ຍົກເລີກ</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="lo">&amp;ສໍາເລັດຮູບ</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="lo">&amp;ການຊ່ວຍເຫຼືອ</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="lo">&amp;ຕໍ່ໄປ</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="lo">ຕໍ່ໄປ </target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="lo">ຕັ້ງຄ່າ </target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="lo">&amp;ຕັ້ງຄ່າ </target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="lo">ທີ່ບໍ່ຈໍາເປັນ</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="lo">ການກໍ່ສ້າງ ...</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="lo">ອັກສອນໃນຂັ້ນຕອນຂອງການນີ້</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="lo">ເປີດຈົດຫມາຍແລະລາຍຊື່ພຣະຄໍາໄຟລ໌</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="lo">ໄລຍະການຈັດຕັ້ງ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="lo">ໄລຍະທີ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="lo">ຂອງ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="lo">ຄໍາສັບຕ່າງໆໃນຂັ້ນຕອນນີ້</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections. If you don't seem to be in the middle of doing something, Bloom will select it for you.</source>
         <target xml:lang="lo">{0} ດາວໂຫຼດຂອງທ່ານສໍາເລັດ. ທ່ານສາມາດເບິ່ງ 'ຫນັງສືຈາກພາກ BloomLibrary.org 'ພົບເຫັນຢູ່ໃນການເກັບກໍາໄດ້. ຖ້າວ່າທ່ານບໍ່ແກ້ໄຂມັນ, Bloomຈະໄດ້ຮັບການຄັດເລືອກສໍາລັບທ່ານ.</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="lo">ດາວນ໌ໂຫລດສະບັບສົມບູນ</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="lo">ການດາວໂຫລດປື້ມບັນ</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="lo">ການດາວໂຫລດປື້ມບັນມີບັນຫາ</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="lo">ຖ້າຫາກວ່າທ່ານຕ້ອງການເພື່ອເຮັດໃຫ້ຂໍ້ມູນຂ່າວສານເພີ່ມເຕີມກ່ຽວກັບປື້ມຫົວນີ້. ທ່ານສາມາດໃຊ້ຫນ້ານີ້ເປັນການພາຍໃນຂອງການປົກຫຸ້ມຂອງກັບຄືນໄປບ່ອນ.</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="lo">ຖ້າຫາກວ່າທ່ານຕ້ອງການເພື່ອເຮັດໃຫ້ຂໍ້ມູນຂ່າວສານເພີ່ມເຕີມກ່ຽວກັບປື້ມຫົວນີ້. ທ່ານສາມາດໃຊ້ຫນ້ານີ້, ຊຶ່ງເປັນນອກຂອງການປົກຫຸ້ມຂອງກັບຄືນໄປບ່ອນ.</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Background</source>
         <target xml:lang="lo">ພື້ນຫຼັງ </target>
         <note>ID: EditTab.TextBoxProperties.Background</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the Html used to make this PDF, in Firefox (must be on path)</source>
         <target xml:lang="lo">ເປີດ Html ທີ່ນໍາໃຊ້ເພື່ອເຮັດໃຫ້ PDF ນີ້, ໃນ Chrome (ຕ້ອງເປັນໄປຕາມເສັ້ນທາງ)</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="lo">ຂໍອະໄພ, ລິຂະສິດແລະໃບອະນຸຍາດສໍາລັບການນີ້ບໍ່ສາມາດໄດ້ຮັບການປ່ຽນແປງ.</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="lo">ຂໍອະໄພ, ປື້ມບັນນີ້ແມ່ນມີຊາຍແດນຕິດລົງດັ່ງນັ້ນຮູບພາບຕ່າງໆທີ່ບໍ່ສາມາດໄດ້ຮັບການປ່ຽນແປງ.</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="lo">ຕົກລົງຈະໄດ້ຮັບການໂຍກຍ້າຍອອກຢ່າງຖາວອນຫຼືບໍ່?</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="lo">&amp;ລົບ</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="lo">ຫນ້ານີ້ຈະໄດ້ຮັບການໂຍກຍ້າຍອອກຢ່າງຖາວອນ.</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="lo">ການປ່ຽນແປງການຈັດຫນ້າ  </target>
         <note>ID: EditTab.CustomPage.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true" approved="yes">
         <source xml:lang="en">or</source>
         <target xml:lang="lo">ຫຼື</target>
         <note>ID: EditTab.CustomPage.Or</note>
         <note>Shown between 'Picture' and 'Text' when Custom Page is in Layout mode</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture</source>
         <target xml:lang="lo">ຮູບພາບ</target>
         <note>ID: EditTab.CustomPage.Picture</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <target xml:lang="lo">ຂໍ້ຄວາມ</target>
         <note>ID: EditTab.CustomPage.Text</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <target xml:lang="lo">ກ່ອງຂໍ້ຄວາມ</target>
         <note>ID: EditTab.CustomPage.TextBox</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="lo">ດັດແກ້  </target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="lo">ຕົວຫນັງສືເລືອກເປັນ '{0}', ແຕ່ວ່າມັນບໍ່ໄດ້ຖືກຕິດຕັ້ງຢູ່ໃນຄອມພິວເຕີນີ້. ບາງຕົວຫນັງສືອື່ນໆໄດ້ຖືກນໍາໃຊ້.</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true" approved="yes">
         <source xml:lang="en">That style already exists. Please choose another name.</source>
         <target xml:lang="lo">ແບບທີ່ມີຢູ່ແລ້ວ. ກະລຸນາເລືອກເອົາຊື່ອື່ນ.</target>
         <note>ID: EditTab.FormatDialog.AlreadyExists</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="lo">ການປ່ຽນແປງຂອງຊາຍແດນແລະຄວາມເປັນມາ</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <target xml:lang="lo">ຕົວອັກສອນ</target>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <target xml:lang="lo">ສ້າງ</target>
         <note>ID: EditTab.FormatDialog.Create</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create a new style</source>
         <target xml:lang="lo">ສ້າງເປັນແບບໃຫມ່</target>
         <note>ID: EditTab.FormatDialog.CreateStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Don't see what you need?</source>
         <target xml:lang="lo">ບໍ່ໄດ້ໄປເບິ່ງສິ່ງທີ່ທ່ານຕ້ອງການ?</target>
         <note>ID: EditTab.FormatDialog.DontSeeNeed</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Emphasis</source>
         <target xml:lang="lo">ເນັ້ນຫນັກໃສ່</target>
         <note>ID: EditTab.FormatDialog.Emphasis</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <target xml:lang="lo">ຮູບແບບຕົວຫນັງສື  </target>
         <note>ID: EditTab.FormatDialog.Font</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="lo">ການປ່ຽນແປງຂະຫນາດຮູບແບບຕົວຫນັງສື  </target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="lo">ການປ່ຽນແປງຂະຫນາດຕົວອັກສອນທີ່ສໍາລັບຄໍເຕົ້າໄຂ່ທີ່ທັງຫມົດ '{0}' ແລະພາສາ '{1}'. \n ເປັນສິ່ງທີ່ຂະຫນາດປະຈຸບັນ {2}  ຈຸດ</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="lo">ການປ່ຽນແປງສະຖານລະຫວ່າງສາຍຂອງຂໍ້ຄວາມ.</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Format</source>
         <target xml:lang="lo">ຮູບແບບ</target>
         <note>ID: EditTab.FormatDialog.Format</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="lo">ການປ່ຽນແປງສະຖານລະຫວ່າງສາຍຂອງຂໍ້ຄວາມ.</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New style</source>
         <target xml:lang="lo">ແບບໃຫມ່</target>
         <note>ID: EditTab.FormatDialog.NewStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please use only alphabetical characters. Numbers at the end are ok, as in "part2".</source>
         <target xml:lang="lo">ກະລຸນາໃຊ້ລັກສະນະຂອງຕົວອັກສອນເທົ່ານັ້ນ. ຈໍານວນຢູ່ໃນຕອນທ້າຍແມ່ນແລ້ວງາມ, ໃນ "part2".</target>
         <note>ID: EditTab.FormatDialog.PleaseUseAlpha</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <target xml:lang="lo">ໄລຍະຫ່າງຕົວຫນັງສື</target>
         <note>ID: EditTab.FormatDialog.Spacing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <target xml:lang="lo">ແບບ</target>
         <note>ID: EditTab.FormatDialog.Style</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <target xml:lang="lo">ຊື່ແບບ</target>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="lo">ກ້ວາງພິເສດ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="lo">ຕາມປົກກະຕິ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="lo">ມີການປ່ຽນແປງໄລຍະຫ່າງລະຫວ່າງ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="lo">ກ້ວາງ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="lo">ເມື່ອໃດທີ່ທ່ານໄດ້ເຮັດໄດ້ ປື້ມບັນຕົ້ນສະບັບການນໍາໃຊ້ຫ້ອງການໃນການບັນທຶກການປະກອບສ່ວນເຮັດໄດ້ໂດຍນັກຂຽນ, ປະກອບຮູບແຕ້ມ, ບັນນາທິການ, ແລະອື່ນໆ.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="lo">ໃນເວລາທີ່ທ່ານເຮັດໃຫ້ປື້ມບັນອອກຂອງຫອຍໄດ້, ໃຫ້ນໍາໃຊ້ພາກສະຫນາມນີ້ຈະບອກວ່າຜູ້ທີ່ໄດ້ແປ.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="lo">ຊື່ປື້ມບັນຢູ່ໃນ {lang} </target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright &amp; License</source>
         <target xml:lang="lo">ຄລິກທີ່ນີ້ເພື່ອແກ້ໄຂການລິຂະສິດແລະໃບອະນຸຍາດ.</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="lo">ການນໍາໃຊ້ເພື່ອໃຫ້ໄດ້ຮັບການສະຫນອງທຶນໃດຫນຶ່ງ.</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="lo">ຈໍານວນຫນັງສືມາດຕະຖານສາກົນ. ອອກຈາກເປົ່າຖ້າຫາກວ່າທ່ານບໍ່ຕ້ອງການຂອງເຫຼົ່ານີ້.</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="lo">ຕົ້ນສະບັບ (ຫຼື Shell) ໃນ {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="lo">ການປະກອບສ່ວນເຮັດໄດ້ໂດຍ writers, ປະກອບຮູບແຕ້ມບັນນາທິການ, ແລະອື່ນໆ.,.ໃນ {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="lo">ຄລິກທີ່ນີ້ເພື່ອເລືອກເອົາເລື້ຶອງ</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="lo">ການຢັ້ງຢືນສໍາລັບການສະບັບທ້ອງຖິ່ນ, , ໃນ {lang}</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="lo">ການປ່ຽນແປງ</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, &amp; License</source>
         <target xml:lang="lo">ການປ່ອຍສິນເຊື່ອຮູບພາບດັດແກ້, ລິຂະສິດແລະອະນຸຍາດ.</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="lo">ວາງຮູບພາບ</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="lo">ກ່ອນທີ່ທ່ານຈະສາມາດວາງການຄັດລອກໄປທີ່ clipboard 'ຈາກຄໍາຮ້ອງສະຫມັກຂອງທ່ານ.</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="lo">ຫລາຍຫນ້າ</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="lo">ເລືອກຂະຫນາດຫນ້າແລະປະຖົມນິເທດ</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.Position" sil:dynamic="true">
+      <trans-unit id="EditTab.Position" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Position</source>
         <target xml:lang="lo">ທີ່ຕັ້ງ</target>
         <note>ID: EditTab.Position</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="lo">ການປ່ຽນແປງຂອງຊາຍແດນແລະຄວາມເປັນມາ</target>
         <note>ID: EditTab.StyleEditor.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="lo">ການປ່ຽນແປງຫນ້າຂອງຮູບແບບຕົວຫນັງສື  </target>
         <note>ID: EditTab.StyleEditor.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="lo">ການປ່ຽນແປງຂະຫນາດຮູບແບບຕົວຫນັງສື  </target>
         <note>ID: EditTab.StyleEditor.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="lo">ການປ່ຽນແປງສະຖານລະຫວ່າງສາຍຂອງຂໍ້ຄວາມ.</target>
         <note>ID: EditTab.StyleEditor.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="lo">ກ້ວາງພິເສດ</target>
         <note>ID: EditTab.StyleEditor.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="lo">ຕາມປົກກະຕິ</target>
         <note>ID: EditTab.StyleEditor.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="lo">ມີການປ່ຽນແປງໄລຍະຫ່າງລະຫວ່າງ</target>
         <note>ID: EditTab.StyleEditor.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="lo">ກ້ວາງ</target>
         <note>ID: EditTab.StyleEditor.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="lo">ການປັບການຈັດຮູບແບບສໍາລັບການລົງ</target>
         <note>ID: EditTab.StyleEditorTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="lo">ເພດແມ່ແບບ</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="lo">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="lo">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="lo">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="lo">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="lo">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="lo">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="lo">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="lo">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="lo">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="lo">ລັກສະນະ</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="lo">ຂໍ້ພື້ນຖານແລະຮູບພາບ</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="lo">ຂໍ້ຄວາມແລະຮູບພາບ</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="lo">ຫນ້າຈຸດ</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="lo">ປະເພນີ</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="lo">ວັນທີ່ 1</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="lo">ວັນທີ່ 2</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="lo">ວັນທີ່ 3</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="lo">ວັນທີ່ 4</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="lo">ວັນທີ່ 5a</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="lo">ວັນທີ່ 5b</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="lo">ປົກຫນ້າ</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="lo">ຮູບພາບກ່ຽວກັບທາງລຸ່ມ</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="lo">ຮູບພາບໃນກາງ</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="lo">ພາຍໃນການປົກຫຸ້ມຂອງກັບຄືນໄປບ່ອນ</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="lo">ພາຍໃນປົກຫນ້າ</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="lo">ແນະນໍາ</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="lo">ພຽງແຕ່ຂໍ້ຄວາມ</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="lo">ພຽງແຕ່ຮູບພາບ</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="lo">ພຽງແຕ່ຮູບພາບ</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="lo">ນອກກັບຄືນໄປບ່ອນກວມເອົາ</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="lo">ຮູບພາບແລະຄໍາ</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="lo">ຮູບພາບກ່ຽວກັບຮ່າງ</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="lo">ຮູບພາບໃນກາງ</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="lo">ຫນ້ານີ້ແມ່ນບໍ່ມີເຈດຕະນາ</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="lo">ຫົວຫນ້າ</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="lo">ການຕັ້ງຄ່າພາສາ</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="lo">ກ່າຍ  </target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="lo">ຕັດ</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="lo">ດຶງອອກຈາກ\n ຫນ້າ</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="lo">ກົດ\n ຫນ້າ</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="lo">ວາງ</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="lo">ການແກ້ໄຂ</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="lo">ສອງພາສາ</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="lo">ກ່າຍຂໍ້ມູນກັບຮູບພາບອື່ນໆທີ່ຢູ່ໃນຫນັງສືເຫຼັ້ມນີ້ໄດ້ຫຼືບໍ່?</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="lo">ຕົວເລືອກນີ້ແມ່ນມີພຽງແຕ່ມີຢູ່ໃນ ເຜີຍແຜ່ tab</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="lo">ຫນຶ່ງພາສາ</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="lo">ບໍ່ມີທາງເລືອກອື່ນສໍາລັບແມ່ແບບນີ້.</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="lo">ຮູບພາບຂອງຊັບສິນທາງປັນຍາ</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="lo">ສາມພາສາ</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="lo">ການເຮັດຜູ້ອ່ານແມ່ແບບ</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu">
+      <trans-unit id="HelpMenu.Help Menu" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="lo">ຊ່ວຍເຫຼືອ</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="lo">ການນໍາໃຊ້ ຜູ້ອ່ານແມ່ແບບ</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="lo">ໃຫ້ຄໍາແນະນໍາ</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="lo">ເວັບໄຊທ໌</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="lo">ກວດສອບການອອກສະບັບໃຫມ່</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="lo">ກ່ຽວກັບ Bloom</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <target xml:lang="lo">ເອກະສານ</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem">
+      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem" approved="yes">
         <source xml:lang="en">Key Bloom Concepts</source>
         <target xml:lang="lo">ແນວຄວາມຄິດຕົ້ນຕໍຂອງBloom</target>
         <note>ID: HelpMenu.KeyBloomConceptsToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="lo">ການລົງທະບຽນ</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="lo">Release ຫມາຍເຫດ ..</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem">
+      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem" approved="yes">
         <source xml:lang="en">Report a Problem...</source>
         <target xml:lang="lo">ລາຍງານບັນຫາ ...</target>
         <note>ID: HelpMenu.ReportAProblemToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="lo">ສະແດງໃຫ້ເຫັນເຫດການເຂົ້າສູ່ລະບົບ</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="lo">InDesign XML ຂໍ້ມູນຂ່າວສານ</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="lo">ບໍ່ສະແດງໃຫ້ເຫັນອີກເທື່ອຫນຶ່ງນີ້</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="lo">A4 ແນວຕັ້ງ  </target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="lo">A4 ແນວຕັ້ງ  ຂ້າງໂດຍຂ້າງ</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="lo">A4 ແນວຕັ້ງ  ແບ່ງປັນທົ່ວຫນ້າ</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="lo">A4 ທິດທາງແນວຕັ້ງ  </target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="lo">A5 ແນວຕັ້ງ  </target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="lo">A5 ທິດທາງແນວຕັ້ງ  </target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="lo">A5 ທິດທາງແນວຕັ້ງ  ສອດຄ່ອງຕໍ່ໄປນີ້</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="lo">B5 ທິດທາງແນວຕັ້ງ  </target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="lo">ທີ່ແທ້ຈິງ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="lo">ທາງເລືອກຂອງຂໍ້ຄວາມ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="lo">ສໍາລັບລະດັບນີ້</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="lo">ການຈັດຮູບແບບ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="lo">ສະຫນັບສະຫນູນປະກອບ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="lo">ຈືຂໍ້ມູນການ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="lo">ລະດັບການ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> of </source>
         <target xml:lang="lo">ຂອງ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="lo">ສູງສຸດທີ່ເຄຍ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="lo">ຕໍ່ຫນ້າ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="lo">ຕໍ່ປະໂຫຍກ</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="lo">ການຄາດຄະເນ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="lo">ຕັ້ງຄ່າລະດັບ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="lo">ປື້ມບັນນີ້</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="lo">ຫນ້ານີ້</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="lo">ຈໍານວນທັງຫມົດ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="lo">ເປັນເອກະລັກ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="lo">ຄໍາສັບ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="lo">ການນັບຄໍາສັບ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="lo">ຂ້າພະເຈົ້າຕົກລົງເຫັນດີກັບເງື່ອນໄຂຂອງການນໍາໃຊ້ຫ້ອງສະຫມຸດBloomໄດ້.</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="lo">ທີ່ຢູ່ອີເມວ</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="lo">ລືມລະຫັດຜ່ານ</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="lo">&amp;ການເຂົ້າເຖິງ</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="lo">ລະຫັດຜ່ານ</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="lo">ເງື່ອນໄຂການສະແດງໃຫ້ເຫັນຂອງການນໍາໃຊ້</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="lo">ການເຂົ້າເຖິງ BloomLibrary.org</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="lo">&amp;ສະແດງ ລະຫັດຜ່ານ</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="lo">ແລ້ວມີການເກັບກໍາທີ່ມີຊື່ວ່າໄດ້ທີ່ &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\n ກະລຸນາເລືອກເອົາຊື່ເປັນເອກະລັກ</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="lo">ເລືອກພາສາຂອງທ່ານສໍາລັບການເກັບກໍານີ້.</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="lo">ຕົວຢ່າງ: "ປື້ມບັນສຸຂະພາບ","ເລື່ອງຂອງສັດ"</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="lo">ສໍາລັບການເກັບກໍາຂໍ້ມູນນີ້, ທ່ານຈະໃຫ້ຊື່</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="lo"> ບັນຫາທີ່ມີຊື່ Collection</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="lo">Collectionສ້າງຕັ້ງຂື້ນໃນ: {0}</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="lo">ພ້ອມທີ່ຈະສ້າງCollectionໃຫມ່</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="lo">ເລືອກປະເພດCollection</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="lo">ແຫຼ່ງCollection </target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org and optionally make a Bloom Pack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="lo">Collection ຂອງຫນັງສືໃນຫນຶ່ງຫອຍຫຼືແມ່ຫຼືພາສາຂອງການສື່ສານກວ້າງໄດ້. ທ່ານຈະສາມາດທີ່ຈະອັບໂຫລດໄຍເຫຼົ່ານີ້. BloomLibrary.org ດອກໄມ້ແລະເລືອກທີ່ຈະເຮັດ Bloom ໃຫ້ປະຊາຊົນອື່ນໆເພື່ອໃຫ້ເຂົາເຈົ້າສາມາດເຮັດໃຫ້ແກະສໍາລັບພາສາກໍາເນີດຂອງທ່ານໄດ້.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="lo">ທ້ອງຖິ່ນ / ພາສາທ້ອງຖິ່ນ Collection</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="lo">Collection ເກັບກໍາຂໍ້ມູນຂອງຫນັງສືໃນພາສາທ້ອງຖິ່ນ</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="lo">ໃຫ້ພາສາທີ່ຢູ່</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="lo">ປະເທດ</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="lo">District</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="lo">ເຫຼົ່ານີ້ແມ່ນມີທາງເລືອກອື່ນ Bloom ຈະຈັດວາງໃຫ້ເຂົາເຈົ້າໃນສະຖານທີ່ສິດທິໃນການໃນຫນ້າຫົວຂໍ້ຂອງຫນັງສືທີ່ທ່ານສ້າງ.</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="lo">ຈັງຫວັດ</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="lo">{0} ຫນັງສື</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="lo">ເຮັດ Bloom Collection ໃຫມ່</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="lo">ຊື່ໂຄງການ</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="lo">"ບໍ່ສາມາດທີ່ຈະສ້າງBloomໃຫມ່\nການນໍາໃຊ້ຊື່ວ່າ."</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="lo">ຍິນດີຕ້ອນຮັບ Bloom!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="lo">ທ່ານມີເກືອບພ້ອມທີ່ຈະເລີ່ມຕົ້ນການເຮັດຫນັງສື.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. So the first thing we need to do is make one for you.</source>
         <target xml:lang="lo">ໃນຄໍາສັ່ງທີ່ຈະຮັກສາສິ່ງທີ່ງ່າຍດາຍແລະການຈັດຕັ້ງ, Bloom ເຮັດໃຫ້ປື້ມທັງຫມົດທີ່ທ່ານເຮັດໃນຫນຶ່ງຫຼືຫຼາຍກວ່າ</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="lo">ຄຼິກ 'ຕໍ່ໄປ' ຈະໄດ້ຮັບການເລີ່ມຕົ້ນ.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="lo">Bloom Collections</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="lo">ເອີ້ນເບິ່ງCollectionອື່ນກ່ຽວກັບຄອມພິວເຕີນີ້</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="lo">ຄັດລອກຈາກ Chorus Hub ກ່ຽວກັບການເຄືອຂ່າຍທ້ອງຖິ່ນ</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="lo">ກ່າຍຈາກອິນເຕີເນັດ</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="lo">ກ່າຍຈາກ Drive USB</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="lo">ສ້າງCollectionໃຫມ່</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="lo">ເປີດ / ສ້າງ Collections</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="lo">ອ່ານເພີ່ມເຕີມ</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="lo">"ໄດ້ຜູ້ອື່ນນໍາໃຊ້ສົ່ງ / ຮັບທີ່ຈະແບ່ງປັນການເກັບກໍາຂອງທ່ານ? \n ການນໍາໃຊ້ຫນຶ່ງຂອງປຸ່ມສີແດງນີ້ເພື່ອສໍາເນົາເອົາການເກັບກໍາຂອງເຂົາເຈົ້າກັບຄອມພິວເຕີຂອງທ່ານ.\n\n ຕໍ່ມາ, ການນໍາໃຊ້ສົ່ງ / ຮັບການແບ່ງປັນວຽກງານຂອງທ່ານກັບຄືນໄປບ່ອນທີ່ມີໃຫ້ເຂົາເຈົ້າ."</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="lo">ແທນທີ່ທີ່ມີຢູ່</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="lo">ແຈ້ງການ</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are</source>
         <target xml:lang="lo">ການປ່ຽນແປງທີ່ບໍ່ໄດ້ຮັບອະນຸຍາດ. ເລື່ອງຫນ້າແລະຫນ້າເວັບທີ່ວ່າກັບຄືນໄປບ່ອນຕ້ອງຍັງມີບ່ອນທີ່ພວກເຂົາເຈົ້າມີ</target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="lo">ຍ້າຍທີ່ບໍ່ຖືກຕ້ອງ</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.BadPdf">
+      <trans-unit id="PublishTab.PdfMaker.BadPdf" approved="yes">
         <source xml:lang="en">Bloom had a problem making a PDF of this book. You may need technical help or to contact the developers. But here are some things you can try:</source>
         <target xml:lang="lo">"Bloom ມີບັນຫາເຮັດໃຫ້ PDF ຂອງຫນັງສືນີ້ໄດ້.\nທ່ານອາດຈະຕ້ອງການການຊ່ວຍເຫຼືອດ້ານວິຊາການຫຼືການຕິດຕໍ່ກັບການພັດທະນາ. ແຕ່ໃນທີ່ນີ້ມີບາງສິ່ງບາງຢ່າງທີ່ທ່ານສາມາດພະຍາຍາມ:"</target>
         <note>ID: PublishTab.PdfMaker.BadPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory">
+      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory" approved="yes">
         <source xml:lang="en">Try doing this on a computer with more memory</source>
         <target xml:lang="lo">ພະຍາຍາມດໍາເນີນການນີ້ກ່ຽວກັບຄອມພິວເຕີທີ່ memory ຫຼາຍ</target>
         <note>ID: PublishTab.PdfMaker.TryMoreMemory</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryRestart">
+      <trans-unit id="PublishTab.PdfMaker.TryRestart" approved="yes">
         <source xml:lang="en">Restart your computer and try this again right away</source>
         <target xml:lang="lo">ເປີດຄອມພິວເຕີຂອງທ່ານໃຫມ່ແລະພະຍາຍາມອີກເທື່ອຫນຶ່ງໃນທັນທີ</target>
         <note>ID: PublishTab.PdfMaker.TryRestart</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages">
+      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages" approved="yes">
         <source xml:lang="en">Replace large, high-resolution images in your document with lower-resolution ones</source>
         <target xml:lang="lo">ການປ່ຽນແທນຂະຫນາດໃຫຍ່, ຮູບພາບສູງການແກ້ໄຂໃນເອກະສານຂອງທ່ານກັບຄົນທີ່ຄວາມລະອຽດຕ່ໍາ</target>
         <note>ID: PublishTab.PdfMaker.TrySmallerImages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="lo">ກະລຸນາຕິດຕັ້ງ Adobe Reader ດັ່ງນັ້ນດອກໄມ້ສາມາດສະແດງໃຫ້ເຫັນຫນັງສືສໍາເລັດຂອງທ່ານ.</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="lo">ວ່າເປັນ แปลก ... Adobe Reader ໃຫ້ຄວາມຜິດພາດໃນເວລາທີ່ພະຍາຍາມເພື່ອສະແດງໃຫ້ເຫັນ PDF ວ່າ. ທ່ານຍັງສາມາດພະຍາຍາມປະຢັດ ປື້ມບັນPDF ໄດ້. ໄດ້.</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="lo">ຂໍອະໄພ. Bloom ບໍ່ສາມາດໄດ້ຮັບການສະແດງໃຫ້ເຫັນ Adobe Reader, Bloom ທີ່ນີ້, ດັ່ງນັ້ນທ່ານບໍ່ສາມາດເບິ່ງຫນັງສືຂອງທ່ານແມ່ນສໍາເລັດສົມບູນ. \nກະລຸນາຖອນການຕິດຕັ້ງສະບັບຂອງທ່ານຄືການເປັນ 'Adobe Reader ແລະ (ຕິດຕັ້ງອີກເທື່ອຫນຶ່ງ) ຕິດຕັ້ງ' Adobe Reader'. \nເວັ້ນເສຍແຕ່ວ່າທ່ານໄດ້ຮັບການແກ້ໄຂ, ທ່ານຍັງສາມາດຊ່ວຍປະຢັດ ປື້ມບັນPDF ແລະເປີດໂຄງການ ອື່ນໆ</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="lo">ຂໍ້ມູນພາຍໃນປຶ້ມຄູ່ມື</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book.
  Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="lo">ເຮັດປຶ້ມຄູ່ມືຈາກຫນ້າທີ່ພາຍໃນຂອງຫນັງສືໄດ້. ຫນ້າຈະໄດ້ຮັບການວາງອອກແລະ ປ່ຽນແປງຄໍາສັ່ງຂອງດັ່ງນັ້ນໃນເວລາທີ່ທ່ານເທົ່າມັນ, ທ່ານຈະມີປຶ້ມຄູ່ມືໄດ້. \ n</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="lo">ການອັບໂຫລດ </target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="lo">ການອັບໂຫລດ BloomLibrary.org, ບ່ອນທີ່ຜູ້ອື່ນສາມາດດາວໂຫລດແລະຫັນເຂົ້າໄປໃນພາສາຂອງເຂົາເຈົ້າເອງ.</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="lo">ປົກຫຸ້ມຂອງປື້ມຄູ່ມື</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="lo">ເຮັດ PDF ເປັນພຽງແຕ່ທາງຫນ້າແລະທາງຫລັງ. (ທັງສອງຝ່າຍ), ດັ່ງນັ້ນທ່ານສາມາດພິມອອກໃນເຈ້ຍສີ.</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="lo">ງ່າຍ </target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="lo">ການເຮັດໃຫ້ໄຟລ໌ PDF ຂອງຫນ້າຂອງປຶ້ມນີ້, ຫນຶ່ງຫນ້າຕໍ່ເອກະສານຂອງເຈ້ຍທຸກ.</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system pdf viewer</source>
         <target xml:lang="lo">ເປີດ PDF ໃນຕອນຕົ້ນ viewer pdf ລະບົບ</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="lo">&amp;Print...</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="lo">ເຜີຍແຜ່</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="lo">&amp;ບັນທຶກ PDF...</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="lo">Crop Marks</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="lo">ການຮັບຮູ້</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">AdditionalRequests: </source>
         <target xml:lang="lo">ຂໍເພີ່ມເຕີມ:</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="lo">All rights reserved (Contact the Copyright holder for any permissions.)</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you.  If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="lo">BloomLibrary.org ແລ້ວມີສະບັບທີ່ຜ່ານມາຂອງຫນັງສືຈາກທ່ານນີ້. ຖ້າຫາກວ່າທ່ານອັບໂຫລດມັນອີກເທື່ອຫນຶ່ງ, ມັນຈະໄດ້ຮັບການທົດແທນທີ່ມີສະບັບປະຈຸບັນຂອງທ່ານ.</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="lo">ລິຂະສິດ</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="lo">ສິນເຊື່ອ</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="lo">ມີບັນຫາໃນການດາວໂຫລດຫນັງສືຂອງທ່ານ. ທ່ານອາດຈະມີການເລີ່ມຕົ້ນໃຫມ່ Bloom ຫຼືໄດ້ຮັບການຊ່ວຍເຫຼືອຈາກ technical help.</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="lo">ຂໍອະໄພ, ມີບັນຫາ ການອັບໂຫລດບັນຫາ {0}. ທ່ານອາດຈະຕ້ອງການການຊ່ວຍເຫຼືອຈາກ technical help.</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading</source>
         <target xml:lang="lo">ກະລຸນາກວດເບິ່ງຂໍ້ມູນແມ່ນຖືກຕ້ອງຂ້າງເທິງກ່ອນອັບໂຫຼດ</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded</source>
         <target xml:lang="lo">ຂໍອະໄພ, "{0}" ບໍ່ໄດ້ອັບໂຫລດສົບຜົນສໍາເລັດ</target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes</source>
         <target xml:lang="lo">ໂດຍການອັບໂຫລດທ່ານຢືນຢັນຂໍ້ຕົກລົງຂອງທ່ານທີ່ມີເງື່ອນໄຂ BloomLibrary ຂອງການນໍາໃຊ້ແລະໃຫ້ສິດທິໃນການມັນອະທິບາຍ</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="lo">ບໍ່ມີບັນຫາການອັບໂຫຼດປຶ້ມຂອງທ່ານໄດ້.</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="lo">ພາສາ</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="lo">ການນໍາໃຊ້ / ໃບອະນຸຍາດ</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="lo">ບັນຊີຢູ່ແລ້ວ</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address.  Would you like to log in instead?</source>
         <target xml:lang="lo">"ພວກເຮົາບໍ່ສາມາດເຂົ້າເຖິງທ່ານທີ່ມີທີ່ຢູ່ທີ່, ເນື່ອງຈາກວ່າພວກເຮົາມີບັນຊີແລ້ວທີ່ມີທີ່ຢູ່ທີ່ໄດ້. ທ່ານຕ້ອງການທີ່ຈະເຂົ້າສູ່ລະບົບແທນທີ່ບໍ່?\n"</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="lo">Bloom ບໍ່ສາມາດເຊື່ອມຕໍ່ກັບ Server ເພື່ອກວດພິສູດເຂົ້າສູ່ລະບົບຂອງທ່ານ. ກະລຸນາກວດສອບການເຊື່ອມຕໍ່ເຄືອຂ່າຍຂອງທ່ານ.</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="lo">ການເຂົ້າສູ່ລະບົບບໍ່ສໍາເລັດ</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="lo">Bloom ບໍ່ສາມາດເຊື່ອມຕໍ່ກັບ Server ໃຫ້ສໍາເລັດການລົງທະບຽນຂອງທ່ານ. ນີ້ອາດຈະແມ່ນບັນຫາທີ່ມີການເຊື່ອມຕໍ່ອິນເຕີເນັດ, ເຄື່ອງແມ່ຂ່າຍຂອງພວກເຮົາ, ຫຼືອຸປະກອນຢູ່ໃນລະຫວ່າງບາງ.</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="lo">ໃນຄໍາສັ່ງທີ່ຈະເຂົ້າເຖິງສໍາລັບບັນຊີ BloomLibrary.org, ທ່ານຕ້ອງຫມາຍເອົາຫ້ອງດັ່ງກ່າວຊີ້ໃຫ້ເຫັນວ່າທ່ານຕົກລົງເຫັນດີກັບເງື່ອນໄຂການ BloomLibrary ຂອງການນໍາໃຊ້.</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="lo">ທີ່ຢູ່ອີເມວຈໍາເປັນ</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="lo">ພວກເຮົາບໍ່ມີໃຊ້ໃນການບັນທຶກທີ່ມີອີເມລ໌ທີ່ເປັນ. ທ່ານຕ້ອງການທີ່ຈະເຂົ້າເຖິງຫຼືບໍ່</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="lo">ລະຫັດຜ່ານແລະ ID ຜູ້ໃຊ້ ບໍ່ກົງກັບ</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="lo">ກະລຸນາຕົກລົງເຫັນດີກັບຂໍ້ກໍານົດຂອງການນໍາໃຊ້</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="lo">ກະລຸນາໃສ່ທີ່ຢູ່ອີເມວທີ່ຖືກຕ້ອງ. ພວກເຮົາຈະສົ່ງອີເມວໄປຫາທີ່ຢູ່ນີ້ສະນັ້ນທ່ານສາມາດປັບລະຫັດຜ່ານຂອງທ່ານ.</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="lo">Bloom ບໍ່ສາມາດເຊື່ອມຕໍ່ກັບ Server ໃນການປັບລະຫັດຜ່ານຂອງທ່ານ. ກະລຸນາກວດສອບການເຊື່ອມຕໍ່ເຄືອຂ່າຍຂອງທ່ານ.</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="lo">ລະຫັດຜ່ານເຮັດໃຫມ່ບໍ່ສໍາເລັດ</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="lo">ລະຫັດຜ່ານເຮັດໃຫມ່</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password</source>
         <target xml:lang="lo">ພວກເຮົາຈະສົ່ງ email ໄປ {0} ທີ່ມີຄໍາແນະນໍາສໍາລັບການຕັ້ງຄ່າລະຫັດຜ່ານຂອງທ່ານ.</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="lo">ຂຽນເຂົ້າເຖິງສໍາລັບ BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="lo">ຜູ້ທີ່ບໍ່ຮູ້ຈັກ</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="lo">Bloom ບໍ່ສາມາດເຂົ້າໃນການນໍາໃຊ້ BloomLibrary.org ຂໍ້ມູນທີ່ບັນທຶກໄວ້.</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="lo">ອອກຈາກ BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="lo">ການເຮັດ PDF Preview…</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="lo">ການເຮັດຮູບຂະຫນາດຫຍໍ້</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="lo">ຂໍອະໄພ, ສະບັບຂອງ Bloom Desktop ນີ້ແມ່ນບໍ່ເຫມາະສົມກັບສະບັບປະຈຸບັນຂອງ BloomLibrary.org. ກະລຸນາຍົກລະດັບເພື່ອສະບັບໃຫມ່ໄດ້.</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="lo">ກະລຸນາໃສ່ BloomLibrary.org (ຫຼືລົງທະບຽນ) ກ່ອນທີ່ຈະອັບໂຫລດ.</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="lo">ກະລຸນາທີ່ກໍານົດໄວ້ນີ້ ບັນນາທິການ</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="lo">Step 1: ຢືນຢັນ Metadata</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="lo">Step 2: ການອັບໂຫລດ</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="lo">ຄໍາແນະນໍາ: ໃບອະນຸຍາດການມອບຫມາຍແມ່ນງ່າຍທີ່ຈະຮັບຮູ້ມັນ. ທ່ານສາມາດໃຫ້ບາງສິ່ງບາງຢ່າງເພື່ອທຸກຄົນ.</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="lo">ຄໍາແນະນໍາ: ໃບອະນຸຍາດແມ່ນທີ່ງ່າຍທີ່ຈະຈື່ຈໍາ ເຮັດໃຫ້ມັນງ່າຍຂຶ້ນຫຼາຍສໍາລັບການປະຊາຊົນອື່ນໆທີ່ຈະນໍາໃຊ້ປຶ້ມຂອງທ່ານ, ເຖິງແມ່ນວ່າຖ້າຫາກວ່າພວກເຂົາເຈົ້າແມ່ນບໍ່ຊໍານານໃນພາສາຂອງໃບອະນຸຍາດທີ່ກໍາຫນົດຂອງທ່ານ.</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="lo">ສະຫລຸບຄວາມ</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="lo">ເງື່ອນໄຂການເບິ່ງແລະເງື່ອນໄຂ</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="lo">ຫົວຂໍ້  </target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="lo">ການອັບໂຫລດປື້ມບັນ</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <target xml:lang="lo">ຊົມເຊີຍ, "{0}" ໃນປັດຈຸບັນທີ່ມີຢູ່ໃນ  BloomLibrary.org ({1})</target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="lo">ອັບໂຫລດບໍ່ອະນຸຍາດ</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="lo">ມີບັນຫາການອັບໂຫຼດປຶ້ມຂອງທ່ານ. ທ່ານອາດຈະຈໍາເປັນຕ້ອງ ເປີດໃຫມ່ Bloom ຫຼືໄດ້ຮັບການຊ່ວຍເຫຼືອດ້ານວິຊາການ.</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="lo">ການອັບໂຫຼດຄວາມຄືບຫນ້າ</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="lo">ການອັບໂຫຼດປື້ມບັນ </target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="lo">ການອັບໂຫລດMetadataປຶ້ມ</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, &amp; topic tags to the bloomlibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="lo">ການອັບໂຫລດ {0}</target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="lo">CC-BY-NC</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="lo">ເຂົ້າສູ່ລະບົບ BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="lo">ຂຽນເຂົ້າເຖິງສໍາລັບ BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="lo">ເພີ່ມລະດັບ</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="lo">ເພີ່ມຂັ້ນຕອນ</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="lo">ປື້ມບັນ</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="lo">ຈໍານວນສູງສຸດຂອງຄໍາສັບຕ່າງໆຕໍ່ຫນັງສື</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="lo">ໃຫ້ຄລິກໃສ່ຕົວອັກສອນທີ່ຈະເພີ່ມໃນຂັ້ນຕອນນີ້</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="lo">ຂັ້ນຕອນ Decodable</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true" approved="yes">
         <source xml:lang="en">File needs .txt extension</source>
         <target xml:lang="lo">ໄຟລ໌ຕ້ອງການຂະຫຍາຍ. Txt</target>
         <note>ID: ReaderSetup.FileNeedsTxtExtension</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="lo">ຫນຶ່ງ,</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="lo">ບໍ່ສາມາດອ່ານຮູບແບບນີ້</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="lo">ຊ່ວຍເຫຼືອການສົ່ງອອກແລະການແປງໄຟລ໌ທີ່ຈະນໍາໃຊ້ເປັນຕົວຢ່າງຂໍ້ຄວາມ</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="lo">ຕົວອັກສອນ</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="lo">ຕົວອັກສອນແລະການປະສົມຕົວອັກສອນ</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="lo">ເພື່ອຊ່ວຍໃຫ້ທ່ານ decodable readers, Bloom ທີ່ຈະຮູ້ວ່າຕົວອັກສອນແລະການປະສົມຈົດຫມາຍທີ່ທ່ານຈະໄດ້ຮັບການສິດສອນ.</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="lo">ແຍກຕ່າງຫາກຈົດຫມາຍບຸກຄົນຫຼືການປະສົມຈົດຫມາຍສະບັບທີ່ </target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="lo">ສັງເກດເຫັນວ່າບັນຊີລາຍການປະກອບມີການນໍາໃຊ້ພາສາອັງກິດໃນໂລກ.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="lo">ມັນເປັນການ</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="lo">.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="lo">ລະດັບ </target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="lo">ລະດັບ </target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="lo">ລະດັບ Reader</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="lo">ຄໍາທີ່ຄ້ອງກັນ</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="lo">ຈໍາເປັນເອກະລັກ ນວນສູງສຸດຕໍ່ບັນຊີ</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="lo">ຫນ້າ</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="lo">ຈໍານວນສູງສຸດໃນແຕ່ລະຫນ້າ</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="lo">Powered ໂດຍ</target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="lo">ລະດັບ Reader</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="lo">ລົບລະດັບ {0}</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="lo">ລົບລໍາດັບ {0}</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="lo">ການດຶງແຖວເກັດລະດັບໃຫມ່</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="lo">ການດຶງແຖວເກັດລໍາດັບໃຫມ່</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="lo">, Search Engine ສໍາລັບ ການສອນອ່ານຂຽນ</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="lo">ທີ່ຜ່ານມາແລະໃຫມ່ອັກສອນ</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="lo">ປະໂຍກທີ່</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="lo">ຄໍາສັບຕ່າງໆໃນປະໂຫຍກແຕ່ລະຄົນ</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="lo">ຕິດຕັ້ງ Decodable Reader Tool</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="lo">ຕິດຕັ້ງ Leveled Reader Tool</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <target xml:lang="lo">ການຕິດຕັ້ງຕົວອັກສອນທີ່ສໍາລັບພາສານີ້.</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="lo">ຄໍາສັບຮູບພາບໃຫມ່</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="lo">ຄໍາສັບຮູບພາບ</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="lo">ຂັ້ນຕອນ</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="lo">ຂັ້ນຕອນ</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="lo">ຂັ້ນຕອນຈໍານວນຫຼາຍ</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="lo">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="lo">ສິ່ງທີ່ຄວນຈໍາສໍາລັບໃນລະດັບນີ້:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="lo">ເປັນເອກະລັກ</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="lo">ຄໍາສັບຕ່າງໆ</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage.  There are two ways to give words to Bloom:</source>
         <target xml:lang="lo">ເພື່ອຊ່ວຍໃຫ້ທ່ານເຮັດແນວໃດ decodable, Bloom ສາມາດແນະນໍາທີ່ເຫມາະສົມພາຍໃນຂັ້ນຕອນປະຈຸບັນ. ມີສອງວິທີການເພື່ອເຮັດໃຫ້ Bloom ແມ່ນ:</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="lo">2) ການຈັດວາງໄຟລ໌ໃນຂໍ້ຄວາມຂອງທ່ານ.</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <target xml:lang="lo">Folder ຕົວຢ່າງຂໍ້ຄວາມ</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="lo">1) ປະເພດຄໍາສັບຕ່າງໆຕໍ່ໄປນີ້</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="lo">ອັກສອນ</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this BloomPack will carry your latest decodable and leveled reader settings for the \"{0}\" language. Anyone opening this BloomPack , who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this BloomPack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="lo">ນອກຈາກນີ້, BloomPack ນີ້ຈະປະຕິບັດການຕັ້ງຄ່າຫຼ້າສຸດ decodable ແລະ leveled reader ຂອງທ່ານສໍາລັບ  \"{0}\" ພາສາ. ຜູ້ທີ່ໄດ້ເປີດ BloomPack ນີ້, ມັນຈະເປີດຂຶ້ນ \ "{0} \" ການເກັບກໍາ, ການຕັ້ງຄ່າໃນປະຈຸບັນອ່ານບົດທີ່ decodable ແລະ leveled reader ແທນທີ່ດ້ວຍການຕັ້ງຄ່າໃນ BloomPack ໄດ້. ພວກເຂົາເຈົ້າແມ່ນໄດ້ຮັບຍັງໄດ້ກໍານົດໄວ້ໃນປະຈຸບັນຂອງຄໍາສັບຕ່າງໆທີ່ນໍາໃຊ້ decodable readers.</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="lo">ແມ່ແບບ</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <target xml:lang="lo">ບັນທຶກ Bloom Pack</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <target xml:lang="lo">ເຮັດແມ່ແບບ Bloom Pack …</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="lo">ທີ່ຢູ່ອີເມວ</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="lo">ຊື່ທໍາອິດ</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="lo">ກະລຸນາໃຊ້ເວລານາທີທີ່ຈະລົງທະບຽນ {0}</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="lo">ທ່ານການນໍາໃຊ້ {0} ວິທີການ?</target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="lo">ຂ້ອຍຈະສໍາເລັດຮູບພາຍຫລັງນີ້</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="lo">ອົງການຈັດຕັ້ງ</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="lo">&amp;ລົງທະບຽນ</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="lo">ນາມສະກຸນ</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="lo">ລົງທະບຽນ {0}</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <target xml:lang="lo">ປິດ</target>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.CouldNotSendToServer">
+      <trans-unit id="ReportProblemDialog.CouldNotSendToServer" approved="yes">
         <source xml:lang="en">Bloom was not able to submit your report directly to our server. Please retry or email {0} to {1}.</source>
         <target xml:lang="lo">Bloom ບໍ່ສາມາດສົ່ງບົດລາຍງານຂອງທ່ານໂດຍກົງກັບ Server ຂອງພວກເຮົາ. ກະລຸນາພະຍາຍາມອີກເທື່ອຫນຶ່ງຫຼື ອີແມລ  {0} to {1}.</target>
         <note>ID: ReportProblemDialog.CouldNotSendToServer</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Email">
+      <trans-unit id="ReportProblemDialog.Email" approved="yes">
         <source xml:lang="en">Email</source>
         <target xml:lang="lo">ອີແມລ </target>
         <note>ID: ReportProblemDialog.Email</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeBookButton">
+      <trans-unit id="ReportProblemDialog.IncludeBookButton" approved="yes">
         <source xml:lang="en">Include Book '{0}'</source>
         <target xml:lang="lo">ປະກອບມີປຶ້ມ '{0}'</target>
         <note>ID: ReportProblemDialog.IncludeBookButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton">
+      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton" approved="yes">
         <source xml:lang="en">Include this screenshot</source>
         <target xml:lang="lo">ລວມພາບຫນ້າຈໍນີ້</target>
         <note>ID: ReportProblemDialog.IncludeScreenshotButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Name">
+      <trans-unit id="ReportProblemDialog.Name" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="lo">ຊື່</target>
         <note>ID: ReportProblemDialog.Name</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Retry">
+      <trans-unit id="ReportProblemDialog.Retry" approved="yes">
         <source xml:lang="en">Retry</source>
         <target xml:lang="lo">ລອງໃຫມ່</target>
         <note>ID: ReportProblemDialog.Retry</note>
         <note>Shown if there was an error submitting the report. Lets the user try submitting it again.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SeeDetails">
+      <trans-unit id="ReportProblemDialog.SeeDetails" approved="yes">
         <source xml:lang="en">See what else will be submitted</source>
         <target xml:lang="lo">ແມ່ນຫຍັງທີ່ຈະສົ່ງ.</target>
         <note>ID: ReportProblemDialog.SeeDetails</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SubmitButton">
+      <trans-unit id="ReportProblemDialog.SubmitButton" approved="yes">
         <source xml:lang="en">&amp;Submit</source>
         <target xml:lang="lo">&amp;ສົ່ງ</target>
         <note>ID: ReportProblemDialog.SubmitButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Submitting">
+      <trans-unit id="ReportProblemDialog.Submitting" approved="yes">
         <source xml:lang="en">Submitting to server...</source>
         <target xml:lang="lo">ສົ່ງກັບ Server…..</target>
         <note>ID: ReportProblemDialog.Submitting</note>
         <note>This is shown while Bloom is sending the problem report to our server.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Success">
+      <trans-unit id="ReportProblemDialog.Success" approved="yes">
         <source xml:lang="en">We received your report, thanks for taking the time to help make Bloom better!</source>
         <target xml:lang="lo">ພວກເຮົາໄດ້ຮັບບົດລາຍງານຂອງທ່ານ, ຂໍຂອບໃຈສໍາລັບການກິນທີ່ໃຊ້ເວລາເພື່ອຊ່ວຍເຮັດໃຫ້ Bloomດີກວ່າ</target>
         <note>ID: ReportProblemDialog.Success</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WhatsTheProblem">
+      <trans-unit id="ReportProblemDialog.WhatsTheProblem" approved="yes">
         <source xml:lang="en">What seems to be the problem?</source>
         <target xml:lang="lo">ແມ່ນຫຍັງຄືບັນຫາ?</target>
         <note>ID: ReportProblemDialog.WhatsTheProblem</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WindowTitle">
+      <trans-unit id="ReportProblemDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Report A Problem</source>
         <target xml:lang="lo">ລາຍງານບັນຫາ</target>
         <note>ID: ReportProblemDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Zipping">
+      <trans-unit id="ReportProblemDialog.Zipping" approved="yes">
         <source xml:lang="en">Zipping up book...</source>
         <target xml:lang="lo">ຊິບຫນັງສື ...</target>
         <note>ID: ReportProblemDialog.Zipping</note>
         <note>This is shown while Bloom is creating the problem report. It's generally too fast to see, unless you include a large book.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="lo">ຫນັງສືພື້ນຖານ</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="lo">ປື້ມບັນຂະຫນາດໃຫຍ່</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="lo">Decodable Reader</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="lo">Leveled Reader</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="lo">ວັດຈະນານຸກົມຮູບພາບ</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="lo">ປະຕິທິນຜະນັງ</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="lo">ການກະສິກໍາ</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="lo">ນິທານທີ່ເປັນສັດ</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="lo">ທຸລະກິດ</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="lo">ດໍາລົງຊີວິດຂອງຊຸມຊົນ</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="lo">ວັດທະນະທໍາ</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="lo">ວັດຈະນານຸກົມ</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="lo">ສະພາບແວດລ້ອມ</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="lo">ເລື່ອງອ່ານສໍາລັບຄວາມສຸກ</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="lo">ສຸຂະພາບ</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="lo">ສຸຂະພາບ</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="lo">ຄະນິດສາດ </target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.NoTopic" sil:dynamic="true">
+      <trans-unit id="Topics.NoTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">No Topic</source>
         <target xml:lang="lo">ຫົວຂໍ້ທີ່ບໍ່ມີ</target>
         <note>ID: Topics.NoTopic</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="lo">ບໍ່ແມ່ນເລື່ອງອ່ານສໍາລັບຄວາມສຸກ</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="lo">ການພັດທະນາສ່ວນບຸກຄົນ</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="lo">Primer</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="lo">ວິທະຍາສາດ</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="lo">ທາງວິນຍານ</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Story Book" sil:dynamic="true">
+      <trans-unit id="Topics.Story Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Story Book</source>
         <target xml:lang="lo">ປື້ມບັນ Story</target>
         <note>ID: Topics.Story Book</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="lo">ປະເພນີ</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="lo">ເລື່ອງປະເພນີ</target>
         <note>ID: Topics.Traditional Story</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="lo">ການຕິດຕັ້ງ</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
       </trans-unit>
-      <trans-unit id="You may use this space for author/illustrator, or anything else." sil:dynamic="true">
+      <trans-unit id="You may use this space for author/illustrator, or anything else." sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="lo">ທ່ານອາດຈະນໍາໃຊ້ພື້ນທີ່ນີ້ສໍາລັບນັກປະພັນ  /ບຸກຄົນແຕ້ມຮູບໄດ້, ຫຼືຫຍັງອີກແດ່.</target>
         <note>ID: You may use this space for author/illustrator, or anything else.</note>

--- a/DistFiles/localization/ne/Bloom.xlf
+++ b/DistFiles/localization/ne/Bloom.xlf
@@ -2,1192 +2,1192 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="ne" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="AboutDialog.AboutDialogWindowTitle">
+      <trans-unit id="AboutDialog.AboutDialogWindowTitle" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="ne">Bloom को बारेमा</target>
         <note>ID: AboutDialog.AboutDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="ne">डिकोडेबल पाठ्यपुस्तक उपकरण</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="ne">स्तर तोकिएको पाठ्यपुस्तक उपकरण</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="ne">थप...</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allow changes to this shellbook</source>
         <target xml:lang="ne">यो खाका पुस्तकमा फेरबदल गर्न दिनुहोस्</target>
         <note>ID: EditTab.Toolbox.Settings.Unlock</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom normally prevents most changes to shellbooks. If you need to add pages, change images, etc., tick the box below.</source>
         <target xml:lang="ne">सामान्यतया Bloom ले खाका पुस्तकहरूमा फेरबदल गर्न दिँदैन।तपाईंले पृष्ठहरू थप्ने, छविहरू परिवर्तन गर्ने, इत्यादि गर्नुपर्ने भएमा तलको बाकसमा ठीक चिन्ह लगाउनुहोस्।</target>
         <note>ID: EditTab.Toolbox.Settings.UnlockShellBookIntroductionText</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState" approved="yes">
         <source xml:lang="en">Bloom recording is in an unusual state, possibly caused by unplugging a microphone. You will need to restart.</source>
         <target xml:lang="ne">Bloom रेकर्डिङ असामान्य स्थितिमा छ। शायद माइक्रोफोन निकालेको हुनाले यसो भएको हुन सक्छ।तपाईंले यसलाई पुनः सुरू गर्नुपर्ने हुन्छ।</target>
         <note>ID: EditTab.Toolbox.TalkingBook.BadState</note>
         <note>This is very low priority for translation.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput" approved="yes">
         <source xml:lang="en">No input device</source>
         <target xml:lang="ne">इनपुट यन्त्र छैन</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoInput</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic" approved="yes">
         <source xml:lang="en">This computer appears to have no sound recording device available. You will need one to record audio for a talking book.</source>
         <target xml:lang="ne">यो कम्प्युटरमा ध्वनि रेकर्ड गर्ने कुनै उपकरण उपलब्ध छैन जस्तो छ।श्रव्य पुस्तक बनाउन तपाईंले अडियो रेकर्ड गर्न आवश्यक हुन्छ।</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoMic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage" approved="yes">
         <source xml:lang="en">Please hold the button down until you have finished recording</source>
         <target xml:lang="ne">कृपया रेकर्ड गर्ने कार्य नसकिँदासम्म यो बटन थिचिराख्नुहोस्</target>
         <note>ID: EditTab.Toolbox.TalkingBook.PleaseHoldMessage</note>
         <note>Appears when the speak/record button is pressed very briefly</note>
       </trans-unit>
-      <trans-unit id="BloomIntegrity.WindowTitle">
+      <trans-unit id="BloomIntegrity.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom Problem</source>
         <target xml:lang="ne">Bloom मा समस्या</target>
         <note>ID: BloomIntegrity.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="BloomIntegrityDialog.ReportProblem">
+      <trans-unit id="BloomIntegrityDialog.ReportProblem" approved="yes">
         <source xml:lang="en">Report Problem</source>
         <target xml:lang="ne">समस्या रिपोर्ट गर्नुहोस्</target>
         <note>ID: BloomIntegrityDialog.ReportProblem</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName">
+      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName" approved="yes">
         <source xml:lang="en">Possibly this is an old Bloom Pack created before Bloom Packs could handle special characters in file names. You may be able to get the author to re-create it using a current version. If that's not possible a technical expert may be able to repair things.</source>
         <target xml:lang="ne">सम्भवतः यो पुरानो Bloom प्याक हो जुन शायद फाइलको नामहरूमा भएको विशेष वर्णहरूलाई Bloom प्याकले समावेश गर्न सक्नुभन्दा पहिले सिर्जना गरिएको थियो।तपाईंले यसको लेखकलाई हालको संस्करण प्रयोग गरेर यसलाई पुनः बनाउन अनुरोध गर्न सक्नुहुन्छ। त्यसो गर्न सम्भव छैन भने, प्राविधिक विशेषज्ञले यो समस्या समाधान गर्न मद्दत गर्न सक्छ।</target>
         <note>ID: BloomPackInstallDialog.BadCharsInFileName</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="ne">Bloom प्याकको स्थापना</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">
           The {0} Collection is now ready to use on this computer.
         </source>
         <target xml:lang="ne">{0} सङ्ग्रह अब यो कम्प्युटरमा प्रयोग गरिनको लागि तयार छ।</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller" approved="yes">
         <source xml:lang="en">Bloom Pack Installer</source>
         <target xml:lang="ne">Bloom प्याक स्थापनाकर्ता</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstaller</note>
         <note>Displayed as the message box title</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack">
+      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack" approved="yes">
         <source xml:lang="en">This BloomPack appears to be incomplete or corrupt.</source>
         <target xml:lang="ne">यो Bloom प्याक अपूर्ण वा खराब छ जस्तो देखिन्छ।</target>
         <note>ID: BloomPackInstallDialog.CorruptBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.DoesNotExist">
+      <trans-unit id="BloomPackInstallDialog.DoesNotExist" approved="yes">
         <source xml:lang="en">{0} does not exist</source>
         <target xml:lang="ne">{0} विद्यमान छैन</target>
         <note>ID: BloomPackInstallDialog.DoesNotExist</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="ne">Bloom ले  त्यो Bloom प्याक स्थापना गर्न सकेन</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="ne">झिक्दै...</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while Bloom Packs are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="ne">Bloom चलिरहेको छ, तर तपाईंले Bloom लाई अर्कोपटक फेरि सुरु नगर्दासम्म यी सामग्रीहरू देखिनेछैनन्</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.NotInstalled">
+      <trans-unit id="BloomPackInstallDialog.NotInstalled" approved="yes">
         <source xml:lang="en">The Bloom collection will not be installed.</source>
         <target xml:lang="ne">Bloom  सङ्ग्रह स्थापना गरिनेछैन।</target>
         <note>ID: BloomPackInstallDialog.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="ne">{0} खोल्दै...</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Replace">
+      <trans-unit id="BloomPackInstallDialog.Replace" approved="yes">
         <source xml:lang="en">This computer already has a Bloom collection named '{0}'. Do you want to replace it with the one from this Bloom Pack?</source>
         <target xml:lang="ne">यो कम्प्युटरमा पहिले नै '{0}' नामक Bloom सङ्ग्रह रहेको छ। के तपाईं यसलाई यो Bloom प्याकको कुनै एउटा सङ्ग्रहले प्रतिस्थापन गर्न चाहनुहुन्छ?</target>
         <note>ID: BloomPackInstallDialog.Replace</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder">
+      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder" approved="yes">
         <source xml:lang="en">Bloom Packs should have only a single collection folder at the top level of the .ZIP file.</source>
         <target xml:lang="ne"> .ZIP फाइलको शीर्ष तहमा Bloom प्याकको केवल एउटा मात्र सङ्ग्रह फोल्डर हुनुपर्छ।</target>
         <note>ID: BloomPackInstallDialog.SingleCollectionFolder</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.UnableToReplace">
+      <trans-unit id="BloomPackInstallDialog.UnableToReplace" approved="yes">
         <source xml:lang="en">Bloom was not able to remove the existing copy of '{0}'. Quit Bloom if it is running &amp; try again. Otherwise, try again after restarting your computer.</source>
         <target xml:lang="ne">Bloom ले '{0}' को विद्यमान प्रतिलिपिलाई हटाउन सकेन। यदि Bloom चलिरहेको छ भने बन्द गर्नुहोस् र फेरि प्रयास गर्नुहोस्। अथवा, आफ्नो कम्प्युटर रिस्टार्ट गरेर फेरि प्रयास गर्नुहोस्।</target>
         <note>ID: BloomPackInstallDialog.UnableToReplace</note>
       </trans-unit>
-      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true">
+      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To select, use your mouse wheel or point at what you want, then release the key.</source>
         <target xml:lang="ne">चयन गर्न, आफ्नो माउसको व्हील प्रयोग गर्नुहोस् वा पोइन्टरलाई आफूले चाहेको वर्णमा लानुहोस् र कुञ्जीबाट औंला हटाउनुहोस्।</target>
         <note>ID: BookEditor.CharacterMap.Instructions</note>
         <note>When you hold down a key, a popup appears that lets you choose a related character. These instructions are shown in that popup.</note>
       </trans-unit>
-      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is the default for all text boxes with '{0}' style</source>
         <target xml:lang="ne">यो ढाँचा '{0}' शैलीका सबै पाठ बाकसहरूको पूर्वनिर्धारित ढाँचा हो।</target>
         <note>ID: BookEditor.DefaultForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all text boxes with '{0}' style</source>
         <target xml:lang="ne">यो ढाँचा '{0}' शैलीका सबै पाठ बाकसहरूको लागि हो।</target>
         <note>ID: BookEditor.ForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text boxes with '{1}' style</source>
         <target xml:lang="ne">यो ढाँचा '{1}' शैलीका सबै {0} पाठ बाकसहरूको लागि हो।</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true">
+      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sorry, Reader Templates do not allow changes to formatting.</source>
         <target xml:lang="ne">माफ गर्नुहोस्, पाठ्यपुस्तक टेम्प्लेटहरूले ढाँचा परिवर्तन गर्न दिँदैन।</target>
         <note>ID: BookEditor.FormattingDisabled</note>
       </trans-unit>
-      <trans-unit id="BookStorage.FolderMoved">
+      <trans-unit id="BookStorage.FolderMoved" approved="yes">
         <source xml:lang="en">It appears that some part of the folder path to this book has been moved or renamed. As a result, Bloom cannot save your changes to this page, and will need to exit now. If you haven't been renaming or moving things, please click Details below and report the problem to the developers.</source>
         <target xml:lang="ne">यो पुस्तक अवस्थित फोल्डरको पथबाट केही भाग कतै सारिएको वा नाम परिवर्तन गरिएको छ जस्तो देखिन्छ।फलस्वरूप, Bloom ले तपाईंले यो पृष्ठमा गर्नुभएका परिवर्तनहरू सुरक्षित गर्न सक्दैन, र यसलाई तुरुन्त बन्द गर्न आवश्यक हुनेछ।तपाईंले फोल्डरको पथको कुनैपनि भागको नाम परिवर्तन गर्नुभएको छैन वा कतै सार्नुभएको छैन भने, तल विस्तृत विवरणमा क्लिक गर्नुहोस् र यस समस्याको बारेमा यो सफ्टवेयर विकासकर्ताहरूलाई सूचित गर्नुहोस्।</target>
         <note>ID: BookStorage.FolderMoved</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="ne">प्रोग्रामको उन्नत सेटिङहरू</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate" approved="yes">
         <source xml:lang="en">Automatically update Bloom</source>
         <target xml:lang="ne">Bloom लाई स्वचालित रूपमा अद्यावधिक गर्नुहोस्</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AutoUpdate</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="ne">प्रयोगात्मक आदेशहरू देखाउनुहोस् (उदाहरणको लागि, InDesign मा खुल्ने XML निर्यात गर्ने)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="ne">प्रयोगात्मक टेम्प्लेटहरू देखाउनुहोस् (उदाहरणको लागि, सचित्र शब्दकोष)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="ne">ठूला छविहरूको कारणले हुने मेमोरीको खपत कम गर्न इमेज सर्भर प्रयोग गर्नुहोस्।</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="ne">(प्रयोगात्मक) पठाउने/प्राप्त गर्ने नियन्त्रणहरू देखाउनुहोस्</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom is switching the default font for "{0}" to the new "Andika New Basic".</source>
         <target xml:lang="ne">Bloom ले "{0}" को पूर्वनिर्धारित फन्टलाई नयाँ "Andika New Basic" फन्ट मा बदल्दै छ।</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate1</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This will improve the printed output for most languages. If your language is one of the few that need "Andika", you can switch it back in Settings:Book Making.</source>
         <target xml:lang="ne"> यो फन्टले अधिकांस भाषाहरूमा मुद्रित सामग्रीहरूलाई सुधार्ने छ यदि तपाईंको भाषा "Andika" फन्ट चाहिने थोरै भाषाहरू मध्ये एक हो भने, तपाईंले यसलाई सेटिङहरू:पुस्तक तयार पर्नेमा गएर पुनः बदल्न सक्नुहुन्छ।</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate2</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="ne">पुस्तक तयार पार्नु</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="ne">{0} को पूर्वनिर्धारित फन्ट</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="ne">अगाडि/पछाडिको आवरण पृष्ठमा लेख्ने सामग्रीको प्याक</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftTip">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftTip" approved="yes">
         <source xml:lang="en">Select languages that are written from right to left</source>
         <target xml:lang="ne">दायाँ देखि बायाँतिर लेखिने भाषाहरू चयन गर्नुहोस्</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftTip</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="ne">दायाँ देखि बायाँतिर लेख्ने प्रणाली</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink" approved="yes">
         <source xml:lang="en">Special Script Settings</source>
         <target xml:lang="ne">विशेष लिपि सम्बन्धी सेटिङहरू</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="ne">सेटिङहरू</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="ne">परिवर्तन गर्नुहोस्...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="ne">भाषा 1</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="ne">भाषा 2</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="ne">भाषा 3</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="ne">भाषाहरू</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="ne">सेट गर्नुहोस्...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="ne">मातृभाषा</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="ne">भाषा 2 (उदाहरणको लागि, राष्ट्रिय भाषा)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="ne">भाषा 3 (उदाहरणको लागि, क्षेत्रीय भाषा) (ऐच्छिक)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="ne">हटाउनुहोस्</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="ne">Bloom सङ्ग्रहको नाम</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="ne">देश</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="ne">जिल्ला</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="ne">परियोजनाको जानकारी</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="ne">प्रान्त</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="ne">रिस्टार्ट गर्नुहोस्</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="ne">Bloom बन्द हुनेछ र नयाँ सेटिङहरू सहित यस यो परियोजनालाई पुनः खोल्नेछ।</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="ne">कागज जोगाउने</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver</note>
         <note>Name of a Front/Back Matter Pack that puts credits on the inside of the front cover</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="ne">परम्परागत</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional</note>
         <note>Name of the default Front/Back Matter Pack</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book. These programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="ne">Bloom ले अब यस HTML डकुमेन्टलाई तपाईंको शब्द प्रशोधन प्रोग्राम (सामान्तया Word वा LibreOffice) मा खोल्नेछ। तपाईंले यस पुस्तकको लिखित सामग्री र छविहरूमा काम गर्न सक्नुहुनेछ।यी प्रोग्रामहरूले पुस्तकको सजावट राम्रोसँग संरक्षण गर्न नसक्ने भएकाले, खासै राम्रो हुने अपेक्षा नगर्नुहोस्।</target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="ne">पुस्तक अद्यावधिक गर्नुहोस्</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="ne">थम्बनेल अद्यावधिक गर्नुहोस्</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DuplicateBook">
+      <trans-unit id="CollectionTab.BookMenu.DuplicateBook" approved="yes">
         <source xml:lang="en">Duplicate Book</source>
         <target xml:lang="ne">पुस्तक नक्कल गर्नुहोस्</target>
         <note>ID: CollectionTab.BookMenu.DuplicateBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="ne">पुस्तक मेट्नुहोस्</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="ne">Word वा LibreOffice मा निर्यात गर्नुहोस्...</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="ne">InDesign मा खुल्ने XML मा निर्यात गर्नुहोस्...</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="ne">BloomLibrary.org का पुस्तकहरू</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="ne">सबै पुस्तकहरू अद्यावधिक गर्नुहोस्</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="ne">सबै पुस्तकहरूको जाँच गर्नुहोस्</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="ne">छुटेका छविहरू पुनः प्राप्त गर्नुहोस्...</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="ne">सङ्ग्रहको इतिहास...</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="ne">सङ्ग्रहसम्बन्धी  टिपोटहरू...</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="ne">सङ्ग्रहहरू</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="ne">सङ्ग्रहहरू</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="ne">'{0}' पुस्तक</target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="ne">डिस्कमा भएको फोल्डर खोल्नुहोस्</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="ne">स्वास्थ्य</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <target xml:lang="ne">यो स्रोत प्रयोग गरेर पुस्तक तयार पार्नुहोस्</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_" approved="yes">
         <source xml:lang="en">Create a book in my language using this source book</source>
         <target xml:lang="ne">यो स्रोत पुस्तक प्रयोग गरेर मेरो भाषामा पुस्तक तयार पार्नुहोस्</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate_ToolTip_</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="ne">अन्य सङ्ग्रह</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_" approved="yes">
         <source xml:lang="en">Open/Create/Get Collection</source>
         <target xml:lang="ne">सङ्ग्रह खोल्नुहोस्/बनाउनुहोस्/प्राप्त गर्नुहोस्</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton_ToolTip_</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="ne">नमूना आवरणहरू</target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="ne">प्राप्त गर्नुहोस्/पठाउनुहोस्</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="ne">सेटिङहरू</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ne">स्रोतको सङ्ग्रह</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="ne">अतिरिक्त सङ्ग्रहहरू नामक फोल्डर खोल्नुहोस्</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="ne">टेम्प्लेटहरू</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.TitleMissing">
+      <trans-unit id="CollectionTab.TitleMissing" approved="yes">
         <source xml:lang="en">Title Missing</source>
         <target xml:lang="ne">शीर्षक छैन</target>
         <note>ID: CollectionTab.TitleMissing</note>
         <note>Shown as the thumbnail caption when the book doesn't have a title</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UnableToCheckForUpdate">
+      <trans-unit id="CollectionTab.UnableToCheckForUpdate" approved="yes">
         <source xml:lang="en">Could not connect to the server to check for an update. Are you connected to the internet?</source>
         <target xml:lang="ne">अद्यावधिकको जाँच गर्न सर्भरमा पहुँच गर्न सकिएन। के तपाईं इन्टरनेटमा जडित हुनुहुन्छ?</target>
         <note>ID: CollectionTab.UnableToCheckForUpdate</note>
         <note>Shown when Bloom tries to check for an update but can't, for example because it can't connect to the internet, or a problems with our server, etc.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpToDate">
+      <trans-unit id="CollectionTab.UpToDate" approved="yes">
         <source xml:lang="en">Your Bloom is up to date.</source>
         <target xml:lang="ne">तपाईंको Bloom नवीनतम छ।</target>
         <note>ID: CollectionTab.UpToDate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateCheckInProgress">
+      <trans-unit id="CollectionTab.UpdateCheckInProgress" approved="yes">
         <source xml:lang="en">Bloom is already working on checking for updates.</source>
         <target xml:lang="ne">Bloom ले अद्यावधिकहरू जाँच्ने कार्य पहिले नै थालिसकेको छ।</target>
         <note>ID: CollectionTab.UpdateCheckInProgress</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateFailed">
+      <trans-unit id="CollectionTab.UpdateFailed" approved="yes">
         <source xml:lang="en">A new version appears to be available, but Bloom could not install it.</source>
         <target xml:lang="ne">एउटा नयाँ संस्करण उपलब्ध छ जस्तो छ, तर Bloom ले सो संस्करण स्थापना गर्न सकेन।</target>
         <note>ID: CollectionTab.UpdateFailed</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateInstalled">
+      <trans-unit id="CollectionTab.UpdateInstalled" approved="yes">
         <source xml:lang="en">Update for {0} is ready</source>
         <target xml:lang="ne">{0} को अद्यावधिक तयार छ</target>
         <note>ID: CollectionTab.UpdateInstalled</note>
         <note>Appears after Bloom has downloaded a program update in the background and is ready to switch the user to it the next time they run Bloom.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateNow">
+      <trans-unit id="CollectionTab.UpdateNow" approved="yes">
         <source xml:lang="en">Update Now</source>
         <target xml:lang="ne">अहिले अद्यावधिक गर्नुहोस्</target>
         <note>ID: CollectionTab.UpdateNow</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdatesAvailable">
+      <trans-unit id="CollectionTab.UpdatesAvailable" approved="yes">
         <source xml:lang="en">A new version of Bloom is available.</source>
         <target xml:lang="ne">Bloom को नयाँ संस्करण उपलब्ध छ।</target>
         <note>ID: CollectionTab.UpdatesAvailable</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Updating">
+      <trans-unit id="CollectionTab.Updating" approved="yes">
         <source xml:lang="en">Downloading update to {0} ({1}kb)</source>
         <target xml:lang="ne">अद्यावधिकलाई {0} मा डाउनलोड गर्दै ({1}केबि)</target>
         <note>ID: CollectionTab.Updating</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="ne">यो पुस्तक सम्पादन गर्नुहोस्</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="ne">Bloom प्याक बनाउनुहोस</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <target xml:lang="ne">पाठ्यपुस्तक टेम्प्लेटको Bloom प्याक बनाउनुहोस्...</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdminManagesUpdates">
+      <trans-unit id="CollectionTab.AdminManagesUpdates" approved="yes">
         <source xml:lang="en">Your system administrator manages Bloom updates for this computer.</source>
         <target xml:lang="ne">तपाईंको प्रणालीको प्रशासकले यो कम्प्युटरमा Bloom को अद्यावधिकहरू व्यवस्थापन गर्दछ।</target>
         <note>ID: CollectionTab.AdminManagesUpdates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="ne">उन्नत</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Applying">
+      <trans-unit id="CollectionTab.Applying" approved="yes">
         <source xml:lang="en">Applying updates</source>
         <target xml:lang="ne">अद्यावधिकहरू लागू गर्दै</target>
         <note>ID: CollectionTab.Applying</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="ne">BloomLibrary.org मा थप स्रोत पुस्तकहरू पाउनुहोस्</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ne">स्रोतको सङ्ग्रह</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="ne">नयाँ पुस्तकका स्रोतहरू</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="ne">यो सङ्ग्रह लक गरिएको छ, तसर्थ नयाँ पुस्तकहरू थप्न/हटाउन सकिँदैन।</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="ne">यो एउटा स्रोत सङ्ग्रह भएकाले Bloom ले कुनै विद्यमान आवरणहरूलाई नयाँ आवरणको स्रोतको रूपमा प्रदान गरिरहेको छैन। तपाईं कुनै खाकामा भाषा थप्न चाहनुहुन्छ भने, तपाईंले सो खाकाको प्रतिलिपि बनाउनुभन्दा सो खाका समावेश सङ्ग्रहलाई सम्पादन गर्नु उचित हुन्छ।साथै, हाल भित्ते पात्रोलाई नयाँ खाका बनाउन प्रयोग गर्न सकिँदैन।</target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="ne">थप...</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem">
+      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem" approved="yes">
         <source xml:lang="en">Open or Create Another Collection</source>
         <target xml:lang="ne">अर्को सङ्ग्रह खोल्नुहोस् वा बनाउनुहोस्</target>
         <note>ID: CollectionTab.OpenCreateCollectionMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="ne">नयाँ आवरणका स्रोतहरू</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="ne">पछाडि</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="ne">रद्द गर्नुहोस्</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="ne">&amp;रद्द गर्नुहोस्</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="ne">&amp;सम्पन्न भयो</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="ne">&amp;मद्दत</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Loading" sil:dynamic="true">
+      <trans-unit id="Common.Loading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Loading...</source>
         <target xml:lang="ne">लोड हुँदैछ...</target>
         <note>ID: Common.Loading</note>
         <note>This is shown when Bloom is slowly loading something, so the user doesn't worry about why they don't see the result immediately.</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="ne">&amp;अर्को</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="ne">अर्को</target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="ne">ठीक छ</target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="ne">&amp;ठीक छ</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="ne">ऐच्छिक</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="ne">निर्माण गर्दै...</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="ne">यो चरणमा प्रयोग हुने अक्षरहरू</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="ne">अक्षर र शब्द सूचीको फाइल खोल्नुहोस्</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="ne">चरणहरू सेट अप गर्नुहोस्</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed words in this stage</source>
         <target xml:lang="ne">यो चरणमा प्रयोग गर्न पाइने शब्दहरू</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles" approved="yes">
         <source xml:lang="en">Text files</source>
         <target xml:lang="ne">पाठ्य फाइलहरू</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters" approved="yes">
         <source xml:lang="en">Letters: {0}</source>
         <target xml:lang="ne">अक्षरहरू: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage" approved="yes">
         <source xml:lang="en">The following is a generated report of the decodable stages for {0}. You can make any changes you want to this file, but Bloom will not notice your changes. It is just a report.</source>
         <target xml:lang="ne">देहायको प्रतिवेदन {0} को डिकोडेबल चरणहरूको प्रतिवेदन हो।तपाईंले यो फाइलमा आफूले चाहेको कुनैपनि कुरा परिवर्तन गर्न सक्नुहुन्छ, तर Bloom ले तपाईंले गरेका परिवर्तनहरूलाई ध्यान दिने छैन।यो एउटा प्रतिवेदन मात्र हो।</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords" approved="yes">
         <source xml:lang="en">New Decodable Words: {0}</source>
         <target xml:lang="ne">डिकोड गर्न सकिने नयाँ शब्द: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords" approved="yes">
         <source xml:lang="en">New Sight Words: {0}</source>
         <target xml:lang="ne">धेरै प्रयोग हुने नयाँ शब्द: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage" approved="yes">
         <source xml:lang="en">Stage {0}</source>
         <target xml:lang="ne">चरण {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList" approved="yes">
         <source xml:lang="en">Complete Word List</source>
         <target xml:lang="ne">पूर्ण शब्द सूची</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom can handle only the first {0} words.</source>
         <target xml:lang="ne">Bloom ले पहिलो {0} शब्दहरू मात्र सम्हाल्न सक्छ।</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Generate a letter and word list report</source>
         <target xml:lang="ne">अक्षर र शब्द सूचीको रिपोर्ट निकाल्नुहोस्</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="ne">चरण</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="ne">को</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="ne">यो चरणमा प्रयोग हुने शब्दहरू</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete.You can see it in the 'Books from BloomLibrary.org' section of your Collections.</source>
         <target xml:lang="ne">तपाईंको डाउनलोड ({0}) पूरा भएको छ।तपाईंले यसलाई आफ्नो सङ्ग्रहको 'BloomLibrary.org का पुस्तकहरू' नामक खण्डमा हेर्न सक्नुहुन्छ।</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="ne">डाउनलोड पूरा भयो</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.CopyFailed">
+      <trans-unit id="Download.CopyFailed" approved="yes">
         <source xml:lang="en">Bloom downloaded the book but had problems making it available in Bloom. Please restart your computer and try again. If you get this message again, please click the 'Details' button and report the problem to the Bloom developers</source>
         <target xml:lang="ne">Bloom ले पुस्तक डाउनलोड गर्‍यो तर सो पुस्तकलाई Bloom मा उपलब्ध गराउनमा समस्या भयो।कृपया आफ्नो कम्प्युटर पुनः सुरू गरेर फेरि प्रयास गर्नुहोस्।तपाईंले यो सन्देश फेरि प्राप्त गर्नुभयो भने, कृपया 'विस्तृत विवरण' बटनमा क्लिक गर्नुहोस् र यस समस्याको बारेमा Bloom का विकासकर्ताहरूलाई सूचित गर्नुहोस्</target>
         <note>ID: Download.CopyFailed</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="ne">पुस्तक लाउनलोड गर्दै</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="ne">तपाईंको पुस्तक डाउनलोड गर्दा समस्या आयो।</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddPageButton">
+      <trans-unit id="EditTab.AddPageDialog.AddPageButton" approved="yes">
         <source xml:lang="en">Add Page</source>
         <target xml:lang="ne">पृष्ठ थप्नुहोस्</target>
         <note>ID: EditTab.AddPageDialog.AddPageButton</note>
         <note>This is for the button that LAUNCHES the dialog, not the "Add this page" button that is IN the dialog.</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add This Page</source>
         <target xml:lang="ne">यो पृष्ठ थप्नुहोस्</target>
         <note>ID: EditTab.AddPageDialog.AddThisPageButton</note>
         <note>This is for the button inside the dialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use This Layout</source>
         <target xml:lang="ne">यो सजावट प्रयोग गर्नुहोस्</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Page...</source>
         <target xml:lang="ne">पृष्ठ थप्नुहोस्...</target>
         <note>ID: EditTab.AddPageDialog.Title</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose Different Layout...</source>
         <target xml:lang="ne">अर्को सजावट चयन गर्नुहोस्...</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Converting to this layout will cause some content to be lost.</source>
         <target xml:lang="ne">यो सजावटमा रूपान्तरण गर्नाले केही सामग्री गुम्न सक्छ।</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutWillLoseData</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Continue anyway</source>
         <target xml:lang="ne">तैपनि जारी राख्ने</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutContinueCheckbox</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="ne">यदि तपाईंलाई यस पुस्तकको बारेमा जानकारी राख्न अरू ठाउँ चाहिएमा, तपाईंले यो पृष्ठ प्रयोग गर्न सक्नुहुन्छ, जुन पछाडिको आवरण पृष्ठको भित्रपट्टी छ।</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.</source>
         <target xml:lang="ne">यदि तपाईंलाई यस पुस्तकको बारेमा जानकारी राख्न अरू ठाउँ चाहिएमा, तपाईंले यो पृष्ठ प्रयोग गर्न सक्नुहुन्छ, जुन अगाडिको आवरण पृष्ठको भित्रपट्टी छ।</target>
         <note>ID: EditTab.FrontMatter.InsideFrontCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="ne">यदि तपाईंलाई यस पुस्तकको बारेमा जानकारी राख्न अरू ठाउँ चाहिएमा, तपाईंले यो पृष्ठ प्रयोग गर्न सक्नुहुन्छ, जुन पछाडिको आवरण पृष्ठको बाहिरपट्टी छ।</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Background</source>
         <target xml:lang="ne">पृष्ठभूमि</target>
         <note>ID: EditTab.TextBoxProperties.Background</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">
           Open the HTML used to make this PDF, in Firefox (must be on path)
         </source>
         <target xml:lang="ne">यो PDF बनाउन प्रयोग गरिएको HTML लाई Firefox मा खोल्नुहोस् (निर्धारित पथमा हुनुपर्छ)</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="ne">माफ गर्नुहोस्, यो पुस्तकको प्रतिलिपि अधिकार र इजाजतपत्र परिवर्तन गर्न सकिँदैन।</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="ne">माफ गर्नुहोस्, यो पुस्तकलाई छविहरू परिवर्तन गर्न नमिल्नेगरि लक गरिएको छ।</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="ne">पृष्ठ साँच्चिकै मेटाउने?</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="ne">&amp;मेट्नुहोस्</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="ne">यो पृष्ठकाई सदाका लागि हटाइनेछ।</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="ne">सजावट परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.CustomPage.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true" approved="yes">
         <source xml:lang="en">or</source>
         <target xml:lang="ne">वा</target>
         <note>ID: EditTab.CustomPage.Or</note>
         <note>Shown between 'Picture' and 'Text' when Custom Page is in Layout mode</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture</source>
         <target xml:lang="ne">तस्बिर</target>
         <note>ID: EditTab.CustomPage.Picture</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <target xml:lang="ne">पाठ</target>
         <note>ID: EditTab.CustomPage.Text</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <target xml:lang="ne">पाठ बाकस</target>
         <note>ID: EditTab.CustomPage.TextBox</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord" approved="yes">
         <source xml:lang="en">Sight Word</source>
         <target xml:lang="ne">धेरै प्रयोग हुने शब्दहरू</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable" approved="yes">
         <source xml:lang="en">This word is not decodable in this stage.</source>
         <target xml:lang="ne">यो शब्द यो पृष्ठमा डिकोडेबल छैन।</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample words in this stage</source>
         <target xml:lang="ne">यो चरणमा प्रयोग हुने नमूना शब्दहरू</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="ne">पछाडि</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Back</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4) Check</source>
         <target xml:lang="ne">4) जाँच्नुहोस्</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Check</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Check that you are recording into the correct device and that these levels are showing blue:</source>
         <target xml:lang="ne">1) तपाईं सही यन्त्रमा रेकर्ड गर्दै हुनुहुन्छ र यी स्तरहरू नीलो रङमा देखिएका छन् भनी निश्चित गर्नुहोस्:</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.CheckSettings</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Clear</source>
         <target xml:lang="ne">खाली गर्नुहोस्</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Clear</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Talking Book Tool</source>
         <target xml:lang="ne">श्रव्य पुस्तक उपकरण</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Listen to the whole page</source>
         <target xml:lang="ne">पूरै पृष्ठ सुन्नुहोस्</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Listen</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Look at the highlighted sentence</source>
         <target xml:lang="ne">2) हाइलाइट गरिएको वाक्य हेर्नुहोस्</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.LookAtSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5) Next</source>
         <target xml:lang="ne">5) अर्को</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Next</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3) Speak</source>
         <target xml:lang="ne">3) बोल्नुहोस्</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Speak</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="ne">सम्पादन गर्नुहोस्</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true">
+      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot change these because this is not the original copy.</source>
         <target xml:lang="ne">तपाईंले यिनीहरूलाई परिवर्तन गर्न सक्नुहुन्न किनभने यो मूल प्रति होइन।</target>
         <note>ID: EditTab.EditNotAllowed</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="ne">हाल '{0}' फन्ट चयन गरिएको छ, तर यो फन्ट तपाईंको कम्प्युटरमा स्थापित छैन। अरू कुनै फन्ट प्रयोग गरिनेछ।</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true" approved="yes">
         <source xml:lang="en">That style already exists. Please choose another name.</source>
         <target xml:lang="ne">सो नामको शैली पहिले देखि नै छ। कृपया अर्को नाम छान्नुहोस्।</target>
         <note>ID: EditTab.FormatDialog.AlreadyExists</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="ne">सीमा र पृष्ठभूमि परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <target xml:lang="ne">वर्णहरू</target>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <target xml:lang="ne">सिर्जना गर्नुहोस्</target>
         <note>ID: EditTab.FormatDialog.Create</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create a new style</source>
         <target xml:lang="ne">नयाँ शैली सिर्जना गर्नुहोस्</target>
         <note>ID: EditTab.FormatDialog.CreateStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Don't see what you need?</source>
         <target xml:lang="ne">आफूलाई चाहिएको कुरा देख्नुभएन?</target>
         <note>ID: EditTab.FormatDialog.DontSeeNeed</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Emphasis</source>
         <target xml:lang="ne">महत्त्व</target>
         <note>ID: EditTab.FormatDialog.Emphasis</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <target xml:lang="ne">फन्ट</target>
         <note>ID: EditTab.FormatDialog.Font</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="ne">फन्टको मोहडा परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="ne">'{0}' शैली र '{1}' भाषाका सबै बाकसहरूमा भएको वर्णको आकार परिवर्तन गर्छ।\nहालको वर्णको आकार {2} pt छ।</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="ne">फन्टको आकार परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Format</source>
         <target xml:lang="ne">ढाँचा</target>
         <note>ID: EditTab.FormatDialog.Format</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="ne">पाठको पङ्क्तिहरू बीचको अन्तर परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New style</source>
         <target xml:lang="ne">नयाँ शैली</target>
         <note>ID: EditTab.FormatDialog.NewStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please use only alphabetical characters. Numbers at the end are ok, as in "part2".</source>
         <target xml:lang="ne">कृपया अक्षरीय वर्णहरू मात्र प्रयोग गर्नुहोस् अन्तमा देखिने सङ्ख्याहरू "भाग 2" मा जस्तै ठीक छन्।</target>
         <note>ID: EditTab.FormatDialog.PleaseUseAlpha</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <target xml:lang="ne">अन्तर</target>
         <note>ID: EditTab.FormatDialog.Spacing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <target xml:lang="ne">शैली</target>
         <note>ID: EditTab.FormatDialog.Style</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <target xml:lang="ne">शैलीको नाम</target>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="ne">अधिक फराकिलो</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="ne">सामान्य</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="ne">शब्दहरू बीचको अन्तर परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="ne">फराकिलो</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="ne">शैलीको लागि ढाँचा समायोजन गर्नुहोस्</target>
         <note>ID: EditTab.FormatDialogTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="ne">तपाईंले मूल पुस्तक बनाउँदा, लेखक, चित्रकार, सम्पादक, इत्यादिको योगदानहरू बारे लेख्न यो बाकस प्रयोग गर्नुहोस्। </target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="ne">तपाईंले कुनै आवरणबाट पुस्तक बनाउँदा, अनुवादकको नाम लेख्न यो बाकस प्रयोग गर्नुहोस्।</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="ne">{lang} मा पुस्तकको शीर्षक</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="ne">तपाईंले यो खाली ठाउँ लेखक/चित्रकारको नाम लेख्न, वा अन्य कुनैपनि कुराको लागि प्रयोग गर्न सक्नुहुन्छ।</target>
         <note>ID: EditTab.FrontMatter.AuthorIllustratorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright and License</source>
         <target xml:lang="ne">प्रतिलिपि अधिकार र इजाजतपत्र सम्पादन गर्न क्लिक गर्नुहोस्</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="ne">आर्थिक सहयोग गर्ने कुनैपनि निकायलाई आभार प्रकट गर्न यो बाकस प्रयोग गर्नुहोस्।</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="ne">इन्टरनेसनल स्ट्याण्डर्ड बुक नम्बर।तपाईंसँग यो छैन भने, खाली छोड्नुहोस्।</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="ne">{lang} मा मूल (वा आवरण) कृतज्ञता</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="ne">{lang} मा लेखक, चित्रकार, सम्पादक, इत्यादिका योगदानहरू</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="ne">शीर्षक चयन गर्न क्लिक गर्नुहोस्</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="ne">अनुवादित संस्करणको कृतज्ञता, {lang} मा</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Name of Translator, in {lang}</source>
         <target xml:lang="ne">अनुवादकको नाम, {lang} मा</target>
         <note>ID: EditTab.FrontMatter.NameofTranslatorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.HowToUnlockBook">
+      <trans-unit id="EditTab.HowToUnlockBook" approved="yes">
         <source xml:lang="en">To unlock this shellbook, go into the toolbox on the right, find the gear icon, and click 'Allow changes to this shellbook'.</source>
         <target xml:lang="ne">यो खाका पुस्तिकाको लक खोल्न, दायाँपट्टी रहेको उपकरण पेटीमा जानुहोस्, गियर आइकन फेला पार्नुहोस्, अनि 'यो खाका पुस्तिकामा परिवर्तनहरू गर्न दिनुहोस्' मा क्लिक गर्नुहोस्।</target>
         <note>ID: EditTab.HowToUnlockBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="ne">छवि परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, &amp; License</source>
         <target xml:lang="ne">छविको श्रेय, प्रतिलिपि अधिकार र इजाजतपत्र सम्पादन गर्नुहोस्</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="ne">छवि टाँस्नुहोस्</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cut Image</source>
         <target xml:lang="ne">छवि काट्नुहोस्</target>
         <note>ID: EditTab.Image.CutImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Copy Image</source>
         <target xml:lang="ne">छवि प्रतिलिपि गर्नुहोस्</target>
         <note>ID: EditTab.Image.CopyImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse">
+      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse" approved="yes">
         <source xml:lang="en">Cancel this import</source>
         <target xml:lang="ne">यो आयात रद्द गर्नुहोस्</target>
         <note>ID: EditTab.JpegWarningDialog.DoNotUse</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.Photograph">
+      <trans-unit id="EditTab.JpegWarningDialog.Photograph" approved="yes">
         <source xml:lang="en">Use the JPEG file</source>
         <target xml:lang="ne">यो JPEG फाइल प्रयोग गर्नुहोस्</target>
         <note>ID: EditTab.JpegWarningDialog.Photograph</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WarningText">
+      <trans-unit id="EditTab.JpegWarningDialog.WarningText" approved="yes">
         <source xml:lang="en">The file you’ve chosen is a “JPEG” file.JPEG files are perfect for photographs and color artwork.
           However, JPEG files are a big problem for black and white line art.
         Problems include:\n• Fuzziness and grey dots.\n• Large file sizes, making the book hard to share.\n• If there are many large JPEGs, Bloom may not have enough memory to make PDF files.\n\n
@@ -1196,2205 +1196,2205 @@
         <target xml:lang="ne">तपाईंले चयन गर्नुभएको फाइल "JPEG" फाइल हो।JPEG फाइलहरू फोटो र रङ्गीन चित्रकलाका लागि उत्तम हुन्छन्।यद्यपि, धर्का कोरेर बनाइएका कालो र सेतो रङका चित्रहरूका लागि JPEG फाइलहरूले ठूलो समस्या खडा गर्छन्।समस्याहरूमा निम्नलिखित पर्दछन्:\n• अस्पष्टता र खरानी रङका थोप्लाहरू।\n• फाइलको आकार ठूलो हुने, जस कारणले पुस्तक आदान प्रदान गर्न गाह्रो हुन्छ।\n• धेरै सङ्ख्यामा ठूला JPEG फाइलहरू छन् भने, PDF फाइलहरू बनाउनका लागि Bloom मा मेमोरी नपुग्न सक्छ।\n\nध्यान दिनुपर्ने कुरा: JPEG फाइल “क्षतिकारक” (अर्थात्, यसबाट अनावश्यक जानकारी हटाइने) भएकाले JPEG फाइललाई PNG, TIFF, वा BMP फाइलमा रूपान्तर गर्नाले झन ठूलो समस्या निम्त्याउँछ।यदि यो धर्का कोरेर बनाइएको कालो र सेतो रङको चित्र हो भने, तपाईंले ती मध्ये एउटा ढाँचामा मूल स्क्यान प्राप्त गर्नु उचित हुन्छ।\n\nकृपया निम्नलिखित मध्येबाट एउटा चयन गर्नुहोस् र “ठीक छ” मा क्लिक गर्नुहोस्:</target>
         <note>ID: EditTab.JpegWarningDialog.WarningText</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="ne">सजावट परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true">
+      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This sentence is too long for this level.</source>
         <target xml:lang="ne">यो वाक्य यस स्तरको लागि धेरै लामो भयो।</target>
         <note>ID: EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong</note>
       </trans-unit>
-      <trans-unit id="EditTab.NewBookName">
+      <trans-unit id="EditTab.NewBookName" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="ne">पुस्तक</target>
         <note>ID: EditTab.NewBookName</note>
         <note>Default file and folder name when you make a new book, but haven't give it a title yet.</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="ne">तपाईंले छवि टाँस्नु अघि, अर्को प्रोग्रामबाट कुनै एउटा छविलाई आफ्नो 'क्लिपबोर्ड' मा प्रतिलिपि गर्नुहोस्।</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="ne">पृष्ठ</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="ne">पृष्ठको आकार र विन्यास चयन गर्नुहोस्</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.Position" sil:dynamic="true">
+      <trans-unit id="EditTab.Position" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Position</source>
         <target xml:lang="ne">अवस्थिति</target>
         <note>ID: EditTab.Position</note>
       </trans-unit>
-      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true">
+      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot put anything in there while making an original book.</source>
         <target xml:lang="ne">मूल पुस्तक बनाउँदा तपाईंले त्यहाँ कुनैपनि कुरा राख्न पाउनुहुन्न।</target>
         <note>ID: EditTab.ReadOnlyInAuthorMode</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="ne">सीमा र पृष्ठभूमि परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.StyleEditor.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="ne">फन्टको मोहडा परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.StyleEditor.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="ne">फन्टको आकार परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.StyleEditor.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="ne">पाठको पङ्क्तिहरू बीचको अन्तर परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.StyleEditor.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="ne">अधिक फराकिलो</target>
         <note>ID: EditTab.StyleEditor.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="ne">सामान्य</target>
         <note>ID: EditTab.StyleEditor.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="ne">शब्दहरू बीचको अन्तर परिवर्तन गर्नुहोस्</target>
         <note>ID: EditTab.StyleEditor.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="ne">फराकिलो</target>
         <note>ID: EditTab.StyleEditor.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="ne">शैलीको लागि ढाँचा समायोजन गर्नुहोस्</target>
         <note>ID: EditTab.StyleEditorTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="ne">टेम्प्लेट पृष्ठहरू</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom">
+      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom" approved="yes">
         <source xml:lang="en">Picture On Bottom</source>
         <target xml:lang="ne">तलको तस्बिर</target>
         <note>ID: EditTab.ThumbnailCaptions.Picture On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="ne">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1 Problem</source>
         <target xml:lang="ne">1 समस्या</target>
         <note>ID: TemplateBooks.PageLabel.1 Problem</note>
         <note>This label indicates a page with one arithmetic problem on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true" approved="yes">
         <source xml:lang="en">10</source>
         <target xml:lang="ne">10</target>
         <note>ID: TemplateBooks.PageLabel.10</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true" approved="yes">
         <source xml:lang="en">11</source>
         <target xml:lang="ne">11</target>
         <note>ID: TemplateBooks.PageLabel.11</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true" approved="yes">
         <source xml:lang="en">12</source>
         <target xml:lang="ne">12</target>
         <note>ID: TemplateBooks.PageLabel.12</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true" approved="yes">
         <source xml:lang="en">13</source>
         <target xml:lang="ne">13</target>
         <note>ID: TemplateBooks.PageLabel.13</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true" approved="yes">
         <source xml:lang="en">14</source>
         <target xml:lang="ne">14</target>
         <note>ID: TemplateBooks.PageLabel.14</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true" approved="yes">
         <source xml:lang="en">15</source>
         <target xml:lang="ne">15</target>
         <note>ID: TemplateBooks.PageLabel.15</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true" approved="yes">
         <source xml:lang="en">16</source>
         <target xml:lang="ne">16</target>
         <note>ID: TemplateBooks.PageLabel.16</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true" approved="yes">
         <source xml:lang="en">17</source>
         <target xml:lang="ne">17</target>
         <note>ID: TemplateBooks.PageLabel.17</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true" approved="yes">
         <source xml:lang="en">18</source>
         <target xml:lang="ne">18</target>
         <note>ID: TemplateBooks.PageLabel.18</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true" approved="yes">
         <source xml:lang="en">19</source>
         <target xml:lang="ne">19</target>
         <note>ID: TemplateBooks.PageLabel.19</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="ne">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2 Problems</source>
         <target xml:lang="ne">2 समस्याहरू</target>
         <note>ID: TemplateBooks.PageLabel.2 Problems</note>
         <note>This label indicates a page with two arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true" approved="yes">
         <source xml:lang="en">20</source>
         <target xml:lang="ne">20</target>
         <note>ID: TemplateBooks.PageLabel.20</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true" approved="yes">
         <source xml:lang="en">21</source>
         <target xml:lang="ne">21</target>
         <note>ID: TemplateBooks.PageLabel.21</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="ne">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3 Problems</source>
         <target xml:lang="ne">3 समस्याहरू</target>
         <note>ID: TemplateBooks.PageLabel.3 Problems</note>
         <note>This label indicates a page with three arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="ne">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4 Problems</source>
         <target xml:lang="ne">4 समस्याहरू</target>
         <note>ID: TemplateBooks.PageLabel.4 Problems</note>
         <note>This label indicates a page with four arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="ne">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="ne">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="ne">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="ne">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="ne">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="ne">अक्षर</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="ne">आधारभूत पाठ र छवि</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="ne">आधारभूत पाठ र तस्बिर</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="ne">श्रेय पृष्ठ</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="ne">कस्टम</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="ne">दिन 1</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="ne">दिन 2</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="ne">दिन 3</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="ne">दिन 4</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="ne">दिन 5a</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="ne">दिन 5b</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="ne">अगाडिको आवरण पृष्ठ</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="ne">तलको छवि</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="ne">बीचको छवि</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="ne">पछाडिको आवरण पृष्ठको भित्रपट्टी</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="ne">अगाडिको आवरण पृष्ठको भित्रपट्टी</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="ne">निर्देशनहरू</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="ne">पाठ मात्र</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="ne">तस्बिर मात्र </target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="ne">छवि मात्र</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="ne">पछाडिको आवरण पृष्ठको भित्रपट्टी</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="ne">तस्बिर र शब्द</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="ne">तलको तस्बिर</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="ne">बीचको तस्बिर</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="ne">यो पृष्ठ स्वेच्छाले खाली छोडिएको हो</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="ne">शीर्षक पृष्ठ</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A blank page that allows you to add items.</source>
         <target xml:lang="ne">एउटा खाली पृष्ठ जहाँ तपाईंले सामग्रीहरू थप्न सक्नुहुन्छ।</target>
         <note>ID: TemplateBooks.PageDescription.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page with a picture on top and a large, centered word below.</source>
         <target xml:lang="ne">माथि तस्बिर र तलपट्टी बीचमा ठूलो शब्द भएको पृष्ठ।</target>
         <note>ID: TemplateBooks.PageDescription.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="ne">बहु भाषिक सेटिङहरू</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip">
+      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip" approved="yes">
         <source xml:lang="en">Choose language to make this a bilingual or trilingual book</source>
         <target xml:lang="ne">यो पुस्तकलाई दुई वा तीनवटा भाषामा लेख्न भाषा चयन गर्नुहोस्</target>
         <note>ID: EditTab.ContentLanguagesDropdown.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="ne">प्रतिलिपि गर्नुहोस्</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTip">
+      <trans-unit id="EditTab.CopyButton.ToolTip" approved="yes">
         <source xml:lang="en">Copy (Ctrl+C)</source>
         <target xml:lang="ne">प्रतिलिपि गर्नुहोस् (Ctrl+C)</target>
         <note>ID: EditTab.CopyButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can copy it</source>
         <target xml:lang="ne">प्रतिलिपि गर्नु अघि तपाईंले केही पाठ चयन गर्नुपर्छ।</target>
         <note>ID: EditTab.CopyButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="ne">काट्नुहोस्</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTip">
+      <trans-unit id="EditTab.CutButton.ToolTip" approved="yes">
         <source xml:lang="en">Cut (Ctrl+X)</source>
         <target xml:lang="ne">काट्नुहोस् (Ctrl+X)</target>
         <note>ID: EditTab.CutButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can cut it</source>
         <target xml:lang="ne">काट्नु अघि तपाईंले केही पाठ चयन गर्नुपर्छ।</target>
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="ne">पृष्ठ\n हटाउनुहोस्</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTip">
+      <trans-unit id="EditTab.DeletePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Remove this page from the book</source>
         <target xml:lang="ne">यो पृष्ठलाई यस पुस्तकबाट हटाउनुहोस्</target>
         <note>ID: EditTab.DeletePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be removed</source>
         <target xml:lang="ne">यस पृष्ठलाई हटाउन सकिँदैन</target>
         <note>ID: EditTab.DeletePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.ChooseLayoutButton">
+      <trans-unit id="EditTab.ChooseLayoutButton" approved="yes">
         <source xml:lang="en">Choose Different Layout</source>
         <target xml:lang="ne">अर्को सजावट चयन गर्नुहोस्</target>
         <note>ID: EditTab.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">
           Duplicate\n   Page
         </source>
         <target xml:lang="ne">प्रतिलिपि\n पृष्ठ</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
         <target xml:lang="ne">यो पृष्ठको प्रतिलिपि गरेर एउटा नयाँ पृष्ठ थप्नुहोस्</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be duplicated</source>
         <target xml:lang="ne">यो पृष्ठको प्रतिलिपि बनाउन सकिँदैन</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="ne">टाँस्नुहोस्</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTip">
+      <trans-unit id="EditTab.PasteButton.ToolTip" approved="yes">
         <source xml:lang="en">Paste (Ctrl+V)</source>
         <target xml:lang="ne">टाँस्नुहोस् (Ctrl+V)</target>
         <note>ID: EditTab.PasteButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing on the Clipboard that you can paste here.</source>
         <target xml:lang="ne">तपाईंले यहाँ टाँस्नका लागि क्लिपबोर्डमा केही छैन।</target>
         <note>ID: EditTab.PasteButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="ne">पूर्वावस्थामा फर्काउनुहोस्</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTip">
+      <trans-unit id="EditTab.UndoButton.ToolTip" approved="yes">
         <source xml:lang="en">Undo (Ctrl+Z)</source>
         <target xml:lang="ne">पूर्वावस्थामा फर्काउनुहोस् (Ctrl+Z)</target>
         <note>ID: EditTab.UndoButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing to undo</source>
         <target xml:lang="ne">पूर्वावस्थामा फर्काउनका लागि केही छैन</target>
         <note>ID: EditTab.UndoButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="ne">दुईवटा भाषा</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="ne">यो जानकारीलाई यो पुस्तकमा भएका अन्य सबै तस्बिरहरूमा प्रतिलिपि गर्ने?</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="ne">यो विकल्प प्रकाशन ट्याबमा मात्र उपलब्ध छ</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="ne">एउटा भाषा</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="ne">यस टेम्प्लेटको लागि सजावटका अन्य विकल्पहरू छैनन्।</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Overflow" sil:dynamic="true">
+      <trans-unit id="EditTab.Overflow" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This box has more text than will fit</source>
         <target xml:lang="ne">यो बाकसमा अटाउनेभन्दा बढी पाठ छ</target>
         <note>ID: EditTab.Overflow</note>
       </trans-unit>
-      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true">
+      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A container on this page is overflowing</source>
         <target xml:lang="ne">यो पृष्ठको एउटा कन्टेनरमा अतिप्रवाह भइरहेको छ</target>
         <note>ID: EditTab.OverflowContainer</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="ne">तस्बिरको बौद्धिक सम्पत्ति अधिकार सम्बन्धी जानकारी</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="ne">तीनवटा भाषा</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="Errors.BookProblem">
+      <trans-unit id="Errors.BookProblem" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.</source>
         <target xml:lang="ne">Bloom लाई यो पुस्तक देखाउनमा समस्या भयो।यसको मतलब तपाईंको काम गुमेको होइन। यसको मतलब कुनै कुराको म्याद सकिएको छ, कुनै कुरा छुटेको छ वा केही गडबड भएको छ भन्ने हो।</target>
         <note>ID: Errors.BookProblem</note>
       </trans-unit>
-      <trans-unit id="Errors.BrokenBook">
+      <trans-unit id="Errors.BrokenBook" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong. Consider using the 'Report a Problem' command under the 'Help' menu.</source>
         <target xml:lang="ne">Bloom लाई यो पुस्तक देखाउनमा समस्या भयो। यसको मतलब तपाईंको काम गुमेको होइन। यसको मतलब कुनै कुराको म्याद सकिएको छ, कुनै कुरा छुटेको छ वा केही गडबड भएको छ भन्ने हो। 'मद्दत' मेनुमा गएर 'समस्या रिपोर्ट गर्नुहोस्' नामक आदेश प्रयोग गर्नुहोस्।</target>
         <note>ID: Errors.BrokenBook</note>
       </trans-unit>
-      <trans-unit id="Errors.CannotConnectToBloomServer">
+      <trans-unit id="Errors.CannotConnectToBloomServer" approved="yes">
         <source xml:lang="en">Bloom was unable to start its own HTTP listener that it uses to talk to its embedded Firefox browser. If this happens even if you just restarted your computer, ask someone to investigate if you have an aggressive firewall product installed. The agressive firewall product may need to be uninstalled before you can use Bloom.</source>
         <target xml:lang="ne">Bloom ले यसमा अन्तरनिहित Firefox ब्राउजरसँग अन्तरक्रिया गर्न प्रयोग गर्ने यसको आफ्नो HTTP श्रोता सुरू गर्न सकेन।तपाईंले आफ्नो कम्प्युटर भर्खरै सुरू गरेको भए तापनि यसो भइरहेको छ भने, तपाईंको कम्प्युटरमा आक्रामक फायरवाल सफ्टवेयर स्थापना गरिएको छ कि भनी जाँच्न कसैलाई आग्रह गर्नुहोस्।तपाईंले Bloom प्रयोग गर्नु अघि सो आक्रामक फायरवाल सफ्टवेयरलाई हटाउन आवश्यक हुन सक्छ।</target>
         <note>ID: Errors.CannotConnectToBloomServer</note>
       </trans-unit>
-      <trans-unit id="Errors.DeniedAccess">
+      <trans-unit id="Errors.DeniedAccess" approved="yes">
         <source xml:lang="en">Your computer denied Bloom access to the book. You may need technical help in setting the operating system permissions for this file.</source>
         <target xml:lang="ne">तपाईंको कम्प्युटरले Bloom लाई पुस्तकमाथि पहुँच गर्न दिएन।यो फाइलको लागि सञ्चालन प्रणालीका अनुमतिहरू समायोजन गर्न तपाईंलाई प्राविधिकको सहयोग चाहिन सक्छ।</target>
         <note>ID: Errors.DeniedAccess</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorSelecting">
+      <trans-unit id="Errors.ErrorSelecting" approved="yes">
         <source xml:lang="en">There was a problem selecting the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="ne">यो पुस्तक चयन गर्नमा समस्या भयो।Bloom लाई पुनः सुरू गरेपछि यो समस्या हल हुन सक्छ।यसो गर्दा नि समस्या हल भएन भने, कृपया 'विस्तृत विवरण' बटनमा क्लिक गर्नुहोस् र यस समस्याको बारेमा Bloom का विकासकर्ताहरूलाई सूचित गर्नुहोस्।</target>
         <note>ID: Errors.ErrorSelecting</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorUpdating">
+      <trans-unit id="Errors.ErrorUpdating" approved="yes">
         <source xml:lang="en">There was a problem updating the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="ne">पुस्तक अद्यावधिक गर्नमा समस्या भयो।Bloom लाई पुनः सुरू गरेपछि यो समस्या हल हुन सक्छ।यसो गर्दा नि समस्या हल भएन भने, कृपया 'विस्तृत विवरण' बटनमा क्लिक गर्नुहोस् र यस समस्याको बारेमा Bloom का विकासकर्ताहरूलाई सूचित गर्नुहोस्।</target>
         <note>ID: Errors.ErrorUpdating</note>
       </trans-unit>
-      <trans-unit id="Errors.NeedNewerVersion">
+      <trans-unit id="Errors.NeedNewerVersion" approved="yes">
         <source xml:lang="en">{0} requires a newer version of Bloom. Download the latest version of Bloom from {1}</source>
         <target xml:lang="ne">{0} को लागि Bloom को नया संस्करण चाहिन्छ। {1} मा गई Bloom को नवीनतम संस्करण डाउनलोड गर्नुहोस्।</target>
         <note>ID: Errors.NeedNewerVersion</note>
         <note>{0} will get the name of the book, {1} will give a link to open the Bloom Library Web page.</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemDeletingFile">
+      <trans-unit id="Errors.ProblemDeletingFile" approved="yes">
         <source xml:lang="en">Bloom had a problem deleting this file: {0}</source>
         <target xml:lang="ne">Bloom लाई यो फाइल मेटाउनमा समस्या भयो: {0}</target>
         <note>ID: Errors.ProblemDeletingFile</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemImportingPicture">
+      <trans-unit id="Errors.ProblemImportingPicture" approved="yes">
         <source xml:lang="en">Bloom had a problem importing this picture.</source>
         <target xml:lang="ne">Bloom लाई यो तस्बिर आयात गर्नमा समस्या भयो।</target>
         <note>ID: Errors.ProblemImportingPicture</note>
       </trans-unit>
-      <trans-unit id="Errors.ReportThisProblemButton">
+      <trans-unit id="Errors.ReportThisProblemButton" approved="yes">
         <source xml:lang="en">Report this problem to Bloom Support</source>
         <target xml:lang="ne">यो समस्याको बारेमा Bloom सहायतालाई सूचित गर्नुहोस्</target>
         <note>ID: Errors.ReportThisProblemButton</note>
       </trans-unit>
-      <trans-unit id="Errors.SomethingWentWrong">
+      <trans-unit id="Errors.SomethingWentWrong" approved="yes">
         <source xml:lang="en">Sorry, something went wrong.</source>
         <target xml:lang="ne">माफ गर्नुहोस्, केही गडबड भयो।</target>
         <note>ID: Errors.SomethingWentWrong</note>
       </trans-unit>
-      <trans-unit id="Errors.XMatterNotFound">
+      <trans-unit id="Errors.XMatterNotFound" approved="yes">
         <source xml:lang="en">This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer.You can either install a Bloom Pack that will give you '{0}', or go to Settings:Book Making and change to another Front/Back Matter Pack.</source>
         <target xml:lang="ne">यस पुस्तकले अगाडि/पछाडिको आवरण पृष्ठमा लेख्ने सामग्रीको '{0}' नामक प्याक माग गर्‍यो, तर Bloom ले सो सामग्रीलाई यो कम्प्युटरमा फेला पार्न सकेन।तपाईंले या त '{0}' उपलब्ध गराउने Bloom प्याक स्थापना गर्न, वा सेटिङहरू:पुस्तक बनाउनेमा गएर अगाडि/पछाडिको आवरण पृष्ठमा लेख्ने सामग्रीको अर्को प्याक परिवर्तन गर्न सक्नुहुन्छ।</target>
         <note>ID: Errors.XMatterNotFound</note>
       </trans-unit>
-      <trans-unit id="Errors.ZoneAlarm">
+      <trans-unit id="Errors.ZoneAlarm" approved="yes">
         <source xml:lang="en">Bloom cannot start properly, and this symptom has been observed on machines with ZoneAlarm installed. Note: disabling ZoneAlarm does not help. Nor does restarting with it turned off. Something about the installation of ZoneAlarm causes the problem, and so far only uninstalling ZoneAlarm has been shown to fix the problem.</source>
         <target xml:lang="ne">Bloom सुचारू रूपमा सुरू हुन सक्दैन, र यो लक्षण ZoneAlarm स्थापना गरिएका उपकरणहरूमा देखिने गरेको छ।ध्यान दिनुपर्ने कुरा: ZoneAlarm लाई अक्षम बनाएर यो समस्या हल हुँदैन।न त यसलाई बन्द गरेर पुनः सुरू गरेर नै यो समस्या हल हुन्छ।ZoneAlarm स्थापना गर्दाको कुनै तत्वले गर्दा यो समस्या हुन्छ, र अहिलेसमम्म ZoneAlarm लाई हटाउँदा मात्र यो समस्या हल हुने देखिएको छ।</target>
         <note>ID: Errors.ZoneAlarm</note>
       </trans-unit>
-      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true">
+      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This page is an experimental prototype which may have many problems, for which we apologize.</source>
         <target xml:lang="ne">यो पृष्ठ प्रयोगात्मक नमूना हो र यसमा धेरै समस्याहरू हुन सक्छन् जसको लागि हामी क्षमाप्रार्थी छौं।</target>
         <note>ID: EditTab.ExperimentalNotice</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="ne">पाठ्यपुस्तक टेम्प्लेटहरू बनाउने</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="ne">मद्दत</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Get Help</source>
         <target xml:lang="ne">मद्दत प्राप्त गर्नुहोस्</target>
         <note>ID: HelpMenu.Help Menu_ToolTip_</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="ne">पाठ्यपुस्तक टेम्प्लेटहरू प्रयोग गने</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="ne">सुझाव दिनुहोस्</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="ne">वेबसाइट</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="ne">नयाँ संस्करण जाँच्नुहोस्</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="ne">Bloom को बारेमा</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <target xml:lang="ne">प्रलेखन</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem">
+      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem" approved="yes">
         <source xml:lang="en">Key Bloom Concepts</source>
         <target xml:lang="ne">Bloom का मुख्य अवधारणाहरू</target>
         <note>ID: HelpMenu.KeyBloomConceptsToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="ne">दर्ता</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="ne">रिलिज नोटहरू...</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem">
+      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem" approved="yes">
         <source xml:lang="en">Report a Problem...</source>
         <target xml:lang="ne">समस्या रिपोर्ट गर्नुहोस्...</target>
         <note>ID: HelpMenu.ReportAProblemToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="ne">कार्यक्रमको अभिलेख देखाउनुहोस्</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.trainingVideos">
+      <trans-unit id="HelpMenu.trainingVideos" approved="yes">
         <source xml:lang="en">Training Videos</source>
         <target xml:lang="ne">प्रशिक्षण भिडियोहरू</target>
         <note>ID: HelpMenu.trainingVideos</note>
       </trans-unit>
-      <trans-unit id="InstallProblem.BloomPdfMaker">
+      <trans-unit id="InstallProblem.BloomPdfMaker" approved="yes">
         <source xml:lang="en">A component of Bloom, BloomPdfMaker.exe, seems to be missing. This prevents previews and printing. Antivirus software sometimes does this. You may need technical help to repair the Bloom installation and protect this file from being deleted again.</source>
         <target xml:lang="ne">Bloom को एउटा अवयव, BloomPdfMaker.exe छैन जस्तो देखिन्छ।यो नहुँदा पूर्वावलोकन गर्न र छाप्न सकिँदैन।कहिलेकाहीँ एन्टिभाइरस सफ्टवेयरको कारणले यसो हुन्छ।Bloom लाई राम्रोसँग स्थापना गर्न र भविष्यमा यो फाइल फेरि मेटिन नदिन तपाईंलाई प्राविधिकको सहयोग आवश्यक पर्न सक्छ।</target>
         <note>ID: InstallProblem.BloomPdfMaker</note>
       </trans-unit>
-      <trans-unit id="LameEncoder.Progress">
+      <trans-unit id="LameEncoder.Progress" approved="yes">
         <source xml:lang="en">Converting to mp3</source>
         <target xml:lang="ne">mp3 ढाँचामा रूपान्तर गर्दै</target>
         <note>ID: LameEncoder.Progress</note>
         <note>Appears in progress indicator</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.RightToLeftCheck">
+      <trans-unit id="LanguageFontDetails.RightToLeftCheck" approved="yes">
         <source xml:lang="en">This script is right to left</source>
         <target xml:lang="ne">यो लिपि दायाँदेखि बायाँतिर लेखिने लिपि हो</target>
         <note>ID: LanguageFontDetails.RightToLeftCheck</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.TallerLinesCheck">
+      <trans-unit id="LanguageFontDetails.TallerLinesCheck" approved="yes">
         <source xml:lang="en">This script requires taller lines</source>
         <target xml:lang="ne">यो लिपिको लागि अग्ला पङ्क्तिहरू चाहिन्छ</target>
         <note>ID: LanguageFontDetails.TallerLinesCheck</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="ne">InDesign XML सम्बन्धी जानकारी</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="ne">यो कुरा फेरि नदेखाउनुहोस्</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle">
+      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle" approved="yes">
         <source xml:lang="en">JPEG Warning</source>
         <target xml:lang="ne">JPEG सम्बन्धी चेतावनी</target>
         <note>ID: EditTab.JpegWarningDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="ne">A4Landscape</target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="ne">A4Landscape SideBySide</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="ne">A4Landscape SplitAcrossPages</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="ne">A4Portrait</target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="ne">A5Landscape</target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="ne">A5Portrait</target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="ne">A5Portrait BottomAlign</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Landscape</source>
         <target xml:lang="ne">A6Landscape</target>
         <note>ID: LayoutChoices.A6Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Portrait</source>
         <target xml:lang="ne">A6Portrait</target>
         <note>ID: LayoutChoices.A6Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="ne">B5Portrait</target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">HalfLetterPortrait</source>
         <target xml:lang="ne">HalfLetterPortrait</target>
         <note>ID: LayoutChoices.HalfLetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterLandscape</source>
         <target xml:lang="ne">LetterLandscape</target>
         <note>ID: LayoutChoices.LetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterPortrait</source>
         <target xml:lang="ne">LetterPortrait</target>
         <note>ID: LayoutChoices.LetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">QuarterLetterLandscape</source>
         <target xml:lang="ne">QuarterLetterLandscape</target>
         <note>ID: LayoutChoices.QuarterLetterLandscape</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="ne">वास्तविक</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="ne">शीर्षकको रोजाई</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="ne">यस स्तरको लागि</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="ne">ढाँचा</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="ne">चित्रद्वारा सहायता</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="ne">ध्यानमा राख्नुहोस्</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="ne">स्तर</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> of </source>
         <target xml:lang="ne"> मध्ये </target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="ne">अधिकतम</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="ne">प्रति पृष्ठ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="ne">सबैभन्दा लामो वाक्य</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="ne">पूर्वानुमान</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="ne">स्तरहरू तय गर्नुहोस्</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="ne">यो पुस्तक</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="ne">यो पृष्ठ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="ne">कुल</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="ne"> विशेष वा फरक</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="ne">शब्दावली</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="ne">शब्द सङ्ख्या</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog.WindowTitle">
+      <trans-unit id="LicenseDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom {0}</source>
         <target xml:lang="ne">Bloom {0}</target>
         <note>ID: LicenseDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog._acceptButton">
+      <trans-unit id="LicenseDialog._acceptButton" approved="yes">
         <source xml:lang="en">I accept the terms of the license agreement</source>
         <target xml:lang="ne">म इजाजतपत्रको सम्झौताका सर्तहरू स्वीकार्छु</target>
         <note>ID: LicenseDialog._acceptButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="ne">म Bloom Library को प्रयोगका सर्तहरूमा सहमत छु</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="ne">इमेल ठेगाना</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="ne">पासवर्ड बिर्सेँ</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="ne">&amp;लग इन</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="ne">पासवर्ड</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="ne">प्रयोगका सर्तहरू देखाउनुहोस्</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="ne">BloomLibrary.org मा लग इन गर्नुहोस्</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="ne">&amp;पासवर्ड देखाउनुहोस्</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="ne">&lt;a href='file://{0}'&gt;{0}&lt;/a&gt; मा सो नामको सङ्ग्रह पहिले नै छ।\nकृपया विशेष वा फरक नाम छान्नुहोस्।</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="ne">यस सङ्ग्रहको लागि मुख्य भाषा छान्नुहोस्</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="ne">उदाहरणको लागि: "स्वास्थ्य सम्बन्धी पुस्तकहरू", "PNG जनावरको कथाहरू"</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="ne">तपाईं यस सङ्ग्रहलाई के नाम दिन चाहनुहुन्छ?</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="ne">सङ्ग्रहको नाममा समस्या देखियो</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="ne">सङ्ग्रह निम्नलिखित स्थानमा बन्नेछ: {0}</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="ne">नयाँ सङ्ग्रह बनाउन तयार </target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FontAndScriptPage">
+      <trans-unit id="NewCollectionWizard.FontAndScriptPage" approved="yes">
         <source xml:lang="en">Font and Script</source>
         <target xml:lang="ne">फन्ट र लिपि</target>
         <note>ID: NewCollectionWizard.FontAndScriptPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="ne">सङ्ग्रहको प्रकार चयन गर्नुहोस्</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions" approved="yes">
         <source xml:lang="en">If you already have a collection you want to open, click  the 'Cancel' button.</source>
         <target xml:lang="ne">आफूले खोल्न चाहेको सङ्ग्रह तपाईंसँग पहिले नै छ भने, 'रद्द बटनळथि‍च्‍नुहोस्</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ne">स्रोतको सङ्ग्रह</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org. You may also make a Bloom Pack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="ne">एक वा बढी साझा भाषाहरूमा लेखिएका खाका वा टेम्प्लेट पुस्तकहरूको सङ्ग्रह।तपाईंले यी खाकाहरूलाई BloomLibrary.org मा अपलोड गर्न सक्नुहुन्छ।अरूले तपाईंका खाकाहरू प्रयोग गरेर आफ्नो मातृभाषामा पुस्तकहरू लेख्न सकून् भनेर तपाईंले Bloom प्याक बनाएर अरूलाई उपलब्ध गराउन पनि सक्नुहुन्छ।</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="ne">मातृभाषा/स्थानीय भाषाको सङ्ग्रह</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="ne">स्थानीय भाषामा लेखिएका पुस्तकहरूको सङ्ग्रह।</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="ne">भाषाको स्थान निर्दिष्ट गर्नुहोस्</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="ne">देश</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="ne">जिल्ला</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="ne">यी ऐच्छिक हुन्।Bloom ले तिनीहरूलाई तपाईंले बनाउनुभएको पुस्तकको शीर्षक पृष्ठमा सही ठाउँमा राखिदिनेछ।</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="ne">प्रान्त</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="ne">{0} पुस्तकहरू</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="ne">नयाँ Bloom सङ्ग्रह बनाउनुहोस्</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="ne"> परियोजनाको नाम</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="ne">सो नाम प्रयोग गरेर नयाँ सङ्ग्रह बनाउन सकिएन।</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="ne">Bloom मा स्वागत छ!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="ne">तपाईं पुस्तकहरू बनाउन लगभग तयार हुनुहुन्छ।</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. The first thing we need to do is make one for you.</source>
         <target xml:lang="ne">सबै कुरालाई सरल र व्यवस्थित राख्न, Bloom ले तपाईंले बनाउनुभएका सबै पुस्तकहरूलाई एक वा एकभन्दा बढी सङ्ग्रहहरूमा राख्दछ। &lt;i&gt;&lt;/i&gt;सर्वप्रथम तपाईंको लागि एउटा सङ्ग्रह बनाउन आवश्यक छ।</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="ne">सुरू गर्न 'अर्को' मा थिच्‌नुहोस् गर्नुहोस्।</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InDropboxMessage">
+      <trans-unit id="OpenCreateCloneControl.InDropboxMessage" approved="yes">
         <source xml:lang="en">Bloom detected that this collection is located in your Dropbox folder. This can cause problems as Dropbox sometimes locks Bloom out of its own files. If you have problems, we recommend that you move your collection somewhere else or disable Dropbox while using Bloom.</source>
         <target xml:lang="ne">Bloom ले यो सङ्ग्रह तपाईंको Dropbox फोल्डरमा छ भनी पत्ता लगाएको छ।कहिलेकाहीँ Dropbox ले Bloom लाई यसका फाइलहरूमाथि पहुँच नदिने भएकाले यसले समस्या निम्त्याउन सक्छ।समस्या देखिएको खण्डमा, हामी तपाईंलाई आफ्नो सङ्ग्रह अन्य कतै सार्न वा Bloom प्रयोग गर्दा Dropbox अक्षम बनाउन सिफारिस गर्दछौं।</target>
         <note>ID: OpenCreateCloneControl.InDropboxMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage">
+      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage" approved="yes">
         <source xml:lang="en">This collection is part of your 'Sources for new books' which you can see in the bottom left of the Collections tab. It cannot be opened for editing.</source>
         <target xml:lang="ne">यो सङ्ग्रह तपाईंको 'नयाँ पुस्तकहरूको स्रोत' को अंश हो जसलाई तपाईंले सङ्ग्रहहरू नामक ट्याबको तल्लो भागको बायाँपट्टी हेर्न सक्नुहुन्छ।यसलाई सम्पादन गर्न सकिँदैन।</target>
         <note>ID: OpenCreateCloneControl.InSourceCollectionMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="ne">Bloom का सङ्ग्रहहरू</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="ne">यो कम्प्युटरमा अर्को सङ्ग्रह खोज्नुहोस्</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="ne">स्थानीय नेटवर्कको Chorus Hub बाट नक्कल गर्नुहोस्?</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="ne">इन्टरनेटबाट नक्कल गर्नुहोस्</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="ne">USB ड्राइभबाट नक्कल गर्नुहोस्</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="ne">नयाँ सङ्ग्रह बनाउनुहोस्</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="ne">सङ्ग्रह खोल्नुहोस्/बनाउनुहोस्</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="ne">थप पढ्नुहोस्</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="ne">के कसैले तपाईंसँग कुनै सङ्ग्रह आदान-प्रदान गर्न पठाउने/प्राप्त गर्ने प्रकार्य प्रयोग गर्नुभएको छ?\nउनीहरूको सङ्ग्रहलाई आफ्नो कम्प्युटरमा प्रतिलिपि गर्न यी राता बटनहरू मध्ये एउटा प्रयोग गर्नुहोस्।\nपछि, उनीहरूसँग आफ्नो रचना आदान-प्रदान गर्न पठाउने/प्राप्त गर्ने प्रकार्य प्रयोग गर्नुहोस्।</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="ne">विद्यमान सङ्ग्रहलाई प्रतिस्थापन गर्नुहोस्</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="ne">सूचना</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are.</source>
         <target xml:lang="ne">सो परिवर्तन गर्ने अनुमति छैन।अगाडि र पछाडिको आवरण पृष्ठ जहाँ छ त्यहीँ रहनुपर्छ।</target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="ne">अमान्य चाल</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.BadPdf">
+      <trans-unit id="PublishTab.PdfMaker.BadPdf" approved="yes">
         <source xml:lang="en">Bloom had a problem making a PDF of this book. You may need technical help or to contact the developers. Here are some things you can try:</source>
         <target xml:lang="ne">Bloom लाई यो पुस्तकको PDF बनाउनमा समस्या भयो। तपाईंलाई प्राविधिक सहयोग चाहिन वा विकासकर्ताहरूलाई सम्पर्क गर्न आवश्यक हुन सक्छ। यहाँ केही उपायहरू दिइएका छन्:</target>
         <note>ID: PublishTab.PdfMaker.BadPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory">
+      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory" approved="yes">
         <source xml:lang="en">Try doing this on a computer with more memory</source>
         <target xml:lang="ne">बढी मेमोरी भएको कम्प्युटरमा गर्ने प्रयास गर्नुहोस्</target>
         <note>ID: PublishTab.PdfMaker.TryMoreMemory</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryRestart">
+      <trans-unit id="PublishTab.PdfMaker.TryRestart" approved="yes">
         <source xml:lang="en">Restart your computer and try this again right away</source>
         <target xml:lang="ne">आफ्नो कम्प्युटरलाई पुनः सुरू गर्नुहोस् र त्यसपछि तुरुन्त यो कार्य गर्ने प्रयास गर्नुहोस्</target>
         <note>ID: PublishTab.PdfMaker.TryRestart</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages">
+      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages" approved="yes">
         <source xml:lang="en">Replace large, high-resolution images in your document with lower-resolution ones</source>
         <target xml:lang="ne">तपाईंको डकुमेन्टमा भएका ठूला, उच्च रेजोल्युसनका छविहरूलाई कम रेजोल्युसनका छविहरूले प्रतिस्थापन गर्नुहोस्</target>
         <note>ID: PublishTab.PdfMaker.TrySmallerImages</note>
       </trans-unit>
-      <trans-unit id="PageList.CantMoveWhenTranslating">
+      <trans-unit id="PageList.CantMoveWhenTranslating" approved="yes">
         <source xml:lang="en">Pages can not be re-ordered when you are translating a book.</source>
         <target xml:lang="ne">तपाईंले पुस्तक अनुवाद गरिरहँदा पृष्ठहरूको क्रम मिलाउन सकिँदैन।</target>
         <note>ID: PageList.CantMoveWhenTranslating</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="ne">Bloom ले तपाईंलाई तयार पुस्तक देखाउन कृपया Adobe Reader स्थापना गर्नुहोस्।तबसम्म, तपाईंले यस PDF पुस्तकलाई सुरक्षित गरेर यसलाई अन्य कुनै प्रोग्रामबाट खोल्न सक्नुहुन्छ।</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF.You can still try saving the PDF Book.</source>
         <target xml:lang="ne">अचम्मै भयो त...PDF देखाउने प्रयास गर्दा Adobe Reader ले त्रुटि देखायो।तपाईंले यस PDF पुस्तकलाई सुरक्षित गरेर राख्न सक्नुहुन्छ।</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="ne">दुःखको कुरा।Bloom ले Adobe Reader माथि पहुँच गर्न सकेन, तसर्थ Bloom ले तपाईंको तयार पुस्तक देखाउन सक्दैन।\nतपाईसँग भएको Adobe Reader हटाएर नयाँ Adobe Reader (पुनः) स्थापना गर्नुहोस्।\nयसको समाधान नहुँदासम्म, तपाईंले यस PDF पुस्तकलाई सुरक्षित गरेर यसलाई अन्य कुनै प्रोग्रामबाट खोल्न सक्नुहुन्छ।</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="ne">लघु पुस्तिकाको भित्री सामग्रीहरू</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book.Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="ne">यस पुस्तकका भित्री पानाहरू प्रयोग गरेर लघु पुस्तिका बनाउनुहोस्पानाहरूलाई निकालेर फेरि मिलेइनेछ जसले गर्दा तपाईंले यसलाई पट्याउँदा यो लघु पुस्तिकामा परिणत हुनेछ।\n</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="ne">अपलोड गर्नुहोस्</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="ne">BloomLibrary.org मा अपलोड गर्नुहोस्, जहाँबाट अरूले यसलाई डाउनलोड गरेर आफ्नो भाषामा अनुवाद गर्न सक्नेछन्।</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="ne">लघु पुस्तिकाको आवारण पृष्ठ</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="ne">रङ्गीन कागजमा छाप्नका लागि अगाडि र पछाडिको आवरण पृष्ठको (भित्र र बाहिर दुवै पट्टीको) छुट्टै PDF बनाउनुहोस्।</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubButton">
+      <trans-unit id="PublishTab.EpubButton" approved="yes">
         <source xml:lang="en">ePUB</source>
         <target xml:lang="ne">ePUB</target>
         <note>ID: PublishTab.EpubButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation">
+      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation" approved="yes">
         <source xml:lang="en">This PDF viewer can be improved by installing the free Adobe Reader on this computer.</source>
         <target xml:lang="ne">PDF हेर्ने यो अनुप्रयोगलाई आफ्नो कम्प्युटरमा निःशुल्क रूपमा उपलब्ध Adobe Reader स्थापना गरेर सुधार्न सकिन्छ।</target>
         <note>ID: PublishTab.Notifications.AdobeReaderRecommendation</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="ne">सामान्य</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="ne">एउटा कागजमा एउटा पाना राखेर यस पुस्तकको हरेक पानाको PDF बनाउनुहोस्।</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system PDF viewer</source>
         <target xml:lang="ne">यस PDF लाई प्रणालीको PDF हेर्ने पूर्वनिर्धारित अनुप्रयोगबाट खोल्नुहोस्</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="ne">&amp;छाप्नुहोस्...</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="ne">प्रकाशन गर्नुहोस्</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="ne">&amp;PDF सुरक्षित गर्नुहोस्...</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveEpub">
+      <trans-unit id="PublishTab.SaveEpub" approved="yes">
         <source xml:lang="en">&amp;Save ePUB...</source>
         <target xml:lang="ne">&amp;ePUB सुरक्षित गर्नुहोस्...</target>
         <note>ID: PublishTab.SaveEpub</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="ne">क्रप मार्कहरू</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="ne">कृतज्ञता</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">Additional Requests: </source>
         <target xml:lang="ne">अतिरिक्त अनुरोधहरू:</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="ne">सर्वाधिकार सुरक्षित (कुनैपनि अनुमतिका लागि प्रतिलिपि अधिकार धारकलाई सम्पर्क गर्नुहोस्।)</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you. If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="ne">BloomLibrary.org ले तपाईंबाट यो पुस्तक पहिले नै प्राप्त गरिसकेको छ।तपाईंले यसलाई अपडो गर्नुभयो भने, पहिलेको पुस्तकलाई हालको संस्करणले प्रतिस्थापन गर्नेछ।</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="ne">प्रतिलिपि अधिकार</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="ne">श्रेय</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="ne">तपाईंको पुस्तक डाउनलोड गर्दा समस्या आयो।तपाईंले Bloom फेरि सुरू गर्न वा प्राविधिक सहयोग लिन आवश्यक हुन सक्छ।</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.TimeoutProblemNotice">
+      <trans-unit id="Download.TimeoutProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading the book: something took too long. You can try again at a different time, or write to us at issues@bloomlibrary.org if you cannot get the download to work from your location.</source>
         <target xml:lang="ne">पुस्तक डाउनलोड गर्दा समस्या भयो: कुनै कुराले धेरै समय लगायो।तपाईंले पछि फेरि प्रयास गर्न सक्नुहुन्छ, वा यदि तपाईंले आफ्नो स्थानबाट डाउनलोड गर्न सक्नुभएन भने, यस समस्याको बारेमा लेखेर issues@bloomlibrary.org मा इमेल पठाउनुहोस्।</target>
         <note>ID: Download.TimeoutProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="ne">माफ गर्नुहोस्, {0} अपलोड गर्नमा समस्या भयो। केही विवरणहरू तल दिइएका छन्। तपाईंलाई प्राविधिक सहायता आवश्यक पर्न सक्छ।</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading</source>
         <target xml:lang="ne">अपलोड गर्नु अघि माथिका एक वा सोभन्दा बढी विषयहरूमा तपाईंको ध्यानाकर्षण गराउन चाहन्छौं</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded</source>
         <target xml:lang="ne">माफ गर्नुहोस्, "{0}" सफलतापूर्वक अपलोड भएन।</target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes</source>
         <target xml:lang="ne">अपलोड गरेर, तपाईं Bloom Library को प्रयोगका सर्तहरूमा सहमति जनाउनुहुन्छ र त्यसमा व्याख्या गरिएका अधिकारहरू प्रदान गर्नुहुन्छ</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="ne">तपाईंको पुस्तक अपलोड गर्दा समस्या आयो।</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="ne">भाषाहरू</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="ne">प्रयोग/इजाजतपत्र</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="ne">खाता पहिले नै छ</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address. Would you like to log in instead?</source>
         <target xml:lang="ne">सो ठेगाना भएको खाता हामीसँग पहिले नै भएकाले, हामी सो ठेगाना प्रयोग गरेर तपाईंलाई साइन अप गराउन सक्दैनौं। बरु लग इन गर्न चाहनुहुन्छ?</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="ne">तपाईंको लग इन प्रमाणीकरण गर्न Bloom ले सर्भरमा जडान गर्न सकेन। कृपया आफ्नो इन्टरनेटको जडान जाँच्नुहोस्।</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="ne">लग इन गर्न सकिएन</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="ne">तपाईंको लग इन वा साइन अप सम्पन्न गर्न Bloom ले सर्भरमा जडान गर्न सकेन। तपाईंको इन्टरनेट जडान, हाम्रो सर्भर वा यिनी बीचका कुनै उपकरणमा समस्या हुन सक्छ।</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="ne">BloomLibrary.org खाताका लागि साइन अप गर्न, तपाईंले BloomLibrary को प्रयोगका सर्तहरूमा सहमति जनाउँदै यो बाकसमा चिन्ह लगाउनुपर्छ।</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="ne">इमेल आवश्यक छ</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="ne">हाम्रो अभिलेखमा सो इमेल भएको प्रयोगकर्ता छैन। साइन अप गर्न चाहनुहुन्छ?</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="ne">पासवर्ड र प्रयोगकर्ता ID मिलेन</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="ne">कृपया प्रयोगका सर्तहरूमा सहमति जनाउनुहोस्</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="ne">कृपया मान्य इमेल ठेगाना प्रविष्ट गर्नुहोस्।हामी यो ठेगानामा एउटा इमेल पठाउने छौं जस मार्फत तपाईंले आफ्नो पासवर्ड रिसेट गर्न सक्नुहुन्छ।</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="ne">तपाईंको पासवर्ड रिसेट गर्न Bloom ले सर्भरमा जडान गर्न सकेन।कृपया आफ्नो इन्टरनेटको जडान जाँच्नुहोस्।</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="ne">पासवर्ड रिसेट गर्न असफल भयो</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="ne">पासवर्ड रिसेट गर्दै</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password</source>
         <target xml:lang="ne">तपाईंको पासवर्ड रिसेट गर्ने निर्देशनहरू सहित हामी {0} मा एउटा इमेल पठाउँदै छौं</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="ne">Bloom Library मा साइन अप गर्नुहोस्</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="ne">अज्ञात प्रयोगकर्ता</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="ne">Bloom ले तपाईंले सुरक्षित गर्नुभएको इमेल र पासवर्ड प्रयोग गरेर BloomLibrary.org मा साइन इन गर्न सकेन।कृपया आफ्नो इन्टरनेटको जडान जाँच्नुहोस्।</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="ne">BloomLibrary.org बाट लग आउट गर्नुहोस्</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="ne">PDF को पूर्वावलोकन बनाउँदै...</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="ne">थम्बनेल छवि बनाउँदै...</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.NoLangsFound">
+      <trans-unit id="PublishTab.Upload.NoLangsFound" approved="yes">
         <source xml:lang="en">(None found)</source>
         <target xml:lang="ne">(कुनै फेला परेन)</target>
         <note>ID: PublishTab.Upload.NoLangsFound</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="ne">माफ गर्नुहोस्, Bloom Desktop को यो संस्करण BloomLibrary.org को हालको संस्करणसँग अनुकूल छैन।कृपया नयाँ संस्करणमा स्तरवृद्धि गर्नुहोस्।</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.IncompleteTranslation">
+      <trans-unit id="PublishTab.Upload.IncompleteTranslation" approved="yes">
         <source xml:lang="en">(incomplete translation)</source>
         <target xml:lang="ne">(आंशिक)</target>
         <note>ID: PublishTab.Upload.IncompleteTranslation</note>
         <note>This is added after the language name, in order to indicate that some parts of the book have not been translated into this language yet.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="ne">अपलोड गर्नु अघि कृपया BloomLibrary.org मा लग इन गर्नुहोस् (वा साइन अप गर्नुहोस्)</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="ne">कृपया यसलाई सम्पादन ट्याबबाट सेट गर्नुहोस्</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="ne">चरण 1: मेटाडाटा पुष्टि गर्नुहोस्</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="ne">चरण 2: अपलोड गर्नुहोस्</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="ne">सुझाव: Creative Commons इजाजतपत्र निर्दिष्ट गर्नाले केही निश्चित अनुमतिहरू सबैलाई स्पष्ट रूपमा प्रदान गर्न सजिलो हुन्छ।</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="ne">सुझाव: Creative Commons इजाजतपत्रहरूले तपाईंको कस्टम इजाजतपत्रको भाषा राम्रोसँग नआउने भएपनि, अरूलाई तपाईंको पुस्तक प्रयोग गर्न धेरै सजिलो बनाउँछ।</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="ne">सारांश</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="ne">प्रयोगका सर्तहरू देखाउनुहोस्</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TimeProblem">
+      <trans-unit id="PublishTab.Upload.TimeProblem" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. This is probably because your computer is set to use the wrong timezone or your system time is badly wrong. See http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html for how to fix this.</source>
         <target xml:lang="ne">तपाईंको पुस्तक अपलोड गर्दा समस्या आयो।सम्भवतः तपाईंको कम्प्युटरमा गलत समय क्षेत्र सेट गरिएको वा तपाईंको प्रणालीको समय एकदमै गलत भएको हुनाले यस्तो भएको हुन सक्छ।यो समस्या समाधान गर्ने उपायका लागि http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html मा हेर्नुहोस्।</target>
         <note>ID: PublishTab.Upload.TimeProblem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="ne">शीर्षक</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="ne">पुस्तक अपलोड गर्नुहोस्</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <target xml:lang="ne">बधाई छ, "{0}" अब BloomLibrary.org मा उपलब्ध छ ({1})</target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="ne">अपलोड गर्ने अनुमति छैन</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="ne">तपाईंको पुस्तक अपलोड गर्दा समस्या आयो।तपाईंले Bloom फेरि सुरू गर्न वा प्राविधिक सहयोग लिन आवश्यक हुन सक्छ।</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="ne">अपलोड कार्यको प्रगति</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="ne">पुस्तक अपलोड गर्नुहोस् (Sandbox मा)</target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="ne">पुस्तकको मेटाडाटा अपलोड गर्दै</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, and topic tags to the bloomlibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="ne">{0} अपलोड गर्दै</target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="ne">CC-BY-NC</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="ne">BloomLibrary.org मा लग इन गर्नुहोस्</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="ne">BloomLibrary.org मा साइन अप गर्नुहोस्</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="PublishView._saveButton">
+      <trans-unit id="PublishView._saveButton" approved="yes">
         <source xml:lang="en">Save stub</source>
         <target xml:lang="ne">अधकट्टी सुरक्षित गर्नुहोस्</target>
         <note>ID: PublishView._saveButton</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="ne">स्तर थप्नुहोस्</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="ne">चरण थप्नुहोस्</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <target xml:lang="ne">कृपया नमूना पाठहरूको फोल्डरमा पाठ्य फाइल थप्नुहोस्।</target>
         <note>ID: ReaderSetup.AddTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="ne">पुस्तक</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="ne">प्रति पुस्तक अधिकतम शब्द</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="ne">अक्षरहरूलाई यो चरणमा थप्न तिनीहरूमा क्लिक गर्नुहोस्</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="ne">स्पेसले छुट्याउनुहोस्</target>
         <note>ID: ReaderSetup.CombinationHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <target xml:lang="ne">उदाहरणको लागि "ह रि यो फ ट्याङ ग्रो"</target>
         <note>ID: ReaderSetup.CombinationHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <target xml:lang="ne">अक्षरका संयोजनहरू (बाह्रखरी)</target>
         <note>ID: ReaderSetup.Combinations</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="ne">डिकोडेबल चरणहरू</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true" approved="yes">
         <source xml:lang="en">File needs .TXT extension</source>
         <target xml:lang="ne">फाइलमा .TXT एक्स्टेन्शन हुनुपर्छ</target>
         <note>ID: ReaderSetup.FileNeedsTxtExtension</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="ne">सर्वप्रथम,</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="ne">यो ढाँचा पढ्न सक्दैन</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="ne">नमूना पाठहरूको रूपमा प्रयोग गर्न फाइलहरूलाई निर्यात गर्न र रूपान्तरण गर्न मद्दत</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="ne">भाषा</target>
         <note>ID: ReaderSetup.Language</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <target xml:lang="ne">अक्षर र शब्द बनाउने वर्णहरूलाई वर्णमालाको क्रम अनुसार सूचीकृत गर्नुहोस्</target>
         <note>ID: ReaderSetup.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="ne">स्पेसले छुट्याउनुहोस्</target>
         <note>ID: ReaderSetup.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <target xml:lang="ne">उदाहरणको लागि "क ख ग घ"</target>
         <note>ID: ReaderSetup.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="ne">अक्षर</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="ne">अक्षर र अक्षरको संयोजन</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="ne">तपाईंलाई डिकोडेबल पाठ्यपुस्तकहरू बनाउन मद्दत गर्न, Bloom लाई तपाईंले पढाउन लागेको अक्षर र अक्षरका संयोजनहरू बारे थाहा हुन जरूरी हुन्छ।</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="ne">प्रत्येक अक्षर वा अक्षरको संयोजनलाई स्पेसले छुट्याउनुहोस्। उदाहरणको लागि, अङ्ग्रेजी भाषामा हामी यस्तो प्रयोग गर्न सक्छौं:</target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="ne">अङ्ग्रेजी भाषाको सूचीमा शब्दहरू बनाउन प्रयोग हुने चिन्हहरू, जस्तै </target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="ne">it's</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="ne">मा प्रयोग हुने ' समावेश हुन्छ भन्ने कुरा ध्यानमा राख्नुहोस्।</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="ne">स्तर</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="ne">स्तर </target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="ne">पाठकको स्तर</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="ne">मिल्ने शब्दहरू</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="ne">प्रति पुस्तक अधिकतम अद्वीतीय शब्दहरू</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <target xml:lang="ne">थप शब्दहरू</target>
         <note>ID: ReaderSetup.MoreWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <target xml:lang="ne">यो भाषाको नमूना पाठहरूको फोल्डर खोल्नुहोस्।</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="ne">पृष्ठ</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="ne">प्रति पाना अधिकतम शब्द</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="ne">प्रायोजक: </target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="ne">पाठकको स्तर</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="ne">स्तर {0} हटाउनुहोस्</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="ne">चरण {0} हटाउनुहोस्</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove from this stage</source>
         <target xml:lang="ne">यो चरणबाट हटाउनुहोस्</target>
         <note>ID: ReaderSetup.RemoveWordList</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="ne">स्तरहरूको क्रम मिलाउन पङ्क्तिहरूलाई तान्नुहोस्।</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="ne">चरणहरूको क्रम मिलाउन पङ्क्तिहरूलाई तान्नुहोस्।</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <target xml:lang="ne">शब्द सूची र नमूना पाठहरू</target>
         <note>ID: ReaderSetup.SampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="ne">, साक्षरताका लागि खोज इन्जिन।</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="ne">पहिलेका र नयाँ अक्षरहरू</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="ne">वाक्य</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="ne">प्रति वाक्य अधिकतम शब्द</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="ne">डिकोडेबल पाठ्यपुस्तक उपकरण सेटअप गर्नुहोस्</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="ne">स्तर तोकिएको पाठ्यपुस्तक उपकरण सेट अप गर्नुहोस्</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <target xml:lang="ne">यो भाषाको वर्णमाला सेट अप गर्नुहोस्।</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <target xml:lang="ne">धेरै प्रयोग हुने शब्दहरू भनेका के हुन्?</target>
         <note>ID: ReaderSetup.SightWordHelp</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="ne">धेरै प्रयोग हुने नयाँ शब्द</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="ne">धेरै प्रयोग हुने शब्दहरू</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="ne">चरण</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="ne">चरण</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="ne">चरणहरू</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="ne">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="ne">यो स्तरमा याद राख्नुपर्ने कुराहरू:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="ne">अद्वितीय</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="ne">शब्दहरू</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage. There are two ways to give words to Bloom:</source>
         <target xml:lang="ne">तपाईंलाई डिकोडेबल पाठ्यपुस्तकहरू बनाउन मद्दत गर्न, Bloom ले हालको चरणमा राख्न मिल्ने शब्दहरूको सुझाव दिन सक्छ।Bloom लाई शब्द प्रदान गर्ने दुई तरिका छन्:</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="ne">1) यहाँ शब्दहरू टाइप गरेर</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="ne">2) आफ्नो नमूना पाठहरूको फोल्डरमा</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <target xml:lang="ne">पाठ्य फाइलहरू राखेर</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="ne">अक्षर</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this Bloom Pack will carry your latest decodable and leveled reader settings for the \"{0}\" language.Anyone opening this Bloom Pack , who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this Bloom Pack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="ne">यस अतिरिक्त, यो Bloom प्याकमा \"{0}\" भाषाका लागि नवीनतम डिकोडेबल र स्तर तोकिएको पाठ्यपुस्तकका सेटिङहरू हुनेछन्। यो Bloom प्याक , र त्यसपछि \"{0}\" सङ्ग्रह खोल्ने जोकोहीको हालको डिकोडेबल र स्तर तोकिएको पाठ्यपुस्तकको सेटिङहरूलाई यस Bloom प्याकको सेटिङहरूले प्रतिस्थापन गर्नेछ। उनीहरूले डिकोडेबल पाठ्यपुस्तकहरूमा प्रयोग गर्नका लागि हालको शब्द समूह पनि प्राप्त गर्नेछन्।</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="ne">निम्न पुस्तकहरूलाई टेम्प्लेटमा परिणत गरिनेछ:</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <target xml:lang="ne">Bloom प्याक बचत गर्नुहोस्</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <target xml:lang="ne">पाठ्यपुस्तक टेम्प्लेटको Bloom प्याक बनाउनुहोस्</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="ne">इमेल ठेगाना</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="ne">पहिलो नाम</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="ne">कृपया केही मिनेट समय दिएर {0} दर्ता गर्नुहोस्</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="ne">तपाईं {0} कसरी प्रयोग गर्दै हुनुहुन्छ?</target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="ne">म अड्केँ, म यसलाई पछि पूरा गर्छु।</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="ne">सङ्गठन</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="ne">&amp;दर्ता गर्नुहोस्</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="ne">थर</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="ne">{0} दर्ता गर्नुहोस्</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <target xml:lang="ne">बन्द गर्नुहोस्</target>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.CouldNotSendToServer">
+      <trans-unit id="ReportProblemDialog.CouldNotSendToServer" approved="yes">
         <source xml:lang="en">Bloom was not able to submit your report directly to our server. Please retry or email {0} to {1}.</source>
         <target xml:lang="ne">Bloom ले तपाईंको रिपोर्ट सीधै हाम्रो सर्भरमा पेश गर्न सकेन। कृपया पुनः प्रयास गर्नुहोस् वा {1} लाई {0} इमेल पठाउनुहोस्।</target>
         <note>ID: ReportProblemDialog.CouldNotSendToServer</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Email">
+      <trans-unit id="ReportProblemDialog.Email" approved="yes">
         <source xml:lang="en">Email</source>
         <target xml:lang="ne">इमेल</target>
         <note>ID: ReportProblemDialog.Email</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeBookButton">
+      <trans-unit id="ReportProblemDialog.IncludeBookButton" approved="yes">
         <source xml:lang="en">Include Book '{0}'</source>
         <target xml:lang="ne">'{0}' पुस्तक समावेश गर्नुहोस्</target>
         <note>ID: ReportProblemDialog.IncludeBookButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton">
+      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton" approved="yes">
         <source xml:lang="en">Include this screenshot</source>
         <target xml:lang="ne">यो स्क्रिनसट समावेश गर्नुहोस्</target>
         <note>ID: ReportProblemDialog.IncludeScreenshotButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Name">
+      <trans-unit id="ReportProblemDialog.Name" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="ne">नाम</target>
         <note>ID: ReportProblemDialog.Name</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Retry">
+      <trans-unit id="ReportProblemDialog.Retry" approved="yes">
         <source xml:lang="en">Retry</source>
         <target xml:lang="ne">पुनः प्रयास गर्नुहोस्</target>
         <note>ID: ReportProblemDialog.Retry</note>
         <note>Shown if there was an error submitting the report. Lets the user try submitting it again.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SeeDetails">
+      <trans-unit id="ReportProblemDialog.SeeDetails" approved="yes">
         <source xml:lang="en">See what else will be submitted</source>
         <target xml:lang="ne">अरू के-के पेश गरिनेछ हेर्नुहोस्</target>
         <note>ID: ReportProblemDialog.SeeDetails</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SubmitButton">
+      <trans-unit id="ReportProblemDialog.SubmitButton" approved="yes">
         <source xml:lang="en">&amp;Submit</source>
         <target xml:lang="ne">&amp;पेश गर्नुहोस्</target>
         <note>ID: ReportProblemDialog.SubmitButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Submitting">
+      <trans-unit id="ReportProblemDialog.Submitting" approved="yes">
         <source xml:lang="en">Submitting to server...</source>
         <target xml:lang="ne">सर्भरमा पेश गर्दै...</target>
         <note>ID: ReportProblemDialog.Submitting</note>
         <note>This is shown while Bloom is sending the problem report to our server.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Success">
+      <trans-unit id="ReportProblemDialog.Success" approved="yes">
         <source xml:lang="en">We received your report, thanks for taking the time to help make Bloom better!</source>
         <target xml:lang="ne">हामीले तपाईंको रिपोर्ट पायौं, Bloom लाई अझ राम्रो बनाउन आफ्नो समय दिनुभएकोमा धन्यवाद!</target>
         <note>ID: ReportProblemDialog.Success</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WhatsTheProblem">
+      <trans-unit id="ReportProblemDialog.WhatsTheProblem" approved="yes">
         <source xml:lang="en">What seems to be the problem?</source>
         <target xml:lang="ne">समस्या के हो त?</target>
         <note>ID: ReportProblemDialog.WhatsTheProblem</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WindowTitle">
+      <trans-unit id="ReportProblemDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Report A Problem</source>
         <target xml:lang="ne">समस्या रिपोर्ट गर्नुहोस्</target>
         <note>ID: ReportProblemDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Zipping">
+      <trans-unit id="ReportProblemDialog.Zipping" approved="yes">
         <source xml:lang="en">Zipping up book...</source>
         <target xml:lang="ne">पुस्तक जिप गर्दै...</target>
         <note>ID: ReportProblemDialog.Zipping</note>
         <note>This is shown while Bloom is creating the problem report. It's generally too fast to see, unless you include a large book.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.linkLabel1">
+      <trans-unit id="ReportProblemDialog.linkLabel1" approved="yes">
         <source xml:lang="en">Will not be private</source>
         <target xml:lang="ne">गोप्य हुनेछैन</target>
         <note>ID: ReportProblemDialog.linkLabel1</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.IGetIt">
+      <trans-unit id="SamplePrintNotification.IGetIt" approved="yes">
         <source xml:lang="en">I get it. Do not show this again.</source>
         <target xml:lang="ne">मैले बुझेँ।यो कुरा फेरि नदेखाउनुहोस्।</target>
         <note>ID: SamplePrintNotification.IGetIt</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.PleaseNotice">
+      <trans-unit id="SamplePrintNotification.PleaseNotice" approved="yes">
         <source xml:lang="en">Please notice the sample printer settings below. Use them as a guide while you set up the printer.</source>
         <target xml:lang="ne">कृपया तल प्रिन्टरको नमूना सेटिङहरूलाई ध्यान दिएर हेर्नुहोस्।आफ्नो प्रिन्टर सेट अप गर्दा यिनीहरूलाई मार्गदर्शनको रूपमा प्रयोग गर्नुहोस्।</target>
         <note>ID: SamplePrintNotification.PleaseNotice</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Arithmetic</source>
         <target xml:lang="ne">अङ्क गणित</target>
         <note>ID: TemplateBooks.BookName.Arithmetic</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="ne">आधारभूत पुस्तक</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="ne">ठूलो पुस्तक</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="ne">डिकोडेबल पाठ्यपुस्तक</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="ne">स्तर तोकिएको पाठ्यपुस्तक</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="ne">सचित्र शब्दकोष</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="ne">भित्ते पात्रो</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vaccinations</source>
         <target xml:lang="ne">खोपहरू</target>
         <note>ID: TemplateBooks.BookName.Vaccinations</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="ne">कृषि</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="ne">जनावरका कथाहरू</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="ne">व्यवसाय</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="ne">सामुदायिक रहन सहन</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="ne">संस्कृति</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="ne">शब्दकोष</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="ne">वातावरण</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="ne">काल्पनिक</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="ne">स्वास्थ्य</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="ne">कसरी गर्ने</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="ne">गणित</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.NoTopic" sil:dynamic="true">
+      <trans-unit id="Topics.NoTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">No Topic</source>
         <target xml:lang="ne">शीर्षक छैन</target>
         <note>ID: Topics.NoTopic</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="ne">सत्यमा आधारित</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="ne">व्यक्तिगत विकास</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="ne">वर्णमाला</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="ne">विज्ञान</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="ne">आध्यात्मिक</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Story Book" sil:dynamic="true">
+      <trans-unit id="Topics.Story Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Story Book</source>
         <target xml:lang="ne">कथा</target>
         <note>ID: Topics.Story Book</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="ne">परम्परा</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="ne">पौराणिक कथा</target>
         <note>ID: Topics.Traditional Story</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="ne">सेटअप गर्नुहोस्</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>

--- a/DistFiles/localization/ne/IntegrityFailureAdvice.xlf
+++ b/DistFiles/localization/ne/IntegrityFailureAdvice.xlf
@@ -2,77 +2,77 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="IntegrityFailureAdvice-en.md" datatype="html" source-language="en" target-language="ne">
     <body>
-      <trans-unit id="integrity.title">
+      <trans-unit id="integrity.title" approved="yes">
         <source xml:lang="en">Bloom cannot find some of its own files, and cannot continue</source>
         <target xml:lang="ne">Bloom ले कतिपय आफ्नै फाइलहरू फेला पार्न सक्‍दैन र जारी राख्न सक्दैन</target>
         <note>ID: integrity.title</note>
       </trans-unit>
-      <trans-unit id="integrity.causes">
+      <trans-unit id="integrity.causes" approved="yes">
         <source xml:lang="en">Possible Causes</source>
         <target xml:lang="ne">सम्भावित कारणहरू</target>
         <note>ID: integrity.causes</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.1">
+      <trans-unit id="integrity.causes.1" approved="yes">
         <source xml:lang="en">Your antivirus may have "quarantined" one or more Bloom files.</source>
         <target xml:lang="ne">तपाईंको एन्टिभाइरसले Bloom को एक वा सोभन्दा बढी फाइलहरूलाई "अलग्गै राखेको" हुन सक्छ।</target>
         <note>ID: integrity.causes.1</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.2">
+      <trans-unit id="integrity.causes.2" approved="yes">
         <source xml:lang="en">Your computer administrator may have your computer "locked down" to prevent bad things, but in such a way that Bloom could not place these files where they belong. </source>
         <target xml:lang="ne">तपाईंको कम्प्युटर प्रशासकले कम्प्युटरलाई हानिकारक कुराहरूबाट जोगाउन कम्प्युटर "लक डाउन" गरेको हुनाले Bloom ले यी फाइलहरूलाई ती रहने वास्तविक ठाउँमा राख्न नसकेको हुन सक्छ।</target>
         <note>ID: integrity.causes.2</note>
       </trans-unit>
-      <trans-unit id="integrity.todo">
+      <trans-unit id="integrity.todo" approved="yes">
         <source xml:lang="en">What To Do</source>
         <target xml:lang="ne">अब के गर्ने त ?</target>
         <note>ID: integrity.todo</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas">
+      <trans-unit id="integrity.todo.ideas" approved="yes">
         <source xml:lang="en">After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas:</source>
         <target xml:lang="ne">तपाईंले यो रिपोर्ट पेश गरेपछि, हामी तपाईंलाई सम्पर्क गरेर त्‍यसलाई समाधान गर्न मद्दत गर्नेछौं। त्यतिखेरसम्मका लागि, तल केही उपायहरू दिइएका छन्:</target>
         <note>ID: integrity.todo.ideas</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Reinstall">
+      <trans-unit id="integrity.todo.ideas.Reinstall" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="ne">Bloom प्रेाग्रामलाई फेरि सुरु  गर्नुहोस् यसपटक यो ठीकसँग खुल्छ कि खुल्दैन हेर्नुहोस्।</target>
         <note>ID: integrity.todo.ideas.Reinstall</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Antivirus">
+      <trans-unit id="integrity.todo.ideas.Antivirus" approved="yes">
         <source xml:lang="en">If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>.</source>
         <target xml:lang="ne">त्यसो गर्दा पनि यो समस्या समाधान भएन भने, तपाईंको एन्टिभाइरस प्रोग्रामको प्रदायकसँग कुरा गर्नुहोस्। यदि "छुटेका फाइलहरू" खण्ड तल अन्तिममा ".exe" लेखिएको कुनै पनि फाइल देखिएमा, <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g> मा भएको Bloom प्रोग्राम फोल्डरलाई "श्वेतसूचीमा" राख्‍नुहोस्।</target>
         <note>ID: integrity.todo.ideas.Antivirus</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVAST">
+      <trans-unit id="integrity.todo.ideas.AVAST" approved="yes">
         <source xml:lang="en">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">Instructions</g>.</source>
         <target xml:lang="ne">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">निर्देशनहरू</g>.</target>
         <note>ID: integrity.todo.ideas.AVAST</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Norton">
+      <trans-unit id="integrity.todo.ideas.Norton" approved="yes">
         <source xml:lang="en">Norton Antivirus: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">Instructions from Symantec</g>.</source>
         <target xml:lang="ne">Norton एन्टिभाइरस: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">Symantec को निर्देशन</g>.</target>
         <note>ID: integrity.todo.ideas.Norton</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVG">
+      <trans-unit id="integrity.todo.ideas.AVG" approved="yes">
         <source xml:lang="en">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">Instructions from AVG</g>.</source>
         <target xml:lang="ne">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">AVG को निर्देशन</g>.</target>
         <note>ID: integrity.todo.ideas.AVG</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Others">
+      <trans-unit id="integrity.todo.ideas.Others" approved="yes">
         <source xml:lang="en">Others: Google for "whitelist directory name-of-your-antivirus"</source>
         <target xml:lang="ne">अन्य: Google मा "whitelist directory आफूले-प्रयोग-गर्ने-एन्टिभाइरसको-नाम" खोज्नुहोस्।</target>
         <note>ID: integrity.todo.ideas.Others</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Restart">
+      <trans-unit id="integrity.todo.ideas.Restart" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="ne">Bloom प्रेाग्रामलाई फेरि सुरु गर्नुहोस् यसपटक यो ठीकसँग खुल्छ कि खुल्दैन हेर्नुहोस्।</target>
         <note>ID: integrity.todo.ideas.Restart</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Retrieve">
+      <trans-unit id="integrity.todo.ideas.Retrieve" approved="yes">
         <source xml:lang="en">You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">this image</g>.</source>
         <target xml:lang="ne">पाईंको एन्टिभाइरस प्रोग्रामले Bloom को जुन भाग हटाएको थियो त्यस भागलाई पुनः प्राप्त गर्ने प्रयास गर्न पनि सक्नुहुन्छ। AVG को हकमा, तपाईंले AVG को "options" (विकल्पहरू) मेनु फेला पारेर "virus vault" (भाइरस सङ्ग्रहस्थान) मा थिच्‍नुहोस् र सो सङ्ग्रहस्थानमा रहेको Bloom फाइलमा थिचेर "restore" (पुर्वावस्‍थामा) थिच्नुहेास् गर्नुपर्छ। दृश्यात्मक मार्गदर्शनकेा लागि, <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">यो दृश्यलाई हेर्नुहेास्</g> स्।</target>
         <note>ID: integrity.todo.ideas.Retrieve</note>
       </trans-unit>
-      <trans-unit id="integrity.missing">
+      <trans-unit id="integrity.missing" approved="yes">
         <source xml:lang="en">Missing Files</source>
         <target xml:lang="ne">छुटेका फाइलहरू</target>
         <note>ID: integrity.missing</note>

--- a/DistFiles/localization/ne/Palaso.xlf
+++ b/DistFiles/localization/ne/Palaso.xlf
@@ -2,579 +2,579 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Palaso.dll" source-language="en" target-language="ne" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="AboutDialog.AboutDialogWindowTitle">
+      <trans-unit id="AboutDialog.AboutDialogWindowTitle" approved="yes">
         <source xml:lang="en">About</source>
         <target xml:lang="ne">बारेमा</target>
         <note>ID: AboutDialog.AboutDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.NoUpdates">
+      <trans-unit id="AboutDialog.NoUpdates" approved="yes">
         <source xml:lang="en">No Updates</source>
         <target xml:lang="ne">कुनै अद्यावधिक छैन</target>
         <note>ID: AboutDialog.NoUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._checkForUpdates">
+      <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
         <source xml:lang="en">Check For Updates</source>
         <target xml:lang="ne">अद्यावधिकहरू जाँच्नुहोस्</target>
         <note>ID: AboutDialog._checkForUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._releaseNotesLabel">
+      <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="ne">रिलिज नोटहरू</target>
         <note>ID: AboutDialog._releaseNotesLabel</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.General">
+      <trans-unit id="Application.AlreadyRunning.General" approved="yes">
         <source xml:lang="en">Another copy of the application is already running. If you cannot find it, restart your computer.</source>
         <target xml:lang="ne">यो अनुप्रयोगको अर्को प्रति पहिले देखि नै चलिरहेको छ। तपाईंले यसलाई फेला पार्न सक्नुभएन भने, आफ्नो कम्प्युटर पुन:सुरु गर्नुहोस्।</target>
         <note>ID: Application.AlreadyRunning.General</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.Specific">
+      <trans-unit id="Application.AlreadyRunning.Specific" approved="yes">
         <source xml:lang="en">Another copy of {0} is already running. If you cannot find that copy of {0}, restart your computer.</source>
         <target xml:lang="ne">{0} को अर्को प्रति पहिले देखि नै चलिरहेको छ। यदि तपाईंले {0} को अर्को प्रति फेला पार्न सक्नुभएन भने, आफ्नो कम्प्युटर पुन:सुरु गर्नुहोस्।</target>
         <note>ID: Application.AlreadyRunning.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.General">
+      <trans-unit id="Application.ProblemStarting.General" approved="yes">
         <source xml:lang="en">There was a problem starting the application which might require that you restart your computer.</source>
         <target xml:lang="ne">यो अनुप्रयोग खोल्दा समस्या आयो जसको कारण तपाईंले आफ्नो कम्प्युटर पुन:सुरु गर्न आवश्यक हुन सक्छ।</target>
         <note>ID: Application.ProblemStarting.General</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.Specific">
+      <trans-unit id="Application.ProblemStarting.Specific" approved="yes">
         <source xml:lang="en">There was a problem starting {0} which might require that you restart your computer.</source>
         <target xml:lang="ne">{0} खोल्दा समस्या आयो जसको कारण तपाईंले आफ्नो कम्प्युटर पुन:सुरु गर्न आवश्यक हुन सक्छ।</target>
         <note>ID: Application.ProblemStarting.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.General">
+      <trans-unit id="Application.WaitingFinish.General" approved="yes">
         <source xml:lang="en">Waiting for other application to finish...</source>
         <target xml:lang="ne">अर्को अनुप्रयोगले काम सकाउने प्रतीक्षा गर्नु</target>
         <note>ID: Application.WaitingFinish.General</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.Specific">
+      <trans-unit id="Application.WaitingFinish.Specific" approved="yes">
         <source xml:lang="en">Waiting for other {0} to finish...</source>
         <target xml:lang="ne">{0} काम सकाउने प्रतीक्षा गर्नु...</target>
         <note>ID: Application.WaitingFinish.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="ne">&amp;रद्द गर्नुहोस्</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.No">
+      <trans-unit id="Common.No" approved="yes">
         <source xml:lang="en">No</source>
         <target xml:lang="ne">होइन</target>
         <note>ID: Common.No</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="ne">&amp;ठीक छ</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Yes">
+      <trans-unit id="Common.Yes" approved="yes">
         <source xml:lang="en">Yes</source>
         <target xml:lang="ne">हो</target>
         <note>ID: Common.Yes</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="ne">{0} लाई रद्दी टोकरीमा सारिनेछ।</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
         <note>Parameter {0} is a description of the things being deleted (e.g., "The selected files"</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="ne">{0} लाई रद्दी टोकरीमा सारिनेछ।</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
         <note>Parameter {0} is a file name</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Confirm Delete</source>
         <target xml:lang="ne"> मेटाउने निश्चित गर्नुहोस </target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="ne">&amp;रद्द गर्नुहोस्</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="ne">&amp;मेट्नुहोस्</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.AlmostMatchingImages">
+      <trans-unit id="ImageToolbox.AlmostMatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images with names close to {1}</source>
         <target xml:lang="ne">लगभग {1} सँग नाम मिल्ने {0} तस्विरहरू फेला परे</target>
         <note>ID: ImageToolbox.AlmostMatchingImages</note>
         <note>The {0} will be replaced by the number of images found.  The {1} will be replaced with the search string.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ArtOfReading">
+      <trans-unit id="ImageToolbox.ArtOfReading" approved="yes">
         <source xml:lang="en">Art Of Reading</source>
         <target xml:lang="ne">पढ्ने कला</target>
         <note>ID: ImageToolbox.ArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Camera">
+      <trans-unit id="ImageToolbox.Camera" approved="yes">
         <source xml:lang="en">Camera</source>
         <target xml:lang="ne">क्यामेरा</target>
         <note>ID: ImageToolbox.Camera</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
         <source xml:lang="en">Use {0}</source>
         <target xml:lang="ne">{0} प्रयोग गर्नुहोस्</target>
         <note>ID: ImageToolbox.CopyExemplarMetadata</note>
         <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Crop">
+      <trans-unit id="ImageToolbox.Crop" approved="yes">
         <source xml:lang="en">Crop</source>
         <target xml:lang="ne">काटछाँट गर्नुहोस्</target>
         <note>ID: ImageToolbox.Crop</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.DownloadArtOfReading">
+      <trans-unit id="ImageToolbox.DownloadArtOfReading" approved="yes">
         <source xml:lang="en">Download Art Of Reading Installer</source>
         <target xml:lang="ne">पढ्ने कला (Art Of Reading) को स्थापनाकर्ता डाउनलोड गर्नुहोस्</target>
         <note>ID: ImageToolbox.DownloadArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EditMetadataLink">
+      <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
         <source xml:lang="en">Edit...</source>
         <target xml:lang="ne">सम्पादन गर्नुहोस्...</target>
         <note>ID: ImageToolbox.EditMetadataLink</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EnterSearchTerms">
+      <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
         <source xml:lang="en">This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.</source>
         <target xml:lang="ne">यो 'पढ्ने कला' को सङ्ग्रह हो।माथिको बाकसमा आफूले खोज्न चाहेको कुरा टाइप गर्नुहोस् र ENTER थिच्नुहोस्। तपाईंले अङ्ग्रेजी र इन्डोनेसियाली भाषामा शब्दहरू टाइप गर्न सक्नुहुन्छ।</target>
         <note>ID: ImageToolbox.EnterSearchTerms</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.FileButton">
+      <trans-unit id="ImageToolbox.FileButton" approved="yes">
         <source xml:lang="en">File</source>
         <target xml:lang="ne">फाइल</target>
         <note>ID: ImageToolbox.FileButton</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
         <target xml:lang="ne">माफ गर्नुहोस्, तस्‍विर प्राप्त गर्ने क्रममा केही गडबडी भयो।</target>
         <note>ID: ImageToolbox.GenericGettingImageProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericProblem">
+      <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
         <target xml:lang="ne">माफ गर्नुहोस्, तस्‍विरको उपकरण पेटीमा केही गडबड भयो।</target>
         <note>ID: ImageToolbox.GenericProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GetPicture">
+      <trans-unit id="ImageToolbox.GetPicture" approved="yes">
         <source xml:lang="en">Get Picture</source>
         <target xml:lang="ne">तस्बिर प्राप्त गर्नुहोस्</target>
         <note>ID: ImageToolbox.GetPicture</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
         <source xml:lang="en">Image Toolbox</source>
         <target xml:lang="ne">तस्‍विरको उपकरण पेटी</target>
         <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.InstallArtOfReading">
+      <trans-unit id="ImageToolbox.InstallArtOfReading" approved="yes">
         <source xml:lang="en">Install the Art Of Reading package (this may be very slow)</source>
         <target xml:lang="ne">पढ्ने कलाको प्याकेज स्थापना गर्नुहोस् (यो एकदमै सुस्त हुन सक्छ)</target>
         <note>ID: ImageToolbox.InstallArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.MatchingImages">
+      <trans-unit id="ImageToolbox.MatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images</source>
         <target xml:lang="ne">{0} तस्बिरहरू फेला परे</target>
         <note>ID: ImageToolbox.MatchingImages</note>
         <note>The {0} will be replaced by the number of matching images</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NewMultilingual">
+      <trans-unit id="ImageToolbox.NewMultilingual" approved="yes">
         <source xml:lang="en">Did you know that there is a new version of this collection which lets you search in Arabic, Bengali, Chinese, English, French, Indonesian, Hindi, Portuguese, Spanish, Thai, or Swahili?  It is free and available for downloading.</source>
         <target xml:lang="ne">के तपाईंलाई अरबिक, बङ्गाली, चिनियाँ, अङ्ग्रेजी, फ्रेन्च, इन्डोनेसियाली, हिन्दी, पर्चुगाली, स्पेनिश, थाई वा स्वाहिली भाषामा खोजी गर्न सकिने यस सङ्ग्रहको एउटा नयाँ संस्करण उपलब्ध छ भन्ने कुरा थाहा छ ? यसलाई तपाईंले निःशुल्क रूपमा डाउनलोड गर्न सक्नुहुन्छ।</target>
         <note>ID: ImageToolbox.NewMultilingual</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoArtOfReading">
+      <trans-unit id="ImageToolbox.NoArtOfReading" approved="yes">
         <source xml:lang="en">This computer doesn't appear to have the 'Art Of Reading' gallery installed yet.</source>
         <target xml:lang="ne">यो कम्प्युटरमा अहिले सम्म 'पढ्ने कला' को सङ्ग्रह स्थापना गरिएको छ जस्तो देखिदैन </target>
         <note>ID: ImageToolbox.NoArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoMatchingImages">
+      <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
         <source xml:lang="en">Found no matching images</source>
         <target xml:lang="ne">कुनै मिल्दो तस्‍विर फेला परेन</target>
         <note>ID: ImageToolbox.NoMatchingImages</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PictureFiles">
+      <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
         <source xml:lang="en">picture files</source>
         <target xml:lang="ne">तस्बिर फाइलहरू</target>
         <note>ID: ImageToolbox.PictureFiles</note>
         <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice" approved="yes">
         <source xml:lang="en">Problem Getting Image</source>
         <target xml:lang="ne">तस्‍विर प्राप्त गर्नमा समस्या भयो</target>
         <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemLoadingImage">
+      <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
         <source xml:lang="en">Sorry, there was a problem loading that image.</source>
         <target xml:lang="ne">माफ गर्नुहोस्, तस्‍विर लोड गर्नमा समस्या भयो।</target>
         <note>ID: ImageToolbox.ProblemLoadingImage</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
         <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
         <target xml:lang="ne">यो तस्बिरमा निम्न विवरणहरू छैनन्:\n\nयसलाई कसले सिर्जना गरेको हो?\nयसलाई कसले प्रयोग गर्न सक्छ?</target>
         <note>ID: ImageToolbox.PromptForMissingMetadata</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Scanner">
+      <trans-unit id="ImageToolbox.Scanner" approved="yes">
         <source xml:lang="en">Scanner</source>
         <target xml:lang="ne">स्क्यानर</target>
         <note>ID: ImageToolbox.Scanner</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchArtOfReading">
+      <trans-unit id="ImageToolbox.SearchArtOfReading" approved="yes">
         <source xml:lang="en">Search the Art of Reading Gallery</source>
         <target xml:lang="ne">पढ्ने कलाको सङ्ग्रह खोज्नुहोस्</target>
         <note>ID: ImageToolbox.SearchArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchLanguage">
+      <trans-unit id="ImageToolbox.SearchLanguage" approved="yes">
         <source xml:lang="en">The search box is currently set to {0}</source>
         <target xml:lang="ne">खोज बाकसलाई हाल {0} मा सेट गरिएको छ</target>
         <note>ID: ImageToolbox.SearchLanguage</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SetUpMetadataLink">
+      <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
         <source xml:lang="en">Set up metadata...</source>
         <target xml:lang="ne">मेटाडाटा सेट अप गर्नुहोस्...</target>
         <note>ID: ImageToolbox.SetUpMetadataLink</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.AlternateNamesHeader">
+      <trans-unit id="LanguageLookup.AlternateNamesHeader" approved="yes">
         <source xml:lang="en">Other Names</source>
         <target xml:lang="ne">अन्य नामहरू</target>
         <note>ID: LanguageLookup.AlternateNamesHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2" approved="yes">
         <source xml:lang="en">This list should include all the ISO-639 languages, including all the alternative names known to ethnologue.com.\n\nIf necessary, use the "Unlisted Language" option, which will be selected for you now.</source>
         <target xml:lang="ne">यो सूचीमा ethnologue.com मा भएका सम्पूर्ण वैकल्पिक नामहरू सहित सम्पूर्ण ISO-639 भाषाहरू समावेश हुनुपर्छ।\n\nआवश्यक भएमा, "असूचीकृत भाषा" नामक विकल्प प्रयोग गर्नुहोस्, जुन अहिले तपाईंको लागि चयन गरिनेछ।</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue" approved="yes">
         <source xml:lang="en">Ethnologue.com</source>
         <target xml:lang="ne">Ethnologue.com</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
         <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
         <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
         <target xml:lang="ne">भाषाका 639-3 कोडहरूको बारेमा र नयाँ कोडहरूको लागि कसरी आवेदन दिने</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
         <source xml:lang="en">About The ISO Language Registry</source>
         <target xml:lang="ne">ISO भाषा रेजिस्ट्रीको बारेमा</target>
         <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CodeHeader">
+      <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
         <source xml:lang="en">Code</source>
         <target xml:lang="ne">कोड</target>
         <note>ID: LanguageLookup.CodeHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryCount">
+      <trans-unit id="LanguageLookup.CountryCount" approved="yes">
         <source xml:lang="en">{0} Countries</source>
         <target xml:lang="ne">{0} देशहरू</target>
         <note>ID: LanguageLookup.CountryCount</note>
         <note>Shown when there are multiple countries and it is just confusing to list them all. {0} is a count of countries.</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryHeader">
+      <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="ne">देश</target>
         <note>ID: LanguageLookup.CountryHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
         <source xml:lang="en">You can change how the language name will be displayed here:</source>
         <target xml:lang="ne">तपाईंले यहाँ भाषाको नाम प्रदर्शन हुने तरिका परिवर्तन गर्न सक्नुहुन्छ:</target>
         <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
         <source xml:lang="en">Lookup Language Code...</source>
         <target xml:lang="ne">भाषाको कोड खोज्नुहोस्...</target>
         <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.PrimaryNameHeader">
+      <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="ne">नाम</target>
         <note>ID: LanguageLookup.PrimaryNameHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel">
+      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel" approved="yes">
         <source xml:lang="en">Show regional dialects</source>
         <target xml:lang="ne">क्षेत्रीय भाषाहरू देखाउनुहोस्</target>
         <note>ID: LanguageLookup.ShowRegionalDialectsLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.UnlistedLanguage">
+      <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
         <source xml:lang="en">Unlisted Language</source>
         <target xml:lang="ne">असूचीकृत भाषा</target>
         <note>ID: LanguageLookup.UnlistedLanguage</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
         <source xml:lang="en">Can't find your language?</source>
         <target xml:lang="ne">आफ्नो भाषा फेला पार्न सक्नुभएन?</target>
         <note>ID: LanguageLookup._cannotFindLanguageLink</note>
       </trans-unit>
-      <trans-unit id="MemoryWarning">
+      <trans-unit id="MemoryWarning" approved="yes">
         <source xml:lang="en">Unfortunately, {0} is starting to get short of memory, and may soon slow down or experience other problems. We recommend that you quit and restart it when convenient.</source>
         <target xml:lang="ne">दुर्भाग्यवश, {0} मा मेमोरी अपुग हुन थालेको छ, र यो छिटै सुस्त हुन वा यसमा अन्य समस्याहरू आउन सक्छ। हामी तपाईंलाई यसलाई बन्द गरेर पुनः आफूलाई पायक पर्ने समयमा सुरू गर्न सिफारिस गर्दछौं।</target>
         <note>ID: MemoryWarning</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Creator">
+      <trans-unit id="MetadataDisplay.Creator" approved="yes">
         <source xml:lang="en">Creator: {0}</source>
         <target xml:lang="ne">सर्जक: {0}</target>
         <note>ID: MetadataDisplay.Creator</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.CreatorLabel">
+      <trans-unit id="MetadataDisplay.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="ne">सर्जक</target>
         <note>ID: MetadataDisplay.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.LicenseInfo">
+      <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
         <source xml:lang="en">License Info</source>
         <target xml:lang="ne">इजाजतपत्र सम्बन्धी जानकारी</target>
         <note>ID: MetadataDisplay.LicenseInfo</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You must keep the copyright and credits for authors, illustrators, etc.</source>
         <target xml:lang="ne">तपाईंले लेखक, चित्रकार, इत्यादिको प्रतिलिपि अधिकार सूचना र नाम राख्नुपर्छ।</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.AttributionRequired</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You are free to make commercial use of this work.</source>
         <target xml:lang="ne">तपाईंले यस रचनालाई व्यापारिक प्रयोजनका लागि प्रयोग गर्न पाउनुहुन्छ।</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work.</source>
         <target xml:lang="ne">तपाईंले यस रचनालाई समायोज गर्न वा यसमा आफ्नो तर्फबाट थपथाप गर्न पाउनुहुन्छ।</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.Derivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work, but you may distribute the resulting work only under the same or similar license to this one.</source>
         <target xml:lang="ne">तपाईंले यस रचनालाई समायोज गर्न वा यसमा आफ्नो तर्फबाट थपथाप गर्न पाउनुहुन्छ, तर परिणामी रचनालाई त्‍यसको मूल इजाजतपत्र वा सो सरहको इजाजतपत्र अन्तर्गत मात्र वितरण गर्न पाउनुहुन्छ।</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not make changes or build upon this work without permission.</source>
         <target xml:lang="ne">तपाईंले अनुमति नलिइकन यस रचनामा परिवर्तनहरू गर्न वा यसलाई आधार स्रोतको रूपमा प्रयोग गर्न पाउनुहुन्न।</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NoDerivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not use this work for commercial purposes.</source>
         <target xml:lang="ne">तपाईंले यो रचनालाई व्यापारिक प्रयोजनका लागि प्रयोग गर्न पाउनुहुन्न।</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NonCommercial</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For permission to reuse, contact the copyright holder.</source>
         <target xml:lang="ne">पुनः प्रयोग गर्ने अनुमति लिन, प्रतिलिपि अघिकार धारकसंग  सम्पर्क गर्नुहोस्।</target>
         <note>ID: MetadataDisplay.Licenses.NullLicense</note>
         <note>This is used when all we have is a copyright, no other license.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.NoLicense">
+      <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
         <source xml:lang="en">No license specified</source>
         <target xml:lang="ne">कुनै इजाजतपत्र तोकिएको छैन</target>
         <note>ID: MetadataDisplay.NoLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowCommercialUse">
+      <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
         <source xml:lang="en">Allow commercial uses of your work?</source>
         <target xml:lang="ne">आफ्नो रचनालाई व्यापारिक प्रयोजनका लागि अनुमति दिने?</target>
         <note>ID: MetadataEditor.AllowCommercialUse</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowDerivatives">
+      <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
         <source xml:lang="en">Allow modifications of your work?</source>
         <target xml:lang="ne">आफ्नो रचना परिमार्जन गर्न अनुमति दिने?</target>
         <note>ID: MetadataEditor.AllowDerivatives</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CopyrightHolder">
+      <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
         <source xml:lang="en">Copyright Holder</source>
         <target xml:lang="ne">प्रतिलिपि अधिकार धारक</target>
         <note>ID: MetadataEditor.CopyrightHolder</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons">
+      <trans-unit id="MetadataEditor.CreativeCommons" approved="yes">
         <source xml:lang="en">Creative Commons</source>
         <target xml:lang="ne">Creative Commons</target>
         <note>ID: MetadataEditor.CreativeCommons</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreatorLabel">
+      <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="ne">सर्जक</target>
         <note>ID: MetadataEditor.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CustomLicense">
+      <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="ne">कस्टम</target>
         <note>ID: MetadataEditor.CustomLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleNoCredit">
+      <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
         <source xml:lang="en">Copyright and License</source>
         <target xml:lang="ne">प्रतिलिपि अधिकार र इजाजतपत्र</target>
         <note>ID: MetadataEditor.TitleNoCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleWithCredit">
+      <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
         <source xml:lang="en">Credit, Copyright, and License</source>
         <target xml:lang="ne">श्रेय, प्रतिलिपि अधिकार र इजाजतपत्र</target>
         <note>ID: MetadataEditor.TitleWithCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.UnknownLicense">
+      <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <target xml:lang="ne">कुनै पनि अनुमति लिन प्रतिलिपि अधिकार धारकसंग सम्पर्क गर्नुहोस्</target>
         <note>ID: MetadataEditor.UnknownLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.YesShareAlike">
+      <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
         <source xml:lang="en">Yes, as long as others share alike</source>
         <target xml:lang="ne">हुन्छ, अरूले पनि समान रूपमा आदान-प्रदान गर्छन् भने</target>
         <note>ID: MetadataEditor.YesShareAlike</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.additionalRequestsLabel">
+      <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
         <source xml:lang="en">Additional Requests</source>
         <target xml:lang="ne">अतिरिक्त अनुरोधहरू</target>
         <note>ID: MetadataEditor.additionalRequestsLabel</note>
         <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.betterLinkLabel1">
+      <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
         <source xml:lang="en">more info</source>
         <target xml:lang="ne">थप जानकारी</target>
         <note>ID: MetadataEditor.betterLinkLabel1</note>
         <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere tha defines it.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
         <source xml:lang="en">Not Enforceable</source>
         <target xml:lang="ne">लागूयोग्य छैन</target>
         <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
         <note>While this screen allows it, legally you can't enforce any additions to a creative commons license. This link takes you to the clause that says that. This link is visible only if you choose Creative Commons but then type in  the "Additional Request" box.</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <target xml:lang="ne">यसले प्रारम्भिक प्रयोगकर्ताहरूका लागि आवश्यक नरहेको अन्य बटनहरू पनि लुकाउन सक्छ।</target>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.CtrlShiftHint">
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
         <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
         <target xml:lang="ne">तपाईंले Ctrl र Shift कुञ्जीहरूलाई एकैपटक थिचेर थामिराख्दा यो बटन देखा पर्नेछ।</target>
         <note>ID: SettingsProtection.CtrlShiftHint</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+      <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
         <source xml:lang="en">Settings...</source>
         <target xml:lang="ne">सेटिङहरू...</target>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
         <source xml:lang="en">Hide the button that opens settings.</source>
         <target xml:lang="ne">सेटिङहरू खोल्ने बटन लुकाउनुहोस्।</target>
         <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
         <source xml:lang="en">Factory Password</source>
         <target xml:lang="ne">फ्याक्ट्री पासवर्ड</target>
         <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
         <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
         <target xml:lang="ne">यस उपकरणलाई निष्क्रिय बनाउन सक्ने अप्रत्याशित परिवर्तनहरू हुन नदिन यी सेटिङहरूलाई लक गरिएका छन्।</target>
         <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
         <source xml:lang="en">Settings Protection Password</source>
         <target xml:lang="ne">सेटिङ सुरक्षाको पासवर्ड</target>
         <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox">
+      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
         <source xml:lang="en">Show Characters</source>
         <target xml:lang="ne">वर्णहरू देखाउनुहोस्</target>
         <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordNotice">
+      <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
         <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always google for "{1}" and "{2}".</source>
         <target xml:lang="ne">यी सेटिङहरूको फ्याक्ट्री पासवर्ड "{0}" हो। यसलाई बिर्सनुभएको खण्डमा, तपाईंले जुन सुकै बेला "{1}" र "{2}" लाई Google मा खोज्न सक्नुहुन्छ।</target>
         <note>ID: SettingsProtection.PasswordNotice</note>
         <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
         <source xml:lang="en">Require the factory password to get into settings.</source>
         <target xml:lang="ne">सेटिङहरूमा जान फ्याक्टी पासवर्ड प्रविष्ट गर्न आवश्यक हुने बनाउनुहोस्।</target>
         <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
         <source xml:lang="en">Settings Protection</source>
         <target xml:lang="ne">सेटिङहरूको सुरक्षा</target>
         <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Font">
+      <trans-unit id="WSFontControl.Font" approved="yes">
         <source xml:lang="en">&amp;Font:</source>
         <target xml:lang="ne">&amp;फन्ट:</target>
         <note>ID: WSFontControl.Font</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.FontNotAvailable">
+      <trans-unit id="WSFontControl.FontNotAvailable" approved="yes">
         <source xml:lang="en">(The selected font is not available on this machine. Using default.)</source>
         <target xml:lang="ne">(चयन गरिएको फन्ट यो यन्त्रमा उपलब्ध छैन। पूर्वनिर्धारित फन्ट प्रयोग गरिनेछ।)</target>
         <note>ID: WSFontControl.FontNotAvailable</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.RightToLeftWS">
+      <trans-unit id="WSFontControl.RightToLeftWS" approved="yes">
         <source xml:lang="en">This is a &amp;right to left writing system.</source>
         <target xml:lang="ne">यो &amp;दायाँ देखि बायाँतिर लेख्ने प्रणाली हो।</target>
         <note>ID: WSFontControl.RightToLeftWS</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Size">
+      <trans-unit id="WSFontControl.Size" approved="yes">
         <source xml:lang="en">&amp;Size:</source>
         <target xml:lang="ne">&amp;आकार:</target>
         <note>ID: WSFontControl.Size</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.TestArea">
+      <trans-unit id="WSFontControl.TestArea" approved="yes">
         <source xml:lang="en">&amp;Test Area:</source>
         <target xml:lang="ne">&amp;परीक्षण क्षेत्र:</target>
         <note>ID: WSFontControl.TestArea</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
         <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
         <target xml:lang="ne">तपाईंलाई चाहिएको किबोर्ड सूचीकृत छैन भने, किबोर्ड सेट अप गर्न तल उपयुक्त स्राेतमा क्लिक गर्नुहोस्</target>
         <note>ID: WSKeyboardControl.KeyboardNotListed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
         <source xml:lang="en">Windows keyboard settings</source>
         <target xml:lang="ne">Windows किबोर्ड सेटिङहरू</target>
         <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
         <source xml:lang="en">Available keyboards</source>
         <target xml:lang="ne">उपलब्ध किबोर्डहरू</target>
         <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
         <source xml:lang="en">Previously used keyboards</source>
         <target xml:lang="ne">पहिले प्रयोग गरिएका किबोर्डहरू</target>
         <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
         <source xml:lang="en">Keyman Configuration</source>
         <target xml:lang="ne">Keyman को कन्फिगरेसन</target>
         <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
         <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
         <target xml:lang="ne">Keyman 5.0 वा सोभन्दा पछिल्लो संस्करण स्थापना गरिएको छैन।</target>
         <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
         <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
         <target xml:lang="ne">{0} पाठ टाइप गर्ने &amp;किबोर्ड चयन गर्नुहोस्</target>
         <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.TestAreaCaption">
+      <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
         <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
         <target xml:lang="ne">&amp;परीक्षण क्षेत्र (आफ्नो किबोर्डको परीक्षण गर्न केही कुरा टाइप गर्न यो क्षेत्र प्रयोग गर्नुहोस्।)</target>
         <note>ID: WSKeyboardControl.TestAreaCaption</note>
       </trans-unit>
-      <trans-unit id="Warning">
+      <trans-unit id="Warning" approved="yes">
         <source xml:lang="en">Warning</source>
         <target xml:lang="ne">चेतावनी</target>
         <note>ID: Warning</note>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption" approved="yes">
         <source xml:lang="en">Unable to connect to SLDR</source>
         <target xml:lang="ne">SLDR मा जडान गर्न सकिएन</target>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrCaption</note>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText" approved="yes">
         <source xml:lang="en">The application is unable to connect to the SIL Locale Data Repository to retrieve the latest information about this language. If you create this writing system, the default settings might be incorrect or out of date. Are you sure you want to create a new writing system?</source>
         <target xml:lang="ne">यो भाषाको बारेमा नवीनतम जानकारी प्राप्त गर्न यो अनुप्रयोगले SIL Locale Data Repository माथि पहुँच गर्न सकेन। तपाईंले यो लेखन प्रणाली सिर्जना गर्नुभयो भने, पूर्वनिर्धारित सेटिङहरू गलत वा पुराना हुन सक्छन्। तपाईं निश्चित रूपमा नयाँ लेखन प्रणाली सिर्जना गर्न चाहनुहुन्छ?</target>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrText</note>

--- a/DistFiles/localization/ne/TrainingVideos.xlf
+++ b/DistFiles/localization/ne/TrainingVideos.xlf
@@ -2,17 +2,17 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="TrainingVideos-en.md" datatype="html" source-language="en" target-language="ne">
     <body>
-      <trans-unit id="training.videos">
+      <trans-unit id="training.videos" approved="yes">
         <source xml:lang="en">Bloom Training Videos</source>
         <target xml:lang="ne">Bloom प्रशिक्षण भिडियो</target>
         <note>ID: training.videos</note>
       </trans-unit>
-      <trans-unit id="training.videos.watch">
+      <trans-unit id="training.videos.watch" approved="yes">
         <source xml:lang="en">If you are connected to the internet now, you can watch videos in your web browser:</source>
         <target xml:lang="ne">यदि तपाईं अहिले इन्टरनेट चलाइरहनुभएको छ भने, तपाईं आफ्नो वेब ब्राउरमा भिडियोहरू हेर्न सक्नुहुन्छ:</target>
         <note>ID: training.videos.watch</note>
       </trans-unit>
-      <trans-unit id="training.videos.all">
+      <trans-unit id="training.videos.all" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-a" html:href="http://tiny.cc/bloomVimeo">All videos</g>
         </source>
@@ -20,12 +20,12 @@
           <g id="genid-1" ctype="x-html-a" html:href="http://tiny.cc/bloomVimeo">सबै भिडियोहरू</g> </target>
         <note>ID: training.videos.all</note>
       </trans-unit>
-      <trans-unit id="training.videos.intro">
+      <trans-unit id="training.videos.intro" approved="yes">
         <source xml:lang="en">Introductory Videos</source>
         <target xml:lang="ne">परिचयात्मक भिडियोहरू</target>
         <note>ID: training.videos.intro</note>
       </trans-unit>
-      <trans-unit id="training.videos.whofor">
+      <trans-unit id="training.videos.whofor" approved="yes">
         <source xml:lang="en">
           <g id="genid-2" ctype="x-html-a" html:href="https://vimeo.com/114043219">Bloom: Who is it for</g>
         </source>
@@ -33,7 +33,7 @@
           <g id="genid-2" ctype="x-html-a" html:href="https://vimeo.com/114043219">Bloom: यो कसको लागि हो</g> </target>
         <note>ID: training.videos.whofor</note>
       </trans-unit>
-      <trans-unit id="training.videos.templates">
+      <trans-unit id="training.videos.templates" approved="yes">
         <source xml:lang="en">
           <g id="genid-3" ctype="x-html-a" html:href="https://vimeo.com/114024308">Understanding Templates and Shell Books</g>
         </source>
@@ -42,7 +42,7 @@
         </target>
         <note>ID: training.videos.templates</note>
       </trans-unit>
-      <trans-unit id="training.videos.basicbook">
+      <trans-unit id="training.videos.basicbook" approved="yes">
         <source xml:lang="en">
           <g id="genid-4" ctype="x-html-a" html:href="https://vimeo.com/112825489">Using the Basic Book template</g>
         </source>
@@ -51,7 +51,7 @@
         </target>
         <note>ID: training.videos.basicbook</note>
       </trans-unit>
-      <trans-unit id="training.videos.readers">
+      <trans-unit id="training.videos.readers" approved="yes">
         <source xml:lang="en">
           <g id="genid-5" ctype="x-html-a" html:href="http://tiny.cc/usingBloomReaderTemplates">Using Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -60,12 +60,12 @@
         </target>
         <note>ID: training.videos.readers</note>
       </trans-unit>
-      <trans-unit id="training.videos.advanced">
+      <trans-unit id="training.videos.advanced" approved="yes">
         <source xml:lang="en">Advanced Topics</source>
         <target xml:lang="ne">गहन शीर्षकहरू</target>
         <note>ID: training.videos.advanced</note>
       </trans-unit>
-      <trans-unit id="training.videos.formatting">
+      <trans-unit id="training.videos.formatting" approved="yes">
         <source xml:lang="en">
           <g id="genid-6" ctype="x-html-a" html:href="https://vimeo.com/117820891">Changing the format of text</g>
         </source>
@@ -74,7 +74,7 @@
         </target>
         <note>ID: training.videos.formatting</note>
       </trans-unit>
-      <trans-unit id="training.videos.custompage">
+      <trans-unit id="training.videos.custompage" approved="yes">
         <source xml:lang="en">
           <g id="genid-7" ctype="x-html-a" html:href="https://vimeo.com/116868148">Using the Custom Page template</g>
         </source>
@@ -83,7 +83,7 @@
         </target>
         <note>ID: training.videos.custompage</note>
       </trans-unit>
-      <trans-unit id="training.videos.specialcharacters">
+      <trans-unit id="training.videos.specialcharacters" approved="yes">
         <source xml:lang="en">
           <g id="genid-8" ctype="x-html-a" html:href="https://vimeo.com/117927599">Inserting special characters</g>
         </source>
@@ -92,7 +92,7 @@
         </target>
         <note>ID: training.videos.specialcharacters</note>
       </trans-unit>
-      <trans-unit id="training.videos.readertemplates">
+      <trans-unit id="training.videos.readertemplates" approved="yes">
         <source xml:lang="en">
           <g id="genid-9" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">Making a set of Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -101,24 +101,24 @@
         </target>
         <note>ID: training.videos.readertemplates</note>
       </trans-unit>
-      <trans-unit id="training.videos.offline">
+      <trans-unit id="training.videos.offline" approved="yes">
         <source xml:lang="en">Offline Viewing</source>
         <target xml:lang="ne">अफलाइन हेर्ने</target>
         <note>ID: training.videos.offline</note>
       </trans-unit>
-      <trans-unit id="training.videos.download">
+      <trans-unit id="training.videos.download" approved="yes">
         <source xml:lang="en">If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer:</source>
         <target xml:lang="ne">यदि तपाईं इन्टरनेट नभएको बेला  यी मध्ये कुनै पनि भिडियोहरू देखाउन वा आदान-प्रदान गर्नकाे लागि डाउनलोड गर्न चाहनुहुन्छ भने, तपाईंले ती आफ्नो कम्प्युटरमा डाउनलोड गर्न सक्नुहुन्छ:</target>
         <note>ID: training.videos.download</note>
       </trans-unit>
-      <trans-unit id="training.videos.hires">
+      <trans-unit id="training.videos.hires" approved="yes">
         <source xml:lang="en">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">High Resolution</g> (Large files)</source>
         <target xml:lang="ne">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">उच्च रेजोल्युसन</g> (ठूला फाइलहरू)</target>
         <note>ID: training.videos.hires</note>
       </trans-unit>
-      <trans-unit id="training.videos.lores">
+      <trans-unit id="training.videos.lores" approved="yes">
         <source xml:lang="en">
           <g id="genid-11" ctype="x-html-a" html:href="http://tiny.cc/bloomSDVideos">Low Resolution</g> (Smaller files)</source>
         <target xml:lang="ne">

--- a/DistFiles/localization/ne/leveledReaderInfo.xlf
+++ b/DistFiles/localization/ne/leveledReaderInfo.xlf
@@ -2,59 +2,59 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="leveledReaderInfo-en.html" datatype="html" source-language="en" target-language="ne">
     <body>
-      <trans-unit id="leveled.reader.vocabulary">
+      <trans-unit id="leveled.reader.vocabulary" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="ne">शब्दावली</target>
         <note>ID: leveled.reader.vocabulary</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.simple">
+      <trans-unit id="leveled.reader.start.simple" approved="yes">
         <source xml:lang="en">At beginning levels, use simple words that are familiar to children. If it is possible in your language, use words with only one syllable. As children move up to higher levels, you can begin to use words with more syllables. You can begin to use less familiar words. Children should be able to guess the meaning of these less familiar words from the context of the surrounding words and sentences, as well as from the illustrations.</source>
         <target xml:lang="ne">प्रारम्भिक स्तरमा बालबालिकाहरूले जानेबुझेका सरल शब्दहरू प्रयोग गर्नुहोस्। यदि तपाईंको भाषामा सम्भव छ भने, एउटा मात्र उच्चारण एकाङ्क भएका शब्दहरू प्रयोग गर्नुहोस्। बच्चाहरू माथिल्लो स्तरमा उक्लदैँ जाँदा तपाईंले बढी उच्चारण एकाङ्क भएका शब्दहरू प्रयोग गर्न सक्नुहुन्छ। तपाईंले कम परिचित शब्दहरू प्रयोग गर्न सुरू गर्न सक्नुहुन्छ। बालबालिकाहरूले सेरोफेरोका शब्द तथा वाक्यहरूका साथै चित्रहरूको सहायताले यी कम परिचित शब्दहरूको अर्थ ठम्याउन सक्नुपर्छ।</target>
         <note>ID: leveled.reader.start.simple</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.formatting">
+      <trans-unit id="leveled.reader.formatting" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="ne">ढाँचा</target>
         <note>ID: leveled.reader.formatting</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.large">
+      <trans-unit id="leveled.reader.start.large" approved="yes">
         <source xml:lang="en">Beginner readers will benefit from a larger font with clear spacing between words. Having the words or sentences in the same location on each page is also helpful. As readers progress to higher levels, font size and spacing will decrease and sentences can appear in different locations on the page.</source>
         <target xml:lang="ne">प्रारम्भिक पाठकहरूलाई ठूलो फन्ट र शब्दहरूको बीचमा स्पष्ट अन्तर हुँदा सजिलो हुन्छ। शब्द वा वाक्यहरू हरेक पानामा उही स्थानमा हुनुले पनि मद्दत पुर्‍याउँछ। पाठकहरू माथिल्लो स्तरमा उक्लँदै गर्दा, फन्टको आकार र अन्तर कम हुनेछन् र पानामा वाक्यहरू पहिलेकोभन्दा फरक ठाउँमा देखा पर्न सक्‍नेछन्।</target>
         <note>ID: leveled.reader.start.large</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.increase.sizes">
+      <trans-unit id="leveled.reader.increase.sizes" approved="yes">
         <source xml:lang="en">To increase the font size, line-spacing, and word-spacing in Bloom, click in a text box and then on the grey "cog" icon in the lower left-hand corner. If you do this and then make a template book, books made with that template will also use those font settings.</source>
         <target xml:lang="ne">Bloom मा फन्टको आकार ठूलो बनाउन, पङ्क्ति र शब्दहरू बीचको अन्तर बढाउन, पाठ बाकसमा क्लिक गरेर तल्लो बायाँ कुनामा रहेको "cog" लेखिएकेा चिन्‍हमा क्लिक गर्नुहोस्। तपाईंले यसो गरेर टेम्प्लेट पुस्तक बनाउनुभयो भने, सो टेम्प्लेट प्रयोग गरेर बनाइएका पुस्तकहरूमा पनि सोही फन्ट सेटिङहरू प्रयोग हुनेछन्।</target>
         <note>ID: leveled.reader.increase.sizes</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.predictability">
+      <trans-unit id="leveled.reader.predictability" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="ne">पूर्वानुमान</target>
         <note>ID: leveled.reader.predictability</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repeat.patterns">
+      <trans-unit id="leveled.reader.repeat.patterns" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-em">Predictability</g> in a text means that the reader can guess what would come next. You can increase predictability by using repeated patterns. Here are some patterns you can use:</source>
         <target xml:lang="ne">
           <g id="genid-1" ctype="x-html-em">पूर्वानुमान</g> पाठमा हुनुको मतलब पाठकले त्यसपछि आउने शब्द अन्दाज लगाउन सक्छ भनिएको हो। तपाईंले एकै किसिमका शैलीहरू दोहोर्‍याएर  पूर्वानुमान क्षमता बढाउन सक्नुहुन्छ। तपाईंले प्रयोग गर्न सक्नुहुने केही शैलीहरू यहाँ दिइएका छन्:</target>
         <note>ID: leveled.reader.repeat.patterns</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repetition">
+      <trans-unit id="leveled.reader.repetition" approved="yes">
         <source xml:lang="en">Repetition - repeating parts of the text, for example, using the same sentence with each page and just changing one word in the sentence</source>
         <target xml:lang="ne">दोहोर्‍याइ - पाठका भागहरू दोहोर्‍याउने, उदाहरणको लागि, प्रत्येक पृष्ठमा एउटै वाक्य प्रयोग गर्ने र सो वाक्यमा केवल एउटा मात्र शब्द परिवर्तन गर्ने।</target>
         <note>ID: leveled.reader.repetition</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.sequencing">
+      <trans-unit id="leveled.reader.sequencing" approved="yes">
         <source xml:lang="en">Sequencing - a story with a known sequence such as the days of the week or that uses numbers in a pattern</source>
         <target xml:lang="ne">अनुक्रमण - हप्ताको बार जस्ता विदित अनुक्रम भएको कथा वा अङ्कहरूलाई ढाँचामा प्रयोग गर्ने पाठ।</target>
         <note>ID: leveled.reader.sequencing</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.building.sequence">
+      <trans-unit id="leveled.reader.building.sequence" approved="yes">
         <source xml:lang="en">Building Sequence - a story with a pattern that is repeated and added to with each new page</source>
         <target xml:lang="ne">अनुक्रम बनाउने - दोहोरिने र प्रत्येक पृष्ठमा थपिने ढाँचा भएको कथा।</target>
         <note>ID: leveled.reader.building.sequence</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.rhyme">
+      <trans-unit id="leveled.reader.rhyme" approved="yes">
         <source xml:lang="en">Rhyme - a story with a pattern or sequence that also includes rhyme. For example:
         <g id="genid-2" ctype="x-html-blockquote" html:class="poetry">
           <g id="genid-3" ctype="x-html-pre">Brown Bear, Brown Bear, What do you see?
@@ -77,64 +77,64 @@ Yellow Duck, Yellow Duck, What do you see?</g>
       </target>
         <note>ID: leveled.reader.rhyme</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations">
+      <trans-unit id="leveled.reader.illustrations" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="ne">चित्रको सहायता:</target>
         <note>ID: leveled.reader.illustrations</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.help">
+      <trans-unit id="leveled.reader.illustrations.help" approved="yes">
         <source xml:lang="en">Illustrations provide support to the story. Illustrations relate to the story in different ways at different <g id="genid-5" ctype="x-html-em">levels</g> and for different types of readers (see below). Remember that in many cultures that don't have a lot of printed material around, complex pictures may be difficult to understand.
     </source>
         <target xml:lang="ne">चित्रहरूले कथा बुझ्न सजिलो बनाउँछन्। कथामा प्रयेाग भएका चित्रहरूले स्‍तर अनुसार अर्थ दिन्छ। <g id="genid-5" ctype="x-html-em">स्तरमा</g> विभिन्न किसिमका पाठकहरूको लागि कथाले विभिन्न खाले अर्थ प्रदान गर्दछ (तल हेर्नुहोस्)। प्रायः खासै धेरै छापिएका सामग्रीहरू नभएका  संस्कृतिहरूमा जटिल तस्बिरहरूलाई बुझ्न गाह्रो हुन्छ भन्ने कुरा याद राख्नुहोस्।
     </target>
         <note>ID: leveled.reader.illustrations.help</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.emergent.reader">
+      <trans-unit id="leveled.reader.illustrations.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-6" ctype="x-html-strong">Emergent Readers</g> the pictures should closely match the storyline. The reader should be able to predict the story line just by looking at the pictures. The illustrations at this level should be simple.
       </source>
         <target xml:lang="ne">
           <g id="genid-6" ctype="x-html-strong">उदगामी पाठकहरूका लागि</g>  तस्बिरहरू कथावस्तुसँग निकट रूपमा सम्बन्धित हुनुपर्छ। पाठकले तस्बिरलाई हेरेर मात्र पनि कथावस्‍तु ठम्याउन सक्नुपर्छ। यस स्तरमा चित्रहरू सरल हुनुपर्छ।</target>
         <note>ID: leveled.reader.illustrations.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.early.reader">
+      <trans-unit id="leveled.reader.illustrations.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-7" ctype="x-html-strong">Early Readers</g> the pictures should offer some support to the story line. As the amount of text increases, the reader is less reliant on the pictures and gets more meaning from the text. The illustrations can be more complex.
       </source>
         <target xml:lang="ne">
           <g id="genid-7" ctype="x-html-strong">प्रारम्भिक पाठकहरूका लागि</g> तस्बिरहरूले कथावस्तु बुझाइमा केही सहायता प्रदान गरेको हुनुपर्छ। पाठको मात्रा बढ्दै जाँदा, पाठकले तस्बिरहरूको सहायता लिने क्रम घट्दै जान्छ र उनीहरूले पाठबाटै बढी अर्थ पाउँछन्। यो स्तरमा चित्रहरू बढी जटिल हुन सक्छन्।</target>
         <note>ID: leveled.reader.illustrations.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.fluent.reader">
+      <trans-unit id="leveled.reader.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-8" ctype="x-html-strong">Fluent Readers</g> the pictures should offer little or no support to the story line. The reader relies more on the text than the pictures for meaning. The illustrations can be even more complex.
       </source>
         <target xml:lang="ne">
           <g id="genid-8" ctype="x-html-strong">प्रवीण पाठकहरूका लागि</g> तस्बिरहरूले कथावस्तु बुझाइमा थोरै वा कुनै सहायता प्रदान गर्नु हुँदैन। अर्थ बुझ्नको लागि पाठक तस्बिरमा भन्दा बढी पाठमा निर्भर हुन्छ। यो स्तरमा चित्रहरू झनै बढी जटिल हुन सक्छन्।</target>
         <note>ID: leveled.reader.fluent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice">
+      <trans-unit id="leveled.reader.topic.choice" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="ne">शीर्षकको रोजाइ</target>
         <note>ID: leveled.reader.topic.choice</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.discussion">
+      <trans-unit id="leveled.reader.topic.choice.discussion" approved="yes">
         <source xml:lang="en">Books can be on many topics. When developing books for beginning readers, choose topics that are familiar to them. Readers will be eager to read and will read more if they are reading about things they find interesting and familiar. For more experienced readers, topics can include information that the reader is not already familiar with.</source>
         <target xml:lang="ne">पुस्तकहरूको शीर्षक धेरै हुन सक्छन्। प्रारम्भिक पाठकहरूका लागि पुस्तक बनाउँदा उनीहरूले जानेबुझेका शीर्षकहरू छान्नुहोस्। त्यसो गर्दा पाठकहरू सो पाठ पढ्न उत्सुक हुनेछन् र उनीहरूलाई रुचि लाग्ने वा उनीहरूले जानेबुझेका कुराहरूको बारेमा पढ्न पाउँदा उनीहरू बढी समय पढ्ने गर्छन्। अनुभवी पाठकहरूको हकमा, शीर्षकहरूमा पाठकलाई राम्रोसँग ज्ञान नभएको जानकारी समावेश गर्न सकिन्छ।</target>
         <note>ID: leveled.reader.topic.choice.discussion</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.emergent.reader">
+      <trans-unit id="leveled.reader.topic.choice.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-9" ctype="x-html-strong">Emergent Readers</g> the book should be concrete, should focus on one idea/theme, and should be familiar and easy to understand.
       </source>
         <target xml:lang="ne">
           <g id="genid-9" ctype="x-html-strong">उदगामी पाठकहरूका लागि</g> पुस्तक यथार्थपूर्ण अथवा ठोस हुनुपर्छ, एउटा विचार/विषयवस्तुमा केन्द्रित हुनुपर्छ र परिचित तथा सजिलै बुझ्न सकिने हुनुपर्छ।</target>
         <note>ID: leveled.reader.topic.choice.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.early.reader">
+      <trans-unit id="leveled.reader.topic.choice.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-10" ctype="x-html-strong">Early Readers</g>, develop a story around a familiar concept but in greater depth.
       </source>
         <target xml:lang="ne">
           <g id="genid-10" ctype="x-html-strong">प्रारम्भिक पाठकहरूका लागि</g>, कुनै परिचित अवधारणामा केन्द्रित रहेर तर अलि गहिकिलो कथा विकास गर्नुहोस्।</target>
         <note>ID: leveled.reader.topic.choice.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.fluent.reader">
+      <trans-unit id="leveled.reader.topic.choice.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-11" ctype="x-html-strong">Fluent Readers</g> the concepts can expand beyond what is familiar, be more varied, and be abstract.
       </source>
         <target xml:lang="ne">

--- a/DistFiles/localization/ru/Bloom.xlf
+++ b/DistFiles/localization/ru/Bloom.xlf
@@ -2,3345 +2,3345 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="ru" datatype="plaintext" product-version="3.6.5.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="BloomIntegrity.WindowTitle">
+      <trans-unit id="BloomIntegrity.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom Problem</source>
         <target xml:lang="ru">Проблема</target>
         <note>ID: BloomIntegrity.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="BloomIntegrityDialog.ReportProblem">
+      <trans-unit id="BloomIntegrityDialog.ReportProblem" approved="yes">
         <source xml:lang="en">Report Problem</source>
         <target xml:lang="ru">Отправить отзыв о проблеме</target>
         <note>ID: BloomIntegrityDialog.ReportProblem</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName">
+      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName" approved="yes">
         <source xml:lang="en">Possibly this is an old BloomPack created before BloomPacks could handle special characters in file names. You may be able to get the author to re-create it using a current version. If that's not possible a technical expert may be able to repair things.</source>
         <target xml:lang="ru">Возможно, ранее был создан старый Bloom Pack до того, как BloomPacks могли бы обработать специальные символы в именах файлов. Вы можете предложить автору создать файл заново, используя новую версию. Если это не возможно, обратитесь к вашему техническому эксперту</target>
         <note>ID: BloomPackInstallDialog.BadCharsInFileName</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="ru">Установка Bloom Pack</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="ru">Коллекция {0} установлена и готова к использованию</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller" approved="yes">
         <source xml:lang="en">Bloom Pack Installer</source>
         <target xml:lang="ru">Установка Bloom Pack</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstaller</note>
         <note>Displayed as the message box title</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack">
+      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack" approved="yes">
         <source xml:lang="en">This BloomPack appears to be incomplete or corrupt.</source>
         <target xml:lang="ru">Bloom Pack поврежден</target>
         <note>ID: BloomPackInstallDialog.CorruptBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.DoesNotExist">
+      <trans-unit id="BloomPackInstallDialog.DoesNotExist" approved="yes">
         <source xml:lang="en">{0} does not exist</source>
         <target xml:lang="ru">{0} не существует</target>
         <note>ID: BloomPackInstallDialog.DoesNotExist</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="ru">Невозможно установить Bloom Pack</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="ru">Извлечение...</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while BloomPacks are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="ru">Bloom уже запущен, но вы сможете увидеть ваши материалы только после перезапуска Bloom</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.NotInstalled">
+      <trans-unit id="BloomPackInstallDialog.NotInstalled" approved="yes">
         <source xml:lang="en">The Bloom collection will not be installed.</source>
         <target xml:lang="ru">Коллекция Bloom не будет установлена</target>
         <note>ID: BloomPackInstallDialog.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="ru">{0} открывается...</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Replace">
+      <trans-unit id="BloomPackInstallDialog.Replace" approved="yes">
         <source xml:lang="en">This computer already has a Bloom collection named '{0}'. Do you want to replace it with the one from this Bloom Pack?</source>
         <target xml:lang="ru">На этом компьютере уже существует коллеция '{0}'. Вы хотите ее заменить этим Bloom Pack?</target>
         <note>ID: BloomPackInstallDialog.Replace</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder">
+      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder" approved="yes">
         <source xml:lang="en">Bloom Packs should have only a single collection folder at the top level of the zip file.</source>
         <target xml:lang="ru">Bloom Pack должны иметь только одну папку в верхнем уровне ZIP файла.</target>
         <note>ID: BloomPackInstallDialog.SingleCollectionFolder</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.UnableToReplace">
+      <trans-unit id="BloomPackInstallDialog.UnableToReplace" approved="yes">
         <source xml:lang="en">Bloom was not able to remove the existing copy of '{0}'. Quit Bloom if it is running &amp; try again. Otherwise, try again after restarting your computer.</source>
         <target xml:lang="ru">Невозможно удалить существующую копию '{0}'. Закройте Bloom, если он запущен и попробуйте заново. В ином случае, попробуйте перезагрузить компьютер.</target>
         <note>ID: BloomPackInstallDialog.UnableToReplace</note>
       </trans-unit>
-      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true">
+      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To select, use your mouse wheel or point at what you want, then release the key.</source>
         <target xml:lang="ru">Для выбора, используйте колесо мыши или наведите мышь, затем отпустите клавишу</target>
         <note>ID: BookEditor.CharacterMap.Instructions</note>
         <note>When you hold down a key, a popup appears that lets you choose a related character. These instructions are shown in that popup.</note>
       </trans-unit>
-      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is the default for all text boxes with '{0}' style</source>
         <target xml:lang="ru">Это форматирование по умолчанию для всех текстов со стилем '{0}'</target>
         <note>ID: BookEditor.DefaultForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all text boxes with '{0}' style</source>
         <target xml:lang="ru">Данное форматирование используется для всех текстовых блоков со стилем '{0}'</target>
         <note>ID: BookEditor.ForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text boxes with '{1}' style</source>
         <target xml:lang="ru">Данное форматирование используется для всех {0} текстовых блоков со стилем '{1}'</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true">
+      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sorry, Reader Templates do not allow changes to formatting.</source>
         <target xml:lang="ru">Извините, Просмотрщик Шаблонов не позволяет делать изменения в форматировании.</target>
         <note>ID: BookEditor.FormattingDisabled</note>
       </trans-unit>
-      <trans-unit id="BookStorage.FolderMoved">
+      <trans-unit id="BookStorage.FolderMoved" approved="yes">
         <source xml:lang="en">It appears that some part of the folder path to this book has been moved or renamed. As a result, Bloom cannot save your changes to this page, and will need to exit now. If you haven't been renaming or moving things, please click Details below and report the problem to the developers.</source>
         <target xml:lang="ru">Некоторые части пути к папке с этой книгой были перемещены или переименованы. В результате, Bloom не может сохранить изменения для этой страницы, и будет закрыт.  Если вы не перемещали и не переименовывали пути, пожалуйста, кликните Детали ниже и отправьте отзыв о проблеме разработчикам.</target>
         <note>ID: BookStorage.FolderMoved</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="ru">Дополнительные настройки программы</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate" approved="yes">
         <source xml:lang="en">Automatically update Bloom</source>
         <target xml:lang="ru">Автоматически обновлять Bloom</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AutoUpdate</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export ePUB, Record Audio for Talking Book)</source>
         <target xml:lang="ru">Показывать экспериментальные команды (например, Экспортировать XML для InDesign)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="ru">Показывать экспериментальные шаблоны (например, Иллюстрированный словарь)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="ru">Управление функцией "Отправить/Получить" (Экспериментальная) </target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="ru">Использовать Сервер изображений, чтобы уменьшить размер используемой памяти для крупных изображений</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom is switching the default font for "{0}" to the new "Andika New Basic".</source>
         <target xml:lang="ru">Bloom изменил шрифт по умолчанию для "{0}" на новый "Andika New Basic".</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate1</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This will improve the printed output for most languages. If your language is one of the few that need "Andika", you can switch it back in Settings:Book Making.</source>
         <target xml:lang="ru">Это поможет улучшить публикацию для большинства языков. Если ваш язык является одним из тех, которым нужно использовать "Andika", вы можете переключить его обратно в разделе "Создание книги" в настройках</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate2</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="ru">Создание книги</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="ru">Шрифт по умолчанию для {0}</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="ru">Лицевая/Задняя</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="ru">Экономия бумаги</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver</note>
         <note>Name of a Front/Back Matter Pack that puts credits on the inside of the front cover</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="ru">Традиционный</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional</note>
         <note>Name of the default Front/Back Matter Pack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="ru">Система письма справа налево</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink" approved="yes">
         <source xml:lang="en">Special Script Settings</source>
         <target xml:lang="ru">Специальные настройки системы письма</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="ru">Настройки</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="ru">Изменить...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="ru">Первый язык</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="ru">Второй язык</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="ru">Третий язык</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="ru">Языки</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="ru">Удалить</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="ru">Установить...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="ru">Родной язык</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="ru">Второй язык (например, национальный)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="ru">Третий язык (например, региональный) (дополнительно)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="ru">Название коллекции Bloom</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="ru">Страна</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="ru">Район</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="ru">Информация о проекте</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="ru">Область</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="ru">Перезапуск</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="ru">Bloom перезапустит этот проект, чтобы применить настройки.</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <target xml:lang="ru">Создать Bloom Pack...</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdminManagesUpdates">
+      <trans-unit id="CollectionTab.AdminManagesUpdates" approved="yes">
         <source xml:lang="en">Your system administrator manages Bloom updates for this computer.</source>
         <target xml:lang="ru">Ваш системный администратор управляет обновлениями Bloom на этом компьютере</target>
         <note>ID: CollectionTab.AdminManagesUpdates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="ru">Дополнительно</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Applying">
+      <trans-unit id="CollectionTab.Applying" approved="yes">
         <source xml:lang="en">Applying updates</source>
         <target xml:lang="ru">Установка обновлений</target>
         <note>ID: CollectionTab.Applying</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="ru">Получить больше заготовок на BloomLibrary.org</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ru">Коллекция Заготовок</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DuplicateBook">
+      <trans-unit id="CollectionTab.BookMenu.DuplicateBook" approved="yes">
         <source xml:lang="en">Duplicate Book</source>
         <target xml:lang="ru">Скопировать книгу</target>
         <note>ID: CollectionTab.BookMenu.DuplicateBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="ru">Удалить книгу</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book, but these programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="ru">Bloom откроет HTML документ в вашем текстовом редакторе (например, Word или LibreOffice). Вы сможете работать с текстом и изображениями этой книги, но эти программы обычно не предназначены для верстки и подготовки к публикации.</target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="ru">Экспортировать в Word или LibreOffice</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="ru">Экспортировать в XML для InDesign</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="ru">Обновить книгу</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="ru">Обновить эскизы</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="ru">Заготовки для новых книг</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="ru">Коллекция заблокирована, поэтому новые книги не могут быть добавлены или удалены</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="ru">Книги из BloomLibrary.org</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="ru">Обновить все книги</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="ru">Проверить все книги</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="ru">Восстановить отсутствующие изображения...</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="ru">История коллекции...</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="ru">Заметки коллекции...</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="ru">Коллекции</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="ru">Коллекции</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="ru">Сборка...</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="ru">Книга '{0}'</target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="ru">Открыть папку на диске</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="ru">Редактировать эту книгу</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="ru">Состояние</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="ru">Поскольку это коллекция заготовок Bloom не может использовать существующие образцы для создания новых образцов. Если вы хотите добавить язык в образец, для этого вы должны редактировать коллекцию, содержащую образец, а не делать ее копию. Также Wall Calendar не может быть использован для создания новых образцов</target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="ru">Создать Bloom Pack</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <target xml:lang="ru">Создать книгу используя эту заготовку</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_" approved="yes">
         <source xml:lang="en">Create a book in my language using this source book</source>
         <target xml:lang="ru">Создать книгу на моем языке, используя этот источник</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate_ToolTip_</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="ru">Больше...</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="ru">Другие коллекции</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem">
+      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem" approved="yes">
         <source xml:lang="en">Open or Create Another Collection</source>
         <target xml:lang="ru">Открыть или создать коллекцию</target>
         <note>ID: CollectionTab.OpenCreateCollectionMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Progress">
+      <trans-unit id="CollectionTab.Progress" approved="yes">
         <source xml:lang="en">({0}% complete)</source>
         <target xml:lang="ru">({0}% завершено)</target>
         <note>ID: CollectionTab.Progress</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.RestartToUpdate">
+      <trans-unit id="CollectionTab.RestartToUpdate" approved="yes">
         <source xml:lang="en">Restart to Update</source>
         <target xml:lang="ru">Перезапустите приложение, чтобы обновить</target>
         <note>ID: CollectionTab.RestartToUpdate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="ru">Образцы</target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="ru">Отправить/Получить</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="ru">Настройки</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ru">Коллекция Заготовок</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="ru">Открыть дополнительную папку с коллекциями</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="ru">Заготовки для новых образцов</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="ru">Шаблоны</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.TitleMissing">
+      <trans-unit id="CollectionTab.TitleMissing" approved="yes">
         <source xml:lang="en">Title Missing</source>
         <target xml:lang="ru">Заголовок отсутствует</target>
         <note>ID: CollectionTab.TitleMissing</note>
         <note>Shown as the thumbnail caption when the book doesn't have a title</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UnableToCheckForUpdate">
+      <trans-unit id="CollectionTab.UnableToCheckForUpdate" approved="yes">
         <source xml:lang="en">Could not connect to the server to check for an update. Are you connected to the internet?</source>
         <target xml:lang="ru">Не удалось соединиться с сервером для проверки доступных обновлений. Проверьте подключение к интернету.</target>
         <note>ID: CollectionTab.UnableToCheckForUpdate</note>
         <note>Shown when Bloom tries to check for an update but can't, for example because it can't connect to the internet, or a problems with our server, etc.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpToDate">
+      <trans-unit id="CollectionTab.UpToDate" approved="yes">
         <source xml:lang="en">Your Bloom is up to date.</source>
         <target xml:lang="ru">Ваш Bloom обновлен до последней версии.</target>
         <note>ID: CollectionTab.UpToDate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateCheckInProgress">
+      <trans-unit id="CollectionTab.UpdateCheckInProgress" approved="yes">
         <source xml:lang="en">Bloom is already working on checking for updates.</source>
         <target xml:lang="ru">Bloom уже проверяет доступные обновления</target>
         <note>ID: CollectionTab.UpdateCheckInProgress</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateFailed">
+      <trans-unit id="CollectionTab.UpdateFailed" approved="yes">
         <source xml:lang="en">A new version appears to be available, but Bloom could not install it.</source>
         <target xml:lang="ru">Доступна новая версия, но Bloom не может установить ее.</target>
         <note>ID: CollectionTab.UpdateFailed</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateInstalled">
+      <trans-unit id="CollectionTab.UpdateInstalled" approved="yes">
         <source xml:lang="en">Update for {0} is ready</source>
         <target xml:lang="ru">Обновление для {0} готово</target>
         <note>ID: CollectionTab.UpdateInstalled</note>
         <note>Appears after Bloom has downloaded a program update in the background and is ready to switch the user to it the next time they run Bloom.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateNow">
+      <trans-unit id="CollectionTab.UpdateNow" approved="yes">
         <source xml:lang="en">Update Now</source>
         <target xml:lang="ru">Обновить сейчас</target>
         <note>ID: CollectionTab.UpdateNow</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdatesAvailable">
+      <trans-unit id="CollectionTab.UpdatesAvailable" approved="yes">
         <source xml:lang="en">A new version of Bloom is available.</source>
         <target xml:lang="ru">Доступна новая версия Bloom</target>
         <note>ID: CollectionTab.UpdatesAvailable</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Updating">
+      <trans-unit id="CollectionTab.Updating" approved="yes">
         <source xml:lang="en">Downloading update to {0} ({1}K)</source>
         <target xml:lang="ru">Загрузка обновлений для {0} ({1}K)</target>
         <note>ID: CollectionTab.Updating</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="ru">Назад</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="ru">Отмена</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="ru">&amp;Отмена</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="ru">&amp;Завершить</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="ru">&amp;Помощь</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="ru">&amp;Далее</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="ru">Далее</target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK">
+      <trans-unit id="Common.OK" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="ru">ОК</target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="ru">&amp;ОК</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="ru">дополнительно</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections.</source>
         <target xml:lang="ru">Ваша загрузка ({0}) завершена. Вы можете найти ее в разделе "Книги из BloomLibrary.org" в ваших коллекциях.</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="ru">Загрузка завершена</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.CopyFailed">
+      <trans-unit id="Download.CopyFailed" approved="yes">
         <source xml:lang="en">Bloom downloaded the book but had problems making it available in Bloom. Please restart your computer and try again. If you get this message again, please click the 'Details' button and report the problem to the Bloom developers</source>
         <target xml:lang="ru">Bloom загрузил книгу, но возникли проблемы с доступом к ней. Пожалуйста, перезагрузите компьютер и попробуйте еще раз. Если данное сообщение возникнет снова, нажмите "Детали" и отправьте отчет о проблеме разработчикам.</target>
         <note>ID: Download.CopyFailed</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="ru">Загрузка книги</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="ru">Возникла проблема с загрузкой вашей книги</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="ru">Возникла проблема с загрузкой вашей книги. Вам необходимо перезапустить Bloom или обратиться в поддержку.</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.TimeoutProblemNotice">
+      <trans-unit id="Download.TimeoutProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading the book: something took too long. You can try again at a different time, or write to us at issues@bloomlibrary.org if you cannot get the download to work from your location.</source>
         <target xml:lang="ru">Возникла проблема с загрузкой книги, процесс занимает слишком много времени. Вы можете попробовать снова в другой раз, или напишите нам по адресу "issues@bloomlibrary.org" в случае, если вы не можете воспользоваться загрузкой в вашем регионе.</target>
         <note>ID: Download.TimeoutProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddPageButton">
+      <trans-unit id="EditTab.AddPageDialog.AddPageButton" approved="yes">
         <source xml:lang="en">Add Page</source>
         <target xml:lang="ru">Добавить страницу</target>
         <note>ID: EditTab.AddPageDialog.AddPageButton</note>
         <note>This is for the button that LAUNCHES the dialog, not the "Add this page" button that is IN the dialog.</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add This Page</source>
         <target xml:lang="ru">Добавить эту страницу</target>
         <note>ID: EditTab.AddPageDialog.AddThisPageButton</note>
         <note>This is for the button inside the dialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use This Layout</source>
         <target xml:lang="ru">Использовать этот макет</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Continue anyway</source>
         <target xml:lang="ru">Все равно продолжить</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutContinueCheckbox</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose Different Layout...</source>
         <target xml:lang="ru">Выбрать другой макет</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Converting to this layout will cause some content to be lost.</source>
         <target xml:lang="ru">Преобразование в этот макет может привести к потере некоторых данных</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutWillLoseData</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Page...</source>
         <target xml:lang="ru">Добавить страницу...</target>
         <note>ID: EditTab.AddPageDialog.Title</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="ru">Если вам нужно добавить больше информации о книге, вы можете использовать внутреннюю части обложки.</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="ru">Если вам нужно добавить больше информации о книге, вы можете использовать внутреннюю сторону задней обложки</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Background</source>
         <target xml:lang="ru">Фон</target>
         <note>ID: EditTab.TextBoxProperties.Background</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="ru">Два языка</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the Html used to make this PDF, in Firefox (must be on path)</source>
         <target xml:lang="ru">Открыть HTML, который был использован для создания этого PDF, в программе Firefox (должен быть указан в путях)</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="ru">К сожалению, информация об авторских правах и лицензии не могут быть изменены</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="ru">Извините, эта книга заблокирована, поэтому изображения не могут быть изменены.</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ChooseLayoutButton">
+      <trans-unit id="EditTab.ChooseLayoutButton" approved="yes">
         <source xml:lang="en">Choose Different Layout</source>
         <target xml:lang="ru">Выбрать другой макет</target>
         <note>ID: EditTab.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="ru">Вы действительно хотите удалить страницу?</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="ru">&amp;Удалить</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="ru">Эта страница будет окончательно удалена</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="ru">Настройки языков</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip">
+      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip" approved="yes">
         <source xml:lang="en">Choose language to make this a bilingual or trilingual book</source>
         <target xml:lang="ru">Выберите язык, чтобы сделать двуязычную или трехъязычную книгу</target>
         <note>ID: EditTab.ContentLanguagesDropdown.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="ru">Копировать</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTip">
+      <trans-unit id="EditTab.CopyButton.ToolTip" approved="yes">
         <source xml:lang="en">Copy (Ctrl-c)</source>
         <target xml:lang="ru">Копировать (Ctrl-c)</target>
         <note>ID: EditTab.CopyButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can copy it</source>
         <target xml:lang="ru">Вам необходимо выбрать текст, который вы собираетесь скопировать</target>
         <note>ID: EditTab.CopyButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="ru">Скопировать эту информацию для всех других изображений в этой книге?</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="ru">Изменить макет</target>
         <note>ID: EditTab.CustomPage.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true" approved="yes">
         <source xml:lang="en">or</source>
         <target xml:lang="ru">или</target>
         <note>ID: EditTab.CustomPage.Or</note>
         <note>Shown between 'Picture' and 'Text' when Custom Page is in Layout mode</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture</source>
         <target xml:lang="ru">Изображение</target>
         <note>ID: EditTab.CustomPage.Picture</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <target xml:lang="ru">Текст</target>
         <note>ID: EditTab.CustomPage.Text</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <target xml:lang="ru">Текстовый блок</target>
         <note>ID: EditTab.CustomPage.TextBox</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="ru">Вырезать</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTip">
+      <trans-unit id="EditTab.CutButton.ToolTip" approved="yes">
         <source xml:lang="en">Cut (Ctrl-x)</source>
         <target xml:lang="ru">Вырезать (Ctrl-x)</target>
         <note>ID: EditTab.CutButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can cut it</source>
         <target xml:lang="ru">Вам необходимо выделить текст, который вы хотите вырезать</target>
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="ru">Удалить страницу</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTip">
+      <trans-unit id="EditTab.DeletePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Remove this page from the book</source>
         <target xml:lang="ru">Удалить эту страницу из книги</target>
         <note>ID: EditTab.DeletePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be removed</source>
         <target xml:lang="ru">Эта страница не может быть удалена</target>
         <note>ID: EditTab.DeletePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="ru">Дублировать страницу</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
         <target xml:lang="ru">Вставьте новую страницу, которая является дубликатом</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be duplicated</source>
         <target xml:lang="ru">Эта страница не может быть дублирована</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="ru">Редактировать</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true">
+      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot change these because this is not the original copy.</source>
         <target xml:lang="ru">Вы не можете делать изменения, поскольку это не оригинальная копия</target>
         <note>ID: EditTab.EditNotAllowed</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord" approved="yes">
         <source xml:lang="en">Sight Word</source>
         <target xml:lang="ru">Слово</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable" approved="yes">
         <source xml:lang="en">This word is not decodable in this stage.</source>
         <target xml:lang="ru">Это слово не может быть декодировано на данной стадии.</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true">
+      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This sentence is too long for this level.</source>
         <target xml:lang="ru">Это предложение слишком длинное для этого уровня.</target>
         <note>ID: EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong</note>
       </trans-unit>
-      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true">
+      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This page is an experimental prototype which may have many problems, for which we apologize.</source>
         <target xml:lang="ru">Эта страница является экспериментальным прототипом, который может работать некорректно, поэтому заранее приносим извинения.</target>
         <note>ID: EditTab.ExperimentalNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="ru">Выбранный шрифт '{0}', но он не установлен на вашем компьютере. Необходимо использовать другой шрифт.</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true" approved="yes">
         <source xml:lang="en">That style already exists. Please choose another name.</source>
         <target xml:lang="ru">Такой стиль уже существует. Пожалуйста, выберите другое название.</target>
         <note>ID: EditTab.FormatDialog.AlreadyExists</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="ru">Измените границы и фон</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <target xml:lang="ru">Буквы</target>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <target xml:lang="ru">Создать</target>
         <note>ID: EditTab.FormatDialog.Create</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create a new style</source>
         <target xml:lang="ru">Создать новый стиль</target>
         <note>ID: EditTab.FormatDialog.CreateStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Don't see what you need?</source>
         <target xml:lang="ru">Вы не можете найти то, что нужно?</target>
         <note>ID: EditTab.FormatDialog.DontSeeNeed</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Emphasis</source>
         <target xml:lang="ru">Ударение</target>
         <note>ID: EditTab.FormatDialog.Emphasis</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <target xml:lang="ru">Шрифт</target>
         <note>ID: EditTab.FormatDialog.Font</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="ru">Изменить начертание шрифта</target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="ru">Изменяет размер текста для всех блоков со стилем '{0}' и языком '{1}'. \nИспользуемый размер {2}pt.</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="ru">Изменить размер шрифта</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Format</source>
         <target xml:lang="ru">Формат</target>
         <note>ID: EditTab.FormatDialog.Format</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="ru">Изменить межстрочный интервал в тексте</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New style</source>
         <target xml:lang="ru">Новый стиль</target>
         <note>ID: EditTab.FormatDialog.NewStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please use only alphabetical characters. Numbers at the end are ok, as in "part2".</source>
         <target xml:lang="ru">Пожалуйста, используйте только буквы алфавита. Можно также использовать цифры в окончаниях, например "часть2".</target>
         <note>ID: EditTab.FormatDialog.PleaseUseAlpha</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <target xml:lang="ru">Интервал</target>
         <note>ID: EditTab.FormatDialog.Spacing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <target xml:lang="ru">Стиль</target>
         <note>ID: EditTab.FormatDialog.Style</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <target xml:lang="ru">Название стиля</target>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="ru">Очень широкий</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="ru">Нормальный</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="ru">Изменить расстояние между словами</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="ru">Широкий</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="ru">Изменить форматирование для стиля</target>
         <note>ID: EditTab.FormatDialogTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="ru">Вы можете использовать эту часть чтобы указать автора или иллюстратора</target>
         <note>ID: EditTab.FrontMatter.AuthorIllustratorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="ru">Когда вы создаете оригинальную книгу, используйте этот блок, чтобы указать авторов, иллюстраторов, редакторов и других</target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="ru">Если вы делаете книгу из оболочки, используйте этот блок, чтобы указать переводчиков.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="ru">Название книги на языке {lang}</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright &amp; License</source>
         <target xml:lang="ru">Нажмите, чтобы редактировать информацию об авторских права и лицензии</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="ru">Используйте это поле, чтобы указать спонсирующие организации</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="ru">Международный стандартный книжный номер. Оставьте пустым, если у вас нет ISBN.</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.</source>
         <target xml:lang="ru">Если вам нужно указать информацию об этой книге, вы можете использовать внутреннюю сторону обложки.</target>
         <note>ID: EditTab.FrontMatter.InsideFrontCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Name of Translator, in {lang}</source>
         <target xml:lang="ru">Имя переводчика, на языке {lang}</target>
         <note>ID: EditTab.FrontMatter.NameofTranslatorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="ru">Авторские права, на языке {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="ru">Писатели, иллюстраторы, редакторы и другие, кто участвовал в создании этой книги, на языке {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalHadNoCopyrightSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalHadNoCopyrightSentence" approved="yes">
         <source xml:lang="en">Adapted from original without a copyright notice.</source>
         <target xml:lang="ru">Основано на оригинальном произведении без указания авторских прав</target>
         <note>ID: EditTab.FrontMatter.OriginalHadNoCopyrightSentence</note>
         <note>On the Credits page of a book being translated, Bloom shows this if the original book did not have a copyright notice.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalLicenseSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalLicenseSentence" approved="yes">
         <source xml:lang="en">Licensed under {0}.</source>
         <target xml:lang="ru">Лицензия {0}</target>
         <note>ID: EditTab.FrontMatter.OriginalLicenseSentence</note>
         <note>On the Credits page of a book being translated, Bloom puts texts like 'Licensed under CC-BY', so that we have a record of what the license was for the original book. Put {0} in the translation, where the license should go in the sentence.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalCopyrightSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalCopyrightSentence" approved="yes">
         <source xml:lang="en">Adapted from original, {0}.</source>
         <target xml:lang="ru">Основано на оригинальном произведении {0}</target>
         <note>ID: EditTab.FrontMatter.OriginalCopyrightSentence</note>
         <note>On the Credits page of a book being translated, Bloom shows the original copyright. Put {0} in the translation where the copyright notice should go. For example in English, 'Adapted from original, {0}.' comes out like 'Adapted from original, Copyright 2011 SIL'.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="ru">Кликните, чтобы выбрать тему</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="ru">Авторские права на переведенную версию, на языке {lang}</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="ru">Изменить изображение</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Copy Image</source>
         <target xml:lang="ru">Скопировать изображение</target>
         <note>ID: EditTab.Image.CopyImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cut Image</source>
         <target xml:lang="ru">Вырезать изображение</target>
         <note>ID: EditTab.Image.CutImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, &amp; License</source>
         <target xml:lang="ru">Редактировать информацию об авторских правах и лицензии на изображение</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="ru">Вставить изображение</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse">
+      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse" approved="yes">
         <source xml:lang="en">Cancel this import</source>
         <target xml:lang="ru">Отмена импорта</target>
         <note>ID: EditTab.JpegWarningDialog.DoNotUse</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.Photograph">
+      <trans-unit id="EditTab.JpegWarningDialog.Photograph" approved="yes">
         <source xml:lang="en">Use the JPEG file</source>
         <target xml:lang="ru">Использовать JPEG файл</target>
         <note>ID: EditTab.JpegWarningDialog.Photograph</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WarningText">
+      <trans-unit id="EditTab.JpegWarningDialog.WarningText" approved="yes">
         <source xml:lang="en">The file you’ve chosen is a “jpeg” file. JPEGs are perfect for photographs and color artwork. However, JPEGs are a big problem for black and white line art. Problems include:\n• Fuzziness and grey dots.\n• Large file sizes, making the book hard to share.\n• If there are many large JPEGs, Bloom may not have enough memory to make PDFs.\n\nNote: Because JPEG is “lossy”, converting a JPEG to PNG, TIFF, or bmp actually makes things even worse. If this is black and white line art, you want to get an original scan in one of those formats.\n\nPlease select from one of the following, then click “OK”:</source>
         <target xml:lang="ru">Файл, который вы выбрали, является "jpeg" файлом. Такие файлы хорошо подходят для фотографий и цветных изображений. Однако, jpeg не очень подходит для черно-белых линейных изображений. Могут возникнуть следующие проблемы:\n• Размытость и серые точки\n• Большой размер файлов, что делает книгу менее удобной для распространения\n• Если много файлов jpeg большого размера, Bloom может не хватить памяти для создания PDF\n\nОбратите внимание - из-за того, что jpeg является "сжатым" форматом, конвертация его в PNG, TIFF или BMP делает качество только хуже. Если ваше изображение является черно-белым и линейным, лучше сканировать его сразу в перечисленные форматы.\n\nПожалуйста, выберите из списка ниже, и нажмите  "OK":</target>
         <note>ID: EditTab.JpegWarningDialog.WarningText</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle">
+      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle" approved="yes">
         <source xml:lang="en">JPEG Warning</source>
         <target xml:lang="ru">JPEG предупреждение</target>
         <note>ID: EditTab.JpegWarningDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="ru">Эта опция доступна во вкладке "Публикация"</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="ru">Изменить макет</target>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="ru">Один язык</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NewBookName">
+      <trans-unit id="EditTab.NewBookName" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="ru">Книга</target>
         <note>ID: EditTab.NewBookName</note>
         <note>Default file and folder name when you make a new book, but haven't give it a title yet.</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="ru">Перед тем, как вставить изображение, скопируйте его в буфер обмена из другой программы.</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="ru">Для данного макета нет других опций.</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are</source>
         <target xml:lang="ru">Это изменение не допускается. Передняя и задняя страница должны оставаться там, где они есть</target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="ru">Неверное передвижение</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="ru">Страницы</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="ru">Выберите размер и ориентацию страницы</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="ru">Вставить</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTip">
+      <trans-unit id="EditTab.PasteButton.ToolTip" approved="yes">
         <source xml:lang="en">Paste (Ctrl+v)</source>
         <target xml:lang="ru">Вставить (Ctrl+v)</target>
         <note>ID: EditTab.PasteButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing on the Clipboard that you can paste here.</source>
         <target xml:lang="ru">В буфере обмена нет ничего, что вы могли бы вставить здесь.</target>
         <note>ID: EditTab.PasteButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Position" sil:dynamic="true">
+      <trans-unit id="EditTab.Position" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Position</source>
         <target xml:lang="ru">Позиция</target>
         <note>ID: EditTab.Position</note>
       </trans-unit>
-      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true">
+      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot put anything in there while making an original book.</source>
         <target xml:lang="ru">Вы не можете ничего вставить здесь при создании оригинальной книги</target>
         <note>ID: EditTab.ReadOnlyInAuthorMode</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="ru">Изменить границу и фон</target>
         <note>ID: EditTab.StyleEditor.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="ru">Изменить начертание шрифта</target>
         <note>ID: EditTab.StyleEditor.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="ru">Изменить размер шрифта</target>
         <note>ID: EditTab.StyleEditor.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="ru">Изменить межстрочный интервал</target>
         <note>ID: EditTab.StyleEditor.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="ru">Очень широкий</target>
         <note>ID: EditTab.StyleEditor.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="ru">Нормальный</target>
         <note>ID: EditTab.StyleEditor.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="ru">Изменить интервал между словами</target>
         <note>ID: EditTab.StyleEditor.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="ru">Широкий</target>
         <note>ID: EditTab.StyleEditor.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="ru">Изменить форматирование для стиля</target>
         <note>ID: EditTab.StyleEditorTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="ru">Шаблоны страниц</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom" sil:dynamic="true">
+      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture On Bottom</source>
         <target xml:lang="ru">Изображение на Bloom</target>
         <note>ID: EditTab.ThumbnailCaptions.Picture On Bottom</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="ru">Информация об авторских правах на изображение</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="ru">Работа над Букварем</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom can handle only the first {0} words.</source>
         <target xml:lang="ru">Bloom может обработать только первые {0} слов.</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed words in this stage</source>
         <target xml:lang="ru">Допустимые слова на данном этапе</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles" approved="yes">
         <source xml:lang="en">Text files</source>
         <target xml:lang="ru">Текстовые файлы</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters" approved="yes">
         <source xml:lang="en">Letters: {0}</source>
         <target xml:lang="ru">Буквы: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage" approved="yes">
         <source xml:lang="en">The following is a generated report of the decodable stages for {0}.  You can make any changes you want to this file, but Bloom will not notice your changes.  It is just a report.</source>
         <target xml:lang="ru">Сгенерирован отчет о стадиях для {0}. Вы можете сделать любые изменения в этом файле, но на работу Bloom они не повлияют. Это только отчет.</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords" approved="yes">
         <source xml:lang="en">New Decodable Words: {0}</source>
         <target xml:lang="ru">Новые слова Букваря: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords" approved="yes">
         <source xml:lang="en">New Sight Words: {0}</source>
         <target xml:lang="ru">Новые слова: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage" approved="yes">
         <source xml:lang="en">Stage {0}</source>
         <target xml:lang="ru">Стадия {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList" approved="yes">
         <source xml:lang="en">Complete Word List</source>
         <target xml:lang="ru">Завершенный список слов</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="ru">Буквы для данной стадии</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="ru">Открыть файл со списками букв и слов</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Generate a letter and word list report</source>
         <target xml:lang="ru">Сгенерировать отчет о буквах и словах</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample words in this stage</source>
         <target xml:lang="ru">Образцы слов для данной стадии</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="ru">Установить стадии</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="ru">Стадия</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="ru">Слова для данной стадии</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="ru">Работа над Букварем с уровнями</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="ru">Актуальный</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="ru">Выбор темы</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="ru">Для данного уровня</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="ru">Форматирование</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="ru">Поддержка иллюстраций</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="ru">Сохранить</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="ru">Уровень</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="ru">Максимальный</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="ru">для каждой страницы</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="ru">Предсказуемость</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="ru">Установить уровни</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="ru">Эта книга</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="ru">Эта страница</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="ru">всего</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="ru">уникальный</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="ru">Словарь</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="ru">Подсчет слов</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="ru">Больше...</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allow changes to this shellbook</source>
         <target xml:lang="ru">Принять изменения для этого образца</target>
         <note>ID: EditTab.Toolbox.Settings.Unlock</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom normally prevents most changes to shellbooks. If you need to add pages, change images, etc., tick the box below.</source>
         <target xml:lang="ru">Bloom обычно не позволяет делать большинство изменений в образцах. Если вам нужно добавить страницы, изменить изображения и т.д., отметьте ниже</target>
         <note>ID: EditTab.Toolbox.Settings.UnlockShellBookIntroductionText</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState" approved="yes">
         <source xml:lang="en">Bloom recording is in an unusual state, possibly caused by unplugging a microphone. You will need to restart.</source>
         <target xml:lang="ru">Bloom испытвает неполадки с записью, возможно ваш микрофон отключен. Необходиме перезапустить программу.</target>
         <note>ID: EditTab.Toolbox.TalkingBook.BadState</note>
         <note>This is very low priority for translation.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput" approved="yes">
         <source xml:lang="en">No input device</source>
         <target xml:lang="ru">Нет оборудования</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoInput</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic" approved="yes">
         <source xml:lang="en">This computer appears to have no sound recording device available. You will need one to record audio for a talking book.</source>
         <target xml:lang="ru">Похоже, в вашем компьютере отсутствует звуковая карта, поддерживающая запись.</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoMic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage" approved="yes">
         <source xml:lang="en">Please hold the button down until you have finished recording</source>
         <target xml:lang="ru">Пожалуйста, удерживайте кнопку, пока запись не завершится</target>
         <note>ID: EditTab.Toolbox.TalkingBook.PleaseHoldMessage</note>
         <note>Appears when the speak/record button is pressed very briefly</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="ru">Назад</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Back</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4) Check</source>
         <target xml:lang="ru">4) Проверка</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Check</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Check that you are recording into the correct device and that these levels are showing blue:</source>
         <target xml:lang="ru">1) Проверьте, что вы записываете на нужном оборудовании и уровни являются синими:</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.CheckSettings</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Clear</source>
         <target xml:lang="ru">Чисто</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Clear</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Talking Book Tool</source>
         <target xml:lang="ru">Аудиокнига</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Listen to the whole page</source>
         <target xml:lang="ru">Прослушать целую страницу</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Listen</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Look at the highlighted sentence</source>
         <target xml:lang="ru">2) Посмотрите на подсвеченное предложение</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.LookAtSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5) Next</source>
         <target xml:lang="ru">5) Далее</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Next</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3) Speak</source>
         <target xml:lang="ru">3) Говорите</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Speak</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="ru">Самое длинное предложение</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="ru">Три языка</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="ru">Назад</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTip">
+      <trans-unit id="EditTab.UndoButton.ToolTip" approved="yes">
         <source xml:lang="en">Undo (Ctrl+z)</source>
         <target xml:lang="ru">Назад (Cntrl+z)</target>
         <note>ID: EditTab.UndoButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing to undo</source>
         <target xml:lang="ru">Нет операций для отмены</target>
         <note>ID: EditTab.UndoButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="Errors.BookProblem">
+      <trans-unit id="Errors.BookProblem" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.</source>
         <target xml:lang="ru">Bloom испытывает проблемы с отображением данной книги. Это не означает, что ваша работа потеряна, но, возможно что-то устарело, отсутствует или повреждено.</target>
         <note>ID: Errors.BookProblem</note>
       </trans-unit>
-      <trans-unit id="Errors.BrokenBook">
+      <trans-unit id="Errors.BrokenBook" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong. Consider using the 'Report a Problem' command under the 'Help' menu.</source>
         <target xml:lang="ru">Bloom испытывает проблемы с отображением данной книги. Это не означает, что ваша работа потеряна, но, возможно что-то устарело, отсутствует или повреждено. Попробуйте отправить "Отчет об ошибке" в разделе "Помощь"</target>
         <note>ID: Errors.BrokenBook</note>
       </trans-unit>
-      <trans-unit id="Errors.CannotConnectToBloomServer">
+      <trans-unit id="Errors.CannotConnectToBloomServer" approved="yes">
         <source xml:lang="en">Bloom was unable to start its own HTTP listener that it uses to talk to its embedded Firefox browser. If this happens even if you just restarted your computer, then ask someone to investigate if you have an aggressive firewall product installed, which may need to be uninstalled before you can use Bloom.</source>
         <target xml:lang="ru">Bloom не может запустить собственный HTTP listener, который используется для вставки в браузер Firefox. Если эта проблема продолжается даже после перезагрузки компьютера, возможно, на вашем компьютере нужно поменять настройки брандмауэра</target>
         <note>ID: Errors.CannotConnectToBloomServer</note>
       </trans-unit>
-      <trans-unit id="Errors.DeniedAccess">
+      <trans-unit id="Errors.DeniedAccess" approved="yes">
         <source xml:lang="en">Your computer denied Bloom access to the book. You may need technical help in setting the operating system permissions for this file.</source>
         <target xml:lang="ru">Ваш компьютер не предоставляет доступа к книге. Чтобы Bloom мог открыть книгу, необходимо изменить настройки доступа для этого файла.</target>
         <note>ID: Errors.DeniedAccess</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorSelecting">
+      <trans-unit id="Errors.ErrorSelecting" approved="yes">
         <source xml:lang="en">There was a problem selecting the book.  Restarting Bloom may fix the problem.  If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="ru">Возникла проблема с выбором книги. Перезапуск Bloom может помочь в данной ситуации. Если нет, нажмите "Детали" и отправьте отчет об ошибке разработчкам.</target>
         <note>ID: Errors.ErrorSelecting</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorUpdating">
+      <trans-unit id="Errors.ErrorUpdating" approved="yes">
         <source xml:lang="en">There was a problem updating the book.  Restarting Bloom may fix the problem.  If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="ru">Возникла проблема с обновлением книги. Перезапуск Bloom может помочь в этой ситуации. Если нет, нажмите "Детали" и отправьте отчет об ошибке разработчикам.</target>
         <note>ID: Errors.ErrorUpdating</note>
       </trans-unit>
-      <trans-unit id="Errors.NeedNewerVersion">
+      <trans-unit id="Errors.NeedNewerVersion" approved="yes">
         <source xml:lang="en">{0} requires a newer version of Bloom. Download the latest version of Bloom from {1}</source>
         <target xml:lang="ru">{0} требует более новую версию Bloom. Загрузите и установите последнюю версию с {1}</target>
         <note>ID: Errors.NeedNewerVersion</note>
         <note>{0} will get the name of the book, {1} will give a link to open the Bloom Library Web page.</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemDeletingFile">
+      <trans-unit id="Errors.ProblemDeletingFile" approved="yes">
         <source xml:lang="en">Bloom had a problem deleting this file: {0}</source>
         <target xml:lang="ru">Возникла ошибка при удалении файла {0}</target>
         <note>ID: Errors.ProblemDeletingFile</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemImportingPicture">
+      <trans-unit id="Errors.ProblemImportingPicture" approved="yes">
         <source xml:lang="en">Bloom had a problem importing this picture.</source>
         <target xml:lang="ru">Возникла проблема при импортировании этого изображения.</target>
         <note>ID: Errors.ProblemImportingPicture</note>
       </trans-unit>
-      <trans-unit id="Errors.ReportThisProblemButton">
+      <trans-unit id="Errors.ReportThisProblemButton" approved="yes">
         <source xml:lang="en">Report this problem to Bloom Support</source>
         <target xml:lang="ru">Отправить отчет об ошибке в поддержку Bloom</target>
         <note>ID: Errors.ReportThisProblemButton</note>
       </trans-unit>
-      <trans-unit id="Errors.SomethingWentWrong">
+      <trans-unit id="Errors.SomethingWentWrong" approved="yes">
         <source xml:lang="en">Sorry, something went wrong.</source>
         <target xml:lang="ru">Извините, но возникли какие-то проблемы.</target>
         <note>ID: Errors.SomethingWentWrong</note>
       </trans-unit>
-      <trans-unit id="Errors.XMatterNotFound">
+      <trans-unit id="Errors.XMatterNotFound" approved="yes">
         <source xml:lang="en">This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a BloomPack that will give you '{0}', or go to Settings:Book Making and change to another Front/Back Matter Pack.</source>
         <target xml:lang="ru">Это книга требует вводный и завершающий комплект '{0}', но Bloom не смог обнаружить его на вашем компьютере.  Попробуйте установить BloomPack, который содержит '{0}', или измените их в разделе "Создание книги" в настройках</target>
         <note>ID: Errors.XMatterNotFound</note>
       </trans-unit>
-      <trans-unit id="Errors.ZoneAlarm">
+      <trans-unit id="Errors.ZoneAlarm" approved="yes">
         <source xml:lang="en">Bloom cannot start properly, and this symptom has been observed on machines with ZoneAlarm installed. Note: disabling ZoneAlarm does not help. Nor does restarting with it turned off. Something about the installation of ZoneAlarm causes the problem, and so far only uninstalling ZoneAlarm has been shown to fix the problem.</source>
         <target xml:lang="ru">Bloom не может запуститься. Возможно, на вашем компьютере установлена программа ZoneAlarm. Вам необходимо полностью удалить эту программу с вашего компьтера.</target>
         <note>ID: Errors.ZoneAlarm</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="ru">Создание шаблонов просмотрщика</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="ru">Проверить на наличие обновлений</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="ru">О программе Bloom</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Help. Lots of help!</source>
         <target xml:lang="ru">Помощь. Очень много помощи!</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu">
+      <trans-unit id="HelpMenu.Help Menu" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="ru">Помощь</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem">
+      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem" approved="yes">
         <source xml:lang="en">Key Bloom Concepts</source>
         <target xml:lang="ru">Ключевые понятия Bloom</target>
         <note>ID: HelpMenu.KeyBloomConceptsToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="ru">Отзывы и предложения</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="ru">Регистрация</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="ru">О релизе</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem">
+      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem" approved="yes">
         <source xml:lang="en">Report a Problem...</source>
         <target xml:lang="ru">Отчет об ошибке...</target>
         <note>ID: HelpMenu.ReportAProblemToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="ru">Показать историю событий</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="ru">Использование шаблонов просмотрщика</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="ru">Вебсайт</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.trainingVideos">
+      <trans-unit id="HelpMenu.trainingVideos" approved="yes">
         <source xml:lang="en">Training Videos</source>
         <target xml:lang="ru">Обучающие видео</target>
         <note>ID: HelpMenu.trainingVideos</note>
       </trans-unit>
-      <trans-unit id="InstallProblem.BloomPdfMaker">
+      <trans-unit id="InstallProblem.BloomPdfMaker" approved="yes">
         <source xml:lang="en">A component of Bloom, BloomPdfMaker.exe, seems to be missing. This prevents previews and printing. Antivirus software sometimes does this. You may need technical help to repair the Bloom installation and protect this file from being deleted again.</source>
         <target xml:lang="ru">Возможно отсутствует компонент BloomPdfMaker.exe. Он необходим для предосмотра и для печати. Антивирусные программы иногда удаляют его. Вам нужна техническая помощь для восстановления Bloom и для защиты этого файла от дальнейшего удаления.</target>
         <note>ID: InstallProblem.BloomPdfMaker</note>
       </trans-unit>
-      <trans-unit id="LameEncoder.Progress">
+      <trans-unit id="LameEncoder.Progress" approved="yes">
         <source xml:lang="en"> Converting to mp3</source>
         <target xml:lang="ru">Конвертация в mp3</target>
         <note>ID: LameEncoder.Progress</note>
         <note>Appears in progress indicator</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.RightToLeftCheck">
+      <trans-unit id="LanguageFontDetails.RightToLeftCheck" approved="yes">
         <source xml:lang="en">This script is right to left</source>
         <target xml:lang="ru">Эта система письма справа налево</target>
         <note>ID: LanguageFontDetails.RightToLeftCheck</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.TallerLinesCheck">
+      <trans-unit id="LanguageFontDetails.TallerLinesCheck" approved="yes">
         <source xml:lang="en">This script requires taller lines</source>
         <target xml:lang="ru">Этот шрифт требует более высоких строк</target>
         <note>ID: LanguageFontDetails.TallerLinesCheck</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="ru">А4 Горизонтальная</target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="ru">А4 Горизонтальная - обе стороны</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="ru">А4 Горизонтальная - разделить страницы</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="ru">А4 Портретная</target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="ru">А5 Горизонтальная</target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="ru">А5 Портретная</target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="ru">А5 Портретная - выравнивание по нижней стороне</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Landscape</source>
         <target xml:lang="ru">А6 Горизонтальная</target>
         <note>ID: LayoutChoices.A6Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Portrait</source>
         <target xml:lang="ru">А6 Портретная</target>
         <note>ID: LayoutChoices.A6Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="ru">B5 Портретная</target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">HalfLetterPortrait</source>
         <target xml:lang="ru">Letter 1/4 Портретная</target>
         <note>ID: LayoutChoices.HalfLetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterLandscape</source>
         <target xml:lang="ru">Letter Горизонтальная</target>
         <note>ID: LayoutChoices.LetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterPortrait</source>
         <target xml:lang="ru">Letter Портретная</target>
         <note>ID: LayoutChoices.LetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">QuarterLetterLandscape</source>
         <target xml:lang="ru">Letter 1/4 Горизонтальная</target>
         <note>ID: LayoutChoices.QuarterLetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog.WindowTitle">
+      <trans-unit id="LicenseDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom {0}</source>
         <target xml:lang="ru">Bloom {0}</target>
         <note>ID: LicenseDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog._acceptButton">
+      <trans-unit id="LicenseDialog._acceptButton" approved="yes">
         <source xml:lang="en">I accept the terms of the license agreement</source>
         <target xml:lang="ru">Я принимаю условия пользовательского соглашения</target>
         <note>ID: LicenseDialog._acceptButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="ru">Я принимаю условия использования Bloom Library</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="ru">Адрес email</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="ru">Забыл пароль</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="ru">&amp;Логин</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="ru">Пароль</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="ru">&amp;Показать пароль</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="ru">Показать пользовательское соглашение</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="ru">Вход в BloomLibrary.org</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="ru">Уже существует коллекция с таким именем, &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nПожалуйста, придумайте уникальное имя.</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="ru">Выберите основной язык для этой коллекции</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="ru">Например: "Книги о здоровье", "Истории о животных"</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="ru">Как бы вы хотели назвать эту колекцию?</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="ru">Проблема с именем коллекции</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="ru">Коллекция будет расположена в {0}</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="ru">Все готово к созданию новой коллекции</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FontAndScriptPage">
+      <trans-unit id="NewCollectionWizard.FontAndScriptPage" approved="yes">
         <source xml:lang="en">Font and Script</source>
         <target xml:lang="ru">Шрифт и система письма</target>
         <note>ID: NewCollectionWizard.FontAndScriptPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="ru">Выберите тип коллекции</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions" approved="yes">
         <source xml:lang="en">If you already have a collection you want to open, click  the 'Cancel' button.</source>
         <target xml:lang="ru">Если у вас есть готовая коллекция, которую вы хотите открыть, нажмите кнопку "Отмена"</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ru">Коллекция источников</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org and optionally make a Bloom Pack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="ru">Коллекция образцов или шаблонов книг на одном или нескольких языках. Вы можете загрузить эти образцы на BloomLibrary.org и создать Bloom Pack, который будет доступен для других пользователей, чтобы они смогли их использовать для создания своих книг.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="ru">Коллекция на родном или региональном языке</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="ru">Коллекция книг на родном языке</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="ru">Укажите локацию языка</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="ru">Страна</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="ru">Район</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="ru">Дополнительно, Bloom может разместить их на титульном листе ваших книг.</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="ru">Область/край</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="ru">{0} Книг</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="ru">Создать новую коллекцию Bloom</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="ru">Название проекта</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="ru">Невозможно создать коллекцию с таким именем</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="ru">Добро пожаловать в Bloom!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="ru">Вы практически готовы к тому, чтобы создавать книги.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. So the first thing we need to do is make one for you.</source>
         <target xml:lang="ru">Для лучшей организации данных, Bloom хранит все книги в созданных вами &lt;i&gt;Коллекциях&lt;/i&gt;. Поэтому, первым делом, мы создадим коллекцию</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="ru">Нажмите "Далее", чтобы начать</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InDropboxMessage">
+      <trans-unit id="OpenCreateCloneControl.InDropboxMessage" approved="yes">
         <source xml:lang="en">Bloom detected that this collection is located in your Dropbox folder. This can cause problems as Dropbox sometimes locks Bloom out of its own files. If you have problems, we recommend that you move your collection somewhere else or disable Dropbox while using Bloom.</source>
         <target xml:lang="ru">Bloom обнаружил, что эта коллекция располагается в папке Dropbox. Из-за этого могут возникнуть проблемы, поскольку Dropbox иногда блокирует доступ к этой папке для других программ. Мы рекомендуем вам переместить файлы в другую папку, или же отключать Dropbox всякий раз, когда пользуетесь Bloom.</target>
         <note>ID: OpenCreateCloneControl.InDropboxMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage">
+      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage" approved="yes">
         <source xml:lang="en">This collection is part of your 'Sources for new books' which you can see in the bottom left of the Collections tab. It cannot be opened for editing.</source>
         <target xml:lang="ru">Эта коллекция является частью раздела с источниками для новых книг, которые вы можете обнаружить в нижней части вкладки "Коллекции". Она не может быть открыта для редактирования.</target>
         <note>ID: OpenCreateCloneControl.InSourceCollectionMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="ru">Коллекции Bloom</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="ru">Найти другие коллекции на компьютере</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="ru">Копировать из Chorus Hub в локальной сети</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="ru">Копировать из интернета</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="ru">Копировать с USB диска</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="ru">Создать новую коллекцию</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="ru">Открыть/Создать коллекции</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="ru">Узнать больше</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="ru">Кто-нибудь еще использует Отправить/Получить для того, чтобы делиться коллекциями?\nИспользуйте одну из этих красных кнопок, чтобы скопировать чужие коллекции на ваш компьютер.\nПозже, вы можете использовать функцию Отправить/Получить, чтобы делиться своими коллекциями с другими.</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PageList.CantMoveWhenTranslating">
+      <trans-unit id="PageList.CantMoveWhenTranslating" approved="yes">
         <source xml:lang="en">Pages can not be re-ordered when you are translating a book</source>
         <target xml:lang="ru">Страницы не могут изменить сортировку во время процесса перевода книги</target>
         <note>ID: PageList.CantMoveWhenTranslating</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="ru">Пожалуйста, установите Adobe Reader для того, чтобы просмотреть готовую книгу. До этого, вы можете только сохранить книгу в формате PDF и открыть в любой другой программе.</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="ru">Странно, но Adobe Reader выдает ошибку во время попытки открыть PDF. Попробуйте просто сохранить книгу в формате PDF.</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="ru">Грустные новости. Bloom не может найти Adobe Reader, чтобы показать готовую книгу. \nПопробуйте переустановить Adobe Reader. В любом случае, вы можете сохранить книгу в формате PDF.</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="ru">Буклет внутри</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book.
  Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="ru">Создайте буклет из внутренних страниц книги. \nСтраницы будут расположены таким образом, чтобы после их складывания получился буклет.</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="ru">Загрузить</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="ru">Загрузить на BloomLibrary.org, где другие могут скачивать и адаптировать материалы для своих языков.</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="ru">Обложка буклета</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="ru">Создайте PDF для обложки и задника, для того чтобы распечатать его отдельно на цветном принтере.</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubButton">
+      <trans-unit id="PublishTab.EpubButton" approved="yes">
         <source xml:lang="en">ePUB</source>
         <target xml:lang="ru">EPUB</target>
         <note>ID: PublishTab.EpubButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="ru">Не показывать снова</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="ru">Информация об InDesign XML</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation">
+      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation" approved="yes">
         <source xml:lang="en">This PDF viewer can be improved by installing the free Adobe Reader on this computer.</source>
         <target xml:lang="ru">Этот просмотрщик PDF может быть улучшен после установки бесплатного Adobe Reader</target>
         <note>ID: PublishTab.Notifications.AdobeReaderRecommendation</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="ru">Простая</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="ru">Создайте PDF со всеми страницами, каждая на лист бумаги</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system pdf viewer</source>
         <target xml:lang="ru">Откройте PDF в просмотрщике по умолчанию</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="ru">Заменить существующее</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="ru">Примечание</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.BadPdf">
+      <trans-unit id="PublishTab.PdfMaker.BadPdf" approved="yes">
         <source xml:lang="en">Bloom had a problem making a PDF of this book. You may need technical help or to contact the developers. But here are some things you can try:</source>
         <target xml:lang="ru">Bloom столкнулся с проблемой при создании PDF для этой книги. Попробуйте сообщить об ошибке разработчикам. Но все же вы можете попробовать следующее:</target>
         <note>ID: PublishTab.PdfMaker.BadPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory">
+      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory" approved="yes">
         <source xml:lang="en">Try doing this on a computer with more memory</source>
         <target xml:lang="ru">Попробуйте сделать это на другом компьютере, с большим количеством памяти</target>
         <note>ID: PublishTab.PdfMaker.TryMoreMemory</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryRestart">
+      <trans-unit id="PublishTab.PdfMaker.TryRestart" approved="yes">
         <source xml:lang="en">Restart your computer and try this again right away</source>
         <target xml:lang="ru">Перезагрузите компьютер и попробуйте снова</target>
         <note>ID: PublishTab.PdfMaker.TryRestart</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages">
+      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages" approved="yes">
         <source xml:lang="en">Replace large, high-resolution images in your document with lower-resolution ones</source>
         <target xml:lang="ru">Замените большие изображения высокого разрешения на более маленькие</target>
         <note>ID: PublishTab.PdfMaker.TrySmallerImages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="ru">&amp;Печать...</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="ru">Публикация</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="ru">&amp;Сохранить PDF</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveEpub">
+      <trans-unit id="PublishTab.SaveEpub" approved="yes">
         <source xml:lang="en">&amp;Save ePUB...</source>
         <target xml:lang="ru">&amp;Сохранить EPUB</target>
         <note>ID: PublishTab.SaveEpub</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="ru">Обрезать отметки</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="ru">Благодарности</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">AdditionalRequests: </source>
         <target xml:lang="ru">Дополнительные запросы:</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="ru">Все права защищены (Для получения разрешения, свяжитесь с владельцем авторских прав)</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="ru">СС-BY-NC</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you.  If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="ru">BloomLibrary.org уже содержит предыдущую версию вашей книги. Если загрузить снова, она будет заменена на более свежую версию.</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="ru">Авторские права</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="ru">благодарности</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="ru">Извините, но возникла ошибка при загрузке {0}. Более детальная информация ниже. Возможно, вам понадобится техническая помощью</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading</source>
         <target xml:lang="ru">Одно или несколько полей нуждаются в вашем внимании перед тем, как приступить к загрузке</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded</source>
         <target xml:lang="ru">Извините, {0} не удалось успешно загрузить</target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes</source>
         <target xml:lang="ru">Во время загрузки, вы подтвердили ваше соглашение с Bloom Library и предоставили права для использования, которые в нем указаны</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="ru">Возникла проблема с загрузкой вашей книги</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="ru">Языки</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="ru">Использование/Лицензия</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="ru">Аккаунт уже существует</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address.  Would you like to log in instead?</source>
         <target xml:lang="ru">Мы не можем зарегистрировать вас с данным адресом, поскольку аккаунт с таким адресом уже существует. Может, вместо регистрации, вы хотели бы войти?</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="ru">Bloom не смог соединиться с сервером для проверки вашей учетной записи. Пожалуйста, проверьте ваше соединение.</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="ru">Вход не удался</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="ru">Bloom не смог соединиться с сервером, чтобы завершить вход или регистрацию. Возможно, проблема с интернетом, нашим сервером или провайдером.</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="ru">Для того, чтобы зарегистрироваться в BloomLibrary.org, вам необходимо отметить все пункты о согласии с пользовательским соглашением BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="ru">Необходим Email</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="ru">Не можем найти пользователя с таким email адресом. Может, вы хотели бы зарегистрироваться?</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="ru">Пароль и логин не совпадают</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="ru">Пожалуйста, согласитесь с пользовательским соглашением</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="ru">Пожалуйста, укажите ваш email адрес. Мы отправим письмо для сброса пароля.</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="ru">Blom не смог соединиться с сервером, чтобы сбросить ваш пароль. Пожалуйста, проверьте ваше интернет соединение.</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="ru">Не удалось сбросить пароль</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="ru">Сброс пароля</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password</source>
         <target xml:lang="ru">Мы отправляем письмо на {0} с инструкциями как сбросить пароль</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="ru">Зарегистрироваться на Bloom Library</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="ru">Неизвестное имя пользователя</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="ru">Bloom не смог совершить вход на BloomLibrary.org. Проверьте ваше интернет соединение</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="ru">Войти в BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="ru">Выйти из BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="ru">Создание предосмотра PDF</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="ru">Создание эскизного изображения</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.NoLangsFound">
+      <trans-unit id="PublishTab.Upload.NoLangsFound" approved="yes">
         <source xml:lang="en">(None found)</source>
         <target xml:lang="ru">(не найдено)</target>
         <note>ID: PublishTab.Upload.NoLangsFound</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="ru">Извините, эта версия Bloom не совместима с BloomLibrary.org. Пожалуйста, обновитесь.</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.IncompleteTranslation">
+      <trans-unit id="PublishTab.Upload.IncompleteTranslation" approved="yes">
         <source xml:lang="en">(incomplete translation)</source>
         <target xml:lang="ru">(частично)</target>
         <note>ID: PublishTab.Upload.IncompleteTranslation</note>
         <note>This is added after the language name, in order to indicate that some parts of the book have not been translated into this language yet.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="ru">Пожалуйста, войдите в BloomLibrary.org (или зарегистрируйтесь) перед загрузкой</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="ru">Пожалуйста, укажите это с вкладке Редактировать</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="ru">Зарегистрироваться в BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="ru">Шаг 1: Подтвердите метаданные</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="ru">Шаг 2: Загрузка</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="ru">Подсказка: Применение лицензии Creative Commons даст возможность другим пользователям использовать ваши материалы.</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="ru">Подсказка: лицензия Creative Commons позволяет другим легко использовать вашу книгу, даже если они не могут прочитать вашу специальную лицензия</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="ru">Итог</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="ru">Показать пользовательское соглашение</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TimeProblem">
+      <trans-unit id="PublishTab.Upload.TimeProblem" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. This is probably because your computer is set to use the wrong timezone or your system time is badly wrong. See http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html for how to fix this.</source>
         <target xml:lang="ru">Возникла проблема с загрузкой вашей книги. Возможно, в вашем компьютере неправильно настроено время и часовые пояса. Подробная информация: http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html</target>
         <note>ID: PublishTab.Upload.TimeProblem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="ru">Заголовок</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="ru">Загрузить книгу</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <target xml:lang="ru">Поздравляем! "{0}" теперь доступно на BoomLibrary.org ({1})</target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="ru">Загрузка не доступна</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="ru">Возникла проблема с загрузкой вашей книги. Попробуйте перезапустить Bloom или обратитесь в техподдержку</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="ru">Процесс загрузки</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="ru">Загрузить книгу (в Песочницу)</target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="ru">Загрузка метаданных книги</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, &amp; topic tags to the bloomlibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="ru">Загрузка {0}</target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishView._saveButton">
+      <trans-unit id="PublishView._saveButton" approved="yes">
         <source xml:lang="en">Save stub</source>
         <target xml:lang="ru">Сохранить корешок</target>
         <note>ID: PublishView._saveButton</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="ru">Добавить уровень</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="ru">Добавить стадию</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <target xml:lang="ru">Пожалуйста, добавьте тексты в папку с исходными текстами</target>
         <note>ID: ReaderSetup.AddTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="ru">Книга</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="ru">Максимальное количество слов в книге</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="ru">Кликните на буквы чтобы добавить их в эту стадию</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="ru">Разделить пробелами</target>
         <note>ID: ReaderSetup.CombinationHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <target xml:lang="ru">Например, "на ко пре лю"</target>
         <note>ID: ReaderSetup.CombinationHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <target xml:lang="ru">Комбинации букв (Графемы)</target>
         <note>ID: ReaderSetup.Combinations</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="ru">Стадии</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true" approved="yes">
         <source xml:lang="en">File needs .txt extension</source>
         <target xml:lang="ru">В названии файла требуется указать расширение .txt</target>
         <note>ID: ReaderSetup.FileNeedsTxtExtension</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="ru">Во-первых,</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="ru">Не удается прочитать этот формат</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="ru">Помощь в экспорте и конвертации файлов для использования их в качестве исходных текстов</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="ru">Язык</target>
         <note>ID: ReaderSetup.Language</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <target xml:lang="ru">Список букв и словообразующих знаков в алфавитном порядке</target>
         <note>ID: ReaderSetup.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="ru">Разделить пробелами</target>
         <note>ID: ReaderSetup.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <target xml:lang="ru">Например, "а б в г"</target>
         <note>ID: ReaderSetup.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="ru">Буквы</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="ru">Буквы и комбинации букв</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="ru">Чтобы помочь вам в создании букваря, Bloom требуются буквы и комбинации букв, которые вы будете изучать</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="ru">Разделить комбинации букв пробелами. Например:</target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="ru">Заметьте, что список включает в себя символы, которые использовались для создания слов, к примеру </target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="ru">это</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="ru">.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="ru">Уровень</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="ru">Уровень</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="ru">Уровни букваря</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="ru">совпадающие слова</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="ru">Максимальное количество уникальных слов в книге</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <target xml:lang="ru">Больше слов</target>
         <note>ID: ReaderSetup.MoreWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <target xml:lang="ru">Открыть папку с исходными текстами для данного языка</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="ru">Страница</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="ru">Максимальное количство слов на странице</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="ru">При поддержке</target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="ru">Уровни букваря</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="ru">Удалить уровень {0}</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="ru">Удалить стадию {0}</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove from this stage</source>
         <target xml:lang="ru">Удалить с этой стадии</target>
         <note>ID: ReaderSetup.RemoveWordList</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="ru">Перетащите ряды, чтобы изменить порядок уровней</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="ru">Перетащите ряды, чтобы изменить порядок стадий</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <target xml:lang="ru">Список слов и исходные тексты</target>
         <note>ID: ReaderSetup.SampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="ru">, Поисковик</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="ru">Предыдущие и новые буквы</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="ru">Предложение</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="ru">Максимальное количество слов в предложении</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="ru">Установить букварь</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="ru">Установить букварь с уровнями</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <target xml:lang="ru">установить алфавит для данного языка</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <target xml:lang="ru">Какие слова наиболее употребимые?</target>
         <note>ID: ReaderSetup.SightWordHelp</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="ru">Новые наиболее употребляемые слова</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="ru">Наиболее употребляемые слова</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="ru">Стадия</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="ru">Стадия</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="ru">Стадии</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="ru">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="ru">Запомнить в данном уровне:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="ru">Уникальный</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="ru">Слова</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage.  There are two ways to give words to Bloom:</source>
         <target xml:lang="ru">Чтобы помочь вам в создании букваря, Bloom может предложить слова, подходящие для данного уровня. Есть 2 способа добавить слова в Bloom:</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="ru">2) Поместите текстовые файлы в ваш</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <target xml:lang="ru">Папка с исходными текстами</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="ru">1) Напишите слова здесь</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="ru">Буквы</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this BloomPack will carry your latest decodable and leveled reader settings for the \"{0}\" language. Anyone opening this BloomPack , who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this BloomPack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="ru">Дополнительно, этот Bloom Pack будет содержать последние настройки букварей для \"{0}\" языка. Те, кто будет использовать этот Bloom Pack, могут открыть коллекцию  \"{0}\" и использовать буквари с вашими настройками. Также они смогут использовать наборы слов с этих букварей.</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="ru">Эти книги будут созданы в следующих шаблонах:</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <target xml:lang="ru">Сохранить Bloom Pack</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <target xml:lang="ru">Создать Bloom Pack с шаблоном букваря</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="ru">Ваш Email</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="ru">Ваше Имя</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="ru">Регистрация {0}</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="ru">Как вы используете {0}?</target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="ru">Я займусь этим позже</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="ru">Организация</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="ru">&amp;Зарегистрировать</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="ru">Ваша Фамилия</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="ru">Зарегистрировать {0}</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <target xml:lang="ru">Закрыть</target>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Email">
+      <trans-unit id="ReportProblemDialog.Email" approved="yes">
         <source xml:lang="en">Email</source>
         <target xml:lang="ru">Email</target>
         <note>ID: ReportProblemDialog.Email</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.FileTooLarge">
+      <trans-unit id="ReportProblemDialog.FileTooLarge" approved="yes">
         <source xml:lang="en">Unfortunately, {0} is too large to upload. If we need the book in order to work on your problem we will contact you.</source>
         <target xml:lang="ru">К сожалению, {0} слишком тяжела для отправки. Если нам понадобится книга для решения вашей проблемы, мы свяжемся с вами.</target>
         <note>ID: ReportProblemDialog.FileTooLarge</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeBookButton">
+      <trans-unit id="ReportProblemDialog.IncludeBookButton" approved="yes">
         <source xml:lang="en">Include Book '{0}'</source>
         <target xml:lang="ru">Включить книгу '{0}'</target>
         <note>ID: ReportProblemDialog.IncludeBookButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton">
+      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton" approved="yes">
         <source xml:lang="en">Include this screenshot</source>
         <target xml:lang="ru">Включить этот скриншот</target>
         <note>ID: ReportProblemDialog.IncludeScreenshotButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Name">
+      <trans-unit id="ReportProblemDialog.Name" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="ru">Имя</target>
         <note>ID: ReportProblemDialog.Name</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Retry">
+      <trans-unit id="ReportProblemDialog.Retry" approved="yes">
         <source xml:lang="en">Retry</source>
         <target xml:lang="ru">Попробовать снова</target>
         <note>ID: ReportProblemDialog.Retry</note>
         <note>Shown if there was an error submitting the report. Lets the user try submitting it again.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SeeDetails">
+      <trans-unit id="ReportProblemDialog.SeeDetails" approved="yes">
         <source xml:lang="en">See what else will be submitted</source>
         <target xml:lang="ru">Посмотрите, что будет отправлено</target>
         <note>ID: ReportProblemDialog.SeeDetails</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SubmitButton">
+      <trans-unit id="ReportProblemDialog.SubmitButton" approved="yes">
         <source xml:lang="en">&amp;Submit</source>
         <target xml:lang="ru">&amp;Отправить</target>
         <note>ID: ReportProblemDialog.SubmitButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Submitting">
+      <trans-unit id="ReportProblemDialog.Submitting" approved="yes">
         <source xml:lang="en">Submitting to server...</source>
         <target xml:lang="ru">Отправка на сервер...</target>
         <note>ID: ReportProblemDialog.Submitting</note>
         <note>This is shown while Bloom is sending the problem report to our server.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Success">
+      <trans-unit id="ReportProblemDialog.Success" approved="yes">
         <source xml:lang="en">We received your report, thanks for taking the time to help make Bloom better!</source>
         <target xml:lang="ru">Мы получили ваш отчет, спасибо, что помогаете нам делать Bloom лучше!</target>
         <note>ID: ReportProblemDialog.Success</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WhatsTheProblem">
+      <trans-unit id="ReportProblemDialog.WhatsTheProblem" approved="yes">
         <source xml:lang="en">What seems to be the problem?</source>
         <target xml:lang="ru">В чем проблема?</target>
         <note>ID: ReportProblemDialog.WhatsTheProblem</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Zipping">
+      <trans-unit id="ReportProblemDialog.Zipping" approved="yes">
         <source xml:lang="en">Zipping up book...</source>
         <target xml:lang="ru">Упаковка книги</target>
         <note>ID: ReportProblemDialog.Zipping</note>
         <note>This is shown while Bloom is creating the problem report. It's generally too fast to see, unless you include a large book.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.linkLabel1">
+      <trans-unit id="ReportProblemDialog.linkLabel1" approved="yes">
         <source xml:lang="en">Will not be private</source>
         <target xml:lang="ru">Будет неприватным</target>
         <note>ID: ReportProblemDialog.linkLabel1</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.PleaseNotice">
+      <trans-unit id="SamplePrintNotification.PleaseNotice" approved="yes">
         <source xml:lang="en">Please notice the sample printer settings below. Use them as a guide while you set up the printer.</source>
         <target xml:lang="ru">Пожалуйста, обратите внимание на настройки печати образцов. </target>
         <note>ID: SamplePrintNotification.PleaseNotice</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.WindowTitle">
+      <trans-unit id="SamplePrintNotification.WindowTitle" approved="yes">
         <source xml:lang="en">Sample Print Settings</source>
         <target xml:lang="ru">Настройки печати образца</target>
         <note>ID: SamplePrintNotification.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="ScriptSettingsDialog.RightToLeftScriptCheckBox">
+      <trans-unit id="ScriptSettingsDialog.RightToLeftScriptCheckBox" approved="yes">
         <source xml:lang="en">This script is right to left</source>
         <target xml:lang="ru">Эта система письма справа налево</target>
         <note>ID: ScriptSettingsDialog.RightToLeftScriptCheckBox</note>
       </trans-unit>
-      <trans-unit id="ScriptSettingsDialog.ScriptSettingsWindowTitle">
+      <trans-unit id="ScriptSettingsDialog.ScriptSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Special Script Settings...</source>
         <target xml:lang="ru">Специальные настройки системы письма</target>
         <note>ID: ScriptSettingsDialog.ScriptSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="ScriptSettingsDialog.TallerLinesCheckBox">
+      <trans-unit id="ScriptSettingsDialog.TallerLinesCheckBox" approved="yes">
         <source xml:lang="en">This script requires taller lines</source>
         <target xml:lang="ru">Этот шрифт требует более высоких строк</target>
         <note>ID: ScriptSettingsDialog.TallerLinesCheckBox</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="ru">Базовая Книга</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="ru">Большая Книга</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="ru">Букварь</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="ru">Букварь с уровнями</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="ru">Иллюстрированный Словарь</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vaccinations</source>
         <target xml:lang="ru">Вакцинация</target>
         <note>ID: TemplateBooks.BookName.Vaccinations</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="ru">Настенный Календарь</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A blank page that allows you to add items.</source>
         <target xml:lang="ru">Пустая страница для добавления новых элементов</target>
         <note>ID: TemplateBooks.PageDescription.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page with a picture on top and a large, centered word below.</source>
         <target xml:lang="ru">Страница с картинкой сверху и большой подписью под ней</target>
         <note>ID: TemplateBooks.PageDescription.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="ru">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true" approved="yes">
         <source xml:lang="en">10</source>
         <target xml:lang="ru">10</target>
         <note>ID: TemplateBooks.PageLabel.10</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true" approved="yes">
         <source xml:lang="en">11</source>
         <target xml:lang="ru">11</target>
         <note>ID: TemplateBooks.PageLabel.11</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true" approved="yes">
         <source xml:lang="en">12</source>
         <target xml:lang="ru">12</target>
         <note>ID: TemplateBooks.PageLabel.12</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true" approved="yes">
         <source xml:lang="en">13</source>
         <target xml:lang="ru">13</target>
         <note>ID: TemplateBooks.PageLabel.13</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true" approved="yes">
         <source xml:lang="en">14</source>
         <target xml:lang="ru">14</target>
         <note>ID: TemplateBooks.PageLabel.14</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true" approved="yes">
         <source xml:lang="en">15</source>
         <target xml:lang="ru">15</target>
         <note>ID: TemplateBooks.PageLabel.15</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true" approved="yes">
         <source xml:lang="en">16</source>
         <target xml:lang="ru">16</target>
         <note>ID: TemplateBooks.PageLabel.16</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true" approved="yes">
         <source xml:lang="en">17</source>
         <target xml:lang="ru">17</target>
         <note>ID: TemplateBooks.PageLabel.17</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true" approved="yes">
         <source xml:lang="en">18</source>
         <target xml:lang="ru">18</target>
         <note>ID: TemplateBooks.PageLabel.18</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true" approved="yes">
         <source xml:lang="en">19</source>
         <target xml:lang="ru">19</target>
         <note>ID: TemplateBooks.PageLabel.19</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="ru">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true" approved="yes">
         <source xml:lang="en">20</source>
         <target xml:lang="ru">20</target>
         <note>ID: TemplateBooks.PageLabel.20</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true" approved="yes">
         <source xml:lang="en">21</source>
         <target xml:lang="ru">21</target>
         <note>ID: TemplateBooks.PageLabel.21</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="ru">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="ru">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="ru">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="ru">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="ru">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="ru">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="ru">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="ru">Алфавит</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="ru">Базовый Текст и Изображение</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="ru">Базовый Текст и Картинка</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="ru">Авторские права</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="ru">Нестандартная</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="ru">День 1</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="ru">День 2</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="ru">День 3</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="ru">День 4</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="ru">День 5а</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="ru">День 5б</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="ru">Обложка</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="ru">Изображение внизу</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="ru">Изображение посередине</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="ru">Внутрення сторона задней обложки</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="ru">Внутрення сторона обложки</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="ru">Инструкции</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="ru">Только текст</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="ru">Только картинка</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="ru">Только изображение</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="ru">Задняя обложка</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="ru">Картинка и подпись</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="ru">Картинка по центру</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="ru">Картинка снизу</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="ru">Эта страница изначально пустая</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="ru">Титульная страница</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="ru">Установка</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="ru">Сельское хозяйство</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="ru">Истории о животных</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="ru">Предпринимательство</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="ru">Жизнь общества</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="ru">Культура</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="ru">Словарь</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="ru">Окружающая среда</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="ru">Фантастика</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="ru">Здоровье</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="ru">Полезные советы</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="ru">Математика</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.NoTopic" sil:dynamic="true">
+      <trans-unit id="Topics.NoTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">No Topic</source>
         <target xml:lang="ru">Без темы</target>
         <note>ID: Topics.NoTopic</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="ru">Публицистика</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="ru">Личное развитие</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="ru">Букварь</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="ru">Наука</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="ru">Духовная литература</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Story Book" sil:dynamic="true">
+      <trans-unit id="Topics.Story Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Story Book</source>
         <target xml:lang="ru">Истории</target>
         <note>ID: Topics.Story Book</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="ru">Традиция</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="ru">Традиционные истории</target>
         <note>ID: Topics.Traditional Story</note>

--- a/DistFiles/localization/ru/Palaso.xlf
+++ b/DistFiles/localization/ru/Palaso.xlf
@@ -4,579 +4,579 @@
     xmlns:sil="http://sil.org/software/XLiff" version="1.2">
     <file original="Palaso.dll" source-language="en" target-language="ru" datatype="plaintext" product-version="3.6.5.0" sil:hard-linebreak-replacement="\n">
         <body>
-            <trans-unit id="AboutDialog.AboutDialogWindowTitle">
+            <trans-unit id="AboutDialog.AboutDialogWindowTitle" approved="yes">
                 <source xml:lang="en">About</source>
                 <target xml:lang="ru">Информация</target>
                 <note>ID: AboutDialog.AboutDialogWindowTitle</note>
             </trans-unit>
-            <trans-unit id="AboutDialog.NoUpdates">
+            <trans-unit id="AboutDialog.NoUpdates" approved="yes">
                 <source xml:lang="en">No Updates</source>
                 <target xml:lang="ru">Нет обновлений</target>
                 <note>ID: AboutDialog.NoUpdates</note>
             </trans-unit>
-            <trans-unit id="AboutDialog._checkForUpdates">
+            <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
                 <source xml:lang="en">Check For Updates</source>
                 <target xml:lang="ru">Проверить на наличие обновлений</target>
                 <note>ID: AboutDialog._checkForUpdates</note>
             </trans-unit>
-            <trans-unit id="AboutDialog._releaseNotesLabel">
+            <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
                 <source xml:lang="en">Release Notes</source>
                 <target xml:lang="ru">Что нового</target>
                 <note>ID: AboutDialog._releaseNotesLabel</note>
             </trans-unit>
-            <trans-unit id="Application.AlreadyRunning.General">
+            <trans-unit id="Application.AlreadyRunning.General" approved="yes">
                 <source xml:lang="en">Another copy of the application is already running. If you cannot find it, restart your computer.</source>
                 <target xml:lang="ru">Другая копия приложения уже запущена. Если вы не можете найти ее, попробуйте перезагрузить компьютер.</target>
                 <note>ID: Application.AlreadyRunning.General</note>
             </trans-unit>
-            <trans-unit id="Application.AlreadyRunning.Specific">
+            <trans-unit id="Application.AlreadyRunning.Specific" approved="yes">
                 <source xml:lang="en">Another copy of {0} is already running. If you cannot find that {0}, restart your computer.</source>
                 <target xml:lang="ru">Другая копия {0} уже запущена. Если вы не можете найти {0} попробуйте перезагрузить компьютер.</target>
                 <note>ID: Application.AlreadyRunning.Specific</note>
                 <note>{0} is the application name</note>
             </trans-unit>
-            <trans-unit id="Application.ProblemStarting.General">
+            <trans-unit id="Application.ProblemStarting.General" approved="yes">
                 <source xml:lang="en">There was a problem starting the application which might require that you restart your computer.</source>
                 <target xml:lang="ru">Возникла проблема с запуском приложения. Потребуется перезагрузка компьютера.</target>
                 <note>ID: Application.ProblemStarting.General</note>
             </trans-unit>
-            <trans-unit id="Application.ProblemStarting.Specific">
+            <trans-unit id="Application.ProblemStarting.Specific" approved="yes">
                 <source xml:lang="en">There was a problem starting {0} which might require that you restart your computer.</source>
                 <target xml:lang="ru">Возникла проблема с запуском {0}. Потребуется перезагрузка компьютера.</target>
                 <note>ID: Application.ProblemStarting.Specific</note>
                 <note>{0} is the application name</note>
             </trans-unit>
-            <trans-unit id="Application.WaitingFinish.General">
+            <trans-unit id="Application.WaitingFinish.General" approved="yes">
                 <source xml:lang="en">Waiting for other application to finish...</source>
                 <target xml:lang="ru">Ожидание завершения других приложений</target>
                 <note>ID: Application.WaitingFinish.General</note>
             </trans-unit>
-            <trans-unit id="Application.WaitingFinish.Specific">
+            <trans-unit id="Application.WaitingFinish.Specific" approved="yes">
                 <source xml:lang="en">Waiting for other {0} to finish...</source>
                 <target xml:lang="ru">Ожидание завершения других {0}</target>
                 <note>ID: Application.WaitingFinish.Specific</note>
                 <note>{0} is the application name</note>
             </trans-unit>
-            <trans-unit id="Common.CancelButton">
+            <trans-unit id="Common.CancelButton" approved="yes">
                 <source xml:lang="en">&amp;Cancel</source>
                 <target xml:lang="ru">&amp;Отмена</target>
                 <note>ID: Common.CancelButton</note>
             </trans-unit>
-            <trans-unit id="Common.No">
+            <trans-unit id="Common.No" approved="yes">
                 <source xml:lang="en">No</source>
                 <target xml:lang="ru">Нет</target>
                 <note>ID: Common.No</note>
             </trans-unit>
-            <trans-unit id="Common.OKButton">
+            <trans-unit id="Common.OKButton" approved="yes">
                 <source xml:lang="en">&amp;OK</source>
                 <target xml:lang="ru">&amp;ОК</target>
                 <note>ID: Common.OKButton</note>
             </trans-unit>
-            <trans-unit id="Common.Yes">
+            <trans-unit id="Common.Yes" approved="yes">
                 <source xml:lang="en">Yes</source>
                 <target xml:lang="ru">Да</target>
                 <note>ID: Common.Yes</note>
             </trans-unit>
-            <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+            <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
                 <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
                 <target xml:lang="ru">{0} будет перемещен в Корзину</target>
                 <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
                 <note>Param 0 is a description of the things being deleted (e.g., "The selected files"</note>
             </trans-unit>
-            <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+            <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
                 <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
                 <target xml:lang="ru">{0} будет перемещен в Корзину</target>
                 <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
                 <note>Param 0 is a file name</note>
             </trans-unit>
-            <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+            <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
                 <source xml:lang="en">Confirm Delete</source>
                 <target xml:lang="ru">Подтвердить удаление</target>
                 <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
             </trans-unit>
-            <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+            <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
                 <source xml:lang="en">&amp;Cancel</source>
                 <target xml:lang="ru">&amp;Отмена</target>
                 <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
             </trans-unit>
-            <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+            <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
                 <source xml:lang="en">&amp;Delete</source>
                 <target xml:lang="ru">&amp;Удалить</target>
                 <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.AlmostMatchingImages">
+            <trans-unit id="ImageToolbox.AlmostMatchingImages" approved="yes">
                 <source xml:lang="en">Found {0} images with names close to {1}</source>
                 <target xml:lang="ru">Найдено {0} изображений с названиями, похожими на {1}</target>
                 <note>ID: ImageToolbox.AlmostMatchingImages</note>
                 <note>The {0} will be replaced by the number of images found.  The {1} will be replaced with the search string.</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.ArtOfReading">
+            <trans-unit id="ImageToolbox.ArtOfReading" approved="yes">
                 <source xml:lang="en">Art Of Reading</source>
                 <target xml:lang="ru">Искусство чтения</target>
                 <note>ID: ImageToolbox.ArtOfReading</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.Camera">
+            <trans-unit id="ImageToolbox.Camera" approved="yes">
                 <source xml:lang="en">Camera</source>
                 <target xml:lang="ru">Камера</target>
                 <note>ID: ImageToolbox.Camera</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+            <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
                 <source xml:lang="en">Use {0}</source>
                 <target xml:lang="ru">Использовать {0}</target>
                 <note>ID: ImageToolbox.CopyExemplarMetadata</note>
                 <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.Crop">
+            <trans-unit id="ImageToolbox.Crop" approved="yes">
                 <source xml:lang="en">Crop</source>
                 <target xml:lang="ru">Обрезать</target>
                 <note>ID: ImageToolbox.Crop</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.DownloadArtOfReading">
+            <trans-unit id="ImageToolbox.DownloadArtOfReading" approved="yes">
                 <source xml:lang="en">Download Art Of Reading Installer</source>
                 <target xml:lang="ru">Загрузить установщик Искусства чтения</target>
                 <note>ID: ImageToolbox.DownloadArtOfReading</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.EditMetadataLink">
+            <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
                 <source xml:lang="en">Edit...</source>
                 <target xml:lang="ru">Редактировать...</target>
                 <note>ID: ImageToolbox.EditMetadataLink</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.EnterSearchTerms">
+            <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
                 <source xml:lang="en">This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.</source>
                 <target xml:lang="ru">Это галерея "Искусство чтения". Напишите, что вы хотели бы найти в поле выше, затем нажмите ENTER. Вы можете использовать английские и индонезийские слова.</target>
                 <note>ID: ImageToolbox.EnterSearchTerms</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.FileButton">
+            <trans-unit id="ImageToolbox.FileButton" approved="yes">
                 <source xml:lang="en">File</source>
                 <target xml:lang="ru">Файл</target>
                 <note>ID: ImageToolbox.FileButton</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+            <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
                 <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
                 <target xml:lang="ru">Извините, что-то пошло не так при получении данного изображения</target>
                 <note>ID: ImageToolbox.GenericGettingImageProblem</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.GenericProblem">
+            <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
                 <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
                 <target xml:lang="ru">Извините, что-то пошло не так с ImageToolbox</target>
                 <note>ID: ImageToolbox.GenericProblem</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.GetPicture">
+            <trans-unit id="ImageToolbox.GetPicture" approved="yes">
                 <source xml:lang="en">Get Picture</source>
                 <target xml:lang="ru">Получить Картинку</target>
                 <note>ID: ImageToolbox.GetPicture</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+            <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
                 <source xml:lang="en">Image Toolbox</source>
                 <target xml:lang="ru">Image Toolbox</target>
                 <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.InstallArtOfReading">
+            <trans-unit id="ImageToolbox.InstallArtOfReading" approved="yes">
                 <source xml:lang="en">Install the Art Of Reading package (this may be very slow)</source>
                 <target xml:lang="ru">Установка пакета "Искусств чтения" (может занимать продолжительное время)</target>
                 <note>ID: ImageToolbox.InstallArtOfReading</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.MatchingImages">
+            <trans-unit id="ImageToolbox.MatchingImages" approved="yes">
                 <source xml:lang="en">Found {0} images</source>
                 <target xml:lang="ru">Найдено {0} изображений</target>
                 <note>ID: ImageToolbox.MatchingImages</note>
                 <note>The {0} will be replaced by the number of matching images</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.NewMultilingual">
+            <trans-unit id="ImageToolbox.NewMultilingual" approved="yes">
                 <source xml:lang="en">Did you know that there is a new version of this collection which lets you search in Arabic, Bengali, Chinese, English, French, Indonesian, Hindi, Portuguese, Spanish, Thai, or Swahili?  It is free and available for downloading.</source>
                 <target xml:lang="ru">Знаете ли вы, что в новой версии этой коллекции, вы можете искать на арабском, бенгальском, китайском, английском, французском, индонезийском, хинди, португальском, испанском, тайском и суахили? Она доступна для скачивания бесплатно.</target>
                 <note>ID: ImageToolbox.NewMultilingual</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.NoArtOfReading">
+            <trans-unit id="ImageToolbox.NoArtOfReading" approved="yes">
                 <source xml:lang="en">This computer doesn't appear to have the 'Art Of Reading' gallery installed yet.</source>
                 <target xml:lang="ru">Похоже, на этом компьютере не установлена галерея "Искусство чтения".</target>
                 <note>ID: ImageToolbox.NoArtOfReading</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.NoMatchingImages">
+            <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
                 <source xml:lang="en">Found no matching images</source>
                 <target xml:lang="ru">Не найдено подходящих изображений</target>
                 <note>ID: ImageToolbox.NoMatchingImages</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.PictureFiles">
+            <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
                 <source xml:lang="en">picture files</source>
                 <target xml:lang="ru">файлы картинок</target>
                 <note>ID: ImageToolbox.PictureFiles</note>
                 <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+            <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice" approved="yes">
                 <source xml:lang="en">Problem Getting Image</source>
                 <target xml:lang="ru">Проблема с получением изображения</target>
                 <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.ProblemLoadingImage">
+            <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
                 <source xml:lang="en">Sorry, there was a problem loading that image.</source>
                 <target xml:lang="ru">Извините, но возникла проблема с загрузкой этого изображения.</target>
                 <note>ID: ImageToolbox.ProblemLoadingImage</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+            <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
                 <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
                 <target xml:lang="ru">Неизвестна информация об этом изображении:\n\nКто его создал?\nКто может его использовать?</target>
                 <note>ID: ImageToolbox.PromptForMissingMetadata</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.Scanner">
+            <trans-unit id="ImageToolbox.Scanner" approved="yes">
                 <source xml:lang="en">Scanner</source>
                 <target xml:lang="ru">Сканер</target>
                 <note>ID: ImageToolbox.Scanner</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.SearchArtOfReading">
+            <trans-unit id="ImageToolbox.SearchArtOfReading" approved="yes">
                 <source xml:lang="en">Search the Art of Reading Gallery</source>
                 <target xml:lang="ru">Поиск по галерее "Искусство чтения"</target>
                 <note>ID: ImageToolbox.SearchArtOfReading</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.SearchLanguage">
+            <trans-unit id="ImageToolbox.SearchLanguage" approved="yes">
                 <source xml:lang="en">The search box is currently set to {0}</source>
                 <target xml:lang="ru">Поиск установлен на {0}</target>
                 <note>ID: ImageToolbox.SearchLanguage</note>
             </trans-unit>
-            <trans-unit id="ImageToolbox.SetUpMetadataLink">
+            <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
                 <source xml:lang="en">Set up metadata...</source>
                 <target xml:lang="ru">Добавление метаданных...</target>
                 <note>ID: ImageToolbox.SetUpMetadataLink</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.AlternateNamesHeader">
+            <trans-unit id="LanguageLookup.AlternateNamesHeader" approved="yes">
                 <source xml:lang="en">Other Names</source>
                 <target xml:lang="ru">Другие имена</target>
                 <note>ID: LanguageLookup.AlternateNamesHeader</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2">
+            <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2" approved="yes">
                 <source xml:lang="en">This list should include all the ISO-639 languages, including all the alternative names known to ethnologue.com.\n\nIf necessary, use the "Unlisted Language" option, which will be selected for you now.</source>
                 <target xml:lang="ru">Этот список должен включать в себя все языки ISO-639, включая все альтернативные названия, известные ethnologue.com. Если необходиме, вы можете использовать опцию "Языка нет в списке".</target>
                 <note>ID: LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+            <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue" approved="yes">
                 <source xml:lang="en">Ethnologue.com</source>
                 <target xml:lang="ru">Ethnologue.com</target>
                 <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
                 <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+            <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
                 <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
                 <target xml:lang="ru">О языковых кодах 639-3 и как зарегистрировать новые</target>
                 <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+            <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
                 <source xml:lang="en">About The ISO Language Registry</source>
                 <target xml:lang="ru">О регистре языков ISO</target>
                 <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.CodeHeader">
+            <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
                 <source xml:lang="en">Code</source>
                 <target xml:lang="ru">Код</target>
                 <note>ID: LanguageLookup.CodeHeader</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.CountryCount">
+            <trans-unit id="LanguageLookup.CountryCount" approved="yes">
                 <source xml:lang="en">{0} Countries</source>
                 <target xml:lang="ru">{0} Страны</target>
                 <note>ID: LanguageLookup.CountryCount</note>
                 <note>Shown when there are multiple countries and it is just confusing to list them all.</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.CountryHeader">
+            <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
                 <source xml:lang="en">Country</source>
                 <target xml:lang="ru">Страна</target>
                 <note>ID: LanguageLookup.CountryHeader</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+            <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
                 <source xml:lang="en">You can change how the language name will be displayed here:</source>
                 <target xml:lang="ru">Здесь вы можете изменить как будет отображаться название языка:</target>
                 <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+            <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
                 <source xml:lang="en">Lookup Language Code...</source>
                 <target xml:lang="ru">Искать код языка...</target>
                 <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.PrimaryNameHeader">
+            <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
                 <source xml:lang="en">Name</source>
                 <target xml:lang="ru">Имя</target>
                 <note>ID: LanguageLookup.PrimaryNameHeader</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel">
+            <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel" approved="yes">
                 <source xml:lang="en">Show regional dialects</source>
                 <target xml:lang="ru">Показать региональные диалекты</target>
                 <note>ID: LanguageLookup.ShowRegionalDialectsLabel</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup.UnlistedLanguage">
+            <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
                 <source xml:lang="en">Unlisted Language</source>
                 <target xml:lang="ru">Языка нет в списке</target>
                 <note>ID: LanguageLookup.UnlistedLanguage</note>
             </trans-unit>
-            <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+            <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
                 <source xml:lang="en">Can't find your language?</source>
                 <target xml:lang="ru">Не можете найти ваш язык?</target>
                 <note>ID: LanguageLookup._cannotFindLanguageLink</note>
             </trans-unit>
-            <trans-unit id="MemoryWarning">
+            <trans-unit id="MemoryWarning" approved="yes">
                 <source xml:lang="en">Unfortunately, {0} is starting to get short of memory, and may soon slow down or experience other problems. We recommend that you quit and restart it when convenient.</source>
                 <target xml:lang="ru">К сожалению, {0} не хватает памяти и может замедлить свою работу. Рекомендуем вам выйти и перезапустить в удобное для вас время.</target>
                 <note>ID: MemoryWarning</note>
             </trans-unit>
-            <trans-unit id="MetadataDisplay.Creator">
+            <trans-unit id="MetadataDisplay.Creator" approved="yes">
                 <source xml:lang="en">Creator: {0}</source>
                 <target xml:lang="ru">Создатель: {0}</target>
                 <note>ID: MetadataDisplay.Creator</note>
             </trans-unit>
-            <trans-unit id="MetadataDisplay.CreatorLabel">
+            <trans-unit id="MetadataDisplay.CreatorLabel" approved="yes">
                 <source xml:lang="en">Creator</source>
                 <target xml:lang="ru">Создатель</target>
                 <note>ID: MetadataDisplay.CreatorLabel</note>
             </trans-unit>
-            <trans-unit id="MetadataDisplay.LicenseInfo">
+            <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
                 <source xml:lang="en">License Info</source>
                 <target xml:lang="ru">Информация о Лицензии</target>
                 <note>ID: MetadataDisplay.LicenseInfo</note>
             </trans-unit>
-            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true">
+            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true" approved="yes">
                 <source xml:lang="en">You must keep the copyright and credits for authors, illustrators, etc.</source>
                 <target xml:lang="ru">Вы должны сохранять авторские права авторов, иллюстраторов и т.д.</target>
                 <note>ID: MetadataDisplay.Licenses.CreativeCommons.AttributionRequired</note>
                 <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
             </trans-unit>
-            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true">
+            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true" approved="yes">
                 <source xml:lang="en">You are free to make commercial use of this work.</source>
                 <target xml:lang="ru">Вы можете использовать эту работу в коммерческих целях</target>
                 <note>ID: MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed</note>
                 <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
             </trans-unit>
-            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true">
+            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true" approved="yes">
                 <source xml:lang="en">You may adapt and add to this work.</source>
                 <target xml:lang="ru">Вы можете адаптировать эту работу и вносить в нее изменения</target>
                 <note>ID: MetadataDisplay.Licenses.CreativeCommons.Derivatives</note>
                 <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
             </trans-unit>
-            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true">
+            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true" approved="yes">
                 <source xml:lang="en">You may adapt and add to this work, but you may distribute the resulting work only under the same or similar license to this one.</source>
                 <target xml:lang="ru">Вы можете адаптировать эту работу и вносить в нее изменения.. Но для распространения результата, вам необходимо использовать под такой же или подобной лицензией</target>
                 <note>ID: MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike</note>
                 <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
             </trans-unit>
-            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true">
+            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true" approved="yes">
                 <source xml:lang="en">You may not make changes or build upon this work without permission.</source>
                 <target xml:lang="ru">Вы не можете вносить изменения в эту работу и использвать ее как основу для своих работ без получения разрешения</target>
                 <note>ID: MetadataDisplay.Licenses.CreativeCommons.NoDerivatives</note>
                 <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
             </trans-unit>
-            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true">
+            <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true" approved="yes">
                 <source xml:lang="en">You may not use this work for commercial purposes.</source>
                 <target xml:lang="ru">Вы не можете использовать эту работу в коммерческих целях</target>
                 <note>ID: MetadataDisplay.Licenses.CreativeCommons.NonCommercial</note>
                 <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
             </trans-unit>
-            <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true">
+            <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true" approved="yes">
                 <source xml:lang="en">For permission to reuse, contact the copyright holder.</source>
                 <target xml:lang="ru">Для получения разрешения для использования, свяжитесь с обладателем авторских прав</target>
                 <note>ID: MetadataDisplay.Licenses.NullLicense</note>
                 <note>This is used when all we have is a copyright, no other license.</note>
             </trans-unit>
-            <trans-unit id="MetadataDisplay.NoLicense">
+            <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
                 <source xml:lang="en">No license specified</source>
                 <target xml:lang="ru">Лицензия не указана</target>
                 <note>ID: MetadataDisplay.NoLicense</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.AllowCommercialUse">
+            <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
                 <source xml:lang="en">Allow commercial uses of your work?</source>
                 <target xml:lang="ru">Разрешить коммерческое использование вашей работы?</target>
                 <note>ID: MetadataEditor.AllowCommercialUse</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.AllowDerivatives">
+            <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
                 <source xml:lang="en">Allow modifications of your work?</source>
                 <target xml:lang="ru">Разрешить вносить изменения в вашу работу?</target>
                 <note>ID: MetadataEditor.AllowDerivatives</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.CopyrightHolder">
+            <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
                 <source xml:lang="en">Copyright Holder</source>
                 <target xml:lang="ru">Владелец авторских прав</target>
                 <note>ID: MetadataEditor.CopyrightHolder</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.CreativeCommons">
+            <trans-unit id="MetadataEditor.CreativeCommons" approved="yes">
                 <source xml:lang="en">Creative Commons</source>
                 <target xml:lang="ru">Creative Commons</target>
                 <note>ID: MetadataEditor.CreativeCommons</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.CreatorLabel">
+            <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
                 <source xml:lang="en">Creator</source>
                 <target xml:lang="ru">Создатель</target>
                 <note>ID: MetadataEditor.CreatorLabel</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.CustomLicense">
+            <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
                 <source xml:lang="en">Custom</source>
                 <target xml:lang="ru">Другие</target>
                 <note>ID: MetadataEditor.CustomLicense</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.TitleNoCredit">
+            <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
                 <source xml:lang="en">Copyright &amp; License</source>
                 <target xml:lang="ru">Авторские права и Лицензия</target>
                 <note>ID: MetadataEditor.TitleNoCredit</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.TitleWithCredit">
+            <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
                 <source xml:lang="en">Credit, Copyright, &amp; License</source>
                 <target xml:lang="ru">Благодарности, Авторские права и Лицензия</target>
                 <note>ID: MetadataEditor.TitleWithCredit</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.UnknownLicense">
+            <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
                 <source xml:lang="en">Contact the copyright holder for any permissions</source>
                 <target xml:lang="ru">Связаться с владельцем авторских прав для получения разрешения</target>
                 <note>ID: MetadataEditor.UnknownLicense</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.YesShareAlike">
+            <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
                 <source xml:lang="en">Yes, as long as others share alike</source>
                 <target xml:lang="ru">Да, с распространением на тех же условиях</target>
                 <note>ID: MetadataEditor.YesShareAlike</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.additionalRequestsLabel">
+            <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
                 <source xml:lang="en">Additional Requests</source>
                 <target xml:lang="ru">Дополнительные запросы</target>
                 <note>ID: MetadataEditor.additionalRequestsLabel</note>
                 <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.betterLinkLabel1">
+            <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
                 <source xml:lang="en">more info</source>
                 <target xml:lang="ru">Больше информации</target>
                 <note>ID: MetadataEditor.betterLinkLabel1</note>
                 <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere that defines it.</note>
             </trans-unit>
-            <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+            <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
                 <source xml:lang="en">Not Enforceable</source>
                 <target xml:lang="ru">Не подлежит исполнению</target>
                 <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
                 <note>While this screen allows it, legally you can't enforce any additions to a creative commons license. This link takes you to the clause that says that. This link is visible only if you choose Creative Commons but then type in  the "Additional Request" box.</note>
             </trans-unit>
-            <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+            <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
                 <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
                 <target xml:lang="ru">Вы можете скрывать другие кнопки, которые не нежны неопытным пользователям.</target>
                 <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
             </trans-unit>
-            <trans-unit id="SettingsProtection.CtrlShiftHint">
+            <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
                 <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
                 <target xml:lang="ru">Эта кнопка будет появляться, когда вы будете нажимать Ctrl и Shift одновременно</target>
                 <note>ID: SettingsProtection.CtrlShiftHint</note>
             </trans-unit>
-            <trans-unit id="SettingsProtection.LauncherButtonLabel">
+            <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
                 <source xml:lang="en">Settings Protection...</source>
                 <target xml:lang="ru">Настройки...</target>
                 <note>ID: SettingsProtection.LauncherButtonLabel</note>
             </trans-unit>
-            <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+            <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
                 <source xml:lang="en">Hide the button that opens settings.</source>
                 <target xml:lang="ru">Скрыть кнопку настроек</target>
                 <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
             </trans-unit>
-            <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+            <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
                 <source xml:lang="en">Factory Password</source>
                 <target xml:lang="ru">Заводской пароль</target>
                 <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
             </trans-unit>
-            <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+            <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
                 <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
                 <target xml:lang="ru">Чтобы избежать случайных изменений, которые могут повредить вашей работе, эти настройки были заблокированы.</target>
                 <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
             </trans-unit>
-            <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+            <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
                 <source xml:lang="en">Settings Protection Password</source>
                 <target xml:lang="ru">Настройки пароля</target>
                 <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
             </trans-unit>
-            <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox">
+            <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
                 <source xml:lang="en">Show Characters</source>
                 <target xml:lang="ru">Показать символы</target>
                 <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
             </trans-unit>
-            <trans-unit id="SettingsProtection.PasswordNotice">
+            <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
                 <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always google for "{1}" and "{2}".</source>
                 <target xml:lang="ru">Заводской пароль для этих настроек "{0}". Если вы забыли его, вы можете всегда найти его в интернете по запросу "{2}" для "{1}"</target>
                 <note>ID: SettingsProtection.PasswordNotice</note>
                 <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
             </trans-unit>
-            <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+            <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
                 <source xml:lang="en">Require the factory password to get into settings.</source>
                 <target xml:lang="ru">Требуется заводской пароль, чтобы получить доступ к настройкам</target>
                 <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
             </trans-unit>
-            <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+            <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
                 <source xml:lang="en">Settings Protection</source>
                 <target xml:lang="ru">Защита настроек</target>
                 <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
             </trans-unit>
-            <trans-unit id="WSFontControl.Font">
+            <trans-unit id="WSFontControl.Font" approved="yes">
                 <source xml:lang="en">&amp;Font:</source>
                 <target xml:lang="ru">&amp;Шрифт:</target>
                 <note>ID: WSFontControl.Font</note>
             </trans-unit>
-            <trans-unit id="WSFontControl.FontNotAvailable">
+            <trans-unit id="WSFontControl.FontNotAvailable" approved="yes">
                 <source xml:lang="en">(The selected font is not available on this machine. Using default.)</source>
                 <target xml:lang="ru">(Выбранный шрифт недоступен на вашем компьютере. Будет использован шрифт по умолчанию)</target>
                 <note>ID: WSFontControl.FontNotAvailable</note>
             </trans-unit>
-            <trans-unit id="WSFontControl.RightToLeftWS">
+            <trans-unit id="WSFontControl.RightToLeftWS" approved="yes">
                 <source xml:lang="en">This is a &amp;right to left writing system.</source>
                 <target xml:lang="ru">Это &amp;система письма справа налево</target>
                 <note>ID: WSFontControl.RightToLeftWS</note>
             </trans-unit>
-            <trans-unit id="WSFontControl.Size">
+            <trans-unit id="WSFontControl.Size" approved="yes">
                 <source xml:lang="en">&amp;Size:</source>
                 <target xml:lang="ru">&amp;Размер:</target>
                 <note>ID: WSFontControl.Size</note>
             </trans-unit>
-            <trans-unit id="WSFontControl.TestArea">
+            <trans-unit id="WSFontControl.TestArea" approved="yes">
                 <source xml:lang="en">&amp;Test Area:</source>
                 <target xml:lang="ru">&amp;Тестово поле:</target>
                 <note>ID: WSFontControl.TestArea</note>
             </trans-unit>
-            <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+            <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
                 <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
                 <target xml:lang="ru">Если нужная вам клавиатура не указана в списке, кликните ссылку ниже чтобы установить ее.</target>
                 <note>ID: WSKeyboardControl.KeyboardNotListed</note>
             </trans-unit>
-            <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+            <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
                 <source xml:lang="en">Windows keyboard settings</source>
                 <target xml:lang="ru">Настройки Windows клавиатуры</target>
                 <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
             </trans-unit>
-            <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+            <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
                 <source xml:lang="en">Available keyboards</source>
                 <target xml:lang="ru">Доступные клавиатуры</target>
                 <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
             </trans-unit>
-            <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+            <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
                 <source xml:lang="en">Previously used keyboards</source>
                 <target xml:lang="ru">Предыдущая клавиатура</target>
                 <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
             </trans-unit>
-            <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+            <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
                 <source xml:lang="en">Keyman Configuration</source>
                 <target xml:lang="ru">Конфигурация Keyman</target>
                 <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
             </trans-unit>
-            <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+            <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
                 <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
                 <target xml:lang="ru">Keyman 5.0+ не установлен</target>
                 <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
             </trans-unit>
-            <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+            <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
                 <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
                 <target xml:lang="ru">Выберите &amp;клавиатуру, которая будет использована для набора {0} текста</target>
                 <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
             </trans-unit>
-            <trans-unit id="WSKeyboardControl.TestAreaCaption">
+            <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
                 <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
                 <target xml:lang="ru">&amp;Тестовое поле (Попробуйте напечатать что-нибудь, чтобы проверить клавиатура)</target>
                 <note>ID: WSKeyboardControl.TestAreaCaption</note>
             </trans-unit>
-            <trans-unit id="Warning">
+            <trans-unit id="Warning" approved="yes">
                 <source xml:lang="en">Warning</source>
                 <target xml:lang="ru">Предупреждение</target>
                 <note>ID: Warning</note>
             </trans-unit>
-            <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption">
+            <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption" approved="yes">
                 <source xml:lang="en">Unable to connect to SLDR</source>
                 <target xml:lang="ru">Невозможно соединиться с SLDR</target>
                 <note>ID: WritingSystemSetupView.UnableToConnectToSldrCaption</note>
             </trans-unit>
-            <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText">
+            <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText" approved="yes">
                 <source xml:lang="en">The application is unable to connect to the SIL Locale Data Repository to retrieve the latest information about this language. If you create this writing system, the default settings might be incorrect or out of date. Are you sure you want to create a new writing system?</source>
                 <target xml:lang="ru">Приложение не может соединиться с репозиторием SIL Local Data Repository, чтобы восстановить последнюю информацию об этом языке. Если вы создаете систему письма, настройки по умолчанию могут оказать недействительными или устаревшими. Вы уверены, что хотите создать новую систему письма?</target>
                 <note>ID: WritingSystemSetupView.UnableToConnectToSldrText</note>

--- a/DistFiles/localization/rw/Bloom.xlf
+++ b/DistFiles/localization/rw/Bloom.xlf
@@ -2,1933 +2,1933 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="rw" datatype="plaintext" product-version="2.0.1084.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template BloomPack...</source>
         <target xml:lang="rw">Gukora Ipaki ntangarugero ya Bloom y'umusomyi...</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="rw">Ku rwego rwo hejuru</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="rw">Igikoresho gifasha umusomyi gusobanukirwa</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="rw">Igikoresho cy'umusomyi umenyereye</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="rw">Ibindi...</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="rw">Ikuzanya {0} riratunganye ku buryo ryakoreshwa kuri iyi mudasobwa.</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="rw">Bloom ntiyashoboye kwensitara iyo paki ya Bloom</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="rw">Ehambura...</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while BloomPacks are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="rw">Bloom yamaze gufunguka, ariko amakuru ayirimo ntagaragara kugeza ikindi gihe uri bwongere kuyifungura</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="rw">Indimi eshatu</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="rw">Itunganya ryimbitse rya porogaramu</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="rw">Kwerekana Komande z'igerageza (urg. Kwimirira XML muri InDesign)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="rw">KwerekanaIntangarugero z'igerageza (urg. Inkoranya y'amashusho)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="rw">Gukoresha seriveri y'ishusho mu kuganbanya ikoreshwa rya memwari n'amashusho manini.</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="rw">Ugukora ishusho ntubyangano...</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="rw">Ugukora Igitabo</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="rw">Inyuguti/Ipaki y'inyuma ni ingenzi</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="rw">Itunganya</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="rw">Guhindura...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="rw">Ururimi rwa 1</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="rw">Ururimi rwa 2</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="rw">Ururimi rwa 3</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="rw">Indimi</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="rw">Gutunganya...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="rw">Ururimi kavukire</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="rw">Ururimi 2 (urg. Ururimi rw'igihugu)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="rw">Ururimi 3 (urg. Ururimi rw'Akarere) (Si itegeko)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="rw">Gukuramo</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="rw">Izina ry'ikusanyirizo rya Bloom</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="rw">Igihugu</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="rw">Akarere</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="rw">Amakuru ku mushinga</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="rw">Intara</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="rw">Kongera gutangira</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="rw">Bloom igiye kwifunga yongere ifungure uyu mushinga mu yindi mitunganyirize.</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="rw">Gukosora Igitabo</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="rw">Guhuza n'igihe ishusho ntubyangano</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="rw">Gusiba Igitabo</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="rw">Kwimurira muri Word cyangwa LibreOffice...</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export To XML For InDesign...</source>
         <target xml:lang="rw">Kwimurira muri XML igenewe InDesign...</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="rw">Ibitabo byavanywe kuri BloomLibrary.org</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="rw">Guhuza n'igihe ibitabo byose</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="rw">Kontorora ibitabo byose</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="rw">Garura amashusho yose abura...</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="rw">Amateka y'ikusanyirizo...</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="rw">Note z'ikusanyirizo...</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="rw">Amakusanyirizo</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="rw">Amasanyirizo</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="rw">Igitabo '{0}'</target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="rw">Gufungura idosiye iri ku idisiki</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="rw">Ubuzima</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <target xml:lang="rw">Gukora igitabo ukoresheje ibi</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="rw">Irindi kusanyirizo</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="rw">Imiterere ntangarugero</target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="rw">Kwakira/Kohereza</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="rw">Itunganya</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="rw">Gufungura Idosye y'ikusanyirizo ry'inyongera</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="rw">Imbata ntangarugero</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="rw">Nonosora iki gitabo</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="rw">Gukora ipaki ya Bloom</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="rw">Habwa ibindi bitabo ntangarugero kuri BloomLibrary.org</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="rw">Ikusanyirizo ntangarugero</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="rw">Inkomoko y'ibitabo bishya</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="rw">Iri kusanyirizo rirafunze, bityo nta bitabo bishya bishobora kongerwamo/gukurwamo</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="rw">Ibindi...</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="rw">Intangarugero ku miterere mishya y'ibitabo</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="rw">&amp;Hagarika</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="rw">&amp;Kurangiza</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="rw">&amp;Ibikurikira</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="rw">&amp;OK</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="rw">ukoresha ushatse</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="rw">Iyubakwa...</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="rw">Guteganya intambwe</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="rw">Intambwe</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="rw">cya</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections. If you don't seem to be in the middle of doing something, Bloom will select it for you.</source>
         <target xml:lang="rw">Ibyo wakururaga ({0}) byarangiye. Ushobora kubisanga mu gice cyitwa 'Ikusanyabitabo rya Bloom' kiboneka mu makusanyirizo yawe. Niba usa n'udafite ikintu uri gukora, Bloom iribukikugaragarize ubwayo.</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="rw">Gukurura byarangiye</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="rw">Gukurura igitabo</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="rw">Habaye ikibazo mu gukurura igitabo cyawe</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="rw">Niba ukeneye ahantu ho gushyira amakuru y'inyongera kuri iki gitabo, ushobora gukoresha iyiu paji, ariyo gikobokobo cy'inyuma ku gice cyacyo cy'imbere.</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="rw">Niba ukeneye ahantu ho gushyira amakuru y'inyongera kuri iki gitabo, ushobora gukoresha iyi paji, ariyo gikobokobo cy'inyuma ku gice cyacyo cy'inyuma.</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the Html used to make this PDF, in Chrome (must be on path)</source>
         <target xml:lang="rw">Gufungura Html yakoreshejwe hakorwa iyi PDF, muri Chrom (igomba kuba iri ku nzira)</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="rw">Tukwiseguyeho, uburenganzira bw'umwanditsi kimwe n'uburenganzira kuri iki gitabo ntibishobora guhindurwa.</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="rw">Tukwiseguyeho, iki gitabo kirafunzwe kugira ngo amashusho yacyo adahindurwa.</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="rw">Ushaka koko guhanagura iyi paji?</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="rw">&amp;Guhanagura</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="rw">{0} irahita yoherezwa mu gakangara k'ibyasiibwe</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="rw">Kunoza</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="rw">Inyuguti yatoranyijwe ubu ni '{0}', ariko rero ntyensitaye kuri iyi mudasobwa. Izindi nyuguti ziri bukoreshwe mu mwanya wayo.</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="rw">Guhindura ubunini bw'inyuguti zigize umwandiko ku tuzu twose dufite inyuguti '{0}' n'ururimi '{1}'.\nubunini bw'iki gihe ni {2}pt.</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="rw">Umutwe w'igitabo mu {lang}</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright &amp; License</source>
         <target xml:lang="rw">Kanda uhindure Uburenganzira bw'umwanditsi &amp; n'amabwiriza</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="rw">Koresha aha mu gushimira urwego urwo ari rwo rwose rwaguteye inkunga.</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="rw">Inomero mpuzamahanga ndangabuziranenge bw'igitabo. Siga uyu mwanya urimo ubusa niba nta yo ufite.</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="rw">Ugushimira umwimerere (cyangwa Intangarugero) wakoreshejwe mu {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="rw">Ibyatanzwe n'abanditsi, abashushanyi, abanonosoranyandiko, nbd., mu {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="rw">Kanda uhitemo insanganyamatsiko</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="rw">Ugushimira inonosora rishingiye ku ihindurandimi, mu {lang}</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="rw">Guhindura ishusho</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="rw">Kubambikaho ishusho</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="rw">Guhindura imisusire</target>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="rw">Amapaji</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="rw">Guhitamo ubunini bw'urupapuro n'icyerekezo</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="rw">Tengeneza imiterere y'inyuguti</target>
         <note>ID: EditTab.FormatDialogTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="rw">Amapaji ntangarugero</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="rw">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="rw">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="rw">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="rw">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="rw">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="rw">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="rw">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="rw">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="rw">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="rw">Itonde ry'inyuguti</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="rw">Inyandiko y'ibanze &amp; Ishusho</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="rw">Inyandiko y'ibanze &amp; Ifoto</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="rw">Ipaji yo gushima</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="rw">Umunsi 1</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="rw">Umunsi 2</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="rw">Umunsi 3</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="rw">Umunsi 4</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="rw">Umunsi 5a</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="rw">Umunsi 5b</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="rw">Igikobokobo cy'imbere</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="rw">Ishusho hasi</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="rw">Ishusho hagati</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="rw">Igikobokobo cy'inyuma mo imbere</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="rw">Igikobokobo cy'imbere mo imbere</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="rw">Amabwiriza</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="rw">Inyandiko gusa</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="rw">Ifoto gusa</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="rw">Ishusho gusa</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="rw">Igikobokobo cy'inyuma hanze</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="rw">Ifoto &amp; Ijambo</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="rw">Ifoto hasi</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="rw">Ifoto hagati</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="rw">Iyi paji ntiyanditsweho ku bushake</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="rw">Ipaji ijyaho Umutwe</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="rw">Imitunganyirize y'indimi nyinshi</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="rw">Koporora</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="rw">Kata</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove Page</source>
         <target xml:lang="rw">Kuramo ipaji</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="rw">Koramo\n   Ebyiri</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="rw">Bambika</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="rw">Subizayo</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="rw">Indimi ebyiri</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="rw">Ururimi rumwe</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="rw">Nta yinsi misusire iriho kuri iyi ntangarugero.</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="rw">Amakuru kuri nyir'ifoto</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="rw">Indimi eshatu</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu">
+      <trans-unit id="HelpMenu.Help Menu" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="rw">Nkunganire</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="rw">Vuga uko wifuza ko byamera</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="rw">Site ya interineti</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="rw">Reba niba nta nonosora rishya ryasohotse</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="rw">Ibirebana na Bloom</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <target xml:lang="rw">Ishyinguranyandiko</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="rw">Ukwiyandikisha</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="rw">Amakuru kuri porogaramu yasohotse</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="rw">Kwerekana uko abantu bagije binjira</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="rw">Amakuru kuri XML ya InDesign</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="rw">Ntiwongere kwerekana ibi ukundi</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="rw">Urupapuro rutambitse A4</target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="rw">Urupapuro rutambitse A4 Uruhande ku ruhande</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="rw">Urupapuro rutambitse A4 Rusatuye amapaji yose</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="rw">Urupapuro ruhagaze A4</target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="rw">Urupapuro ruhagaze A5</target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="rw">Urupapuro ruhagaze A5 Hasi haringanijwe</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="rw">Urupapuro ruhagaze B5</target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="rw">Cy'ukuri</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="rw">By'iyi ntambwe</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="rw">Kuzirikana</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="rw">Urwego</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> of </source>
         <target xml:lang="rw"> cya </target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="rw">Hejuru</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="rw">ku ipaji</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="rw">ku nteruro</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="rw">Guteganya inzego</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="rw">Iki gitabo</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="rw">Iyi paji</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="rw">igiteranyo</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="rw">cyihariye</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="rw">Ukubara amagambo</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="rw">Nemeranya n'amabwiriza yagenwe mu ikoreshwa ry'Ikusanyabitabo rya Bloom</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="rw">Aderese ya Imeyili</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="rw">Kwibagirwa ijambobanga</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="rw">&amp;Kwinjira</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="rw">Ijambobanga</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="rw">Kwerkana amabwiriza y'imikoreshereze</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="rw">Injira muri BloomLibrary.org</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="rw">&amp;Kwerekana Ijambobanga</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="rw">Ikusanyirizo rifite izina nk'iri risanzweho, warisanga kuri &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nTwagusabaga guhitamo izina rindi.</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="rw">Guhitamo ururimo rw'ibanze rw'iri kisanyirizo</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="rw">Ingero: "Ibitabo by'ubuzima", "Inkuru z'inyamaswa PNG" </target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="rw">Wifuza kwita ute iri kusanyirizo?</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="rw">Ikusanyirizo riri bushyirwe kuri: {0}</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="rw">Itegure gukora ikusanyirizo rishya</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="rw">Guhitamo ubwoko bw'ikusanyirizo</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="rw">Inkomoko y'ikusanyirizo</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="rw">Ikusanyirizo mu rurimi kavukire/Ururimi gakondo</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="rw">Ikusanyirizo ry'ibitabo mu rurimi gakondo.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="rw">Gutanga aho ururimi ruvugwa</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="rw">Igihugu</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="rw">Akarere</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="rw">Intara</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="rw">Ibitabo {0}</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="rw">Gukora ikusanyirizo rishya rya Bloom</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="rw">Gukora ikusanyirizo rishya  ukoresheje iri zina ntibyashobotse</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="rw">Ikaze kuri Bloom!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="rw">Uri hafi gutangira gukora ibitabo.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="rw">Kanda 'Ibikurikira' kugira ngo utangire</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="rw">Amakusanyirizo ya Bloom</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="rw">Shakisha irindi kusanyirizo kuri iyi mudasobwa</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="rw">Koporora ubikuye kuri Chorus Hub ku rusobesangano lokali</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="rw">Gukoporora bivuye kuri interineti</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="rw">Gukopororo bivuye kuri USB</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="rw">Gukora ikusanyirizo rishya</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="rw">Gufungura/Gukora amakusanyirizo</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="rw">Soma n'ibindi</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="rw">Simbuza ibisanzwemo</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="rw">Icyitonderwa</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are</source>
         <target xml:lang="rw">Iri hindura ntiryemewe. Igikobokobo cy'imbere n'igikobokobo cy'inyuma bigomba kuguma aho biri</target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="rw">Iyimura ridafite akamaro</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="rw">Turasaba ko wakwensitara Adobe Reader kugira ngo Bloom ibe yagaragaza igitabo kirangiye. Kugeza igihe uzabikorera, ushobora gukomeza kubika igitabo muri PDF no kugifungurira mu zindi porogaramu.</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="rw">Ntibisanzwe... Adobe Reader yagaragaje ko habaye ikosa mu gihe hageragezwaga kugaragaza iyo PDF. Ushobora gukomeza kugerageza kubika igitabo cya PDF.</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="rw">Amakuru ababaje. Bloom ntiyashoboye kubona Adobe Reader yo kwerekana hano, ubwo rero Bloom ntishobora kugaragaza igitabo cyuzuye.\nUbwo rero wakuramo inonosora ufite rya 'Adobe Reader' ukongera kwensitara 'Adobe Reader".\nKugeza igihe biri bukosokere, ushobora gukomeza kubika igitabo muri PDF no kugifungura mu zindi porogaramu.</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="rw">Imbere h'agatabo</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book.
  Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="rw">Kora agatabo ukoresheje amapaji y'imbere muri iki gitabo. Amapaji araramburwa ku buryo yipanga ku murongo maze igihe uyazinze aze gutanga agatabo.</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="rw">Koherezayo</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="rw">Kohereza kuri BloomLibrary.org, aho abandi bashobora gukurura igitabo cyawe bakagihindura mu ndimi kavukire z'iwabo.</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="rw">Igifubiko cy'agatabo</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="rw">Cyoroheje</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="rw">Kora PDF ya buri paji y'igitabo,ipaji imwe ku urupapuro rumwe.</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system pdf viewer</source>
         <target xml:lang="rw">Fungura PDF muri sisitemu ntangarugero isoma pdf</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="rw">&amp;Capurura...</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="rw">Gutangaza</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="rw">&amp;Kubika PDF...</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="rw">Gucimbura ibirango</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="rw">Ugushimira</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">AdditionalRequests: </source>
         <target xml:lang="rw">Ibisabwa by'inyongera:</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="rw">Uburenganzira bw'umwanditsi bugomba kubahirizwa (Vugana n'ufite uburenganzira kuri iyi nyandiko ku burenganzira bwose waba wifuza.)</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you.  If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="rw">BloomLibrary.org yamaze kwakira inonosora rya mbere ry'iki gitabo wanditse. Niba wongeye kucyinjizamo, kirasimburwa n'igishya ushaka gushyiramo.</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="rw">Uburenganzira bw'umuhanzi</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="rw">Abashimirwa by'umwihariko</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="rw">Habaye ikibazo cyo gukurura igitabo cyawe. Urasabwa kongera gutangira Bloom cyangwa gushaka ubufasha bwa tekiniki.</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="rw">Tukwiseguyeho, habaye ikibazo cyo kwinjizamo {0}. Amakuru arambuye ni akurikira. Ushobora gukenera ubufasha bwa tekiniki.</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading</source>
         <target xml:lang="rw">Umwe cyanwa myinshi mu myanya yo hejuru ikeneye ko uyitaho mbere yo kwinjizamo</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded</source>
         <target xml:lang="rw">Tukwiseguyeho, "{0}" kwinjizamo ibitabo ntibyakunze</target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes</source>
         <target xml:lang="rw">Mu gihe winjijemo, wemeye amabwiriza y'ubwumvikane bw'imikoreshereze ya Bloom Library kandi utanze uburenganzira ayo masezerano avuga.</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="rw">Habaye ikibazo mu kwinjizamo igitabo cyawe.</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="rw">Indimi</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="rw">Ikoreshwa/Uburenganzira</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="rw">Iyi konti isanzweho</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address.  Would you like to log in instead?</source>
         <target xml:lang="rw">Ntidushoboye kutuma winjira ukoresheje iyo aderese, kuberako dusanzwe dufite konti iyikoresha. Waba se ahubwo wifuza kwinjira?</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="rw">Bloom ntishobora kwihuza na seriveri ngo igenzure ikwinjira kwawe. Twagusabaga ko ugenzura konegisiyo y'urusobe mpuzamasangano rwawe.</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="rw">Kwinjiramo byanze</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="rw">Bloom ntiyashoboye kwihuza burundu na seriveri kugira ngo urangize kwinjira cyangwa gusohoka. Ibi bishobora kuba byatewe na konegisiyo yawe ya interineti, seriveri yacu cyangwa ibikoresho bimwe bihuza izo nzira bitameze neza.</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="rw">Kugira ngo wiyandikishe kuri konti ya BloomLibrary.org, usabwa gukanda ku kazu kagaragaza ko wemeye amabwiriza y'imikoreshereze ya BloomLibrary.</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="rw">Imeyili irakenewe</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="rw">Ntidufite umuntu ukoresha iyi imeyili. Waba wifuza kwiyandikisha?</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="rw">Ijambobanga n'akazina winjiriraho ntibihuye</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="rw">Turasaba ko wakwemeranya n'amabwiriza y'ikoreshwa</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="rw">Turagusaba ko wakwinjizamo aderese ya imeyili nyayo. Turi bukoherereze imeyili kuriyi aderese kugira ngo ushobore guhindura ijambobanga ryawe.</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="rw">Bloom ntishobora kwihuza na seriveri ngo uhindure ijambo banga ryawe. Twasabaga ko wagenzura konegisiyo yawe ya interineti.</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="rw">Guhindura ijambobanga byanze</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="rw">Guhindura ijambobanga</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password</source>
         <target xml:lang="rw">Twohereje imeyili kuri {0} n'amabwiriza y'uburyo bwo guhindura ijambobanga ryawe</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="rw">Kwiyandikisha ku Ikusanyabitabo rya Bloom</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="rw">Umukoresha utazwi</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="rw">Sohoka muri BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="rw">Ukubyerekanisha PDF</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="rw">Ugukora ishusho ntubyangano...</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="rw">Twagusabaga kubanza kwinjira muri BloomLibrary.org (cyangwa kwiyandikisha) mbereyo kwinjizamo ibitabo</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="rw">Twasabaga ko wasibanganya ibi mu mwanya w'inonosora</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="rw">Intambwe 1: Kwemeza ibiranganyandiko</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="rw">Intambwe 2: Kukururiramo</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="rw">Incamake</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="rw">Kwerekana amabwiriza y'ikoresha</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="rw">Umutwe</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="rw">Kwinjizamo igitabo</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="rw">Indimi eshatu</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="rw">Uho kwinjizamo bigeze</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="rw">Kwinjiza igitabo (muri Sandbook)</target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="rw">Ugusunikiramo {0}</target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="rw">CC-BY-NC</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="rw">Injira kuri BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="rw">Kwiyandikisha kuri BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="rw">Kongeraho intera</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="rw">Kongeraho intambwe</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <target xml:lang="rw">Twagusabaga ko wongera inyandiko mu idosiye y'inyandiko z'icyitegererezo.</target>
         <note>ID: ReaderSetup.AddTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="rw">Igitabo</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="rw">Amagambo yose ashoboka ku gitabo</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="rw">Kanda ku nyuguti uzongere kuri iyi ntambwe.</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="rw">Gitandukanya 'imyanya</target>
         <note>ID: ReaderSetup.CombinationHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <target xml:lang="rw">Urg. "ai oo sh ng th ing"</target>
         <note>ID: ReaderSetup.CombinationHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <target xml:lang="rw">Iyungikanya ry'inyuguti (Ibihekane)</target>
         <note>ID: ReaderSetup.Combinations</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="rw">Inzego zo gusemura ubutumwa</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="rw">Ubwa mbere,</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="rw">Ntishobora gusoma iyi miterere</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="rw">Gufasha mu kwimuririra ahandi no guhindura amafishiye yo gukoreshwa nk'imyandiko ntangarugero</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="rw">Ururimi</target>
         <note>ID: ReaderSetup.Language</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <target xml:lang="rw">Gutondekanya inyuguti n'inyandiko y'ikomora ry'amagambo mu buryo bw'itonde ry'inyuguti.</target>
         <note>ID: ReaderSetup.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="rw">Gitandukanya 'imyanya</target>
         <note>ID: ReaderSetup.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <target xml:lang="rw">Urg. "a b c d"</target>
         <note>ID: ReaderSetup.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="rw">Inyuguti</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="rw">Inyuguti n'ibihekane</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="rw">ni</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="rw">.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="rw">Urwego</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="rw">Urwego</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="rw">Inzego z'abasomyi</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> matching words</source>
         <target xml:lang="rw"> uguhuza amagambo </target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="rw">Amagambo yose ashoboka kuri buri gitabo mu gihe agaragaye rimwe gusa</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <target xml:lang="rw">Andi magambo</target>
         <note>ID: ReaderSetup.MoreWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <target xml:lang="rw">Gufungura idosiye y'inyandiko z'icyitegererezo z'uru rurimi</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="rw">Ipaji</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="rw">Amagambo yose ashoboka kuri buri paaji</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="rw">Byakozwe na</target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="rw">Inzego z'abasomyi</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="rw">Kuramo urwego {0}</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="rw">Kuramo intambwe {0}</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="rw">Kurubana imbariro upange neza inzego.</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="rw">Kurubana imbariro upange neza intambwe.</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <target xml:lang="rw">Urutonde rw'amagambo n'inyandiko z'icyitegererezo</target>
         <note>ID: ReaderSetup.SampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="rw">, Urubuga rw'ishakisha ku bijyanye n'ugusoma no kwandika.</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="rw">Inyuguti zabanje n'inshya</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="rw">Interuro</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="rw">Amagambo yose ashoboka muri buri nteruro</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <target xml:lang="rw">gushyiraho itonde ry'inyuguti z'uru rurimi</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <target xml:lang="rw">Amagambo y'irebero ni iki?</target>
         <note>ID: ReaderSetup.SightWordHelp</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="rw">Amagambo mashya y'irebero</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="rw">Amagambo y'irebero</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="rw">Intambwe</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="rw">Intambwe</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="rw">Intambwe</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="rw">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="rw">Ibintu ukwiye kuzirikana kuri uru rwego:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="rw">Cyihariye</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="rw">Amagambo</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="rw">2) Gushyira ifishiye y'inyandiko zawe muri</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Text Folder</source>
         <target xml:lang="rw">Idosiye ibamo inyandiko z'icyitegererezo</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="rw">1) Andika amagambo hano</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="rw">Inyuguti</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="rw">Imeyili</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="rw">Izina ry'idini</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="rw">Turasaba ko wafata umunota umwe ukiyandikisha {0}</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="rw">Ukoresha ute {0}?</target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="rw">Byanyobeye, ibi ndabirangiza nyuma.</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="rw">Ikigo</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="rw">&amp;Kwiyandikisha</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="rw">Izina ry'umuryango</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="rw">Kwiyandikisha {0}</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="rw">Igitabo cy'ibanze</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="rw">Igitabo kinini</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="rw">Umusomyi ugishakisha</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="rw">Umusomyi umenyereye</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="rw">Inkoranya y'Amashusho</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="rw">Kalendari yo ku rukuta</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="rw">Ubuhinzi</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="rw">Inkuru z'inyamaswa</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="rw">Bizinesi</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="rw">Imibereho y'abaturage</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="rw">Umuco</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="rw">Inkoranyamagambo</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="rw">Ibidukikije</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="rw">Inkuru mpimbano</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="rw">Ubuzima</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="rw">Ni gute bikorwa</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="rw">Imibare</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="rw">Inkuru zitari mpimbano</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="rw">Iterambere bwite rya muntu</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="rw">Igitabo cy'inyigisho</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="rw">Ubumenyi</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="rw">Cy'iyobokamana</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="rw">Ubumenyi gakondo</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="rw">Inkuru za kera</target>
         <note>ID: Topics.Traditional Story</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="rw">Ikora</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>

--- a/DistFiles/localization/sw/Bloom.xlf
+++ b/DistFiles/localization/sw/Bloom.xlf
@@ -2,3491 +2,3491 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="sw" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="BloomIntegrity.WindowTitle">
+      <trans-unit id="BloomIntegrity.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom Problem</source>
         <target xml:lang="sw">Tatizo la Bloom</target>
         <note>ID: BloomIntegrity.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="BloomIntegrityDialog.ReportProblem">
+      <trans-unit id="BloomIntegrityDialog.ReportProblem" approved="yes">
         <source xml:lang="en">Report Problem</source>
         <target xml:lang="sw">Ripoti Tatizo</target>
         <note>ID: BloomIntegrityDialog.ReportProblem</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName">
+      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName" approved="yes">
         <source xml:lang="en">Possibly this is an old Bloom Pack created before Bloom Packs could handle special characters in file names. You may be able to get the author to re-create it using a current version. If that's not possible a technical expert may be able to repair things.</source>
         <target xml:lang="sw">Kuna uwezekana kuwa hii ni seti ya kitambo ya Bloom iliyotengenezwa kabla ya Seti ya Bloom kuwa na uwezo wa kushughulikia herufi za kipekee katika majina ya faili.Unaweza kupata mwandishi ili apate kukiandaa upya kwa kutumia tafsiri ya kisasa. Iwapo hii haiwezekani mtaalamu wa kiufundi anaweza kukarabati vitu.</target>
         <note>ID: BloomPackInstallDialog.BadCharsInFileName</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="sw">Kuweka Seti ya Bloom</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="sw">Mkusanyiko sasa uko tayari kutumika kwenye kompyuta hii {0}. </target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller" approved="yes">
         <source xml:lang="en">Bloom Pack Installer</source>
         <target xml:lang="sw">Kifaa cha kuweka Seti ya Bloom</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstaller</note>
         <note>Displayed as the message box title</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack">
+      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack" approved="yes">
         <source xml:lang="en">This BloomPack appears to be incomplete or corrupt.</source>
         <target xml:lang="sw">Seti hii ya Bloom inaonekana kutokamilika au kuharibika.</target>
         <note>ID: BloomPackInstallDialog.CorruptBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.DoesNotExist">
+      <trans-unit id="BloomPackInstallDialog.DoesNotExist" approved="yes">
         <source xml:lang="en">{0} does not exist</source>
         <target xml:lang="sw">{0} haipo</target>
         <note>ID: BloomPackInstallDialog.DoesNotExist</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="sw">Bloom haikuweza kuweka Seti hiyo ya Bloom.</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="sw">Kutoa...</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while Bloom Packs are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="sw">Bloom tayari inaendelea, lakini yaliyomo hayatajitokeza hadi wakati huo mwingine utakapofungua Bloom</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.NotInstalled">
+      <trans-unit id="BloomPackInstallDialog.NotInstalled" approved="yes">
         <source xml:lang="en">The Bloom collection will not be installed.</source>
         <target xml:lang="sw">Mkusanyiko wa Bloom hautaweza kuweka.</target>
         <note>ID: BloomPackInstallDialog.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="sw">Kufungua {0}...</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Replace">
+      <trans-unit id="BloomPackInstallDialog.Replace" approved="yes">
         <source xml:lang="en">This computer already has a Bloom collection named '{0}'. Do you want to replace it with the one from this Bloom Pack?</source>
         <target xml:lang="sw">Kompyuta hii tayari ina mkusanyiko wa Bloom kwa jina '{0}'. Je, unataka kuubadilisha kwa huu mwingine ulio kwenye Seti hii ya Bloom?</target>
         <note>ID: BloomPackInstallDialog.Replace</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder">
+      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder" approved="yes">
         <source xml:lang="en">Bloom Packs should have only a single collection folder at the top level of the .ZIP file.</source>
         <target xml:lang="sw">Seti za Bloom zinapaswa kuwa na folda moja tu ya mkusanyiko kwenye ngazi ya juu ya .ZIP faili.</target>
         <note>ID: BloomPackInstallDialog.SingleCollectionFolder</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.UnableToReplace">
+      <trans-unit id="BloomPackInstallDialog.UnableToReplace" approved="yes">
         <source xml:lang="en">Bloom was not able to remove the existing copy of '{0}'. Quit Bloom if it is running &amp; try again. Otherwise, try again after restarting your computer.</source>
         <target xml:lang="sw">Bloom haikuweza kutoa nakala iliyopo ya '{0}'. Funga Bloom iwapo imefunguliwa na ujaribu tena. Vinginevyo, jaribu tena baada ya kufungua kompyuta yako upya.</target>
         <note>ID: BloomPackInstallDialog.UnableToReplace</note>
       </trans-unit>
-      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true">
+      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To select, use your mouse wheel or point at what you want, then release the key.</source>
         <target xml:lang="sw">Ili kuchagua, tumia gurudumu la mausi yako au uelekeze unachokitaka, kisha uachilie kii.</target>
         <note>ID: BookEditor.CharacterMap.Instructions</note>
         <note>When you hold down a key, a popup appears that lets you choose a related character. These instructions are shown in that popup.</note>
       </trans-unit>
-      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is the default for all text boxes with '{0}' style.</source>
         <target xml:lang="sw">Aina hii ya muundo kwa kawaida hutumika kwa visanduku vyote vya maandishi viliyo na mtindo '{0}'.</target>
         <note>ID: BookEditor.DefaultForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all text boxes with '{0}' style.</source>
         <target xml:lang="sw">Aina hii ya muundo inatumika kwa visanduku vyote vya matini vilivyo na mtindo wa '{0}'.</target>
         <note>ID: BookEditor.ForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text boxes with '{1}' style.</source>
         <target xml:lang="sw">Aina hii ya muundo hutumika kwa {0} visanduku vyote vya maandishi vilivyo na mtindo wa '{1}'.</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true">
+      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sorry, Reader Templates do not allow changes to formatting.</source>
         <target xml:lang="sw">Samahani, Vigezo vya msomaji haviruhusu mabadiliko kwa muundo.</target>
         <note>ID: BookEditor.FormattingDisabled</note>
       </trans-unit>
-      <trans-unit id="BookStorage.FolderMoved">
+      <trans-unit id="BookStorage.FolderMoved" approved="yes">
         <source xml:lang="en">It appears that some part of the folder path to this book has been moved or renamed. As a result, Bloom cannot save your changes to this page, and will need to exit now. If you haven't been renaming or moving things, please click Details below and report the problem to the developers.</source>
         <target xml:lang="sw">Inaonekana kwamba baadhi ya sehemu za njia ya folda kufikia kitabu hiki zimetolewa au kupewa jina upya. Hivyo, Bloom haiwezi kuhifadhi mabadiliko yako ya ukurasa huu, na itahitaji kujifunga sasa. Iwapo hujakuwa ukivipa vitu majina upya au kuvisongesha, tafadhali bofya Maelezo yaliyo hapa chini na uripoti tatizo hili kwa wataalamu husika.</target>
         <note>ID: BookStorage.FolderMoved</note>
       </trans-unit>
-      <trans-unit id="Browser.CopyTroubleshootingInfo">
+      <trans-unit id="Browser.CopyTroubleshootingInfo" approved="yes">
         <source xml:lang="en">Copy Troubleshooting Information</source>
         <target xml:lang="sw">Nakili Habari ya kinachosababisha Tatizo</target>
         <note>ID: Browser.CopyTroubleshootingInfo</note>
       </trans-unit>
-      <trans-unit id="Browser.OpenPageInFirefox">
+      <trans-unit id="Browser.OpenPageInFirefox" approved="yes">
         <source xml:lang="en">Open Page in Firefox (which must be in the PATH environment variable).</source>
         <target xml:lang="sw">Fungua ukurasa kwenye Mtandao (ambao ni lazima uwe kwenye hali inayoweza kubadilika ya NJIA).</target>
         <note>ID: Browser.OpenPageInFirefox</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="sw">Mpangilio wa hali ya Juu wa Programu</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate" approved="yes">
         <source xml:lang="en">Automatically update Bloom</source>
         <target xml:lang="sw">Fanya Bloom kujitengeneza upya</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AutoUpdate</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="sw">Onyesha Maagizo ya Kimajaribio (kama vile XML ya nje ya Mtindo wa Ndani)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="sw">Onyesha Vigezo vya Kimajaribio (kama vile kamusi ya picha.)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="sw">(Kimajaribio) Onyesha Tuma/Pokea Udhibiti</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="sw">Tumia chanzo cha picha ili kupunguza matumizi ya nafasi kwa picha kubwa.</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom is switching the default font for "{0}" to the new "Andika New Basic".</source>
         <target xml:lang="sw">Bloom inabadilisha fonti ya kawaida ya "{0}" kuwa mpya ya "Andika Mpya ya Kimsingi".</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate1</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This will improve the printed output for most languages. If your language is one of the few that need "Andika", you can switch it back in Settings:Book Making.</source>
         <target xml:lang="sw">Hii itaboresha matokeo ya machapisho ya lugha nyingi. Iwapo lugha yako ni mojawapo ya chache zinazohitaji "Andika", unaweza kuirudisha tena kwenye mpangilio:Kutengeneza Kitabu.</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate2</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="sw">Kutengeneza Kitabu</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="sw">Fonti ya Kawaida kwa {0}</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="sw">Seti ya Machapisho ya Mbele/Nyuma</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="sw">Kihifadhi Karatasi</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver</note>
         <note>Name of a Front/Back Matter Pack that puts credits on the inside of the front cover</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="sw">Desturi</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional</note>
         <note>Name of the default Front/Back Matter Pack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="sw">Mfumo wa Kulia hadi Kushoto wa Kuandika</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink" approved="yes">
         <source xml:lang="en">Special Script Settings</source>
         <target xml:lang="sw">Mipangilio ya Kipekee ya Hati</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="sw">Mipangilio</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="sw">Badilisha...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="sw">Lugha ya 1</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="sw">Lugha ya 2</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="sw">Lugha ya 3</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="sw">Lugha</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="sw">Toa</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="sw">Weka...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="sw">Lugha ya Mama</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="sw">Lugha ya 2 (e.g. Lugha ya Kitaifa)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="sw">Lugha yangu 3 (kama vile lugha ya eneo) (Sio lazima)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="sw">Jina la Mkusanyiko wa Bloom</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="sw">Nchi</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="sw">Wilaya</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="sw">Habari kuhusu Mradi</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="sw">Mkoa</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="sw">Anzisha upya</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="sw">Bloom itafunga na kufungua tena mradi huu kwa mpangilio mpya.</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <target xml:lang="sw">Tengeneza Seti ya Bloom ya Kigezo cha Msomaji...</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdminManagesUpdates">
+      <trans-unit id="CollectionTab.AdminManagesUpdates" approved="yes">
         <source xml:lang="en">Your system administrator manages Bloom updates for this computer.</source>
         <target xml:lang="sw">Utawala wa mfumo wako hudhibiti utengenezaji upya wa kompyuta hii.</target>
         <note>ID: CollectionTab.AdminManagesUpdates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="sw">Ya hali ya juu</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Applying">
+      <trans-unit id="CollectionTab.Applying" approved="yes">
         <source xml:lang="en">Applying updates</source>
         <target xml:lang="sw">Kutumia utengenezaji upya</target>
         <note>ID: CollectionTab.Applying</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="sw">Pata vitabu vingi zaidi vya vyanzo kwenye BloomLibrary.org</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="sw">Mkusanyiko wa vyanzo</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DuplicateBook">
+      <trans-unit id="CollectionTab.BookMenu.DuplicateBook" approved="yes">
         <source xml:lang="en">Duplicate Book</source>
         <target xml:lang="sw">Nakili Kitabu</target>
         <note>ID: CollectionTab.BookMenu.DuplicateBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="sw">Futa Kitabu</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book. These programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="sw">Bloom sasa itafungua nyaraka hii HTML kwenye programu yako ya kutengeneza maneno(kwa kawaida neno au Ofisi ya Libre). Utaweza kufanya kazi kwa maandishi na picha za kitabu hiki. Programu hizi kwa kawaida sio nzuri kwa kuhifadhi mtindo, hivyo usitarajie mengi.</target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="sw">Peleka kwenye neno au Ofisi ya Libre...</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="sw">Peleka kwa XML kwa mtindo wa ndani...</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="sw">Tengeneza upya Kitabu</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="sw">Tengeneza upya ukucha wa dole gumba</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="sw">Vyanzo Vya Vitabu Vipya</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="sw">Mkusanyiko huu umefungwa, kwa hivyo vitabu vipya haviwezi kuongezwa/kutolewa.</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="sw">Vitabu kutoka kwenye BloomLibrary.org</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="sw">Tengeneza Upya Vitabu Vyote</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="sw">Angalia kwa Makini Vitabu Vyote</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="sw">Rudisha Picha Zinazokosekana...</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="sw">Historia ya Mkusanyiko...</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="sw">Maelezo ya Mkusanyiko...</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="sw">Mikusanyiko</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="sw">Mikusanyiko</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="sw">Kujenga...</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="sw">Kitabu '{0}'</target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="sw">Fungua Folda kwenye Diski</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="sw">Hariri kitabu hiki</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="sw">Afya</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="sw">Kwa kuwa huu ni mkusanyiko wa chanzo, Broom haipeani sheli zozote zingine kama vyanzo vya sheli mpya. Iwapo unataka kuongeza lugha kwa sheli, badala yake unapaswa kuhariri mkusanyiko ulio na sheli, badala ya kutengeneza nakala yake. Pia, Kalenda ya Ukuta kwa sasa haiwezi kutumika kutengeneza Sheli mpya.</target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="sw">Tengeneza seti ya Bloom</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source.</source>
         <target xml:lang="sw">Tengeneza kitabu kwa kutumia chanzo hiki.</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate_ToolTip_" approved="yes">
         <source xml:lang="en">Create a book in my language using this source book.</source>
         <target xml:lang="sw">Tengeneza kitabu kwa lugha yangu kwa kutumia kitabu hiki kama chanzo.</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate_ToolTip_</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="sw">Zaidi...</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="sw">Mkusanyiko Mwingine</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton_ToolTip_" approved="yes">
         <source xml:lang="en">Open/Create/Get Collection</source>
         <target xml:lang="sw">Fungua/Tengeneza/Pata mkusanyiko</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton_ToolTip_</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem">
+      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem" approved="yes">
         <source xml:lang="en">Open or Create Another Collection</source>
         <target xml:lang="sw">Fungua au Utengeneze Mkusanyiko Mwingine</target>
         <note>ID: CollectionTab.OpenCreateCollectionMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="sw">Sampuli za Sheli </target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="sw">Tuma/Pokea</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="sw">Mipangilio</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="sw">Mkusanyiko wa Vyanzo</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="sw">Fungua Folda nyingine ya Mikusanyiko</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="sw">Vyanzo Vya Sheli Mpya</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="sw">Vielelezo</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.TitleMissing">
+      <trans-unit id="CollectionTab.TitleMissing" approved="yes">
         <source xml:lang="en">Title Missing</source>
         <target xml:lang="sw"> Mada iliyokosekana</target>
         <note>ID: CollectionTab.TitleMissing</note>
         <note>Shown as the thumbnail caption when the book doesn't have a title.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UnableToCheckForUpdate">
+      <trans-unit id="CollectionTab.UnableToCheckForUpdate" approved="yes">
         <source xml:lang="en">Could not connect to the server to check for an update. Are you connected to the internet?</source>
         <target xml:lang="sw">Hauwezi kuunganishwa kwa mtandao ili kupata utengenezaji upya. Umejiunganisha na intaneti?</target>
         <note>ID: CollectionTab.UnableToCheckForUpdate</note>
         <note>Shown when Bloom tries to check for an update but can't, for example because it can't connect to the internet, or a problems with our server, etc.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpToDate">
+      <trans-unit id="CollectionTab.UpToDate" approved="yes">
         <source xml:lang="en">Your Bloom is up to date.</source>
         <target xml:lang="sw">Bloom yako iko katika hali ya kisasa.</target>
         <note>ID: CollectionTab.UpToDate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateCheckInProgress">
+      <trans-unit id="CollectionTab.UpdateCheckInProgress" approved="yes">
         <source xml:lang="en">Bloom is already working on checking for updates.</source>
         <target xml:lang="sw">Bloom hufanya kazi kila wakati kwa kuchunguza utengenezaji upya.</target>
         <note>ID: CollectionTab.UpdateCheckInProgress</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateFailed">
+      <trans-unit id="CollectionTab.UpdateFailed" approved="yes">
         <source xml:lang="en">A new version appears to be available, but Bloom could not install it.</source>
         <target xml:lang="sw">Tafsiri mpya inaonekana kupatikana, lakini Bloom isiingeweza kuiweka.</target>
         <note>ID: CollectionTab.UpdateFailed</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateInstalled">
+      <trans-unit id="CollectionTab.UpdateInstalled" approved="yes">
         <source xml:lang="en">Update for {0} is ready.</source>
         <target xml:lang="sw">Utengenezaji upya wa {0} uko tayari.</target>
         <note>ID: CollectionTab.UpdateInstalled</note>
         <note>Appears after Bloom has downloaded a program update in the background and is ready to switch the user to it the next time they run Bloom.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateNow">
+      <trans-unit id="CollectionTab.UpdateNow" approved="yes">
         <source xml:lang="en">Update Now</source>
         <target xml:lang="sw">Fanya maboresho upya Sasa</target>
         <note>ID: CollectionTab.UpdateNow</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdatesAvailable">
+      <trans-unit id="CollectionTab.UpdatesAvailable" approved="yes">
         <source xml:lang="en">A new version of Bloom is available.</source>
         <target xml:lang="sw">Tafsiri mpya ya Bloom inapatikana.</target>
         <note>ID: CollectionTab.UpdatesAvailable</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Updating">
+      <trans-unit id="CollectionTab.Updating" approved="yes">
         <source xml:lang="en">Downloading update to {0} ({1}kb).</source>
         <target xml:lang="sw">Kuchukua maboresho na kuweka kwa {0} ({1}kb).</target>
         <note>ID: CollectionTab.Updating</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="sw">Nyuma</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="sw">Batilisha</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="sw">U&amp;batilishe</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="sw">U&amp;malize</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.Help" sil:dynamic="true">
+      <trans-unit id="Common.Help" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="sw">Usaidizi</target>
         <note>ID: Common.Help</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="sw">&amp;Usaidie</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Loading" sil:dynamic="true">
+      <trans-unit id="Common.Loading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Loading...</source>
         <target xml:lang="sw">Inashughulikia...</target>
         <note>ID: Common.Loading</note>
         <note>This is shown when Bloom is slowly loading something, so the user doesn't worry about why they don't see the result immediately.</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="sw">&amp;Inayofuata</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="sw">Inayofuata</target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="sw">SAWA</target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="sw">&amp;SAWA</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="sw">Hiyari</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections.</source>
         <target xml:lang="sw">Upakuaji wako mtandaoni ({0}) umekamilika. Unaweza kuliona katika 'Vitabu kutoka kwenye kitengo cha Mkusanyiko wako cha BloomLibrary.org'.</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="sw">Upakuaji mtandaoni umekamilika</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.CopyFailed">
+      <trans-unit id="Download.CopyFailed" approved="yes">
         <source xml:lang="en">Bloom downloaded the book but had problems making it available in Bloom. Please restart your computer and try again. If you get this message again, please click the 'Details' button and report the problem to the Bloom developers.</source>
         <target xml:lang="sw">Bloom ilitoa kitabu lakini ilipata matatizo katika kukifanya kuonekana kwenye Bloom. Tafadhali fungua kompyuta yako upya na ujaribu tena. Iwapo utapata ujumbe huu tena, tafadhali bofya kwenye kitufe cha 'Maelezo' na uripoti tatizo hili kwa wataalamu husika wa Bloom.</target>
         <note>ID: Download.CopyFailed</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="sw">Kupakua kitabu mtandaoni</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="sw">Kulikuwa na tatizo katika upakuaji wa kitabu chako.</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="sw">Kulikuwa na tatizo katika upakuaji kitabu chako.Unaweza kuhitajika kufungua upya Bloom au kupata usaidizii wa kiufudi.</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.TimeoutProblemNotice">
+      <trans-unit id="Download.TimeoutProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading the book: something took too long. You can try again at a different time, or write to us at issues@BloomLibrary.org if you cannot get the download to work from your location.</source>
         <target xml:lang="sw">Kulikuwa na tatizo wakati wa kupakua kitabu hiki: kitu fulani kilitumia muda mrefu sana. Unaweza kujaribu tena wakati mwingine, au utuandikie kwa issues@BloomLibrary.org iwapo huwezi kupata toleo la kitabu ili kufanya kazi kutoka mahali ulipo.</target>
         <note>ID: Download.TimeoutProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddPageButton">
+      <trans-unit id="EditTab.AddPageDialog.AddPageButton" approved="yes">
         <source xml:lang="en">Add Page</source>
         <target xml:lang="sw">Ongeza Ukurasa</target>
         <note>ID: EditTab.AddPageDialog.AddPageButton</note>
         <note>This is for the button that LAUNCHES the dialog, not the "Add this page" button that is IN the dialog.</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add This Page</source>
         <target xml:lang="sw">Ongeza Ukurasa Huu</target>
         <note>ID: EditTab.AddPageDialog.AddThisPageButton</note>
         <note>This is for the button inside the dialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use This Layout</source>
         <target xml:lang="sw">Tumia Muundo huu</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Continue anyway</source>
         <target xml:lang="sw">Endelea hata hivyo</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutContinueCheckbox</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose Different Layout...</source>
         <target xml:lang="sw">Chagua muundo Tofauti...</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Converting to this layout will cause some content to be lost.</source>
         <target xml:lang="sw">Kubadilisha hadi kuwa katika muundo huu kutafanya baadhi ya yaliyohumu kupotea.</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutWillLoseData</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Page...</source>
         <target xml:lang="sw">Ongeza Ukurasa...</target>
         <note>ID: EditTab.AddPageDialog.Title</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="sw">Iwapo unahitaji mahali pa kuandika habari zaidi kuhusu kitabu, unaweza kutumia ukurasa huu, ambao ndio wa ndani wa jalada la nyuma.</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="sw">Iwapo unahitaji mahali pa kuandika habari zaidi kuhusu kitabu, unaweza kutumia ukurasa huu ambao ndio wa nje wa jalada la nyuma.</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Background</source>
         <target xml:lang="sw">Usuli</target>
         <note>ID: EditTab.TextBoxProperties.Background</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="sw">Lugha mbili</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the HTML used to make this PDF, in Firefox (must be on path)</source>
         <target xml:lang="sw">Fungua  iliyotumika kutengeneza hima , kwenye mtandao (lazima iwe kwenye njia)</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="sw">Samahani, haki ya kunakili na leseni ya kitabu hiki haiwezi kubadilishwa.</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="sw">Samahani, kitabu hiki kimefungiwa ili picha zisiweze kubadilishwa.</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ChooseLayoutButton">
+      <trans-unit id="EditTab.ChooseLayoutButton" approved="yes">
         <source xml:lang="en">Choose Different Layout</source>
         <target xml:lang="sw">Chagua Muundo Tofauti</target>
         <note>ID: EditTab.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="sw">Hakika Ukurasa Ufutwe?</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="sw">U&amp;fute</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="sw">Ukurasa huu utatolewa na hauwezi kurejeshwa tena.</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="sw">Mipangilio ya Lugha nyingi</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip">
+      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip" approved="yes">
         <source xml:lang="en">Choose language to make this a bilingual or trilingual book</source>
         <target xml:lang="sw">Chagua lugha ili kufanya hiki kuwa kitabu cha lugha mbili au lugha tatu</target>
         <note>ID: EditTab.ContentLanguagesDropdown.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="sw">Nakili</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTip">
+      <trans-unit id="EditTab.CopyButton.ToolTip" approved="yes">
         <source xml:lang="en">Copy (Ctrl+C)</source>
         <target xml:lang="sw">Nakili (Ctrl+C)</target>
         <note>ID: EditTab.CopyButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can copy it</source>
         <target xml:lang="sw">Unapaswa kuchagua baadhi ya maandishi kabla ya kuinakili</target>
         <note>ID: EditTab.CopyButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="sw">Nakili habari hii kwenye picha zote katika kitabu hiki?</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="sw">Badilisha Muundo</target>
         <note>ID: EditTab.CustomPage.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> or </source>
         <target xml:lang="sw"> au </target>
         <note>ID: EditTab.CustomPage.Or</note>
         <note>Shown between 'Picture' and 'Text' when Custom Page is in Layout mode</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture</source>
         <target xml:lang="sw">Picha</target>
         <note>ID: EditTab.CustomPage.Picture</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <target xml:lang="sw">Maandishi</target>
         <note>ID: EditTab.CustomPage.Text</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <target xml:lang="sw">Kisanduku cha maandishi</target>
         <note>ID: EditTab.CustomPage.TextBox</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="sw">Kata</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTip">
+      <trans-unit id="EditTab.CutButton.ToolTip" approved="yes">
         <source xml:lang="en">Cut (Ctrl+X)</source>
         <target xml:lang="sw">Kata (Ctrl+X)</target>
         <note>ID: EditTab.CutButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can cut it</source>
         <target xml:lang="sw">Unapaswa kuchagua baadhi ya maandishi kabla ya kuyakata</target>
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="sw">Toa  \n Ukurasa</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTip">
+      <trans-unit id="EditTab.DeletePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Remove this page from the book</source>
         <target xml:lang="sw">Toa ukurasa huu kwenye kitabu</target>
         <note>ID: EditTab.DeletePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be removed</source>
         <target xml:lang="sw">Ukurasa huu hauwezi kutolewa</target>
         <note>ID: EditTab.DeletePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="sw">Fanya kurasa\n kuwa mbili</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
         <target xml:lang="sw">Ingiza ukurasa mpya ambao ni nakala ya huu</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be duplicated</source>
         <target xml:lang="sw">Ukurasa huu hauwezi kunakiliwa</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="sw">Hakiki</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true">
+      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot change these because this is not the original copy.</source>
         <target xml:lang="sw">Hauwezi kubadilisha hii kwa kuwa hii siyo nakala ya kwanza.</target>
         <note>ID: EditTab.EditNotAllowed</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord" approved="yes">
         <source xml:lang="en">Sight Word</source>
         <target xml:lang="sw">Neno Linaloonekana</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable" approved="yes">
         <source xml:lang="en">This word is not decodable in this stage.</source>
         <target xml:lang="sw">Neno ili haliwezi kufasiriwa katika ukurasa huu.</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true">
+      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This sentence is too long for this level.</source>
         <target xml:lang="sw">Sentensi ni ndefu sana kwa hatua hii.</target>
         <note>ID: EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong</note>
       </trans-unit>
-      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true">
+      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This page is an experimental prototype which may have many problems, for which we apologize.</source>
         <target xml:lang="sw">Ukurasa huu ni sampuli ya awali ya majaribio ambayo inaweza kuwa na matatizo mengi, ambapo tunaomba radhi.</target>
         <note>ID: EditTab.ExperimentalNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="sw">Fonti iliyochaguliwa kwa sasa ni '', lakini haijawekwa kwenye kompyuta hii.Fonti nyingine itatumiwa.</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true" approved="yes">
         <source xml:lang="en">That style already exists. Please choose another name.</source>
         <target xml:lang="sw">Mtindo huo tayari uko. Tafadhali chagua jina lingine</target>
         <note>ID: EditTab.FormatDialog.AlreadyExists</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="sw">Badilisha mpaka na usuli</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <target xml:lang="sw">Herufi</target>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <target xml:lang="sw">Tengeneza</target>
         <note>ID: EditTab.FormatDialog.Create</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create a new style</source>
         <target xml:lang="sw">Tengeneza mtindo mpya</target>
         <note>ID: EditTab.FormatDialog.CreateStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Don't see what you need?</source>
         <target xml:lang="sw">Je, huoni unachohitaji?</target>
         <note>ID: EditTab.FormatDialog.DontSeeNeed</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Emphasis</source>
         <target xml:lang="sw">Mkazo</target>
         <note>ID: EditTab.FormatDialog.Emphasis</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <target xml:lang="sw">Fonti</target>
         <note>ID: EditTab.FormatDialog.Font</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="sw">Badilisha fonti</target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="sw">Badilisha ukubwa wa maandishi kwa visanduku vyote vilivyo na mtindo wa '{0}' na lugha '{1}'.\nUkubwa uliopo sasa ni pt {2}.</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="sw">Badilisha ukubwa wa fonti</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Format</source>
         <target xml:lang="sw">mpangilio</target>
         <note>ID: EditTab.FormatDialog.Format</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="sw">Badilisha nafasi kati ya mistari ya maandishi</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New style</source>
         <target xml:lang="sw">Mtindo mpya</target>
         <note>ID: EditTab.FormatDialog.NewStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please use only alphabetical characters. Numbers at the end are ok, as in "part2".</source>
         <target xml:lang="sw">Tafadhali tumia tu herufi za kialfabeti. Nambari zilizo mwisho ziko sawa, kama zilivyo kwenye "sehemu ya2".</target>
         <note>ID: EditTab.FormatDialog.PleaseUseAlpha</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <target xml:lang="sw">Kuweka nafasi</target>
         <note>ID: EditTab.FormatDialog.Spacing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <target xml:lang="sw">Mtindo</target>
         <note>ID: EditTab.FormatDialog.Style</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <target xml:lang="sw">Jina la Mtindo</target>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="sw">Pana Kupita Kiasi</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="sw">Kawaida</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="sw">Badilisha nafasi kati ya maneno</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="sw">Pana</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="sw">Badilisha muundo kwa mtindo</target>
         <note>ID: EditTab.FormatDialogTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="sw">Unaweza kutumia nafasi hii kwa mwandishi/mchoraji, au chochote kile.</target>
         <note>ID: EditTab.FrontMatter.AuthorIllustratorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="sw">Unapotengeneza kitabu cha kwanza, tumia kisanduku hiki ili kurekodi mchango uliopeanwa na waandishi, wachoraji, wahakiki, na kadhalika.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="sw">Unapotengeneza kitabu kutoka kwa sheli, tumia kitabu hiki kusema aliyetafsri.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="sw">Jina la Kitabu {lang}</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright and License</source>
         <target xml:lang="sw">Bofya kwenye Kuhakiki Haki ya Kunakili na Leseni.</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="sw">Tumia hii kutambua maajenti wote waliopeana usaidizi wa kifedha.</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="sw">Nambari ya Wastani ya Kitabu ya Kimataifa. Acha wazi iwapo huna mojawapo ya hizi.</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.</source>
         <target xml:lang="sw">Iwapo unahitaji mahali pa kuandika habari zaidi kuhusu kitabu, unaweza kutumia ukurasa huu, ambao ni wa upande wa ndani wa jalada la mbele.</target>
         <note>ID: EditTab.FrontMatter.InsideFrontCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Name of Translator, in {lang}</source>
         <target xml:lang="sw">Jina la mtafsiri, aliyepo {lang}</target>
         <note>ID: EditTab.FrontMatter.NameofTranslatorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="sw">Ya kwanza au utambulizi wa (Sheli) katika {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="sw">Mchango uliotolewa na waandishi, wafundishi, wahakiki, na kadhalika katika {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="sw">Bofya ili kuchagua mada</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="sw">Utambulizi wa tafsiri, katika {lang}</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.HowToUnlockBook">
+      <trans-unit id="EditTab.HowToUnlockBook" approved="yes">
         <source xml:lang="en">To unlock this shellbook, go into the toolbox on the right, find the gear icon, and click 'Allow changes to this shellbook'.</source>
         <target xml:lang="sw">Ili kufungua kitabu hiki cha sheli, nenda kwenye kijisanduku cha vifaa katika upande wa kulia, tafuta ikoni ya gia, na ukliki 'Kubali mabadiliko kwa kitabu hiki cha sheli'.</target>
         <note>ID: EditTab.HowToUnlockBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="sw">Badilisha Picha</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Copy Image</source>
         <target xml:lang="sw">Nakili Picha</target>
         <note>ID: EditTab.Image.CopyImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cut Image</source>
         <target xml:lang="sw">Kata Picha</target>
         <note>ID: EditTab.Image.CutImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, and License</source>
         <target xml:lang="sw">Hariri Sifa za Picha, Haki ya kunakili, na Leseni</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="sw">Weka Picha</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse">
+      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse" approved="yes">
         <source xml:lang="en">Cancel this import</source>
         <target xml:lang="sw">Batilisha ubebaji huu</target>
         <note>ID: EditTab.JpegWarningDialog.DoNotUse</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.Photograph">
+      <trans-unit id="EditTab.JpegWarningDialog.Photograph" approved="yes">
         <source xml:lang="en">Use the JPEG file</source>
         <target xml:lang="sw">Tumia JPEG Jalada</target>
         <note>ID: EditTab.JpegWarningDialog.Photograph</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WarningText">
+      <trans-unit id="EditTab.JpegWarningDialog.WarningText" approved="yes">
         <source xml:lang="en">The file you’ve chosen is a “JPEG” file. JPEG files are perfect for photographs and color artwork. However, JPEG files are a big problem for black and white line art. Problems include:\n• Fuzziness and grey dots.\n• Large file sizes, making the book hard to share.\n• If there are many large JPEGs, Bloom may not have enough memory to make PDF files.\n\nNote: Because JPEG is “lossy”, converting a JPEG to PNG, TIFF, or BMP actually makes things even worse. If this is black and white line art, you want to get an original scan in one of those formats.\n\nPlease select from one of the following, then click “OK”:</source>
         <target xml:lang="sw">Faili uliyochagua ni faili “JPEG”. JPEG faili huwa bora zaidi kwa picha na kazi ya sanaa ya rangi. Hata hivyo, JPEG faili huwa tatizo kuu kwa sanaa ya mistari mieusi na mieupe. Matatizo yanajumuisha:\n• Siobainika na vitone vya rangi ya kijivuu.\n• Faili kubwa, na kuifanya vigumu kusambaza kitabu.\n• Iwapo kuna vingi vikubwa JPEG, Bloom huenda isiwe na nafasi ya kutosha ili kutengeneza PDF faili.\n\nKumbuka: Kwa sababu JPEG ni “hasara”, kubadilisha JPEG kuwa PNG, TIFF,  BMP kwa kweli huharibu mambo zaidi. Iwapo hii ni sanaa ya mstari mweusi na mweupe, unataka kupata skani kwa mojawapo ya miundo hiyo.\n\nTafadhali chagua mojawapo ya yafuatayo, kisha bofya “SAWA”:</target>
         <note>ID: EditTab.JpegWarningDialog.WarningText</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle">
+      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle" approved="yes">
         <source xml:lang="en">JPEG Warning</source>
         <target xml:lang="sw">JPEG Onyo</target>
         <note>ID: EditTab.JpegWarningDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="sw">Chaguo hili linapatikana tu kwenye nembo ya Kuchapisha.</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="sw">Badilisha Muundo</target>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="sw">Lugha moja</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NewBookName">
+      <trans-unit id="EditTab.NewBookName" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="sw">Kitabu</target>
         <note>ID: EditTab.NewBookName</note>
         <note>Default file and folder name when you make a new book, but haven't give it a title yet.</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="sw">Kabla ya kuweka picha, nakili moja kwa 'klipbodi', kutoka kwa programu nyingine.</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="sw">Hakuna chaguo lingine la miundo kwa kigezo hiki.</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Overflow" sil:dynamic="true">
+      <trans-unit id="EditTab.Overflow" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This box has more text than will fit</source>
         <target xml:lang="sw">Kisanduku hiki kina maandishi mengi zaidi kuliko yatakayotoshea</target>
         <note>ID: EditTab.Overflow</note>
       </trans-unit>
-      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true">
+      <trans-unit id="EditTab.OverflowContainer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A container on this page is overflowing</source>
         <target xml:lang="sw">Kifaa kwenye ukurasa huu kimejaa kupita kiasi</target>
         <note>ID: EditTab.OverflowContainer</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are.</source>
         <target xml:lang="sw">Mabadiliko hayo hayakubaliwi. Machapisho ya upande wa mbele na machapisho ya upande wa nyuma yanapaswa kusalia pale yalipo.</target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="sw">Hatua Isiyofaa</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="sw">Kurasa</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="sw">Chagua ukubwa wa ukurasa na maelekezo</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="sw">Weka baada ya kunakili</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTip">
+      <trans-unit id="EditTab.PasteButton.ToolTip" approved="yes">
         <source xml:lang="en">Paste (Ctrl+V)</source>
         <target xml:lang="sw">Weka baada ya kunakili(Ctrl+V) </target>
         <note>ID: EditTab.PasteButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing on the Clipboard that you can paste here.</source>
         <target xml:lang="sw">Hakuna chochote kwenye klipbodi ambacho unaweza kuweka hapa.</target>
         <note>ID: EditTab.PasteButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Position" sil:dynamic="true">
+      <trans-unit id="EditTab.Position" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Position</source>
         <target xml:lang="sw">Mahali/Nafasi</target>
         <note>ID: EditTab.Position</note>
       </trans-unit>
-      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true">
+      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot put anything in there while making an original book.</source>
         <target xml:lang="sw">Huwezi kuweka chochote pale ndani unapotengeneza kitabu cha kwanza.</target>
         <note>ID: EditTab.ReadOnlyInAuthorMode</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="sw">Badilisha mpaka na usuli</target>
         <note>ID: EditTab.StyleEditor.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="sw">Badilisha fonti</target>
         <note>ID: EditTab.StyleEditor.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="sw">Badilisha ukubwa wa fonti</target>
         <note>ID: EditTab.StyleEditor.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="sw">Badilisha nafasi kati ya mistari ya maandishi</target>
         <note>ID: EditTab.StyleEditor.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="sw">Pana kupita kiasi</target>
         <note>ID: EditTab.StyleEditor.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="sw">Kawaida</target>
         <note>ID: EditTab.StyleEditor.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="sw">Badilisha nafasi kati ya maneno</target>
         <note>ID: EditTab.StyleEditor.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="sw">Pana</target>
         <note>ID: EditTab.StyleEditor.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="sw">Ongeza au punguza muundo wa mtindo</target>
         <note>ID: EditTab.StyleEditorTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="sw">Kurasa za Vigezo</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom">
+      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom" approved="yes">
         <source xml:lang="en">Picture On Bottom</source>
         <target xml:lang="sw">Picha upande wa Chini</target>
         <note>ID: EditTab.ThumbnailCaptions.Picture On Bottom</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="sw">Habari kuhusu Taaluma ya Kifaa</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="sw">Kifaa cha kusoma kinachoweza Kufasiriwa</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom can handle only the first {0} words.</source>
         <target xml:lang="sw">Bloom inaweza tu kukubali maneno ya kwanza tu {0}. </target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed words in this stage</source>
         <target xml:lang="sw">Majina yanayokubaliwa katika awamu hii</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles" approved="yes">
         <source xml:lang="en">Text files</source>
         <target xml:lang="sw">Jalada za  maandishi</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters" approved="yes">
         <source xml:lang="en">Letters: {0}</source>
         <target xml:lang="sw">Herufi: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage" approved="yes">
         <source xml:lang="en">The following is a generated report of the decodable stages for {0}. You can make any changes you want to this file, but Bloom will not notice your changes. It is just a report.</source>
         <target xml:lang="sw">Ifuatayo ni ripoti iliyotolewa ya awamu zinazoweza kufasiriwa kwa {0}. Unaweza kufanya mabadiliko yoyote unayotaka kwa faili hii,lakini Bloom Haitatambua mabadiliko yako.Ni ripoti tu.</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords" approved="yes">
         <source xml:lang="en">New Decodable Words: {0}</source>
         <target xml:lang="sw">Majina Mapya Yanayoweza Kufasiriwa: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords" approved="yes">
         <source xml:lang="en">New Sight Words: {0}</source>
         <target xml:lang="sw">Majina mapya Yanayoonekana: {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage" approved="yes">
         <source xml:lang="en">Stage {0}</source>
         <target xml:lang="sw">hatua {0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList" approved="yes">
         <source xml:lang="en">Complete Word List</source>
         <target xml:lang="sw">Kamilisha Orodha ya Majina</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="sw">Herufi katika ukurasa huu</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="sw">Fungua jalada la Orodha ya Herufi na Maneno</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Generate a letter and word list report</source>
         <target xml:lang="sw">Anzisha ripoti ya orodha ya herufi na neno</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample words in this stage</source>
         <target xml:lang="sw">Chukua maneno kutoka kwenye awamu hii</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="sw">Panga hatua</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="sw">Hatua</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="sw">ya</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="sw">Maneno kwenye awamu hii</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="sw">Kifaa cha Kusoma kilichopewa ngazi</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="sw">Kamili</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true" approved="yes">
         <source xml:lang="en">avg per sentence</source>
         <target xml:lang="sw">Uwiano kwa kila sentensi</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Average</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="sw">Uchaguzi wa Mada</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="sw">Kwa ngazi hii</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="sw">Kubadilisha Muundo</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="sw">Usaidizi wa Maelezo</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="sw">Kumbuka</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="sw">Ngazi</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
         <note>Used to create string "Level # of #". The space after this word is added programmatically.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="sw">ya</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
         <note>Used to create string "Level # of #". The spaces on each side of this word are added programmatically.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="sw">Idadi ya juu zaidi</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="sw">kwa kila ukurasa</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="sw">sentensi ndefu zaidi</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="sw">Uwezekano wa kutabiriwa</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="sw">Anzisha ngazi</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="sw">Kitabu Hiki</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="sw">Ukurasa Huu</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="sw">jumla</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="sw">kipekee</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="sw">Msamiati</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="sw">Idadi ya Maneno</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="sw">Zaidi...</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allow changes to this shellbook</source>
         <target xml:lang="sw">Kubali mabadiliko kwenye kitabu hiki cha sheli</target>
         <note>ID: EditTab.Toolbox.Settings.Unlock</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom normally prevents most changes to shellbooks. If you need to add pages, change images, etc., tick the box below.</source>
         <target xml:lang="sw">Bloom kwa kawaida huzuia mabadiliko mengi kwenye vitabu vya sheli. Iwapo utahitaji kuongeza kurasa, kubadlisha picha na kadhalika, weka alama kwenye kisanduku kilicho hapa chini.</target>
         <note>ID: EditTab.Toolbox.Settings.UnlockShellBookIntroductionText</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState" approved="yes">
         <source xml:lang="en">Bloom recording is in an unusual state, possibly caused by unplugging a microphone. You will need to restart.</source>
         <target xml:lang="sw">Kurekodi kwa Bloom kuko katika hali isiyo ya kawaida, ambayo huenda ikawa imesababishwa na kutoa mikrofoni. Utahitajika kuianzisha upya.</target>
         <note>ID: EditTab.Toolbox.TalkingBook.BadState</note>
         <note>This is very low priority for translation.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput" approved="yes">
         <source xml:lang="en">No input device</source>
         <target xml:lang="sw">Hakuna kifaa cha ndani</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoInput</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic" approved="yes">
         <source xml:lang="en">This computer appears to have no sound recording device available. You will need one to record audio for a talking book.</source>
         <target xml:lang="sw">Kompyuta hii inaonekana kutokuwa na kifaa cha kurekodi sauti. Utahitajika kurekodi sauti ya kitabu kilicho na sauti.</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoMic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage" approved="yes">
         <source xml:lang="en">Please hold the button down until you have finished recording</source>
         <target xml:lang="sw">Tafadhali shikilia kitufe ukielekeza upande wa chini hadi umalize kurekodi</target>
         <note>ID: EditTab.Toolbox.TalkingBook.PleaseHoldMessage</note>
         <note>Appears when the speak/record button is pressed very briefly</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="sw">Nyuma</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Back</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4) Check</source>
         <target xml:lang="sw">4) Angalia</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Check</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Check that you are recording into the correct device and that these levels are showing blue:</source>
         <target xml:lang="sw">1) Angalia ili kuhakikisha kuwa unarekodi kwenye kifaa kinachofaa na kuwa ngazi hizi zinaonyesha rangi ya buluu:</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.CheckSettings</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Clear</source>
         <target xml:lang="sw">Maliza</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Clear</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Talking Book Tool</source>
         <target xml:lang="sw">Kifaa cha Kitabu kilicho na Sauti</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Listen to the whole page</source>
         <target xml:lang="sw">Sikiliza ukurasa wote</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Listen</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Look at the highlighted sentence</source>
         <target xml:lang="sw">2) Angalia sentensi iliyosisitizwa</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.LookAtSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5) Next</source>
         <target xml:lang="sw">5) Inayofuata</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Next</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3) Speak</source>
         <target xml:lang="sw">3) Zungumza</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Speak</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an e-book that can play recordings while highlighting sentences.</source>
         <target xml:lang="sw">Tengeneza kitabu cha mtandao ambacho kinaweza kucheza yaliyorekodiwa unapoweka alama ya kusisitiza kwa sentensi.</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.ToolPurpose</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="sw">sentensi ndefu zaidi</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="sw">Lugha tatu</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="sw">Batilisha</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTip">
+      <trans-unit id="EditTab.UndoButton.ToolTip" approved="yes">
         <source xml:lang="en">Undo (Ctrl+Z)</source>
         <target xml:lang="sw">Batilisha (Ctrl+Z)</target>
         <note>ID: EditTab.UndoButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing to undo</source>
         <target xml:lang="sw">Hakuna chochote cha kubatilisha</target>
         <note>ID: EditTab.UndoButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="Errors.BookProblem">
+      <trans-unit id="Errors.BookProblem" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.</source>
         <target xml:lang="sw">Bloom imekuwa na tatizo katika kuonyesha kitabu hiki. Hii haimaanishi kuwa kazi yako imepotea, lakini inamaanisha kuwa kuna kitu kimepitwa na wakati, kimepotea, au kimeharibika.</target>
         <note>ID: Errors.BookProblem</note>
       </trans-unit>
-      <trans-unit id="Errors.BrokenBook">
+      <trans-unit id="Errors.BrokenBook" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong. Consider using the 'Report a Problem' command under the 'Help' menu.</source>
         <target xml:lang="sw">Bloom imekuwa na tatizo katika kuonyesha kitabu hiki. Hii haimaanishi kuwa kazi yako imepotea, lakini inamaanisha kuwa kuna kitu kimepitwa na wakati, kimepotea, au kimeharibika. Kubali kutumia kielelezo cha 'Ripoti Tatizo' kilicho chini ya 'Usaidizi'.</target>
         <note>ID: Errors.BrokenBook</note>
       </trans-unit>
-      <trans-unit id="Errors.CannotConnectToBloomServer">
+      <trans-unit id="Errors.CannotConnectToBloomServer" approved="yes">
         <source xml:lang="en">Bloom was unable to start its own HTTP listener that it uses to talk to its embedded Firefox browser. If this happens even if you just restarted your computer, ask someone to investigate if you have an aggressive firewall product installed. The agressive firewall product may need to be uninstalled before you can use Bloom.</source>
         <target xml:lang="sw">Bloom ilishindwa kuanzisha kifaa cha HTTP cha kusikiza ambacho huwa inatumia kuwasiliana na kifaa chake kilichotiwa ndani cha mtandao wa intaneti. Iwapo hii itatendeka hata ingawa ulikuwa tu umefungua upya kompyuta yako, ambia mtu achunguze iwapo una kifaa kinachotumika kwa nguvu ambacho kimewekwa kwenye mtandao. Kifaa hiki kinachotumika kwa nguvu kilicho kwenye mtandao kinaweza kuhitajika kutolewa kabla ya wewe kuweza kutumia Bloom.</target>
         <note>ID: Errors.CannotConnectToBloomServer</note>
       </trans-unit>
-      <trans-unit id="Errors.DeniedAccess">
+      <trans-unit id="Errors.DeniedAccess" approved="yes">
         <source xml:lang="en">Your computer denied Bloom access to the book. You may need technical help in setting the operating system permissions for this file.</source>
         <target xml:lang="sw">Kompyuta yako ilikataza Blook kupata kitabu. Unaweza kuhitaji usaidizi wa kifundi ili kuandaa mfumo wa utenda kazi idhini ya kupata faili hii.</target>
         <note>ID: Errors.DeniedAccess</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorSelecting">
+      <trans-unit id="Errors.ErrorSelecting" approved="yes">
         <source xml:lang="en">There was a problem selecting the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="sw">Kulikuwa na tatizo katika kuchagua kitabu. Kufungua upya Bloom kunaweza kusuluhisha tatizo hili. Iwapo haitawezekana, tafadhali kliki kifute cha 'Maelezo' na uripoti tatizo kwa Wataalamu husika wa Bloom.</target>
         <note>ID: Errors.ErrorSelecting</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorUpdating">
+      <trans-unit id="Errors.ErrorUpdating" approved="yes">
         <source xml:lang="en">There was a problem updating the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="sw">Kulikuwa na tatizo katika kutengeneza upya kitabu. Kufungua upya Bloom kunaweza kusuluhisha tatizo hili. Iwapo haitawezekana, tafadhali kliki kifute cha 'Maelezo' na uripoti tatizo kwa Wataalamu husika wa Bloom.</target>
         <note>ID: Errors.ErrorUpdating</note>
       </trans-unit>
-      <trans-unit id="Errors.NeedNewerVersion">
+      <trans-unit id="Errors.NeedNewerVersion" approved="yes">
         <source xml:lang="en">{0} requires a newer version of Bloom. Download the latest version of Bloom from {1}.</source>
         <target xml:lang="sw">{0} huhitaji tafsiri mpya zaidi ya Bloom. Toa tafsiti mpya ya Bloom kutoka kwa {1}.</target>
         <note>ID: Errors.NeedNewerVersion</note>
         <note>{0} will get the name of the book, {1} will give a link to open the Bloom Library Web page.</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemDeletingFile">
+      <trans-unit id="Errors.ProblemDeletingFile" approved="yes">
         <source xml:lang="en">Bloom had a problem deleting this file: {0}</source>
         <target xml:lang="sw">Bloom inapata tatizo katika kufuta picha hii: {0}</target>
         <note>ID: Errors.ProblemDeletingFile</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemImportingPicture">
+      <trans-unit id="Errors.ProblemImportingPicture" approved="yes">
         <source xml:lang="en">Bloom had a problem importing this picture.</source>
         <target xml:lang="sw">Bloom ilipata tatizo katika kuipokea picha hii</target>
         <note>ID: Errors.ProblemImportingPicture</note>
       </trans-unit>
-      <trans-unit id="Errors.ReportThisProblemButton">
+      <trans-unit id="Errors.ReportThisProblemButton" approved="yes">
         <source xml:lang="en">Report this problem to Bloom Support</source>
         <target xml:lang="sw">Ripoti tatizo hili kwa Usaidizi wa </target>
         <note>ID: Errors.ReportThisProblemButton</note>
       </trans-unit>
-      <trans-unit id="Errors.SomethingWentWrong">
+      <trans-unit id="Errors.SomethingWentWrong" approved="yes">
         <source xml:lang="en">Sorry, something went wrong.</source>
         <target xml:lang="sw">Samahani, kuna jambo limeharibika.</target>
         <note>ID: Errors.SomethingWentWrong</note>
       </trans-unit>
-      <trans-unit id="Errors.XMatterNotFound">
+      <trans-unit id="Errors.XMatterNotFound" approved="yes">
         <source xml:lang="en">This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a Bloom Pack that will give you '{0}', or go to Settings:Book Making and change to another Front/Back Matter Pack.</source>
         <target xml:lang="sw">Kitabu hiki kilihitaji seti ya machapisho ya Mbele/Nyuma iitwayo '{0}', lakini Bloom haikuipata kwenye kompyuta hii. Unaweza kuweka Seti ya Bloom itakayokupa '{0}', au uende kwa Mpangilio:Kutengeneza Kitabu na ubadilishe kuwa seti tofauti ya machapisho ya Mbele/Nyuma.</target>
         <note>ID: Errors.XMatterNotFound</note>
       </trans-unit>
-      <trans-unit id="Errors.ZoneAlarm">
+      <trans-unit id="Errors.ZoneAlarm" approved="yes">
         <source xml:lang="en">Bloom cannot start properly, and this symptom has been observed on machines with ZoneAlarm installed. Note: disabling ZoneAlarm does not help. Nor does restarting with it turned off. Something about the installation of ZoneAlarm causes the problem, and so far only uninstalling ZoneAlarm has been shown to fix the problem.</source>
         <target xml:lang="sw">Bloom haiwezi kujifungua inavyofaa, na dalili hii imeonekana kwenye mashine zilizowekwa King'ora cha Eneo. Kumbuka: kuzima King'ora cha Eneo hakusaidii. Wala kufungua upya huku kikiwa kimezimwa. Kitu fulani kuhusu uwekaji wa King'ora cha Eneo husababisha tatizo, na hivyo kukitoa king'ora cha eneo tu kumeonyesha kusuluhisha tatizo.</target>
         <note>ID: Errors.ZoneAlarm</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="sw">Kutengeneza Vigezo vya Kusoma</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="sw">Tafuta Tafsri Mpya</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="sw">Kuhusu Blooom</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <target xml:lang="sw">Hifadhi ya hati</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="sw">Usaidizi</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true">
+      <trans-unit id="HelpMenu.Help Menu_ToolTip_" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Get Help</source>
         <target xml:lang="sw">Pata Usaidizi</target>
         <note>ID: HelpMenu.Help Menu_ToolTip_</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem">
+      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem" approved="yes">
         <source xml:lang="en">Key Bloom Concepts</source>
         <target xml:lang="sw">Dhana Kuu za Bloom</target>
         <note>ID: HelpMenu.KeyBloomConceptsToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="sw">Toa Pendekezo</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="sw">Usajili</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="sw">Achilia muhtasari...</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem">
+      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem" approved="yes">
         <source xml:lang="en">Report a Problem...</source>
         <target xml:lang="sw">Ripoti Tatizo...</target>
         <note>ID: HelpMenu.ReportAProblemToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="sw">Onyesha sehemu ya tukio</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="sw">Kutumia Vigezo vya Msomaji</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="sw">Mfumo wa Kimtandao</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.trainingVideos">
+      <trans-unit id="HelpMenu.trainingVideos" approved="yes">
         <source xml:lang="en">Training Videos</source>
         <target xml:lang="sw">Video za Kufundisha</target>
         <note>ID: HelpMenu.trainingVideos</note>
       </trans-unit>
-      <trans-unit id="InstallProblem.BloomPdfMaker">
+      <trans-unit id="InstallProblem.BloomPdfMaker" approved="yes">
         <source xml:lang="en">A component of Bloom, BloomPdfMaker.exe, seems to be missing. This prevents previews and printing. Antivirus software sometimes does this. You may need technical help to repair the Bloom installation and protect this file from being deleted again.</source>
         <target xml:lang="sw">Sehemu ya Bloom, BloomPdfMaker.exe, inaonekana kupotea. Hii inazuia kuonekana kwa onyesho la awali na uchapishaji. programu ya antivairasi wakati mwingine hufanya hivi. Unaweza kuhitaji usadizi wa kifundi ili kukarabati uwekaji wa Bloom na kuzuia faili hii kufutika tena.</target>
         <note>ID: InstallProblem.BloomPdfMaker</note>
       </trans-unit>
-      <trans-unit id="LameEncoder.Progress">
+      <trans-unit id="LameEncoder.Progress" approved="yes">
         <source xml:lang="en">Converting to mp3</source>
         <target xml:lang="sw">Kubadilisha kuwa mp3</target>
         <note>ID: LameEncoder.Progress</note>
         <note>Appears in progress indicator</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.RightToLeftCheck">
+      <trans-unit id="LanguageFontDetails.RightToLeftCheck" approved="yes">
         <source xml:lang="en">This script is right to left</source>
         <target xml:lang="sw">Hati hii imeandikwa kutoka kulia kwenda kushoto</target>
         <note>ID: LanguageFontDetails.RightToLeftCheck</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.TallerLinesCheck">
+      <trans-unit id="LanguageFontDetails.TallerLinesCheck" approved="yes">
         <source xml:lang="en">This script requires taller lines</source>
         <target xml:lang="sw">Hati hii inahitaji mistari mirefu zaidi</target>
         <note>ID: LanguageFontDetails.TallerLinesCheck</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="sw">Aina ya muundo wa A4</target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="sw">Muundo wa A4 wa Kila upande</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="sw">Muundo wa A4 Hugawanya Katikati ya Kurasa</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="sw">Picha ya A4</target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="sw">Muundo wa A5</target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="sw">Picha ya A5</target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="sw">Mpangilio wa chini wa picha ya A5</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Landscape</source>
         <target xml:lang="sw">Muundo wa A6</target>
         <note>ID: LayoutChoices.A6Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Portrait</source>
         <target xml:lang="sw">Picha ya A6</target>
         <note>ID: LayoutChoices.A6Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="sw">Picha ya B5</target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">HalfLetterPortrait</source>
         <target xml:lang="sw">PIcha ya Nusu Herufi</target>
         <note>ID: LayoutChoices.HalfLetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterLandscape</source>
         <target xml:lang="sw">Muundo wa Herufi</target>
         <note>ID: LayoutChoices.LetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterPortrait</source>
         <target xml:lang="sw">Picha ya Herufi</target>
         <note>ID: LayoutChoices.LetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">QuarterLetterLandscape</source>
         <target xml:lang="sw">Muundo wa Nusu Herufi</target>
         <note>ID: LayoutChoices.QuarterLetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog.WindowTitle">
+      <trans-unit id="LicenseDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom {0}</source>
         <target xml:lang="sw">Bloom {0}</target>
         <note>ID: LicenseDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog._acceptButton">
+      <trans-unit id="LicenseDialog._acceptButton" approved="yes">
         <source xml:lang="en">I accept the terms of the license agreement</source>
         <target xml:lang="sw">Ninakubali makubaliano ya masharti ya leseni</target>
         <note>ID: LicenseDialog._acceptButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="sw">Ninakubaliana na Masharti ya matumizi ya Maktaba ya Bloom</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="sw">Anwani ya Barua pepe</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="sw">Umesahau neno la siri</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="sw">Ingia kwenye akaunti</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="sw">neno la siri</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="sw">onyesha neno la siri</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="sw">Onyesha Masharti ya Matumizi</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="sw">Ingia kwenye BloomLibrary.org</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="sw">Tayari kuna mkusanyiko ulio na jina kama hilo, kwenye &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nTafadhali chagua jina la kipekee.</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="sw">Chagua lugha kuu ya Mkusanyiko huu</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="sw">Kwa mfano: "Vitabu vya Afya", "PNG Hadithi za Wanyama"</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="sw">Je, ungependa kuupa mkusanyiko huu jina lipi?</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="sw">Tatizo la Jina la Mkusanyiko</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="sw">Mkusanyiko utaanzishwa kwenye: {0}</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="sw">Tayari kutengeneza Mkusanyiko Mpya</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FontAndScriptPage">
+      <trans-unit id="NewCollectionWizard.FontAndScriptPage" approved="yes">
         <source xml:lang="en">Font and Script</source>
         <target xml:lang="sw">Fonti na Hati</target>
         <note>ID: NewCollectionWizard.FontAndScriptPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="sw">Chagua Aina ya Mkusanyiko</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions" approved="yes">
         <source xml:lang="en">If you already have a collection you want to open, click  the 'Cancel' button.</source>
         <target xml:lang="sw">Iwapo tayari una mkusanyiko ambao ungependa kufungua, kliki kwenye kifute cha 'Batilisha'.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="sw">Mkusanyiko wa chanzo</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org. You may also make a Bloom Pack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="sw">Mkusanyiko wa sheli au vitabu vya vigezo katika lugha moja au zaidi za mawasiliano mapana. Utaweza kuziweka sheli hizi kwenye BloomLibrary.org. Pia unaweza kutengeneza Seti ya Bloom kuwapa wengine ili waweze kutengeneza vitabu kwa lugha ya mama kutoka kwa sheli zako.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="sw">Mkusanyikko wa Lugha ya mama/Lugha ya eneo</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="sw">Mkusanyiko wa vitabu katika lugha ya eneo.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="sw">Peana Eneo la Lugha</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="sw">Nchi</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="sw">Wilaya</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="sw">Hizi sio za lazimaBloom itaziweka mahali panapofaa kwenye ukurasa wa mada ya vitabu utakavyotengeneza.</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="sw">Mkoa</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="sw">{0} Vitabu</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="sw">Tengeneza Mkusanyiko Mpya wa Bloom</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="sw">Jina la Mradi</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="sw">Imeshindwa kutengeneza jina la mkusanyiko.</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="sw">Karibu kwenye Bloom!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="sw">Uko tayari kuanza kutengeneza vitabu.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. The first thing we need to do is make one for you.</source>
         <target xml:lang="sw">Ili kufanya mambo kuwa rahisi na kuwa yenye mpangilio, Bloom huweka vitabu vyote unavyotengeneza kwenye &lt;i&gt;Mkusanyiko&lt;/i&gt;mmoja au zaidi. Jambo la kwanza tunalopaswa kufanya ni kukutengenezea moja.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="sw">Kliki 'Yanayofuata' ili kuanza.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InDropboxMessage">
+      <trans-unit id="OpenCreateCloneControl.InDropboxMessage" approved="yes">
         <source xml:lang="en">Bloom detected that this collection is located in your Dropbox folder. This can cause problems as Dropbox sometimes locks Bloom out of its own files. If you have problems, we recommend that you move your collection somewhere else or disable Dropbox while using Bloom.</source>
         <target xml:lang="sw">Bloom iligundua kuwa mkusanyiko huu uko kwenye folda yako ya dropbox. Hii inaweza kusababisha matatizo kwa kuwa wakati mwingine dropboksi wakati mwingine hufungia Bloom kutoka kwa faili zake. Iwapo una matatizo, tunapendekeza kuwa usongeshe mkusanyiko wako mahali pengine au uizime dropboksi yako utakapokuwa ukitumia Bloom.</target>
         <note>ID: OpenCreateCloneControl.InDropboxMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage">
+      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage" approved="yes">
         <source xml:lang="en">This collection is part of your 'Sources for new books' which you can see in the bottom left of the Collections tab. It cannot be opened for editing.</source>
         <target xml:lang="sw">Mkusanyiko huu ni sehemu ya 'Vyanzo vya vitabu vipya' ambavyo unaweza kuviona chini upande wa kushoto wa Nembo ya Mkusanyiko. Haiwezi kufunguliwa ili kuhakikiwa.</target>
         <note>ID: OpenCreateCloneControl.InSourceCollectionMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="sw">Mikusanyiko wa Bloom</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="sw">Tafuta kwa kutumia mtandao mkusanyiko mwingine ulio kwenye kompyuta hii</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="sw">Nakili kutoka kwa Chorus Hub kwenye Mfumo wa mtandao wa Eneo</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="sw">Nakili kutoka kwa Intaneti</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="sw">Nakili kutoka kwa Kiendesha mtambo cha USB</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="sw">Tengeneza Mkusanyiko Mpya</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="sw">Fungua/Tengeneza Mikusanyiko</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="sw">Soma Zaidi</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="sw">Je, kuna yeyote ambaye ametumia Tuma/Pokea kutumia mkusanyiko na wewe?\nTumia mojawapo wa vifute hivi vya rangi nyekundu ili kunakili mkusanyiko wake kwenye kompyuta yako.\nBaadaye, tumia Tuma/Pokea ili kuwatumia tena kazi yako.</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PageList.CantMoveWhenTranslating">
+      <trans-unit id="PageList.CantMoveWhenTranslating" approved="yes">
         <source xml:lang="en">Pages can not be re-ordered when you are translating a book.</source>
         <target xml:lang="sw">Kurasa haziwezi kupangwa upya unapotafsiri kitabu.</target>
         <note>ID: PageList.CantMoveWhenTranslating</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="sw">Tafadhali weka Kifaa cha kusoma cha Adobe ili Bloom iweze kuonyesha kitabu chako kilichokamilika. Hadi hapo, bado unaweza kuhifadhi PDF Kitabu na ukifungue kwenye programu nyingine.</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="sw">Hilo sio jambo la kawaida... Kifaa cha kusoma cha Adobe kilionyesha kuwepo kwa hitilafu katika harakati ya kujaribu kuonyesha hiyo PDF. Bado unaweza kujaribu kuhifadhi PDF Kitabu.</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="sw">Ripoti Mbaya. Bloom haikuweza kupata Kifaa cha Adobe cha Kusoma ili kuonyesha hapa, hivyo Bloom haiwezi kukuonyesha kitabu chako kilichokamilika.\nTafadhali toa tafsiri ilioko ya 'Kifaa cha kusoma cha Adobe' na uweke upya 'Kifaa cha kusoma cha Adobe'.\nHadi utakapoweza kufanya hivyo, bado uaweza kuhifadhi PDF Kitabu na kukifungua kwenye programu nyingine.</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="sw">Pande za ndani za Vijitabu</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book. Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="sw">Tengeneza kijitabu kutokana na kurasa za ndani za kitabuKurasa zitatolewa na kupangwa upya ili utakapokikunja, utakuwa na kijitabua.\n</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="sw">Weka</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="sw">Weka kwa BloomLibrary.org, pale ambapo watu wengine wanaweza kukitoa na kukitafsiri kwa lugha zao wenyewe.</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="sw">Ngozi ya Kijitabu</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="sw">Tengeneza PDF ya mbele tu na nyuma (pande zote), ili uweze kuchapisha kwenye karatasi ya rangi.</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubButton">
+      <trans-unit id="PublishTab.EpubButton" approved="yes">
         <source xml:lang="en">ePUB</source>
         <target xml:lang="sw">ePUB</target>
         <note>ID: PublishTab.EpubButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an ePUB (electronic book) out of this book, allowing it to be read on various electronic reading devices.</source>
         <target xml:lang="sw">Tengeneza ePUB (kitabu cha kielektroniki) kutokana na kitabu hiki, ukikiruhusu kuweza kusomwa kwenye vifaa tofauti vya kusoma vya kielektroniki.</target>
         <note>ID: PublishTab.EpubRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="sw">Usionyeshe Hii Tena</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="sw">Habari kuhusu Muundo wa Ndani wa XML</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation">
+      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation" approved="yes">
         <source xml:lang="en">This PDF viewer can be improved by installing the free Adobe Reader on this computer.</source>
         <target xml:lang="sw">PDF kifaa cha kutazama kinaweza kuboreshwa kwa kuweka kifaa cha kusoma cha Adobe cha bure kwenye kompyuta hii.</target>
         <note>ID: PublishTab.Notifications.AdobeReaderRecommendation</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="sw">Rahisi</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="sw">Tengeneza PDF ya kila ukurasa wa kitabu, ukurasa mmoja kwa kila kipande cha karatasi.</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system PDF viewer</source>
         <target xml:lang="sw">Fungua PDF kifaa cha kutazama kwenye mfumo wa kawaida PDF </target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="sw">Kuchukua nafasi ya yaliyokuwemo</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="sw">Tangazo</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.BadPdf">
+      <trans-unit id="PublishTab.PdfMaker.BadPdf" approved="yes">
         <source xml:lang="en">Bloom had a problem making a PDF of this book. You may need technical help or to contact the developers. But here are some things you can try:</source>
         <target xml:lang="sw">Bloom ilikuwa na tatizo katika kutengeneza PDF kitabu hiki. Unaweza kuhitaji usaidizi wa kifundi au uwasiliane na wataalamu husika wa Bloom. Lakini hapa ni baadhi ya mambo unayoweza kujaribu:</target>
         <note>ID: PublishTab.PdfMaker.BadPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory">
+      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory" approved="yes">
         <source xml:lang="en">Try doing this on a computer with more memory</source>
         <target xml:lang="sw">Jaribu kufanya hivi kwa kompyuta iliyo na nafasi zaidi</target>
         <note>ID: PublishTab.PdfMaker.TryMoreMemory</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryRestart">
+      <trans-unit id="PublishTab.PdfMaker.TryRestart" approved="yes">
         <source xml:lang="en">Restart your computer and try this again right away</source>
         <target xml:lang="sw">Fungua upya kompyuta yako na na ujaribuu hii tena mara moja</target>
         <note>ID: PublishTab.PdfMaker.TryRestart</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages">
+      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages" approved="yes">
         <source xml:lang="en">Replace large, high-resolution images in your document with lower-resolution ones</source>
         <target xml:lang="sw">Weka picha zilizo na uthabiti wa chini kwenye nafasi ya zile zilizo na udhabiti wa juu kwenye chapisho lako</target>
         <note>ID: PublishTab.PdfMaker.TrySmallerImages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="sw">U&amp;chapishe...</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="sw">Chapisha</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="sw">&amp;Uhifadhi ...</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveEpub">
+      <trans-unit id="PublishTab.SaveEpub" approved="yes">
         <source xml:lang="en">&amp;Save ePUB...</source>
         <target xml:lang="sw">U&amp;hifadhi ePUB...</target>
         <note>ID: PublishTab.SaveEpub</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="sw">Alama </target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="sw">Kukiri</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">Additional Requests: </source>
         <target xml:lang="sw">Maombi zaidi: </target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="sw">Haki zote zimehifadhiwa (Wasiliana na anayemiliki haki ili kupata Idhini yoyote.)</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="sw">CC-BY-NC</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you. If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="sw">BloomLibrary.org Tayari ina tafsiri nyingine ya kitabu hiki kutoka kwako.Iwapo utakiweka tena, tafsiri hiyo nafasi yake itachukuliwa na tafsiri yako ya sasa.</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="sw">Haki Miliki</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="sw">sifa</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="sw">Samahani, kulikuwa na tatizo katika kuweka {0}. Baadhi ya maelezo yanafuata. Unaweza kuhitaji usaidizi wa kiufundi.</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading.</source>
         <target xml:lang="sw">Nyanja moja au zaidi ya zilizoko hapo juu zinahitaji uangalifu wako kabla ya kuweka.</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded. Sometimes this is caused by temporary problems with the servers we use. It's worth trying again in an hour or two. If you regularly get this problem please report it to us.</source>
         <target xml:lang="sw">Samahani, "" haikufaulu kuwekwa. Wakati mwingine hii husababishwa na matatizo yasiyo ya kudumu yanayotokana na vifaa tunavyotumia. Ni muhimu kujaribu tena kwa muda wa saa moja au mbili. Iwapo utapata tatizo hili mara kwa mara tafadhali piga ripoti kwetu.</target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes.</source>
         <target xml:lang="sw">Kwa kuweka, unadhibitisha makubaliano yako na Masharti ya matumizi ya Maktaba ya Bloom na unaipa haki inayostahili.</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="sw">Kulikuwa na tatizo katika kuweka kitabu chako.</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="sw">Lugha</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="sw">Matumizi/Leseni</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="sw">Akaunti Tayari Ipo</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address. Would you like to log in instead?</source>
         <target xml:lang="sw">Hatuwezi tukakufungulia akaunti kwa kutumia anwani hiyo, kwa kuwa tayari tuna akaunti inayotumia anwani hiyo. Je, badala yake ungependa kuingia kwenye akaunti yako?</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="sw">Bloom haikuweza kuungana na mtandao ili kuthibitisha kuingia kwako. Tafadhali angalia intaneti yako.</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="sw">Huwezi kuingia</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="sw">Bloom haijaweza kuunganishwa na mtandao ili kukamilisha kuingia kwako akaunti yako au kufungua akaunti mpya. Hii inaweza kuwa tatizo kutokana na uunganishaji wa intaneti, mtandao wetu, au baadhi ya vifaa hapo katikati.</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="sw">Ili kufungua akaunti ya BloomLibrary.org, unapaswa kuweka alama kwenye kisanduku ukiashiria kuwa unakubaliana na Sheria za Matumizi ya Maktaba ya Bloom.</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="sw">Barua pepe inahitajika</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="sw">Hatuna kwenye rekodi zetu yeyote anayetumia barua pepe hiyo. Je, ungependa kufungua akaunti?</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="sw">Neno la siri na jina lako la utambulizo havikuambatana</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="sw">Tafadhali kubaliana na Masharti ya Matumizi</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="sw">Tafadhali weka anwani za barua pepe inayotumika. Tutatuma barua pepe kwa anwani hii ili uweze kubadilisha neno lako la siri.</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="sw">Bloom haijaweza kuunganishwa na mtandao ili kubadilisha neno lako la siri. Tafadhali angalia intaneti yako.</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="sw">Ubadilishaji wa neno la siri umefeli</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="sw">Kubadilisha neno la siri</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password.</source>
         <target xml:lang="sw">Tunatuma barua pepe kwa {0} ikiwa na maagizo ya jinsi ya kubadilisha neno lako la siri.</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="sw">Fungua akaunti yako kwa Maktaba ya Bloom.</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="sw">Mtumiaji asiyejulikana</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="sw">Bloom haijaweza kuingia kwa BloomLibrary.org kwa kutumia hati za utambulisho zilizohifadhiwa. Tafadhali angalia intaneti yako.</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="sw">Ingia kwenye BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="sw">Toka kwenye BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="sw">Kutengeneza PDF Onyesho la awali...</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="sw">Kutengeneza picha ya ukucha wa dole gumbai...</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.NoLangsFound">
+      <trans-unit id="PublishTab.Upload.NoLangsFound" approved="yes">
         <source xml:lang="en">(None found)</source>
         <target xml:lang="sw">(Haipatikani)</target>
         <note>ID: PublishTab.Upload.NoLangsFound</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="sw">Samahani, tafsiri hii ya kompyuta ya Bloom haiambatani na tafsiri iliyopo yao BloomLibrary.org. Tafadhali ifanye kuwa ya tafsiri ya hivi karibuni.</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.IncompleteTranslation">
+      <trans-unit id="PublishTab.Upload.IncompleteTranslation" approved="yes">
         <source xml:lang="en">(incomplete translation)</source>
         <target xml:lang="sw">(nusu)</target>
         <note>ID: PublishTab.Upload.IncompleteTranslation</note>
         <note>This is added after the language name, in order to indicate that some parts of the book have not been translated into this language yet.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="sw">Tafadhali ingia kwenye BloomLibrary.org (au ufungue akaunti) kabla ya kuweka</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="sw">Tafadhali andaa hii kutoka kwa chaguo la kuhariri</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="sw">Fungua akaunti ya BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="sw">Hatua ya 1: Thibitisha Metadata</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="sw">Hatua ya 2: Weka</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="sw">Pendekezo: Kupeana leseni bunifu ya Kawaida huifanya rahisi kwako kupeana idhini fulani kwa kila mtu.</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="sw">Pendekezo: Leseni Bunifu za Kawaida, hufanya kuwa rahisi zaidi kwa wengine kutumia kitabu chako, hata kama hawana ufasaha katika lugha yako ya leseni ya kawaida.</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="sw">Muhtasari</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="sw">Onyesha Masharti ya Matumizi</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TimeProblem">
+      <trans-unit id="PublishTab.Upload.TimeProblem" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. This is probably because your computer is set to use the wrong timezone or your system time is badly wrong. See http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html for how to fix this.</source>
         <target xml:lang="sw">Kulikuwa na tatizo katika kuweka kitabu chako. Hii huenda ikawa ni kwa sababu kompyuta yako imeundwa ili kutumia wakati usio sahihi wa eneo au saa yako ya mfumo ni mbaya sana. Tazama http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html jinsi ya kurekebisha hii.</target>
         <note>ID: PublishTab.Upload.TimeProblem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="sw">Mada</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="sw">Weka Kitabu</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <target xml:lang="sw">Hongera, "{0}" sasa kinapatikana kwenye BloomLibrary.org ({1})</target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="sw">Haikubaliwi Kuweka Kitabu</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="sw">Kulikuwa na tatizo katika kuweka kitabu chako. Unaweza kuhitajika kufungua upya Bloom au kupata usaidizii wa kiufudi.</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="sw">Hali ya kuendelea kuweka</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="sw">Weka kitabu (kwenye Sandbox)</target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="sw">Kuweka metadata ya kitabu</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, and topic tags to the BloomLibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="sw">Kuweka {0}</target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishView._saveButton">
+      <trans-unit id="PublishView._saveButton" approved="yes">
         <source xml:lang="en">Save stub</source>
         <target xml:lang="sw">Chaguo la kuhifadhi</target>
         <note>ID: PublishView._saveButton</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="sw">Ongeza Ngazi</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="sw">Ongeza Awamu</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <target xml:lang="sw">Tafadhali ongeza maandishi kwa folda ya Sampuli ya Maandishi.</target>
         <note>ID: ReaderSetup.AddTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">allowed words</source>
         <target xml:lang="sw">maneno yanayokubaliwa</target>
         <note>ID: ReaderSetup.AllowedWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <target xml:lang="sw">Faili za maneno zinazokubaliwa</target>
         <note>ID: ReaderSetup.AllowedWordsFile</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <target xml:lang="sw">Faili za maneno zinazokubaliwa</target>
         <note>ID: ReaderSetup.AllowedWordsFileHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Avg</source>
         <target xml:lang="sw">Avg</target>
         <note>ID: ReaderSetup.AverageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="sw">Kitabu</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="sw">Idadi ya juu zaidi ya maneno kwa kila kitabu</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose...</source>
         <target xml:lang="sw">Chagua...</target>
         <note>ID: ReaderSetup.ChooseAllowedWordsFile</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="sw">Kliki kwenye herufi ili kuziongeza kwa awamu hii.</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="sw">Tenganisha kwa kutumia uwazi</target>
         <note>ID: ReaderSetup.CombinationHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <target xml:lang="sw">Kwa mfano "ai oo sh ng th"</target>
         <note>ID: ReaderSetup.CombinationHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <target xml:lang="sw">Kuunganisha herufi (Grafimu)</target>
         <note>ID: ReaderSetup.Combinations</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="sw">Awamu zinazoweza Kufasiriwa</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true" approved="yes">
         <source xml:lang="en">File needs .TXT extension</source>
         <target xml:lang="sw">Faili zinahitaji kupanuliwa kwa .TXT </target>
         <note>ID: ReaderSetup.FileNeedsTxtExtension</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="sw">Kwanza,</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="sw">Muundo huu hauwezi kusomeka</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="sw">Saidia katika kutuma na kubadilisha faili ili kutumika kama sampuli ya maandishi</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="sw">Lugha</target>
         <note>ID: ReaderSetup.Language</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <target xml:lang="sw">Orodhesha herufi na herufi zinazounda maneno katika mpangilio wa alfabeti.</target>
         <note>ID: ReaderSetup.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="sw">Tenganisha kwa kutumia nafasi</target>
         <note>ID: ReaderSetup.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <target xml:lang="sw">Kwa mfano "a b ch d"</target>
         <note>ID: ReaderSetup.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="sw">Herufi</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="sw">Herufi na uunganishaji wa herufi</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="sw">Ili kukusaidia kutengeneza kifaa cha kusoma kinachoweza kufasiriwa, Bloom inahitaji kujua herufi na uunganishaji wa herufi utakaokuwa ukifundisha.</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="sw">Tenganisha kila herufi au uunganishaji wa herufi kwa nafasi. Kwa mfano, hapa ni kile tunachoweza kutumia kwa lugha ya Kiingereza:</target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="sw">Tambua kuwa orodha ya kiingereza inajumuisha alama zinazotumiwa kutengeneza maneno, kama ' katika </target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="sw">it's</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="sw">.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="sw">Hatua</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="sw">Hatua</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="sw">Ngazi za msomaji</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="sw">majina yanayoambatana</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Average Length of Sentences in Book</source>
         <target xml:lang="sw">Urefu wa wastani wa juu zaidi wa sentensi katika kitabu</target>
         <note>ID: ReaderSetup.MaxAverageWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="sw">Idadi ya juu zaidi ya maneno ya kipekee kwenye kitabu</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <target xml:lang="sw">Maneno zaidi</target>
         <note>ID: ReaderSetup.MoreWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <target xml:lang="sw">Fungua folda ile ile ya maandishi kwa lugha hii.</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="sw">Ukurasa</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="sw">Idadi ya juu zaidi ya maneno kwa kila ukurasa</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="sw">Imewezeshwa na </target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="sw">Ngazi za msomaji</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="sw">Toa ngazi </target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="sw">Toa Awamu {0}</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove from this stage</source>
         <target xml:lang="sw">Toa kutoka kwa ukurasa huu</target>
         <note>ID: ReaderSetup.RemoveWordList</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="sw">Vuta mstari ili kupanga ngazi.</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="sw">Vuta mistari ili kupanga awamu.</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <target xml:lang="sw">Orodha ya Maneno na Sampuli ya Matini</target>
         <note>ID: ReaderSetup.SampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Words</source>
         <target xml:lang="sw">Sampuli ya Maneno</target>
         <note>ID: ReaderSetup.SampleWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="sw">, Injini ya Kutafuta ya Kusoma na Kuandika.</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="sw">Herufi za hapo awali na zile mpya</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="sw">Sentensi</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="sw">Idadi ya juu zaidi ya maneno kwa kila Sentensi.</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="sw">Andaa kifaa cha Kusoma kinachoweza Kufasiriwa</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="sw">Andaa kifaa cha kusoma kilichopewa ngazi</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up the alphabet for this language.</source>
         <target xml:lang="sw">Andaa alfabeti ya lugha hii.</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <target xml:lang="sw">Je, majina yanayoonekana ni nini?</target>
         <note>ID: ReaderSetup.SightWordHelp</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="sw">Majina mapya ya yanayoonekana</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="sw">Majina yanayoonekana</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="sw">hatua</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="sw">Hatua</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="sw">Hatua</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="sw">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="sw">Mambo ya kukumbukwa kuhusu ngazi hii:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="sw">Kipekee</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="sw">Maneno</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage. There are two ways to give words to Bloom:</source>
         <target xml:lang="sw">Ili kukusaidia kutengeneza vifaa vya kusoma vinavyoweza kufasiriwa, Bloom inaweza kupendekeza maneno ambayo yanaweza kutoshea kati ya awamu iliopo. Kuna njia mbili za kupeana majina kwa Bloom.</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="sw">2) Weka Faili za Maandishi kwa</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <target xml:lang="sw">Folda ya Sampuli yako ya Matini</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="sw">1) Piga Chapa Maneno yako Hapa</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using lists of allowed words to define stages</source>
         <target xml:lang="sw">Tunatumia orodha ya maneno yaliyokubaliwa ili kutoa maelezo kuhusu awamu</target>
         <note>ID: ReaderSetup.Words.UseAllowedWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using letters with sight words to define stages</source>
         <target xml:lang="sw">Tunatumia herufi zilizo na maneno yanayoonekana kutoa maelezo kuhusu awamu</target>
         <note>ID: ReaderSetup.Words.UseLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="sw">Herufi</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this Bloom Pack will carry your latest decodable and leveled reader settings for the \"{0}\" language. Anyone opening this Bloom Pack, who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this Bloom Pack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="sw">Kwa kuongeza, seti hii ya Bloom itabeba mpangilio wa kifaa cha kusoma kilichopewa ngazi na kinachoweza kufasiriwa cha hivi karibuni cha lugha ya \"{0}\". Yeyote anayefungua seti hii ya Bloom, ambaye basi anafungua mkusanyiko wa \"{0}\" , atahitajika kubadilisha mpangilio wa kifaa chake cha kusoma kilichopewa ngazi na kutumia mpangilio ulio kwenye seti hii ya Bloom. Pia atapata kikundi cha majina ya kisasa ili kuyatumia kwenye vifaa vya kusoma vinavyoweza kufasiriwa.</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="sw">Vitabu vifuatavyo vitafanywa kuwa vigezo:</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <target xml:lang="sw">Hifadhi seti ya Blooma</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <target xml:lang="sw">Tengeneza Seti ya Bloom ya Kifaa cha kusoma</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="sw">Barua pepe</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="sw">Jina la Kwanza</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="sw">Tafadhali chukua dakika moja kujisaji {0}</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="sw">Je, unaitumia vipi {0}?</target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="sw">Nimekwama, nitamaliza hii baadaye</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="sw">Mpangilio</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="sw">U&amp;jisajili</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="sw">Jina la Familia</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="sw">Jisajili {0}</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <target xml:lang="sw">Funga</target>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.CouldNotSendToServer">
+      <trans-unit id="ReportProblemDialog.CouldNotSendToServer" approved="yes">
         <source xml:lang="en">Bloom was not able to submit your report directly to our server. Please retry or email {0} to {1}.</source>
         <target xml:lang="sw">Bloom haikuweza kupeana ripoti yako moja kwa moja hadi kwa mtandao wetu.Tafadhali jaribu tena au uandike barua pepe {0} kwa {1}.</target>
         <note>ID: ReportProblemDialog.CouldNotSendToServer</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Email">
+      <trans-unit id="ReportProblemDialog.Email" approved="yes">
         <source xml:lang="en">Email</source>
         <target xml:lang="sw">Barua pepe</target>
         <note>ID: ReportProblemDialog.Email</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeBookButton">
+      <trans-unit id="ReportProblemDialog.IncludeBookButton" approved="yes">
         <source xml:lang="en">Include Book '{0}'</source>
         <target xml:lang="sw">Jumuisha Kitabu '{0}'</target>
         <note>ID: ReportProblemDialog.IncludeBookButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton">
+      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton" approved="yes">
         <source xml:lang="en">Include this screenshot</source>
         <target xml:lang="sw">Jumuisha picha hii ya kutoka kwa skrini</target>
         <note>ID: ReportProblemDialog.IncludeScreenshotButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Name">
+      <trans-unit id="ReportProblemDialog.Name" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="sw">Jina</target>
         <note>ID: ReportProblemDialog.Name</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Retry">
+      <trans-unit id="ReportProblemDialog.Retry" approved="yes">
         <source xml:lang="en">Retry</source>
         <target xml:lang="sw">Jaribu tena</target>
         <note>ID: ReportProblemDialog.Retry</note>
         <note>Shown if there was an error submitting the report. Lets the user try submitting it again.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SeeDetails">
+      <trans-unit id="ReportProblemDialog.SeeDetails" approved="yes">
         <source xml:lang="en">See what else will be submitted</source>
         <target xml:lang="sw">Tazama ni nini kingine kinapaswa kupeanwa</target>
         <note>ID: ReportProblemDialog.SeeDetails</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SubmitButton">
+      <trans-unit id="ReportProblemDialog.SubmitButton" approved="yes">
         <source xml:lang="en">&amp;Submit</source>
         <target xml:lang="sw">U&amp;peane</target>
         <note>ID: ReportProblemDialog.SubmitButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Submitting">
+      <trans-unit id="ReportProblemDialog.Submitting" approved="yes">
         <source xml:lang="en">Submitting to server...</source>
         <target xml:lang="sw">Inapeana kwa mtandao...</target>
         <note>ID: ReportProblemDialog.Submitting</note>
         <note>This is shown while Bloom is sending the problem report to our server.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Success">
+      <trans-unit id="ReportProblemDialog.Success" approved="yes">
         <source xml:lang="en">We received your report, thanks for taking the time to help make Bloom better!</source>
         <target xml:lang="sw">Tulipokea ripoti yako, asante kwa kutenga muda wako ili kusaidia Bloom kuwa bora zaidi!</target>
         <note>ID: ReportProblemDialog.Success</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WhatsTheProblem">
+      <trans-unit id="ReportProblemDialog.WhatsTheProblem" approved="yes">
         <source xml:lang="en">What seems to be the problem?</source>
         <target xml:lang="sw">Je, ni nini inaonekana kuwa tatizo?</target>
         <note>ID: ReportProblemDialog.WhatsTheProblem</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WindowTitle">
+      <trans-unit id="ReportProblemDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Report A Problem</source>
         <target xml:lang="sw">Ripoti Tatizo</target>
         <note>ID: ReportProblemDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Zipping">
+      <trans-unit id="ReportProblemDialog.Zipping" approved="yes">
         <source xml:lang="en">Zipping up book...</source>
         <target xml:lang="sw">Kufunga kitabu...</target>
         <note>ID: ReportProblemDialog.Zipping</note>
         <note>This is shown while Bloom is creating the problem report. It's generally too fast to see, unless you include a large book.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.linkLabel1">
+      <trans-unit id="ReportProblemDialog.linkLabel1" approved="yes">
         <source xml:lang="en">Will not be private</source>
         <target xml:lang="sw">Haitakuwa siri</target>
         <note>ID: ReportProblemDialog.linkLabel1</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.IGetIt">
+      <trans-unit id="SamplePrintNotification.IGetIt" approved="yes">
         <source xml:lang="en">I get it. Do not show this again.</source>
         <target xml:lang="sw">Naelewa. Usionyeshe hii tena.</target>
         <note>ID: SamplePrintNotification.IGetIt</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.PleaseNotice">
+      <trans-unit id="SamplePrintNotification.PleaseNotice" approved="yes">
         <source xml:lang="en">Please notice the sample printer settings below. Use them as a guide while you set up the printer.</source>
         <target xml:lang="sw">Tafadhali tambua sampuli ya mpangilio wa mtambo wa kuchapisha hapa chini. Utumia kama mwongozo unapoandaa mtambo wa kuchapisha.</target>
         <note>ID: SamplePrintNotification.PleaseNotice</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Arithmetic</source>
         <target xml:lang="sw">Hesabu</target>
         <note>ID: TemplateBooks.BookName.Arithmetic</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="sw">Kitabu cha Kimsingi</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="sw">Kitabu Kikubwa</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="sw">Kifaa cha kusoma kinachoweza kufasiriwa</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="sw">Kifaa cha kusoma kilichopewa Ngazi</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="sw">Kamusi ya Picha</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vaccinations</source>
         <target xml:lang="sw">Chanjo</target>
         <note>ID: TemplateBooks.BookName.Vaccinations</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="sw">Kalenda ya Ukuta</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A blank page that allows you to add items.</source>
         <target xml:lang="sw">Ukurasa ulio mtupu unaokuruhusu kuongeza vipengee.</target>
         <note>ID: TemplateBooks.PageDescription.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page with a picture on top and a large, centered word below.</source>
         <target xml:lang="sw">Ukurasa ulio na picha juu na jina kubwa lilioandikwa katikati hapa chini.</target>
         <note>ID: TemplateBooks.PageDescription.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="sw">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1 Problem</source>
         <target xml:lang="sw">Tatizo 1</target>
         <note>ID: TemplateBooks.PageLabel.1 Problem</note>
         <note>This label indicates a page with one arithmetic problem on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true" approved="yes">
         <source xml:lang="en">10</source>
         <target xml:lang="sw">10</target>
         <note>ID: TemplateBooks.PageLabel.10</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true" approved="yes">
         <source xml:lang="en">11</source>
         <target xml:lang="sw">11</target>
         <note>ID: TemplateBooks.PageLabel.11</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true" approved="yes">
         <source xml:lang="en">12</source>
         <target xml:lang="sw">12</target>
         <note>ID: TemplateBooks.PageLabel.12</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true" approved="yes">
         <source xml:lang="en">13</source>
         <target xml:lang="sw">13</target>
         <note>ID: TemplateBooks.PageLabel.13</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true" approved="yes">
         <source xml:lang="en">14</source>
         <target xml:lang="sw">14</target>
         <note>ID: TemplateBooks.PageLabel.14</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true" approved="yes">
         <source xml:lang="en">15</source>
         <target xml:lang="sw">15</target>
         <note>ID: TemplateBooks.PageLabel.15</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true" approved="yes">
         <source xml:lang="en">16</source>
         <target xml:lang="sw">16</target>
         <note>ID: TemplateBooks.PageLabel.16</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true" approved="yes">
         <source xml:lang="en">17</source>
         <target xml:lang="sw">17</target>
         <note>ID: TemplateBooks.PageLabel.17</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true" approved="yes">
         <source xml:lang="en">18</source>
         <target xml:lang="sw">18</target>
         <note>ID: TemplateBooks.PageLabel.18</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true" approved="yes">
         <source xml:lang="en">19</source>
         <target xml:lang="sw">19</target>
         <note>ID: TemplateBooks.PageLabel.19</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="sw">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2 Problems</source>
         <target xml:lang="sw">Matatizo 2</target>
         <note>ID: TemplateBooks.PageLabel.2 Problems</note>
         <note>This label indicates a page with two arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true" approved="yes">
         <source xml:lang="en">20</source>
         <target xml:lang="sw">20</target>
         <note>ID: TemplateBooks.PageLabel.20</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true" approved="yes">
         <source xml:lang="en">21</source>
         <target xml:lang="sw">21</target>
         <note>ID: TemplateBooks.PageLabel.21</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="sw">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3 Problems</source>
         <target xml:lang="sw">Matatizo 3</target>
         <note>ID: TemplateBooks.PageLabel.3 Problems</note>
         <note>This label indicates a page with three arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="sw">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4 Problems</source>
         <target xml:lang="sw">Matatizo 4</target>
         <note>ID: TemplateBooks.PageLabel.4 Problems</note>
         <note>This label indicates a page with four arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="sw">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="sw">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="sw">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="sw">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="sw">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="sw">Alfabeti</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="sw">Matini ya Kimsingi na Picha</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="sw">Matini ya Kimsingi na Picha</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="sw">Ukurasa wa Sifa</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="sw">Kaida</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="sw">Siku ya 1</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="sw">Siku ya 2</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="sw">Siku ya 3</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="sw">Siku ya 4</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="sw">Siku ya 5a</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="sw">Siku ya 5b</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Factory</source>
         <target xml:lang="sw">Kiwanda</target>
         <note>ID: TemplateBooks.PageLabel.Factory</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="sw">Jalada la Mbele</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front/Back Matter</source>
         <target xml:lang="sw">Machapisho ya Mbele/Nyuma</target>
         <note>ID: TemplateBooks.PageLabel.FrontBackMatter</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="sw">Picha upande wa Chini</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="sw">Picha Katikati</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="sw">Jalada la Ndani upande wa Nyuma</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="sw">Jalada la ndani upande wa nje </target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="sw">Maagizo</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="sw">Maandishi tu</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="sw">Picha tu</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="sw">Picha tu</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="sw">Jalada la Nyuma ya Nje</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="sw">Kihifadhi Karatasi</target>
         <note>ID: TemplateBooks.PageLabel.Paper Saver</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="sw">Picha na neno</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="sw">Picha Katikati</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="sw">Picha upande wa Chini</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SIL-Cameroon</source>
         <target xml:lang="sw">SIL-Cameroon</target>
         <note>ID: TemplateBooks.PageLabel.SIL-Cameroon</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Super Paper Saver</source>
         <target xml:lang="sw">Kihifadhi Karatasi kilicho Bora zaidi</target>
         <note>ID: TemplateBooks.PageLabel.Super Paper Saver</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="sw">Ukurasa Huu Umeachwa Wazi Kimakusudi</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="sw">Ukurasa wa Mada</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="sw">Jadi</target>
         <note>ID: TemplateBooks.PageLabel.Traditional</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="sw">Pangilia</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="sw">Kilimo</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="sw">Hadithi za Wanyama</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="sw">Biashara</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="sw">Kuishi kwa Jamii</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="sw">Utamaduni</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="sw">Kamusi</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="sw">Mazingira</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="sw">Ya Kubuniwa</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="sw">Afya</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="sw">Jinsi ya</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="sw">Hesabu</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.NoTopic" sil:dynamic="true">
+      <trans-unit id="Topics.NoTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">No Topic</source>
         <target xml:lang="sw">Hakuna Mada</target>
         <note>ID: Topics.NoTopic</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="sw">Hakuna cha Kubuniwa</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="sw">Maendeleo ya Kibinafsi</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="sw">Prima</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="sw">Sayansi</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="sw">Kiroho</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Story Book" sil:dynamic="true">
+      <trans-unit id="Topics.Story Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Story Book</source>
         <target xml:lang="sw">Kitabu cha hadithi</target>
         <note>ID: Topics.Story Book</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="sw">Desturi</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="sw">Hadithi za Kitamaduni</target>
         <note>ID: Topics.Traditional Story</note>

--- a/DistFiles/localization/sw/IntegrityFailureAdvice.xlf
+++ b/DistFiles/localization/sw/IntegrityFailureAdvice.xlf
@@ -2,77 +2,77 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="IntegrityFailureAdvice-en.md" datatype="html" source-language="en" target-language="sw">
     <body>
-      <trans-unit id="integrity.title">
+      <trans-unit id="integrity.title" approved="yes">
         <source xml:lang="en">Bloom cannot find some of its own files, and cannot continue</source>
         <target xml:lang="sw">Bloom haiwezi kupata baadhi ya faili zake, na hivyo haiwezi kuendelea</target>
         <note>ID: integrity.title</note>
       </trans-unit>
-      <trans-unit id="integrity.causes">
+      <trans-unit id="integrity.causes" approved="yes">
         <source xml:lang="en">Possible Causes</source>
         <target xml:lang="sw">Sababu</target>
         <note>ID: integrity.causes</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.1">
+      <trans-unit id="integrity.causes.1" approved="yes">
         <source xml:lang="en">Your antivirus may have "quarantined" one or more Bloom files.</source>
         <target xml:lang="sw">Kizuia virusi chako kinaweza kuwa kimeweka "kizuizini" faili moja au zaidi za Bloom.</target>
         <note>ID: integrity.causes.1</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.2">
+      <trans-unit id="integrity.causes.2" approved="yes">
         <source xml:lang="en">Your computer administrator may have your computer "locked down" to prevent bad things, but in such a way that Bloom could not place these files where they belong. </source>
         <target xml:lang="sw">Uendeshaji wa kompyuta yako unaweza kufanya kompyuta yako "kufungwa" ili kuzuia mambo mabaya, lakini kwa njia ambayo Bloom isingeweza kuweka faili hizi pale zinapopaswa kuwa.</target>
         <note>ID: integrity.causes.2</note>
       </trans-unit>
-      <trans-unit id="integrity.todo">
+      <trans-unit id="integrity.todo" approved="yes">
         <source xml:lang="en">What To Do</source>
         <target xml:lang="sw">Unachopaswa Kufanya</target>
         <note>ID: integrity.todo</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas">
+      <trans-unit id="integrity.todo.ideas" approved="yes">
         <source xml:lang="en">After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas:</source>
         <target xml:lang="sw">Baada ya kukabidhi ripoti hii, tutawasiliana na wewe na tukusaidie kuitengeneza. Kwa sasa, haya ni baadhi ya maoni:</target>
         <note>ID: integrity.todo.ideas</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Reinstall">
+      <trans-unit id="integrity.todo.ideas.Reinstall" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="sw">Fungua kifaa cha kuweka Bloom tena, na uone iwapo itafunguka vyema wakati huu.</target>
         <note>ID: integrity.todo.ideas.Reinstall</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Antivirus">
+      <trans-unit id="integrity.todo.ideas.Antivirus" approved="yes">
         <source xml:lang="en">If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>.</source>
         <target xml:lang="sw">Iwapo hiyo haitarekebisha, ni wakati wa kuwasiliana na programu ya kupigana na virusi.Iwapo kitengo kilicho hapa chini cha "Faili zilizopotea" kinaonyesha faili zozote zinazoanza kwa ".exe", amua "kuweka rangi nyeupe" kwa jalada la programu ya Bloom, ambalo liko .</target>
         <note>ID: integrity.todo.ideas.Antivirus</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVAST">
+      <trans-unit id="integrity.todo.ideas.AVAST" approved="yes">
         <source xml:lang="en">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">Instructions</g>.</source>
         <target xml:lang="sw">lAVAST: Maagizo kutoka kwa AVAST.</target>
         <note>ID: integrity.todo.ideas.AVAST</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Norton">
+      <trans-unit id="integrity.todo.ideas.Norton" approved="yes">
         <source xml:lang="en">Norton Antivirus: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">Instructions from Symantec</g>.</source>
         <target xml:lang="sw">Kizuia virusi cha Norton : Maelekezo kutoka kwa Symantec.</target>
         <note>ID: integrity.todo.ideas.Norton</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVG">
+      <trans-unit id="integrity.todo.ideas.AVG" approved="yes">
         <source xml:lang="en">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">Instructions from AVG</g>.</source>
         <target xml:lang="sw">AVG: Matekelezo kutoka kwa AVG.</target>
         <note>ID: integrity.todo.ideas.AVG</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Others">
+      <trans-unit id="integrity.todo.ideas.Others" approved="yes">
         <source xml:lang="en">Others: Google for "whitelist directory name-of-your-antivirus"</source>
         <target xml:lang="sw">Mengine: Tafuta kutoka kwa Google "orodha nyeupe ya jina-la-kizuia-chako-cha-virusi"</target>
         <note>ID: integrity.todo.ideas.Others</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Restart">
+      <trans-unit id="integrity.todo.ideas.Restart" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="sw">Fungua kifaa cha kuweka Bloom tena, na uone iwapo itafunguka vyema wakati huu.</target>
         <note>ID: integrity.todo.ideas.Restart</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Retrieve">
+      <trans-unit id="integrity.todo.ideas.Retrieve" approved="yes">
         <source xml:lang="en">You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">this image</g>.</source>
         <target xml:lang="sw">Pia unaweza kujaribu kupata tena sehemu ya Bloom ambayo programu yako ya kuzuia virusi ilichukua kutoka kwake.Kwa AVG, unahitajika kutafuta AVG menu ya "chaguo", bofya "ruka virusi", bofya kwa faili ya Bloom katika vuka, na ubofye "rejesha upya". Kwa mwongozo unaoonekana, tazama <g id="genid-1" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">picha hii</g>.</target>
         <note>ID: integrity.todo.ideas.Retrieve</note>
       </trans-unit>
-      <trans-unit id="integrity.missing">
+      <trans-unit id="integrity.missing" approved="yes">
         <source xml:lang="en">Missing Files</source>
         <target xml:lang="sw">Faili Zilizopotea</target>
         <note>ID: integrity.missing</note>

--- a/DistFiles/localization/sw/MissingLameModule.xlf
+++ b/DistFiles/localization/sw/MissingLameModule.xlf
@@ -2,19 +2,19 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="MissingLameModule-en.html" datatype="html" source-language="en" target-language="sw">
     <body>
-      <trans-unit id="missing.lame.please.install">
+      <trans-unit id="missing.lame.please.install" approved="yes">
         <source xml:lang="en">Please Install LAME</source>
         <target xml:lang="sw">Tafadhali weka LAME</target>
         <note>ID: missing.lame.please.install</note>
       </trans-unit>
-      <trans-unit id="missing.lame.bloom.needs.lame">
+      <trans-unit id="missing.lame.bloom.needs.lame" approved="yes">
         <source xml:lang="en">This book has audio recordings. Bloom can use these to make a "Talking Book" e-book. However, Bloom needs a program called "LAME for Audacity" in order to create the mp3 files that the book will use. Setting it up is easy. First download and run <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>. Next, restart Bloom.
       </source>
         <target xml:lang="sw">Kitabu hiki kina sauti zilizorekodiwa. Bloom inaweza kutumia hizi kutengeneza e-book ya "Kitabu kilicho na sauti". Hata hivyo, Bloom huhitaji programu iitwayo "LAME for Audacity" ili kutengeneza faili za MP3 zitakazotumiwa na kitabu. Ni rahisi kuiweka. Kwanza ipakue kisha uifungue <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>. Kisha, fungua upya Bloom.
       </target>
         <note>ID: missing.lame.bloom.needs.lame</note>
       </trans-unit>
-      <trans-unit id="missing.lame.audio.optional">
+      <trans-unit id="missing.lame.audio.optional" approved="yes">
         <source xml:lang="en">If you prefer to go ahead and publish your book without audio, click <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">here</g>.
       </source>
         <target xml:lang="sw">Iwapo unapendelea kuendelea na kuchapisha kitabu chako bila sauti, bofya <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">hapa</g>.

--- a/DistFiles/localization/sw/Palaso.xlf
+++ b/DistFiles/localization/sw/Palaso.xlf
@@ -2,595 +2,595 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Palaso.dll" source-language="en" target-language="sw" datatype="plaintext" product-version="3.1.000.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="AboutDialog.BuiltOnDate">
+      <trans-unit id="AboutDialog.BuiltOnDate" approved="yes">
         <source xml:lang="en">Built on {0}</source>
         <target xml:lang="sw">Imejengwa kwa {0}</target>
         <note>ID: AboutDialog.BuiltOnDate</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.NoUpdates">
+      <trans-unit id="AboutDialog.NoUpdates" approved="yes">
         <source xml:lang="en">No Updates</source>
         <target xml:lang="sw">Hakuna utengenezaji upya</target>
         <note>ID: AboutDialog.NoUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.WindowTitle">
+      <trans-unit id="AboutDialog.WindowTitle" approved="yes">
         <source xml:lang="en">About {0}</source>
         <target xml:lang="sw">Kuhusu {0}</target>
         <note>ID: AboutDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._checkForUpdates">
+      <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
         <source xml:lang="en">Check For Updates</source>
         <target xml:lang="sw">Tafuta utengenezaji upya</target>
         <note>ID: AboutDialog._checkForUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._releaseNotesLabel">
+      <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="sw">Muhtasari wa toleo</target>
         <note>ID: AboutDialog._releaseNotesLabel</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.General">
+      <trans-unit id="Application.AlreadyRunning.General" approved="yes">
         <source xml:lang="en">Another copy of the application is already running. If you cannot find it, restart your computer.</source>
         <target xml:lang="sw">Nakala nyingine ya programu tayari inaendelea. Iwapo huwezi kuipata, fungua upya kompyuta yako.</target>
         <note>ID: Application.AlreadyRunning.General</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.Specific">
+      <trans-unit id="Application.AlreadyRunning.Specific" approved="yes">
         <source xml:lang="en">Another copy of {0} is already running. If you cannot find that copy of {0}, restart your computer.</source>
         <target xml:lang="sw">Nakala nyingine ya {0} tayari inaendelea. Iwapo huwezi kupata nakala hiyo ya {0}, fungua upya kompyuta yako.</target>
         <note>ID: Application.AlreadyRunning.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.General">
+      <trans-unit id="Application.ProblemStarting.General" approved="yes">
         <source xml:lang="en">There was a problem starting the application which might require that you restart your computer.</source>
         <target xml:lang="sw">Kulikuwa na tatizo katika kuanzisha programu ambayo inaweza kukuhitaji kufungua upya kompyuta yako.</target>
         <note>ID: Application.ProblemStarting.General</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.Specific">
+      <trans-unit id="Application.ProblemStarting.Specific" approved="yes">
         <source xml:lang="en">There was a problem starting {0} which might require that you restart your computer.</source>
         <target xml:lang="sw">Kulikuwa na tatizo katika kuanzisha {0} ambayo inaweza kukuhitaji kufungua upya kompyuta yako.</target>
         <note>ID: Application.ProblemStarting.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.General">
+      <trans-unit id="Application.WaitingFinish.General" approved="yes">
         <source xml:lang="en">Waiting for other application to finish...</source>
         <target xml:lang="sw">Kungoja programu nyingine kumaliza...</target>
         <note>ID: Application.WaitingFinish.General</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.Specific">
+      <trans-unit id="Application.WaitingFinish.Specific" approved="yes">
         <source xml:lang="en">Waiting for other {0} to finish...</source>
         <target xml:lang="sw">Kungoja {0} nyingine kumaliza...</target>
         <note>ID: Application.WaitingFinish.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="sw">U&amp;batilishe</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.No">
+      <trans-unit id="Common.No" approved="yes">
         <source xml:lang="en">No</source>
         <target xml:lang="sw">La</target>
         <note>ID: Common.No</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="sw">&amp;Sawa</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Yes">
+      <trans-unit id="Common.Yes" approved="yes">
         <source xml:lang="en">Yes</source>
         <target xml:lang="sw">Ndiyo</target>
         <note>ID: Common.Yes</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="sw">{0} itapelekwa kwenye pipa la takataka.</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
         <note>Parameter {0} is a description of the things being deleted (e.g., "The selected files")</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="sw">{0} itapelekwa kwenye pipa la takataka.</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
         <note>Parameter {0} is a file name</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Confirm Delete</source>
         <target xml:lang="sw">Thibitisha Kufutwa</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="sw">U&amp;batilishe</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="sw">U&amp;fute</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.AlmostMatchingImages">
+      <trans-unit id="ImageToolbox.AlmostMatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images with names close to {1}</source>
         <target xml:lang="sw">Zipo picha {0} zilizo na majina yanayokaribiana na </target>
         <note>ID: ImageToolbox.AlmostMatchingImages</note>
         <note>The {0} will be replaced by the number of images found.  The {1} will be replaced with the search string.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ArtOfReading">
+      <trans-unit id="ImageToolbox.ArtOfReading" approved="yes">
         <source xml:lang="en">Art Of Reading</source>
         <target xml:lang="sw">Sanaa ya Kusoma</target>
         <note>ID: ImageToolbox.ArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Camera">
+      <trans-unit id="ImageToolbox.Camera" approved="yes">
         <source xml:lang="en">Camera</source>
         <target xml:lang="sw">Kamera</target>
         <note>ID: ImageToolbox.Camera</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
         <source xml:lang="en">Use {0}</source>
         <target xml:lang="sw">Tumia {0}</target>
         <note>ID: ImageToolbox.CopyExemplarMetadata</note>
         <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Crop">
+      <trans-unit id="ImageToolbox.Crop" approved="yes">
         <source xml:lang="en">Crop</source>
         <target xml:lang="sw">Kata</target>
         <note>ID: ImageToolbox.Crop</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.DownloadArtOfReading">
+      <trans-unit id="ImageToolbox.DownloadArtOfReading" approved="yes">
         <source xml:lang="en">Download Art Of Reading Installer</source>
         <target xml:lang="sw">Pakua Kifaa cha Kuweka Sanaa ya Kusoma</target>
         <note>ID: ImageToolbox.DownloadArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EditMetadataLink">
+      <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
         <source xml:lang="en">Edit...</source>
         <target xml:lang="sw">Hakiki...</target>
         <note>ID: ImageToolbox.EditMetadataLink</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EnterSearchTerms">
+      <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
         <source xml:lang="en">This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.</source>
         <target xml:lang="sw">Hii ni sanaa ya 'Sanaa ya Kusoma'. Katika kisanduku kilicho hapo juu, andika unachotafuta, kisha ubonyeze INGIA. Unaweza kupiga chapa maneno kwa Kiingereza na kiindonesia.</target>
         <note>ID: ImageToolbox.EnterSearchTerms</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.FileButton">
+      <trans-unit id="ImageToolbox.FileButton" approved="yes">
         <source xml:lang="en">File</source>
         <target xml:lang="sw">Faili</target>
         <note>ID: ImageToolbox.FileButton</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
         <target xml:lang="sw">Samahani, kulikuwa na hitilafu katika kupata picha.</target>
         <note>ID: ImageToolbox.GenericGettingImageProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericProblem">
+      <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
         <target xml:lang="sw">Samahani kulikuwa na hitilafu kwenye Kisanduku cha vifaa cha picha</target>
         <note>ID: ImageToolbox.GenericProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GetPicture">
+      <trans-unit id="ImageToolbox.GetPicture" approved="yes">
         <source xml:lang="en">Get Picture</source>
         <target xml:lang="sw">Pata picha</target>
         <note>ID: ImageToolbox.GetPicture</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
         <source xml:lang="en">Image Toolbox</source>
         <target xml:lang="sw">Kisanduku cha vifaa cha picha</target>
         <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.InstallArtOfReading">
+      <trans-unit id="ImageToolbox.InstallArtOfReading" approved="yes">
         <source xml:lang="en">Install the Art Of Reading package (this may be very slow)</source>
         <target xml:lang="sw">Weka kifurushi cha Sanaa ya Kusoma (hii inaweza kutendeka polepole sana)</target>
         <note>ID: ImageToolbox.InstallArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.MatchingImages">
+      <trans-unit id="ImageToolbox.MatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images</source>
         <target xml:lang="sw">Picha {0} zilipatikana</target>
         <note>ID: ImageToolbox.MatchingImages</note>
         <note>The {0} will be replaced by the number of matching images</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NewMultilingual">
+      <trans-unit id="ImageToolbox.NewMultilingual" approved="yes">
         <source xml:lang="en">Did you know that there is a new version of this collection which lets you search in Arabic, Bengali, Chinese, English, French, Indonesian, Hindi, Portuguese, Spanish, Thai, or Swahili? It is free and available for downloading.</source>
         <target xml:lang="sw">Je, unajua kuwa kuna toleo jipya la mkusanyiko huu inayokuruhusu kutafuta kwa Kiarabu, Kibengali, Kichina, Kiingereza, Kifaransa, Kiindonesia, Kihindi, Kireno, Kihispania, Kithai au Kiswahili? Ni bure na inapatika kupakua.</target>
         <note>ID: ImageToolbox.NewMultilingual</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoArtOfReading">
+      <trans-unit id="ImageToolbox.NoArtOfReading" approved="yes">
         <source xml:lang="en">This computer doesn't appear to have the 'Art Of Reading' gallery installed yet.</source>
         <target xml:lang="sw">Kompyuta hii inaonekana bado haijawekwa sanaa ya 'Sanaa ya Kusoma'.</target>
         <note>ID: ImageToolbox.NoArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoMatchingImages">
+      <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
         <source xml:lang="en">Found no matching images</source>
         <target xml:lang="sw">Hakuna picha zinazoambatana zilizopatikana</target>
         <note>ID: ImageToolbox.NoMatchingImages</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PictureFiles">
+      <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
         <source xml:lang="en">picture files</source>
         <target xml:lang="sw">faili za picha</target>
         <note>ID: ImageToolbox.PictureFiles</note>
         <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice" approved="yes">
         <source xml:lang="en">Problem Getting Image</source>
         <target xml:lang="sw">Tatizo katika kupata picha</target>
         <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemLoadingImage">
+      <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
         <source xml:lang="en">Sorry, there was a problem loading that image.</source>
         <target xml:lang="sw">Samahani, kulikuwa na tatizo katika kupata picha hiyo.</target>
         <note>ID: ImageToolbox.ProblemLoadingImage</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
         <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
         <target xml:lang="sw">Picha hii haijui:\n\nNi nani aliyeitengeneza?\nNi nani anayeweza kuitumia?</target>
         <note>ID: ImageToolbox.PromptForMissingMetadata</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Scanner">
+      <trans-unit id="ImageToolbox.Scanner" approved="yes">
         <source xml:lang="en">Scanner</source>
         <target xml:lang="sw">Skana</target>
         <note>ID: ImageToolbox.Scanner</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchArtOfReading">
+      <trans-unit id="ImageToolbox.SearchArtOfReading" approved="yes">
         <source xml:lang="en">Search the Art of Reading Gallery</source>
         <target xml:lang="sw">Tafuta katika Sanaa ya Sanaa ya Kusoma</target>
         <note>ID: ImageToolbox.SearchArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchLanguage">
+      <trans-unit id="ImageToolbox.SearchLanguage" approved="yes">
         <source xml:lang="en">The search box is currently set to {0}</source>
         <target xml:lang="sw">Kwa sasa kisanduku cha kutafuta kiko {0}</target>
         <note>ID: ImageToolbox.SearchLanguage</note>
         <note>The {0} will be replaced by the name of the language used in the searches.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SetUpMetadataLink">
+      <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
         <source xml:lang="en">Set up metadata...</source>
         <target xml:lang="sw">Tayarisha Metadata...</target>
         <note>ID: ImageToolbox.SetUpMetadataLink</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.AlternateNamesHeader">
+      <trans-unit id="LanguageLookup.AlternateNamesHeader" approved="yes">
         <source xml:lang="en">Other Names</source>
         <target xml:lang="sw">Majina Mengine</target>
         <note>ID: LanguageLookup.AlternateNamesHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2" approved="yes">
         <source xml:lang="en">This list should include all the ISO-639 languages, including all the alternative names known to ethnologue.com.\n\nIf necessary, use the "Unlisted Language" option, which will be selected for you now.</source>
         <target xml:lang="sw">Orodha hii inapaswa kujumuisha lugha zote za ISO-639 ikijumuisha majina yote mbadala yanayojulikana kwa ethnologue.com.\n\nIkiwa itahitajika, tumia chaguo la "Lugha isiyoorodheshwa", ambalo litachaguliwa sasa.</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue" approved="yes">
         <source xml:lang="en">Ethnologue.com</source>
         <target xml:lang="sw">Ethnologue.com</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
         <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
         <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
         <target xml:lang="sw">Kuhusu Majina Mafupi ya Lugha 639-3 na Jinsi ya Kupata Mengine Mapya</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
         <source xml:lang="en">About The ISO Language Registry</source>
         <target xml:lang="sw">Kuhusu usajili wa Lugha wa ISO</target>
         <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CodeHeader">
+      <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
         <source xml:lang="en">Code</source>
         <target xml:lang="sw">Jina la fupi</target>
         <note>ID: LanguageLookup.CodeHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryCount">
+      <trans-unit id="LanguageLookup.CountryCount" approved="yes">
         <source xml:lang="en">{0} Countries</source>
         <target xml:lang="sw">{0} Nchi</target>
         <note>ID: LanguageLookup.CountryCount</note>
         <note>Shown when there are multiple countries and it is just confusing to list them all. {0} is a count of countries.</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryHeader">
+      <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="sw">Nchi</target>
         <note>ID: LanguageLookup.CountryHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
         <source xml:lang="en">You can change how the language name will be displayed here:</source>
         <target xml:lang="sw">Unaweza kubadilisha jinsi jina la lugha litaonekana hapa:</target>
         <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
         <source xml:lang="en">Lookup Language Code...</source>
         <target xml:lang="sw">Tazama Jina Fupi la Lugha...</target>
         <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.PrimaryNameHeader">
+      <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="sw">Jina</target>
         <note>ID: LanguageLookup.PrimaryNameHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel">
+      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel" approved="yes">
         <source xml:lang="en">Show regional dialects</source>
         <target xml:lang="sw">Onyesha lahaja za kieneo</target>
         <note>ID: LanguageLookup.ShowRegionalDialectsLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.UnlistedLanguage">
+      <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
         <source xml:lang="en">Unlisted Language</source>
         <target xml:lang="sw">Lugha Isiyoorodheshwa</target>
         <note>ID: LanguageLookup.UnlistedLanguage</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
         <source xml:lang="en">Can't find your language?</source>
         <target xml:lang="sw">Hauwezi Kupata lugha yako?</target>
         <note>ID: LanguageLookup._cannotFindLanguageLink</note>
       </trans-unit>
-      <trans-unit id="MemoryWarning">
+      <trans-unit id="MemoryWarning" approved="yes">
         <source xml:lang="en">Unfortunately, {0} is starting to get short of memory, and may soon slow down or experience other problems. We recommend that you quit and restart it when convenient.</source>
         <target xml:lang="sw">Kwa bahati mbaya, kumbukumbu la {0} linaanza kuelekea kuisha, na hivi karibuni inaweza kusonga polepole au kupata matatizo mengine. Tunapendekeza kuwa uache au uifungue upya inapofaa.</target>
         <note>ID: MemoryWarning</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Creator">
+      <trans-unit id="MetadataDisplay.Creator" approved="yes">
         <source xml:lang="en">Creator: {0}</source>
         <target xml:lang="sw">Aliyetengeneza: {0}</target>
         <note>ID: MetadataDisplay.Creator</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.CreatorLabel">
+      <trans-unit id="MetadataDisplay.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="sw">Aliyetengeneza</target>
         <note>ID: MetadataDisplay.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.LicenseInfo">
+      <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
         <source xml:lang="en">License Info</source>
         <target xml:lang="sw">Habari kuhusu Leseni</target>
         <note>ID: MetadataDisplay.LicenseInfo</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You must keep the copyright and credits for authors, illustrators, etc.</source>
         <target xml:lang="sw">Ni lazima uweke hati umiliki na sifa kwa waandishi, wachoraji, na kadhalika.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.AttributionRequired</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You are free to make commercial use of this work.</source>
         <target xml:lang="sw">Uko huru kutumia toleo hili kwa njia ya kibiashara.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work.</source>
         <target xml:lang="sw">Unaruhusiwa kuibadilisha na kuongeza kwa toleo hili.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.Derivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work, but you may distribute the resulting work only under the same or similar license to this one.</source>
         <target xml:lang="sw">Unaweza kuibadilisha na kuongeza kwa toleo hili, lakini lazima usambaze matokeo ya kazi hii tu chini ya leseni hiyo hiyo au leseni inayofanana na hii.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not make changes or build upon this work without permission.</source>
         <target xml:lang="sw">Huruhusiwi kufanya mabadiliko au kuongeza chochote zaidi kwa toleo hili bila idhini.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NoDerivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not use this work for commercial purposes.</source>
         <target xml:lang="sw">Huruhusiwi kutumia toleo hili kwa shughuli za kibiashara.</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NonCommercial</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For permission to reuse, contact the copyright holder.</source>
         <target xml:lang="sw">Iwapo utataka kuitumia tena, tafadhali wasiliana na aliye na haki ya kumiliki.</target>
         <note>ID: MetadataDisplay.Licenses.NullLicense</note>
         <note>This is used when all we have is a copyright, no other license.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.NoLicense">
+      <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
         <source xml:lang="en">No license specified</source>
         <target xml:lang="sw">Hakuna leseni maalum</target>
         <note>ID: MetadataDisplay.NoLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowCommercialUse">
+      <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
         <source xml:lang="en">Allow commercial uses of your work?</source>
         <target xml:lang="sw">Kubali kazi yako kutumika kwa shughuli za kibiashara?</target>
         <note>ID: MetadataEditor.AllowCommercialUse</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowDerivatives">
+      <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
         <source xml:lang="en">Allow modifications of your work?</source>
         <target xml:lang="sw">Kubali kazi yako ibadilishwe?</target>
         <note>ID: MetadataEditor.AllowDerivatives</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CopyrightHolder">
+      <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
         <source xml:lang="en">Copyright Holder</source>
         <target xml:lang="sw">Anayemiliki haki ya Kunakili </target>
         <note>ID: MetadataEditor.CopyrightHolder</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons">
+      <trans-unit id="MetadataEditor.CreativeCommons" approved="yes">
         <source xml:lang="en">Creative Commons</source>
         <target xml:lang="sw">Creative Commons</target>
         <note>ID: MetadataEditor.CreativeCommons</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental">
+      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental" approved="yes">
         <source xml:lang="en">Intergovernmental Version</source>
         <target xml:lang="sw">Tafsiri ya kati ya kiserikali</target>
         <note>ID: MetadataEditor.CreativeCommons.Intergovernmental</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreatorLabel">
+      <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="sw">Aliyetengeneza</target>
         <note>ID: MetadataEditor.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CustomLicense">
+      <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="sw">Kawaida</target>
         <note>ID: MetadataEditor.CustomLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleNoCredit">
+      <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
         <source xml:lang="en">Copyright and License</source>
         <target xml:lang="sw">Haki ya kunakili na Leseni</target>
         <note>ID: MetadataEditor.TitleNoCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleWithCredit">
+      <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
         <source xml:lang="en">Credit, Copyright, and License</source>
         <target xml:lang="sw">Sifa, Haki ya kunakili, na Leseni</target>
         <note>ID: MetadataEditor.TitleWithCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.UnknownLicense">
+      <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <target xml:lang="sw">Wasiliana na aliye na haki ya kunakili ili kupata idhini</target>
         <note>ID: MetadataEditor.UnknownLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.YesShareAlike">
+      <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
         <source xml:lang="en">Yes, as long as others share alike</source>
         <target xml:lang="sw">Ndiyo, kama wengine wataishirikisha vile vile</target>
         <note>ID: MetadataEditor.YesShareAlike</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.additionalRequestsLabel">
+      <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
         <source xml:lang="en">Additional Requests</source>
         <target xml:lang="sw">Maombi zaidi</target>
         <note>ID: MetadataEditor.additionalRequestsLabel</note>
         <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.betterLinkLabel1">
+      <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
         <source xml:lang="en">more info</source>
         <target xml:lang="sw">habari zaidi</target>
         <note>ID: MetadataEditor.betterLinkLabel1</note>
         <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere that defines it.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
         <source xml:lang="en">Not Enforceable</source>
         <target xml:lang="sw">Haiwezi Kutekelezwa</target>
         <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
         <note>While this screen allows it, legally you can't enforce any additions to a creative commons license. This link takes you to the clause that says that. This link is visible only if you choose Creative Commons but then type in  the "Additional Request" box.</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <target xml:lang="sw">Hii pia inaweza kuficha vitufe vingine ambavyo havihitajiki na mtumiaji asiye na ufasaha wa juu.</target>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.CtrlShiftHint">
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
         <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
         <target xml:lang="sw">Kitufe kitajitokeza utakapofinya kii za Ctrl na Shift kwa pamoja.</target>
         <note>ID: SettingsProtection.CtrlShiftHint</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+      <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
         <source xml:lang="en">Settings...</source>
         <target xml:lang="sw">Mipangilio...</target>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
         <source xml:lang="en">Hide the button that opens settings.</source>
         <target xml:lang="sw">Ficha kitufe kinachofungua mipangilio.</target>
         <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
         <source xml:lang="en">Factory Password</source>
         <target xml:lang="sw">Neno la siri la awali</target>
         <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
         <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
         <target xml:lang="sw">Ili kuzuia mabadiliko yasiyokusudiwa, ambayo yanaweza kubadilisha kifaa hiki na kukifanya kutokutendea kazi, mipangilio hii imefungwa.</target>
         <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
         <source xml:lang="en">Settings Protection Password</source>
         <target xml:lang="sw">Neno la Siri la kulinda Mipangilio</target>
         <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox">
+      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
         <source xml:lang="en">Show Characters</source>
         <target xml:lang="sw">Onyesha Herufi</target>
         <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordNotice">
+      <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
         <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always google for "{1}" and "{2}".</source>
         <target xml:lang="sw">Neno la siri la awali la mipangilio hii ni "{0}". Iwapo utalisahau, unaweza kulitafuta kwenye google kwa "{1}" na "{2}"</target>
         <note>ID: SettingsProtection.PasswordNotice</note>
         <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
         <source xml:lang="en">Require the factory password to get into settings.</source>
         <target xml:lang="sw">Hitaji neno la siri la awali ili kuingia kwenye mipangilio.</target>
         <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
         <source xml:lang="en">Settings Protection</source>
         <target xml:lang="sw">Ulinzi wa mipangilio</target>
         <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
       </trans-unit>
-      <trans-unit id="ShowReleaseNotesDialog.WindowTitle">
+      <trans-unit id="ShowReleaseNotesDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="sw">Muhtasari wa toleo</target>
         <note>ID: ShowReleaseNotesDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Font">
+      <trans-unit id="WSFontControl.Font" approved="yes">
         <source xml:lang="en">&amp;Font:</source>
         <target xml:lang="sw">&amp;Fonti:</target>
         <note>ID: WSFontControl.Font</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.FontNotAvailable">
+      <trans-unit id="WSFontControl.FontNotAvailable" approved="yes">
         <source xml:lang="en">(The selected font is not available on this machine. Using default.)</source>
         <target xml:lang="sw">(Fonti iliyochaguliwa haipatikani kwenye mtambo huu. Tunatumia kawaida)</target>
         <note>ID: WSFontControl.FontNotAvailable</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.RightToLeftWS">
+      <trans-unit id="WSFontControl.RightToLeftWS" approved="yes">
         <source xml:lang="en">This is a &amp;right to left writing system.</source>
         <target xml:lang="sw">Huu ni mfumo wa kuandika wa kutoka kulia kwenda kushoto.</target>
         <note>ID: WSFontControl.RightToLeftWS</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Size">
+      <trans-unit id="WSFontControl.Size" approved="yes">
         <source xml:lang="en">&amp;Size:</source>
         <target xml:lang="sw">U&amp;kubwa:</target>
         <note>ID: WSFontControl.Size</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.TestArea">
+      <trans-unit id="WSFontControl.TestArea" approved="yes">
         <source xml:lang="en">&amp;Test Area:</source>
         <target xml:lang="sw">&amp;Eneo la kujaribisha:</target>
         <note>ID: WSFontControl.TestArea</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
         <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
         <target xml:lang="sw">Iwapo kibodi unayohitaji haijaorodheshwa, bofya kiunganishi kinachofaa hapa chini ili kuiweka. </target>
         <note>ID: WSKeyboardControl.KeyboardNotListed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
         <source xml:lang="en">Windows keyboard settings</source>
         <target xml:lang="sw">Mipangilio ya Windosi ya kibodi</target>
         <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
         <source xml:lang="en">Available keyboards</source>
         <target xml:lang="sw">Kibodi zinazopatikana</target>
         <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
         <source xml:lang="en">Previously used keyboards</source>
         <target xml:lang="sw">Kibodi zilizotumika hapo awali</target>
         <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
         <source xml:lang="en">Keyman Configuration</source>
         <target xml:lang="sw">Mipangilio ya Keyman</target>
         <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
         <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
         <target xml:lang="sw">Keyman 5.0 au ya karibu zaidi haijawekwa.</target>
         <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
         <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
         <target xml:lang="sw">Chagua kibodi ambayo utatumia kuandika maandishi {0}</target>
         <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.TestAreaCaption">
+      <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
         <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
         <target xml:lang="sw">&amp;Eneo la kujaribisha (Tumia eneo hili ili kupiga chapa kitu cha kujaribisha kibodi yako)</target>
         <note>ID: WSKeyboardControl.TestAreaCaption</note>
       </trans-unit>
-      <trans-unit id="Warning">
+      <trans-unit id="Warning" approved="yes">
         <source xml:lang="en">Warning</source>
         <target xml:lang="sw">Onyo</target>
         <note>ID: Warning</note>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption" approved="yes">
         <source xml:lang="en">Unable to connect to SLDR</source>
         <target xml:lang="sw">Imeshindwa kuunganishwa na SLDR</target>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrCaption</note>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText" approved="yes">
         <source xml:lang="en">The application is unable to connect to the SIL Locale Data Repository to retrieve the latest information about this language. If you create this writing system, the default settings might be incorrect or out of date. Are you sure you want to create a new writing system?</source>
         <target xml:lang="sw">Programu imeshindwa kuunganishwa na Akiba ya Data ya SIL ili kupata habari ya hivi karibuni kuhusu lugha hii. Iwapo utatengeneza mfumo huu wa kuandika, mipangilio ya awali inaweza kutokuwa sahihi au kupitwa na wakati. Una uhakika kuwa unataka kutengeneza mfumo mpya wa kuandika?</target>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrText</note>

--- a/DistFiles/localization/sw/TrainingVideos.xlf
+++ b/DistFiles/localization/sw/TrainingVideos.xlf
@@ -2,17 +2,17 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="TrainingVideos-en.md" datatype="html" source-language="en" target-language="sw">
     <body>
-      <trans-unit id="training.videos">
+      <trans-unit id="training.videos" approved="yes">
         <source xml:lang="en">Bloom Training Videos</source>
         <target xml:lang="sw">Video ya Bloom ya Kufundisha</target>
         <note>ID: training.videos</note>
       </trans-unit>
-      <trans-unit id="training.videos.watch">
+      <trans-unit id="training.videos.watch" approved="yes">
         <source xml:lang="en">If you are connected to the internet now, you can watch videos in your web browser:</source>
         <target xml:lang="sw">Iwapo uko kwenye mtandao sasa hivi, unaweza kutazama video kwenye kivinjari chako:</target>
         <note>ID: training.videos.watch</note>
       </trans-unit>
-      <trans-unit id="training.videos.all">
+      <trans-unit id="training.videos.all" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-a" html:href="http://tiny.cc/bloomVimeo">All videos</g>
         </source>
@@ -21,12 +21,12 @@
         </target>
         <note>ID: training.videos.all</note>
       </trans-unit>
-      <trans-unit id="training.videos.intro">
+      <trans-unit id="training.videos.intro" approved="yes">
         <source xml:lang="en">Introductory Videos</source>
         <target xml:lang="sw">Video za Utangulizi</target>
         <note>ID: training.videos.intro</note>
       </trans-unit>
-      <trans-unit id="training.videos.whofor">
+      <trans-unit id="training.videos.whofor" approved="yes">
         <source xml:lang="en">
           <g id="genid-2" ctype="x-html-a" html:href="https://vimeo.com/114043219">Bloom: Who is it for</g>
         </source>
@@ -35,7 +35,7 @@
         </target>
         <note>ID: training.videos.whofor</note>
       </trans-unit>
-      <trans-unit id="training.videos.templates">
+      <trans-unit id="training.videos.templates" approved="yes">
         <source xml:lang="en">
           <g id="genid-3" ctype="x-html-a" html:href="https://vimeo.com/114024308">Understanding Templates and Shell Books</g>
         </source>
@@ -44,7 +44,7 @@
         </target>
         <note>ID: training.videos.templates</note>
       </trans-unit>
-      <trans-unit id="training.videos.basicbook">
+      <trans-unit id="training.videos.basicbook" approved="yes">
         <source xml:lang="en">
           <g id="genid-4" ctype="x-html-a" html:href="https://vimeo.com/112825489">Using the Basic Book template</g>
         </source>
@@ -53,7 +53,7 @@
         </target>
         <note>ID: training.videos.basicbook</note>
       </trans-unit>
-      <trans-unit id="training.videos.readers">
+      <trans-unit id="training.videos.readers" approved="yes">
         <source xml:lang="en">
           <g id="genid-5" ctype="x-html-a" html:href="http://tiny.cc/usingBloomReaderTemplates">Using Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -62,12 +62,12 @@
         </target>
         <note>ID: training.videos.readers</note>
       </trans-unit>
-      <trans-unit id="training.videos.advanced">
+      <trans-unit id="training.videos.advanced" approved="yes">
         <source xml:lang="en">Advanced Topics</source>
         <target xml:lang="sw">Mada Kuu</target>
         <note>ID: training.videos.advanced</note>
       </trans-unit>
-      <trans-unit id="training.videos.formatting">
+      <trans-unit id="training.videos.formatting" approved="yes">
         <source xml:lang="en">
           <g id="genid-6" ctype="x-html-a" html:href="https://vimeo.com/117820891">Changing the format of text</g>
         </source>
@@ -76,7 +76,7 @@
         </target>
         <note>ID: training.videos.formatting</note>
       </trans-unit>
-      <trans-unit id="training.videos.custompage">
+      <trans-unit id="training.videos.custompage" approved="yes">
         <source xml:lang="en">
           <g id="genid-7" ctype="x-html-a" html:href="https://vimeo.com/116868148">Using the Custom Page template</g>
         </source>
@@ -85,7 +85,7 @@
         </target>
         <note>ID: training.videos.custompage</note>
       </trans-unit>
-      <trans-unit id="training.videos.specialcharacters">
+      <trans-unit id="training.videos.specialcharacters" approved="yes">
         <source xml:lang="en">
           <g id="genid-8" ctype="x-html-a" html:href="https://vimeo.com/117927599">Inserting special characters</g>
         </source>
@@ -94,7 +94,7 @@
         </target>
         <note>ID: training.videos.specialcharacters</note>
       </trans-unit>
-      <trans-unit id="training.videos.readertemplates">
+      <trans-unit id="training.videos.readertemplates" approved="yes">
         <source xml:lang="en">
           <g id="genid-9" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">Making a set of Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -103,24 +103,24 @@
         </target>
         <note>ID: training.videos.readertemplates</note>
       </trans-unit>
-      <trans-unit id="training.videos.offline">
+      <trans-unit id="training.videos.offline" approved="yes">
         <source xml:lang="en">Offline Viewing</source>
         <target xml:lang="sw">Kutazama bila kutumia intaneti</target>
         <note>ID: training.videos.offline</note>
       </trans-unit>
-      <trans-unit id="training.videos.download">
+      <trans-unit id="training.videos.download" approved="yes">
         <source xml:lang="en">If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer:</source>
         <target xml:lang="sw">Iwapo ungependa kupata video yoyote kati ya hizi kutoka kwenye mtandao ili kuonyesha au kusambaza wakati ambapo hakuna intaneti, unaweza kuweka video hizi kwenye kompyuta yako:</target>
         <note>ID: training.videos.download</note>
       </trans-unit>
-      <trans-unit id="training.videos.hires">
+      <trans-unit id="training.videos.hires" approved="yes">
         <source xml:lang="en">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">High Resolution</g> (Large files)</source>
         <target xml:lang="sw">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">Uthabiti wa Juu</g> (Faili kubwa)</target>
         <note>ID: training.videos.hires</note>
       </trans-unit>
-      <trans-unit id="training.videos.lores">
+      <trans-unit id="training.videos.lores" approved="yes">
         <source xml:lang="en">
           <g id="genid-11" ctype="x-html-a" html:href="http://tiny.cc/bloomSDVideos">Low Resolution</g> (Smaller files)</source>
         <target xml:lang="sw">

--- a/DistFiles/localization/sw/bloomEpubPreview.xlf
+++ b/DistFiles/localization/sw/bloomEpubPreview.xlf
@@ -2,89 +2,89 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="bloomEpubPreview-en.html" datatype="html" source-language="en" target-language="sw">
     <body>
-      <trans-unit id="epubpreview.describe">
+      <trans-unit id="epubpreview.describe" approved="yes">
         <source xml:lang="en">This is an <g id="genid-1" ctype="x-html-a" html:href="https://en.wikipedia.org/wiki/ePUB">ePUB</g> (e-book) version of your book. <g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">It contains audio, so that new readers can listen as they read.</g>
       </source>
         <target xml:lang="sw">Hii ni tafsiri ya  <g id="genid-1" ctype="x-html-a" html:href="https://en.wikipedia.org/wiki/ePUB">ePUB</g> (e-book) ya kitabu chako.<g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">Ina sauti, ili wasomi waweze kusikiliza wanaposoma.</g>
       </target>
         <note>ID: epubpreview.describe</note>
       </trans-unit>
-      <trans-unit id="epubpreview.recording.butnotalk">
+      <trans-unit id="epubpreview.recording.butnotalk" approved="yes">
         <source xml:lang="en">This book has some recordings, but this audio is not included in the ePUB.</source>
         <target xml:lang="sw">Kitabu hiki kina baadhi ya rekodi, lakini sauti hii haijajumuishwa katika ePUB.</target>
         <note>ID: epubpreview.recording.butnotalk</note>
       </trans-unit>
-      <trans-unit id="epubpreview.preview">
+      <trans-unit id="epubpreview.preview" approved="yes">
         <source xml:lang="en">Preview</source>
         <target xml:lang="sw">Onyesha</target>
         <note>ID: epubpreview.preview</note>
       </trans-unit>
-      <trans-unit id="epubpreview.resizing">
+      <trans-unit id="epubpreview.resizing" approved="yes">
         <source xml:lang="en">You can resize the preview by dragging the lower right corner of this simulated device. See how your book will look on screens of various sizes.</source>
         <target xml:lang="sw">Unaweza kubadilisha ukubwa wakati wa kuonyesha kwa kuvuta pembe ya chini ya upande wa kulia wa kifaa hiki kilichoigizwa. Tazama jinsi kitabu chako kitakavyoonekana kwenye skrini za ukubwa tofauti.</target>
         <note>ID: epubpreview.resizing</note>
       </trans-unit>
-      <trans-unit id="epubpreview.readium">
+      <trans-unit id="epubpreview.readium" approved="yes">
         <source xml:lang="en">This page uses the <g id="genid-3" ctype="x-html-a" html:href="http://readium.org/">Readium</g> ePUB reader. Books will likely look different on different readers.
       </source>
         <target xml:lang="sw">Ukurasa huu hutumia kifaa cha kusoma cha  <g id="genid-3" ctype="x-html-a" html:href="http://readium.org/">Readium</g> ePUB.  Huenda vitabu vikaonekana kuwa tofauti kwa wasomaji tofauti.
       </target>
         <note>ID: epubpreview.readium</note>
       </trans-unit>
-      <trans-unit id="epubpreview.talkingbookpreview">
+      <trans-unit id="epubpreview.talkingbookpreview" approved="yes">
         <source xml:lang="en">The preview here cannot yet play Talking Books. You can listen to it using Adobe's Free <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html">Digital Editions</g> e-book reader.
       </source>
         <target xml:lang="sw">Kwa kuonyesha hapa, bado haitawezekana kucheza Vitabu vilivyo na Sauti. Unaweza kuisikiza kwa kutumia <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html">Digital Editions</g> ya bure ya Adobe.  Kifaa cha kusoma e-book.
       </target>
         <note>ID: epubpreview.talkingbookpreview</note>
       </trans-unit>
-      <trans-unit id="epubpreview.ontodevice">
+      <trans-unit id="epubpreview.ontodevice" approved="yes">
         <source xml:lang="en">Getting this book onto your Device</source>
         <target xml:lang="sw">Kuweka Kitabu Hiki Kwenye Kifaa Chako</target>
         <note>ID: epubpreview.ontodevice</note>
       </trans-unit>
-      <trans-unit id="epubpreview.usingdropbox">
+      <trans-unit id="epubpreview.usingdropbox" approved="yes">
         <source xml:lang="en">A handy way to get books to your phone is to set up Dropbox or similar service on both your computer and your phone/tablet. Just click Save ePUB and then choose your Dropbox folder. On your phone, open the Dropbox app and select your book. If you are using a laptop, you can also try the free <g id="genid-5" ctype="x-html-a" html:href="http://www.ushareit.com/">ShareIt</g> program to send files from your laptop to a phone or tablet.
       </source>
         <target xml:lang="sw">Njia nzuri ya kutia kitabu kwenye simu yako ni kwa kuweka Dropbox au huduma sawa kwenye kompyuta yako na simu/tableti yako. bofya hifadhi ePUB na kisha uchague jalada lako la Dropbox. Kwenye simu yako, fungua Dropbox na uchague kitabu. Iwapo unatumia kipakatalishi, pia unaweza kujaribu programu isiyolipishwa ya <g id="genid-5" ctype="x-html-a" html:href="http://shareit.lenovo.com/">Shirikisha</g> ili kutuma faili kutoka kwa kipakatalishi chako hadi kwa simu au tableti.
       </target>
         <note>ID: epubpreview.usingdropbox</note>
       </trans-unit>
-      <trans-unit id="epubpreview.recommended.reader">
+      <trans-unit id="epubpreview.recommended.reader" approved="yes">
         <source xml:lang="en">Recommended Reader</source>
         <target xml:lang="sw">Kifaa cha kusoma Kilichopendekezwa</target>
         <note>ID: epubpreview.recommended.reader</note>
       </trans-unit>
-      <trans-unit id="epubpreview.gitden.okay">
+      <trans-unit id="epubpreview.gitden.okay" approved="yes">
         <source xml:lang="en">Our testing has shown <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Gitden Reader</g> to be a good choice for Android and IOS (IPhone &amp; IPad) devices.
       </source>
         <target xml:lang="sw">Majaribio yetu yameonyesha <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Kifaa cha kusoma cha Gitden</g> kuwa chaguo nzuri kwa vifaa vya Androidi na IOS (IPhoni &amp; IPadi).
       </target>
         <note>ID: epubpreview.gitden.okay</note>
       </trans-unit>
-      <trans-unit id="epubpreview.gitden.limits">
+      <trans-unit id="epubpreview.gitden.limits" approved="yes">
         <source xml:lang="en">To listen to this Talking Book using Gitden on a phone or tablet, you will need to disable Gitden's "Text To Speech" feature. Then it will show you the audio controls.</source>
         <target xml:lang="sw">Ili kusikiza Vitabu hivi vilivyo na Sauti kwa kutumia Gitden kwenye simu au tableti, utahitajika kuzima sehemu ya Gitden ya "Maandishi Hadi Usemi". Kisha itakuelekeza kwenye udhibiti wa sauti.</target>
         <note>ID: epubpreview.gitden.limits</note>
       </trans-unit>
-      <trans-unit id="epubpreview.make.it.talk">
+      <trans-unit id="epubpreview.make.it.talk" approved="yes">
         <source xml:lang="en">Make it Talk</source>
         <target xml:lang="sw">Ifanye kutoa Sauti</target>
         <note>ID: epubpreview.make.it.talk</note>
       </trans-unit>
-      <trans-unit id="epubpreview.talking.book.tool">
+      <trans-unit id="epubpreview.talking.book.tool" approved="yes">
         <source xml:lang="en">If you want to make a "Talking Book" that new readers can read-along with, use Bloom's <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">Talking Book Tool</g> to add voice recordings.
       </source>
         <target xml:lang="sw">Iwapo ungependa kutengeneza "Kitabu kilicho na sauti" ambacho wasomi wa mara ya kwanza wanaweza kutumia wanaposoma, tumia'  <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">Kifaa cha Kitabu kilicho na Sauti</g> cha Bloom kuongeza sauti zilizorekodiwa.
       </target>
         <note>ID: epubpreview.talking.book.tool</note>
       </trans-unit>
-      <trans-unit id="epubpreview.write.us">
+      <trans-unit id="epubpreview.write.us" approved="yes">
         <source xml:lang="en">Write to us!</source>
         <target xml:lang="sw">Tuandikie!</target>
         <note>ID: epubpreview.write.us</note>
       </trans-unit>
-      <trans-unit id="epubpreview.use.help.report">
+      <trans-unit id="epubpreview.use.help.report" approved="yes">
         <source xml:lang="en">Are you interested in distributing Bloom books for use on phones and other ebook readers? Is there something you would need us to do before it is useful for you? Please use the Help:Report A Problem command to send us feedback. Thanks!</source>
         <target xml:lang="sw">Je, ungependa kusambaza vitabu vya Bloom vya kutumia kwa simu na kwenye vifaa vingine vya kusoma vya mtandao? Je, kuna jambo ambalo ungependa tufanye kwanza lililo la muhimu kwako? Tafadhali tumia Usaindizi:Ripoti Tatizo amrisha kututumia majibu. Asante!</target>
         <note>ID: epubpreview.use.help.report</note>

--- a/DistFiles/localization/sw/leveledReaderInfo.xlf
+++ b/DistFiles/localization/sw/leveledReaderInfo.xlf
@@ -2,58 +2,58 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="leveledReaderInfo-en.html" datatype="html" source-language="en" target-language="sw">
     <body>
-      <trans-unit id="leveled.reader.vocabulary">
+      <trans-unit id="leveled.reader.vocabulary" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="sw">Msamiati</target>
         <note>ID: leveled.reader.vocabulary</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.simple">
+      <trans-unit id="leveled.reader.start.simple" approved="yes">
         <source xml:lang="en">At beginning levels, use simple words that are familiar to children. If it is possible in your language, use words with only one syllable. As children move up to higher levels, you can begin to use words with more syllables. You can begin to use less familiar words. Children should be able to guess the meaning of these less familiar words from the context of the surrounding words and sentences, as well as from the illustrations.</source>
         <target xml:lang="sw">Katika ngazi za mwanzo, tumia maneno rahisi ambayo yanajulikana kwa watoto.Iwapo itawezekana katika lugha yako, tumia maneno yaliyo na silabi moja. Watoto wanavyozidi kupanda ngazi za juu zaidi, unaweza ukaanza kutumia maneno yaliyo na silabi zaidi ya moja. Unaweza ukaanza kutumia maneno yasiyojulikana sana. Watoto wanapaswa kuweza kubahatisha maana ya maneno haya yasiyojulikana kwao sana kutokana na mazingira ya maneno na sentensi zinazowazingira, na pia kutokana na maelezo.</target>
         <note>ID: leveled.reader.start.simple</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.formatting">
+      <trans-unit id="leveled.reader.formatting" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="sw">Kubadilisha Muundo</target>
         <note>ID: leveled.reader.formatting</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.large">
+      <trans-unit id="leveled.reader.start.large" approved="yes">
         <source xml:lang="en">Beginner readers will benefit from a larger font with clear spacing between words. Having the words or sentences in the same location on each page is also helpful. As readers progress to higher levels, font size and spacing will decrease and sentences can appear in different locations on the page.</source>
         <target xml:lang="sw">Wasomaji wanaoanza kujifunza watanufaika kutokana na fonti kubwa zaidi iliyo na nafasi kati ya maneno. Kuwa na maneno au sentensi kwenye eneo moja kwa kila ukurasa pia unasaidia. Jinsi msomaji anavyoendelea kwa ngazi za juu zaidi, ukubwa wa fonti na nafasi inayoachwa itapungua na sentensi zinaweza kuonekana katika maeneo tofauti kwenye ukurasa.</target>
         <note>ID: leveled.reader.start.large</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.increase.sizes">
+      <trans-unit id="leveled.reader.increase.sizes" approved="yes">
         <source xml:lang="en">To increase the font size, line-spacing, and word-spacing in Bloom, click in a text box and then on the grey "cog" icon in the lower left-hand corner. If you do this and then make a template book, books made with that template will also use those font settings.</source>
         <target xml:lang="sw">Ili kuongeza ukubwa wa fonti, bofyai kwenye kisanduku cha matini na kisha kwenye alama ya "cog" iliyo na rangi ya kijivu katika pembe iliyo chini kwenye upande wa mkono wa kushoto. Iwapo utafanya hivi na kisha utengeneze kitabu cha kielelezo, vitabu vilivyotengenezwa kwa kielelezo hicho pia vitatumia mpangilio huo wa ukubwa wa fonti.</target>
         <note>ID: leveled.reader.increase.sizes</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.predictability">
+      <trans-unit id="leveled.reader.predictability" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="sw">Uwezekano wa kutabiriwa</target>
         <note>ID: leveled.reader.predictability</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repeat.patterns">
+      <trans-unit id="leveled.reader.repeat.patterns" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-em">Predictability</g> in a text means that the reader can guess what would come next. You can increase predictability by using repeated patterns. Here are some patterns you can use:</source>
         <target xml:lang="sw"> <g id="genid-1" ctype="x-html-em">Uwezekano wa kutabiriwa</g>katika maandishi inamaanisha kuwa msomaji anaweza kubashiri kitakachofuata. Unaweza kuongeza uwezo wa kutabiri kwa kutumia mtindo wa kurudia. Hapa ni baadhi ya mitindo unayoweza kutumia:</target>
         <note>ID: leveled.reader.repeat.patterns</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repetition">
+      <trans-unit id="leveled.reader.repetition" approved="yes">
         <source xml:lang="en">Repetition - repeating parts of the text, for example, using the same sentence with each page and just changing one word in the sentence</source>
         <target xml:lang="sw">Kurudia - kurudia sehemu ya maandishi, kwa mfano, kutumia sentensi sawa kwa kila ukurasa na kubadilisha tu neno moja katika sentensi</target>
         <note>ID: leveled.reader.repetition</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.sequencing">
+      <trans-unit id="leveled.reader.sequencing" approved="yes">
         <source xml:lang="en">Sequencing - a story with a known sequence such as the days of the week or that uses numbers in a pattern</source>
         <target xml:lang="sw">Kufululiza - Hadithi iliyo na mfululizo unaojulikana kama vile siku za wiki au ile inayotumia nambari katika mtindo</target>
         <note>ID: leveled.reader.sequencing</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.building.sequence">
+      <trans-unit id="leveled.reader.building.sequence" approved="yes">
         <source xml:lang="en">Building Sequence - a story with a pattern that is repeated and added to with each new page</source>
         <target xml:lang="sw">Kujenga mfululizo - hadidhi iliyo na mfululizo uliorudiwa na kuongezewa kwa kila ukurasa mpya</target>
         <note>ID: leveled.reader.building.sequence</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.rhyme">
+      <trans-unit id="leveled.reader.rhyme" approved="yes">
         <source xml:lang="en">Rhyme - a story with a pattern or sequence that also includes rhyme. For example:
         <g id="genid-2" ctype="x-html-blockquote" html:class="poetry">
           <g id="genid-3" ctype="x-html-pre">Brown Bear, Brown Bear, What do you see?
@@ -76,64 +76,64 @@ duku duku lemba kwa fuus!</g>
       </target>
         <note>ID: leveled.reader.rhyme</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations">
+      <trans-unit id="leveled.reader.illustrations" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="sw">Usaidizi wa michoro</target>
         <note>ID: leveled.reader.illustrations</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.help">
+      <trans-unit id="leveled.reader.illustrations.help" approved="yes">
         <source xml:lang="en">Illustrations provide support to the story. Illustrations relate to the story in different ways at different <g id="genid-5" ctype="x-html-em">levels</g> and for different types of readers (see below). Remember that in many cultures that don't have a lot of printed material around, complex pictures may be difficult to understand.
     </source>
         <target xml:lang="sw">Maelezo hupeana usaidizi kwa hadithi. Maelezo huhusiana na hadithi kwa njia tofauti kwa ngazi tofauti <g id="genid-5" ctype="x-html-em">ngazi</g> na kwa wasomajii wa aina mbalimbali (tazama hapa chini). Kumbuka kuwa katika tamaduni nyingi ambazo huwa hazina maandishi mengi yaliyochapiswa, inaweza kuwa vigumu kuelewa picha ngumu.
     </target>
         <note>ID: leveled.reader.illustrations.help</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.emergent.reader">
+      <trans-unit id="leveled.reader.illustrations.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-6" ctype="x-html-strong">Emergent Readers</g> the pictures should closely match the storyline. The reader should be able to predict the story line just by looking at the pictures. The illustrations at this level should be simple.
       </source>
         <target xml:lang="sw">Kwa <g id="genid-6" ctype="x-html-strong">Wasomaji wanaoibuka</g> picha zinapaswa kufanana kwa karibu na mfuatano wa hadithi. Msomaji anapaswa kuwa na uwezo wa kubahatisha mfuatano wa hadithi kwa kutazama picha tu. Maelezo katika ngazi hii yanapaswa kuwa rahisi.
       </target>
         <note>ID: leveled.reader.illustrations.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.early.reader">
+      <trans-unit id="leveled.reader.illustrations.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-7" ctype="x-html-strong">Early Readers</g> the pictures should offer some support to the story line. As the amount of text increases, the reader is less reliant on the pictures and gets more meaning from the text. The illustrations can be more complex.
       </source>
         <target xml:lang="sw">Kwa <g id="genid-7" ctype="x-html-strong">Wasomaji wa mapema</g> picha zinapaswa kupeana baadhi ya usaidizi kwa mfuatano wa hadithi. Jinsi kiwango cha matini kinavyoongezeka, msomaji anaendelea kutotegemea picha sana na kupata maana zaidi kutoka kwa maandishi. Michoro inaweza kuwa magumu.
       </target>
         <note>ID: leveled.reader.illustrations.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.fluent.reader">
+      <trans-unit id="leveled.reader.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-8" ctype="x-html-strong">Fluent Readers</g> the pictures should offer little or no support to the story line. The reader relies more on the text than the pictures for meaning. The illustrations can be even more complex.
       </source>
         <target xml:lang="sw">Kwa <g id="genid-8" ctype="x-html-strong">Msomaji aliye na ufasaha</g> picha zinapaswa kupeana usaidizi mdogo au kutosaidia kabisa katika kuelewa mfuatano wa hadithi. Msomaji anategemea sana matini kuliko picha ili kupata maana. Maelezo hata yanaweza kuwa magumu zaidi.
       </target>
         <note>ID: leveled.reader.fluent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice">
+      <trans-unit id="leveled.reader.topic.choice" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="sw">Uchaguzi wa Mada</target>
         <note>ID: leveled.reader.topic.choice</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.discussion">
+      <trans-unit id="leveled.reader.topic.choice.discussion" approved="yes">
         <source xml:lang="en">Books can be on many topics. When developing books for beginning readers, choose topics that are familiar to them. Readers will be eager to read and will read more if they are reading about things they find interesting and familiar. For more experienced readers, topics can include information that the reader is not already familiar with.</source>
         <target xml:lang="sw">Vitabu vinaweza kuwa na mada tofauti. Unapotengeneza vitabu vya wasomaji wanaoanza kujifunza, chagua mada zinazojulikana kwao. Wasomaji watakuwa na hamu ya kusoma na watasoma zaidi iwapo wanasoma kuhusu vitu wanavyopata kuwa vya kupendeza na wanavyovijua. Kwa wasomaji walio na tajriba zaidi, mada zinaweza kujumuisha habari ambayo msomaji tayari hajui kuihusu.</target>
         <note>ID: leveled.reader.topic.choice.discussion</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.emergent.reader">
+      <trans-unit id="leveled.reader.topic.choice.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-9" ctype="x-html-strong">Emergent Readers</g> the book should be concrete, should focus on one idea/theme, and should be familiar and easy to understand.
       </source>
         <target xml:lang="sw">Kwa <g id="genid-9" ctype="x-html-strong">Wasomaji wanaoibuka</g> kitabu kinapaswa kuwa kimekamilika, kinapaswa kulenga maudhui/dhana moja, kinapaswa kuwa kinajulikana na rahisi kukielewa.
       </target>
         <note>ID: leveled.reader.topic.choice.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.early.reader">
+      <trans-unit id="leveled.reader.topic.choice.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-10" ctype="x-html-strong">Early Readers</g>, develop a story around a familiar concept but in greater depth.
       </source>
         <target xml:lang="sw">Kwa <g id="genid-10" ctype="x-html-strong">Wasomaji wa mapema</g>, endeleza hadithi inayozunguka dhana fulani inayojulikana lakini kwa undani zaidi.
       </target>
         <note>ID: leveled.reader.topic.choice.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.fluent.reader">
+      <trans-unit id="leveled.reader.topic.choice.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-11" ctype="x-html-strong">Fluent Readers</g> the concepts can expand beyond what is familiar, be more varied, and be abstract.
       </source>
         <target xml:lang="sw">Kwa <g id="genid-11" ctype="x-html-strong">Msomaji fasaha</g> dhana zinaweza kupanuka kupita yale yanayojulikana, yawe ya aina nyingi zaidi, na dhahani.

--- a/DistFiles/localization/ta/Bloom.xlf
+++ b/DistFiles/localization/ta/Bloom.xlf
@@ -2,2300 +2,2300 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="ta" datatype="plaintext" product-version="3.0.53.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="ta">Decodable படிப்பான் கருவி</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="ta">மறுக்கும் படிப்பான் கருவி</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="ta">மேலும்...</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="ta">Bloom தொகுப்பு நிறுவல்</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="ta">இந்த {0} தொகுப்பு தற்போது இந்தக் கணினியில் பயன்படுத்த தயார்.</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="ta">Bloom தொடங்கப்பட முடியவில்லை அந்த Bloom கட்டை நிறுவு</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="ta">இதிலிருந்து பகுதி நகலெடுக்கிறது...</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while BloomPacks are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="ta">Bloom ஏற்கனவே இயங்குகிறது, ஆனால் அடுத்த முறை நீங்கள் Bloom இயக்க up until உள்ளடக்கங்களை காண்பிக்க இருக்கும்</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="ta">திறக்கிறது {0}...</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text in boxes with '{1}' style</source>
         <target xml:lang="ta">அனைத்து {0} உரை பெட்டிகளிலும் '{1}' பாணியுடன் உள்ளது இந்த வடிவமைத்தல்</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="ta">மேம்பட்ட நிரல் அமைப்புகள்</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="ta">பசோதனை கட்டளைகள் (எ.கா. ஏற்றுமதி XML-InDesign) காண்பி</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="ta">பசோதனை வார்ப்புருக்கள் (எ.கா. படம் அகராதி) காண்பி</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="ta">நினைவக பயன்பாடு கொண்ட பெரிய படிமங்கள் குறைக்க உருவம் சேவையகம் பயன்படுத்து.</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="ta">(பசோதனை) அனுப்பு/பெறு கட்டுப்பாடுகள் காண்பி</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="ta">புத்தகத்தை வெளியிடுகிறார்</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="ta">இயல்புநிலை எழுத்துருவை {0}</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="ta">முன்/பின் விவகாரத்தை கட்டு</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="ta">வலமிருந்து இடமாக எழுதும் முறைமை</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="ta">அமைப்புகள்</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="ta">மாற்று...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="ta">மொழி 1</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="ta">மொழி 2</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="ta">மொழி 3</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="ta">மொழிகள்</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="ta">அமை...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="ta">நாட்டு(அ)மாவட்ட மொழி</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="ta">மொழி 2 (எ.கா. தேசிய மொழி)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="ta">மொழி 3 (எ.கா. பிராந்திய மொழி) (விருப்ப)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="ta">நீக்கு</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="ta">Bloom தொகுப்பு பெயர்</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="ta">நாடு</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="ta">மாவட்ட</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="ta">திட்டம் தகவல்</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="ta">மாகாணம்</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="ta">மறுதொடக்கம்</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="ta">Bloom இருக்கும் மூடிய பின் மறுபடி திறந்து புதிய அமைப்புகளுடன் இந்த திட்டம்.</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book, but these programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="ta">Bloom இந்த HTML ஆவணத்தை உங்கள் சொற்செயலி நிரலில் (இயல்பாக சொல் அல்லது மையம் Office) திறக்கும் இப்போது. நீங்கள் உரை மற்றும் இந்த புத்தகத்தில் படிமங்கள் வேலை இருக்கும், ஆனால் இந்த நிரல்களை உருவமைப்பு, எனவே வேண்டாம் எதிர்பார்க்கும் அதிகம் பரப்பவும் கொண்டு மிக நன்றாக இயல்பாக வேண்டாம்.</target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="ta">புத்தகம் புதுப்பி</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="ta">சிறு உருவம் புதுப்பித்தல்</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="ta">புத்தகம் நீக்கு</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="ta">சொல் அல்லது மையம் Office ஏற்றுமதி...</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="ta">ஏற்றுமதி செய் XML-InDesign...</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="ta">BloomLibrary.org நூல்களுக்கு</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="ta">அனைத்து புத்தகங்களை புதுப்பித்தல்கள் வேண்டாம்</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="ta">அனைத்து புத்தகங்களை காசோலைகளை வேண்டாம்</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="ta">காணாமல் போன படிமங்கள் மீட்க...</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="ta">தொகுப்பு வரலாறு...</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="ta">தொகுப்பு குறிப்புகள்...</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="ta">தொகுப்புகள்</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="ta">தொகுப்புகள்</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="ta">அந்த புத்தகம் '{0}'</target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="ta">வட்டில் கோப்புறை திற</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="ta">சுகாதார</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <target xml:lang="ta">இந்த மூல பயன்படுத்தி ஒரு புத்தகம் உருவாக்கு</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="ta">மற்ற தொகுப்பு</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="ta">மாதிரி உதிரிபாகங்கள்</target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="ta">அனுப்பு/பெறு</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="ta">அமைப்புகள்</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ta">மூல தொகுப்பை</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="ta">கோப்புறை திற கூடுதல் தொகுப்புகள்</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="ta">வார்ப்புருக்கள்</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="ta">இந்த புத்தகம் திருத்து</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="ta">Bloom கட்டு அமை</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template BloomPack...</source>
         <target xml:lang="ta">படிப்பவர் வார்ப்புரு BloomPack அமை...</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="ta">மேம்பட்ட</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="ta">At BloomLibrary.org புத்தகங்கள் மூலம் பெற</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ta">மூல தொகுப்பை</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="ta">புதிய புத்தகங்கள் வட்டாரங்கள்</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="ta">இந்தத் தொகுப்பில் பூட்டப்பட்டுள்ளது, எனவே புதிய புத்தகங்கள் சேர்க்க/நீக்க முடியாது.</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="ta">மூல தொகுப்பை இது, Bloom இல்லை காலகட்டத்தில் எந்த தற்போதுள்ள உதிரிபாகங்கள் இவ்வாறு புதிய உதிரிபாகங்கள் வட்டாரங்கள். ஒரு மொழி ஒரு கூடு சேர்க்க வேண்டுமானால், அதற்கு பதிலாக வேண்டும் கூடு கொண்ட அல்லாமல் அதன் நகல் ஈட்டும் தொகுப்பு திருத்து. மேலும், சுவர் காலண்டரை தற்போது பயன்படுத்த முடியாது ஒரு புதிய கூடு ஏற்படுத்த.</target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="ta">மேலும்...</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="ta">புதிய உதிரிபாகங்கள் வட்டாரங்கள்</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="ta">பின்</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="ta">ரத்து செய்</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="ta">ரத்து செய்</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="ta">பூர்த்தி செய்</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="ta">உதவி</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="ta">அடுத்த</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="ta">அடுத்த</target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="ta">சரி</target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="ta">சரி</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="ta">விருப்ப</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="ta">கட்டிடம்...</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="ta">இந்த நிலையில் உள்ள எழுத்துக்கள்</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="ta">ஒரு எழுத்து மற்றும் சொல் பட்டியல் கோப்பை திறக்க</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="ta">கட்டத்தில் அமை</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="ta">நிலை</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="ta">நிலை இருந்த</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="ta">இந்த நிலையில் வார்த்தைகளை</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections. If you don't seem to be in the middle of doing something, Bloom will select it for you.</source>
         <target xml:lang="ta">உங்கள் பதிவிறக்கம் ({0}) நிறைவடைந்தது. உங்கள் தொகுப்புகள், 'புத்தகங்கள் Bloom நூலகத்தில் இருந்து' பிரிவு அது நீங்கள் காண முடியும். நீங்கள் ஏதோ செய்கிறது மத்தியை இருக்க வேண்டாம் தான், என்றால் Bloom தேர்ந்தெடுத்து கொள்கிறேன் உங்களுக்காக.</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="ta">பதிவிறக்கம் நிறைவடைந்தது</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="ta">புத்தகம் பதிவிறக்குகிறது</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="ta">உங்கள் புத்தகம் பதிவிறக்கம் சிக்கல் ஏற்பட்டுள்ளது.</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="ta">நீங்கள் எங்கோ புத்தகத்தை பற்றி மேலும் தகவல் வைக்க, இருந்தால், பின் முகப்பு உள் இது இந்த பக்கம் பயன்படுத்தலாம்.</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="ta">நீங்கள் எங்கோ புத்தகத்தை பற்றி மேலும் தகவல் வைக்க, இருந்தால் மாறி பின் முகப்பு இது இந்த பக்கம் பயன்படுத்தலாம்.</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the Html used to make this PDF, in Firefox (must be on path)</source>
         <target xml:lang="ta">திற, Html பயன்படும் இந்த PDF, Chrome (இருக்க வேண்டும் பாதை) செய்யவும்</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="ta">மன்னிக்கவும், பதிப்புரிமை மற்றும் இந்த புத்தகம் உரிமம் மாற்ற முடியாது.</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="ta">மன்னிக்கவும், இந்த புத்தகம் பூட்டப்பட்டுள்ளது கீழே அதனால் படிமங்கள் மாற்ற முடியாது.</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="ta">உண்மையிலேயே பக்கத்தை நீக்கு?</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="ta">நீக்கு</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="ta">இப்பக்கம் கடைசியாக நிரந்தரமாக நீக்கப்படும்.</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="ta">திருத்து</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="ta">நடப்பு தேர்ந்தெடுத்த எழுத்துரு என்பது '{0}', ஆனால் அது நிறுவப்படவில்லை இந்தக் கணினியில். மற்ற சில எழுத்துரு பயன்படுத்தப்படும்.</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="ta">போது நீங்கள் ஒரு மூல புத்தகம் குறித்து, எழுத்தாளர்கள், illustrators, அரசியல்வாதிகளாகவும், ஆகிய செய்த பங்களிப்புகள் பதிவிட இந்த பெட்டியை பயன்படுத்தவும்.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="ta">ஒரு புத்தகத்தில் இருந்து ஒரு கூடு மேற்கொள்ளும்போது, இந்தப் பெட்டியைப் பயன்படுத்தி மொழிபெயர்ப்பு யார் இட்டு கூறுங்கள்.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="ta">புத்தக தலைப்பு உள்ள {lang}</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright &amp; License</source>
         <target xml:lang="ta">பதிப்புரிமை &amp; உரிமம் திருத்து கிளிக் செய்யவும்</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="ta">இதனை பயன்படுத்த எந்த நல்கை வழங்குவதற்கான.</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="ta">சர்வதேச நிலையான புத்தக எண். இல்லையெனில் இவற்றுள் வெறுமையாக விடவும்.</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="ta">அசல் (அல்லது கூடு) ஒப்புகை உள்ள {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="ta">எழுத்தாளர்கள், விளக்கமளிப்பவரான, அரசியல்வாதிகளாகவும், முதலிய, {lang} செய்த பங்களிப்புகள்</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="ta">தலைப்பை தேர்வு செய்ய கிளிக் செய்யவும்</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="ta"> விளக்கமளிப்பவரான மொழிபெயர்ப்பதற்கு பதிப்பிற்கு, {lang}</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="ta">உருவத்தை மாற்று!!</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, &amp; License</source>
         <target xml:lang="ta">உருவம் வரைவுகள் , பதிப்புரிமை, &amp; உரிமம் திருத்து</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="ta">உருவம் ஒட்டு</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="ta">வடிவமைப்பை மாற்று</target>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="ta">ஒரு உருவத்தை நீங்கள் ஒட்டலாம், முன் வேறு நிரலில் இருந்து ஒரு இழு உங்கள் 'கிளிப்போர்டு', நகலெடு.</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="ta">பக்கங்கள்</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="ta">ஒரு பக்க அளவு மற்றும் திசையை தேர்ந்தெடு</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="ta">கரை மற்றும் பின்னணி மாற்ற</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="ta">எழுத்துரு முகத்தை மாற்ற</target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="ta">அனைத்து பெட்டிகளை சுமந்து பாணி '{0}' மற்றும் மொழி '{1}' உரை அளவை மாற்றும்.\n{2} தமிழகத்தில் நடப்பு அளவு உள்ளது.</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="ta">எழுத்துரு அளவை மாற்ற</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="ta">உரையின் வரிகள் இடையே இடைவெளி மாற்ற</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="ta">கூடுதல் உலகத்தின்</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="ta">சராசரி</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="ta">சொற்களை இடையே இடைவெளி மாற்ற</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="ta">அகலம்</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="ta">பாணி வடிவமைப்பு சரிசெய்</target>
         <note>ID: EditTab.FormatDialogTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="ta">வார்ப்புரு பக்கங்கள்</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="ta">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="ta">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="ta">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="ta">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="ta">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="ta">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="ta">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="ta">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="ta">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="ta">அகர வரிசை</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="ta">அடிப்படை உரை &amp; உருவம்</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="ta">அடிப்படை உரை &amp; படம்</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="ta">வரைவு பக்கம்</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="ta">விருப்பம்</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="ta">நாள் 1</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="ta">நாள் 2</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="ta">நாள் 3</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="ta">நாள் 4</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="ta">நாள் 5a</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="ta">நாள் 5b</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="ta">முன்னணி முகப்பு</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="ta">கீழ் பிம்பத்தை</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="ta">நடு பிம்பத்தை</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="ta">உள்ளே பின் முகப்பு</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="ta">உள்ளே முன்னணி முகப்பு</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="ta">நெறிமுறைகள்</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="ta">வெறும் உரை</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="ta">ஒரு படத்தை வெறும்</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="ta">ஒரு உருவத்தை மட்டும்</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="ta">வெளியே பின் முகப்பு</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="ta">படம் &amp; சொல்</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="ta">கீழே உள்ள படம்</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="ta">மத்தியில் உள்ள படத்தை</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="ta">இப்பக்கம் கடைசியாக தெரிந்தே வெற்றாக இருக்கிறது</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="ta">தலைப்பு பக்கம்</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="ta">பன்மொழி அமைப்புகள்</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="ta">நகல்</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="ta">வெட்டு</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTip">
+      <trans-unit id="EditTab.CutButton.ToolTip" approved="yes">
         <source xml:lang="en">Cut (Ctrl-x)</source>
         <target xml:lang="ta">(Ctrl-x) வெட்டு</target>
         <note>ID: EditTab.CutButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can cut it</source>
         <target xml:lang="ta">நீங்கள் நீங்கள் அதை வெட்ட முடியும் முன் சில உரையை தேர்ந்தெடுக்க வேண்டும்</target>
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="ta">நீக்கு \nபக்கம்</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTip">
+      <trans-unit id="EditTab.DeletePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Remove this page from the book</source>
         <target xml:lang="ta">இப்பக்கம் கடைசியாக புத்தகத்தில் இருந்து அகற்று</target>
         <note>ID: EditTab.DeletePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be removed</source>
         <target xml:lang="ta">இப்பக்கம் கடைசியாக நீக்க முடியாது</target>
         <note>ID: EditTab.DeletePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="ta">நகல் பக்கம்</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
         <target xml:lang="ta">இதை, பிரதி இது ஒரு புதிய பக்கத்தை செருகு</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be duplicated</source>
         <target xml:lang="ta">இப்பக்கம் கடைசியாக படியெடுக்க இயலாது</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="ta">ஒட்டு</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTip">
+      <trans-unit id="EditTab.PasteButton.ToolTip" approved="yes">
         <source xml:lang="en">Paste (Ctrl+v)</source>
         <target xml:lang="ta">ஒட்டு (Ctrl + v)</target>
         <note>ID: EditTab.PasteButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing on the Clipboard that you can paste here.</source>
         <target xml:lang="ta">எதுவும் இல்லை என்று நீங்கள் இங்கே ஒட்டலாம் கிளிப்போர்டில்.</target>
         <note>ID: EditTab.PasteButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="ta">செயல்தவிர்</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTip">
+      <trans-unit id="EditTab.UndoButton.ToolTip" approved="yes">
         <source xml:lang="en">Undo (Ctrl+z)</source>
         <target xml:lang="ta">(Ctrl + z) செயல்தவிர்</target>
         <note>ID: EditTab.UndoButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="ta">இரண்டு மொழிகள்</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="ta">அனைத்து மற்ற படங்கள் இந்த புத்தகத்தில் இந்த தகவலை நகலெடுக்க?</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="ta">இந்த விருப்பம் கிடைக்கத்தக்கதாய் மட்டும் வெளியிடு தாவலில்.</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="ta">ஒரு மொழி</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="ta">மற்ற வடிவமைப்பு விருப்பங்கள் இல்லை இந்த வார்ப்புருவிற்கு உள்ளன.</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="ta">படம் அறிவுசார் தகவல்</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="ta">மூன்று மொழிகள்</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="ta">கட்டிடம் படிப்பவர் வார்ப்புருக்கள்</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu">
+      <trans-unit id="HelpMenu.Help Menu" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="ta">உதவி</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="ta">படிப்பவர் வார்ப்புருக்கள் பயன்படுத்தி</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="ta">கருத்தளிக்க</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="ta">வலை தளம்</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="ta">பார் புதிய பதிப்பு</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="ta">Bloom பற்றி</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <target xml:lang="ta">ஆவணப்படுத்தல்</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="ta">பதிவு</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="ta">வெளியீட்டு அறிக்கை...</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="ta">நிகழ்வு பதிவை காண்பி</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="ta">இண்டிசைன் XML தகவல்</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="ta">இதனை மீண்டும் காண்பிக்க வேண்டாம்</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="ta">A4நிலைபரப்பு </target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="ta">A4நிலைபரப்பு அருகருகே</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="ta">A4நிலைபரப்பு பக்கங்கள் முழுவதும் பிரிந்தது</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="ta">A4 உருவப்படம்</target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="ta">A5Landscape</target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="ta">A5 உருவப்படம்</target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="ta">A5 உருவப்படம் கீழே சீரமை</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="ta">B5 உருவப்படம்</target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="ta">சரியான</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="ta">தலைப்பை இடம்பெயர</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="ta">இந்த நிலை</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="ta">வடிவமைத்தல்</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration support</source>
         <target xml:lang="ta">சித்திரம் ஆதரவு</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="ta">மனதில் வைத்துக்</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="ta">நிலை</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> of </source>
         <target xml:lang="ta">உடைய</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="ta">மேக்ஸ்</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="ta">ஒரு பக்கத்திற்கு</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="ta">ஒரு வாக்கியத்தை</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="ta">கணிப்பது</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="ta">நிலைகள் அமை</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="ta">இந்த புத்தகம்</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="ta">இப்பக்கம் கடைசியாக</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="ta">மொத்த</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="ta">பிரத்யேக</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="ta">சொல்லகராதி</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="ta">சொல் எண்ணிக்கை</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="ta">நான் உடன்படுகிறேன் என்பதைக் Bloom நூலகத்தில் பயன்படுத்தும் விதிகள்</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="ta">மின்னஞ்சல் முகவரி</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="ta">கடவுச்சொல் மறந்து</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="ta">உள்நுழைவு</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="ta">கடவுச்சொல்</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="ta">விதிமுறைகள் காண்பி</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="ta">புகுபதிகை செய்ய BloomLibrary.org</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="ta">கடவுச்சொல் காண்பி</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="ta">அந்த பெயர், &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;இல் தொகுப்பு ஏற்கனவே உள்ளது.\nதயவுசெய்து தனித்துவ பெயர் எடுக்கவும்.</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="ta">இந்த சேகரிப்பிற்கான முக்கிய மொழியை தேர்வு செய்யவும்</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="ta">உதாரணங்கள்: "உடல் புத்தகங்கள்", "PNG விலங்கு கதைகள்"</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="ta">என்ன விரும்புகிறீர்கள் இந்தத் தொகுப்பில் அழைப்பு?</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="ta">தொகுப்பு பெயர் கோளாறு</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="ta">தொகுப்பு உருவாக்கப்படும்: {0}</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="ta">புதிய தொகுப்பு உருவாக்க தயாராக</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="ta">தொகுப்பு வகை தேர்ந்தெடுக்கவும்</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="ta">மூல தொகுப்பை</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org and optionally make a BloomPack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="ta">ஒன்று அல்லது மேற்பட்ட மொழிகளில் விரிந்த இண்டர்நெட் கூடு அல்லது வார்ப்புரு தொகுப்பை புத்தகங்களில். நீங்கள் செய்ய BloomLibrary.org இந்த உதிரிபாகங்கள் பதிவேற்றும் மற்றும் optionally எனவே அவர்கள் உடன் உங்கள் உதிரிபாகங்கள் vernacular புத்தகங்கள் எளிதாக மற்றவர்களுக்கு அளிக்க ஒரு BloomPack ஏற்படுத்து முடியும் இருக்கும்.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="ta">நாட்டு(அ)மாவட்ட/உள்ளூர் மொழி தொகுப்பு</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="ta">உள்ளூர் மொழி ஒரு வசூல்.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="ta">மொழி இருப்பிடத்தை அளிக்கவும்</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="ta">நாடு</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="ta">மாவட்ட</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="ta">விருப்ப உள்ளன. Bloom இருக்கும் இடத்தில் அவற்றை நீங்கள் உருவாக்க புத்தகங்களை தலைப்பு பக்கத்தில் வலது இடங்களில்.</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="ta">மாகாணம்</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="ta">{0} புத்தகங்கள்</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="ta">புதிய Bloom தொகுப்பை உருவாக்க</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="ta">திட்டப்பணி பெயர்</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="ta">அந்த பெயரை பயன்படுத்தி ஒரு புதிய தொகுப்பை உருவாக்க இயலவில்லை.</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="ta">Bloom வருக!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="ta">புத்தகங்கள் ஈட்டும் தொடங்க ஏறக்குறைய தயாராக உள்ளீர்கள்.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. So the first thing we need to do is make one for you.</source>
         <target xml:lang="ta">எளிய மற்றும் ஒருங்கிணைக்கப்பட்ட விஷயங்களை வைத்துக், வகையில் Bloom ஒன்று அல்லது மேற்பட்ட &lt;i&gt;தொகுப்புகள்&lt;/i&gt;நீங்கள் செய்யவும் அனைத்து புத்தகங்கள் உருளும். எனவே நாம் மேற்கொள்ள முதல் விஷயம் உள்ளது ஒன்று உங்களுக்காக செய்யவும்.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="ta">தொடங்குவதற்கு 'அடுத்து' கிளிக் செய்யவும்.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="ta">Bloom தொகுப்புகள்</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="ta">இந்தக் கணினியில் மற்றொரு தொகுப்பு உலாவு</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="ta">உள்பகுதி பிணையத்தில் கோரஸ் மையமாக இருந்து நகலெடு</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="ta">இணைய இருந்து நகலெடு</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="ta">USB இயக்ககத்தில் இருந்து நகலெடு</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="ta">புதிய தொகுப்பு உருவாக்க</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="ta">திற/உருவாக்க தொகுப்புகள்</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="ta">மேலும் படிக்க</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="ta">செய்துள்ளது வேறொருவர் பயன்படுத்த அனுப்பு/பெறு ஒரு தொகுப்பை உங்களுடன் பகிர?\nபயன்பாடு இந்த சிவப்பு பொத்தான்கள் அவர்களின் தொகுப்பு உங்கள் கணினியில் நகலெடுக்க ஒன்றை.\nபின்னர், அவர்களுடன் மீண்டும் உங்கள் பணி பகிர அனுப்பு/பெறு பயன்படுத்தவும்.</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="ta">தற்போதுள்ள மாற்றிடு</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="ta">அறிவிப்பு</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are</source>
         <target xml:lang="ta">அந்த மாற்றம் அனுமதிக்கப்படாது. அவை முன்னணியில் விவகாரம் மற்றும் பின் விவகாரத்தை பக்கங்கள் இருங்கள்</target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="ta">செல்லுபடியாகா நகர்த்தல்</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="ta">தயவுசெய்து உங்கள் நிறைவடைந்த புத்தக Bloom காண்பிக்க முடியும் என்று அடோப் ரீடர் நிறுவ. அதன்பின் வரை நீங்கள் இன்னும் PDF புத்தகம் சேமிக்க மற்றும் சில மற்ற நிரலில் திறக்கவும்.</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="ta">புதுப்புது தான்... கொடுத்த பிழை காண்பி முயலும் போது அடோப் ரீடர் அந்த PDF. நீங்கள் இன்னும் முயற்சி செய்யலாம், PDF புத்தகம் சேமிக்கிறது.</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="ta">பலமின்மை செய்தி. Bloom கண்டறிய உங்கள் நிறைவடைந்த புத்தக Bloom காண்பிக்க முடியாது அதனால் இங்கே காட்ட அடோப் ரீடர் பெற முடியும்.\nதயவுசெய்து நிறுவல்நீக்கம் உங்கள் தற்போதுள்ள பதிப்பில் 'அடோப் ரீடர்' மற்றும் 'அடோப் ரீடர்' நிறுவ (re).\nநீங்கள் நிலையான என்று பெற, வரை நீங்கள் இன்னும் PDF புத்தகம் சேமிக்க மற்றும் சில மற்ற நிரலில் திறக்கவும்.</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="ta">கையேடு உட்பக்கம்	</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book.
  Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="ta">உள்ளே இருந்து ஒரு கையேடு ஏற்படுத்து புத்தகத்தின் பக்கங்கள்.
  பக்கங்கள் வைக்கப்பட்டிருப்பதை மற்றும் அதனால் போது நீங்கள் அதை fold, நீங்கள் ஒரு கையேடு அவகாசம் இருக்கும் reordered இருக்கும்.(-999)</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="ta">பதிவேற்றும்</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="ta">BloomLibrary.org, எங்கே மற்றவர்கள் முடியும் தகவலிறக்கம் செய்து தங்கள் சொந்த மொழி-ஐ மொழிமாற்றம் இதில் பதிவேற்றும்.</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="ta">கையேடு முகப்பு</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="ta">அணி வெறும் ஒரு PDF உருவாக்கு மற்றும் (இரு தரப்பும்), பின், அச்சிடும் வண்ண காகிதம்.</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="ta">எளிய</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="ta">புத்தகத்தின் ஒரு காகித வலைப்பின்னலின் ஒரு பக்கம் ஒவ்வொரு பக்கத்தின் ஒரு PDF செய்யவும்.</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system pdf viewer</source>
         <target xml:lang="ta">இயல்புநிலை முறைமை pdf காட்டி, PDF திறக்கவும்</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="ta">அச்சிடு...</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="ta">பிரசுரி</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="ta">PDF சேமி...</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="ta">பயிர் குறிகளை</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="ta">ஒப்புக்கொள்ளுதல்</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">AdditionalRequests: </source>
         <target xml:lang="ta">கூடுதல் கோரிக்கைகள்</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="ta">அனைத்து உரிமைகளும் பாதுகாக்கப்பட்டவை (தொடர்பு எந்த அனுமதிகள் பதிப்புரிமை கொண்டிருப்பவர்கள்.)</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you.  If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="ta">BloomLibrary.org ஏற்கனவே ஒரு முந்தைய பதிப்பில் இருந்து நீங்கள் இந்த புத்தகம் உள்ளது.  நீங்கள் பதிவேற்றும் அது மீண்டும், இருந்தால் அது மாற்றப்படும் உங்கள் நடப்பு பதிப்புடன்.</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="ta">பதிப்புரிமை</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="ta">வரவுகளை</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="ta">உங்கள் புத்தகம் பதிவிறக்கம் சிக்கல் ஏற்பட்டுள்ளது. Bloom மறுதொடக்கம் செய்யவும் அல்லது தொழில்நுட்ப உதவி பெற வேண்டும்.</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="ta">மன்னிக்கவும், வெட்டுதல் {0} சிக்கல். சில விவரங்கள் பின்பற்றவும். தொழில்நுட்ப உதவி வேண்டும்.</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading</source>
         <target xml:lang="ta">ஒன்று அல்லது மேற்பட்ட புலங்கள் மேலே வெட்டுதல் முன் உங்கள் கவனம் தேவை</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded</source>
         <target xml:lang="ta">மன்னிக்கவும், "{0}" வெற்றிகரமாக பணியிடத்தில் தகவலிறக்கம் செய்யப்படவில்லை</target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes</source>
         <target xml:lang="ta">வெட்டுதல், மூலம் நீங்கள் உங்கள் ஒப்பந்தம், Bloom நூலகத்தில் பயன்படுத்தும் விதிகள் உறுதிசெய் மற்றும் அது விவரிக்கும் உரிமைகளையும்</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="ta">உங்கள் புத்தகம் வெட்டுதல் சிக்கல் ஏற்பட்டுள்ளது.</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="ta">மொழிகள்</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="ta">பயன்பாட்டு/உரிமம்</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="ta">கணக்கு ஏற்கனவே உள்ளது</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address.  Would you like to log in instead?</source>
         <target xml:lang="ta">நாங்கள் முடியாது நீங்கள் உடன் உள்நுழைய அந்த முகவரி, ஏனென்றால் நாங்கள் ஏற்கனவே அந்த முகவரி கொண்ட கணக்கு.  அதற்கு பதிலாக உள்நுழைய விரும்புகிறீர்களா?</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="ta">Bloom இணைக்க முடியவில்லை சரிபார்க்க உங்கள் உள்நுழைதலை சேவையகம். உங்கள் வலையமைப்பு இணைப்பை சரிபார்க்கவும்.</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="ta">உள்நுழைதல் தோல்வியுற்றது</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="ta">Bloom இணைக்க முடியவில்லை உங்கள் உள்நுழைவு அல்லது signup நிறைவுசெய்ய சேவகன். இது உங்கள் இணைய இணைப்பு, நமது சேவையகம் அல்லது சில உபகரணங்கள் சிக்கல் between உள்ளே இருக்கும் முடியவில்லை.</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="ta">உள்நுழைய ஒரு BloomLibrary.org கணக்கு, வகையில் என்று ஒப்புக்கொள்கிறீர்கள் பயன்படுத்தும் BloomLibrary விதிகள் காட்டும் பெட்டியை நீங்கள் சரிபார்க்க வேண்டும்.</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="ta">மின்னஞ்சல் தேவை</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="ta">உடன் ஆகியவற்றை ஆதாரங்களுடன் ஒரு பயனர் எங்களிடம் வேண்டாம். நீங்கள் உள்நுழைய விரும்புகிறீர்களா?</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="ta">கடவுச்சொல் மற்றும் பயனர் ID பொருந்தவில்லை</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="ta">தயவுசெய்து விதிமுறைகள் ஏற்றுக்கொள்ள</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="ta">ஒரு செல்லத்தக்க மின்னஞ்சல் முகவரியை உள்ளிடவும். நாங்கள் உங்களுக்கு ஒரு மின்னஞ்சல் இந்த முகவரிக்கு அனுப்பு எனவே உங்கள் கடவுச்சொல் மீட்டமை.</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="ta">Bloom இணைக்க முடியவில்லை உங்கள் கடவுச்சொல்லை மீட்டமைக்க சேவகன். உங்கள் வலையமைப்பு இணைப்பை சரிபார்க்கவும்.</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="ta">கடவுச்சொல் மீட்டமை தோல்வியுற்றது</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="ta">கடவுச்சொல் மீட்டமைத்தல்</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password</source>
         <target xml:lang="ta">நாம் அனுப்பும் ஒரு மின்னஞ்சல் உங்கள் கடவுச்சொல்லை மீட்டமைக்க வழிமுறைகளை கொண்டு {0}</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="ta">உள்நுழைய Bloom நூலகம்.</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="ta">அறியாத பயனீட்டாளர்</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="ta">Bloom முடியவில்லை இல்லை புகுபதிகை செய்ய உங்கள் சேமிக்கப்பட்ட நம்பிக்கைச்சான்றை பயன்படுத்தி BloomLibrary.org. உங்கள் வலையமைப்பு இணைப்பை சரிபார்க்கவும்.</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="ta">வெளியே BloomLibrary.org உள்நுழையவும்</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="ta">PDF முன்னோட்டம் ஈட்டும்...</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="ta">சிறு உருவம் ஈட்டும்...</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="ta">மன்னிக்கவும், இந்த பதிப்பு Bloom டெஸ்க்டாப் இணக்கமாக இல்லை BloomLibrary.org தற்போதைய பதிப்பு. தயவுகூர்ந்து புதிய பதிப்பிற்கு மேம்படுத்தி மேம்படுத்தல்.</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="ta">புகுபதிகை செய்ய BloomLibrary.org (அல்லது உள்நுழைய) வெட்டுதல் முன்</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="ta">தயவுசெய்து திருத்து தாவலில் இருந்து இது அமை</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="ta">படி 1: மீத்தரவு உறுதிசெய்</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="ta">படி 2: பதிவேற்றும்</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="ta">ஆலோசனை: ஆக்கப்பூர்வ செய்தியாக உரிமம் Assigning எளிதாக்குகிறது தெளிவாகக் ஒவ்வொருவரிடமும் சில அனுமதிகள் வழங்க உங்களுக்காக.</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="ta">ஆலோசனை: ஆக்கப்பூர்வ செய்தியாக உரிமங்கள் எளிதாக்கு பெரிதும் மற்றவர்களின் பயன்பாட்டுக்கு உங்கள் புத்தகம் என்றால் அவர்கள் மொழியில் உங்கள் விருப்பம் உரிமம் பேசியும் இல்லை.</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="ta">சுருக்கம்</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="ta">விதிமுறைகள் காண்பி</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="ta">தலைப்பு</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="ta">புத்தகம் பதிவேற்றும்</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <target xml:lang="ta">வாழ்த்துக்கள், "{0}" இருக்கும் பட்சத்தில் இப்போது BloomLibrary.org ({1})</target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="ta">பதிவேற்றும் அனுமதிக்கப்படாது</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="ta">உங்கள் புத்தகம் வெட்டுதல் சிக்கல் ஏற்பட்டுள்ளது. Bloom மறுதொடக்கம் செய்யவும் அல்லது தொழில்நுட்ப உதவி பெற வேண்டும்.</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="ta">பதிவேற்றும் முன்னேற்றம்</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="ta">பதிவேற்றும் புத்தகத்தை ( மணல் பெட்டி)</target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="ta">புத்தகம் மீத்தரவு வெட்டுதல்</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, &amp; topic tags to the bloomlibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="ta">{0} வெட்டுதல்</target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="ta">நகல்-மூலம்-என்.சி</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="ta">புகுபதிகை செய்ய BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="ta">BloomLibrary.org பதிவாக்க</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="ta">மட்டம் சேர்</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="ta">மேடை சேர்</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <target xml:lang="ta">தயவுசெய்து உரைகள் மாதிரி உரைகள் கோப்புறை சேர்.</target>
         <note>ID: ReaderSetup.AddTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="ta">புத்தகம்</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="ta">ஒரு புத்தகம் அதிகபட்ச சொற்கள்</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="ta">இந்த நிலையில் அவற்றை சேர்க்க கடிதங்கள் click செய்யவும்.</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="ta">இடைவெளிகளை மூலம் தனி</target>
         <note>ID: ReaderSetup.CombinationHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <target xml:lang="ta">எ.கா "ai ஊவிடம் sh ng th அலுவலகங்களான"</target>
         <note>ID: ReaderSetup.CombinationHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <target xml:lang="ta">கடிதம் சேர்க்கைகளை (வரிவடிவ எழுத்து)</target>
         <note>ID: ReaderSetup.Combinations</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="ta">Decodable தொடங்குகிறது</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="ta">முதல்,</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="ta">இந்த வடிவமைப்பை படிக்க முடியவில்லை</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="ta">ஏற்றுமதி மற்றும் மாதிரி texts பயன்படுத்த கோப்புகளை மாற்றுவதற்கு உதவி</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="ta">மொழி</target>
         <note>ID: ReaderSetup.Language</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <target xml:lang="ta">கடிதங்கள் மற்றும் அகரவரிசை வரிசையில் வார்த்தை-அமைக்க கேரக்டர்கள் பட்டியல்.</target>
         <note>ID: ReaderSetup.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="ta">இடைவெளிகளை மூலம் தனி</target>
         <note>ID: ReaderSetup.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <target xml:lang="ta">எ.கா. "a b c d"</target>
         <note>ID: ReaderSetup.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="ta">கடிதங்கள்</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="ta">கடிதங்கள் மற்றும் எழுத்து சேர்க்கைகளை</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="ta">உதவும் decodable படிப்பான்கள், Bloom கடிதங்கள் மற்றும் நீங்கள் கற்பித்தல் இருக்கும் எழுத்து சேர்க்கைகளை தேவைப்படுகிறது.</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="ta">ஒவ்வொரு எழுத்து அல்லது எழுத்து இரண்டும் கொண்ட ஒரு இடம் தனி. உதாரணமாக, இங்கே என்பது என்ன நாங்கள் இருக்கலாம் பயன்படுத்த ஆங்கில மொழி:</target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="ta">ஆங்கில பட்டியலில் அடங்கும் போன்ற சொற்கள், தயாரிக்க பயன்படுத்தப்படும் சின்னங்கள் கவனிக்கவும் ' உள்ள</target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="ta">அது</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="ta">.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="ta">நிலை</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="ta">நிலை</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="ta">படிப்பவர் நிலைகள்</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="ta">பொருத்தமான சொற்கள்</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="ta">ஒரு புத்தகம் அதிகபட்ச பிரத்யேக சொற்கள்</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <target xml:lang="ta">மேலும் சொற்களை</target>
         <note>ID: ReaderSetup.MoreWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <target xml:lang="ta">இந்த மொழிக்கான மாதிரி உரை கோப்புறையை திறக்கவும்.</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="ta">கடைசியாக</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="ta">ஒவ்வொரு பக்கத்திலும் அதிகபட்ச சொற்கள்</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="ta">இதனால் இயங்குகிறது</target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="ta">படிப்பவர் நிலைகள்</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="ta">நிலை {0} நீக்கு</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="ta">மேடை {0} நீக்கு</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="ta">நிலைகள் மறு வரிசையாக்க இழுத்து வேண்டிய வரிசைகளை இழுக்கவும்.</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="ta">கட்டத்தில் மறு வரிசையாக்க இழுத்து வேண்டிய வரிசைகளை இழுக்கவும்.</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <target xml:lang="ta">சொல் பட்டியல்கள் மற்றும் மாதிரி உரைகள்</target>
         <note>ID: ReaderSetup.SampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="ta">, எழுத்தறிவு தேடு பொறி.</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="ta">முந்தைய மற்றும் புதிய எழுத்துக்கள்</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="ta">தண்டனை</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="ta">ஒவ்வொரு வரியின் அதிகபட்ச வார்த்தைகளை</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="ta">Decodable படிப்பான் கருவி அமை</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="ta">மறுக்கும் படிப்பான் கருவி அமை</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <target xml:lang="ta">இந்த மொழிக்கான அகர வரிசை அமைக்கவும்.</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <target xml:lang="ta">கண்பார்வையில் சொற்கள் என்றால் என்ன?</target>
         <note>ID: ReaderSetup.SightWordHelp</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="ta">புதிய பயனுள்ளதாகக் சொற்கள்</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="ta">கண்பார்வையில் சொற்கள்</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="ta">நிலை</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="ta">நிலை</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="ta">நிலைகளில்</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="ta">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="ta">இந்த நிலை நினைவில் விஷயங்கள்:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="ta">பிரத்யேக</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="ta">சொற்கள்</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage.  There are two ways to give words to Bloom:</source>
         <target xml:lang="ta">உதவும் decodable படிப்பான்கள், தற்போதைய நிலையில் க்குள் பொருத்த சொற்களை Bloom ஆலோசனை செய்யலாம்.  Bloom சொற்களை கொடுக்க இரண்டு வழிகள் இருக்கின்றன:</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="ta">2) உள்ள இடம் உரை கோப்புகள் உங்கள்</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Text Folder</source>
         <target xml:lang="ta">மாதிரி உரை கோப்புறை</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="ta">1) வகை சொற்களை இங்கு</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="ta">கடிதங்கள்</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this BloomPack will carry your latest decodable and leveled reader settings for the "{0}" language. Anyone opening this BloomPack , who then opens a "{0}" collection, will have their current decodable and leveled reader settings replaced by the settings in this BloomPack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="ta">மேலும், இந்த BloomPack தொடர்வோம் "{0}" மொழி உங்கள் சமீபத்திய decodable மற்றும் மறுக்கும் படிப்பவர் அமைப்புகளை. இந்த BloomPack உள்ள அமைப்புகள் மாற்றப்பட்டது அவர்களின் தற்போதைய decodable மற்றும் மறுக்கும் படிப்பவர் அமைப்புகள் யார் யார் பின் "{0}" தொகுப்பை திறக்கும், இந்த BloomPack திறக்கும் வேண்டிவரும். அவர்கள் கிடைக்கும் சொற்களை நடப்பு தொகுப்பை decodable படிப்பான்கள் பயன்படுத்தும்.</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="ta">வார்ப்புருக்கள்-ஐ பின்வரும் புத்தகங்கள் வெளியிடப்படும்:</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save BloomPack</source>
         <target xml:lang="ta">BloomPack சேமி</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template BloomPack</source>
         <target xml:lang="ta">படிப்பவர் வார்ப்புரு BloomPack உருவாக்கு</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="ta">மின்னஞ்சல் முகவரி</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="ta">முதல் பெயர்</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="ta">தயவுசெய்து {0} பதிவு செய்ய ஒரு நிமிடம் எடுத்துக்</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="ta">எப்படி நீங்கள் பயன்படுத்தும் {0}?</target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="ta">நான் நின்றுபோனது இருக்கிறேன், நான் இருக்கும் முடி இது பின்னர்.</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="ta">அமைப்பு</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="ta">பதிவுசெய்</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="ta">துணைப்பெயர்</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="ta">{0} பதிவு</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="ta">அடிப்படை புத்தகம்</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="ta">பெரிய புத்தகம்</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="ta">Decodable படிப்பான்</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="ta">மறுக்கும் படிப்பான்</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="ta">படம் அகராதி</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="ta">சுவரில் நாள்காட்டி</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="ta">விவசாயம்</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="ta">விலங்கு கதைகள்</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="ta">வியாபாரம்</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="ta">சமூக வாழும்</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="ta">பண்பாடு</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="ta">அகராதி</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="ta">சூழல்</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="ta">புனைவு</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="ta">சுகாதார</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="ta">இது எப்படி</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="ta">கணக்கு</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="ta">அல்லாத கீழேயுள்ளது</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="ta">சுய முன்னேற்றம்</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="ta">நடத்திய</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="ta">அறிவியல்</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="ta">துறவி</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="ta">பாரம்பரியம்</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="ta">பாரம்பரிய கதை</target>
         <note>ID: Topics.Traditional Story</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="ta">அமைவு</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
       </trans-unit>
-      <trans-unit id="You may use this space for author/illustrator, or anything else." sil:dynamic="true">
+      <trans-unit id="You may use this space for author/illustrator, or anything else." sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="ta">எழுத்தாளர்/illustrator, அல்லது வேறு எதுவும் இந்த இடம் உபயோகித்து.</target>
         <note>ID: You may use this space for author/illustrator, or anything else.</note>

--- a/DistFiles/localization/ta/Palaso.xlf
+++ b/DistFiles/localization/ta/Palaso.xlf
@@ -2,395 +2,395 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Palaso.dll" source-language="en" target-language="ta" datatype="plaintext" product-version="3.0.53.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="AboutDialog.AboutDialogWindowTitle">
+      <trans-unit id="AboutDialog.AboutDialogWindowTitle" approved="yes">
         <source xml:lang="en">About</source>
         <target xml:lang="ta">பற்றி</target>
         <note>ID: AboutDialog.AboutDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.NoUpdates">
+      <trans-unit id="AboutDialog.NoUpdates" approved="yes">
         <source xml:lang="en">No Updates</source>
         <target xml:lang="ta">புதுப்பிகள் ஏதும்</target>
         <note>ID: AboutDialog.NoUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._checkForUpdates">
+      <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
         <source xml:lang="en">Check For Updates</source>
         <target xml:lang="ta">புதுப்பித்தல்களை பார்</target>
         <note>ID: AboutDialog._checkForUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._releaseNotesLabel">
+      <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="ta">வெளியீட்டு அறிக்கை</target>
         <note>ID: AboutDialog._releaseNotesLabel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="ta">ரத்து செய்</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.No">
+      <trans-unit id="Common.No" approved="yes">
         <source xml:lang="en">No</source>
         <target xml:lang="ta">இல்லை</target>
         <note>ID: Common.No</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="ta">சரி</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Yes">
+      <trans-unit id="Common.Yes" approved="yes">
         <source xml:lang="en">Yes</source>
         <target xml:lang="ta">ஆம்</target>
         <note>ID: Common.Yes</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="ta">{0} மறுசுழற்சிக் கூடைக்கு நகர்த்தப்படும்.</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
         <note>Param 0 is a description of the things being deleted (e.g., "The selected files"</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="ta">{0} மறுசுழற்சிக் கூடைக்கு நகர்த்தப்படும்.</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
         <note>Param 0 is a file name</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Confirm Delete</source>
         <target xml:lang="ta">நீக்குதல் உறுதிசெய்</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="ta">ரத்து செய்</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="ta">நீக்கு</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ArtOfReading">
+      <trans-unit id="ImageToolbox.ArtOfReading" approved="yes">
         <source xml:lang="en">Art Of Reading</source>
         <target xml:lang="ta">வாசித்தல் கலை</target>
         <note>ID: ImageToolbox.ArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Camera">
+      <trans-unit id="ImageToolbox.Camera" approved="yes">
         <source xml:lang="en">Camera</source>
         <target xml:lang="ta">கேமரா</target>
         <note>ID: ImageToolbox.Camera</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
         <source xml:lang="en">Use {0}</source>
         <target xml:lang="ta">{0} பயன்படுத்து</target>
         <note>ID: ImageToolbox.CopyExemplarMetadata</note>
         <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Crop">
+      <trans-unit id="ImageToolbox.Crop" approved="yes">
         <source xml:lang="en">Crop</source>
         <target xml:lang="ta">பயிர்</target>
         <note>ID: ImageToolbox.Crop</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EditMetadataLink">
+      <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
         <source xml:lang="en">Edit...</source>
         <target xml:lang="ta">திருத்து...</target>
         <note>ID: ImageToolbox.EditMetadataLink</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EnterSearchTerms">
+      <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
         <source xml:lang="en">This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.</source>
         <target xml:lang="ta">'கலை, வாசித்தல்' தொகுப்பு இது. மேற்கண்ட பெட்டியில் என்ன நீங்கள் உள்ளன தேடுகிறது தட்டச்சு செய்யவும், பிறகு ENTER விசையை அழுத்தவும். ஆங்கிலம் மற்றும் இந்தோனேசியம் சொற்களை தட்டச்சு செய்யலாம்.</target>
         <note>ID: ImageToolbox.EnterSearchTerms</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.FileButton">
+      <trans-unit id="ImageToolbox.FileButton" approved="yes">
         <source xml:lang="en">File</source>
         <target xml:lang="ta">கோப்பு</target>
         <note>ID: ImageToolbox.FileButton</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
         <target xml:lang="ta">மன்னிக்கவும், ஏதோ சென்று தவறான போது உருவம் பெறுகிறது.</target>
         <note>ID: ImageToolbox.GenericGettingImageProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericProblem">
+      <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
         <target xml:lang="ta">மன்னிக்கவும், ஏதோ சென்று, பட பெட்டி கொண்டு தவறான</target>
         <note>ID: ImageToolbox.GenericProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GetPicture">
+      <trans-unit id="ImageToolbox.GetPicture" approved="yes">
         <source xml:lang="en">Get Picture</source>
         <target xml:lang="ta">படம் பெறு</target>
         <note>ID: ImageToolbox.GetPicture</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
         <source xml:lang="en">Image Toolbox</source>
         <target xml:lang="ta">உருவம் கருவிபெட்டி</target>
         <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoMatchingImages">
+      <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
         <source xml:lang="en">Found no matching images</source>
         <target xml:lang="ta">எந்த பொருத்தமான படிமங்கள் காணப்படவில்லை</target>
         <note>ID: ImageToolbox.NoMatchingImages</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PictureFiles">
+      <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
         <source xml:lang="en">picture files</source>
         <target xml:lang="ta">படம் கோப்புகள்</target>
         <note>ID: ImageToolbox.PictureFiles</note>
         <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice" approved="yes">
         <source xml:lang="en">Problem Getting Image</source>
         <target xml:lang="ta">படிமம் பெறுகிறது சிக்கல்</target>
         <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemLoadingImage">
+      <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
         <source xml:lang="en">Sorry, there was a problem loading that image.</source>
         <target xml:lang="ta">மன்னிக்கவும், இருந்தது அந்த உருவம் ஒரு சிக்கல்.</target>
         <note>ID: ImageToolbox.ProblemLoadingImage</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
         <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
         <target xml:lang="ta">இந்தப் படிமத்தை இல்லை இல்லை know:\n\nஅதனை யார்?\nயார் அதை பயன்படுத்தலாம்?</target>
         <note>ID: ImageToolbox.PromptForMissingMetadata</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Scanner">
+      <trans-unit id="ImageToolbox.Scanner" approved="yes">
         <source xml:lang="en">Scanner</source>
         <target xml:lang="ta">ஸ்கேனர்</target>
         <note>ID: ImageToolbox.Scanner</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SetUpMetadataLink">
+      <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
         <source xml:lang="en">Set up metadata...</source>
         <target xml:lang="ta">மீத்தரவு அமை...</target>
         <note>ID: ImageToolbox.SetUpMetadataLink</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.AlternateNamesHeader">
+      <trans-unit id="LanguageLookup.AlternateNamesHeader" approved="yes">
         <source xml:lang="en">Other Names</source>
         <target xml:lang="ta">மற்ற பெயர்கள்</target>
         <note>ID: LanguageLookup.AlternateNamesHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue" approved="yes">
         <source xml:lang="en">Ethnologue.com</source>
         <target xml:lang="ta">Ethnologue.com</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
         <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
         <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
         <target xml:lang="ta">மொழி 639-3 குறியீடுகள் &amp; புதியவை விண்ணப்பிக்க எப்படி பற்றி</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
         <source xml:lang="en">About The ISO Language Registry</source>
         <target xml:lang="ta">ISO மொழி பதிவகம் பற்றி</target>
         <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CodeHeader">
+      <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
         <source xml:lang="en">Code</source>
         <target xml:lang="ta">குறியீடு</target>
         <note>ID: LanguageLookup.CodeHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryHeader">
+      <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="ta">நாடு</target>
         <note>ID: LanguageLookup.CountryHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
         <source xml:lang="en">You can change how the language name will be displayed here:</source>
         <target xml:lang="ta">எப்படி மொழி பெயர் காண்பிக்கப்படும் இங்கு நீங்கள் மாற்றலாம்:</target>
         <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
         <source xml:lang="en">Lookup Language Code...</source>
         <target xml:lang="ta">பார்த்து மொழி குறியீடு...</target>
         <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.PrimaryNameHeader">
+      <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="ta">பெயர்</target>
         <note>ID: LanguageLookup.PrimaryNameHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.UnlistedLanguage">
+      <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
         <source xml:lang="en">Unlisted Language</source>
         <target xml:lang="ta">பட்டியலிடாத மொழி</target>
         <note>ID: LanguageLookup.UnlistedLanguage</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
         <source xml:lang="en">Can't find your language?</source>
         <target xml:lang="ta">உங்கள் மொழி கண்டுபிடிக்க முடியவில்லை?</target>
         <note>ID: LanguageLookup._cannotFindLanguageLink</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Creator">
+      <trans-unit id="MetadataDisplay.Creator" approved="yes">
         <source xml:lang="en">Creator: {0}</source>
         <target xml:lang="ta">உருவாக்கியவர் {0}</target>
         <note>ID: MetadataDisplay.Creator</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.LicenseInfo">
+      <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
         <source xml:lang="en">License Info</source>
         <target xml:lang="ta">உரிமம் தகவல்</target>
         <note>ID: MetadataDisplay.LicenseInfo</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.NoLicense">
+      <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
         <source xml:lang="en">No license specified</source>
         <target xml:lang="ta">குறிப்பிட்ட உரிமத்தை</target>
         <note>ID: MetadataDisplay.NoLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowCommercialUse">
+      <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
         <source xml:lang="en">Allow commercial uses of your work?</source>
         <target xml:lang="ta">உங்கள் வேலை வணிக பயன்பாடுகளும் அனுமதி?</target>
         <note>ID: MetadataEditor.AllowCommercialUse</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowDerivatives">
+      <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
         <source xml:lang="en">Allow modifications of your work?</source>
         <target xml:lang="ta">உங்கள் வேலை மாற்றமைவுகள் அனுமதி?</target>
         <note>ID: MetadataEditor.AllowDerivatives</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CopyrightHolder">
+      <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
         <source xml:lang="en">Copyright Holder</source>
         <target xml:lang="ta">பதிப்புரிமை கொண்டிருப்பவர்கள்</target>
         <note>ID: MetadataEditor.CopyrightHolder</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons">
+      <trans-unit id="MetadataEditor.CreativeCommons" approved="yes">
         <source xml:lang="en">Creative Commons</source>
         <target xml:lang="ta">ஆக்கப்பூர்வ செய்தியாக</target>
         <note>ID: MetadataEditor.CreativeCommons</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreatorLabel">
+      <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="ta">உருவாக்கியவர்</target>
         <note>ID: MetadataEditor.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CustomLicense">
+      <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="ta">விருப்பம்</target>
         <note>ID: MetadataEditor.CustomLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleNoCredit">
+      <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
         <source xml:lang="en">Copyright &amp; License</source>
         <target xml:lang="ta">பதிப்புரிமை &amp; உரிமம்</target>
         <note>ID: MetadataEditor.TitleNoCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleWithCredit">
+      <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
         <source xml:lang="en">Credit, Copyright, &amp; License</source>
         <target xml:lang="ta">கடன், பதிப்புரிமை, &amp; உரிமம்</target>
         <note>ID: MetadataEditor.TitleWithCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.UnknownLicense">
+      <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <target xml:lang="ta">எந்த அனுமதிகள் பதிப்புரிமை கொண்டிருப்பவர்கள் உதவிக்கு</target>
         <note>ID: MetadataEditor.UnknownLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.YesShareAlike">
+      <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
         <source xml:lang="en">Yes, as long as others share alike</source>
         <target xml:lang="ta">ஆம், உள்ளவர்களை மற்றவர்கள் போல பகிர</target>
         <note>ID: MetadataEditor.YesShareAlike</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.additionalRequestsLabel">
+      <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
         <source xml:lang="en">Additional Requests</source>
         <target xml:lang="ta">கூடுதல் கோரிக்கைகள்</target>
         <note>ID: MetadataEditor.additionalRequestsLabel</note>
         <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.betterLinkLabel1">
+      <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
         <source xml:lang="en">more info</source>
         <target xml:lang="ta">மேலும் தகவல்</target>
         <note>ID: MetadataEditor.betterLinkLabel1</note>
         <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere tha defines it.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
         <source xml:lang="en">Not Enforceable</source>
         <target xml:lang="ta">இல்லை அமல்படுத்தப்பட</target>
         <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <target xml:lang="ta">இது கூட மறைக்க எந்த தேவை அல்லாத-மேம்பட்ட பயனரால் மற்ற பொத்தான்கள் இருக்கலாம்.</target>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.CtrlShiftHint">
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
         <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
         <target xml:lang="ta">பிடித்திருக்கையில் Ctrl மற்றும் Shift விசைகளை இணைந்து உள்ள பொத்தானை கிடைக்கப்பட்ட.</target>
         <note>ID: SettingsProtection.CtrlShiftHint</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+      <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
         <source xml:lang="en">Settings...</source>
         <target xml:lang="ta">அமைப்புகள்...</target>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
         <source xml:lang="en">Hide the button that opens settings.</source>
         <target xml:lang="ta">பொத்தான் அமைப்புகள் திறக்கும் மறை.</target>
         <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
         <source xml:lang="en">Factory Password</source>
         <target xml:lang="ta">தொழிற்சாலை கடவுச்சொல்</target>
         <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
         <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
         <target xml:lang="ta">உங்களுக்கு வேலை நிறுத்த இந்த கருவி ஏற்படுத்தலாம் எதிர்பாராத மாற்றங்கள் தடுக்க, இந்த அமைப்புகள் உங்களுக்கு பூட்டப்பட்டுள்ளது.</target>
         <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
         <source xml:lang="en">Settings Protection Password</source>
         <target xml:lang="ta">அமைப்புகளை பாதுகாப்பு கடவுச்சொல்</target>
         <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox">
+      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
         <source xml:lang="en">Show Characters</source>
         <target xml:lang="ta">எழுத்துக்குறிகளைக் காண்பி</target>
         <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordNotice">
+      <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
         <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always google for "{1}" and "{2}".</source>
         <target xml:lang="ta">இந்த அமைப்புகளை தொழிற்சாலை கடவுச்சொல்லை உள்ளது "{0}".  நீங்கள் அதை மறந்து, என்றால் நீங்கள் முடியும் எப்போதும் google "{1}" மற்றும் "{2}"</target>
         <note>ID: SettingsProtection.PasswordNotice</note>
         <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
         <source xml:lang="en">Require the factory password to get into settings.</source>
         <target xml:lang="ta">அமைப்புகள் வர தொழிற்சாலை கடவுச்சொல் தேவைப்படும்.</target>
         <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
         <source xml:lang="en">Settings Protection</source>
         <target xml:lang="ta">பாதுகாப்பு அமைப்புகள்</target>
         <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
         <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
         <target xml:lang="ta">நீங்கள் விசைப்பலகையை பட்டியலில், இல்லையெனில் தகுந்த கீழே உள்ள இணைப்பை சொடுக்கவும் அது அமைக்க</target>
         <note>ID: WSKeyboardControl.KeyboardNotListed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
         <source xml:lang="en">Windows keyboard settings</source>
         <target xml:lang="ta">Windows விசைப்பலகை அமைப்புகள்</target>
         <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
         <source xml:lang="en">Available keyboards</source>
         <target xml:lang="ta">கிடைக்கப்பெறும் விசைப்பலகைகள்</target>
         <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
         <source xml:lang="en">Previously used keyboards</source>
         <target xml:lang="ta">முன்பு விசைப்பலகைகள் பயன்படுத்தப்படுகிறது</target>
         <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
         <source xml:lang="en">Keyman Configuration</source>
         <target xml:lang="ta">Keyman உள்ளமைவு</target>
         <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
         <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
         <target xml:lang="ta">Keyman 5.0 அல்லது பிந்தைய நிறுவப்படவில்லை.</target>
         <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
         <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
         <target xml:lang="ta">கொண்ட {0} உரை தட்டச்சு செய்ய விசைப்பலகை தேர்ந்தெடு</target>
         <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.TestAreaCaption">
+      <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
         <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
         <target xml:lang="ta">சோதனை பகுதி (பயன்பாடு இந்த பகுதிக்கு வெளியே விசைப்பலகையைப் சோதிக்க ஏதேனும் தட்டச்சு செய்ய.)</target>
         <note>ID: WSKeyboardControl.TestAreaCaption</note>

--- a/DistFiles/localization/te/Bloom.xlf
+++ b/DistFiles/localization/te/Bloom.xlf
@@ -2,2299 +2,2299 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="te" datatype="plaintext" product-version="3.0.53.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="te">డికోడాబల్ రీడర్ </target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="te">తనపై రీడర్ సాధనం</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="te">మరింత</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="te">బ్లూమ్ ప్యాక్ సంస్థాపన</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="te">సేకరణ ఇప్పుడు ఈ కంప్యూటర్లో ఉపయోగించడానికి సిద్ధంగా ఉంది</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="te">ఆ  వర్ధిల్లు ప్యాక్ ఇన్స్టాల్ పొందలేదు</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="te">రాబట్టే</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while BloomPacks are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="te">బ్లూమ్ ఇప్పటికే నడుస్తున్న, కానీ కంటెంట్ మీ తదుపరి టర్న్ వరకు ప్రదర్శించబడతాయి లేదు వికసించిన</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="te">ప్రారంభ</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text in boxes with '{1}' style</source>
         <target xml:lang="te">ఈ ఫార్మాటింగ్ '{1}' శైలి తో బాక్సులను అన్ని {0} టెక్స్ట్ ఉంది</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="te">ఆధునిక కార్యక్రమం సెట్టింగ్</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="te">ప్రయోగాత్మక ఆదేశాలను చూపించు (ఉదాహరణకు. InDesign ఎగుమతి XML)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="te">ప్రయోగాత్మక టెంప్లేట్లు చూపించు (ఉదాహరణకు. చిత్రాన్ని నిఘంటువు)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="te">పెద్ద చిత్రాలు మెమొరీ వినియోగాన్ని తగ్గించడానికి చిత్రాన్ని సర్వర్ ఉపయోగించడానికి</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="te">షో పంపండి / అందుకుంటారు నియంత్రణలు</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="te">పందెపులెక్కలు</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="te">డిఫాల్ట్ ఫాంట్ {0}</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="te">ముందు / వెనుక ఉన్నా ప్యాక్</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="te">కుడి ఎడమ వ్రాసే వ్యవస్థ</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="te">సెట్టింగులు</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="te">మార్పు</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="te">భాష 1</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="te">భాష 2</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="te">భాష 3</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="te">భాషలు</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="te">సెట్</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="te">వ్యవహారిక భాషలో</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="te">భాష 2 (ఉదాహరణకు: జాతీయ భాష)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="te">భాష 3 (ఉదాహరణకు: ప్రాంతీయ భాష) (ఐచ్ఛిక)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="te">తొలగించడానికి</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="te">వర్ధిల్లు సేకరణ పేర్లు</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="te">దేశం</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="te">జిల్లా</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="te">ప్రాజెక్ట్ సమాచారం</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="te">రాష్ట్రభాగము</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="te">పునఃప్రారంభమైన</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="te">బ్లూమ్ మూసివేసి, కొత్త సెట్టింగులు ఈ ప్రాజెక్ట్ ఓపెన్ ఉన్నాము.</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book, but these programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="te">వర్ధిల్లు ఇప్పుడు ఈ HTML పత్రం తెరుచుకోవడం</target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="te">నవీకరణ పుస్తకం</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="te">నవీకరణ సూక్ష్మచిత్రం</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="te">పుస్తకం తొలగించండి</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="te">పదం లేదా లిబ్రేఆఫీస్ ఎగుమతి</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="te">InDesign కోసం XML ఎగుమతి</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="te">ఈ నుండి పుస్తకాలు వర్ధిల్లు వికసించిన లైబ్రరీ. ఆర్గ్</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="te">అన్ని పుస్తకాల నవీకరణలను చేయండి</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="te">అన్ని పుస్తకాలు చెక్కుల చేయండి</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="te">రెస్క్యూ తప్పిపోయిన చిత్రాలు</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="te">సేకరణ చరిత్ర</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="te">సేకరణ గమనికలు</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="te">సేకరణలు</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="te">సేకరణలు</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="te">పుస్తకం '{0}'</target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="te">డిస్కులో ఫోల్డర్ను తెరువు</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="te">ఆరోగ్యం</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <target xml:lang="te">ఈ సోర్స్ ఉపయోగించి ఒక పుస్తకం తయారు</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="te">ఇతర సేకరణ</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="te">నమూనా గుండ్లు</target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="te">పంపడానికి / అందుకోవడానికి</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="te">సెట్టింగులు</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="te">మూలం సేకరణ</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="te">ఓపెన్ అదనపు సేకరణలు ఫోల్డర్</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="te">టెంప్లేట్లు</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="te">ఈ పుస్తకం సంకలనం</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="te">బ్లూమ్ తిరిగి తయారు</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template BloomPack...</source>
         <target xml:lang="te">రీడర్ టెంప్లేట్ బ్లూమ్ ప్యాక్ చేయి ...</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="te">అధునాతన</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="te">మరింత ఆధార పుస్తకం పొందండివికసించిన లైబ్రరీ వద్ద</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="te">మూలం సేకరణ</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="te">కొత్త పుస్తకాల కోసం వర్గాలు</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="te">ఈ సేకరణ లాక్ ఉంది, </target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="te">ఈ సోర్స్ సేకరణ ఎందుకంటే, వికసించిన కొత్త గుండ్లు కోసం మూలాలుగా ఇప్పటికే ఉన్న ఏదైనా గుండ్లు అందించటం లేదు.మీరు బదులుగా, షెల్ భాషను జోడించడానికి అనుకుంటే మీరు షెల్ containging సేకరణ సవరించాల్సిన అవసరంఅంతేకానీ ఒక కాపీని తయారు కంటే. అలాగే ప్రస్తుతం గోడ క్యాలెండర్ ఒక కొత్త షెల్ చేయడానికి ఉపయోగిస్తారు సాధ్యం కాదు.</target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="te">మరింత</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="te">కొత్త గుండ్లు కోసం వర్గాలు</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="te">తిరిగి</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="te">రద్దు</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="te">రద్దు</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="te">ముగింపు</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="te">&amp;సహాయం</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="te">తదుపరి</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="te">తదుపరి</target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="te">సరే</target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="te">సరే</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="te">ఐచ్ఛిక</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="te">భవనం</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="te">ఈ దశలో లెటర్స్.</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="te">ఒక అక్షరం మరియు పద జాబితా ఫైలు తెరువు</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="te">సెటప్ దశల్లో</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="te">వేదిక</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="te">యొక్క</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="te">ఈ దశలో పదాలు.</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections. If you don't seem to be in the middle of doing something, Bloom will select it for you.</source>
         <target xml:lang="te">మీ డౌన్లోడ్ ({0}) పూర్తయింది. మీరు మీ సేకరణలు 'పుస్తకాలు బ్లూమ్ లైబ్రరీ నుండి' విభాగంలో ఇది చూడగలరు మీరు ఏదో చేయడం మధ్యలో అనిపించడం లేదు ఉంటే.బూమ్ మీరు దానిని ఎంచుకోవచ్చు</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="te">పూర్తి డౌన్లోడ్</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="te">డౌన్లోడ్ పుస్తకం</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="te">మీ పుస్తకాన్ని డౌన్లోడ్ సమస్య ఉంది</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="te">మీరు పుస్తకం గురించి మరింత సమాచారం ఉంచాలి ఎక్కడో అవసరం ఉంటే, మీరు ఈ పేజీని ఉపయోగించవచ్చు,,ఇది తిరిగి కవర్ లోపలి ఉంది</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="te">మీరు పుస్తకం గురించి మరింత సమాచారం ఉంచాలి somwhere అవసరం ఉంటే, మీరు ఈ పేజీని ఉపయోగించవచ్చుతిరిగి కవర్ బయట ఇది</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the Html used to make this PDF, in Firefox (must be on path)</source>
         <target xml:lang="te">క్షమించండి, ఈ పుస్తకం కాపీరైట్ మరియు లైసెన్స్ మారలేదు</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="te">చిత్రాలు మారలేదు కాబట్టి క్షమించాలి, ఈ పుస్తకం డౌన్ లాక్</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="te">ఈ పేజీ శాశ్వతంగా తొలగించబడుతుంది</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="te">నిజంగా పేజీ తొలగించండి?</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="te">తొలగించండి</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="te">ఈ పేజీ శాశ్వతంగా తొలగించబడుతుంది</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="te">మార్చు</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="te">ప్రస్తుత ఎంపిక ఫాంట్ '{0}' ఉంది, కానీ అది ఈ కంప్యూటర్లో ఇన్స్టాల్ కాలేదు. కొన్ని ఇతర font ఉపయోగించబడుతుంది.</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="te">మీరు ఒక అసలు పుస్తకం తయారు చేసినప్పుడు, మొదలైనవి రచయితలు, చిత్రకారులు, సంపాదకులు, చేసిన రచనలు రికార్డ్ చేయడానికి ఈ పెట్టెను ఉపయోగించండి,</target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="te">మీరు ఒక షెల్ నుండి ఒక పుస్తకం తయారు చేసినప్పుడు, అనువాద చేసింది ఎవరు చెప్పడానికి ఈ పెట్టెను ఉపయోగించండి.</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="te">భాషలో పుస్తకం శీర్షిక</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright &amp; License</source>
         <target xml:lang="te">కాపీరైట్ &amp; లైసెన్స్ సవరించడానికి క్లిక్</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="te">ఏ ఫండింగ్ ఏజెన్సీలు గుర్తించి ఈ ఉపయోగించడానికి</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="te">అంతర్జాతీయ ప్రామాణిక పుస్తకం సంఖ్య. మీరు ఈ ఒక లేదు లేకపోతే వదిలివేయండి.</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="te">ఒరిజినల్ (లేదా shell) {భాషను} లో రసీదులు</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="te">{భాషను}, మొదలైనవి రచయితలు, చిత్రకారులు, సంపాదకులు, చేసిన రచనలు</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="te">విషయం ఎంచుకోవడానికి క్లిక్</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="te">అనువాదం వెర్షన్ (భాష) కోసం అందినట్లు</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="te">మార్పు చిత్రం</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, &amp; License</source>
         <target xml:lang="te">మార్చు చిత్రం క్రెడిట్స్ కాపీరైట్ &amp; లైసెన్సు</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="te">పేస్ట్ చిత్రం</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="te">లేఅవుట్ను మార్చడం</target>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="te">మీరు చిత్రం పేస్ట్ ముందు, మరొక కార్యక్రమం నుండి మీ 'క్లిప్బోర్డ్కు' పై ఒక కాపీ</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="te">పేజీలు</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="te">ఒక పేజీ పరిమాణం మరియు దిశను ఎంపిక</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="te">సరిహద్దు మరియు నేపథ్య మార్చడానికి</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="te">ఫాంట్ ముఖం మార్చండి</target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="te">శైలి '{0}' మరియు భాష '{1}'. \ N ప్రస్తుత పరిమాణం {2} pt మోస్తున్న అన్ని బాక్సులను కోసం టెక్స్ట్ పరిమాణం మార్పులు.</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="te">ఫాంట్ పరిమాణాన్ని మార్చు</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="te">టెక్స్ట్ యొక్క పంక్తులు మధ్య ఖాళీలో మార్పులు</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="te">విస్తృత అదనపు</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="te">సాధారణ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="te">పదాల మధ్య ఖాళీలో మార్పులు</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="te">వైడ్</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="te">శైలి ఫార్మాటింగ్ సర్దుబాటు</target>
         <note>ID: EditTab.FormatDialogTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="te">టెంప్లేట్ పేజీలు</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="te">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="te">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="te">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="te">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="te">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="te">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="te">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="te">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="te">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="te">అక్షరమాల</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="te">ప్రాథమిక పాఠం &amp; చిత్రం</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="te">ప్రాథమిక పాఠం &amp; చిత్రాన్ని</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="te">క్రెడిట్స్ పేజీ</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="te">కస్టమ్</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="te">రోజు 1</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="te">రోజు 2</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="te">రోజు 3</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="te">రోజు 4</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="te">రోజు 5a</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="te">రోజు 5b</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="te">ముందు కవర్</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="te">అడుగున చిత్రం</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="te">మధ్యలో చిత్రం</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="te">తిరిగి కవర్ లోపల</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="te">ముందు కవర్ లోపల</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="te">సూచనలను</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="te">కేవలం టెక్స్ట్</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="te">కేవలం ఒక చిత్రాన్ని</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="te">కేవలం ఒక చిత్రం</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="te">తిరిగి కవర్ బయట</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="te">చిత్రాన్ని &amp; పదం</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="te">అడుగున చిత్రాన్ని</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="te">మధ్యలో చిత్రంలో</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="te">ఈ పేజీని ఉద్దేశపూర్వకంగా ఖాళీగా ఉంది</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="te">టైటిల్ పేజీ</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="te">బహుభాషా సెట్టింగులు</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="te">ప్రతిని</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="te">కట్</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTip">
+      <trans-unit id="EditTab.CutButton.ToolTip" approved="yes">
         <source xml:lang="en">Cut (Ctrl-x)</source>
         <target xml:lang="te">కట్ (Ctrl + x)</target>
         <note>ID: EditTab.CutButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can cut it</source>
         <target xml:lang="te">మీరు కట్ ముందు మీరు కొంత టెక్స్ట్ ఎంచుకోండి అవసరం</target>
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="te">తొలగించడానికి \n పేజీ</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTip">
+      <trans-unit id="EditTab.DeletePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Remove this page from the book</source>
         <target xml:lang="te">పుస్తకం నుండి ఈ పేజీని తొలగించండి</target>
         <note>ID: EditTab.DeletePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be removed</source>
         <target xml:lang="te">ఈ పేజీ తొలగించడం సాధ్యం కాదు</target>
         <note>ID: EditTab.DeletePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="te">నకిలీ \n పేజీ</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
         <target xml:lang="te">ఈ ఒక నకిలీ ఉంది దీనిలో ఒక కొత్త పేజీ ఇన్సర్ట్</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be duplicated</source>
         <target xml:lang="te">ఈ పేజీకి నకలు ఉండకూడదు</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="te">పేస్ట్</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTip">
+      <trans-unit id="EditTab.PasteButton.ToolTip" approved="yes">
         <source xml:lang="en">Paste (Ctrl+v)</source>
         <target xml:lang="te">అతికించండి (Ctrl + z)</target>
         <note>ID: EditTab.PasteButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing on the Clipboard that you can paste here.</source>
         <target xml:lang="te">మీరు ఇక్కడ అతికించండి క్లిప్బోర్డ్కు న ఏమీ లేదు</target>
         <note>ID: EditTab.PasteButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="te">దిద్దుబాటు రద్దుచెయ్యి</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTip">
+      <trans-unit id="EditTab.UndoButton.ToolTip" approved="yes">
         <source xml:lang="en">Undo (Ctrl+z)</source>
         <target xml:lang="te">నాశనము చేసినది (Ctrl+z)</target>
         <note>ID: EditTab.UndoButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="te">రెండు భాషలు</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="te">ఈ పుస్తకం లో అన్ని ఇతర చిత్రాలు ఈ సమాచారాన్ని కాపీ?</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="te">ఈ ఐచ్చికము మాత్రమే ప్రచురించవచ్చు టాబ్ లో ఉంది.</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="te">ఒకే భాష</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="te">ఈ టెంప్లేట్ కోసం ఏ ఇతర లేఅవుట్ ఎంపికలు ఉన్నాయి</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="te">మేధో ఆస్తి సమాచారం చిత్రం</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="te">మూడు భాషా</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="te">భవనం రీడర్ టెంప్లేట్లు</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu">
+      <trans-unit id="HelpMenu.Help Menu" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="te">సహాయం</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="te">రీడర్ టెంప్లేట్ ఉపయోగించి</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="te">ఒక సలహా</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="te">వెబ్ సైట్</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="te">కొత్త వెర్షన్ను తనిఖీ</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="te">వర్ధిల్లు గురించి</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <target xml:lang="te">డాక్యుమెంటేషన్</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="te">నమోదు</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="te">విడుదల గమనికలు</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="te">షో ఈవెంట్ లాగ్</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="te">InDesign XML సమాచారం</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="te">మళ్ళీ ఈ చూపవద్దు</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="te">A4ప్రకృతి దృశ్యం</target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="te">A4ఇరువర్గాలు భూభాగం వైపు</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="te">A4పేజీలు అంతటా భూభాగం స్ప్లిట్</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="te">A4చిత్తరువు</target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="te">A5 భూభాగం</target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="te">A5చిత్తరువు</target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="te">A5చిత్తరువు క్రిందికి సమలేఖనం</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="te">B5చిత్తరువు</target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="te">అసలు</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="te">విషయం యొక్క ఎంపిక</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="te">ఈ స్థాయి కోసం</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="te">ఫార్మాటింగ్</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration support</source>
         <target xml:lang="te">ఇలస్ట్రేషన్ మద్దతు</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="te">గుర్తుంచుకోండి</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="te">స్థాయి</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> of </source>
         <target xml:lang="te">ఆఫ్</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="te">మాక్స్</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="te">పేజీకి</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="te">వాక్యం పెర్</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="te">అంచనాను</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="te">అప్ సెట్ స్థాయిలు</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="te">ఈ బుక్</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="te">ఈ పేజీని</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="te">మొత్తం</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="te">ప్రత్యేక</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="te">పదజాలం</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="te">పద కౌంట్స్</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="te">నేను వికసించిన లైబ్రరీ యొక్క నిబంధనలను అంగీకరిస్తున్నారు</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="te">ఇమెయిల్ చిరునామా</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="te">పాస్వర్డ్ మరచిపోయాను</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="te">&amp;లాగిన్</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="te">పాస్వర్డ్</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="te">ఉపయోగం షో నిబంధనలు</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="te">bloomlibrary.org లాగిన్</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="te">షో పాస్వర్డ్ను</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="te">ఆ పేరు తో ఒక సేకరణ ఇప్పటికే ఉంది, at &lt;a href='file;//{0}'&gt;{0}&lt;/a&gt;.\n Please pick a unique name.</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="te">ఈ సేకరణ ప్రధాన భాషను ఎంచుకోండి</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="te">ఉదాహరణలు: "ఆరోగ్య పుస్తకాలు". "PNG జంతువుల కథలను"</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="te">మీరు ఈ సేకరణ కాల్ ఏమి చేయాలనుకుంటున్నారు?</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="te">సేకరణ పేరును సమస్య</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="te">సేకరణ రూపొందించినవారు ఉంటుంది {0}</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="te">ఒక కొత్త సేకరణ సృష్టించడానికి సిద్ధంగా</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="te">సేకరణ రకం ఎంచుకోండి</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="te">మూలం సేకరణ</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org and optionally make a BloomPack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="te">విస్తృత కమ్యూనికేషన్ ఒకటి లేదా ఎక్కువ భాషలలో షెల్ లేదా టెంప్లేట్ పుస్తకాల సేకరణ. మీరు BloomLibrary.org ఈ గుండ్లు అప్లోడ్ మరియు వైకల్పికంగా వారు మీ పెంకులు తో వ్యావహారికంలో పుస్తకాలు చేయవచ్చు తద్వారా ఇతరులకు ఇవ్వాలని ఒక BloomPack తయారు చేయగలరు.</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="te">వ్యావహారికంలో / స్థానిక భాష సేకరణ</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="te">స్థానిక భాషలో పుస్తకాల సేకరణ</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="te">భాష నగర ఇస్తుంది</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="te">దేశం</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="te">జిల్లా</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="te">ఈ వైకల్పికం. బ్లూమ్ మీరు సృష్టించడానికి పుస్తకాల టైటిల్ పేజీలో కుడి ప్రదేశాల్లో వాటిని ఉంచండి</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="te">రాష్ట్రభాగము</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="te">{0}పుస్తకాలు</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="te">కొత్త వికసించిన సేకరణ సృష్టించడానికి</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="te">ప్రాజెక్ట్ పేరు</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="te">పేర్లు ఉపయోగించి ఒక కొత్త సేకరణ సృష్టించడానికి చేయలేక</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="te">బ్లూమ్ కు స్వాగతం</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="te">మీరు పుస్తకాలు మేకింగ్ ప్రారంభించడానికి దాదాపు సిద్ధంగా ఉన్నాయి</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. So the first thing we need to do is make one for you.</source>
         <target xml:lang="te">సాధారణ మరియు వ్యవస్థీకృత విషయాలను చేయడానికి.బ్లూమ్ మీరు ఒకటి లేదా ఎక్కువ చేసే అన్ని పుస్తకాలు ఉంచుతుంది &lt;i&gt; సేకరణలు &lt;/ i&gt;కాబట్టి మేము చెయ్యాల్సిన మొదటి విషయం మీరు ఒక చేయడానికి ఉంది.</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="te">'తదుపరి' క్లిక్ ప్రారంభించడానికి</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="te">బ్లూమ్ సేకరణలు</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="te">ఈ కంప్యూటర్లో ఏ ఇతర సేకరణలు బ్రౌజ్</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="te">లోకల్ నెట్వర్క్లో chors స్థావరంలో కాపీ</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="te">ఇంటర్నెట్ నుండి కాపీ</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="te">USB డ్రైవ్ నుండి కాపీ</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="te">కొత్త సేకరణ సృష్టించడానికి</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="te">ఓపెన్ / సృష్టించడానికి సేకరణలు</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="te">మరింత చదవండి</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="te">ఎవరైనా else మీరు ఒక సేకరణ భాగస్వామ్యం పంపు / recieve ఉపయోగించింది?\n మీ కంప్యూటర్లో వారి సేకరణకు కాపీ ఈ ఎరుపు బటన్లు ఒకటి ఉపయోగించండి.\n తరువాత, వారితో తిరిగి మీ పని భాగస్వామ్యం స్వీకరించండి / పంపండి ఉపయోగించండి.</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="te">ఇప్పటికే భర్తీ</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="te">నోటీసు</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are</source>
         <target xml:lang="te">ఆ మార్పు అనుమతి లేదు. వారు ఎక్కడ ఫ్రంట్ పదార్థం మరియు తిరిగి మేటర్ పేజీలు కొనసాగించాలి.</target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="te">చెల్లని తరలింపు</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="te">బ్లూమ్ మీ పూర్తి పుస్తకం చూపవచ్చు కనుక Adobe Reader ని వ్యవస్థాపించాలా దయచేసి. అప్పటి వరకు, మీరు ఇప్పటికీ PDF పుస్తకం సేవ్ చేయవచ్చు మరియు కొన్ని ఇతర ప్రోగ్రామ్ లో తెరవండి.</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="te">ఆ వింత ఉంది. ఆ PDF చూపించడానికి ప్రయత్నించే సమయంలో .. అడోబ్ రీడర్ ఒక లోపం ఇచ్చింది. మీరు ఇప్పటికీ PDF పుస్తకం పొదుపు ప్రయత్నించవచ్చు.</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="te">విచారంగా వార్తలు. బ్లూమ్, ఇక్కడ చూపడానికి అడోబ్ రీడర్ పొందలేకపోతున్నాము ఉందికాబట్టి బ్లూమ్ మీ పూర్తి పుస్తకం చూపించదు. \ n'అడోబ్ రీడర్' మీ ఇప్పటికే ఉన్న వెర్షన్ను అన్ఇన్స్టాల్ మరియు 'అడోబ్ రీడర్' మళ్ళీ ఇన్స్టాల్ చెయ్యండి. \n మీరు స్థిర వచ్చేవరకు, మీరు ఇప్పటికీ PDF పుస్తకం సేవ్ మరియు కొన్ని ఇతర ప్రోగ్రామ్ లో ఓపెన్ చేయవచ్చు.</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="te">బుక్లెట్ insides</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book.
  Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="te">పుస్తకం లోపల పేజీల నుండి ఒక బుక్లెట్ తయారు. పేజీలు నిర్మించబడ్డాయి మరియు మీరు అది భాగాల్లో ఉన్నప్పుడు, మీరు ఒక బుక్లెట్ ఉంటుంది కాబట్టి స్పందించవచ్చు చేయబడుతుంది. \ n</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="te">అప్లోడ్</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="te">బ్లూమ్ లైబ్రరీ అప్లోడ్. ఇతరులు డౌన్లోడ్ మరియు వారి సొంత భాషలోకి స్థానీకరణ ఇక్కడ ఆర్గ్,</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="te">బుక్లెట్ కవర్</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="te">కేవలం ముందు మరియు వెనుక (రెండు వైపులా) ఒక PDF చేయడానికి, కాబట్టి మీరు రంగు కాగితం మీద ముద్రించవచ్చు</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="te">సాధారణ</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="te">పుస్తకం ప్రతి పేజీ ఒక PDF కాగితం ముక్క చొప్పున ఒక పేజీ తయారు</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system pdf viewer</source>
         <target xml:lang="te">డిఫాల్ట్ వ్యవస్థ PDF వ్యూయర్ PDF తెరువు</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="te">&amp;ముద్రణ</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="te">ప్రచురిస్తున్నాను</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="te">&amp;సేవ్ PDF</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="te">పంట మార్కులు</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="te">ముందరి</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">AdditionalRequests: </source>
         <target xml:lang="te">అదనపు విన్నపాలు</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="te">అన్ని హక్కులు రిజర్వు  (ఏ అనుమతులు కోసం కాపీ కుడి హోల్డర్ సంప్రదించండి)</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you.  If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="te">బ్లూమ్ library.org alrady మీరు ఈ పుస్తకం ఒక మునుపటి వెర్షన్ ఉంది. మీరు మళ్ళీ దాన్ని అప్లోడ్ చేస్తే, అది మీ ప్రస్తుత వెర్షన్ తో భర్తీ చేయనున్నారు.</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="te">కాపీరైట్</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="te">క్రెడిట్స్</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="te">మీ పుస్తకం డౌన్లోడ్ చేస్తున్నప్పుడు సమస్య సంభవించింది. మీరు వికసించిన పునఃప్రారంభించుము లేదా సాంకేతిక సహాయాన్ని పొందడానికి అవసరం కావచ్చు.</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="te">క్షమించండి, సమస్య అప్లోడ్ ఉంది {0}, కొన్ని వివరాలు అనుసరించండి. మీరు సాంకేతిక సహాయం అవసరం కావచ్చు.</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading</source>
         <target xml:lang="te">ఒకటి లేదా ఎక్కువ ఖాళీలను పైన అప్లోడ్ ముందు మీ శ్రద్ధ అవసరం</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded</source>
         <target xml:lang="te">క్షమించండి, {0} విజయవంతంగా అప్లోడ్ చేయలేదు</target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes</source>
         <target xml:lang="te">అప్ లోడ్ చేసి ఉపయోగ బ్లూమ్ లైబ్రరీ పదాలతో మీ అంగీకారాన్ని నిర్ధారించండి మరియు వివరిస్తుంది హక్కులను మంజూరు</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="te">మీ పుస్తకం అప్లోడ్ సమస్య ఉంది</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="te">భాషలు</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="te">వాడుక / లైసెన్స్</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="te">ఖాతా ఇప్పటికే ఉనికిలో</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address.  Would you like to log in instead?</source>
         <target xml:lang="te">మేము ఇప్పటికే ఆ చిరునామాతో ఒక ఖాతాను కలిగి ఎందుకంటే మేము, ఆ చిరునామాతో మీరు సైన్ అప్ చేయలేరు. మీరు బదులుగా లాగిన్ అనుకుంటున్నారా?</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="te">బ్లూమ్ మీ లాగిన్ ధ్రువీకరించడం సర్వర్కు కనెక్ట్ చేయడం సాధ్యం కాలేదు. మీ నెట్వర్క్ కనెక్షన్ను తనిఖీ చేయండి.</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="te">లాగిన్ విఫలమైంది</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="te">బ్లూమ్ మీ లాగిన్ ధ్రువీకరించడం లేదా సైన్ అప్ సర్వర్కు కనెక్ట్ చేయడం సాధ్యం కాలేదు. మీ ఇంటర్నెట్ కనెక్షన్, మా సర్వర్, లేదా మధ్య కొన్ని పరికరాలు ఒక సమస్య కావచ్చు.</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="te">ఒక బ్లూమ్ library.org ఖాతా కోసం సైన్ అప్ చేయడానికి, మీరు ఉపయోగించవచ్చు బ్లూమ్స్ లైబ్రరీ పరంగా ఓ అంగీకరిస్తున్నారు సూచిస్తూ బాక్స్ తనిఖీ చెయ్యాలి.</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="te">ఇమెయిల్ అవసరమైన</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="te">మేము ఇమెయిల్ తో రికార్డు యూజర్ కలిగి లేదు. మీరు సైన్ అప్ అనుకుంటున్నారా?</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="te">పాస్వర్డ్ మరియు యూజర్ ID సరిపోలడం లేదు</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="te">ఉపయోగాలు నిబంధనలకు అంగీకరించకుంటే దయచేసి</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="te">ఒక చెల్లుబాటు అయ్యే ఇమెయిల్ చిరునామా ఎంటర్ చెయ్యండి. మీరు మీ పాస్వర్డ్ను రీసెట్ చేయవచ్చు కాబట్టి మేము ఈ చిరునామాకు ఒక ఇమెయిల్ పంపుతుంది.</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="te">బ్లూమ్ మీ పాస్వర్డ్ను రీసెట్ సర్వర్కు కనెక్ట్ చేయడం సాధ్యం కాలేదు. మీ నెట్వర్క్ కనెక్షన్ను తనిఖీ చెయ్యండి.</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="te">పాస్వర్డ్ రీసెట్ విఫలమైంది</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="te">రీసెట్ పాస్వర్డ్ను</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password</source>
         <target xml:lang="te">మేము మీ పాస్వర్డ్ను రీసెట్ చేయడానికి ఎలా సూచనలతో {0} కు ఒక ఇమెయిల్ పంపుతున్నారు.</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="te">బ్లూమ్ లైబ్రరీ కోసం సైన్ అప్</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="te">తెలియని వినియోగదారు</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="te">బ్లూమ్ మీ సేవ్ ఆధారాలను ఉపయోగించి బ్లూమ్ లైబ్రరీ .org లోకి లాగిన్ కాలేదు. మీ నెట్వర్క్ కనెక్షన్ను తనిఖీ చెయ్యండి.</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="te">BLOOMLibrary నుండి లాగ్ అవుట్. ఆర్గ్</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="te">PDF సమీక్ష మేకింగ్</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="te">సూక్ష్మచిత్రం చిత్రం మేకింగ్</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="te">క్షమించండి, బ్లూమ్ డెస్క్టాప్ యొక్క ఈ వెర్షన్ బ్లూమ్ library.org ప్రస్తుత వెర్షన్ అనుకూలత లేదు.ఒక కొత్త వెర్షన్కు దయచేసి అప్గ్రేడ్ చేయండి</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="te">దయచేసి లాగిన్ బ్లూమ్ Library.org</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="te">మార్చు టాబ్ నుండి ఈ సెట్ చెయ్యండి</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="te">స్టెప్ 1 మెటా డేటా నిర్ధారించండి</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="te">స్టెప్ 2 అప్లోడ్</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="te">సలహా: ఒక సృజనాత్మక కామన్స్ లైసెన్సు కేటాయించడం సులభం మీరు స్పష్టంగా అందరికీ నిర్దిష్ట అనుమతి మంజూరు చేస్తుంది.</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="te">సలహా: క్రియేటివ్ కామన్స్ లైసెన్సు వారు మీ కస్టమ్ లైసెన్సు యొక్క భాషలో నిష్ణాతులు కానప్పటికీ, ఇతరులు మీ పుస్తకం ఉపయోగించడానికి కోసం అది చాలా సులభం.</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="te">సారాంశం</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="te">ఉపయోగం షో నిబంధనలు</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="te">టైటిల్</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="te">పుస్తకం అప్లోడ్</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <target xml:lang="te">అభినందనలు, "{0}" బ్లూమ్ లైబ్రరీ లో ఇప్పుడు అందుబాటులో ఉంది. ఆర్గ్ {1}</target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="te">అప్లోడ్ అనుమతి లేదు</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="te">మీ పుస్తకం అప్లోడ్ సమస్య ఉంది, మీరు వికసించిన పునఃప్రారంభించుము లేదా సాంకేతిక సహాయాన్ని పొందడానికి అవసరం కావచ్చు.</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="te">పురోగతి అప్లోడ్</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="te">పురోగతి అప్లోడ్ (to sand box ) </target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="te">అప్లోడ్ పుస్తకం మెటాడేటా</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, &amp; topic tags to the bloomlibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="te">అప్లోడ్</target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="te">CC-BY-NC</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="te">BLOOMLibrary .org లాగిన్</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="te">బ్లూమ్ లైబ్రరీ కోసం సైన్ అప్</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="te">స్థాయి జోడించండి</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="te">రంగస్థల జోడించండి</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <target xml:lang="te">దయచేసి నమూనా పాఠాలు ఫోల్డర్ పాఠాలు జోడించండి</target>
         <note>ID: ReaderSetup.AddTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="te">పుస్తకం</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="te">పుస్తకం ప్రకారం గరిష్ట పదాలు</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="te">ఈ దశలో వాటిని జోడించడానికి అక్షరాల మీద క్లిక్</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="te">sapces ద్వారా ప్రత్యేక</target>
         <note>ID: ReaderSetup.CombinationHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <target xml:lang="te">ఉదాహరణకు: "ai oo sh ng th ing"</target>
         <note>ID: ReaderSetup.CombinationHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <target xml:lang="te">అక్షర కలయికలు (Graphemes)</target>
         <note>ID: ReaderSetup.Combinations</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="te">దానిని decodable దశల్లో</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="te">మొదటి</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="te">ఈ ఫార్మాట్ చదువలేదు</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="te">నమూనా పాఠాలు ఉపయోగించడానికి ఫైళ్లు ఎగుమతి, మార్చడానికి సహాయం</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="te">భాష</target>
         <note>ID: ReaderSetup.Language</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <target xml:lang="te">జాబితా అక్షరాలు మరియు అక్షర క్రమంలో పదం ఏర్పాటు అక్షరాలు</target>
         <note>ID: ReaderSetup.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="te">ఖాళీలతో వేరు</target>
         <note>ID: ReaderSetup.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <target xml:lang="te">ఉదాహరణకు: "a b c d" </target>
         <note>ID: ReaderSetup.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="te">అక్షరాలు</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="te">అక్షరాలు మరియు అక్షరాలు కలయికలు.</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="te">మీరు దానిని decodable పాఠకులు మీకు సహాయం చేయడానికి, వికసించిన అక్షరాలు మరియు మీరు బోధించే ఉంటుంది అక్షరాలు కాంబినేషన్ తెలుసుకోవాలి.</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="te">ఒక ఖాళీ తో ప్రతి అక్షరం లేదా లేఖ కలయిక విభజించండి. ఉదాహరణకు, ఇక్కడ, మేము ఆంగ్ల భాష కోసం ఉపయోగించుకునే ఏమిటి.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="te">ఇంగ్లీష్ జాబితాలో వంటి, పదాలను తయారు ఉపయోగిస్తారు చిహ్నాలు కలిగి గమనించండి.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="te">ఇది</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="te">.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="te">స్థాయి</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="te">స్థాయి</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="te">రీడర్ స్థాయిలు</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="te">మ్యాచింగ్ పదాలు</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="te">పుస్తకం ప్రకారం గరిష్ట ఏకైక పదాలు</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <target xml:lang="te">మరింత పదాలు</target>
         <note>ID: ReaderSetup.MoreWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <target xml:lang="te">ఈ భాషలో మాదిరి వచనం ఫోల్డర్ తెరవడానికి</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="te">పేజీ</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="te">ప్రతి పేజీలో గరిష్ట పదాలు</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="te">ద్వారా ఆధారితం</target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="te">రీడర్ స్థాయిలు</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="te">స్థాయి తొలగించడానికి {0}</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="te">రంగస్థల తొలగించడానికి {0}</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="te">స్థాయిలు క్రమాన్ని వరుసలు లాగండి</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="te">దశల్లో క్రమాన్ని వరుసలు లాగండి</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <target xml:lang="te">పద జాబితాలను మరియు నమూనా పాఠాలు</target>
         <note>ID: ReaderSetup.SampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="te">అక్షరాస్యత కోసం శోధన ఇంజిన్</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="te">ప్రివ్యూ మరియు కొత్త అక్షరాలు</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="te">వాక్యం</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="te">ప్రతి వాక్యం లో గరిష్ట పదాలు</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="te">దానిని decodable రీడర్ టూల్ అప్ సెట్</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="te">సెటప్ రీడర్ టూల్ సమం.</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <target xml:lang="te">ఈ భాషలో సెటప్ వర్ణమాల</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <target xml:lang="te">దృష్టి పదాలు ఏవి?</target>
         <note>ID: ReaderSetup.SightWordHelp</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="te">కొత్త దృష్టి పదాలు</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="te">దృష్టి పదాలు</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="te">వేదిక</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="te">వేదిక</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="te">దశల్లో</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="te">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="te">విషయాలు ఈ స్థాయి గుర్తుంచుకోవడానికి:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="te">ఏకైక</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="te">పదాలు.</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage.  There are two ways to give words to Bloom:</source>
         <target xml:lang="te">మీరు దానిని decodable పాఠకులు మీకు సహాయం చేయడానికి, బ్లూమ్ ప్రస్తుత దశలో తగిన పదాలు సూచించగలరు. వర్ధిల్లు పదాలు ఇవ్వాలని రెండు మార్గం ఉన్నాయి:</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="te">2) ప్లేస్ టెక్స్ట్ ఫైళ్లు మీ</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Text Folder</source>
         <target xml:lang="te">మాదిరి వచనం ఫోల్డర్</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="te">1) ఇక్కడ టైప్</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="te">అక్షరాలు</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this BloomPack will carry your latest decodable and leveled reader settings for the "{0}" language. Anyone opening this BloomPack , who then opens a "{0}" collection, will have their current decodable and leveled reader settings replaced by the settings in this BloomPack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="te">అదనంగా, ఈ BloomPack "{0}" భాష కోసం మీ తాజా దానిని decodable మరియు తనపై రీడర్ సెట్టింగులు, అప్పుడు ఒక "{0}" సేకరణ తెరుస్తుంది ఎవరు ఈ BloomPack ప్రారంభ ఎవరైనా, తమ ప్రస్తుత దానిని decodable మరియు తనపై రీడర్ అమరికలు settings భర్తీ ఉంటుంది ఉంటాను ఈ BloomPack సెట్టింగులు ద్వారా భర్తీ. వారు కూడా దానిని decodable పాఠకులు ఉపయోగం కోసం పదాల ప్రస్తుత సెట్ పొందుతారు.</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="te">తరువాతి పుస్తకాలను టెంప్లేట్లు తయారు చేస్తుంది.</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save BloomPack</source>
         <target xml:lang="te">సేవ్ BloomPack</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template BloomPack</source>
         <target xml:lang="te">రీడర్ మూస BloomPack చేయండి</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="te">ఇమెయిల్ చిరునామా</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="te">మొదటి పేరు</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="te">నమోదు ఒక నిమిషం దయచేసి{0}</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="te">మీరు ఎలా ఉపయోగిస్తున్నారు(0)?</target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="te">నేను కూరుకుపోయి, నేను తరువాత ఈ పూర్తి</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="te">సంస్థ</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="te">&amp;నమోదు</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="te">ఇంటిపేరు</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="te">నమోదు {0}</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="te">ప్రాథమిక పుస్తకం</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="te">పెద్ద పుస్తకం</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="te">దానిని decodable రీడర్</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="te">తనపై వచ్చిన రీడర్</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="te">చిత్రాన్ని నిఘంటువు</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="te">గోడ క్యాలెండర్</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="te">వ్యవసాయం</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="te">జంతు కథలు</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="te">వ్యాపార</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="te">కమ్యూనిటీ దేశం</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="te">సంస్కృతి</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="te">నిఘంటువు</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="te">వాతావరణంలో</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="te">కట్టుకథ</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="te">ఆరోగ్య</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="te">ఎలా</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="te">గణిత</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="te">నాన్ ఫిక్షన్</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="te">వ్యక్తిగత అభివృద్ధి</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="te">ప్రైమర్</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="te">విజ్ఞానము</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="te">ఆధ్యాత్మికం</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="te">సంప్రదాయం</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="te">సంప్రదాయ కథ</target>
         <note>ID: Topics.Traditional Story</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="te">సెటప్</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
       </trans-unit>
-      <trans-unit id="You may use this space for author/illustrator, or anything else." sil:dynamic="true">
+      <trans-unit id="You may use this space for author/illustrator, or anything else." sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="te">రచయిత / చిత్రకారుడు, లేదా మరేదైనా కోసం ఈ స్థలం ఉపయోగించవచ్చు.</target>
         <note>ID: You may use this space for author/illustrator, or anything else.</note>

--- a/DistFiles/localization/te/Palaso.xlf
+++ b/DistFiles/localization/te/Palaso.xlf
@@ -2,395 +2,395 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Palaso.dll" source-language="en" target-language="te" datatype="plaintext" product-version="3.0.53.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="AboutDialog.AboutDialogWindowTitle">
+      <trans-unit id="AboutDialog.AboutDialogWindowTitle" approved="yes">
         <source xml:lang="en">About</source>
         <target xml:lang="te">గురించి</target>
         <note>ID: AboutDialog.AboutDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="AboutDialog.NoUpdates">
+      <trans-unit id="AboutDialog.NoUpdates" approved="yes">
         <source xml:lang="en">No Updates</source>
         <target xml:lang="te">ఏ నవీకరణలు</target>
         <note>ID: AboutDialog.NoUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._checkForUpdates">
+      <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
         <source xml:lang="en">Check For Updates</source>
         <target xml:lang="te">నవీకరణలు కోసం తనిఖీ</target>
         <note>ID: AboutDialog._checkForUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._releaseNotesLabel">
+      <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="te">విడుదల గమనికలు</target>
         <note>ID: AboutDialog._releaseNotesLabel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="te">రద్దు</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.No">
+      <trans-unit id="Common.No" approved="yes">
         <source xml:lang="en">No</source>
         <target xml:lang="te">ఏ</target>
         <note>ID: Common.No</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="te">సరే</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Yes">
+      <trans-unit id="Common.Yes" approved="yes">
         <source xml:lang="en">Yes</source>
         <target xml:lang="te">అవును</target>
         <note>ID: Common.Yes</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="te">{0} రీసైకిల్ బిన్ తరలించబడతాయి</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
         <note>Param 0 is a description of the things being deleted (e.g., "The selected files"</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="te">{0} రీసైకిల్ బిన్ తరలించబడతాయి</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
         <note>Param 0 is a file name</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Confirm Delete</source>
         <target xml:lang="te">నిర్ధారించండి తొలగించండి</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="te">రద్దు</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="te">తొలగించండి</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ArtOfReading">
+      <trans-unit id="ImageToolbox.ArtOfReading" approved="yes">
         <source xml:lang="en">Art Of Reading</source>
         <target xml:lang="te">పఠనం ఆర్ట్</target>
         <note>ID: ImageToolbox.ArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Camera">
+      <trans-unit id="ImageToolbox.Camera" approved="yes">
         <source xml:lang="en">Camera</source>
         <target xml:lang="te">కెమెరా</target>
         <note>ID: ImageToolbox.Camera</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
         <source xml:lang="en">Use {0}</source>
         <target xml:lang="te">యూజ్{0}</target>
         <note>ID: ImageToolbox.CopyExemplarMetadata</note>
         <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Crop">
+      <trans-unit id="ImageToolbox.Crop" approved="yes">
         <source xml:lang="en">Crop</source>
         <target xml:lang="te">పంట</target>
         <note>ID: ImageToolbox.Crop</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EditMetadataLink">
+      <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
         <source xml:lang="en">Edit...</source>
         <target xml:lang="te">మార్చు...</target>
         <note>ID: ImageToolbox.EditMetadataLink</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EnterSearchTerms">
+      <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
         <source xml:lang="en">This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.</source>
         <target xml:lang="te">ఈ 'కళ చాలక గ్యాలరీ' ఉంది. పైన బాక్స్ లో నమోదు నొక్కండి, అప్పుడు మీరు శోధిస్తున్నారు ఏమి టైప్ చేయండి. మీరు ఇంగ్లీష్ మరియు ఇండోనేషియా లో టైప్ చేయవచ్చు.</target>
         <note>ID: ImageToolbox.EnterSearchTerms</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.FileButton">
+      <trans-unit id="ImageToolbox.FileButton" approved="yes">
         <source xml:lang="en">File</source>
         <target xml:lang="te">ఫైల్</target>
         <note>ID: ImageToolbox.FileButton</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
         <target xml:lang="te">చిత్రం పొందడానికి క్షమించండి, ఏదో తప్పు జరిగింది</target>
         <note>ID: ImageToolbox.GenericGettingImageProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericProblem">
+      <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
         <target xml:lang="te">క్షమించండి, ఏదో చిత్రం టూల్ బాక్స్ తప్పు జరిగింది</target>
         <note>ID: ImageToolbox.GenericProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GetPicture">
+      <trans-unit id="ImageToolbox.GetPicture" approved="yes">
         <source xml:lang="en">Get Picture</source>
         <target xml:lang="te">చిత్రాన్ని పొందండి</target>
         <note>ID: ImageToolbox.GetPicture</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
         <source xml:lang="en">Image Toolbox</source>
         <target xml:lang="te">చిత్రం పేజీలు</target>
         <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoMatchingImages">
+      <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
         <source xml:lang="en">Found no matching images</source>
         <target xml:lang="te">సరిపోలే చిత్రాలను దొరకలేదు</target>
         <note>ID: ImageToolbox.NoMatchingImages</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PictureFiles">
+      <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
         <source xml:lang="en">picture files</source>
         <target xml:lang="te">చిత్రాన్ని ఫైళ్లు</target>
         <note>ID: ImageToolbox.PictureFiles</note>
         <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice" approved="yes">
         <source xml:lang="en">Problem Getting Image</source>
         <target xml:lang="te">సమస్య పొందడానికి చిత్రం</target>
         <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemLoadingImage">
+      <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
         <source xml:lang="en">Sorry, there was a problem loading that image.</source>
         <target xml:lang="te">ఆ చిత్రం లోడ్ ఒక సమస్య ఉంది</target>
         <note>ID: ImageToolbox.ProblemLoadingImage</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
         <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
         <target xml:lang="te">చిత్రం తెలియదు: \ n \ n ఎవరు దానిని ఉపయోగించవచ్చు?</target>
         <note>ID: ImageToolbox.PromptForMissingMetadata</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Scanner">
+      <trans-unit id="ImageToolbox.Scanner" approved="yes">
         <source xml:lang="en">Scanner</source>
         <target xml:lang="te">స్కానర్</target>
         <note>ID: ImageToolbox.Scanner</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SetUpMetadataLink">
+      <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
         <source xml:lang="en">Set up metadata...</source>
         <target xml:lang="te">అప్ సెట్ మెటాడేటా</target>
         <note>ID: ImageToolbox.SetUpMetadataLink</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.AlternateNamesHeader">
+      <trans-unit id="LanguageLookup.AlternateNamesHeader" approved="yes">
         <source xml:lang="en">Other Names</source>
         <target xml:lang="te">ఇతర పేర్లు</target>
         <note>ID: LanguageLookup.AlternateNamesHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue" approved="yes">
         <source xml:lang="en">Ethnologue.com</source>
         <target xml:lang="te">Ethnologue.com</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
         <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
         <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
         <target xml:lang="te">భాష గురించి 639-3 కోడ్లను &amp; క్రొత్త వాటిని దరఖాస్తు ఎలా</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
         <source xml:lang="en">About The ISO Language Registry</source>
         <target xml:lang="te">ISO భాషను రిజిస్ట్రీ గురించి</target>
         <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CodeHeader">
+      <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
         <source xml:lang="en">Code</source>
         <target xml:lang="te">కోడ్</target>
         <note>ID: LanguageLookup.CodeHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryHeader">
+      <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="te">దేశం</target>
         <note>ID: LanguageLookup.CountryHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
         <source xml:lang="en">You can change how the language name will be displayed here:</source>
         <target xml:lang="te">మీరు భాష పేరు ఇక్కడ ప్రదర్శించబడుతుంది ఎలా మార్చవచ్చు</target>
         <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
         <source xml:lang="en">Lookup Language Code...</source>
         <target xml:lang="te">భాష కోడ్ వెదకండి</target>
         <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.PrimaryNameHeader">
+      <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="te">పేరు</target>
         <note>ID: LanguageLookup.PrimaryNameHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.UnlistedLanguage">
+      <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
         <source xml:lang="en">Unlisted Language</source>
         <target xml:lang="te">జాబితా చెయ్యని భాషా</target>
         <note>ID: LanguageLookup.UnlistedLanguage</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
         <source xml:lang="en">Can't find your language?</source>
         <target xml:lang="te">మీ భాషను దొరకదు?</target>
         <note>ID: LanguageLookup._cannotFindLanguageLink</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Creator">
+      <trans-unit id="MetadataDisplay.Creator" approved="yes">
         <source xml:lang="en">Creator: {0}</source>
         <target xml:lang="te">సృష్టికర్త</target>
         <note>ID: MetadataDisplay.Creator</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.LicenseInfo">
+      <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
         <source xml:lang="en">License Info</source>
         <target xml:lang="te">లైసెన్సు</target>
         <note>ID: MetadataDisplay.LicenseInfo</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.NoLicense">
+      <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
         <source xml:lang="en">No license specified</source>
         <target xml:lang="te">పేర్కొన్న ఎటువంటి లైసెన్స్</target>
         <note>ID: MetadataDisplay.NoLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowCommercialUse">
+      <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
         <source xml:lang="en">Allow commercial uses of your work?</source>
         <target xml:lang="te">మీ పని వ్యాపార ఉపయోగాలు అనుమతించాలా?</target>
         <note>ID: MetadataEditor.AllowCommercialUse</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowDerivatives">
+      <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
         <source xml:lang="en">Allow modifications of your work?</source>
         <target xml:lang="te">మీ పని మార్పులతో అనుమతించాలా?</target>
         <note>ID: MetadataEditor.AllowDerivatives</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CopyrightHolder">
+      <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
         <source xml:lang="en">Copyright Holder</source>
         <target xml:lang="te">కాపీరైట్ హక్కుదారు</target>
         <note>ID: MetadataEditor.CopyrightHolder</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons">
+      <trans-unit id="MetadataEditor.CreativeCommons" approved="yes">
         <source xml:lang="en">Creative Commons</source>
         <target xml:lang="te">క్రియేటివ్ కామన్స్</target>
         <note>ID: MetadataEditor.CreativeCommons</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreatorLabel">
+      <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="te">సృష్టికర్త</target>
         <note>ID: MetadataEditor.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CustomLicense">
+      <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="te">కస్టమ్</target>
         <note>ID: MetadataEditor.CustomLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleNoCredit">
+      <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
         <source xml:lang="en">Copyright &amp; License</source>
         <target xml:lang="te">కాపీరైట్ &amp; లైసెన్సు</target>
         <note>ID: MetadataEditor.TitleNoCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleWithCredit">
+      <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
         <source xml:lang="en">Credit, Copyright, &amp; License</source>
         <target xml:lang="te">క్రెడిట్, కాపీరైట్ &amp; లైసెన్సు</target>
         <note>ID: MetadataEditor.TitleWithCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.UnknownLicense">
+      <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <target xml:lang="te">క్రెడిట్, ఏ అనుమతులు కోసం కాపీహక్కుదారుని</target>
         <note>ID: MetadataEditor.UnknownLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.YesShareAlike">
+      <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
         <source xml:lang="en">Yes, as long as others share alike</source>
         <target xml:lang="te">అవును, కాలం ఇతరులు ఇలానే పంచుకోవాలి వంటి</target>
         <note>ID: MetadataEditor.YesShareAlike</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.additionalRequestsLabel">
+      <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
         <source xml:lang="en">Additional Requests</source>
         <target xml:lang="te">అదనపు విన్నపాలు</target>
         <note>ID: MetadataEditor.additionalRequestsLabel</note>
         <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.betterLinkLabel1">
+      <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
         <source xml:lang="en">more info</source>
         <target xml:lang="te">మరింత సమాచారం</target>
         <note>ID: MetadataEditor.betterLinkLabel1</note>
         <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere tha defines it.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
         <source xml:lang="en">Not Enforceable</source>
         <target xml:lang="te">అమలు చేయలేని</target>
         <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <target xml:lang="te">ఈ కూడా కాని ఆధునిక వినియోగదారు అవసరమైన ఇతర బటన్లు దాచవచ్చు.</target>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.CtrlShiftHint">
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
         <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
         <target xml:lang="te">బటన్ మీరు Ctrl తగ్గేందుకు మరియు కలిసి కీలను Shift ఉన్నప్పుడు కనిపిస్తాయి</target>
         <note>ID: SettingsProtection.CtrlShiftHint</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+      <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
         <source xml:lang="en">Settings Protection...</source>
         <target xml:lang="te">సెట్టింగులు రక్షణ ...</target>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
         <source xml:lang="en">Hide the button that opens settings.</source>
         <target xml:lang="te">సెట్టింగులను తెరుచుకునే బటన్ దాచు.</target>
         <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
         <source xml:lang="en">Factory Password</source>
         <target xml:lang="te">ఫ్యాక్టరీ పాస్వర్డ్ను</target>
         <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
         <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
         <target xml:lang="te">ఈ సాధనం మీరు కోసం పని ఆపడానికి కారణం కావచ్చు ఇది ప్రమాదవశాత్తు మార్పులు నివారించడానికి, ఈ సెట్టింగులను లాక్ చేశారు.</target>
         <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
         <source xml:lang="en">Settings Protection Password</source>
         <target xml:lang="te">సెట్టింగులు రక్షణ పాస్వర్డ్ను</target>
         <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox">
+      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
         <source xml:lang="en">Show Characters</source>
         <target xml:lang="te">కార్యక్రమం పాత్రలు</target>
         <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordNotice">
+      <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
         <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always google for "{1}" and "{2}".</source>
         <target xml:lang="te">ఈ సెట్టింగులను కోసం కర్మాగారం పాస్వర్డ్ "{0}". మీరు మర్చిపోతే, మీరు ఎల్లప్పుడూ "{1}" మరియు "{2}" కోసం గూగుల్ చేయవచ్చు</target>
         <note>ID: SettingsProtection.PasswordNotice</note>
         <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
         <source xml:lang="en">Require the factory password to get into settings.</source>
         <target xml:lang="te">సెట్టింగులను పొందడానికి ఫ్యాక్టరీ పాస్వర్డ్ అవసరం</target>
         <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
         <source xml:lang="en">Settings Protection</source>
         <target xml:lang="te">సెట్టింగులు రక్షణ</target>
         <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
         <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
         <target xml:lang="te">మీరు అవసరం కీబోర్డ్ జాబితా కాకపోతే, దానిని సెట్ క్రింద తగిన లింక్ క్లిక్ చేయండి.</target>
         <note>ID: WSKeyboardControl.KeyboardNotListed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
         <source xml:lang="en">Windows keyboard settings</source>
         <target xml:lang="te">విండో కీబోర్డ్ సెట్టింగ్లు</target>
         <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
         <source xml:lang="en">Available keyboards</source>
         <target xml:lang="te">అందుబాటులో కీబోర్డులు</target>
         <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
         <source xml:lang="en">Previously used keyboards</source>
         <target xml:lang="te">గతంలో ఉపయోగించిన కీబోర్డ్</target>
         <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
         <source xml:lang="en">Keyman Configuration</source>
         <target xml:lang="te">Keyman ఆకృతీకరణ</target>
         <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
         <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
         <target xml:lang="te">Keyman 5.0 or తరువాత ఇన్స్టాల్ కాలేదు.</target>
         <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
         <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
         <target xml:lang="te">{0} టెక్స్ట్ టైప్ చేయడానికి ఇది ఫలక ఎంచుకోండి</target>
         <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.TestAreaCaption">
+      <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
         <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
         <target xml:lang="te">&amp; టెస్ట్ ఏరియా (మీ కీబోర్డ్ పరీక్షించడానికి ఏదో టైప్ ఈ ప్రాంతంలో ఉపయోగించండి.)</target>
         <note>ID: WSKeyboardControl.TestAreaCaption</note>

--- a/DistFiles/localization/th/Bloom.xlf
+++ b/DistFiles/localization/th/Bloom.xlf
@@ -2,2496 +2,2496 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="th" datatype="plaintext" product-version="3.0.100.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="th">เครื่องมือ Decodable Reader  </target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="th">เครื่องมือ Leveled Reader</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="th">อื่น ๆ ...</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName">
+      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName" approved="yes">
         <source xml:lang="en">Possibly this is an old BloomPack created before BloomPacks could handle special characters in file names. You may be able to get the author to re-create it using a current version. If that's not possible a technical expert may be able to repair things.</source>
         <target xml:lang="th">อาจเป็นไปได้นี้เป็นBloomPackเก่าสร้างขึ้นก่อน BloomPacks สามารถจัดการอักขระพิเศษในชื่อไฟล์. คุณอาจจะสามารถที่จะได้รับของผู้เขียนที่จะสร้างใหม่อีกครั้งโดยใช้รุ่นปัจจุบัน. หากเป็นไปไม่ได้ผู้เชี่ยวชาญด้านเทคนิคอาจจะไม่สามารถที่จะซ่อมแซมสิ่ง</target>
         <note>ID: BloomPackInstallDialog.BadCharsInFileName</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="th">การติดตั้ง Bloom Pack</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="th">ตอนนี้ {0} Collection พร้อมที่จะใช้ในคอมพิวเตอร์เครื่องนี้</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller" approved="yes">
         <source xml:lang="en">Bloom Pack Installer</source>
         <target xml:lang="th">Bloom Pack Installer</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstaller</note>
         <note>Displayed as the message box title</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.DoesNotExist">
+      <trans-unit id="BloomPackInstallDialog.DoesNotExist" approved="yes">
         <source xml:lang="en">{0} does not exist</source>
         <target xml:lang="th">{0} ไม่มี</target>
         <note>ID: BloomPackInstallDialog.DoesNotExist</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="th">Bloom ไม่สามารถที่จะติดตั้งที่BloomPack</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="th">การถอน….</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while BloomPacks are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="th">Bloomทำงานอยู่ แต่เนื้อหาจะไม่ปรากฏขึ้นจนกว่าจะถึงเวลาถัดไปที่คุณทำBloom</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.NotInstalled">
+      <trans-unit id="BloomPackInstallDialog.NotInstalled" approved="yes">
         <source xml:lang="en">The Bloom collection will not be installed.</source>
         <target xml:lang="th">Bloom Collectionจะไม่ได้รับการติดตั้ง</target>
         <note>ID: BloomPackInstallDialog.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="th">การเปิด {0}…</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Replace">
+      <trans-unit id="BloomPackInstallDialog.Replace" approved="yes">
         <source xml:lang="en">This computer already has a Bloom collection named '{0}'. Do you want to replace it with the one from this Bloom Pack?</source>
         <target xml:lang="th">คอมพิวเตอร์นี้มีBloom Collection อยู่แล้ว '{0}'. คุณต้องการที่จะแทนที่ด้วยหนึ่งจาก Bloom Pack นี้ไม่?</target>
         <note>ID: BloomPackInstallDialog.Replace</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder">
+      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder" approved="yes">
         <source xml:lang="en">Bloom Packs should have only a single collection folder at the top level of the zip file.</source>
         <target xml:lang="th">Bloom Packs ควรจะมีเพียงโฟลเดอร์เดียวCollectionที่ระดับบนสุดของไฟล์ซิป</target>
         <note>ID: BloomPackInstallDialog.SingleCollectionFolder</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.UnableToReplace">
+      <trans-unit id="BloomPackInstallDialog.UnableToReplace" approved="yes">
         <source xml:lang="en">Bloom was not able to remove the existing copy of '{0}'. Quit Bloom if it is running &amp; try again. Otherwise, try again after restarting your computer.</source>
         <target xml:lang="th">Bloom ก็ไม่สามารถที่จะเอาสำเนาที่มีอยู่ของ '{0}'. ออกจากBloomถ้ามีการทำงานและลองอีกครั้ง. มิฉะนั้นลองอีกครั้งหลังจากรีสตาร์ทเครื่องคอมพิวเตอร์ของคุณ</target>
         <note>ID: BloomPackInstallDialog.UnableToReplace</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all text boxes with '{0}' style</source>
         <target xml:lang="th">การจัดรูปแบบนี้มีไว้สำหรับกล่องข้อความทั้งหมดที่มี '{0}' สไตล์</target>
         <note>ID: BookEditor.ForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text in boxes with '{1}' style</source>
         <target xml:lang="th">การจัดรูปแบบนี้มีไว้สำหรับทุก {0} ข้อความในกล่องที่มี '{1}' สไตล์</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="th">การตั้งค่าโปรแกรมขั้นสูง</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="th">ปรากฏในคำสั่งการทดสอบ (เช่นส่งออกไปยัง InDesign ในรูปแบบ XML)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="th">แสดงผลการทดลองแม่แบบ (ตัวอย่าง: พจนานุกรมรูปภาพ)</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="th">กรุณาใช้ Image Server การดำเนินงานภาพใหญ่นี้สามารถลดการใช้หน่วยความจำ</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="th">(ทดสอบ) แสดงส่ง / รับการควบคุม</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="th">การผลิตหนังสือ</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="th">แบบอักษรเริ่มต้นสำหรับ {0}</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="th">ด้านหน้า / หลัง Matter Pack</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="th">ขวาไปซ้ายระบบการเขียน</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="th">การตั้งค่า </target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="th">เปลี่ยน ...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="th">ภาษา 1</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="th">ภาษา 2</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="th">ภาษา 3</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="th">ภาษา </target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="th">การจัดตั้ง …</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="th">ภาษาท้องถิ่น</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="th">ภาษาที่ 2 (ตัวอย่าง: ภาษาประจำชาติ)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)   (Optional)</source>
         <target xml:lang="th">ภาษาที่ 3 (ตัวอย่างเช่นภาษาของแคว้น) (ถ้ามี)</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="th">ลบ</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="th">ชื่อของ Bloom Collection</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="th">ประเทศ</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="th">ตำบล</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="th">ข้อมูลโครงการ</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="th">จังหวัด</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="th">เริ่มต้นใหม่</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="th">Bloom จะปิดแล้วเปิดโครงการเพื่อการตั้งค่าใหม่</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book, but these programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="th">Bloom จะเปิดไฟล์ HTML (Word หรือ LibreOffice)ในประมวลผลคำของคุณ. โปรดทราบว่าคุณสามารถจัดการกับข้อความของหนังสือหรือภาพ แต่ไม่จำเป็นต้องสามารถที่จะบันทึกรูปแบบ</target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="th">การปรับปรุงหนังสือ </target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="th">การปรับปรุง Thumbnail</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="th">ลบหนังสือ</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="th">ส่งออกไปยัง Word หรือ LibreOffice ...</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="th">การส่งออกในรูปแบบ XML เพื่อ InDesign ...</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="th">หนังสือจาก BloomLibrary.org</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="th">อัพเดททั้งหมดหนังสือ</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="th">ตรวจสอบหนังสือทั้งหมด</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="th">การเก็บรักษาของภาพที่หายไป ...</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="th">การเก็บรวบรวมประวัติศาสตร์ ...</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="th">บันทึกการเก็บรวบรวม ...</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="th">Collections</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="th">Collections</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="th">{0} หนังสือ</target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="th">เปิดโฟลเดอร์ในดิสก์</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="th">สุขภาพ</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <target xml:lang="th">ทำหนังสือโดยใช้แหล่งนี้</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="th">Collection อื่น ๆ</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is is the button you use to create a new collection, open a new one, or get one from a repository somewhere</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="th">Shells ตัวอย่าง </target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="th">การส่งผ่าน / การรับ</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="th">จัดตั้งขึ้น</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="th">แหล่งCollection</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="th">เปิดโฟลเดอร์ Collection อื่น ๆ</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="th">แบบเทมเพลต</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="th">การแก้ไขหนังสือเล่มนี้</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="th">ทำ Bloom Pack</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <target xml:lang="th">ทำแม่แบบผู้อ่าน Bloom Pack ...</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="th">ก้าวหน้า</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="th">ได้รับแหล่งหนังสืออื่น ๆที่ BloomLibrary.org</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="th">Source Collection</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="th">แหล่งที่มาสำหรับหนังสือใหม่</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="th">การเก็บรวบรวมนี้ถูกล็อกคุณไม่สามารถเพิ่มหรือลบหนังสือได้</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="th">เพราะที่นี่เป็นcollectionแหล่ง,Bloom ไม่ได้นำเสนอ shells ใด ๆ ที่มีอยู่เป็นแหล่งที่มาสำหรับ shells ใหม่. ถ้าคุณต้องการที่จะเพิ่มภาษาที่จะ shell, แทนที่คุณจำเป็นต้องแก้ไข collection ที่มี shell, มากกว่าการทำสำเนาของมัน. นอกจากนี้ Wall Calendar ขณะนี้ยังไม่สามารถนำมาใช้เพื่อShell ใหม่.</target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="th">อื่น ๆ ...</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
         <note>Brings up the localization dialog</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem">
+      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem" approved="yes">
         <source xml:lang="en">Open or Create Another Collection</source>
         <target xml:lang="th">เปิดหรือสร้าง Collection อีก</target>
         <note>ID: CollectionTab.OpenCreateCollectionMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="th">แหล่งสำหรับ Shells ใหม่</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="th">กลับ</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="th">ยกเลิก</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="th">&amp;ยกเลิก</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="th">&amp;เสร็จ</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="th">&amp;การช่วยเหลือ</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="th">&amp;ถัดไป</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="th">ถัดไป </target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK" sil:dynamic="true">
+      <trans-unit id="Common.OK" sil:dynamic="true" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="th">กำหนด </target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="th">&amp;กำหนด </target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="th">ไม่จำเป็น</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="th">การก่อสร้าง ...</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="th">ตัวอักษรในขั้นตอนนี้</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="th">เปิดตัวอักษรและไฟล์รายการคำ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="th">ขั้นตอนการจัดตั้ง</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="th">ขั้นตอน</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="th">ของ</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="th">คำในขั้นตอนนี้</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections. If you don't seem to be in the middle of doing something, Bloom will select it for you.</source>
         <target xml:lang="th">{0} ของคุณการดาวน์โหลดเสร็จสมบูรณ์ คุณสามารถดูได้ที่ 'Books from BloomLibrary.org'  ส่วนที่พบในการเก็บรวบรวม หากคุณไม่ได้แก้ไขได้Bloomจะเลือกให้.</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="th">ดาวน์โหลดเสร็จสมบูรณ์</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="th">การดาวน์โหลดหนังสือ</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="th">การดาวน์โหลดหนังสือมีปัญหา</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="th">ถ้าคุณต้องการที่ใดที่หนึ่งที่จะนำข้อมูลเพิ่มเติมเกี่ยวกับหนังสือเล่มนี้ คุณสามารถใช้หน้านี้ซึ่งเป็นด้านในของฝาหลัง</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="th">ถ้าคุณต้องการที่ใดที่หนึ่งที่จะนำข้อมูลเพิ่มเติมเกี่ยวกับหนังสือเล่มนี้ คุณสามารถใช้หน้านี้ซึ่งเป็นด้านนอกของฝาหลัง</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true">
+      <trans-unit id="EditTab.TextBoxProperties.Background" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Background</source>
         <target xml:lang="th">พื้นหลัง</target>
         <note>ID: EditTab.TextBoxProperties.Background</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the Html used to make this PDF, in Firefox (must be on path)</source>
         <target xml:lang="th">เปิด Html ใช้ในการสร้างรูปแบบไฟล์ PDF นี้ใน Chrome (ต้องอยู่บนเส้นทาง)</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="th">ขออภัยลิขสิทธิ์และใบอนุญาตสำหรับหนังสือเล่มนี้ไม่สามารถเปลี่ยนแปลงได้</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="th">ขออภัยหนังสือเล่มนี้ถูกล็อคลงเพื่อให้ภาพที่ไม่สามารถเปลี่ยนแปลงได้</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="th">ตกลงที่จะลบหน้านี้หรือไม่?</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="th">&amp;ลบ</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="th">หน้านี้จะถูกลบออกอย่างถาวร</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="th">เปลี่ยนเค้าโครง</target>
         <note>ID: EditTab.CustomPage.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true" approved="yes">
         <source xml:lang="en">or</source>
         <target xml:lang="th">หรือ</target>
         <note>ID: EditTab.CustomPage.Or</note>
         <note>Shown between 'Picture' and 'Text' when Custom Page is in Layout mode</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture</source>
         <target xml:lang="th">ภาพ</target>
         <note>ID: EditTab.CustomPage.Picture</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <target xml:lang="th">ข้อความ</target>
         <note>ID: EditTab.CustomPage.Text</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <target xml:lang="th">กล่องข้อความ</target>
         <note>ID: EditTab.CustomPage.TextBox</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="th">แก้ไข</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="th">แบบอักษรที่เลือกในปัจจุบันคือ '{0}' แต่มันไม่ได้ติดตั้งบนคอมพิวเตอร์เครื่องนี้ บางตัวอักษรอื่น ๆ จะถูกนำมาใช้</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true" approved="yes">
         <source xml:lang="en">That style already exists. Please choose another name.</source>
         <target xml:lang="th">สไตล์ที่มีอยู่แล้ว โปรดเลือกชื่ออื่น</target>
         <note>ID: EditTab.FormatDialog.AlreadyExists</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="th">เปลี่ยนเส้นขอบและพื้นหลัง</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <target xml:lang="th">ตัวอักษร</target>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <target xml:lang="th">สร้าง</target>
         <note>ID: EditTab.FormatDialog.Create</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create a new style</source>
         <target xml:lang="th">สร้างรูปแบบใหม่</target>
         <note>ID: EditTab.FormatDialog.CreateStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Don't see what you need?</source>
         <target xml:lang="th">คุณไม่เห็นสิ่งที่คุณต้องการ?</target>
         <note>ID: EditTab.FormatDialog.DontSeeNeed</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Emphasis</source>
         <target xml:lang="th">ความสำคัญ</target>
         <note>ID: EditTab.FormatDialog.Emphasis</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <target xml:lang="th">ตัวอักษร</target>
         <note>ID: EditTab.FormatDialog.Font</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="th">เปลี่ยนขนาดแบบอักษร</target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="th">เปลี่ยนขนาดตัวอักษรสำหรับกล่องทั้งหมดถือสไตล์ '{0}' และภาษา '{1}'. \nขนาดปัจจุบันเป็น {2} จุด</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="th">เปลี่ยนระยะห่างระหว่างบรรทัดของข้อความ</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Format</source>
         <target xml:lang="th">รูปแบบ</target>
         <note>ID: EditTab.FormatDialog.Format</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="th">เปลี่ยนระยะห่างระหว่างบรรทัดของข้อความ</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New style</source>
         <target xml:lang="th">สไตล์ใหม่</target>
         <note>ID: EditTab.FormatDialog.NewStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please use only alphabetical characters. Numbers at the end are ok, as in "part2".</source>
         <target xml:lang="th">กรุณาใช้ตัวอักษรตัวอักษรเท่านั้น ตัวเลขที่สิ้นสุดจะ ok ในขณะที่ "part2"</target>
         <note>ID: EditTab.FormatDialog.PleaseUseAlpha</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <target xml:lang="th">ระยะห่าง</target>
         <note>ID: EditTab.FormatDialog.Spacing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <target xml:lang="th">สไตล์</target>
         <note>ID: EditTab.FormatDialog.Style</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <target xml:lang="th">ชื่อสไตล์</target>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="th">กว้างพิเศษ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="th">ปกติ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="th">เปลี่ยนระยะห่างระหว่างคำ</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="th">กว้าง</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="th">เมื่อคุณมีการทำหนังสือเล่มเดิมใช้กล่องนี้เพื่อบันทึกการมีส่วนร่วมทำโดยนักเขียนนักวาดภาพประกอบ, บรรณาธิการ ฯลฯ</target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="th">เมื่อคุณทำหนังสือจากเปลือกใช้ช่องนี้เพื่อบอกผู้ที่ได้แปล</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="th">ชื่อหนังสือใน {lang}</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright &amp; License</source>
         <target xml:lang="th">คลิกที่นี่เพื่อแก้ไขลิขสิทธิ์และใบอนุญาต</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="th">ใช้สิ่งนี้เพื่อรับทราบหน่วยงานระดมทุนใด ๆ</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="th">หมายเลขหนังสือมาตรฐานสากล. ปล่อยว่างไว้ถ้าคุณไม่ได้มีหนึ่งในจำนวนนี้</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="th">ต้นฉบับ (หรือ Shell) ใน {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="th">การมีส่วนร่วมทำโดยนักเขียนนักวาดภาพประกอบ, บรรณาธิการ ฯลฯ, ใน {lang}</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="th">คลิกที่นี่เพื่อเลือกอาร์เรย์ของหัวข้อ</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="th">การรับรองสำหรับรุ่นที่แปล, ใน {lang}</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="th">เปลี่ยนรูป</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, &amp; License</source>
         <target xml:lang="th">แก้ไขเครดิตภาพ, ลิขสิทธิ์และใบอนุญาต</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="th">แปะรูป</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="th">ก่อนที่คุณจะสามารถวางภาพ คัดลอกลงบน 'clipboard' ของคุณจากโปรแกรมอื่น</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="th">หลายหน้า</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="th">เลือกขนาดหน้าและการวางแนว</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.Position" sil:dynamic="true">
+      <trans-unit id="EditTab.Position" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Position</source>
         <target xml:lang="th">ที่ตั้ง</target>
         <note>ID: EditTab.Position</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="th">เปลี่ยนเส้นขอบและพื้นหลัง</target>
         <note>ID: EditTab.StyleEditor.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="th">เปลี่ยนหน้าอักษร</target>
         <note>ID: EditTab.StyleEditor.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="th">เปลี่ยนขนาดแบบอักษร</target>
         <note>ID: EditTab.StyleEditor.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="th">เปลี่ยนระยะห่างระหว่างบรรทัดของข้อความ</target>
         <note>ID: EditTab.StyleEditor.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="th">กว้างพิเศษ</target>
         <note>ID: EditTab.StyleEditor.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="th">ปกติ</target>
         <note>ID: EditTab.StyleEditor.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="th">เปลี่ยนระยะห่างระหว่างคำ</target>
         <note>ID: EditTab.StyleEditor.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="th">กว้าง</target>
         <note>ID: EditTab.StyleEditor.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="th">ปรับรูปแบบสำหรับรูปแบบ</target>
         <note>ID: EditTab.StyleEditorTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="th">หน้าแม่แบบ</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="th">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="th">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="th">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="th">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="th">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="th">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="th">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="th">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="th">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="th">ตัวอักษร</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="th">ข้อความพื้นฐานและภาพ</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="th">ข้อความและรูปภาพ</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="th">เครดิตหน้า</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="th">ประเพณี</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="th">วันที่ 1</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="th">วันที่ 2</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="th">วันที่ 3</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="th">วันที่ 4</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="th">วันที่ 5a</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="th">วันที่ 5b</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="th">ปกหน้า</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="th">ภาพที่แสดงด้านล่าง</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="th">ภาพในกลาง</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="th">ปกหลังด้านใน</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="th">ภายในปกหน้า</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="th">คำแนะนำ</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="th">เพียงแค่ข้อความ</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="th">เพียงแค่รูปภาพ</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="th">เพียงแค่ภาพ</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="th">นอกปกหลัง</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="th">รูปภาพและคำ</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="th">รูปภาพที่ด้านล่าง</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="th">ภาพในกลาง</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="th">หน้านี้จะว่างเปล่าจงใจ</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="th">ชื่อหน้า</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="th">การตั้งค่าการพูดได้หลายภาษา</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="th">อัด</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="th">ตัด</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="th">ลบ\n หน้า</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="th">อัด\n หน้า</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="th">แปะ</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="th">แก้</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="th">สองภาษา</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="th">อัดข้อมูลนี้ไปภาพอื่น ๆ ทั้งหมดในหนังสือเล่มนี้หรือไม่?</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="th">ตัวเลือกนี้จะใช้ได้เฉพาะในประกาศ tab</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="th">หนึ่งภาษา</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="th">ไม่มีตัวเลือกรูปแบบอื่น ๆ สำหรับแม่แบบนี้</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="th">รูปภาพข้อมูลทรัพย์สินทางปัญญา</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="th">สามภาษา</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="th">การทำผู้อ่านแม่แบบ</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu">
+      <trans-unit id="HelpMenu.Help Menu" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="th">ช่วย</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="th">การใช้แม่แบบอ่าน</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="th">ให้คำแนะนำได้</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="th">เว็บไซต์</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="th">ตรวจสอบรุ่นใหม่</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="th">เกี่ยวกับ Bloom</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Documentation</source>
         <target xml:lang="th">เอกสาร</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem">
+      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem" approved="yes">
         <source xml:lang="en">Key Bloom Concepts</source>
         <target xml:lang="th">แนวคิดหลักของ Bloom</target>
         <note>ID: HelpMenu.KeyBloomConceptsToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="th">การลงทะเบียน</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="th">บันทึกรี ...</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem">
+      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem" approved="yes">
         <source xml:lang="en">Report a Problem...</source>
         <target xml:lang="th">รายงานปัญหา ...</target>
         <note>ID: HelpMenu.ReportAProblemToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="th">แสดงบันทึกเหตุการณ์</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="th">InDesign XML ข้อมูล</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="th">อย่าแสดงข้อความนี้อีก</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="th">A4 แนวนอน</target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="th">A4 แนวนอน เคียงบ่าเคียงไหล่</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="th">A4 แนวนอน  แยกข้ามหน้า</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="th">A4 แนวตั้ง</target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="th">A5 แนวนอน</target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="th">A5 แนวตั้ง</target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="th">A5 แนวตั้ง จัดชิดด้านล่าง</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="th">B5 แนวตั้ง</target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="th">แท้</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="th">ทางเลือกของข้อความ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="th">สำหรับระดับนี้</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="th">การจัดรูปแบบ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="th">สนับสนุนภาพประกอบ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="th">จำไว้</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="th">ระดับ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> of </source>
         <target xml:lang="th">ของ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="th">ที่สุด</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="th">ต่อหน้า</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="th">ต่อประโยค</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="th">ความสามารถทายได้</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="th">ตั้งค่าระดับ</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="th">หนังสือเล่มนี้</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="th">หน้านี้</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="th">ทั้งหมด</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="th">เป็นเอกลักษณ์</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="th">ประมวลคำศัพท์</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="th">นับคำว่า</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="th">ผมเห็นด้วยกับข้อตกลงการใช้ห้องสมุดBloomในการใช้งาน</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="th">ที่อยู่อีเมล</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="th">ลืมรหัสผ่าน</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="th">&amp;Login</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="th">รหัสผ่าน</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="th">แสดงเงื่อนไขการใช้</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="th">การเข้าสู่ระบบ BloomLibrary.org</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="th">&amp;แสดง รหัสผ่าน</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="th">มีอยู่แล้วการเก็บรวบรวมที่มีชื่อว่า ที่ &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\n กรุณาเลือกชื่อที่ไม่ซ้ำ</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="th">เลือกภาษาหลักสำหรับการเก็บรวบรวมนี้</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="th">ตัวอย่าง: "หนังสือสุขภาพ", "เรื่องสัตว์ PNG"</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="th">สำหรับการเก็บรวบรวมนี้คุณจะตั้งชื่ออะไร</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="th">ปัญหาเกี่ยวกับชื่อ Collection</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="th">Collectionถูกสร้างขึ้นที่: {0}</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="th">พร้อมที่จะสร้างCollectionใหม่</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="th">เลือกประเภทCollection</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="th">แหล่งCollection</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org and optionally make a Bloom Pack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="th">Collection ของหนังสือเปลือกหรือแม่แบบในหนึ่งหรือภาษาของการสื่อสารที่กว้างขึ้น. คุณจะสามารถที่จะอัปโหลดเปลือกหอยเหล่านี้ไป BloomLibrary.org และเลือกที่จะทำ Bloom ให้กับคนอื่นเพื่อให้พวกเขาสามารถทำให้หนังสือภาษาพื้นเมืองด้วยเปลือกหอยของคุณ</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="th">ภาษาถิ่น / ภาษาท้องถิ่น Collection</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="th">Collection ของหนังสือในภาษาท้องถิ่น</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="th">ให้ที่อยู่ภาษา</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="th">ประเทศ</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="th">ตำบล</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="th">เหล่านี้เป็นตัวเลือก. Bloom จะวางไว้ในสถานที่ที่เหมาะสมที่ชื่อหน้าของหนังสือที่คุณสร้าง</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="th">จังหวัด</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="th">{0} หนังสือ</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="th">ทำ Bloom Collection ใหม่</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="th">ชื่อโครงการ</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="th">โดยใช้ชื่อที่ไม่สามารถสร้างCollectionใหม่</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="th">ยินดีต้อนรับ Bloom!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="th">คุณอยู่ที่เกือบจะพร้อมที่จะเริ่มต้นการทำหนังสือ</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. So the first thing we need to do is make one for you.</source>
         <target xml:lang="th">เพื่อที่จะให้สิ่งที่ง่ายและการจัดระเบียบ, Bloom ช่วยให้หนังสือทุกเล่มที่คุณทำในหนึ่งหรือมากกว่า</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="th">คลิก 'ถัดไป' เพื่อเริ่มต้น</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="th">Bloom Collections</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="th">เลือกดูCollectionอื่นบนคอมพิวเตอร์เครื่องนี้</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="th">คัดลอกจาก Chorus Hub ในเครือข่ายท้องถิ่น</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="th">คัดลอกจากอินเทอร์เน็ต</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="th">คัดลอกจากUSBไดรฟ์</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="th">สร้างCollectionใหม่</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="th">เปิด / สร้าง Collections</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="th">อ่านเพิ่มเติม</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="th">มีคนอื่นที่ใช้ในการส่ง / รับCollectionที่จะแบ่งปันกับคุณ? \n ให้ใช้ปุ่มใดปุ่มหนึ่งสีแดงเหล่านี้เพื่อคัดลอกColletionของพวกเขาไปยังเครื่องคอมพิวเตอร์ของคุณ. \n ต่อมาใช้ส่ง / รับที่จะร่วมกันทำงานของคุณกลับมาพร้อมกับพวกเขา</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="th">แทนที่ที่มีอยู่</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="th">แจ้งให้ทราบ</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are</source>
         <target xml:lang="th">การเปลี่ยนแปลงที่ไม่ได้รับอนุญาต.เรื่องหน้าและหน้าเรื่องกลับต้องอยู่ที่พวกเขาอยู่</target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="th">ย้ายที่ไม่ถูกต้อง</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.BadPdf">
+      <trans-unit id="PublishTab.PdfMaker.BadPdf" approved="yes">
         <source xml:lang="en">Bloom had a problem making a PDF of this book. You may need technical help or to contact the developers. But here are some things you can try:</source>
         <target xml:lang="th">"Bloom มีปัญหาการทำรูปแบบไฟล์ PDF ของหนังสือเล่มนี้\nคุณอาจต้องการความช่วยเหลือทางเทคนิคหรือการที่จะติดต่อนักพัฒนา แต่ที่นี่มีบางสิ่งที่คุณสามารถลอง:"</target>
         <note>ID: PublishTab.PdfMaker.BadPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory">
+      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory" approved="yes">
         <source xml:lang="en">Try doing this on a computer with more memory</source>
         <target xml:lang="th">ลองทำเช่นนี้บนคอมพิวเตอร์ที่มี memory เพิ่มเติม</target>
         <note>ID: PublishTab.PdfMaker.TryMoreMemory</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryRestart">
+      <trans-unit id="PublishTab.PdfMaker.TryRestart" approved="yes">
         <source xml:lang="en">Restart your computer and try this again right away</source>
         <target xml:lang="th">เปิดคอมพิวเตอร์ของคุณใหม่และพยายามที่นี้อีกครั้งทันที</target>
         <note>ID: PublishTab.PdfMaker.TryRestart</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages">
+      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages" approved="yes">
         <source xml:lang="en">Replace large, high-resolution images in your document with lower-resolution ones</source>
         <target xml:lang="th">เปลี่ยนขนาดใหญ่ภาพความละเอียดสูงในเอกสารของคุณกับคนที่มีความละเอียดต่ำ</target>
         <note>ID: PublishTab.PdfMaker.TrySmallerImages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="th">กรุณาติดตั้ง Adobe Reader เพื่อให้บลูมสามารถแสดงหนังสือของคุณเสร็จสมบูรณ์</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="th">นั่นคือแปลก ... Adobe Reader ให้ข้อผิดพลาดเมื่อพยายามที่จะแสดงให้เห็นว่ารูปแบบไฟล์ PDF คุณยังสามารถลองบันทึกหนังสือในรูปแบบ PDF</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="th">ขอโทษ. Bloom ก็ไม่สามารถที่จะได้รับที่จะแสดงโปรแกรม Adobe Reader ที่นี่ดังนั้น Bloom ไม่สามารถแสดงหนังสือของคุณเสร็จสมบูรณ์. \n กรุณาถอนการติดตั้งรุ่นของคุณที่มีอยู่ของ 'Adobe Reader' และ (ติดตั้งอีกครั้ง) ติดตั้ง 'Adobe Reader '. จนกว่าคุณจะได้รับการแก้ไขที่คุณยังสามารถบันทึกหนังสือ PDF และเปิดในโปรแกรมอื่น ๆ</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="th">เนื้อหาภายในหนังสือเล่มเล็ก</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book.
  Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="th">ทำหนังสือเล่มเล็กจากหน้าภายในของหนังสือเล่มนี้ หน้าจะได้รับการวางและจัดลำดับใหม่เพื่อที่ว่าเมื่อคุณพับมันคุณจะมีหนังสือเล่มเล็ก. \ n</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="th">การอัปโหลด </target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="th">การอัปโหลด BloomLibrary.org, ที่คนอื่นสามารถดาวน์โหลดและ จำกัด วงเป็นภาษาของตัวเอง</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="th">ปกหนังสือเล่มเล็ก</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="th">ทำไฟล์ PDF เพียงด้านหน้าและด้านหลัง (ทั้งสองฝ่าย), เพื่อให้คุณสามารถพิมพ์ลงบนกระดาษสี</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="th">ง่าย</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="th">ทำไฟล์ PDF ของทุกหน้าของหนังสือเล่มนี้, หนึ่งหน้าต่อชิ้นส่วนของกระดาษ</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system pdf viewer</source>
         <target xml:lang="th">เปิด PDF ในระบบเริ่มต้นการดูไฟล์ PDF</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="th">&amp;พิมพ์…</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="th">ประกาศ</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="th">&amp;บันทึก PDF...</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="th">Crop Marks</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="th">กิตติกรรมประกาศ</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">AdditionalRequests: </source>
         <target xml:lang="th">ขอเพิ่มเติม:</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="th">All rights reserved (Contact the Copyright holder for any permissions.)</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you.  If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="th">BloomLibrary.org แล้วมีรุ่นก่อนหน้าของหนังสือเล่มนี้จากคุณ หากคุณอัปโหลดไปอีกครั้งก็จะถูกแทนที่ด้วยรุ่นปัจจุบันของคุณ</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="th">ลิขสิทธิ์</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="th">หน่วยกิต</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="th">มีปัญหาในการดาวน์โหลดหนังสือของคุณเป็น คุณอาจต้องรีสตาร์ท Bloom หรือได้รับความช่วยเหลือจาก technical help.</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="th">ขออภัย มีปัญหาอัปโหลดไปยัง {0}. คุณอาจต้องการความช่วยเหลือจาก technical help.</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading</source>
         <target xml:lang="th">กรุณาตรวจสอบข้อมูลที่ถูกต้องดังกล่าวข้างต้นก่อนที่จะอัพโหลด</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded</source>
         <target xml:lang="th">ขออภัย "{0}" ไม่ได้ประสบความสำเร็จในการอัปโหลด</target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes</source>
         <target xml:lang="th">โดยการอัปโหลดคุณยืนยันข้อตกลงกับ BloomLibrary เงื่อนไขการใช้และให้สิทธิที่จะอธิบาย</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="th">มีปัญหาในการอัปโหลดหนังสือของคุณ.</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="th">ภาษา</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="th">การใช้งาน / ใบอนุญาต</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="th">บัญชีอยู่แล้ว</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address.  Would you like to log in instead?</source>
         <target xml:lang="th">เราไม่สามารถลงชื่อคุณกับที่อยู่นั้นเพราะเรามีบัญชีที่มีอยู่นั้น คุณต้องการที่จะเข้าสู่ระบบแทนไม่?</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="th">Bloom ไม่สามารถเชื่อมต่อ Server เพื่อตรวจสอบการเข้าสู่ระบบของคุณ กรุณาตรวจสอบการเชื่อมต่อเครือข่ายของคุณ</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="th">การเข้าสู่ไม่สำเร็จ</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="th">Bloom ไม่สามารถเชื่อมต่อกับ Server เพื่อความสมบูรณ์ของเข้าสู่หรือลงทะเบียนของคุณ ซึ่งอาจจะมีปัญหากับการเชื่อมต่ออินเทอร์เน็ตของคุณเซิร์ฟเวอร์ของเราหรืออุปกรณ์ในระหว่างบาง</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="th">เพื่อที่จะลงทะเบียนสำหรับบัญชี BloomLibrary.org คุณต้องตรวจสอบกล่องแสดงว่าคุณเห็นด้วยกับข้อกำหนด BloomLibrary การใช้งาน</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="th">อีเมล์ที่จำเป็น</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="th">เราไม่ได้มีผู้ใช้ในการบันทึกด้วยอีเมล์ที่. คุณต้องการที่จะลงทะเบียนไม่?</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="th">รหัสผ่านและ user ID ไม่ตรงกับ</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="th">กรุณายอมรับข้อตกลงในการใช้</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="th">กรุณาใส่อีเมล์ที่ถูกต้อง. เราจะส่งอีเมลไปยังที่อยู่นี้เพื่อให้คุณสามารถตั้งค่ารหัสผ่านของคุณ</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="th">Bloom ไม่สามารถเชื่อมต่อ Server เพื่อรีเซ็ตรหัสผ่านของคุณ กรุณาตรวจสอบการเชื่อมต่อเครือข่ายของคุณ</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="th">การรีเซ็ตรหัสผ่านไม่สำเร็จ</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="th">การรีเซ็ตรหัสผ่าน</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password</source>
         <target xml:lang="th">เราจะส่งอีเมลไปที่ {0} พร้อมคำแนะนำสำหรับรีเซ็ตรหัสผ่านของคุณ</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="th">ลงทะเบียนสำหรับ BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="th">ผู้ใช้ที่ไม่รู้จัก</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="th">Bloom ไม่สามารถเข้าสู่ระบบเพื่อ BloomLibrary.org ใช้ข้อมูลประจำตัวที่บันทึกไว้</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="th">ออกจาก BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="th">การทำ PDF Preview…</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="th">การทำรูปขนาดย่อ</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="th">ขออภัยรุ่น xxxx นี้ไม่สามารถใช้ร่วมกับรุ่นปัจจุบันของ BloomLibrary.org กรุณาอัพเกรดเป็นรุ่นใหม่กว่า.</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="th">โปรดเข้าสู่ BloomLibrary.org (หรือลงทะเบียน) ก่อนที่จะอัปโหลด</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="th">กรุณาตั้งค่านี้จาก ภาวะบรรณาธิกร</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="th">Step 1: ยืนยัน Metadata</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="th">Step 2: การอัปโหลด</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="th">ข้อเสนอแนะ: การกำหนดใบอนุญาตที่เป็นง่ายต่อการจดจำทำให้   คุณสามารถให้สิทธิ์บางอย่างเพื่อทุกคน</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="th">ข้อเสนอแนะ: ใบอนุญาตที่เป็นง่ายต่อการจดจำทำให้มันง่ายมากสำหรับคนอื่น ๆ ที่จะใช้หนังสือของคุณ, แม้ว่าพวกเขาจะไม่ชำนาญในภาษาของใบอนุญาตที่กำหนดเองของคุณ</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="th">เรื่องย่อ</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="th">แสดงเงื่อนไขการใช้</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="th">หัวข้อ</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="th">การอัปโหลดหนังสือ</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <target xml:lang="th">ขอแสดงความยินดี, "{0}" ตอนนี้ที่มีอยู่ใน  BloomLibrary.org ({1})</target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="th">อัปโหลดไม่ได้รับอนุญาต</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="th">มีปัญหาในการอัปโหลดหนังสือของคุณเป็น. คุณอาจต้องรีสตาร์ท Bloom หรือได้รับความช่วยเหลือทางเทคนิค</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="th">อัพโหลดความคืบหน้า</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="th">อัปโหลดหนังสือ</target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="th">การอัปโหลด เมตาดาต้า หนังสือ</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, &amp; topic tags to the bloomlibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="th">การอัปโหลด {0}</target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="th">CC-BY-NC</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="th">เข้าสู่ BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="th">ลงทะเบียนเพื่อรับ BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="th">เพิ่มอันดับ</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="th">เพิ่มขั้นตอน</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="th">หนังสือ</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="th">จำนวนสูงสุดของคำต่อหนังสือ</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="th">คลิกที่ตัวอักษรเพื่อเพิ่มลงในนี้ขั้นตอนนี้</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="th">ลำดับ Decodable</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true" approved="yes">
         <source xml:lang="en">File needs .txt extension</source>
         <target xml:lang="th">ไฟล์ต้องการขยาย .txt</target>
         <note>ID: ReaderSetup.FileNeedsTxtExtension</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="th">ที่หนึ่ง,</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="th">ไม่สามารถอ่านรูปแบบนี้</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="th">ช่วยให้การส่งออกและการแปลงไฟล์เพื่อใช้เป็นตำราตัวอย่าง</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="th">ตัวอักษร</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="th">ตัวอักษรและการผสมตัวอักษร</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="th">การช่วยให้คุณทำ decodable readers, Bloom ต้องรู้ว่าตัวอักษรและผสมตัวอักษรที่คุณจะได้รับการเรียนการสอน</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="th">แยกแต่ละตัวอักษรหรือตัวอักษรรวมกันมีพื้นที่</target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="th">ขอให้สังเกตว่ารายการภาษาอังกฤษรวมถึงสัญลักษณ์ที่ใช้ในการให้คำ</target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="th">มันเป็น</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="th">.</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="th">ระดับ</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level </source>
         <target xml:lang="th">ระดับ</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="th">ระดับ Reader</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="th">คำที่ตรงกัน</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="th">คำเป็นเอกลักษณ์ที่จำนวนสูงสุดต่อหนังสือ</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="th">หน้า</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="th">คำที่จำนวนสูงสุดในแต่ละหน้า</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="th">ขับเคลื่อนด้วย</target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="th">ระดับ Reader</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="th">เอาออกอันดับ {0}</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="th">เอาออกลำดับ {0}</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="th">การดึงแถวการจัดอันดับใหม่</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="th">การดึงแถวการจัดลำดับใหม่</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="th">, Search Engine เพื่อ การสอนอ่านเขียน</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="th">จดหมายก่อนหน้านี้และใหม่</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="th">ประโยค</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="th">คำที่สูงสุดในแต่ละประโยค</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="th">การติดตั้ง Decodable Reader Tool</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="th">การติดตั้ง Leveled Reader Tool</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <target xml:lang="th">การติดตั้งตัวอักษรสำหรับภาษานี้</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="th">คำภาพใหม่</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="th">คำภาพ</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="th">ขั้นตอน</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="th">ขั้นตอน</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="th">หลายขั้นตอนขั้นตอน</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="th">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="th">สิ่งที่ต้องจำไว้สำหรับระดับนี้:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="th">เป็นเอกลักษณ์</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="th">คำ</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage.  There are two ways to give words to Bloom:</source>
         <target xml:lang="th">เพื่อช่วยให้คุณทำ decodable readers, Bloom สามารถแนะนำคำที่เหมาะสมภายในขั้นตอนปัจจุบัน. มีสองวิธีที่จะให้คำ Bloom คือ:</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="th">2) วางแฟ้มข้อความในของคุณ</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <target xml:lang="th">ตัวอย่างตำราโฟลเดอร์</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="th">1) พิมพ์คำที่นี่</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="th">ตัวอักษร</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this BloomPack will carry your latest decodable and leveled reader settings for the \"{0}\" language. Anyone opening this BloomPack , who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this BloomPack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="th">นอกจากนี้, BloomPack นี้จะพก decodable ล่าสุดของคุณและการตั้งค่า leveled reader สำหรับ \"{0}\" ภาษา. ใครเปิดBloomPackนี้,  ก็จะเปิดขึ้น \"{0}\" collection, จะมีการตั้งค่าปัจจุบัน decodable และ leveled reader แทนที่ด้วยการตั้งค่าใน BloomPack นี้. พวกเขายังจะได้รับชุดปัจจุบันของคำเพื่อใช้ในdecodable readers.</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="th">แบบเทมเพลต</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <target xml:lang="th">บันทึก Bloom Pack</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <target xml:lang="th">ทำแม่แบบผู้อ่าน Bloom Pack ...</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="th">ที่อยู่อีเมล</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="th">ชื่อแรก</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="th">กรุณาใช้เวลาสักครู่ในการลงทะเบียน {0}</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="th">วิธีที่คุณใช้ {0} อย่างไร?</target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="th">ฉันจะจบนี้ในภายหลัง</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="th">องค์กร</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="th">&amp;ลงทะเบียน </target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="th">นามสกุล</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="th">ลงทะเบียน {0}</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <target xml:lang="th">ปิด</target>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.CouldNotSendToServer">
+      <trans-unit id="ReportProblemDialog.CouldNotSendToServer" approved="yes">
         <source xml:lang="en">Bloom was not able to submit your report directly to our server. Please retry or email {0} to {1}.</source>
         <target xml:lang="th">Bloom ไม่สามารถที่จะส่งรายงานของคุณโดยตรง Server ของเรา. โปรดลองอีกครั้งหรืออีเมล์ {0} to {1}.</target>
         <note>ID: ReportProblemDialog.CouldNotSendToServer</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Email">
+      <trans-unit id="ReportProblemDialog.Email" approved="yes">
         <source xml:lang="en">Email</source>
         <target xml:lang="th">อีเมล์</target>
         <note>ID: ReportProblemDialog.Email</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeBookButton">
+      <trans-unit id="ReportProblemDialog.IncludeBookButton" approved="yes">
         <source xml:lang="en">Include Book '{0}'</source>
         <target xml:lang="th">รวมหนังสือ '{0}'</target>
         <note>ID: ReportProblemDialog.IncludeBookButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton">
+      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton" approved="yes">
         <source xml:lang="en">Include this screenshot</source>
         <target xml:lang="th">รวมภาพหน้าจอนี้</target>
         <note>ID: ReportProblemDialog.IncludeScreenshotButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Name">
+      <trans-unit id="ReportProblemDialog.Name" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="th">ชื่อ</target>
         <note>ID: ReportProblemDialog.Name</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Retry">
+      <trans-unit id="ReportProblemDialog.Retry" approved="yes">
         <source xml:lang="en">Retry</source>
         <target xml:lang="th">ลองอีกครั้ง</target>
         <note>ID: ReportProblemDialog.Retry</note>
         <note>Shown if there was an error submitting the report. Lets the user try submitting it again.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SeeDetails">
+      <trans-unit id="ReportProblemDialog.SeeDetails" approved="yes">
         <source xml:lang="en">See what else will be submitted</source>
         <target xml:lang="th">ดูว่าอะไรที่จะเป็นส่งไป</target>
         <note>ID: ReportProblemDialog.SeeDetails</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SubmitButton">
+      <trans-unit id="ReportProblemDialog.SubmitButton" approved="yes">
         <source xml:lang="en">&amp;Submit</source>
         <target xml:lang="th">&amp;ส่ง</target>
         <note>ID: ReportProblemDialog.SubmitButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Submitting">
+      <trans-unit id="ReportProblemDialog.Submitting" approved="yes">
         <source xml:lang="en">Submitting to server...</source>
         <target xml:lang="th">ส่งไปยัง Server</target>
         <note>ID: ReportProblemDialog.Submitting</note>
         <note>This is shown while Bloom is sending the problem report to our server.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Success">
+      <trans-unit id="ReportProblemDialog.Success" approved="yes">
         <source xml:lang="en">We received your report, thanks for taking the time to help make Bloom better!</source>
         <target xml:lang="th">เราได้รับรายงานของคุณขอบคุณที่สละเวลาเพื่อช่วยให้ Bloom ที่ดีขึ้น</target>
         <note>ID: ReportProblemDialog.Success</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WhatsTheProblem">
+      <trans-unit id="ReportProblemDialog.WhatsTheProblem" approved="yes">
         <source xml:lang="en">What seems to be the problem?</source>
         <target xml:lang="th">ปัญหาที่เกิดขึ้นคืออะไร?</target>
         <note>ID: ReportProblemDialog.WhatsTheProblem</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WindowTitle">
+      <trans-unit id="ReportProblemDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Report A Problem</source>
         <target xml:lang="th">รายงานปัญหา</target>
         <note>ID: ReportProblemDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Zipping">
+      <trans-unit id="ReportProblemDialog.Zipping" approved="yes">
         <source xml:lang="en">Zipping up book...</source>
         <target xml:lang="th">ซิปหนังสือ ...</target>
         <note>ID: ReportProblemDialog.Zipping</note>
         <note>This is shown while Bloom is creating the problem report. It's generally too fast to see, unless you include a large book.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="th">หนังสือพื้นฐาน</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="th">หนังสือเล่มใหญ่</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="th">Decodable Reader</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="th">Leveled Reader</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="th">พจนานุกรมรูปภาพ</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="th">ผนังปฏิทิน</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="th">การเกษตร</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="th">เรื่องสัตว์</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="th">ธุรกิจ</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="th">ลิฟวิ่งชุมชน</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="th">วัฒนธรรม</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="th">พจนานุกรม</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="th">สิ่งแวดล้อม</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="th">เรื่องอ่านเล่น</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="th">สุขภาพ</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="th">วิธีการ</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="th">คณิตศาสตร์</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.NoTopic" sil:dynamic="true">
+      <trans-unit id="Topics.NoTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">No Topic</source>
         <target xml:lang="th">กระทู้</target>
         <note>ID: Topics.NoTopic</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="th">ไม่ใช่นิยาย</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="th">พัฒนาส่วนบุคคล</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="th">Primer</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="th">วิทยาศาสตร์</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="th">มโนมัย</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Story Book" sil:dynamic="true">
+      <trans-unit id="Topics.Story Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Story Book</source>
         <target xml:lang="th">หนังสือเรื่อง</target>
         <note>ID: Topics.Story Book</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="th">ประเพณี</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="th">เรื่องแบบดั้งเดิม</target>
         <note>ID: Topics.Traditional Story</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="th">การติดตั้ง</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
       </trans-unit>
-      <trans-unit id="You may use this space for author/illustrator, or anything else." sil:dynamic="true">
+      <trans-unit id="You may use this space for author/illustrator, or anything else." sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="th">คุณอาจจะใช้พื้นที่นี้สำหรับผู้เขียน/ผู้วาดภาพประกอบ, หรือสิ่งอื่น.</target>
         <note>ID: You may use this space for author/illustrator, or anything else.</note>

--- a/DistFiles/localization/zh-CN/Bloom.xlf
+++ b/DistFiles/localization/zh-CN/Bloom.xlf
@@ -2,3543 +2,3543 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Bloom.exe" source-language="en" target-language="zh-CN" datatype="plaintext" product-version="3.7.8.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="BloomIntegrity.WindowTitle">
+      <trans-unit id="BloomIntegrity.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom Problem</source>
         <target xml:lang="zh-CN">Bloom出错</target>
         <note>ID: BloomIntegrity.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="BloomIntegrity.WindowTitle_ToolTip_">
+      <trans-unit id="BloomIntegrity.WindowTitle_ToolTip_" approved="yes">
         <source xml:lang="en">Bloom Problem?</source>
         <target xml:lang="zh-CN">Bloom错误</target>
         <note>ID: BloomIntegrity.WindowTitle_ToolTip_</note>
 	<note>The tooltip did not have any English with it.  What is there is only a guess.</note>
       </trans-unit>
-      <trans-unit id="BloomIntegrityDialog.ReportProblem">
+      <trans-unit id="BloomIntegrityDialog.ReportProblem" approved="yes">
         <source xml:lang="en">Report Problem</source>
         <target xml:lang="zh-CN">报告错误</target>
         <note>ID: BloomIntegrityDialog.ReportProblem</note>
       </trans-unit>
-      <trans-unit id="BloomIntegrityDialog.ReportProblem_ToolTip_">
+      <trans-unit id="BloomIntegrityDialog.ReportProblem_ToolTip_" approved="yes">
         <source xml:lang="en">Report Problem</source>
         <target xml:lang="zh-CN">报告错误</target>
         <note>ID: BloomIntegrityDialog.ReportProblem_ToolTip_</note>
 	<note>The tooltip did not have any English with it.  What is there is only a guess.</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName">
+      <trans-unit id="BloomPackInstallDialog.BadCharsInFileName" approved="yes">
         <source xml:lang="en">Possibly this is an old Bloom Pack created before Bloom Packs could handle special characters in file names. You may be able to get the author to re-create it using a current version. If that's not possible a technical expert may be able to repair things.</source>
         <target xml:lang="zh-CN">创建此资料包时，Bloom还不支持文件名使用特殊字体。你可以请作者创建一个新版资料包，或者寻求技术人员的帮助。</target>
         <note>ID: BloomPackInstallDialog.BadCharsInFileName</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstallation" approved="yes">
         <source xml:lang="en">Bloom Pack Installation</source>
         <target xml:lang="zh-CN">安装Bloom资料包</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstallation</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstalled" approved="yes">
         <source xml:lang="en">The {0} Collection is now ready to use on this computer.</source>
         <target xml:lang="zh-CN">丛书{0}已经可以在此计算机上使用。</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller">
+      <trans-unit id="BloomPackInstallDialog.BloomPackInstaller" approved="yes">
         <source xml:lang="en">Bloom Pack Installer</source>
         <target xml:lang="zh-CN">Bloom资料包安装工具</target>
         <note>ID: BloomPackInstallDialog.BloomPackInstaller</note>
         <note>Displayed as the message box title</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack">
+      <trans-unit id="BloomPackInstallDialog.CorruptBloomPack" approved="yes">
         <source xml:lang="en">This BloomPack appears to be incomplete or corrupt.</source>
         <target xml:lang="zh-CN">此资料包不完全或已损坏。</target>
         <note>ID: BloomPackInstallDialog.CorruptBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.DoesNotExist">
+      <trans-unit id="BloomPackInstallDialog.DoesNotExist" approved="yes">
         <source xml:lang="en">{0} does not exist</source>
         <target xml:lang="zh-CN">{0}不存在</target>
         <note>ID: BloomPackInstallDialog.DoesNotExist</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack">
+      <trans-unit id="BloomPackInstallDialog.ErrorInstallingBloomPack" approved="yes">
         <source xml:lang="en">Bloom was not able to install that Bloom Pack</source>
         <target xml:lang="zh-CN">无法安装Bloom资料包</target>
         <note>ID: BloomPackInstallDialog.ErrorInstallingBloomPack</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Extracting">
+      <trans-unit id="BloomPackInstallDialog.Extracting" approved="yes">
         <source xml:lang="en">Extracting...</source>
         <target xml:lang="zh-CN">正在解压缩</target>
         <note>ID: BloomPackInstallDialog.Extracting</note>
         <note>Shown while Bloom Packs are being installed</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.MustRestartToSee">
+      <trans-unit id="BloomPackInstallDialog.MustRestartToSee" approved="yes">
         <source xml:lang="en">Bloom is already running, but the contents will not show up until the next time you run Bloom</source>
         <target xml:lang="zh-CN">Bloom正在运行，下次运行Bloom时才能看到内容</target>
         <note>ID: BloomPackInstallDialog.MustRestartToSee</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.NotInstalled">
+      <trans-unit id="BloomPackInstallDialog.NotInstalled" approved="yes">
         <source xml:lang="en">The Bloom collection will not be installed.</source>
         <target xml:lang="zh-CN">Bloom丛书未安装成功。</target>
         <note>ID: BloomPackInstallDialog.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Opening">
+      <trans-unit id="BloomPackInstallDialog.Opening" approved="yes">
         <source xml:lang="en">Opening {0}...</source>
         <target xml:lang="zh-CN">正在打开{0}...</target>
         <note>ID: BloomPackInstallDialog.Opening</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.Replace">
+      <trans-unit id="BloomPackInstallDialog.Replace" approved="yes">
         <source xml:lang="en">This computer already has a Bloom collection named '{0}'. Do you want to replace it with the one from this Bloom Pack?</source>
         <target xml:lang="zh-CN">此计算机已经有一个叫‘{0}’的丛书，要用此资料包中的丛书替代它吗？</target>
         <note>ID: BloomPackInstallDialog.Replace</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder">
+      <trans-unit id="BloomPackInstallDialog.SingleCollectionFolder" approved="yes">
         <source xml:lang="en">Bloom Packs should have only a single collection folder at the top level of the .ZIP file.</source>
         <target xml:lang="zh-CN">每个Bloom资料压缩包只能有一层目录</target>
         <note>ID: BloomPackInstallDialog.SingleCollectionFolder</note>
       </trans-unit>
-      <trans-unit id="BloomPackInstallDialog.UnableToReplace">
+      <trans-unit id="BloomPackInstallDialog.UnableToReplace" approved="yes">
         <source xml:lang="en">Bloom was not able to remove the existing copy of '{0}'. Quit Bloom if it is running &amp; try again. Otherwise, try again after restarting your computer.</source>
         <target xml:lang="zh-CN">Bloom无法删除现有的'{0}'。如果Bloom正在运行，请退出程序重试。还不行的话重启计算机再重试。</target>
         <note>ID: BloomPackInstallDialog.UnableToReplace</note>
       </trans-unit>
-      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true">
+      <trans-unit id="BookEditor.CharacterMap.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To select, use your mouse wheel or point at what you want, then release the key.</source>
         <target xml:lang="zh-CN">要选中内容，按住鼠标左键，滚动鼠标滑轮或移动鼠标到待选中区域，然后松开左键</target>
         <note>ID: BookEditor.CharacterMap.Instructions</note>
         <note>When you hold down a key, a popup appears that lets you choose a related character. These instructions are shown in that popup.</note>
       </trans-unit>
-      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.DefaultForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is the default for all text boxes with '{0}' style.</source>
         <target xml:lang="zh-CN">该字体设置是所有带'{0}'样式的文本框的默认字体设置</target>
         <note>ID: BookEditor.DefaultForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForText" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all text boxes with '{0}' style.</source>
         <target xml:lang="zh-CN">所有带'{0}'样式的文本框都用这种字体设置</target>
         <note>ID: BookEditor.ForText</note>
       </trans-unit>
-      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true">
+      <trans-unit id="BookEditor.ForTextInLang" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This formatting is for all {0} text boxes with '{1}' style.</source>
         <target xml:lang="zh-CN">所有带'{1}'样式的{0}文本框都用这种字体设置</target>
         <note>ID: BookEditor.ForTextInLang</note>
       </trans-unit>
-      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true">
+      <trans-unit id="BookEditor.FormattingDisabled" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sorry, Reader Templates do not allow changes to formatting.</source>
         <target xml:lang="zh-CN">抱歉，读物模板不允许对字体设置进行修改</target>
         <note>ID: BookEditor.FormattingDisabled</note>
       </trans-unit>
-      <trans-unit id="BookStorage.FolderMoved">
+      <trans-unit id="BookStorage.FolderMoved" approved="yes">
         <source xml:lang="en">It appears that some part of the folder path to this book has been moved or renamed. As a result, Bloom cannot save your changes to this page, and will need to exit now. If you haven't been renaming or moving things, please click Details below and report the problem to the developers.</source>
         <target xml:lang="zh-CN">文件夹通向本书的部分路径已被移动或重命名，所以Bloom无法保存对本页的修改并将退出程序。如果你没有进行移动或重命名操作，请点击“详细”按钮，向程序开发者报告问题。</target>
         <note>ID: BookStorage.FolderMoved</note>
       </trans-unit>
-      <trans-unit id="Browser.CopyTroubleshootingInfo">
+      <trans-unit id="Browser.CopyTroubleshootingInfo" approved="yes">
         <source xml:lang="en">Copy Troubleshooting Information</source>
         <target xml:lang="zh-CN">复制“排除故障”信息</target>
         <note>ID: Browser.CopyTroubleshootingInfo</note>
       </trans-unit>
-      <trans-unit id="Browser.OpenPageInFirefox">
+      <trans-unit id="Browser.OpenPageInFirefox" approved="yes">
         <source xml:lang="en">Open Page in Firefox (which must be in the PATH environment variable)</source>
         <target xml:lang="zh-CN">用Firefox浏览器打开页面（该浏览器一定要在PATH环境变量里）</target>
         <note>ID: Browser.OpenPageInFirefox</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel" approved="yes">
         <source xml:lang="en">Advanced Program Settings</source>
         <target xml:lang="zh-CN">高级程序设置</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AdvancedProgramSettingsTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.AutoUpdate" approved="yes">
         <source xml:lang="en">Automatically update Bloom</source>
         <target xml:lang="zh-CN">自动更新Bloom</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.AutoUpdate</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands" approved="yes">
         <source xml:lang="en">Show Experimental Commands (e.g. Export XML for InDesign)</source>
         <target xml:lang="zh-CN">显示试验命令（例：为InDesign导出XML）</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalCommands</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates" approved="yes">
         <source xml:lang="en">Show Experimental Templates (e.g. Picture Dictionary)</source>
         <target xml:lang="zh-CN">显示试验模板（例：图片词典）</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowExperimentalTemplates</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive" approved="yes">
         <source xml:lang="en">(Experimental) Show Send/Receive Controls</source>
         <target xml:lang="zh-CN">（实验）显示发送/接收控制</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.ShowSendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer">
+      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer" approved="yes">
         <source xml:lang="en">Use Image Server to reduce memory usage with large images.</source>
         <target xml:lang="zh-CN">处理大图像时请使用图像服务器,以便减少内存用量。</target>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.UseImageServer</note>
         <note>This option will probably go away, as any bugs with the Image Server get ironed out. This has to do with how Bloom works internally; the I.S. makes it work better on slow computers.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom is switching the default font for "{0}" to the new "Andika New Basic".</source>
         <target xml:lang="zh-CN">Bloom正在把"{0}"的默认字体改为"Andika New Basic"。</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate1</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.AndikaNewBasicUpdate2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This will improve the printed output for most languages. If your language is one of the few that need "Andika", you can switch it back in Settings:Book Making.</source>
         <target xml:lang="zh-CN">对大多数语言来说，这会提高打印效果。但是如果你的语言是少数需要“Andika”字体的语言之一，请在设置：图书制作中把字体改回来。</target>
         <note>ID: CollectionSettingsDialog.AndikaNewBasicUpdate2</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel" approved="yes">
         <source xml:lang="en">Book Making</source>
         <target xml:lang="zh-CN">图书制作</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.BookMakingTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Branding">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Branding" approved="yes">
         <source xml:lang="en">Branding</source>
         <target xml:lang="zh-CN">标识</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Branding</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor" approved="yes">
         <source xml:lang="en">Default Font for {0}</source>
         <target xml:lang="zh-CN">{0}的默认字体</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
         <note>{0} is a language name.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack" approved="yes">
         <source xml:lang="en">Front/Back Matter Pack</source>
         <target xml:lang="zh-CN">封皮(前/后)资料包</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="zh-CN">节省纸张装置</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Paper Saver</note>
         <note>Name of a Front/Back Matter Pack that puts credits on the inside of the front cover</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="zh-CN">传统的</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Traditional</note>
         <note>Name of the default Front/Back Matter Pack</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem" approved="yes">
         <source xml:lang="en">Right to Left Writing System</source>
         <target xml:lang="zh-CN">从右至左的书写系统</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.RightToLeftWritingSystem</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink">
+      <trans-unit id="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink" approved="yes">
         <source xml:lang="en">Special Script Settings</source>
         <target xml:lang="zh-CN">特殊文字设置</target>
         <note>ID: CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle">
+      <trans-unit id="CollectionSettingsDialog.CollectionSettingsWindowTitle" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="zh-CN">设置</target>
         <note>ID: CollectionSettingsDialog.CollectionSettingsWindowTitle</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.ChangeLanguageLink" approved="yes">
         <source xml:lang="en">Change...</source>
         <target xml:lang="zh-CN">改变...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.ChangeLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language1InSourceCollection" approved="yes">
         <source xml:lang="en">Language 1</source>
         <target xml:lang="zh-CN">语言1</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language1InSourceCollection</note>
         <note>In a local language collection, we say 'Local Language', but in a source collection, Local Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language2InSourceCollection" approved="yes">
         <source xml:lang="en">Language 2</source>
         <target xml:lang="zh-CN">语言2</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language2InSourceCollection</note>
         <note>In a local language collection, we say 'Language 2 (e.g. National Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.Language3InSourceCollection" approved="yes">
         <source xml:lang="en">Language 3</source>
         <target xml:lang="zh-CN">语言3</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.Language3InSourceCollection</note>
         <note>In a local language collection, we say 'Language 3 (e.g. Regional Language)', but in a source collection, National Language has no relevance, so we use this different label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.LanguageTabLabel" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="zh-CN">语言</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.LanguageTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.RemoveLanguageLink" approved="yes">
         <source xml:lang="en">Remove</source>
         <target xml:lang="zh-CN">删除</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.RemoveLanguageLink</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink" approved="yes">
         <source xml:lang="en">Set...</source>
         <target xml:lang="zh-CN">设立...</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.SetThirdLanguageLink</note>
         <note>If there is no third language specified, the link changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="zh-CN">土语</target>
         <note>ID: CollectionSettingsDialog.LanguageTab.VernacularLanguageLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language2Label" approved="yes">
         <source xml:lang="en">Language 2 (e.g. National Language)</source>
         <target xml:lang="zh-CN">语言2（例如：国家通用语）</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language2Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label">
+      <trans-unit id="CollectionSettingsDialog.LanguageTab._language3Label" approved="yes">
         <source xml:lang="en">Language 3 (e.g. Regional Language)  (Optional)</source>
         <target xml:lang="zh-CN">语言3（例：地区通用语）（可选）</target>
         <note>ID: CollectionSettingsDialog.LanguageTab._language3Label</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName" approved="yes">
         <source xml:lang="en">Bloom Collection Name</source>
         <target xml:lang="zh-CN">Bloom丛书名称</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.BloomCollectionName</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="zh-CN">国家</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Country</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="zh-CN">地区</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.District</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel" approved="yes">
         <source xml:lang="en">Project Information</source>
         <target xml:lang="zh-CN">项目信息</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.ProjectInformationTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province">
+      <trans-unit id="CollectionSettingsDialog.ProjectInformationTab.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="zh-CN">省份</target>
         <note>ID: CollectionSettingsDialog.ProjectInformationTab.Province</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.Restart">
+      <trans-unit id="CollectionSettingsDialog.Restart" approved="yes">
         <source xml:lang="en">Restart</source>
         <target xml:lang="zh-CN">重新启动</target>
         <note>ID: CollectionSettingsDialog.Restart</note>
         <note>If you make certain changes in the settings dialog, the OK button changes to this.</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.RestartMessage">
+      <trans-unit id="CollectionSettingsDialog.RestartMessage" approved="yes">
         <source xml:lang="en">Bloom will close and re-open this project with the new settings.</source>
         <target xml:lang="zh-CN">Bloom将会关闭，再用新设置打开项目。</target>
         <note>ID: CollectionSettingsDialog.RestartMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem">
+      <trans-unit id="CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack...</source>
         <target xml:lang="zh-CN">制作读物模板资料包</target>
         <note>ID: CollectionTab.AddMakeReaderTemplateBloomPackToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdminManagesUpdates">
+      <trans-unit id="CollectionTab.AdminManagesUpdates" approved="yes">
         <source xml:lang="en">Your system administrator manages Bloom updates for this computer.</source>
         <target xml:lang="zh-CN">在这台电脑上，Bloom更新由系统管理员负责。</target>
         <note>ID: CollectionTab.AdminManagesUpdates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem">
+      <trans-unit id="CollectionTab.AdvancedToolStripMenuItem" approved="yes">
         <source xml:lang="en">Advanced</source>
         <target xml:lang="zh-CN">高级</target>
         <note>ID: CollectionTab.AdvancedToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Applying">
+      <trans-unit id="CollectionTab.Applying" approved="yes">
         <source xml:lang="en">Applying updates</source>
         <target xml:lang="zh-CN">使用更新</target>
         <note>ID: CollectionTab.Applying</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkLabel">
+      <trans-unit id="CollectionTab.BloomLibraryLinkLabel" approved="yes">
         <source xml:lang="en">Get more source books at BloomLibrary.org</source>
         <target xml:lang="zh-CN">从BloomLibrary.org获取更多制作书的资源</target>
         <note>ID: CollectionTab.BloomLibraryLinkLabel</note>
         <note>Shown at the bottom of the list of books. User can click on it and it will attempt to open a browser to show the Bloom Library</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption">
+      <trans-unit id="CollectionTab.BloomLibraryLinkVerificationCaption" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="zh-CN">资源集合</target>
         <note>ID: CollectionTab.BloomLibraryLinkVerificationCaption</note>
         <note>get this clicking on BloomLibrary.org link in source collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DuplicateBook">
+      <trans-unit id="CollectionTab.BookMenu.DuplicateBook" approved="yes">
         <source xml:lang="en">Duplicate Book</source>
         <target xml:lang="zh-CN">复制书</target>
         <note>ID: CollectionTab.BookMenu.DuplicateBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.DeleteBook">
+      <trans-unit id="CollectionTab.BookMenu.DeleteBook" approved="yes">
         <source xml:lang="en">Delete Book</source>
         <target xml:lang="zh-CN">删除书</target>
         <note>ID: CollectionTab.BookMenu.DeleteBook</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage">
+      <trans-unit id="CollectionTab.BookMenu.ExportDocMessage" approved="yes">
         <source xml:lang="en">Bloom will now open this HTML document in your word processing program (normally Word or LibreOffice). You will be able to work with the text and images of this book. These programs normally don't do well with preserving the layout, so don't expect much.</source>
         <target xml:lang="zh-CN">Bloom将用您的文字处理程序（一般是word或LibreOffice）打开此HTML文件。这些程序能处理书中的文本或图像，但不一定能很好地保留书的布局。</target>
         <note>ID: CollectionTab.BookMenu.ExportDocMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice">
+      <trans-unit id="CollectionTab.BookMenu.ExportToWordOrLibreOffice" approved="yes">
         <source xml:lang="en">Export to Word or LibreOffice...</source>
         <target xml:lang="zh-CN">导出到Word或LibreOffice...</target>
         <note>ID: CollectionTab.BookMenu.ExportToWordOrLibreOffice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign">
+      <trans-unit id="CollectionTab.BookMenu.ExportToXMLForInDesign" approved="yes">
         <source xml:lang="en">Export to XML for InDesign...</source>
         <target xml:lang="zh-CN">为InDesign输出XML文档</target>
         <note>ID: CollectionTab.BookMenu.ExportToXMLForInDesign</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
+      <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip" approved="yes">
         <source xml:lang="en">Update Book</source>
         <target xml:lang="zh-CN">更新书</target>
         <note>ID: CollectionTab.BookMenu.UpdateFrontMatterToolStrip</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail">
+      <trans-unit id="CollectionTab.BookMenu.UpdateThumbnail" approved="yes">
         <source xml:lang="en">Update Thumbnail</source>
         <target xml:lang="zh-CN">更新缩略图</target>
         <note>ID: CollectionTab.BookMenu.UpdateThumbnail</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourceHeading">
+      <trans-unit id="CollectionTab.BookSourceHeading" approved="yes">
         <source xml:lang="en">Sources For New Books</source>
         <target xml:lang="zh-CN">新书资源</target>
         <note>ID: CollectionTab.BookSourceHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.BookSourcesLockNotice">
+      <trans-unit id="CollectionTab.BookSourcesLockNotice" approved="yes">
         <source xml:lang="en">This collection is locked, so new books cannot be added/removed.</source>
         <target xml:lang="zh-CN">该丛刊已加锁，不能添加或删除书。</target>
         <note>ID: CollectionTab.BookSourcesLockNotice</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Books From BloomLibrary.org" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Books From BloomLibrary.org</source>
         <target xml:lang="zh-CN">BloomLibrary.org 上的书</target>
         <note>ID: CollectionTab.Books From BloomLibrary.org</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks" approved="yes">
         <source xml:lang="en">Do Updates of All Books</source>
         <target xml:lang="zh-CN">更新所有书</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksAndUpdatesOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks">
+      <trans-unit id="CollectionTab.CollectionMenu.doChecksOfAllBooks" approved="yes">
         <source xml:lang="en">Do Checks of All Books</source>
         <target xml:lang="zh-CN">检查所有书</target>
         <note>ID: CollectionTab.CollectionMenu.doChecksOfAllBooks</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages">
+      <trans-unit id="CollectionTab.CollectionMenu.rescueMissingImages" approved="yes">
         <source xml:lang="en">Rescue Missing Images...</source>
         <target xml:lang="zh-CN">寻找丢失的图像</target>
         <note>ID: CollectionTab.CollectionMenu.rescueMissingImages</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showHistory">
+      <trans-unit id="CollectionTab.CollectionMenu.showHistory" approved="yes">
         <source xml:lang="en">Collection History...</source>
         <target xml:lang="zh-CN">丛书历史...</target>
         <note>ID: CollectionTab.CollectionMenu.showHistory</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionMenu.showNotes">
+      <trans-unit id="CollectionTab.CollectionMenu.showNotes" approved="yes">
         <source xml:lang="en">Collection Notes...</source>
         <target xml:lang="zh-CN">丛书笔记...</target>
         <note>ID: CollectionTab.CollectionMenu.showNotes</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.CollectionTabLabel">
+      <trans-unit id="CollectionTab.CollectionTabLabel" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="zh-CN">丛书</target>
         <note>ID: CollectionTab.CollectionTabLabel</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Collections">
+      <trans-unit id="CollectionTab.Collections" approved="yes">
         <source xml:lang="en">Collections</source>
         <target xml:lang="zh-CN">丛书</target>
         <note>ID: CollectionTab.Collections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfiguringBookMessage">
+      <trans-unit id="CollectionTab.ConfiguringBookMessage" approved="yes">
         <source xml:lang="en">Building...</source>
         <target xml:lang="zh-CN">正在建设...</target>
         <note>ID: CollectionTab.ConfiguringBookMessage</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ConfirmRecycleDescription">
+      <trans-unit id="CollectionTab.ConfirmRecycleDescription" approved="yes">
         <source xml:lang="en">The book '{0}'</source>
         <target xml:lang="zh-CN">书‘{0}’</target>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
+      <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk" approved="yes">
         <source xml:lang="en">Open Folder on Disk</source>
         <target xml:lang="zh-CN">打开磁盘里的文件夹</target>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.EditBookButton">
+      <trans-unit id="CollectionTab.EditBookButton" approved="yes">
         <source xml:lang="en">Edit this book</source>
         <target xml:lang="zh-CN">编辑本书</target>
         <note>ID: CollectionTab.EditBookButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Health" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="zh-CN">健康</target>
         <note>ID: CollectionTab.Health</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections">
+      <trans-unit id="CollectionTab.HiddenBookExplanationForSourceCollections" approved="yes">
         <source xml:lang="en">Because this is a source collection, Bloom isn't offering any existing shells as sources for new shells. If you want to add a language to a shell, instead you need to edit the collection containing the shell, rather than making a copy of it. Also, the Wall Calendar currently can't be used to make a new Shell.</source>
         <target xml:lang="zh-CN">因为这是一个资源集合， Bloom的现有壳书不能作为新壳书的来源.如果你想给壳书增加一种语言,你应该修改包含该壳书的资源集合,而不是直接复制该壳书.而且在现阶段,挂历也不能被用于制作新壳书.</target>
         <note>ID: CollectionTab.HiddenBookExplanationForSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBloomPackButton">
+      <trans-unit id="CollectionTab.MakeBloomPackButton" approved="yes">
         <source xml:lang="en">Make Bloom Pack</source>
         <target xml:lang="zh-CN">制作Bloom资料包</target>
         <note>ID: CollectionTab.MakeBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate">
+      <trans-unit id="CollectionTab.MakeBookUsingThisTemplate" approved="yes">
         <source xml:lang="en">Make a book using this source</source>
         <target xml:lang="zh-CN">用该资源制作书</target>
         <note>ID: CollectionTab.MakeBookUsingThisTemplate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.MoreLanguagesMenuItem">
+      <trans-unit id="CollectionTab.MoreLanguagesMenuItem" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="zh-CN">更多...</target>
         <note>ID: CollectionTab.MoreLanguagesMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Open/CreateCollectionButton">
+      <trans-unit id="CollectionTab.Open/CreateCollectionButton" approved="yes">
         <source xml:lang="en">Other Collection</source>
         <target xml:lang="zh-CN">其他丛书</target>
         <note>ID: CollectionTab.Open/CreateCollectionButton</note>
         <note>This is the button you use to create a new collection, open a new one, or get one from a repository somewhere.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem">
+      <trans-unit id="CollectionTab.OpenCreateCollectionMenuItem" approved="yes">
         <source xml:lang="en">Open or Create Another Collection</source>
         <target xml:lang="zh-CN">打开或创建新丛书</target>
         <note>ID: CollectionTab.OpenCreateCollectionMenuItem</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Sample Shells" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Shells</source>
         <target xml:lang="zh-CN">框架书样本</target>
         <note>ID: CollectionTab.Sample Shells</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SendReceive">
+      <trans-unit id="CollectionTab.SendReceive" approved="yes">
         <source xml:lang="en">Send/Receive</source>
         <target xml:lang="zh-CN">发送/接收</target>
         <note>ID: CollectionTab.SendReceive</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SettingsButton">
+      <trans-unit id="CollectionTab.SettingsButton" approved="yes">
         <source xml:lang="en">Settings</source>
         <target xml:lang="zh-CN">设置</target>
         <note>ID: CollectionTab.SettingsButton</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Source Collection" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="zh-CN">资源集合</target>
         <note>ID: CollectionTab.Source Collection</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections">
+      <trans-unit id="CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections" approved="yes">
         <source xml:lang="en">Open Additional Collections Folder</source>
         <target xml:lang="zh-CN">打开更多丛书文件夹</target>
         <note>ID: CollectionTab.SourceBooksMenu.OpenFolderContainingSourceCollections</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.SourcesForNewShellsHeading">
+      <trans-unit id="CollectionTab.SourcesForNewShellsHeading" approved="yes">
         <source xml:lang="en">Sources For New Shells</source>
         <target xml:lang="zh-CN">新框架书资源</target>
         <note>ID: CollectionTab.SourcesForNewShellsHeading</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Templates" sil:dynamic="true">
+      <trans-unit id="CollectionTab.Templates" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Templates</source>
         <target xml:lang="zh-CN">模板</target>
         <note>ID: CollectionTab.Templates</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.TitleMissing">
+      <trans-unit id="CollectionTab.TitleMissing" approved="yes">
         <source xml:lang="en">Title Missing</source>
         <target xml:lang="zh-CN">标题缺失</target>
         <note>ID: CollectionTab.TitleMissing</note>
         <note>Shown as the thumbnail caption when the book doesn't have a title.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UnableToCheckForUpdate">
+      <trans-unit id="CollectionTab.UnableToCheckForUpdate" approved="yes">
         <source xml:lang="en">Could not connect to the server to check for an update. Are you connected to the internet?</source>
         <target xml:lang="zh-CN">无法连接服务器，无法查看更新。请确认您的电脑是否连接到互联网。</target>
         <note>ID: CollectionTab.UnableToCheckForUpdate</note>
         <note>Shown when Bloom tries to check for an update but can't, for example because it can't connect to the internet, or a problems with our server, etc.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpToDate">
+      <trans-unit id="CollectionTab.UpToDate" approved="yes">
         <source xml:lang="en">Your Bloom is up to date.</source>
         <target xml:lang="zh-CN">Bloom已经是最新版本。</target>
         <note>ID: CollectionTab.UpToDate</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateCheckInProgress">
+      <trans-unit id="CollectionTab.UpdateCheckInProgress" approved="yes">
         <source xml:lang="en">Bloom is already working on checking for updates.</source>
         <target xml:lang="zh-CN">Bloom正在检查更新。</target>
         <note>ID: CollectionTab.UpdateCheckInProgress</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateFailed">
+      <trans-unit id="CollectionTab.UpdateFailed" approved="yes">
         <source xml:lang="en">A new version appears to be available, but Bloom could not install it.</source>
         <target xml:lang="zh-CN">Bloom有新版本却无法安装</target>
         <note>ID: CollectionTab.UpdateFailed</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateInstalled">
+      <trans-unit id="CollectionTab.UpdateInstalled" approved="yes">
         <source xml:lang="en">Update for {0} is ready.</source>
         <target xml:lang="zh-CN">已经准备好更新{0}</target>
         <note>ID: CollectionTab.UpdateInstalled</note>
         <note>Appears after Bloom has downloaded a program update in the background and is ready to switch the user to it the next time they run Bloom.</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdateNow">
+      <trans-unit id="CollectionTab.UpdateNow" approved="yes">
         <source xml:lang="en">Update Now</source>
         <target xml:lang="zh-CN">现在更新</target>
         <note>ID: CollectionTab.UpdateNow</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.UpdatesAvailable">
+      <trans-unit id="CollectionTab.UpdatesAvailable" approved="yes">
         <source xml:lang="en">A new version of Bloom is available.</source>
         <target xml:lang="zh-CN">Bloom有新版本</target>
         <note>ID: CollectionTab.UpdatesAvailable</note>
       </trans-unit>
-      <trans-unit id="CollectionTab.Updating">
+      <trans-unit id="CollectionTab.Updating" approved="yes">
         <source xml:lang="en">Downloading update to {0} ({1}kb).</source>
         <target xml:lang="zh-CN">下载更新到{0}({1}K)</target>
         <note>ID: CollectionTab.Updating</note>
       </trans-unit>
-      <trans-unit id="Common.BackButton">
+      <trans-unit id="Common.BackButton" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="zh-CN">后退</target>
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
-      <trans-unit id="Common.Cancel" sil:dynamic="true">
+      <trans-unit id="Common.Cancel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cancel</source>
         <target xml:lang="zh-CN">取消</target>
         <note>ID: Common.Cancel</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="zh-CN">取消（&amp;C）</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.Finish">
+      <trans-unit id="Common.Finish" approved="yes">
         <source xml:lang="en">&amp;Finish</source>
         <target xml:lang="zh-CN">完成(&amp;F)</target>
         <note>ID: Common.Finish</note>
         <note>Used for the Finish button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.Help" sil:dynamic="true">
+      <trans-unit id="Common.Help" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="zh-CN">帮助</target>
         <note>ID: Common.Help</note>
       </trans-unit>
-      <trans-unit id="Common.HelpButton">
+      <trans-unit id="Common.HelpButton" approved="yes">
         <source xml:lang="en">&amp;Help</source>
         <target xml:lang="zh-CN">帮助(&amp;H)</target>
         <note>ID: Common.HelpButton</note>
       </trans-unit>
-      <trans-unit id="Common.Loading" sil:dynamic="true">
+      <trans-unit id="Common.Loading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Loading...</source>
         <target xml:lang="zh-CN">下载中……</target>
         <note>ID: Common.Loading</note>
         <note>This is shown when Bloom is slowly loading something, so the user doesn't worry about why they don't see the result immediately.</note>
       </trans-unit>
-      <trans-unit id="Common.Next">
+      <trans-unit id="Common.Next" approved="yes">
         <source xml:lang="en">&amp;Next</source>
         <target xml:lang="zh-CN">下一步(&amp;N)</target>
         <note>ID: Common.Next</note>
         <note>Used for the Next button in wizards, like that used for making a New Collection</note>
       </trans-unit>
-      <trans-unit id="Common.NextButton">
+      <trans-unit id="Common.NextButton" approved="yes">
         <source xml:lang="en">Next</source>
         <target xml:lang="zh-CN">下一步</target>
         <note>ID: Common.NextButton</note>
         <note>In a wizard, this button takes you to the next step.</note>
       </trans-unit>
-      <trans-unit id="Common.OK">
+      <trans-unit id="Common.OK" approved="yes">
         <source xml:lang="en">OK</source>
         <target xml:lang="zh-CN">确定</target>
         <note>ID: Common.OK</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="zh-CN">确定(&amp;O)</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Optional">
+      <trans-unit id="Common.Optional" approved="yes">
         <source xml:lang="en">optional</source>
         <target xml:lang="zh-CN">可选</target>
         <note>ID: Common.Optional</note>
       </trans-unit>
-      <trans-unit id="Download.Completed">
+      <trans-unit id="Download.Completed" approved="yes">
         <source xml:lang="en">Your download ({0}) is complete. You can see it in the 'Books from BloomLibrary.org' section of your Collections.</source>
         <target xml:lang="zh-CN">{0}已下载完成。可以从“BloomLibrary.org"的"图书”板块找到。</target>
         <note>ID: Download.Completed</note>
       </trans-unit>
-      <trans-unit id="Download.CompletedCaption">
+      <trans-unit id="Download.CompletedCaption" approved="yes">
         <source xml:lang="en">Download complete</source>
         <target xml:lang="zh-CN">下载完毕</target>
         <note>ID: Download.CompletedCaption</note>
       </trans-unit>
-      <trans-unit id="Download.CopyFailed">
+      <trans-unit id="Download.CopyFailed" approved="yes">
         <source xml:lang="en">Bloom downloaded the book but had problems making it available in Bloom. Please restart your computer and try again. If you get this message again, please click the 'Details' button and report the problem to the Bloom developers.</source>
         <target xml:lang="zh-CN">Bloom已经下载了该书，但是无法打开它，请重启计算机再试。如果仍然出现此提示，请点击“详细”向程序工程师报告此问题。</target>
         <note>ID: Download.CopyFailed</note>
       </trans-unit>
-      <trans-unit id="Download.DownloadingDialogTitle">
+      <trans-unit id="Download.DownloadingDialogTitle" approved="yes">
         <source xml:lang="en">Downloading book</source>
         <target xml:lang="zh-CN">正在下载书</target>
         <note>ID: Download.DownloadingDialogTitle</note>
       </trans-unit>
-      <trans-unit id="Download.GenericNetworkProblemNotice">
+      <trans-unit id="Download.GenericNetworkProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book.</source>
         <target xml:lang="zh-CN">下载书时出现问题。</target>
         <note>ID: Download.GenericNetworkProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.ProblemNotice">
+      <trans-unit id="Download.ProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="zh-CN">下载书时出现问题。请重启Bloom或寻求技术支持。</target>
         <note>ID: Download.ProblemNotice</note>
       </trans-unit>
-      <trans-unit id="Download.TimeoutProblemNotice">
+      <trans-unit id="Download.TimeoutProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem downloading the book: something took too long. You can try again at a different time, or write to us at issues@BloomLibrary.org if you cannot get the download to work from your location.</source>
         <target xml:lang="zh-CN">下载书时出现错误，某个部分用了太长时间。请换个时间再试，还是不能下载的话，请写邮件联系我们issues@bloomlibrary.org</target>
         <note>ID: Download.TimeoutProblemNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddPageButton">
+      <trans-unit id="EditTab.AddPageDialog.AddPageButton" approved="yes">
         <source xml:lang="en">Add Page</source>
         <target xml:lang="zh-CN">添加页</target>
         <note>ID: EditTab.AddPageDialog.AddPageButton</note>
         <note>This is for the button that LAUNCHES the dialog, not the "Add this page" button that is IN the dialog.</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.AddThisPageButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add This Page</source>
         <target xml:lang="zh-CN">添加当前页</target>
         <note>ID: EditTab.AddPageDialog.AddThisPageButton</note>
         <note>This is for the button inside the dialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutButton" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use This Layout</source>
         <target xml:lang="zh-CN">使用这种布局</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutContinueCheckbox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Continue anyway</source>
         <target xml:lang="zh-CN">继续</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutContinueCheckbox</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutTitle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose Different Layout...</source>
         <target xml:lang="zh-CN">选择不同的布局...</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.ChooseLayoutWillLoseData" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Converting to this layout will cause some content to be lost.</source>
         <target xml:lang="zh-CN">转换成这种布局将会导致部分内容丢失</target>
         <note>ID: EditTab.AddPageDialog.ChooseLayoutWillLoseData</note>
       </trans-unit>
-      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true">
+      <trans-unit id="EditTab.AddPageDialog.Title" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Page...</source>
         <target xml:lang="zh-CN">添加页...</target>
         <note>ID: EditTab.AddPageDialog.Title</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.InsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the back cover.</source>
         <target xml:lang="zh-CN">如果你需要空间填写更多有关本书的信息,可以使用本页(即封三).</target>
         <note>ID: EditTab.BackMatter.InsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.BackMatter.OutsideBackCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.</source>
         <target xml:lang="zh-CN">如果你需要空间填写更多有关本书的信息,可以使用本页(即封底).</target>
         <note>ID: EditTab.BackMatter.OutsideBackCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.Background" sil:dynamic="true">
+      <trans-unit id="EditTab.Background" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Background</source>
         <target xml:lang="zh-CN">背景</target>
         <note>ID: EditTab.Background</note>
       </trans-unit>
-      <trans-unit id="EditTab.Bilingual">
+      <trans-unit id="EditTab.Bilingual" approved="yes">
         <source xml:lang="en">Two Languages</source>
         <target xml:lang="zh-CN">两种语言</target>
         <note>ID: EditTab.Bilingual</note>
         <note>Shown in edit tab multilingualism chooser, for bilingual mode, 2 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser">
+      <trans-unit id="EditTab.BookContextMenu.openHtmlInBrowser" approved="yes">
         <source xml:lang="en">Open the HTML used to make this PDF, in Firefox (must be on path)</source>
         <target xml:lang="zh-CN">从Firefox(一定要在路径里)打开用于制作该PDF的html文件</target>
         <note>ID: EditTab.BookContextMenu.openHtmlInBrowser</note>
       </trans-unit>
-      <trans-unit id="EditTab.Borders" sil:dynamic="true">
+      <trans-unit id="EditTab.Borders" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Borders</source>
         <target xml:lang="zh-CN">边框</target>
         <note>ID: EditTab.Borders</note>
       </trans-unit>
-      <trans-unit id="EditTab.CannotChangeCopyright">
+      <trans-unit id="EditTab.CannotChangeCopyright" approved="yes">
         <source xml:lang="en">Sorry, the copyright and license for this book cannot be changed.</source>
         <target xml:lang="zh-CN">抱歉，不能更改这本书的版权和许可证。</target>
         <note>ID: EditTab.CannotChangeCopyright</note>
       </trans-unit>
-      <trans-unit id="EditTab.CantPasteImageLocked">
+      <trans-unit id="EditTab.CantPasteImageLocked" approved="yes">
         <source xml:lang="en">Sorry, this book is locked down so that images cannot be changed.</source>
         <target xml:lang="zh-CN">抱歉，这本书已加锁，不能更改图像。</target>
         <note>ID: EditTab.CantPasteImageLocked</note>
       </trans-unit>
-      <trans-unit id="EditTab.ChooseLayoutButton">
+      <trans-unit id="EditTab.ChooseLayoutButton" approved="yes">
         <source xml:lang="en">Choose Different Layout</source>
         <target xml:lang="zh-CN">选择不同的布局</target>
         <note>ID: EditTab.ChooseLayoutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle" approved="yes">
         <source xml:lang="en">Really Delete Page?</source>
         <target xml:lang="zh-CN">确定删除这页吗？</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.ConformRemovePageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog.DeleteButton" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="zh-CN">删除(&amp;D)</target>
         <note>ID: EditTab.ConfirmRemovePageDialog.DeleteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel">
+      <trans-unit id="EditTab.ConfirmRemovePageDialog._messageLabel" approved="yes">
         <source xml:lang="en">This page will be permanently removed.</source>
         <target xml:lang="zh-CN">该页将被永久删除。</target>
         <note>ID: EditTab.ConfirmRemovePageDialog._messageLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown">
+      <trans-unit id="EditTab.ContentLanguagesDropdown" approved="yes">
         <source xml:lang="en">Multilingual Settings</source>
         <target xml:lang="zh-CN">多种语言设置</target>
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
-      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip">
+      <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip" approved="yes">
         <source xml:lang="en">Choose language to make this a bilingual or trilingual book</source>
         <target xml:lang="zh-CN">选择语言制作双语或多语书</target>
         <note>ID: EditTab.ContentLanguagesDropdown.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton">
+      <trans-unit id="EditTab.CopyButton" approved="yes">
         <source xml:lang="en">Copy</source>
         <target xml:lang="zh-CN">复制</target>
         <note>ID: EditTab.CopyButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTip">
+      <trans-unit id="EditTab.CopyButton.ToolTip" approved="yes">
         <source xml:lang="en">Copy (Ctrl+C)</source>
         <target xml:lang="zh-CN">复制（Ctrl-c）</target>
         <note>ID: EditTab.CopyButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CopyButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can copy it</source>
         <target xml:lang="zh-CN">请选中文本内容再复制</target>
         <note>ID: EditTab.CopyButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.CopyImageIPMetadataQuestion">
+      <trans-unit id="EditTab.CopyImageIPMetadataQuestion" approved="yes">
         <source xml:lang="en">Copy this information to all other pictures in this book?</source>
         <target xml:lang="zh-CN">要把该信息复制到本书中的所有图片里吗？</target>
         <note>ID: EditTab.CopyImageIPMetadataQuestion</note>
         <note>get this after you edit the metadata of an image</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="zh-CN">调整布局</target>
         <note>ID: EditTab.CustomPage.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Or" sil:dynamic="true" approved="yes">
         <source xml:lang="en"> or </source>
         <target xml:lang="zh-CN">或者</target>
         <note>ID: EditTab.CustomPage.Or</note>
         <note>Shown between 'Picture' and 'Text' when Custom Page is in Layout mode</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture</source>
         <target xml:lang="zh-CN">图片</target>
         <note>ID: EditTab.CustomPage.Picture</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text</source>
         <target xml:lang="zh-CN">文本</target>
         <note>ID: EditTab.CustomPage.Text</note>
       </trans-unit>
-      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true">
+      <trans-unit id="EditTab.CustomPage.TextBox" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Text Box</source>
         <target xml:lang="zh-CN">文本框</target>
         <note>ID: EditTab.CustomPage.TextBox</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton">
+      <trans-unit id="EditTab.CutButton" approved="yes">
         <source xml:lang="en">Cut</source>
         <target xml:lang="zh-CN">剪切</target>
         <note>ID: EditTab.CutButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTip">
+      <trans-unit id="EditTab.CutButton.ToolTip" approved="yes">
         <source xml:lang="en">Cut (Ctrl+X)</source>
         <target xml:lang="zh-CN">剪切（Ctrl-x）</target>
         <note>ID: EditTab.CutButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.CutButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">You need to select some text before you can cut it</source>
         <target xml:lang="zh-CN">请选中文本内容再剪切</target>
         <note>ID: EditTab.CutButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove\n  Page</source>
         <target xml:lang="zh-CN">删除\n页</target>
         <note>ID: EditTab.DeletePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTip">
+      <trans-unit id="EditTab.DeletePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Remove this page from the book</source>
         <target xml:lang="zh-CN">从该书中删除此页</target>
         <note>ID: EditTab.DeletePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DeletePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be removed</source>
         <target xml:lang="zh-CN">无法删除此页</target>
         <note>ID: EditTab.DeletePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate\n   Page</source>
         <target xml:lang="zh-CN">复制\n页</target>
         <note>ID: EditTab.DuplicatePageButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTip">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTip" approved="yes">
         <source xml:lang="en">Insert a new page which is a duplicate of this one</source>
         <target xml:lang="zh-CN">插入和此页完全相同的新页面</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.DuplicatePageButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">This page cannot be duplicated</source>
         <target xml:lang="zh-CN">无法复制此页</target>
         <note>ID: EditTab.DuplicatePageButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Edit">
+      <trans-unit id="EditTab.Edit" approved="yes">
         <source xml:lang="en">Edit</source>
         <target xml:lang="zh-CN">编辑</target>
         <note>ID: EditTab.Edit</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true">
+      <trans-unit id="EditTab.EditNotAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot change these because this is not the original copy.</source>
         <target xml:lang="zh-CN">无法改动，因为这不是原始版本。</target>
         <note>ID: EditTab.EditNotAllowed</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord" approved="yes">
         <source xml:lang="en">Sight Word</source>
         <target xml:lang="zh-CN">整体识别单词</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable">
+      <trans-unit id="EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable" approved="yes">
         <source xml:lang="en">This word is not decodable in this stage.</source>
         <target xml:lang="zh-CN">在这个细分层次上，还不能拼读此单词</target>
         <note>ID: EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable</note>
       </trans-unit>
-      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true">
+      <trans-unit id="EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This sentence is too long for this level.</source>
         <target xml:lang="zh-CN">对当前等级来说，这个句子过长。</target>
         <note>ID: EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong</note>
       </trans-unit>
-      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true">
+      <trans-unit id="EditTab.ExperimentalNotice" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This page is an experimental prototype which may have many problems, for which we apologize.</source>
         <target xml:lang="zh-CN">抱歉，该页是一个实验模型，存在很多问题，请您原谅。</target>
         <note>ID: EditTab.ExperimentalNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.FontMissing">
+      <trans-unit id="EditTab.FontMissing" approved="yes">
         <source xml:lang="en">The current selected font is '{0}', but it is not installed on this computer. Some other font will be used.</source>
         <target xml:lang="zh-CN">这台电脑上没有当前选中的字体'{0}'，系统会自动使用其他字体。</target>
         <note>ID: EditTab.FontMissing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.AlreadyExists" sil:dynamic="true" approved="yes">
         <source xml:lang="en">That style already exists. Please choose another name.</source>
         <target xml:lang="zh-CN">该样式已经存在,请选择其他名称</target>
         <note>ID: EditTab.FormatDialog.AlreadyExists</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="zh-CN">调整边框和背景</target>
         <note>ID: EditTab.FormatDialog.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CharactersTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Characters</source>
         <target xml:lang="zh-CN">字符</target>
         <note>ID: EditTab.FormatDialog.CharactersTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Create" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create</source>
         <target xml:lang="zh-CN">创建</target>
         <note>ID: EditTab.FormatDialog.Create</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.CreateStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Create a new style</source>
         <target xml:lang="zh-CN">创建新样式</target>
         <note>ID: EditTab.FormatDialog.CreateStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.DontSeeNeed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Don't see what you need?</source>
         <target xml:lang="zh-CN">找不到想要的吗?</target>
         <note>ID: EditTab.FormatDialog.DontSeeNeed</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Emphasis" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Emphasis</source>
         <target xml:lang="zh-CN">强调</target>
         <note>ID: EditTab.FormatDialog.Emphasis</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Font" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Font</source>
         <target xml:lang="zh-CN">字体</target>
         <note>ID: EditTab.FormatDialog.Font</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="zh-CN">改变字体</target>
         <note>ID: EditTab.FormatDialog.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Changes the text size for all boxes carrying the style '{0}' and language '{1}'.\nCurrent size is {2}pt.</source>
         <target xml:lang="zh-CN">更改所有样式为‘{0}’语言为‘{1}’的文本框中的文本字号。\n当前字号为{2}pt.</target>
         <note>ID: EditTab.FormatDialog.FontSizeTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="zh-CN">调整字体大小</target>
         <note>ID: EditTab.FormatDialog.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Format" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Format</source>
         <target xml:lang="zh-CN">格式</target>
         <note>ID: EditTab.FormatDialog.Format</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="zh-CN">调整文本行间距</target>
         <note>ID: EditTab.FormatDialog.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.NewStyle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New style</source>
         <target xml:lang="zh-CN">新样式</target>
         <note>ID: EditTab.FormatDialog.NewStyle</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.PleaseUseAlpha" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please use only alphabetical characters. Numbers at the end are ok, as in "part2".</source>
         <target xml:lang="zh-CN">请只用字母，数字可以放在字母后面使用，如“part2”</target>
         <note>ID: EditTab.FormatDialog.PleaseUseAlpha</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Spacing" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spacing</source>
         <target xml:lang="zh-CN">间距</target>
         <note>ID: EditTab.FormatDialog.Spacing</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.Style" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style</source>
         <target xml:lang="zh-CN">样式</target>
         <note>ID: EditTab.FormatDialog.Style</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.StyleNameTab" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Style Name</source>
         <target xml:lang="zh-CN">样式名称</target>
         <note>ID: EditTab.FormatDialog.StyleNameTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="zh-CN">超宽</target>
         <note>ID: EditTab.FormatDialog.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="zh-CN">正常</target>
         <note>ID: EditTab.FormatDialog.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="zh-CN">调整单词间距</target>
         <note>ID: EditTab.FormatDialog.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialog.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="zh-CN">宽</target>
         <note>ID: EditTab.FormatDialog.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true">
+      <trans-unit id="EditTab.FormatDialogTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="zh-CN">调整格式以适应样式</target>
         <note>ID: EditTab.FormatDialogTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.AuthorIllustratorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may use this space for author/illustrator, or anything else.</source>
         <target xml:lang="zh-CN">可以在此空白处标明作者、画家或其他信息</target>
         <note>ID: EditTab.FrontMatter.AuthorIllustratorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Contributions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you are making an original book, use this box to record contributions made by writers, illustrators, editors, etc.</source>
         <target xml:lang="zh-CN">制作原创读物时,请在这个方框中注明作者、画家、编辑等</target>
         <note>ID: EditTab.FrontMatter.BigBook.Contributions</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BigBook.Translator" sil:dynamic="true" approved="yes">
         <source xml:lang="en">When you make a book from a shell, use this box to tell who did the translation.</source>
         <target xml:lang="zh-CN">用框架书制作读物时,请在这个方框中注明译者</target>
         <note>ID: EditTab.FrontMatter.BigBook.Translator</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book title in {lang}</source>
         <target xml:lang="zh-CN">{lang}语的书名</target>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
         <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to Edit Copyright and License</source>
         <target xml:lang="zh-CN">单击这里，编辑版权与许可证</target>
         <note>ID: EditTab.FrontMatter.CopyrightPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.FundingAgenciesPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Use this to acknowledge any funding agencies.</source>
         <target xml:lang="zh-CN">用这个向资助机构致谢。</target>
         <note>ID: EditTab.FrontMatter.FundingAgenciesPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.ISBNPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <target xml:lang="zh-CN">国际标准书号。没有书号的话，就空着。</target>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.</source>
         <target xml:lang="zh-CN">如果你需要空间填写更多有关本书的信息,可以使用本页(即封二).</target>
         <note>ID: EditTab.FrontMatter.InsideFrontCoverTextPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Name of Translator, in {lang}</source>
         <target xml:lang="zh-CN">译者名,{语言}语</target>
         <note>ID: EditTab.FrontMatter.NameofTranslatorPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <target xml:lang="zh-CN">用{lang}语言写成的原书(或框架书)致谢词</target>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <target xml:lang="zh-CN">用{lang}语言注明作家，插画者，编辑以及其他人所做出的贡献。</target>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalCopyrightSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalCopyrightSentence" approved="yes">
         <source xml:lang="en">Adapted from original, {0}.</source>
         <target xml:lang="zh-CN">改编自原作品，{0}。</target>
         <note>ID: EditTab.FrontMatter.OriginalCopyrightSentence</note>
         <note>On the Credits page of a book being translated, Bloom shows the original copyright. Put {0} in the translation where the copyright notice should go. For example in English, 'Adapted from original, {0}.' comes out like 'Adapted from original, Copyright 2011 SIL'.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalHadNoCopyrightSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalHadNoCopyrightSentence" approved="yes">
         <source xml:lang="en">Adapted from original without a copyright notice.</source>
         <target xml:lang="zh-CN">改编自原作品，没有著作权声明。</target>
         <note>ID: EditTab.FrontMatter.OriginalHadNoCopyrightSentence</note>
         <note>On the Credits page of a book being translated, Bloom shows this if the original book did not have a copyright notice.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.OriginalLicenseSentence">
+      <trans-unit id="EditTab.FrontMatter.OriginalLicenseSentence" approved="yes">
         <source xml:lang="en">Licensed under {0}.</source>
         <target xml:lang="zh-CN">依照{0}授权。</target>
         <note>ID: EditTab.FrontMatter.OriginalLicenseSentence</note>
         <note>On the Credits page of a book being translated, Bloom puts texts like 'Licensed under CC-BY', so that we have a record of what the license was for the original book. Put {0} in the translation, where the license should go in the sentence.</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TopicPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click to choose topic</source>
         <target xml:lang="zh-CN">单击这里，选择主题</target>
         <note>ID: EditTab.FrontMatter.TopicPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
+      <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <target xml:lang="zh-CN">向翻译版本致谢,{语言}语</target>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
       </trans-unit>
-      <trans-unit id="EditTab.HowToUnlockBook">
+      <trans-unit id="EditTab.HowToUnlockBook" approved="yes">
         <source xml:lang="en">To unlock this shellbook, go into the toolbox on the right, find the gear icon, and click 'Allow changes to this shellbook'.</source>
         <target xml:lang="zh-CN">想要解锁本壳书，在右边的工具栏找到齿轮标识，点击并选择“允许修改该壳书”</target>
         <note>ID: EditTab.HowToUnlockBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Image</source>
         <target xml:lang="zh-CN">改变图象</target>
         <note>ID: EditTab.Image.ChangeImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CopyImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Copy Image</source>
         <target xml:lang="zh-CN">复制图像</target>
         <note>ID: EditTab.Image.CopyImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.CutImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cut Image</source>
         <target xml:lang="zh-CN">剪切图像</target>
         <note>ID: EditTab.Image.CutImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.EditMetadata" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Edit Image Credits, Copyright, and License</source>
         <target xml:lang="zh-CN">编辑图像来源，版权和许可证。</target>
         <note>ID: EditTab.Image.EditMetadata</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true">
+      <trans-unit id="EditTab.Image.PasteImage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paste Image</source>
         <target xml:lang="zh-CN">粘贴图像</target>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse">
+      <trans-unit id="EditTab.JpegWarningDialog.DoNotUse" approved="yes">
         <source xml:lang="en">Cancel this import</source>
         <target xml:lang="zh-CN">取消导入</target>
         <note>ID: EditTab.JpegWarningDialog.DoNotUse</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.Photograph">
+      <trans-unit id="EditTab.JpegWarningDialog.Photograph" approved="yes">
         <source xml:lang="en">Use the JPEG file</source>
         <target xml:lang="zh-CN">用JPEG文档</target>
         <note>ID: EditTab.JpegWarningDialog.Photograph</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WarningText">
+      <trans-unit id="EditTab.JpegWarningDialog.WarningText" approved="yes">
         <source xml:lang="en">The file you’ve chosen is a “JPEG” file. JPEG files are perfect for photographs and color artwork. However, JPEG files are a big problem for black and white line art. Problems include:\n• Fuzziness and grey dots.\n• Large file sizes, making the book hard to share.\n• If there are many large JPEGs, Bloom may not have enough memory to make PDF files.\n\nNote: Because JPEG is “lossy”, converting a JPEG to PNG, TIFF, or BMP actually makes things even worse. If this is black and white line art, you want to get an original scan in one of those formats.\n\nPlease select from one of the following, then click “OK”:</source>
         <target xml:lang="zh-CN">您选中的是JPEG文档，JPEG格式不适合黑白线条画。如果原画是黑白线条画，最好扫描并保存成以下格式中的一种，请选择并点击“确定”。</target>
         <note>ID: EditTab.JpegWarningDialog.WarningText</note>
       </trans-unit>
-      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle">
+      <trans-unit id="EditTab.JpegWarningDialog.WindowTitle" approved="yes">
         <source xml:lang="en">JPEG Warning</source>
         <target xml:lang="zh-CN">JPEG警告</target>
         <note>ID: EditTab.JpegWarningDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
+      <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice" approved="yes">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <target xml:lang="zh-CN">该选项只能在"发布"标签中使用。</target>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
       </trans-unit>
-      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true">
+      <trans-unit id="EditTab.LayoutMode.ChangeLayout" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change Layout</source>
         <target xml:lang="zh-CN">调整布局</target>
         <note>ID: EditTab.LayoutMode.ChangeLayout</note>
       </trans-unit>
-      <trans-unit id="EditTab.Monolingual">
+      <trans-unit id="EditTab.Monolingual" approved="yes">
         <source xml:lang="en">One Language</source>
         <target xml:lang="zh-CN">一种语言</target>
         <note>ID: EditTab.Monolingual</note>
         <note>Shown in edit tab multilingualism chooser, for monolingual mode, one language per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.NewBookName">
+      <trans-unit id="EditTab.NewBookName" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="zh-CN">书</target>
         <note>ID: EditTab.NewBookName</note>
         <note>Default file and folder name when you make a new book, but haven't give it a title yet.</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoImageFoundOnClipboard">
+      <trans-unit id="EditTab.NoImageFoundOnClipboard" approved="yes">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <target xml:lang="zh-CN">粘贴图像前,请先用其他程序把图像复制到剪贴板上。</target>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
-      <trans-unit id="EditTab.NoOtherLayouts">
+      <trans-unit id="EditTab.NoOtherLayouts" approved="yes">
         <source xml:lang="en">There are no other layout options for this template.</source>
         <target xml:lang="zh-CN">该模板没有其他布局选项。</target>
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the layout chooser dropdown of the edit tab, if there was only a single layout choice</note>
       </trans-unit>
-      <trans-unit id="EditTab.Overflow" sil:dynamic="true">
+      <trans-unit id="EditTab.Overflow" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This box has more text than will fit</source>
         <target xml:lang="zh-CN">文本超过文本框所能容纳的限制</target>
         <note>ID: EditTab.Overflow</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatter">
+      <trans-unit id="EditTab.PageList.CantMoveXMatter" approved="yes">
         <source xml:lang="en">That change is not allowed. Front matter and back matter pages must remain where they are.</source>
         <target xml:lang="zh-CN">无法改动，书的前后封皮位置必须保持不变。</target>
         <note>ID: EditTab.PageList.CantMoveXMatter</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption">
+      <trans-unit id="EditTab.PageList.CantMoveXMatterCaption" approved="yes">
         <source xml:lang="en">Invalid Move</source>
         <target xml:lang="zh-CN">无法移动</target>
         <note>ID: EditTab.PageList.CantMoveXMatterCaption</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageList.Heading">
+      <trans-unit id="EditTab.PageList.Heading" approved="yes">
         <source xml:lang="en">Pages</source>
         <target xml:lang="zh-CN">页</target>
         <note>ID: EditTab.PageList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip">
+      <trans-unit id="EditTab.PageSizeAndOrientation.Tooltip" approved="yes">
         <source xml:lang="en">Choose a page size and orientation</source>
         <target xml:lang="zh-CN">请选择页面大小和方向</target>
         <note>ID: EditTab.PageSizeAndOrientation.Tooltip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton">
+      <trans-unit id="EditTab.PasteButton" approved="yes">
         <source xml:lang="en">Paste</source>
         <target xml:lang="zh-CN">粘贴</target>
         <note>ID: EditTab.PasteButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTip">
+      <trans-unit id="EditTab.PasteButton.ToolTip" approved="yes">
         <source xml:lang="en">Paste (Ctrl+V)</source>
         <target xml:lang="zh-CN">粘贴（Ctrl+v）</target>
         <note>ID: EditTab.PasteButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.PasteButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing on the Clipboard that you can paste here.</source>
         <target xml:lang="zh-CN">剪贴板中没有能贴在这里的内容</target>
         <note>ID: EditTab.PasteButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="EditTab.Position" sil:dynamic="true">
+      <trans-unit id="EditTab.Position" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Position</source>
         <target xml:lang="zh-CN">位置</target>
         <note>ID: EditTab.Position</note>
       </trans-unit>
-      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true">
+      <trans-unit id="EditTab.ReadOnlyInAuthorMode" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You cannot put anything in there while making an original book.</source>
         <target xml:lang="zh-CN">制作原创书时，这里什么都不能放</target>
         <note>ID: EditTab.ReadOnlyInAuthorMode</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.BorderToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the border and background</source>
         <target xml:lang="zh-CN">调整边框和背景</target>
         <note>ID: EditTab.StyleEditor.BorderToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontFaceToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font face</source>
         <target xml:lang="zh-CN">改变字体</target>
         <note>ID: EditTab.StyleEditor.FontFaceToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.FontSizeToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the font size</source>
         <target xml:lang="zh-CN">调整字体大小</target>
         <note>ID: EditTab.StyleEditor.FontSizeToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.LineSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between lines of text</source>
         <target xml:lang="zh-CN">调整文本行间距</target>
         <note>ID: EditTab.StyleEditor.LineSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingExtraWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Extra Wide</source>
         <target xml:lang="zh-CN">超宽</target>
         <note>ID: EditTab.StyleEditor.WordSpacingExtraWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingNormal" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="zh-CN">正常</target>
         <note>ID: EditTab.StyleEditor.WordSpacingNormal</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingToolTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Change the spacing between words</source>
         <target xml:lang="zh-CN">调整单词间距</target>
         <note>ID: EditTab.StyleEditor.WordSpacingToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditor.WordSpacingWide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wide</source>
         <target xml:lang="zh-CN">宽</target>
         <note>ID: EditTab.StyleEditor.WordSpacingWide</note>
       </trans-unit>
-      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true">
+      <trans-unit id="EditTab.StyleEditorTip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Adjust formatting for style</source>
         <target xml:lang="zh-CN">调整格式以适应样式</target>
         <note>ID: EditTab.StyleEditorTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.TemplatePagesList.Heading">
+      <trans-unit id="EditTab.TemplatePagesList.Heading" approved="yes">
         <source xml:lang="en">Template Pages</source>
         <target xml:lang="zh-CN">模板页</target>
         <note>ID: EditTab.TemplatePagesList.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.LanguageTab">
+      <trans-unit id="EditTab.TextBoxProperties.LanguageTab" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="zh-CN">语言</target>
         <note>ID: EditTab.TextBoxProperties.LanguageTab</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.LocalLanguage">
+      <trans-unit id="EditTab.TextBoxProperties.LocalLanguage" approved="yes">
         <source xml:lang="en">Local Language</source>
         <target xml:lang="zh-CN">土语</target>
         <note>ID: EditTab.TextBoxProperties.LocalLanguage</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.NationalLanguage">
+      <trans-unit id="EditTab.TextBoxProperties.NationalLanguage" approved="yes">
         <source xml:lang="en">National Language</source>
         <target xml:lang="zh-CN">国家通用语</target>
         <note>ID: EditTab.TextBoxProperties.NationalLanguage</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Normal">
+      <trans-unit id="EditTab.TextBoxProperties.Normal" approved="yes">
         <source xml:lang="en">Normal</source>
         <target xml:lang="zh-CN">普通</target>
         <note>ID: EditTab.TextBoxProperties.Normal</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.NormalLabel">
+      <trans-unit id="EditTab.TextBoxProperties.NormalLabel" approved="yes">
         <source xml:lang="en">"Normal" will show local language, and potentially regional or national, depending on the multilingual settings of the book. Use this for most content.</source>
         <target xml:lang="zh-CN">选择“普通”会显示土语，根据本书的多语种设置情况不同，也可能显示地区或国家通用语。该选项适用于大部分内容。</target>
         <note>ID: EditTab.TextBoxProperties.NormalLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.OtherLanguagesLabel">
+      <trans-unit id="EditTab.TextBoxProperties.OtherLanguagesLabel" approved="yes">
         <source xml:lang="en">Use one of these for simple text boxes that are always in only one language.</source>
         <target xml:lang="zh-CN">只用一种语言的简单文本框可选择这些选项中的一项</target>
         <note>ID: EditTab.TextBoxProperties.OtherLanguagesLabel</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.RegionalLanguage">
+      <trans-unit id="EditTab.TextBoxProperties.RegionalLanguage" approved="yes">
         <source xml:lang="en">Regional Language</source>
         <target xml:lang="zh-CN">地区通用语</target>
         <note>ID: EditTab.TextBoxProperties.RegionalLanguage</note>
       </trans-unit>
-      <trans-unit id="EditTab.TextBoxProperties.Title">
+      <trans-unit id="EditTab.TextBoxProperties.Title" approved="yes">
         <source xml:lang="en">Text Box Properties</source>
         <target xml:lang="zh-CN">文本框属性</target>
         <note>ID: EditTab.TextBoxProperties.Title</note>
       </trans-unit>
-      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom">
+      <trans-unit id="EditTab.ThumbnailCaptions.Picture On Bottom" approved="yes">
         <source xml:lang="en">Picture On Bottom</source>
         <target xml:lang="zh-CN">图片在底部</target>
         <note>ID: EditTab.ThumbnailCaptions.Picture On Bottom</note>
       </trans-unit>
-      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog">
+      <trans-unit id="EditTab.TitleOfCopyIPToWholeBooksDialog" approved="yes">
         <source xml:lang="en">Picture Intellectual Property Information</source>
         <target xml:lang="zh-CN">图片知识产权信息</target>
         <note>ID: EditTab.TitleOfCopyIPToWholeBooksDialog</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader Tool</source>
         <target xml:lang="zh-CN">拼读读物工具</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom can handle only the first {0} words.</source>
         <target xml:lang="zh-CN">Bloom只能处理最开始的{0}单词。</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed words in this stage</source>
         <target xml:lang="zh-CN">本细分层次中可使用的单词</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles" approved="yes">
         <source xml:lang="en">Text files</source>
         <target xml:lang="zh-CN">文本文档</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.FileDialogTextFiles</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters" approved="yes">
         <source xml:lang="en">Letters: {0}</source>
         <target xml:lang="zh-CN">字母：{0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportLetters</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage" approved="yes">
         <source xml:lang="en">The following is a generated report of the decodable stages for {0}. You can make any changes you want to this file, but Bloom will not notice your changes. It is just a report.</source>
         <target xml:lang="zh-CN">下面是对{0}的拼读细分层次的总结。可以修改该文档，但Bloom不会启用你的修改，因为它只是一份总结报告。</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords" approved="yes">
         <source xml:lang="en">New Decodable Words: {0}</source>
         <target xml:lang="zh-CN">新拼读单词：{0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportNewDecodableWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords" approved="yes">
         <source xml:lang="en">New Sight Words: {0}</source>
         <target xml:lang="zh-CN">新整体识别单词：{0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportSightWords</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage" approved="yes">
         <source xml:lang="en">Stage {0}</source>
         <target xml:lang="zh-CN">细分层次{0}</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList" approved="yes">
         <source xml:lang="en">Complete Word List</source>
         <target xml:lang="zh-CN">完整的单词列表</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LetterWordReportWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters in this stage</source>
         <target xml:lang="zh-CN">该细分层次中包含的字母</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.LettersInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open a Letter and Word List File</source>
         <target xml:lang="zh-CN">打开字母和单词列表文档</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordList</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Generate a letter and word list report</source>
         <target xml:lang="zh-CN">生成字母和单词列表报告</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample words in this stage</source>
         <target xml:lang="zh-CN">该细分层次中包含的单词举例</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SetUpStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Stages</source>
         <target xml:lang="zh-CN">设置细分层次</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SetUpStages</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.Stage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="zh-CN">细分层次</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.Stage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="zh-CN">，总共</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageOf</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.WordsInThisStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words in this stage</source>
         <target xml:lang="zh-CN">该细分层次中包含的单词</target>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.WordsInThisStage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader Tool</source>
         <target xml:lang="zh-CN">分级读物工具</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Actual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Actual</source>
         <target xml:lang="zh-CN">实际使用词数</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Actual</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Average" sil:dynamic="true" approved="yes">
         <source xml:lang="en">avg per sentence</source>
         <target xml:lang="zh-CN">每句平均词数</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Average</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="zh-CN">话题选择</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.FoThisLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For this Level</source>
         <target xml:lang="zh-CN">针对这个等级</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.FoThisLevel</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Formatting" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="zh-CN">字体设置</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Formatting</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.IllustrationSupport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="zh-CN">配图要求</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.IllustrationSupport</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.KeepInMind" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Keep in mind</source>
         <target xml:lang="zh-CN">注意</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.KeepInMind</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Level" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="zh-CN">等级</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Level</note>
         <note>Used to create string "Level # of #". The space after this word is added programmatically.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelOf" sil:dynamic="true" approved="yes">
         <source xml:lang="en">of</source>
         <target xml:lang="zh-CN">，总共</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelOf</note>
         <note>Used to create string "Level # of #". The spaces on each side of this word are added programmatically.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Max</source>
         <target xml:lang="zh-CN">词数上限</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">per page</source>
         <target xml:lang="zh-CN">每页</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="zh-CN">最长的句子</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.PerSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Predictability" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="zh-CN">内容可预测性</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Predictability</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.SetUpLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Levels</source>
         <target xml:lang="zh-CN">设置等级</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.SetUpLevels</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisBook" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Book</source>
         <target xml:lang="zh-CN">本书</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisBook</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.ThisPage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page</source>
         <target xml:lang="zh-CN">本页</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.ThisPage</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Total" sil:dynamic="true" approved="yes">
         <source xml:lang="en">total</source>
         <target xml:lang="zh-CN">总计</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Total</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Unique" sil:dynamic="true" approved="yes">
         <source xml:lang="en">unique</source>
         <target xml:lang="zh-CN">重复出现的词不算</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Unique</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Vocabulary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="zh-CN">词汇</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Vocabulary</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WordCounts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Counts</source>
         <target xml:lang="zh-CN">单词数</target>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.WordCounts</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.More" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More...</source>
         <target xml:lang="zh-CN">更多...</target>
         <note>ID: EditTab.Toolbox.More</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.Unlock" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allow changes to this shellbook</source>
         <target xml:lang="zh-CN">允许修改这本框架书</target>
         <note>ID: EditTab.Toolbox.Settings.Unlock</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.Settings.UnlockShellBookIntroductionText" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Bloom normally prevents most changes to shellbooks. If you need to add pages, change images, etc., tick the box below.</source>
         <target xml:lang="zh-CN">一般情况下Bloom会阻止对框架书的修改。如果需要加页、改图像等，请勾选下面的方框。</target>
         <note>ID: EditTab.Toolbox.Settings.UnlockShellBookIntroductionText</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.BadState" approved="yes">
         <source xml:lang="en">Bloom recording is in an unusual state, possibly caused by unplugging a microphone. You will need to restart.</source>
         <target xml:lang="zh-CN">可能拔出麦克风时造成Bloom录音状态异常。请重启。</target>
         <note>ID: EditTab.Toolbox.TalkingBook.BadState</note>
         <note>This is very low priority for translation.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoInput" approved="yes">
         <source xml:lang="en">No input device</source>
         <target xml:lang="zh-CN">没有输入设备</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoInput</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.NoMic" approved="yes">
         <source xml:lang="en">This computer appears to have no sound recording device available. You will need one to record audio for a talking book.</source>
         <target xml:lang="zh-CN">这台电脑没有录音设备，制作有声书需要录音设备。</target>
         <note>ID: EditTab.Toolbox.TalkingBook.NoMic</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage">
+      <trans-unit id="EditTab.Toolbox.TalkingBook.PleaseHoldMessage" approved="yes">
         <source xml:lang="en">Please hold the button down until you have finished recording</source>
         <target xml:lang="zh-CN">录音结束再松手</target>
         <note>ID: EditTab.Toolbox.TalkingBook.PleaseHoldMessage</note>
         <note>Appears when the speak/record button is pressed very briefly</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Back" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Back</source>
         <target xml:lang="zh-CN">后退</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Back</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Check" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4) Check</source>
         <target xml:lang="zh-CN">4)检查</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Check</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.CheckSettings" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Check that you are recording into the correct device and that these levels are showing blue:</source>
         <target xml:lang="zh-CN">请用合适的装置录音，音量大小最好控制在蓝色范围内</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.CheckSettings</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Clear" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Clear</source>
         <target xml:lang="zh-CN">清除</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Clear</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Heading" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Talking Book Tool</source>
         <target xml:lang="zh-CN">有声书工具</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Heading</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Listen" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Listen to the whole page</source>
         <target xml:lang="zh-CN">听整页</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Listen</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.LookAtSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Look at the highlighted sentence</source>
         <target xml:lang="zh-CN">2)看高亮的句子</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.LookAtSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Next" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5) Next</source>
         <target xml:lang="zh-CN">5)下一步</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Next</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.Speak" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3) Speak</source>
         <target xml:lang="zh-CN">3)说</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.Speak</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox.TalkingBookTool.ToolPurpose" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an e-book that can play recordings while highlighting sentences.</source>
         <target xml:lang="zh-CN">制作能边放录音边高亮所读句子的电子书</target>
         <note>ID: EditTab.Toolbox.TalkingBookTool.ToolPurpose</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true">
+      <trans-unit id="EditTab.Toolbox._bookSelection.LongestSentence" sil:dynamic="true" approved="yes">
         <source xml:lang="en">longest sentence</source>
         <target xml:lang="zh-CN">最长句</target>
         <note>ID: EditTab.Toolbox._bookSelection.LongestSentence</note>
       </trans-unit>
-      <trans-unit id="EditTab.Trilingual">
+      <trans-unit id="EditTab.Trilingual" approved="yes">
         <source xml:lang="en">Three Languages</source>
         <target xml:lang="zh-CN">三种语言</target>
         <note>ID: EditTab.Trilingual</note>
         <note>Shown in edit tab multilingualism chooser, for trilingual mode, 3 languages per page</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton">
+      <trans-unit id="EditTab.UndoButton" approved="yes">
         <source xml:lang="en">Undo</source>
         <target xml:lang="zh-CN">撤消</target>
         <note>ID: EditTab.UndoButton</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTip">
+      <trans-unit id="EditTab.UndoButton.ToolTip" approved="yes">
         <source xml:lang="en">Undo (Ctrl+Z)</source>
         <target xml:lang="zh-CN">撤销（Ctrl+z）</target>
         <note>ID: EditTab.UndoButton.ToolTip</note>
       </trans-unit>
-      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled">
+      <trans-unit id="EditTab.UndoButton.ToolTipWhenDisabled" approved="yes">
         <source xml:lang="en">There is nothing to undo</source>
         <target xml:lang="zh-CN">没有可撤销的操作</target>
         <note>ID: EditTab.UndoButton.ToolTipWhenDisabled</note>
       </trans-unit>
-      <trans-unit id="Errors.BookProblem">
+      <trans-unit id="Errors.BookProblem" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.</source>
         <target xml:lang="zh-CN">Bloom无法显示该书，这说明该书太过时、或者某个部分丢失或出错。但你的作品并没有丢失。</target>
         <note>ID: Errors.BookProblem</note>
       </trans-unit>
-      <trans-unit id="Errors.BrokenBook">
+      <trans-unit id="Errors.BrokenBook" approved="yes">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong. Consider using the 'Report a Problem' command under the 'Help' menu.</source>
         <target xml:lang="zh-CN">Bloom无法显示该书，这说明该书太过时、或者某个部分丢失或出错。但你的作品并没有丢失。请考虑使用“帮助”菜单下的“报告错误”命令。</target>
         <note>ID: Errors.BrokenBook</note>
       </trans-unit>
-      <trans-unit id="Errors.CannotConnectToBloomServer">
+      <trans-unit id="Errors.CannotConnectToBloomServer" approved="yes">
         <source xml:lang="en">Bloom was unable to start its own HTTP listener that it uses to talk to its embedded Firefox browser. If this happens even if you just restarted your computer, ask someone to investigate if you have an aggressive firewall product installed. The agressive firewall product may need to be uninstalled before you can use Bloom.</source>
         <target xml:lang="zh-CN">Bloom的侦听程序不能从内置的火狐浏览引擎获取信息。请尝试重启Bloom，如果问题仍然存在，请技术人员查看是否因为防火墙太过活跃。是的话，需要卸载防火墙才能使用Bloom。</target>
         <note>ID: Errors.CannotConnectToBloomServer</note>
       </trans-unit>
-      <trans-unit id="Errors.DeniedAccess">
+      <trans-unit id="Errors.DeniedAccess" approved="yes">
         <source xml:lang="en">Your computer denied Bloom access to the book. You may need technical help in setting the operating system permissions for this file.</source>
         <target xml:lang="zh-CN">您的电脑阻止Bloom打开该书。请在技术人员的帮助下设置操作系统对该文档的权限。</target>
         <note>ID: Errors.DeniedAccess</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorSelecting">
+      <trans-unit id="Errors.ErrorSelecting" approved="yes">
         <source xml:lang="en">There was a problem selecting the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="zh-CN">选择书时出现错误。请尝试重启Bloom。如问题仍然存在，请点击“详细”按钮，向Bloom工程师报告此问题。</target>
         <note>ID: Errors.ErrorSelecting</note>
       </trans-unit>
-      <trans-unit id="Errors.ErrorUpdating">
+      <trans-unit id="Errors.ErrorUpdating" approved="yes">
         <source xml:lang="en">There was a problem updating the book. Restarting Bloom may fix the problem. If not, please click the 'Details' button and report the problem to the Bloom Developers.</source>
         <target xml:lang="zh-CN">更新当前书时出现错误。请尝试重启Bloom。如问题仍然存在，请点击“详细”按钮，向Bloom工程师报告此问题。</target>
         <note>ID: Errors.ErrorUpdating</note>
       </trans-unit>
-      <trans-unit id="Errors.NeedNewerVersion">
+      <trans-unit id="Errors.NeedNewerVersion" approved="yes">
         <source xml:lang="en">{0} requires a newer version of Bloom. Download the latest version of Bloom from {1}.</source>
         <target xml:lang="zh-CN">{0}需要最新版Bloom。从{1}下载Bloom的最新版本</target>
         <note>ID: Errors.NeedNewerVersion</note>
         <note>{0} will get the name of the book, {1} will give a link to open the Bloom Library Web page.</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemDeletingFile">
+      <trans-unit id="Errors.ProblemDeletingFile" approved="yes">
         <source xml:lang="en">Bloom had a problem deleting this file: {0}</source>
         <target xml:lang="zh-CN">Bloom无法删除该文档：{0}</target>
         <note>ID: Errors.ProblemDeletingFile</note>
       </trans-unit>
-      <trans-unit id="Errors.ProblemImportingPicture">
+      <trans-unit id="Errors.ProblemImportingPicture" approved="yes">
         <source xml:lang="en">Bloom had a problem importing this picture.</source>
         <target xml:lang="zh-CN">Bloom无法插入图片。</target>
         <note>ID: Errors.ProblemImportingPicture</note>
       </trans-unit>
-      <trans-unit id="Errors.ReportThisProblemButton">
+      <trans-unit id="Errors.ReportThisProblemButton" approved="yes">
         <source xml:lang="en">Report this problem to Bloom Support</source>
         <target xml:lang="zh-CN">向Bloom的技术支持人员报告此问题。</target>
         <note>ID: Errors.ReportThisProblemButton</note>
       </trans-unit>
-      <trans-unit id="Errors.SomethingWentWrong">
+      <trans-unit id="Errors.SomethingWentWrong" approved="yes">
         <source xml:lang="en">Sorry, something went wrong.</source>
         <target xml:lang="zh-CN">Bloom无法显示该书。</target>
         <note>ID: Errors.SomethingWentWrong</note>
       </trans-unit>
-      <trans-unit id="Errors.XMatterNotFound">
+      <trans-unit id="Errors.XMatterNotFound" approved="yes">
         <source xml:lang="en">This Book called for Front/Back Matter pack named '{0}', but Bloom couldn't find that on this computer. You can either install a Bloom Pack that will give you '{0}', or go to Settings:Book Making and change to another Front/Back Matter Pack.</source>
         <target xml:lang="zh-CN">该书需要名为'{0}'的封皮资料包，Bloom无法在当前电脑上找到。您可以安装带有'{0}'的Bloom资料包，也可以去设置：图书制作，换用另一个封皮资料包。</target>
         <note>ID: Errors.XMatterNotFound</note>
       </trans-unit>
-      <trans-unit id="Errors.ZoneAlarm">
+      <trans-unit id="Errors.ZoneAlarm" approved="yes">
         <source xml:lang="en">Bloom cannot start properly, and this symptom has been observed on machines with ZoneAlarm installed. Note: disabling ZoneAlarm does not help. Nor does restarting with it turned off. Something about the installation of ZoneAlarm causes the problem, and so far only uninstalling ZoneAlarm has been shown to fix the problem.</source>
         <target xml:lang="zh-CN">在装有ZoneAlarm的电脑上出现过Bloom无法正常启动的情况。注：禁用和关闭ZoneAlarm不起作用，造成该问题的原因在于ZoneAlarm的安装过程，只有卸载ZoneAlarm才能解决该问题。</target>
         <note>ID: Errors.ZoneAlarm</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.BuildingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Building Reader Templates</source>
         <target xml:lang="zh-CN">创建读物模板</target>
         <note>ID: HelpMenu.BuildingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem">
+      <trans-unit id="HelpMenu.CheckForNewVersionMenuItem" approved="yes">
         <source xml:lang="en">Check For New Version</source>
         <target xml:lang="zh-CN">搜索新版本</target>
         <note>ID: HelpMenu.CheckForNewVersionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.CreditsMenuItem">
+      <trans-unit id="HelpMenu.CreditsMenuItem" approved="yes">
         <source xml:lang="en">About Bloom</source>
         <target xml:lang="zh-CN">关于Bloom</target>
         <note>ID: HelpMenu.CreditsMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.DocumentationMenuItem">
+      <trans-unit id="HelpMenu.DocumentationMenuItem" approved="yes">
         <source xml:lang="en">Help. Lots of help!</source>
         <target xml:lang="zh-CN">帮助，各种各样的帮助！</target>
         <note>ID: HelpMenu.DocumentationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.Help Menu">
+      <trans-unit id="HelpMenu.Help Menu" approved="yes">
         <source xml:lang="en">Help</source>
         <target xml:lang="zh-CN">帮助</target>
         <note>ID: HelpMenu.Help Menu</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem">
+      <trans-unit id="HelpMenu.KeyBloomConceptsToolStripMenuItem" approved="yes">
         <source xml:lang="en">Key Bloom Concepts</source>
         <target xml:lang="zh-CN">Bloom的关键概念</target>
         <note>ID: HelpMenu.KeyBloomConceptsToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.MakeASuggestionMenuItem">
+      <trans-unit id="HelpMenu.MakeASuggestionMenuItem" approved="yes">
         <source xml:lang="en">Make a Suggestion</source>
         <target xml:lang="zh-CN">提意见</target>
         <note>ID: HelpMenu.MakeASuggestionMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.RegistrationMenuItem">
+      <trans-unit id="HelpMenu.RegistrationMenuItem" approved="yes">
         <source xml:lang="en">Registration</source>
         <target xml:lang="zh-CN">注册</target>
         <note>ID: HelpMenu.RegistrationMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReleaseNotesMenuItem">
+      <trans-unit id="HelpMenu.ReleaseNotesMenuItem" approved="yes">
         <source xml:lang="en">Release Notes...</source>
         <target xml:lang="zh-CN">出版说明...</target>
         <note>ID: HelpMenu.ReleaseNotesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem">
+      <trans-unit id="HelpMenu.ReportAProblemToolStripMenuItem" approved="yes">
         <source xml:lang="en">Report a Problem...</source>
         <target xml:lang="zh-CN">报告错误</target>
         <note>ID: HelpMenu.ReportAProblemToolStripMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.ShowEventLogMenuItem">
+      <trans-unit id="HelpMenu.ShowEventLogMenuItem" approved="yes">
         <source xml:lang="en">Show Event Log</source>
         <target xml:lang="zh-CN">显示事件日志</target>
         <note>ID: HelpMenu.ShowEventLogMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem">
+      <trans-unit id="HelpMenu.UsingReaderTemplatesMenuItem" approved="yes">
         <source xml:lang="en">Using Reader Templates </source>
         <target xml:lang="zh-CN">使用读物模板</target>
         <note>ID: HelpMenu.UsingReaderTemplatesMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.WebSiteMenuItem">
+      <trans-unit id="HelpMenu.WebSiteMenuItem" approved="yes">
         <source xml:lang="en">Web Site</source>
         <target xml:lang="zh-CN">网站</target>
         <note>ID: HelpMenu.WebSiteMenuItem</note>
       </trans-unit>
-      <trans-unit id="HelpMenu.trainingVideos">
+      <trans-unit id="HelpMenu.trainingVideos" approved="yes">
         <source xml:lang="en">Training Videos</source>
         <target xml:lang="zh-CN">培训视频</target>
         <note>ID: HelpMenu.trainingVideos</note>
       </trans-unit>
-      <trans-unit id="InstallProblem.BloomPdfMaker">
+      <trans-unit id="InstallProblem.BloomPdfMaker" approved="yes">
         <source xml:lang="en">A component of Bloom, BloomPdfMaker.exe, seems to be missing. This prevents previews and printing. Antivirus software sometimes does this. You may need technical help to repair the Bloom installation and protect this file from being deleted again.</source>
         <target xml:lang="zh-CN">Bloom的重要组成部分BloomPdfMaker.exe丢失了，导致无法预览和打印。这可能是防病毒软件造成的，请寻求技术支持修复Bloom安装程序，不让该部分再被删除。</target>
         <note>ID: InstallProblem.BloomPdfMaker</note>
       </trans-unit>
-      <trans-unit id="LameEncoder.Progress">
+      <trans-unit id="LameEncoder.Progress" approved="yes">
         <source xml:lang="en">Converting to mp3</source>
         <target xml:lang="zh-CN">转成MP3格式</target>
         <note>ID: LameEncoder.Progress</note>
         <note>Appears in progress indicator</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.RightToLeftCheck">
+      <trans-unit id="LanguageFontDetails.RightToLeftCheck" approved="yes">
         <source xml:lang="en">This script is right to left</source>
         <target xml:lang="zh-CN">该字体从右至左书写</target>
         <note>ID: LanguageFontDetails.RightToLeftCheck</note>
       </trans-unit>
-      <trans-unit id="LanguageFontDetails.TallerLinesCheck">
+      <trans-unit id="LanguageFontDetails.TallerLinesCheck" approved="yes">
         <source xml:lang="en">This script requires taller lines</source>
         <target xml:lang="zh-CN">该字体需要更大的行间距</target>
         <note>ID: LanguageFontDetails.TallerLinesCheck</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape</source>
         <target xml:lang="zh-CN">A4 横向</target>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SideBySide</source>
         <target xml:lang="zh-CN">A4 横向并排</target>
         <note>ID: LayoutChoices.A4Landscape SideBySide</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Landscape SplitAcrossPages</source>
         <target xml:lang="zh-CN">A4横向跨页拆分</target>
         <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A4Portrait</source>
         <target xml:lang="zh-CN">A4纵向</target>
         <note>ID: LayoutChoices.A4Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Landscape</source>
         <target xml:lang="zh-CN">A5横向</target>
         <note>ID: LayoutChoices.A5Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait</source>
         <target xml:lang="zh-CN">A5纵向</target>
         <note>ID: LayoutChoices.A5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A5Portrait BottomAlign" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A5Portrait BottomAlign</source>
         <target xml:lang="zh-CN">A5纵向底部对齐</target>
         <note>ID: LayoutChoices.A5Portrait BottomAlign</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Landscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Landscape</source>
         <target xml:lang="zh-CN">A6横向</target>
         <note>ID: LayoutChoices.A6Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.A6Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A6Portrait</source>
         <target xml:lang="zh-CN">A6纵向</target>
         <note>ID: LayoutChoices.A6Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.B5Portrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">B5Portrait</source>
         <target xml:lang="zh-CN">B5纵向</target>
         <note>ID: LayoutChoices.B5Portrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.HalfLetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">HalfLetterPortrait</source>
         <target xml:lang="zh-CN">1/2美式信笺尺寸纵向</target>
         <note>ID: LayoutChoices.HalfLetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterLandscape</source>
         <target xml:lang="zh-CN">美式信笺尺寸横向</target>
         <note>ID: LayoutChoices.LetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.LetterPortrait" sil:dynamic="true" approved="yes">
         <source xml:lang="en">LetterPortrait</source>
         <target xml:lang="zh-CN">美式信笺尺寸纵向</target>
         <note>ID: LayoutChoices.LetterPortrait</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true">
+      <trans-unit id="LayoutChoices.QuarterLetterLandscape" sil:dynamic="true" approved="yes">
         <source xml:lang="en">QuarterLetterLandscape</source>
         <target xml:lang="zh-CN">1/4美式信笺尺寸横向</target>
         <note>ID: LayoutChoices.QuarterLetterLandscape</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog.WindowTitle">
+      <trans-unit id="LicenseDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Bloom {0}</source>
         <target xml:lang="zh-CN">Bloom {0}</target>
         <note>ID: LicenseDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="LicenseDialog._acceptButton">
+      <trans-unit id="LicenseDialog._acceptButton" approved="yes">
         <source xml:lang="en">I accept the terms of the license agreement</source>
         <target xml:lang="zh-CN">我接受许可协议的条款</target>
         <note>ID: LicenseDialog._acceptButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.AgreeToTerms">
+      <trans-unit id="LoginDialog.AgreeToTerms" approved="yes">
         <source xml:lang="en">I agree to the Bloom Library's Terms of Use</source>
         <target xml:lang="zh-CN">我接受Bloom Library的使用条款</target>
         <note>ID: LoginDialog.AgreeToTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Email">
+      <trans-unit id="LoginDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="zh-CN">电子邮件地址</target>
         <note>ID: LoginDialog.Email</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ForgotPassword">
+      <trans-unit id="LoginDialog.ForgotPassword" approved="yes">
         <source xml:lang="en">Forgot Password</source>
         <target xml:lang="zh-CN">忘记密码</target>
         <note>ID: LoginDialog.ForgotPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.LoginButton">
+      <trans-unit id="LoginDialog.LoginButton" approved="yes">
         <source xml:lang="en">&amp;Login</source>
         <target xml:lang="zh-CN">登录(&amp;L)</target>
         <note>ID: LoginDialog.LoginButton</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.Password">
+      <trans-unit id="LoginDialog.Password" approved="yes">
         <source xml:lang="en">Password</source>
         <target xml:lang="zh-CN">密码</target>
         <note>ID: LoginDialog.Password</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowPassword">
+      <trans-unit id="LoginDialog.ShowPassword" approved="yes">
         <source xml:lang="en">&amp;Show Password</source>
         <target xml:lang="zh-CN">显示密码(&amp;S)</target>
         <note>ID: LoginDialog.ShowPassword</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.ShowTerms">
+      <trans-unit id="LoginDialog.ShowTerms" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="zh-CN">显示使用条款</target>
         <note>ID: LoginDialog.ShowTerms</note>
       </trans-unit>
-      <trans-unit id="LoginDialog.WindowTitle">
+      <trans-unit id="LoginDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="zh-CN">登录BloomLibrary.org</target>
         <note>ID: LoginDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName">
+      <trans-unit id="NewCollectionWizard.AlreadyCollectionWithThatName" approved="yes">
         <source xml:lang="en">There is already a collection with that name, at &lt;a href='file://{0}'&gt;{0}&lt;/a&gt;.\nPlease pick a unique name.</source>
         <target xml:lang="zh-CN">该丛书名已被使用：&lt;a href='file://{0}'&gt;{0}&gt;/a&gt;。\n请选择其他名称。</target>
         <note>ID: NewCollectionWizard.AlreadyCollectionWithThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ChooseLanguagePage">
+      <trans-unit id="NewCollectionWizard.ChooseLanguagePage" approved="yes">
         <source xml:lang="en">Choose the Main Language For This Collection</source>
         <target xml:lang="zh-CN">请选择该丛书的主要语言</target>
         <note>ID: NewCollectionWizard.ChooseLanguagePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.ExampleText" approved="yes">
         <source xml:lang="en">Examples: "Health Books", "PNG Animal Stories"</source>
         <target xml:lang="zh-CN">例： “健康书籍”,“PNG动物故事”</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.ExampleText</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel">
+      <trans-unit id="NewCollectionWizard.CollectionNamePage.NameCollectionLabel" approved="yes">
         <source xml:lang="en">What would you like to call this collection?</source>
         <target xml:lang="zh-CN">您想给当前丛书起什么名字？</target>
         <note>ID: NewCollectionWizard.CollectionNamePage.NameCollectionLabel</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionNameProblem">
+      <trans-unit id="NewCollectionWizard.CollectionNameProblem" approved="yes">
         <source xml:lang="en">Collection Name Problem</source>
         <target xml:lang="zh-CN">丛书名称出错</target>
         <note>ID: NewCollectionWizard.CollectionNameProblem</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt">
+      <trans-unit id="NewCollectionWizard.CollectionWillBeCreatedAt" approved="yes">
         <source xml:lang="en">Collection will be created at: {0}</source>
         <target xml:lang="zh-CN">在{0}新建丛书</target>
         <note>ID: NewCollectionWizard.CollectionWillBeCreatedAt</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FinishPage">
+      <trans-unit id="NewCollectionWizard.FinishPage" approved="yes">
         <source xml:lang="en">Ready To Create New Collection</source>
         <target xml:lang="zh-CN">准备创建新丛书</target>
         <note>ID: NewCollectionWizard.FinishPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.FontAndScriptPage">
+      <trans-unit id="NewCollectionWizard.FontAndScriptPage" approved="yes">
         <source xml:lang="en">Font and Script</source>
         <target xml:lang="zh-CN">字体和文字</target>
         <note>ID: NewCollectionWizard.FontAndScriptPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage" approved="yes">
         <source xml:lang="en">Choose the Collection Type</source>
         <target xml:lang="zh-CN">请选择丛书类型</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions" approved="yes">
         <source xml:lang="en">If you already have a collection you want to open, click  the 'Cancel' button.</source>
         <target xml:lang="zh-CN">如果您已经创建了丛书，请点击“取消”按钮。</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.existingCollectionInstructions</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollection" approved="yes">
         <source xml:lang="en">Source Collection</source>
         <target xml:lang="zh-CN">资源集合</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of shell or template books in one or more languages of wider communication. You will be able to upload these shells to BloomLibrary.org. You may also make a Bloom Pack to give to others so that they can make local language books with your shells.</source>
         <target xml:lang="zh-CN">用广泛使用的语言编写的框架书丛书。您可以将这些框架书上传到BloomLibrary.org，也可以制成Bloom资料包，让别人用框架书制作当地语言读物。</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.sourceCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollection" approved="yes">
         <source xml:lang="en">Local Language Collection</source>
         <target xml:lang="zh-CN">土语/当地语言丛书</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollection</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription">
+      <trans-unit id="NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription" approved="yes">
         <source xml:lang="en">A collection of books in a local language.</source>
         <target xml:lang="zh-CN">用当地语言写成的丛书。</target>
         <note>ID: NewCollectionWizard.KindOfCollectionPage.vernacularCollectionDescription</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage">
+      <trans-unit id="NewCollectionWizard.LocationPage" approved="yes">
         <source xml:lang="en">Give Language Location</source>
         <target xml:lang="zh-CN">语言使用地区</target>
         <note>ID: NewCollectionWizard.LocationPage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Country">
+      <trans-unit id="NewCollectionWizard.LocationPage.Country" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="zh-CN">国家</target>
         <note>ID: NewCollectionWizard.LocationPage.Country</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.District">
+      <trans-unit id="NewCollectionWizard.LocationPage.District" approved="yes">
         <source xml:lang="en">District</source>
         <target xml:lang="zh-CN">区域</target>
         <note>ID: NewCollectionWizard.LocationPage.District</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional">
+      <trans-unit id="NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional" approved="yes">
         <source xml:lang="en">These are optional. Bloom will place them in the right places on title page of books you create.</source>
         <target xml:lang="zh-CN">这些是可选项。Bloom会把它们放到你创建的书的扉页。</target>
         <note>ID: NewCollectionWizard.LocationPage.MessageAboutLocationBeingOptional</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.LocationPage.Province">
+      <trans-unit id="NewCollectionWizard.LocationPage.Province" approved="yes">
         <source xml:lang="en">Province</source>
         <target xml:lang="zh-CN">省份</target>
         <note>ID: NewCollectionWizard.LocationPage.Province</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewBookPattern">
+      <trans-unit id="NewCollectionWizard.NewBookPattern" approved="yes">
         <source xml:lang="en">{0} Books</source>
         <target xml:lang="zh-CN">{0}书</target>
         <note>ID: NewCollectionWizard.NewBookPattern</note>
         <note>The {0} is replaced by the name of the language.</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle">
+      <trans-unit id="NewCollectionWizard.NewCollectionWindowTitle" approved="yes">
         <source xml:lang="en">Create New Bloom Collection</source>
         <target xml:lang="zh-CN">新建Bloom丛书</target>
         <note>ID: NewCollectionWizard.NewCollectionWindowTitle</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.ProjectName">
+      <trans-unit id="NewCollectionWizard.ProjectName" approved="yes">
         <source xml:lang="en">Project Name</source>
         <target xml:lang="zh-CN">项目名称</target>
         <note>ID: NewCollectionWizard.ProjectName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName">
+      <trans-unit id="NewCollectionWizard.UnableToCreateANewCollectionUsingThatName" approved="yes">
         <source xml:lang="en">Unable to create a new collection using that name.</source>
         <target xml:lang="zh-CN">无法用该名称创建新丛书。</target>
         <note>ID: NewCollectionWizard.UnableToCreateANewCollectionUsingThatName</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage">
+      <trans-unit id="NewCollectionWizard.WelcomePage" approved="yes">
         <source xml:lang="en">Welcome To Bloom!</source>
         <target xml:lang="zh-CN">欢迎使用Bloom!</target>
         <note>ID: NewCollectionWizard.WelcomePage</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine1" approved="yes">
         <source xml:lang="en">You are almost ready to start making books.</source>
         <target xml:lang="zh-CN">您很快就可以开始制作图书了。</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine1</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine2" approved="yes">
         <source xml:lang="en">In order to keep things simple and organized, Bloom keeps all the books you make in one or more &lt;i&gt;Collections&lt;/i&gt;. The first thing we need to do is make one for you.</source>
         <target xml:lang="zh-CN">为了便于操作和管理，Bloom会将您制作的所有书收集在一个或多个丛书里&lt;i&gt;Collections&lt;/i&gt;。因此首先要为您创建一个丛书。</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine2</note>
       </trans-unit>
-      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3">
+      <trans-unit id="NewCollectionWizard.WelcomePage.WelcomeLine3" approved="yes">
         <source xml:lang="en">Click 'Next' to get started.</source>
         <target xml:lang="zh-CN">单击”下一步“开始。</target>
         <note>ID: NewCollectionWizard.WelcomePage.WelcomeLine3</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InDropboxMessage">
+      <trans-unit id="OpenCreateCloneControl.InDropboxMessage" approved="yes">
         <source xml:lang="en">Bloom detected that this collection is located in your Dropbox folder. This can cause problems as Dropbox sometimes locks Bloom out of its own files. If you have problems, we recommend that you move your collection somewhere else or disable Dropbox while using Bloom.</source>
         <target xml:lang="zh-CN">Bloom发现该丛书位于你的Dropbox文档里，有时这会导致Bloom无法打开自身文件。请将丛书移动到其他位置，或在使用Bloom时禁用Dropbox。</target>
         <note>ID: OpenCreateCloneControl.InDropboxMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage">
+      <trans-unit id="OpenCreateCloneControl.InSourceCollectionMessage" approved="yes">
         <source xml:lang="en">This collection is part of your 'Sources for new books' which you can see in the bottom left of the Collections tab. It cannot be opened for editing.</source>
         <target xml:lang="zh-CN">该丛书属于“新书资源”所以无法修改，“新书资源”位于丛书标签的左下角。</target>
         <note>ID: OpenCreateCloneControl.InSourceCollectionMessage</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.Bloom Collections" approved="yes">
         <source xml:lang="en">Bloom Collections</source>
         <target xml:lang="zh-CN">Bloom丛书</target>
         <note>ID: OpenCreateNewCollectionsDialog.Bloom Collections</note>
         <note>This shows in the file-open dialog that you use to open a different bloom collection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections">
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseForOtherCollections" approved="yes">
         <source xml:lang="en">Browse for another collection on this computer</source>
         <target xml:lang="zh-CN">浏览这台计算机里的其他丛书</target>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub" approved="yes">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <target xml:lang="zh-CN">从局域网上的Chorus Hub复制</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromInternet" approved="yes">
         <source xml:lang="en">Copy from Internet</source>
         <target xml:lang="zh-CN">从互联网上复制</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromInternet</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromUsbDrive" approved="yes">
         <source xml:lang="en">Copy from USB Drive</source>
         <target xml:lang="zh-CN">从U盘上复制</target>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromUsbDrive</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection">
+      <trans-unit id="OpenCreateNewCollectionsDialog.CreateNewCollection" approved="yes">
         <source xml:lang="en">Create New Collection</source>
         <target xml:lang="zh-CN">新建丛书</target>
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
+      <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle" approved="yes">
         <source xml:lang="en">Open/Create Collections</source>
         <target xml:lang="zh-CN">打开/创建丛书</target>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">
+      <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink" approved="yes">
         <source xml:lang="en">Read More</source>
         <target xml:lang="zh-CN">阅读更多</target>
         <note>ID: OpenCreateNewCollectionsDialog.ReadMoreLink</note>
         <note>This opens the Chorus Help to learn more about send/receive.</note>
       </trans-unit>
-      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus">
+      <trans-unit id="OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus" approved="yes">
         <source xml:lang="en">Has someone else used Send/Receive to share a collection with you?\nUse one of these red buttons to copy their collection to your computer.\nLater, use Send/Receive to share your work back with them.</source>
         <target xml:lang="zh-CN">有人用“发送/接收”向你分享丛书吗？\n可以点击红色按钮把他们的丛书复制到你的电脑上。\n然后也通过“发送/接受”与他们分享你的丛书。</target>
         <note>ID: OpenCreateNewCollectionsDialog.TextAboutGetUsingChorus</note>
       </trans-unit>
-      <trans-unit id="PageList.CantMoveWhenTranslating">
+      <trans-unit id="PageList.CantMoveWhenTranslating" approved="yes">
         <source xml:lang="en">Pages can not be re-ordered when you are translating a book.</source>
         <target xml:lang="zh-CN">翻译书时页面不能重新排序</target>
         <note>ID: PageList.CantMoveWhenTranslating</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled">
+      <trans-unit id="PublishTab.AdobeReaderControl.NotInstalled" approved="yes">
         <source xml:lang="en">Please install Adobe Reader so that Bloom can show your completed book. Until then, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="zh-CN">如果要在Bloom上显示已完成的书，请安装Adobe Reader。或者你可以把书保存成PDF格式，再用别的软件打开。</target>
         <note>ID: PublishTab.AdobeReaderControl.NotInstalled</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF">
+      <trans-unit id="PublishTab.AdobeReaderControl.ProblemShowingPDF" approved="yes">
         <source xml:lang="en">That's strange... Adobe Reader gave an error when trying to show that PDF. You can still try saving the PDF Book.</source>
         <target xml:lang="zh-CN">异常...Adobe Reader显示PDF时出错，不过你仍然可以把书保存为PDF格式。</target>
         <note>ID: PublishTab.AdobeReaderControl.ProblemShowingPDF</note>
       </trans-unit>
-      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError">
+      <trans-unit id="PublishTab.AdobeReaderControl.UnknownError" approved="yes">
         <source xml:lang="en">Sad News. Bloom wasn't able to get Adobe Reader to show here, so Bloom can't show your completed book.\nPlease uninstall your existing version of 'Adobe Reader' and (re)install 'Adobe Reader'.\nUntil you get that fixed, you can still save the PDF Book and open it in some other program.</source>
         <target xml:lang="zh-CN">抱歉，Adobe Reader不无法显示，看不到已完成的书。请卸载并重装“Adobe Reader”。在问题解决之前可以把书保存成PDF格式，用其他软件打开。</target>
         <note>ID: PublishTab.AdobeReaderControl.UnknownError</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio">
+      <trans-unit id="PublishTab.BodyOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Insides</source>
         <target xml:lang="zh-CN">小册子内部</target>
         <note>ID: PublishTab.BodyOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.BodyOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a booklet from the inside pages of the book. Pages will be laid out and reordered so that when you fold it, you'll have a booklet.\n</source>
         <target xml:lang="zh-CN">用书的内页制作小册子。为了确保内页折叠后成为一本小册子,页面将被重新排列和布局。</target>
         <note>ID: PublishTab.BodyOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm" approved="yes">
         <source xml:lang="en">Upload</source>
         <target xml:lang="zh-CN">上传</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.ButtonThatShowsUploadForm-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Upload to BloomLibrary.org, where others can download and localize into their own language.</source>
         <target xml:lang="zh-CN">上传到BloomLibrary.org，以便别人下载并修改以适应当地语言。</target>
         <note>ID: PublishTab.ButtonThatShowsUploadForm-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio">
+      <trans-unit id="PublishTab.CoverOnlyRadio" approved="yes">
         <source xml:lang="en">Booklet Cover</source>
         <target xml:lang="zh-CN">小册子封面</target>
         <note>ID: PublishTab.CoverOnlyRadio</note>
       </trans-unit>
-      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.CoverOnlyRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of just the front and back (both sides), so you can  print on colored paper.</source>
         <target xml:lang="zh-CN">把书的封皮部分（封面和封二，封三和封底）做成PDF，以便用彩纸单独打印。</target>
         <note>ID: PublishTab.CoverOnlyRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubButton">
+      <trans-unit id="PublishTab.EpubButton" approved="yes">
         <source xml:lang="en">ePUB</source>
         <target xml:lang="zh-CN">ePUB</target>
         <note>ID: PublishTab.EpubButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.EpubRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make an ePUB (electronic book) out of this book, allowing it to be read on various electronic reading devices.</source>
         <target xml:lang="zh-CN">把该书做成电子版，可以在各种电子阅读设备上使用。</target>
         <note>ID: PublishTab.EpubRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton">
+      <trans-unit id="PublishTab.InDesignDialog.DontShowThisAgainButton" approved="yes">
         <source xml:lang="en">Don't Show This Again</source>
         <target xml:lang="zh-CN">不再显示当前提示</target>
         <note>ID: PublishTab.InDesignDialog.DontShowThisAgainButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.InDesignDialog.WindowTitle">
+      <trans-unit id="PublishTab.InDesignDialog.WindowTitle" approved="yes">
         <source xml:lang="en">InDesign XML Information</source>
         <target xml:lang="zh-CN">InDesign XML 信息</target>
         <note>ID: PublishTab.InDesignDialog.WindowTitle</note>
         <note>This is the title of a dialog about exporting a Bloom book to the InDesign XML format</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation">
+      <trans-unit id="PublishTab.Notifications.AdobeReaderRecommendation" approved="yes">
         <source xml:lang="en">This PDF viewer can be improved by installing the free Adobe Reader on this computer.</source>
         <target xml:lang="zh-CN">在本计算机上安装免费的Adobe Reader可以提高PDF文件的浏览效果。</target>
         <note>ID: PublishTab.Notifications.AdobeReaderRecommendation</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio" approved="yes">
         <source xml:lang="en">Simple</source>
         <target xml:lang="zh-CN">简单</target>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
         <note>Instead of making a booklet, just make normal pages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true">
+      <trans-unit id="PublishTab.OnePagePerPaperRadio-tooltip" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Make a PDF of every page of the book, one page per piece of paper.</source>
         <target xml:lang="zh-CN">把书的每一页都做成PDF，一页一张</target>
         <note>ID: PublishTab.OnePagePerPaperRadio-tooltip</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer">
+      <trans-unit id="PublishTab.OpenThePDFInTheSystemPDFViewer" approved="yes">
         <source xml:lang="en">Open the PDF in the default system PDF viewer</source>
         <target xml:lang="zh-CN">用系统默认的pdf阅览器打开PDF文档</target>
         <note>ID: PublishTab.OpenThePDFInTheSystemPDFViewer</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton">
+      <trans-unit id="PublishTab.OverwriteWarning.ReplaceExistingButton" approved="yes">
         <source xml:lang="en">Replace Existing</source>
         <target xml:lang="zh-CN">替换已存在的</target>
         <note>ID: PublishTab.OverwriteWarning.ReplaceExistingButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle">
+      <trans-unit id="PublishTab.OverwriteWarning.WindowTitle" approved="yes">
         <source xml:lang="en">Notice</source>
         <target xml:lang="zh-CN">通知</target>
         <note>ID: PublishTab.OverwriteWarning.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.BadPdf">
+      <trans-unit id="PublishTab.PdfMaker.BadPdf" approved="yes">
         <source xml:lang="en">Bloom had a problem making a PDF of this book. You may need technical help or to contact the developers. But here are some things you can try:</source>
         <target xml:lang="zh-CN">Bloom无法生成此书的PDF格式。请寻求技术帮助或联系软件开发者，也可以尝试这些做法：</target>
         <note>ID: PublishTab.PdfMaker.BadPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory">
+      <trans-unit id="PublishTab.PdfMaker.TryMoreMemory" approved="yes">
         <source xml:lang="en">Try doing this on a computer with more memory</source>
         <target xml:lang="zh-CN">请使用内存更大的电脑</target>
         <note>ID: PublishTab.PdfMaker.TryMoreMemory</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TryRestart">
+      <trans-unit id="PublishTab.PdfMaker.TryRestart" approved="yes">
         <source xml:lang="en">Restart your computer and try this again right away</source>
         <target xml:lang="zh-CN">重启电脑并立即重试</target>
         <note>ID: PublishTab.PdfMaker.TryRestart</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages">
+      <trans-unit id="PublishTab.PdfMaker.TrySmallerImages" approved="yes">
         <source xml:lang="en">Replace large, high-resolution images in your document with lower-resolution ones</source>
         <target xml:lang="zh-CN">把文档里大的高清图像替换成低清图像</target>
         <note>ID: PublishTab.PdfMaker.TrySmallerImages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PrintButton">
+      <trans-unit id="PublishTab.PrintButton" approved="yes">
         <source xml:lang="en">&amp;Print...</source>
         <target xml:lang="zh-CN">打印(&amp;P)...</target>
         <note>ID: PublishTab.PrintButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Publish">
+      <trans-unit id="PublishTab.Publish" approved="yes">
         <source xml:lang="en">Publish</source>
         <target xml:lang="zh-CN">发布</target>
         <note>ID: PublishTab.Publish</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveButton">
+      <trans-unit id="PublishTab.SaveButton" approved="yes">
         <source xml:lang="en">&amp;Save PDF...</source>
         <target xml:lang="zh-CN">保存成PDF(&amp;S)...</target>
         <note>ID: PublishTab.SaveButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.SaveEpub">
+      <trans-unit id="PublishTab.SaveEpub" approved="yes">
         <source xml:lang="en">&amp;Save ePUB...</source>
         <target xml:lang="zh-CN">保存成ePUB</target>
         <note>ID: PublishTab.SaveEpub</note>
       </trans-unit>
-      <trans-unit id="PublishTab.ShowCropMarks">
+      <trans-unit id="PublishTab.ShowCropMarks" approved="yes">
         <source xml:lang="en">Crop Marks</source>
         <target xml:lang="zh-CN">剪裁标记</target>
         <note>ID: PublishTab.ShowCropMarks</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Acknowledgments">
+      <trans-unit id="PublishTab.Upload.Acknowledgments" approved="yes">
         <source xml:lang="en">Acknowledgments</source>
         <target xml:lang="zh-CN">鸣谢</target>
         <note>ID: PublishTab.Upload.Acknowledgments</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AdditionalRequests">
+      <trans-unit id="PublishTab.Upload.AdditionalRequests" approved="yes">
         <source xml:lang="en">Additional Requests: </source>
         <target xml:lang="zh-CN">其他要求：</target>
         <note>ID: PublishTab.Upload.AdditionalRequests</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.AllReserved">
+      <trans-unit id="PublishTab.Upload.AllReserved" approved="yes">
         <source xml:lang="en">All rights reserved (Contact the Copyright holder for any permissions.)</source>
         <target xml:lang="zh-CN">版权所有（如有需要，请联系版权所有者）</target>
         <note>ID: PublishTab.Upload.AllReserved</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.CcLink">
+      <trans-unit id="PublishTab.Upload.CcLink" approved="yes">
         <source xml:lang="en">CC-BY-NC</source>
         <target xml:lang="zh-CN">CC-BY-NC</target>
         <note>ID: PublishTab.Upload.CcLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting">
+      <trans-unit id="PublishTab.Upload.ConfirmReplaceExisting" approved="yes">
         <source xml:lang="en">BloomLibrary.org already has a previous version of this book from you. If you upload it again, it will be replaced with your current version.</source>
         <target xml:lang="zh-CN">BloomLibrary.org 已有这本书之前的版本。如再次上传，旧版本将会被替换成新版本。</target>
         <note>ID: PublishTab.Upload.ConfirmReplaceExisting</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Copyright">
+      <trans-unit id="PublishTab.Upload.Copyright" approved="yes">
         <source xml:lang="en">Copyright</source>
         <target xml:lang="zh-CN">版权</target>
         <note>ID: PublishTab.Upload.Copyright</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Credits">
+      <trans-unit id="PublishTab.Upload.Credits" approved="yes">
         <source xml:lang="en">credits</source>
         <target xml:lang="zh-CN">致谢</target>
         <note>ID: PublishTab.Upload.Credits</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.ErrorUploading">
+      <trans-unit id="PublishTab.Upload.ErrorUploading" approved="yes">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
         <target xml:lang="zh-CN">抱歉，上传{0}时出错。详情见下文，您可能需要技术支持。</target>
         <note>ID: PublishTab.Upload.ErrorUploading</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FieldsNeedAttention">
+      <trans-unit id="PublishTab.Upload.FieldsNeedAttention" approved="yes">
         <source xml:lang="en">One or more fields above need your attention before uploading.</source>
         <target xml:lang="zh-CN">以上有一个或多个方面需要处理，请处理好后再上传。</target>
         <note>ID: PublishTab.Upload.FieldsNeedAttention</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice">
+      <trans-unit id="PublishTab.Upload.FinalUploadFailureNotice" approved="yes">
         <source xml:lang="en">Sorry, "{0}" was not successfully uploaded. Sometimes this is caused by temporary problems with the servers we use. It's worth trying again in an hour or two. If you regularly get this problem please report it to us.</source>
         <target xml:lang="zh-CN">抱歉，{0}上传不成功</target>
         <note>ID: PublishTab.Upload.FinalUploadFailureNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Gaurantee">
+      <trans-unit id="PublishTab.Upload.Gaurantee" approved="yes">
         <source xml:lang="en">By uploading, you confirm your agreement with the Bloom Library Terms of Use and grant the rights it describes.</source>
         <target xml:lang="zh-CN">上传表示您已经接受Bloom Library的使用条款并授予我们条款中列出的权限。</target>
         <note>ID: PublishTab.Upload.Gaurantee</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.GenericUploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book.</source>
         <target xml:lang="zh-CN">上传书时出现错误。</target>
         <note>ID: PublishTab.Upload.GenericUploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Languages">
+      <trans-unit id="PublishTab.Upload.Languages" approved="yes">
         <source xml:lang="en">Languages</source>
         <target xml:lang="zh-CN">语言</target>
         <note>ID: PublishTab.Upload.Languages</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.License">
+      <trans-unit id="PublishTab.Upload.License" approved="yes">
         <source xml:lang="en">Usage/License</source>
         <target xml:lang="zh-CN">使用/许可证</target>
         <note>ID: PublishTab.Upload.License</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists">
+      <trans-unit id="PublishTab.Upload.Login.AccountAlreadyExists" approved="yes">
         <source xml:lang="en">Account Already Exists</source>
         <target xml:lang="zh-CN">帐户已存在</target>
         <note>ID: PublishTab.Upload.Login.AccountAlreadyExists</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount">
+      <trans-unit id="PublishTab.Upload.Login.AlreadyHaveAccount" approved="yes">
         <source xml:lang="en">We cannot sign you up with that address, because we already have an account with that address. Would you like to log in instead?</source>
         <target xml:lang="zh-CN">该邮件地址已被注册，请登录。</target>
         <note>ID: PublishTab.Upload.Login.AlreadyHaveAccount</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to verify your login. Please check your network connection.</source>
         <target xml:lang="zh-CN">Bloom无法连接服务器，登录验证不成功。请检查网络连接。</target>
         <note>ID: PublishTab.Upload.Login.LoginConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginFailed" approved="yes">
         <source xml:lang="en">Login failed</source>
         <target xml:lang="zh-CN">登录失败</target>
         <note>ID: PublishTab.Upload.Login.LoginFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed">
+      <trans-unit id="PublishTab.Upload.Login.LoginOrSignupConnectionFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to complete your login or signup. This could be a problem with your internet connection, our server, or some equipment in between.</source>
         <target xml:lang="zh-CN">Bloom无法连接服务器，登录或注册不成功。可能您的网络连接、我们的服务器或中间设备出现故障。</target>
         <note>ID: PublishTab.Upload.Login.LoginOrSignupConnectionFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.MustAgreeTerms" approved="yes">
         <source xml:lang="en">In order to sign up for a BloomLibrary.org account, you must check the box indicating that you agree to the BloomLibrary Terms of Use.</source>
         <target xml:lang="zh-CN">要注册BloomLibrary.org帐户，勾选方框表示接受BloomLibrary.org的使用条款。</target>
         <note>ID: PublishTab.Upload.Login.MustAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Need Email">
+      <trans-unit id="PublishTab.Upload.Login.Need Email" approved="yes">
         <source xml:lang="en">Email Needed</source>
         <target xml:lang="zh-CN">必须填上电子邮件</target>
         <note>ID: PublishTab.Upload.Login.Need Email</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser">
+      <trans-unit id="PublishTab.Upload.Login.NoRecordOfUser" approved="yes">
         <source xml:lang="en">We don't have a user on record with that email. Would you like to sign up?</source>
         <target xml:lang="zh-CN">用户记录不存在。请注册。</target>
         <note>ID: PublishTab.Upload.Login.NoRecordOfUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch">
+      <trans-unit id="PublishTab.Upload.Login.PasswordMismatch" approved="yes">
         <source xml:lang="en">Password and user ID did not match</source>
         <target xml:lang="zh-CN">用户名和密码不符</target>
         <note>ID: PublishTab.Upload.Login.PasswordMismatch</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms">
+      <trans-unit id="PublishTab.Upload.Login.PleaseAgreeTerms" approved="yes">
         <source xml:lang="en">Please agree to terms of use</source>
         <target xml:lang="zh-CN">请接受使用条款</target>
         <note>ID: PublishTab.Upload.Login.PleaseAgreeTerms</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail">
+      <trans-unit id="PublishTab.Upload.Login.PleaseProvideEmail" approved="yes">
         <source xml:lang="en">Please enter a valid email address. We will send an email to this address so you can reset your password.</source>
         <target xml:lang="zh-CN">请输入真实的电子邮箱。我们会把重设密码的邮件发送给您。</target>
         <note>ID: PublishTab.Upload.Login.PleaseProvideEmail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetConnectFailed" approved="yes">
         <source xml:lang="en">Bloom could not connect to the server to reset your password. Please check your network connection.</source>
         <target xml:lang="zh-CN">Bloom无法连接服务器，重设密码不成功。请检查网络连接。</target>
         <note>ID: PublishTab.Upload.Login.ResetConnectFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetFailed">
+      <trans-unit id="PublishTab.Upload.Login.ResetFailed" approved="yes">
         <source xml:lang="en">Reset Password failed</source>
         <target xml:lang="zh-CN">重设密码失败</target>
         <note>ID: PublishTab.Upload.Login.ResetFailed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.ResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.ResetPassword" approved="yes">
         <source xml:lang="en">Resetting Password</source>
         <target xml:lang="zh-CN">正在重设密码</target>
         <note>ID: PublishTab.Upload.Login.ResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword">
+      <trans-unit id="PublishTab.Upload.Login.SendingResetPassword" approved="yes">
         <source xml:lang="en">We are sending an email to {0} with instructions for how to reset your password.</source>
         <target xml:lang="zh-CN">重设密码的方法已发送到这个电子邮件地址：{0}</target>
         <note>ID: PublishTab.Upload.Login.SendingResetPassword</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.Signup">
+      <trans-unit id="PublishTab.Upload.Login.Signup" approved="yes">
         <source xml:lang="en">Sign up for Bloom Library.</source>
         <target xml:lang="zh-CN">注册Bloom图书馆。</target>
         <note>ID: PublishTab.Upload.Login.Signup</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Login.UnknownUser">
+      <trans-unit id="PublishTab.Upload.Login.UnknownUser" approved="yes">
         <source xml:lang="en">Unknown user</source>
         <target xml:lang="zh-CN">未知用户</target>
         <note>ID: PublishTab.Upload.Login.UnknownUser</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginFailure">
+      <trans-unit id="PublishTab.Upload.LoginFailure" approved="yes">
         <source xml:lang="en">Bloom could not log in to BloomLibrary.org using your saved credentials. Please check your network connection.</source>
         <target xml:lang="zh-CN">Bloom无法用您的已存信息登录BloomLibrary.org。请检查网络连接。</target>
         <note>ID: PublishTab.Upload.LoginFailure</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.LoginLink">
+      <trans-unit id="PublishTab.Upload.LoginLink" approved="yes">
         <source xml:lang="en">Log in to BloomLibrary.org</source>
         <target xml:lang="zh-CN">登录BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.LoginLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Logout">
+      <trans-unit id="PublishTab.Upload.Logout" approved="yes">
         <source xml:lang="en">Log out of BloomLibrary.org</source>
         <target xml:lang="zh-CN">退出BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.Logout</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingPdf">
+      <trans-unit id="PublishTab.Upload.MakingPdf" approved="yes">
         <source xml:lang="en">Making PDF Preview...</source>
         <target xml:lang="zh-CN">正在生成PDF预览...</target>
         <note>ID: PublishTab.Upload.MakingPdf</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.MakingThumbnail">
+      <trans-unit id="PublishTab.Upload.MakingThumbnail" approved="yes">
         <source xml:lang="en">Making thumbnail image...</source>
         <target xml:lang="zh-CN">正在生成缩略图像...</target>
         <note>ID: PublishTab.Upload.MakingThumbnail</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.NoLangsFound">
+      <trans-unit id="PublishTab.Upload.NoLangsFound" approved="yes">
         <source xml:lang="en">(None found)</source>
         <target xml:lang="zh-CN">（未找到）</target>
         <note>ID: PublishTab.Upload.NoLangsFound</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.OldVersion">
+      <trans-unit id="PublishTab.Upload.OldVersion" approved="yes">
         <source xml:lang="en">Sorry, this version of Bloom Desktop is not compatible with the current version of BloomLibrary.org. Please upgrade to a newer version.</source>
         <target xml:lang="zh-CN">抱歉，您桌面上的Bloom版本与BloomLibrary.org不兼容。请升级为较新的版本。</target>
         <note>ID: PublishTab.Upload.OldVersion</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Partial">
+      <trans-unit id="PublishTab.Upload.Partial" approved="yes">
         <source xml:lang="en">(partial)</source>
         <target xml:lang="zh-CN">（局部的）</target>
         <note>ID: PublishTab.Upload.Partial</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseLogIn">
+      <trans-unit id="PublishTab.Upload.PleaseLogIn" approved="yes">
         <source xml:lang="en">Please log in to BloomLibrary.org (or sign up) before uploading</source>
         <target xml:lang="zh-CN">上传前请登录（或注册）BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.PleaseLogIn</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.PleaseSetThis">
+      <trans-unit id="PublishTab.Upload.PleaseSetThis" approved="yes">
         <source xml:lang="en">Please set this from the edit tab</source>
         <target xml:lang="zh-CN">请在编辑标签里设置</target>
         <note>ID: PublishTab.Upload.PleaseSetThis</note>
         <note>This shows next to the license, if the license has not yet been set.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SignupLink">
+      <trans-unit id="PublishTab.Upload.SignupLink" approved="yes">
         <source xml:lang="en">Sign up for BloomLibrary.org</source>
         <target xml:lang="zh-CN">注册BloomLibrary.org</target>
         <note>ID: PublishTab.Upload.SignupLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step1">
+      <trans-unit id="PublishTab.Upload.Step1" approved="yes">
         <source xml:lang="en">Step 1: Confirm Metadata</source>
         <target xml:lang="zh-CN">第1步: 确定元数据</target>
         <note>ID: PublishTab.Upload.Step1</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Step2">
+      <trans-unit id="PublishTab.Upload.Step2" approved="yes">
         <source xml:lang="en">Step 2: Upload</source>
         <target xml:lang="zh-CN">第2步: 上传</target>
         <note>ID: PublishTab.Upload.Step2</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestAssignCC">
+      <trans-unit id="PublishTab.Upload.SuggestAssignCC" approved="yes">
         <source xml:lang="en">Suggestion: Assigning a Creative Commons License makes it easy for you to clearly grant certain permissions to everyone.</source>
         <target xml:lang="zh-CN">建议：使用创作公用授权，便于清楚地把某些权限授予大家。</target>
         <note>ID: PublishTab.Upload.SuggestAssignCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.SuggestChangeCC">
+      <trans-unit id="PublishTab.Upload.SuggestChangeCC" approved="yes">
         <source xml:lang="en">Suggestion: Creative Commons Licenses make it much easier for others to use your book, even if they aren't fluent in the language of your custom license.</source>
         <target xml:lang="zh-CN">建议：创作公用授权能让大家更方便地使用你的书，即使他们不熟悉你用于自定权限的语言也没关系。</target>
         <note>ID: PublishTab.Upload.SuggestChangeCC</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Summary">
+      <trans-unit id="PublishTab.Upload.Summary" approved="yes">
         <source xml:lang="en">Summary</source>
         <target xml:lang="zh-CN">总结</target>
         <note>ID: PublishTab.Upload.Summary</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TermsLink">
+      <trans-unit id="PublishTab.Upload.TermsLink" approved="yes">
         <source xml:lang="en">Show Terms of Use</source>
         <target xml:lang="zh-CN">显示使用条款</target>
         <note>ID: PublishTab.Upload.TermsLink</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.TimeProblem">
+      <trans-unit id="PublishTab.Upload.TimeProblem" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. This is probably because your computer is set to use the wrong timezone or your system time is badly wrong. See http://www.di-mgt.com.au/wclock/help/wclo_setsysclock.html for how to fix this.</source>
         <target xml:lang="zh-CN">上传书时出现错误。可能因为您的电脑的时区设定错误，或是系统时间出错，修复方法请查看http:www.di-mgt.com.au/wclock/help/wclo_setsysclock.html</target>
         <note>ID: PublishTab.Upload.TimeProblem</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.Title">
+      <trans-unit id="PublishTab.Upload.Title" approved="yes">
         <source xml:lang="en">Title</source>
         <target xml:lang="zh-CN">标题</target>
         <note>ID: PublishTab.Upload.Title</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadButton">
+      <trans-unit id="PublishTab.Upload.UploadButton" approved="yes">
         <source xml:lang="en">Upload Book</source>
         <target xml:lang="zh-CN">上传书</target>
         <note>ID: PublishTab.Upload.UploadButton</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadCompleteNotice">
+      <trans-unit id="PublishTab.Upload.UploadCompleteNotice" approved="yes">
         <source xml:lang="en">Congratulations, "{0}" is now available on BloomLibrary.org ({1})</source>
         <target xml:lang="zh-CN">恭喜，“{0}”已经在BloomLibrary.org ({1})里了。</target>
         <note>ID: PublishTab.Upload.UploadCompleteNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadNotAllowed">
+      <trans-unit id="PublishTab.Upload.UploadNotAllowed" approved="yes">
         <source xml:lang="en">Upload Not Allowed</source>
         <target xml:lang="zh-CN">无法上传</target>
         <note>ID: PublishTab.Upload.UploadNotAllowed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProblemNotice">
+      <trans-unit id="PublishTab.Upload.UploadProblemNotice" approved="yes">
         <source xml:lang="en">There was a problem uploading your book. You may need to restart Bloom or get technical help.</source>
         <target xml:lang="zh-CN">上传书时出现错误。您可能需要重启Bloom或寻求技术支持。</target>
         <note>ID: PublishTab.Upload.UploadProblemNotice</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadProgress">
+      <trans-unit id="PublishTab.Upload.UploadProgress" approved="yes">
         <source xml:lang="en">Upload Progress</source>
         <target xml:lang="zh-CN">上传进程</target>
         <note>ID: PublishTab.Upload.UploadProgress</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadSandbox">
+      <trans-unit id="PublishTab.Upload.UploadSandbox" approved="yes">
         <source xml:lang="en">Upload Book (to Sandbox)</source>
         <target xml:lang="zh-CN">上传书(到沙箱)</target>
         <note>ID: PublishTab.Upload.UploadSandbox</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingBookMetadata">
+      <trans-unit id="PublishTab.Upload.UploadingBookMetadata" approved="yes">
         <source xml:lang="en">Uploading book metadata</source>
         <target xml:lang="zh-CN">正在上传书的元数据</target>
         <note>ID: PublishTab.Upload.UploadingBookMetadata</note>
         <note>In this step, Bloom is uploading things like title, languages, and topic tags to the BloomLibrary.org database.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.Upload.UploadingStatus">
+      <trans-unit id="PublishTab.Upload.UploadingStatus" approved="yes">
         <source xml:lang="en">Uploading {0}</source>
         <target xml:lang="zh-CN">正在上传{0}</target>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Level</source>
         <target xml:lang="zh-CN">添加等级</target>
         <note>ID: ReaderSetup.AddLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Add Stage</source>
         <target xml:lang="zh-CN">添加细分层次</target>
         <note>ID: ReaderSetup.AddStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AddTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Please add texts to the Sample Texts folder.</source>
         <target xml:lang="zh-CN">请在示范文本文件夹里添加文本。</target>
         <note>ID: ReaderSetup.AddTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">allowed words</source>
         <target xml:lang="zh-CN">可使用的单词</target>
         <note>ID: ReaderSetup.AllowedWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <target xml:lang="zh-CN">可用单词文档</target>
         <note>ID: ReaderSetup.AllowedWordsFile</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AllowedWordsFileHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Allowed Words File</source>
         <target xml:lang="zh-CN">可用单词文档</target>
         <note>ID: ReaderSetup.AllowedWordsFileHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.AverageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Avg</source>
         <target xml:lang="zh-CN">平均</target>
         <note>ID: ReaderSetup.AverageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Book</source>
         <target xml:lang="zh-CN">书</target>
         <note>ID: ReaderSetup.BookHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.BookMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words per Book</source>
         <target xml:lang="zh-CN">每书词数上限</target>
         <note>ID: ReaderSetup.BookMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Choose...</source>
         <target xml:lang="zh-CN">选择……</target>
         <note>ID: ReaderSetup.ChooseAllowedWordsFile</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ClickLetter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Click on letters to add them to this stage.</source>
         <target xml:lang="zh-CN">点击字母加入当前页。</target>
         <note>ID: ReaderSetup.ClickLetter</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="zh-CN">用空格隔开</target>
         <note>ID: ReaderSetup.CombinationHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.CombinationHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "ai oo sh ng th ing"</source>
         <target xml:lang="zh-CN">例："ai oo sh ng th ing"</target>
         <note>ID: ReaderSetup.CombinationHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Combinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letter Combinations (Graphemes)</source>
         <target xml:lang="zh-CN">字母组合（字素）</target>
         <note>ID: ReaderSetup.Combinations</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.DecodableStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Stages</source>
         <target xml:lang="zh-CN">拼读的细分层次</target>
         <note>ID: ReaderSetup.DecodableStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FileNeedsTxtExtension" sil:dynamic="true" approved="yes">
         <source xml:lang="en">File needs .TXT extension</source>
         <target xml:lang="zh-CN">文档后缀名应为.txt</target>
         <note>ID: ReaderSetup.FileNeedsTxtExtension</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FirstSetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">First,</source>
         <target xml:lang="zh-CN">首先，</target>
         <note>ID: ReaderSetup.FirstSetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.FormatNotSupported" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Cannot read this format</source>
         <target xml:lang="zh-CN">无法读取当前格式</target>
         <note>ID: ReaderSetup.FormatNotSupported</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.HowToExport" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Help exporting and converting files to use as sample texts</source>
         <target xml:lang="zh-CN">帮助导出文本并将其转换成示范文本</target>
         <note>ID: ReaderSetup.HowToExport</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Language" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Language" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Language</source>
         <target xml:lang="zh-CN">语言</target>
         <note>ID: ReaderSetup.Language</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">List letters and word-forming characters in alphabetic order.</source>
         <target xml:lang="zh-CN">按字母顺序排列字母和成词字符。</target>
         <note>ID: ReaderSetup.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate by spaces</source>
         <target xml:lang="zh-CN">用空格隔开</target>
         <note>ID: ReaderSetup.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">E.g. "a b c d"</source>
         <target xml:lang="zh-CN">例："a b c d"</target>
         <note>ID: ReaderSetup.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="zh-CN">字母</target>
         <note>ID: ReaderSetup.Letters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Header" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters and Letter Combinations</source>
         <target xml:lang="zh-CN">字母和字母组合</target>
         <note>ID: ReaderSetup.Letters.Header</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom needs to know the letters and letter combinations that you will be teaching.</source>
         <target xml:lang="zh-CN">为了制作拼读读物，Bloom需要知道你要教哪些字母和字母组合。</target>
         <note>ID: ReaderSetup.Letters.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Separate each letter or letter combination with a space. For example, here is what we might use for the English language:</source>
         <target xml:lang="zh-CN">用空格隔开单词或单词组合。以英语为例：</target>
         <note>ID: ReaderSetup.Letters.LetterHelp1</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Notice that the English list includes symbols that are used to make words, like ' in </source>
         <target xml:lang="zh-CN">注意：英文列表里有用于造词的符号，如：‘ in”</target>
         <note>ID: ReaderSetup.Letters.LetterHelp2</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">it's</source>
         <target xml:lang="zh-CN">这是</target>
         <note>ID: ReaderSetup.Letters.LetterHelp3</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Letters.LetterHelp4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">.</source>
         <target xml:lang="zh-CN">。</target>
         <note>ID: ReaderSetup.Letters.LetterHelp4</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level</source>
         <target xml:lang="zh-CN">等级</target>
         <note>ID: ReaderSetup.LevelHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.LevelLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Level&amp;nbsp;</source>
         <target xml:lang="zh-CN">等级</target>
         <note>ID: ReaderSetup.LevelLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Levels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="zh-CN">读物等级</target>
         <note>ID: ReaderSetup.Levels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MatchingWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">matching words</source>
         <target xml:lang="zh-CN">匹配单词</target>
         <note>ID: ReaderSetup.MatchingWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxAverageWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Average Length of Sentences in Book</source>
         <target xml:lang="zh-CN">书中句子平均长度的最大值</target>
         <note>ID: ReaderSetup.MaxAverageWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MaxUniqueWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Unique Words per Book</source>
         <target xml:lang="zh-CN">每书词数上限（重复出现的单词不算）</target>
         <note>ID: ReaderSetup.MaxUniqueWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.MoreWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">More Words</source>
         <target xml:lang="zh-CN">更多单词</target>
         <note>ID: ReaderSetup.MoreWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.OpenSampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Open the sample texts folder for this language.</source>
         <target xml:lang="zh-CN">打开这种语言的示范文本文件夹。</target>
         <note>ID: ReaderSetup.OpenSampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page</source>
         <target xml:lang="zh-CN">页</target>
         <note>ID: ReaderSetup.PageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PageMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words on each Page</source>
         <target xml:lang="zh-CN">每页词数上限</target>
         <note>ID: ReaderSetup.PageMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.PoweredBy" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Powered by </source>
         <target xml:lang="zh-CN">技术支持</target>
         <note>ID: ReaderSetup.PoweredBy</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReaderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Reader Levels</source>
         <target xml:lang="zh-CN">读物等级</target>
         <note>ID: ReaderSetup.ReaderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveLevel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Level {0}</source>
         <target xml:lang="zh-CN">删除等级{0}</target>
         <note>ID: ReaderSetup.RemoveLevel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveStage" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove Stage {0}</source>
         <target xml:lang="zh-CN">删除细分层次{0}</target>
         <note>ID: ReaderSetup.RemoveStage</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.RemoveWordList" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Remove from this stage</source>
         <target xml:lang="zh-CN">从当前细分层次删除</target>
         <note>ID: ReaderSetup.RemoveWordList</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderLevels" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder levels.</source>
         <target xml:lang="zh-CN">拖动行重新排列等级顺序。</target>
         <note>ID: ReaderSetup.ReorderLevels</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ReorderStages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Drag rows to reorder stages.</source>
         <target xml:lang="zh-CN">拖动行重新排列细分层次的顺序。</target>
         <note>ID: ReaderSetup.ReorderStages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleTexts" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Word Lists and Sample Texts</source>
         <target xml:lang="zh-CN">单词表和示范文本</target>
         <note>ID: ReaderSetup.SampleTexts</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SampleWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Words</source>
         <target xml:lang="zh-CN">单词举例</target>
         <note>ID: ReaderSetup.SampleWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SearchEngine" sil:dynamic="true" approved="yes">
         <source xml:lang="en">, the Search Engine for Literacy.</source>
         <target xml:lang="zh-CN">用于识字教育的搜索引擎</target>
         <note>ID: ReaderSetup.SearchEngine</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SelectedLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Previous and New Letters</source>
         <target xml:lang="zh-CN">已有字母和新字母</target>
         <note>ID: ReaderSetup.SelectedLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sentence</source>
         <target xml:lang="zh-CN">句子</target>
         <note>ID: ReaderSetup.SentenceHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SentenceMaxWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Maximum Words in each Sentence</source>
         <target xml:lang="zh-CN">每句词数上限</target>
         <note>ID: ReaderSetup.SentenceMaxWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpDecodableReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Decodable Reader Tool</source>
         <target xml:lang="zh-CN">设置拼读读物工具</target>
         <note>ID: ReaderSetup.SetUpDecodableReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetUpLeveledReaderTool" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Set up Leveled Reader Tool</source>
         <target xml:lang="zh-CN">设置分级读物工具</target>
         <note>ID: ReaderSetup.SetUpLeveledReaderTool</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SetupAlphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">set up the alphabet for this language.</source>
         <target xml:lang="zh-CN">为当前语言设置字母</target>
         <note>ID: ReaderSetup.SetupAlphabet</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordHelp" sil:dynamic="true" approved="yes">
         <source xml:lang="en">What are sight words?</source>
         <target xml:lang="zh-CN">什么是整体识别词?</target>
         <note>ID: ReaderSetup.SightWordHelp</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">New Sight Words</source>
         <target xml:lang="zh-CN">新的英语整体识别词</target>
         <note>ID: ReaderSetup.SightWordLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.SightWordsHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sight Words</source>
         <target xml:lang="zh-CN">整体识别词</target>
         <note>ID: ReaderSetup.SightWordsHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage</source>
         <target xml:lang="zh-CN">细分层次</target>
         <note>ID: ReaderSetup.StageHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.StageLabel" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stage </source>
         <target xml:lang="zh-CN">细分层次</target>
         <note>ID: ReaderSetup.StageLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Stages" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Stages</source>
         <target xml:lang="zh-CN">细分层次</target>
         <note>ID: ReaderSetup.Stages</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Synphony" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SynPhony</source>
         <target xml:lang="zh-CN">SynPhony</target>
         <note>ID: ReaderSetup.Synphony</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.ToRemember" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Things to remember for this level:</source>
         <target xml:lang="zh-CN">这个水平要注意的事项:</target>
         <note>ID: ReaderSetup.ToRemember</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.UniqueHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Unique</source>
         <target xml:lang="zh-CN">重复出现的词不算</target>
         <note>ID: ReaderSetup.UniqueHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Words</source>
         <target xml:lang="zh-CN">单词</target>
         <note>ID: ReaderSetup.Words</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.Intro" sil:dynamic="true" approved="yes">
         <source xml:lang="en">To help you make decodable readers, Bloom can suggest words that fit within the current stage. There are two ways to give words to Bloom:</source>
         <target xml:lang="zh-CN">制作拼读读物时，Bloom能建议使用适合当前阶段的词。有两种方法可以为Bloom提供单词：</target>
         <note>ID: ReaderSetup.Words.Intro</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.PlaceTextFiles" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2) Place Text Files in Your</source>
         <target xml:lang="zh-CN">2) 把文档放在</target>
         <note>ID: ReaderSetup.Words.PlaceTextFiles</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.SampleTextFolder" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Sample Texts Folder</source>
         <target xml:lang="zh-CN">示范文本文件夹</target>
         <note>ID: ReaderSetup.Words.SampleTextFolder</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.TypeWordsHere" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1) Type Words Here</source>
         <target xml:lang="zh-CN">1) 在这里输入词</target>
         <note>ID: ReaderSetup.Words.TypeWordsHere</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseAllowedWords" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using lists of allowed words to define stages</source>
         <target xml:lang="zh-CN">我们正在用几个可用单词列表来划分细分层次</target>
         <note>ID: ReaderSetup.Words.UseAllowedWords</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.Words.UseLetters" sil:dynamic="true" approved="yes">
         <source xml:lang="en">We are using letters with sight words to define stages</source>
         <target xml:lang="zh-CN">我们正在用字母和整体识别单词来划分细分层次</target>
         <note>ID: ReaderSetup.Words.UseLetters</note>
       </trans-unit>
-      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true">
+      <trans-unit id="ReaderSetup.lettersHeader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Letters</source>
         <target xml:lang="zh-CN">字母</target>
         <note>ID: ReaderSetup.lettersHeader</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph">
+      <trans-unit id="ReaderTemplateBloomPackDialog.ExplanationParagraph" approved="yes">
         <source xml:lang="en">In addition, this Bloom Pack will carry your latest decodable and leveled reader settings for the \"{0}\" language. Anyone opening this Bloom Pack, who then opens a \"{0}\" collection, will have their current decodable and leveled reader settings replaced by the settings in this Bloom Pack. They will also get the current set of words for use in decodable readers.</source>
         <target xml:lang="zh-CN">此外，Bloom资料包包含的是\"{0}\"语言最新的拼读读物和等级读物的设置数据。所以如果你打开资料包以后又打开\"{0}\"丛书，丛书中的设置将被资料包中的设置覆盖，也将得到可用于拼读读物的所有单词。</target>
         <note>ID: ReaderTemplateBloomPackDialog.ExplanationParagraph</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel">
+      <trans-unit id="ReaderTemplateBloomPackDialog.IntroLabel" approved="yes">
         <source xml:lang="en">The following books will be made into templates:</source>
         <target xml:lang="zh-CN">这本书将被制成模板:</target>
         <note>ID: ReaderTemplateBloomPackDialog.IntroLabel</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton">
+      <trans-unit id="ReaderTemplateBloomPackDialog.SaveBloomPackButton" approved="yes">
         <source xml:lang="en">Save Bloom Pack</source>
         <target xml:lang="zh-CN">保存Bloom资料包</target>
         <note>ID: ReaderTemplateBloomPackDialog.SaveBloomPackButton</note>
       </trans-unit>
-      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle">
+      <trans-unit id="ReaderTemplateBloomPackDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Make Reader Template Bloom Pack</source>
         <target xml:lang="zh-CN">制作读物模板资料包</target>
         <note>ID: ReaderTemplateBloomPackDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Email">
+      <trans-unit id="RegisterDialog.Email" approved="yes">
         <source xml:lang="en">Email Address</source>
         <target xml:lang="zh-CN">电子邮件地址</target>
         <note>ID: RegisterDialog.Email</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.FirstName">
+      <trans-unit id="RegisterDialog.FirstName" approved="yes">
         <source xml:lang="en">First Name</source>
         <target xml:lang="zh-CN">名</target>
         <note>ID: RegisterDialog.FirstName</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Heading">
+      <trans-unit id="RegisterDialog.Heading" approved="yes">
         <source xml:lang="en">Please take a minute to register {0}</source>
         <target xml:lang="zh-CN">请立即注册{0}</target>
         <note>ID: RegisterDialog.Heading</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.HowAreYouUsing">
+      <trans-unit id="RegisterDialog.HowAreYouUsing" approved="yes">
         <source xml:lang="en">How are you using {0}?</source>
         <target xml:lang="zh-CN">你要用{0}来做什么？</target>
         <note>ID: RegisterDialog.HowAreYouUsing</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.IAmStuckLabel">
+      <trans-unit id="RegisterDialog.IAmStuckLabel" approved="yes">
         <source xml:lang="en">I'm stuck, I'll finish this later.</source>
         <target xml:lang="zh-CN">稍后再做。</target>
         <note>ID: RegisterDialog.IAmStuckLabel</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Organization">
+      <trans-unit id="RegisterDialog.Organization" approved="yes">
         <source xml:lang="en">Organization</source>
         <target xml:lang="zh-CN">组织</target>
         <note>ID: RegisterDialog.Organization</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.RegisterButton">
+      <trans-unit id="RegisterDialog.RegisterButton" approved="yes">
         <source xml:lang="en">&amp;Register</source>
         <target xml:lang="zh-CN">&amp;注册</target>
         <note>ID: RegisterDialog.RegisterButton</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.Surname">
+      <trans-unit id="RegisterDialog.Surname" approved="yes">
         <source xml:lang="en">Surname</source>
         <target xml:lang="zh-CN">姓</target>
         <note>ID: RegisterDialog.Surname</note>
       </trans-unit>
-      <trans-unit id="RegisterDialog.WindowTitle">
+      <trans-unit id="RegisterDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Register {0}</source>
         <target xml:lang="zh-CN">注册{0}</target>
         <note>ID: RegisterDialog.WindowTitle</note>
         <note>Place a {0} where the name of the program goes.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Close">
+      <trans-unit id="ReportProblemDialog.Close" approved="yes">
         <source xml:lang="en">Close</source>
         <target xml:lang="zh-CN">关闭</target>
         <note>ID: ReportProblemDialog.Close</note>
         <note>Shown in the button that closes the dialog after a successful report submission.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.CouldNotSendToServer">
+      <trans-unit id="ReportProblemDialog.CouldNotSendToServer" approved="yes">
         <source xml:lang="en">Bloom was not able to submit your report directly to our server. Please retry or email {0} to {1}.</source>
         <target xml:lang="zh-CN">Bloom无法提交报告到服务器。请重试或发送邮件{0}到{1}。</target>
         <note>ID: ReportProblemDialog.CouldNotSendToServer</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Email">
+      <trans-unit id="ReportProblemDialog.Email" approved="yes">
         <source xml:lang="en">Email</source>
         <target xml:lang="zh-CN">邮件</target>
         <note>ID: ReportProblemDialog.Email</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeBookButton">
+      <trans-unit id="ReportProblemDialog.IncludeBookButton" approved="yes">
         <source xml:lang="en">Include Book '{0}'</source>
         <target xml:lang="zh-CN">附加书{0}</target>
         <note>ID: ReportProblemDialog.IncludeBookButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton">
+      <trans-unit id="ReportProblemDialog.IncludeScreenshotButton" approved="yes">
         <source xml:lang="en">Include this screenshot</source>
         <target xml:lang="zh-CN">附加当前截屏</target>
         <note>ID: ReportProblemDialog.IncludeScreenshotButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Name">
+      <trans-unit id="ReportProblemDialog.Name" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="zh-CN">名称</target>
         <note>ID: ReportProblemDialog.Name</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Retry">
+      <trans-unit id="ReportProblemDialog.Retry" approved="yes">
         <source xml:lang="en">Retry</source>
         <target xml:lang="zh-CN">重试</target>
         <note>ID: ReportProblemDialog.Retry</note>
         <note>Shown if there was an error submitting the report. Lets the user try submitting it again.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SeeDetails">
+      <trans-unit id="ReportProblemDialog.SeeDetails" approved="yes">
         <source xml:lang="en">See what else will be submitted</source>
         <target xml:lang="zh-CN">查看还要提交什么</target>
         <note>ID: ReportProblemDialog.SeeDetails</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.SubmitButton">
+      <trans-unit id="ReportProblemDialog.SubmitButton" approved="yes">
         <source xml:lang="en">&amp;Submit</source>
         <target xml:lang="zh-CN">&amp;提交</target>
         <note>ID: ReportProblemDialog.SubmitButton</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Submitting">
+      <trans-unit id="ReportProblemDialog.Submitting" approved="yes">
         <source xml:lang="en">Submitting to server...</source>
         <target xml:lang="zh-CN">正在提交给服务器……</target>
         <note>ID: ReportProblemDialog.Submitting</note>
         <note>This is shown while Bloom is sending the problem report to our server.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Success">
+      <trans-unit id="ReportProblemDialog.Success" approved="yes">
         <source xml:lang="en">We received your report, thanks for taking the time to help make Bloom better!</source>
         <target xml:lang="zh-CN">您的报告已收到，谢谢您帮助我们将Bloom做得更好！</target>
         <note>ID: ReportProblemDialog.Success</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WhatsTheProblem">
+      <trans-unit id="ReportProblemDialog.WhatsTheProblem" approved="yes">
         <source xml:lang="en">What seems to be the problem?</source>
         <target xml:lang="zh-CN">出现了什么问题？</target>
         <note>ID: ReportProblemDialog.WhatsTheProblem</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.WindowTitle">
+      <trans-unit id="ReportProblemDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Report A Problem</source>
         <target xml:lang="zh-CN">报告错误</target>
         <note>ID: ReportProblemDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.Zipping">
+      <trans-unit id="ReportProblemDialog.Zipping" approved="yes">
         <source xml:lang="en">Zipping up book...</source>
         <target xml:lang="zh-CN">正在压缩书……</target>
         <note>ID: ReportProblemDialog.Zipping</note>
         <note>This is shown while Bloom is creating the problem report. It's generally too fast to see, unless you include a large book.</note>
       </trans-unit>
-      <trans-unit id="ReportProblemDialog.linkLabel1">
+      <trans-unit id="ReportProblemDialog.linkLabel1" approved="yes">
         <source xml:lang="en">Will not be private</source>
         <target xml:lang="zh-CN">不用保密</target>
         <note>ID: ReportProblemDialog.linkLabel1</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.IGetIt">
+      <trans-unit id="SamplePrintNotification.IGetIt" approved="yes">
         <source xml:lang="en">I get it. Do not show this again.</source>
         <target xml:lang="zh-CN">我知道了。不再显示此对话框。</target>
         <note>ID: SamplePrintNotification.IGetIt</note>
       </trans-unit>
-      <trans-unit id="SamplePrintNotification.PleaseNotice">
+      <trans-unit id="SamplePrintNotification.PleaseNotice" approved="yes">
         <source xml:lang="en">Please notice the sample printer settings below. Use them as a guide while you set up the printer.</source>
         <target xml:lang="zh-CN">设置打印机时请先看下面的设置示范</target>
         <note>ID: SamplePrintNotification.PleaseNotice</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Arithmetic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Arithmetic</source>
         <target xml:lang="zh-CN">算数</target>
         <note>ID: TemplateBooks.BookName.Arithmetic</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Basic Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Book</source>
         <target xml:lang="zh-CN">普通书</target>
         <note>ID: TemplateBooks.BookName.Basic Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Big Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Big Book</source>
         <target xml:lang="zh-CN">大书</target>
         <note>ID: TemplateBooks.BookName.Big Book</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Decodable Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Decodable Reader</source>
         <target xml:lang="zh-CN">拼读读物</target>
         <note>ID: TemplateBooks.BookName.Decodable Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Leveled Reader" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Leveled Reader</source>
         <target xml:lang="zh-CN">分级读物</target>
         <note>ID: TemplateBooks.BookName.Leveled Reader</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Picture Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture Dictionary</source>
         <target xml:lang="zh-CN">图片词典</target>
         <note>ID: TemplateBooks.BookName.Picture Dictionary</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Vaccinations" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Vaccinations</source>
         <target xml:lang="zh-CN">接种疫苗</target>
         <note>ID: TemplateBooks.BookName.Vaccinations</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.BookName.Wall Calendar" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Wall Calendar</source>
         <target xml:lang="zh-CN">挂历</target>
         <note>ID: TemplateBooks.BookName.Wall Calendar</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">A blank page that allows you to add items.</source>
         <target xml:lang="zh-CN">空白页可自定义内容</target>
         <note>ID: TemplateBooks.PageDescription.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageDescription.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Page with a picture on top and a large, centered word below.</source>
         <target xml:lang="zh-CN">图片在页面上方，单词放大居中位于图片下方</target>
         <note>ID: TemplateBooks.PageDescription.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1</source>
         <target xml:lang="zh-CN">1</target>
         <note>ID: TemplateBooks.PageLabel.1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.1 Problem" sil:dynamic="true" approved="yes">
         <source xml:lang="en">1 Problem</source>
         <target xml:lang="zh-CN">1个问题</target>
         <note>ID: TemplateBooks.PageLabel.1 Problem</note>
         <note>This label indicates a page with one arithmetic problem on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.10" sil:dynamic="true" approved="yes">
         <source xml:lang="en">10</source>
         <target xml:lang="zh-CN">10</target>
         <note>ID: TemplateBooks.PageLabel.10</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.11" sil:dynamic="true" approved="yes">
         <source xml:lang="en">11</source>
         <target xml:lang="zh-CN">11</target>
         <note>ID: TemplateBooks.PageLabel.11</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.12" sil:dynamic="true" approved="yes">
         <source xml:lang="en">12</source>
         <target xml:lang="zh-CN">12</target>
         <note>ID: TemplateBooks.PageLabel.12</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.13" sil:dynamic="true" approved="yes">
         <source xml:lang="en">13</source>
         <target xml:lang="zh-CN">13</target>
         <note>ID: TemplateBooks.PageLabel.13</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.14" sil:dynamic="true" approved="yes">
         <source xml:lang="en">14</source>
         <target xml:lang="zh-CN">14</target>
         <note>ID: TemplateBooks.PageLabel.14</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.15" sil:dynamic="true" approved="yes">
         <source xml:lang="en">15</source>
         <target xml:lang="zh-CN">15</target>
         <note>ID: TemplateBooks.PageLabel.15</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.16" sil:dynamic="true" approved="yes">
         <source xml:lang="en">16</source>
         <target xml:lang="zh-CN">16</target>
         <note>ID: TemplateBooks.PageLabel.16</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.17" sil:dynamic="true" approved="yes">
         <source xml:lang="en">17</source>
         <target xml:lang="zh-CN">17</target>
         <note>ID: TemplateBooks.PageLabel.17</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.18" sil:dynamic="true" approved="yes">
         <source xml:lang="en">18</source>
         <target xml:lang="zh-CN">18</target>
         <note>ID: TemplateBooks.PageLabel.18</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.19" sil:dynamic="true" approved="yes">
         <source xml:lang="en">19</source>
         <target xml:lang="zh-CN">19</target>
         <note>ID: TemplateBooks.PageLabel.19</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2</source>
         <target xml:lang="zh-CN">2</target>
         <note>ID: TemplateBooks.PageLabel.2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.2 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">2 Problems</source>
         <target xml:lang="zh-CN">2个问题</target>
         <note>ID: TemplateBooks.PageLabel.2 Problems</note>
         <note>This label indicates a page with two arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.20" sil:dynamic="true" approved="yes">
         <source xml:lang="en">20</source>
         <target xml:lang="zh-CN">20</target>
         <note>ID: TemplateBooks.PageLabel.20</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.21" sil:dynamic="true" approved="yes">
         <source xml:lang="en">21</source>
         <target xml:lang="zh-CN">21</target>
         <note>ID: TemplateBooks.PageLabel.21</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3</source>
         <target xml:lang="zh-CN">3</target>
         <note>ID: TemplateBooks.PageLabel.3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.3 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">3 Problems</source>
         <target xml:lang="zh-CN">3个问题</target>
         <note>ID: TemplateBooks.PageLabel.3 Problems</note>
         <note>This label indicates a page with three arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4</source>
         <target xml:lang="zh-CN">4</target>
         <note>ID: TemplateBooks.PageLabel.4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.4 Problems" sil:dynamic="true" approved="yes">
         <source xml:lang="en">4 Problems</source>
         <target xml:lang="zh-CN">4个问题</target>
         <note>ID: TemplateBooks.PageLabel.4 Problems</note>
         <note>This label indicates a page with four arithmetic problems on it.</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.5" sil:dynamic="true" approved="yes">
         <source xml:lang="en">5</source>
         <target xml:lang="zh-CN">5</target>
         <note>ID: TemplateBooks.PageLabel.5</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.6" sil:dynamic="true" approved="yes">
         <source xml:lang="en">6</source>
         <target xml:lang="zh-CN">6</target>
         <note>ID: TemplateBooks.PageLabel.6</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.7" sil:dynamic="true" approved="yes">
         <source xml:lang="en">7</source>
         <target xml:lang="zh-CN">7</target>
         <note>ID: TemplateBooks.PageLabel.7</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.8" sil:dynamic="true" approved="yes">
         <source xml:lang="en">8</source>
         <target xml:lang="zh-CN">8</target>
         <note>ID: TemplateBooks.PageLabel.8</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.9" sil:dynamic="true" approved="yes">
         <source xml:lang="en">9</source>
         <target xml:lang="zh-CN">9</target>
         <note>ID: TemplateBooks.PageLabel.9</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Alphabet" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Alphabet</source>
         <target xml:lang="zh-CN">字母</target>
         <note>ID: TemplateBooks.PageLabel.Alphabet</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Image</source>
         <target xml:lang="zh-CN">文本和图像</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Basic Text &amp; Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Basic Text &amp; Picture</source>
         <target xml:lang="zh-CN">文本和图片</target>
         <note>ID: TemplateBooks.PageLabel.Basic Text &amp; Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Credits Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Credits Page</source>
         <target xml:lang="zh-CN">致谢页</target>
         <note>ID: TemplateBooks.PageLabel.Credits Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Custom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="zh-CN">自定义</target>
         <note>ID: TemplateBooks.PageLabel.Custom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 1" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 1</source>
         <target xml:lang="zh-CN">第1天</target>
         <note>ID: TemplateBooks.PageLabel.Day 1</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 2" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 2</source>
         <target xml:lang="zh-CN">第2天</target>
         <note>ID: TemplateBooks.PageLabel.Day 2</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 3" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 3</source>
         <target xml:lang="zh-CN">第3天</target>
         <note>ID: TemplateBooks.PageLabel.Day 3</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 4" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 4</source>
         <target xml:lang="zh-CN">第4天</target>
         <note>ID: TemplateBooks.PageLabel.Day 4</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5a" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5a</source>
         <target xml:lang="zh-CN">第5a天</target>
         <note>ID: TemplateBooks.PageLabel.Day 5a</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Day 5b" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Day 5b</source>
         <target xml:lang="zh-CN">第5b天</target>
         <note>ID: TemplateBooks.PageLabel.Day 5b</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Factory" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Factory</source>
         <target xml:lang="zh-CN">出厂</target>
         <note>ID: TemplateBooks.PageLabel.Factory</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front Cover</source>
         <target xml:lang="zh-CN">封面</target>
         <note>ID: TemplateBooks.PageLabel.Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.FrontBackMatter" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Front/Back Matter</source>
         <target xml:lang="zh-CN">前封和后封</target>
         <note>ID: TemplateBooks.PageLabel.FrontBackMatter</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image On Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image On Bottom</source>
         <target xml:lang="zh-CN">图像在底部</target>
         <note>ID: TemplateBooks.PageLabel.Image On Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Image in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Image in Middle</source>
         <target xml:lang="zh-CN">图像在中间</target>
         <note>ID: TemplateBooks.PageLabel.Image in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Back Cover</source>
         <target xml:lang="zh-CN">封三</target>
         <note>ID: TemplateBooks.PageLabel.Inside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Inside Front Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Inside Front Cover</source>
         <target xml:lang="zh-CN">封二</target>
         <note>ID: TemplateBooks.PageLabel.Inside Front Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Instructions" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Instructions</source>
         <target xml:lang="zh-CN">说明</target>
         <note>ID: TemplateBooks.PageLabel.Instructions</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just Text" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just Text</source>
         <target xml:lang="zh-CN">只有文本</target>
         <note>ID: TemplateBooks.PageLabel.Just Text</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just a Picture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just a Picture</source>
         <target xml:lang="zh-CN">只有图片</target>
         <note>ID: TemplateBooks.PageLabel.Just a Picture</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Just an Image" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Just an Image</source>
         <target xml:lang="zh-CN">只有图像</target>
         <note>ID: TemplateBooks.PageLabel.Just an Image</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Outside Back Cover" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Outside Back Cover</source>
         <target xml:lang="zh-CN">封底</target>
         <note>ID: TemplateBooks.PageLabel.Outside Back Cover</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Paper Saver</source>
         <target xml:lang="zh-CN">节省纸张装置</target>
         <note>ID: TemplateBooks.PageLabel.Paper Saver</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture &amp; Word" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture &amp; Word</source>
         <target xml:lang="zh-CN">图片和单词</target>
         <note>ID: TemplateBooks.PageLabel.Picture &amp; Word</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture in Middle" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture in Middle</source>
         <target xml:lang="zh-CN">图片在中间</target>
         <note>ID: TemplateBooks.PageLabel.Picture in Middle</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Picture on Bottom" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Picture on Bottom</source>
         <target xml:lang="zh-CN">图片在底部</target>
         <note>ID: TemplateBooks.PageLabel.Picture on Bottom</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.SIL-Cameroon" sil:dynamic="true" approved="yes">
         <source xml:lang="en">SIL-Cameroon</source>
         <target xml:lang="zh-CN">世界语文研究院——喀麦隆</target>
         <note>ID: TemplateBooks.PageLabel.SIL-Cameroon</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Super Paper Saver" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Super Paper Saver</source>
         <target xml:lang="zh-CN">超级节省纸张装置</target>
         <note>ID: TemplateBooks.PageLabel.Super Paper Saver</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.This Page Is Intentionally Blank" sil:dynamic="true" approved="yes">
         <source xml:lang="en">This Page Is Intentionally Blank</source>
         <target xml:lang="zh-CN">此页故意空着</target>
         <note>ID: TemplateBooks.PageLabel.This Page Is Intentionally Blank</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Title Page" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Title Page</source>
         <target xml:lang="zh-CN">扉页</target>
         <note>ID: TemplateBooks.PageLabel.Title Page</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true">
+      <trans-unit id="TemplateBooks.PageLabel.Traditional" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional</source>
         <target xml:lang="zh-CN">传统的</target>
         <note>ID: TemplateBooks.PageLabel.Traditional</note>
       </trans-unit>
-      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog">
+      <trans-unit id="TemplateBooks.Wall Calendar.TitleOfSetupDialog" approved="yes">
         <source xml:lang="en">Setup</source>
         <target xml:lang="zh-CN">设置</target>
         <note>ID: TemplateBooks.Wall Calendar.TitleOfSetupDialog</note>
         <note>This is the dialog used to set up the wall calendar</note>
       </trans-unit>
-      <trans-unit id="Topics.Agriculture" sil:dynamic="true">
+      <trans-unit id="Topics.Agriculture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Agriculture</source>
         <target xml:lang="zh-CN">农业</target>
         <note>ID: Topics.Agriculture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Animal Stories" sil:dynamic="true">
+      <trans-unit id="Topics.Animal Stories" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Animal Stories</source>
         <target xml:lang="zh-CN">动物故事</target>
         <note>ID: Topics.Animal Stories</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Business" sil:dynamic="true">
+      <trans-unit id="Topics.Business" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Business</source>
         <target xml:lang="zh-CN">商业</target>
         <note>ID: Topics.Business</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Community Living" sil:dynamic="true">
+      <trans-unit id="Topics.Community Living" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Community Living</source>
         <target xml:lang="zh-CN">社区生活</target>
         <note>ID: Topics.Community Living</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Culture" sil:dynamic="true">
+      <trans-unit id="Topics.Culture" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Culture</source>
         <target xml:lang="zh-CN">文化</target>
         <note>ID: Topics.Culture</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Dictionary" sil:dynamic="true">
+      <trans-unit id="Topics.Dictionary" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Dictionary</source>
         <target xml:lang="zh-CN">字典词典</target>
         <note>ID: Topics.Dictionary</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Environment" sil:dynamic="true">
+      <trans-unit id="Topics.Environment" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Environment</source>
         <target xml:lang="zh-CN">环境</target>
         <note>ID: Topics.Environment</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Fiction</source>
         <target xml:lang="zh-CN">小说</target>
         <note>ID: Topics.Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Health" sil:dynamic="true">
+      <trans-unit id="Topics.Health" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Health</source>
         <target xml:lang="zh-CN">健康</target>
         <note>ID: Topics.Health</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.How To" sil:dynamic="true">
+      <trans-unit id="Topics.How To" sil:dynamic="true" approved="yes">
         <source xml:lang="en">How To</source>
         <target xml:lang="zh-CN">如何</target>
         <note>ID: Topics.How To</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Math" sil:dynamic="true">
+      <trans-unit id="Topics.Math" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Math</source>
         <target xml:lang="zh-CN">数学</target>
         <note>ID: Topics.Math</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.NoTopic" sil:dynamic="true">
+      <trans-unit id="Topics.NoTopic" sil:dynamic="true" approved="yes">
         <source xml:lang="en">No Topic</source>
         <target xml:lang="zh-CN">无主题</target>
         <note>ID: Topics.NoTopic</note>
       </trans-unit>
-      <trans-unit id="Topics.Non Fiction" sil:dynamic="true">
+      <trans-unit id="Topics.Non Fiction" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Non Fiction</source>
         <target xml:lang="zh-CN">非小说</target>
         <note>ID: Topics.Non Fiction</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Personal Development" sil:dynamic="true">
+      <trans-unit id="Topics.Personal Development" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Personal Development</source>
         <target xml:lang="zh-CN">个人发展</target>
         <note>ID: Topics.Personal Development</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Primer" sil:dynamic="true">
+      <trans-unit id="Topics.Primer" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Primer</source>
         <target xml:lang="zh-CN">识字课本</target>
         <note>ID: Topics.Primer</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Science" sil:dynamic="true">
+      <trans-unit id="Topics.Science" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Science</source>
         <target xml:lang="zh-CN">科学</target>
         <note>ID: Topics.Science</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Spiritual" sil:dynamic="true">
+      <trans-unit id="Topics.Spiritual" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Spiritual</source>
         <target xml:lang="zh-CN">信仰</target>
         <note>ID: Topics.Spiritual</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Story Book" sil:dynamic="true">
+      <trans-unit id="Topics.Story Book" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Story Book</source>
         <target xml:lang="zh-CN">故事书</target>
         <note>ID: Topics.Story Book</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Tradition" sil:dynamic="true">
+      <trans-unit id="Topics.Tradition" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Tradition</source>
         <target xml:lang="zh-CN">风俗传统</target>
         <note>ID: Topics.Tradition</note>
         <note>shows in the topics chooser in the edit tab</note>
       </trans-unit>
-      <trans-unit id="Topics.Traditional Story" sil:dynamic="true">
+      <trans-unit id="Topics.Traditional Story" sil:dynamic="true" approved="yes">
         <source xml:lang="en">Traditional Story</source>
         <target xml:lang="zh-CN">传统故事</target>
         <note>ID: Topics.Traditional Story</note>

--- a/DistFiles/localization/zh-CN/IntegrityFailureAdvice.xlf
+++ b/DistFiles/localization/zh-CN/IntegrityFailureAdvice.xlf
@@ -2,77 +2,77 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="IntegrityFailureAdvice-en.md" datatype="html" source-language="en" target-language="zh-CN">
     <body>
-      <trans-unit id="integrity.title">
+      <trans-unit id="integrity.title" approved="yes">
         <source xml:lang="en">Bloom cannot find some of its own files, and cannot continue</source>
         <target xml:lang="zh-CN">Bloom找不到自身内部的一些文件，因此无法继续</target>
         <note>ID: integrity.title</note>
       </trans-unit>
-      <trans-unit id="integrity.causes">
+      <trans-unit id="integrity.causes" approved="yes">
         <source xml:lang="en">Possible Causes</source>
         <target xml:lang="zh-CN">可能的原因</target>
         <note>ID: integrity.causes</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.1">
+      <trans-unit id="integrity.causes.1" approved="yes">
         <source xml:lang="en">Your antivirus may have "quarantined" one or more Bloom files.</source>
         <target xml:lang="zh-CN">1）您的防病毒软件可能把一个或多个Bloom文档“隔离”了。</target>
         <note>ID: integrity.causes.1</note>
       </trans-unit>
-      <trans-unit id="integrity.causes.2">
+      <trans-unit id="integrity.causes.2" approved="yes">
         <source xml:lang="en">Your computer administrator may have your computer "locked down" to prevent bad things, but in such a way that Bloom could not place these files where they belong. </source>
         <target xml:lang="zh-CN">2）您的计算机管理员可能为防止侵害的发生而“锁定”了计算机，导致Bloom不能把文档放在需要的地方。</target>
         <note>ID: integrity.causes.2</note>
       </trans-unit>
-      <trans-unit id="integrity.todo">
+      <trans-unit id="integrity.todo" approved="yes">
         <source xml:lang="en">What To Do</source>
         <target xml:lang="zh-CN">怎么办</target>
         <note>ID: integrity.todo</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas">
+      <trans-unit id="integrity.todo.ideas" approved="yes">
         <source xml:lang="en">After you submit this report, we will contact you and help you work this out. In the meantime, here are some ideas:</source>
         <target xml:lang="zh-CN">提交报告以后，我们将与您联系帮助您解决问题。 同时可以尝试以下方法：</target>
         <note>ID: integrity.todo.ideas</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Reinstall">
+      <trans-unit id="integrity.todo.ideas.Reinstall" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="zh-CN">再次运行Bloom安装程序，看这次能否顺利启动。</target>
         <note>ID: integrity.todo.ideas.Reinstall</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Antivirus">
+      <trans-unit id="integrity.todo.ideas.Antivirus" approved="yes">
         <source xml:lang="en">If that doesn't fix it, it's time to talk to your anti-virus program. If the "Missing Files" section below shows any files which end in ".exe",  consider "whitelisting" the Bloom program folder, which is at <g id="genid-1" ctype="x-html-strong">{{installFolder}}</g>.</source>
         <target xml:lang="zh-CN">如果还是不行，就要看一下您的防病毒软件了。 如果下面的“丢失文件”部分中有以“.exe”结尾的文档，可以尝试在**{{installFolder}}**中把Bloom程序文件夹列入“优良程序名单“。</target>
         <note>ID: integrity.todo.ideas.Antivirus</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVAST">
+      <trans-unit id="integrity.todo.ideas.AVAST" approved="yes">
         <source xml:lang="en">AVAST: <g id="genid-2" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">Instructions</g>.</source>
         <target xml:lang="zh-CN">AVAST：<g id="genid-1" ctype="x-html-a" html:href="http://www.getavast.net/support/managing-exceptions">说明</g>.</target>
         <note>ID: integrity.todo.ideas.AVAST</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Norton">
+      <trans-unit id="integrity.todo.ideas.Norton" approved="yes">
         <source xml:lang="en">Norton Antivirus: <g id="genid-3" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">Instructions from Symantec</g>.</source>
         <target xml:lang="zh-CN">Norton Antivirus: <g id="genid-2" ctype="x-html-a" html:href="https://support.symantec.com/en_US/article.HOWTO80920.html">来自Symantec的说明</g>.</target>
         <note>ID: integrity.todo.ideas.Norton</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.AVG">
+      <trans-unit id="integrity.todo.ideas.AVG" approved="yes">
         <source xml:lang="en">AVG: <g id="genid-4" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">Instructions from AVG</g>.</source>
         <target xml:lang="zh-CN">AVG: <g id="genid-3" ctype="x-html-a" html:href="https://support.avg.com/SupportArticleView?l=en_US&amp;amp;urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning">来自AVG的说明</g>.</target>
         <note>ID: integrity.todo.ideas.AVG</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Others">
+      <trans-unit id="integrity.todo.ideas.Others" approved="yes">
         <source xml:lang="en">Others: Google for "whitelist directory name-of-your-antivirus"</source>
         <target xml:lang="zh-CN">其他：在Google上搜索“ whitelist directory name-of-your-antivirus”</target>
         <note>ID: integrity.todo.ideas.Others</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Restart">
+      <trans-unit id="integrity.todo.ideas.Restart" approved="yes">
         <source xml:lang="en">Run the Bloom installer again, and see if it starts up OK this time.</source>
         <target xml:lang="zh-CN">再次运行Bloom安装程序，看这次能否顺利启动。</target>
         <note>ID: integrity.todo.ideas.Restart</note>
       </trans-unit>
-      <trans-unit id="integrity.todo.ideas.Retrieve">
+      <trans-unit id="integrity.todo.ideas.Retrieve" approved="yes">
         <source xml:lang="en">You can also try and retrieve the part of Bloom that your anti-virus program took from it. For AVG, you need to find the AVG "options" menu, click "virus vault", click on the Bloom file in the vault, and click "restore". For a visual guide, see <g id="genid-5" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">this image</g>.</source>
         <target xml:lang="zh-CN">您也可以尝试找回反病毒软件从Bloom中取走的部分。 对于AVG，您需要找到AVG“选项”菜单，点击“病毒库”，点击库中的Bloom文件并选择“还原”。 视图说明，参见<g id="genid-4" ctype="x-html-a" html:href="https://i.imgur.com/dlRrsSN.png">此图片</g>.</target>
         <note>ID: integrity.todo.ideas.Retrieve</note>
       </trans-unit>
-      <trans-unit id="integrity.missing">
+      <trans-unit id="integrity.missing" approved="yes">
         <source xml:lang="en">Missing Files</source>
         <target xml:lang="zh-CN">丢失文件</target>
         <note>ID: integrity.missing</note>

--- a/DistFiles/localization/zh-CN/MissingLameModule.xlf
+++ b/DistFiles/localization/zh-CN/MissingLameModule.xlf
@@ -2,19 +2,19 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="MissingLameModule-en.html" datatype="html" source-language="en" target-language="zh-CN">
     <body>
-      <trans-unit id="missing.lame.please.install">
+      <trans-unit id="missing.lame.please.install" approved="yes">
         <source xml:lang="en">Please Install LAME</source>
         <target xml:lang="zh-CN">请安装LAME</target>
         <note>ID: missing.lame.please.install</note>
       </trans-unit>
-      <trans-unit id="missing.lame.bloom.needs.lame">
+      <trans-unit id="missing.lame.bloom.needs.lame" approved="yes">
         <source xml:lang="en">This book has audio recordings. Bloom can use these to make a "Talking Book" e-book. However, Bloom needs a program called "LAME for Audacity" in order to create the mp3 files that the book will use. Setting it up is easy. First download and run <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>. Next, restart Bloom.
       </source>
         <target xml:lang="zh-CN">这本书有录音。 Bloom可以用它们制作“有声”电子书。 但是Bloom需要一个名为“LAME for Audacity”的程序才能创建本书要用的MP3文件。 设置该程序很容易。 首先下载并运行 <g id="genid-1" ctype="x-html-a" html:href="http://lame.buanzo.org/#lamewindl">'Lame_v3.99 for Windows.exe'</g>。然后重启Bloom。
       </target>
         <note>ID: missing.lame.bloom.needs.lame</note>
       </trans-unit>
-      <trans-unit id="missing.lame.audio.optional">
+      <trans-unit id="missing.lame.audio.optional" approved="yes">
         <source xml:lang="en">If you prefer to go ahead and publish your book without audio, click <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">here</g>.
       </source>
         <target xml:lang="zh-CN">如果您想直接发布不含音频的书，请点 <g id="genid-2" ctype="x-html-a" html:id="proceedWithoutAudio" html:href="javascript:void(0)">这里</g>。

--- a/DistFiles/localization/zh-CN/Palaso.xlf
+++ b/DistFiles/localization/zh-CN/Palaso.xlf
@@ -2,573 +2,573 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:sil="http://sil.org/software/XLiff" version="1.2">
   <file original="Palaso.dll" source-language="en" target-language="zh-CN" datatype="plaintext" product-version="3.7.8.0" sil:hard-linebreak-replacement="\n">
     <body>
-      <trans-unit id="AboutDialog.NoUpdates">
+      <trans-unit id="AboutDialog.NoUpdates" approved="yes">
         <source xml:lang="en">No Updates</source>
         <target xml:lang="zh-CN">没有更新</target>
         <note>ID: AboutDialog.NoUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._checkForUpdates">
+      <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
         <source xml:lang="en">Check For Updates</source>
         <target xml:lang="zh-CN">搜索更新</target>
         <note>ID: AboutDialog._checkForUpdates</note>
       </trans-unit>
-      <trans-unit id="AboutDialog._releaseNotesLabel">
+      <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
         <source xml:lang="en">Release Notes</source>
         <target xml:lang="zh-CN">发布说明</target>
         <note>ID: AboutDialog._releaseNotesLabel</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.General">
+      <trans-unit id="Application.AlreadyRunning.General" approved="yes">
         <source xml:lang="en">Another copy of the application is already running. If you cannot find it, restart your computer.</source>
         <target xml:lang="zh-CN">另一个相同的程序已经在运行，如果找不到该程序，请重启电脑。</target>
         <note>ID: Application.AlreadyRunning.General</note>
       </trans-unit>
-      <trans-unit id="Application.AlreadyRunning.Specific">
+      <trans-unit id="Application.AlreadyRunning.Specific" approved="yes">
         <source xml:lang="en">Another copy of {0} is already running. If you cannot find that copy of {0}, restart your computer.</source>
         <target xml:lang="zh-CN">另一个相同的{0}已经在运行，如果找不到{0}，请重启电脑。</target>
         <note>ID: Application.AlreadyRunning.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.General">
+      <trans-unit id="Application.ProblemStarting.General" approved="yes">
         <source xml:lang="en">There was a problem starting the application which might require that you restart your computer.</source>
         <target xml:lang="zh-CN">启动程序时出现错误，请重启电脑。</target>
         <note>ID: Application.ProblemStarting.General</note>
       </trans-unit>
-      <trans-unit id="Application.ProblemStarting.Specific">
+      <trans-unit id="Application.ProblemStarting.Specific" approved="yes">
         <source xml:lang="en">There was a problem starting {0} which might require that you restart your computer.</source>
         <target xml:lang="zh-CN">启动{0}时出现错误，请重启电脑。</target>
         <note>ID: Application.ProblemStarting.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.General">
+      <trans-unit id="Application.WaitingFinish.General" approved="yes">
         <source xml:lang="en">Waiting for other application to finish...</source>
         <target xml:lang="zh-CN">正在等待其他程序完成任务...</target>
         <note>ID: Application.WaitingFinish.General</note>
       </trans-unit>
-      <trans-unit id="Application.WaitingFinish.Specific">
+      <trans-unit id="Application.WaitingFinish.Specific" approved="yes">
         <source xml:lang="en">Waiting for other {0} to finish...</source>
         <target xml:lang="zh-CN">正在等待其他{0}完成任务...</target>
         <note>ID: Application.WaitingFinish.Specific</note>
         <note>{0} is the application name</note>
       </trans-unit>
-      <trans-unit id="Common.CancelButton">
+      <trans-unit id="Common.CancelButton" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="zh-CN">撤消(&amp;C)</target>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
-      <trans-unit id="Common.No">
+      <trans-unit id="Common.No" approved="yes">
         <source xml:lang="en">No</source>
         <target xml:lang="zh-CN">不</target>
         <note>ID: Common.No</note>
       </trans-unit>
-      <trans-unit id="Common.OKButton">
+      <trans-unit id="Common.OKButton" approved="yes">
         <source xml:lang="en">&amp;OK</source>
         <target xml:lang="zh-CN">确定(&amp;O)</target>
         <note>ID: Common.OKButton</note>
       </trans-unit>
-      <trans-unit id="Common.Yes">
+      <trans-unit id="Common.Yes" approved="yes">
         <source xml:lang="en">Yes</source>
         <target xml:lang="zh-CN">是</target>
         <note>ID: Common.Yes</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="zh-CN">{0}将被移动到回收站里。</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
         <note>Param {0} is a description of the things being deleted (e.g., "The selected files")</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
         <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
         <target xml:lang="zh-CN">{0}将被移动到回收站里。</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
         <note>Param {0} is a file name</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
         <source xml:lang="en">Confirm Delete</source>
         <target xml:lang="zh-CN">确定删除</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
         <source xml:lang="en">&amp;Cancel</source>
         <target xml:lang="zh-CN">撤消(&amp;C)</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
       </trans-unit>
-      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
         <source xml:lang="en">&amp;Delete</source>
         <target xml:lang="zh-CN">删除(&amp;D)</target>
         <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.AlmostMatchingImages">
+      <trans-unit id="ImageToolbox.AlmostMatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images with names close to {1}</source>
         <target xml:lang="zh-CN">发现图像{0}和{1}名称相近</target>
         <note>ID: ImageToolbox.AlmostMatchingImages</note>
         <note>The {0} will be replaced by the number of images found.  The {1} will be replaced with the search string.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ArtOfReading">
+      <trans-unit id="ImageToolbox.ArtOfReading" approved="yes">
         <source xml:lang="en">Art Of Reading</source>
         <target xml:lang="zh-CN">读物图库</target>
         <note>ID: ImageToolbox.ArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Camera">
+      <trans-unit id="ImageToolbox.Camera" approved="yes">
         <source xml:lang="en">Camera</source>
         <target xml:lang="zh-CN">照相机</target>
         <note>ID: ImageToolbox.Camera</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
         <source xml:lang="en">Use {0}</source>
         <target xml:lang="zh-CN">使用{0}</target>
         <note>ID: ImageToolbox.CopyExemplarMetadata</note>
         <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Crop">
+      <trans-unit id="ImageToolbox.Crop" approved="yes">
         <source xml:lang="en">Crop</source>
         <target xml:lang="zh-CN">剪裁</target>
         <note>ID: ImageToolbox.Crop</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.DownloadArtOfReading">
+      <trans-unit id="ImageToolbox.DownloadArtOfReading" approved="yes">
         <source xml:lang="en">Download Art Of Reading Installer</source>
         <target xml:lang="zh-CN">下载“读物图库”安装程序</target>
         <note>ID: ImageToolbox.DownloadArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EditMetadataLink">
+      <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
         <source xml:lang="en">Edit...</source>
         <target xml:lang="zh-CN">编辑...</target>
         <note>ID: ImageToolbox.EditMetadataLink</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.EnterSearchTerms">
+      <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
         <source xml:lang="en">This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.</source>
         <target xml:lang="zh-CN">这里是“读物图库”。在上方的搜索框里输入要搜索的对象，然后按Enter。用英语个印尼语输入都可以。</target>
         <note>ID: ImageToolbox.EnterSearchTerms</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.FileButton">
+      <trans-unit id="ImageToolbox.FileButton" approved="yes">
         <source xml:lang="en">File</source>
         <target xml:lang="zh-CN">文档</target>
         <note>ID: ImageToolbox.FileButton</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
         <target xml:lang="zh-CN">抱歉，获取图像时出现错误。</target>
         <note>ID: ImageToolbox.GenericGettingImageProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GenericProblem">
+      <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
         <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
         <target xml:lang="zh-CN">抱歉，图像工具箱出现错误。</target>
         <note>ID: ImageToolbox.GenericProblem</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.GetPicture">
+      <trans-unit id="ImageToolbox.GetPicture" approved="yes">
         <source xml:lang="en">Get Picture</source>
         <target xml:lang="zh-CN">获取图片</target>
         <note>ID: ImageToolbox.GetPicture</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
         <source xml:lang="en">Image Toolbox</source>
         <target xml:lang="zh-CN">图像工具箱</target>
         <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.InstallArtOfReading">
+      <trans-unit id="ImageToolbox.InstallArtOfReading" approved="yes">
         <source xml:lang="en">Install the Art Of Reading package (this may be very slow)</source>
         <target xml:lang="zh-CN">安装“读物图库”资料包（可能很慢）</target>
         <note>ID: ImageToolbox.InstallArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.MatchingImages">
+      <trans-unit id="ImageToolbox.MatchingImages" approved="yes">
         <source xml:lang="en">Found {0} images</source>
         <target xml:lang="zh-CN">发现图像{0}</target>
         <note>ID: ImageToolbox.MatchingImages</note>
         <note>The {0} will be replaced by the number of matching images</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NewMultilingual">
+      <trans-unit id="ImageToolbox.NewMultilingual" approved="yes">
         <source xml:lang="en">Did you know that there is a new version of this collection which lets you search in Arabic, Bengali, Chinese, English, French, Indonesian, Hindi, Portuguese, Spanish, Thai, or Swahili? It is free and available for downloading.</source>
         <target xml:lang="zh-CN">该丛书有新版本，支持搜索的语言有阿拉伯语、孟加拉语、汉语、英语、法语、印尼语、印地语、葡萄牙语、西班牙语、泰语和斯瓦西里语。可以免费下载。</target>
         <note>ID: ImageToolbox.NewMultilingual</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoArtOfReading">
+      <trans-unit id="ImageToolbox.NoArtOfReading" approved="yes">
         <source xml:lang="en">This computer doesn't appear to have the 'Art Of Reading' gallery installed yet.</source>
         <target xml:lang="zh-CN">您的电脑尚未安装“读物图库”</target>
         <note>ID: ImageToolbox.NoArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.NoMatchingImages">
+      <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
         <source xml:lang="en">Found no matching images</source>
         <target xml:lang="zh-CN">没有匹配的图像</target>
         <note>ID: ImageToolbox.NoMatchingImages</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PictureFiles">
+      <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
         <source xml:lang="en">picture files</source>
         <target xml:lang="zh-CN">图片文档</target>
         <note>ID: ImageToolbox.PictureFiles</note>
         <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice" approved="yes">
         <source xml:lang="en">Problem Getting Image</source>
         <target xml:lang="zh-CN">获取图片出现错误</target>
         <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.ProblemLoadingImage">
+      <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
         <source xml:lang="en">Sorry, there was a problem loading that image.</source>
         <target xml:lang="zh-CN">抱歉，加载图像时出现错误。</target>
         <note>ID: ImageToolbox.ProblemLoadingImage</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
         <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
         <target xml:lang="zh-CN">该图像不知道：\n\n谁是创作者？\n谁可以使用？</target>
         <note>ID: ImageToolbox.PromptForMissingMetadata</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.Scanner">
+      <trans-unit id="ImageToolbox.Scanner" approved="yes">
         <source xml:lang="en">Scanner</source>
         <target xml:lang="zh-CN">扫描器</target>
         <note>ID: ImageToolbox.Scanner</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchArtOfReading">
+      <trans-unit id="ImageToolbox.SearchArtOfReading" approved="yes">
         <source xml:lang="en">Search the Art of Reading Gallery</source>
         <target xml:lang="zh-CN">搜索“读物图库”</target>
         <note>ID: ImageToolbox.SearchArtOfReading</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SearchLanguage">
+      <trans-unit id="ImageToolbox.SearchLanguage" approved="yes">
         <source xml:lang="en">The search box is currently set to {0}</source>
         <target xml:lang="zh-CN">搜索栏使用的语言是{0}</target>
         <note>ID: ImageToolbox.SearchLanguage</note>
       </trans-unit>
-      <trans-unit id="ImageToolbox.SetUpMetadataLink">
+      <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
         <source xml:lang="en">Set up metadata...</source>
         <target xml:lang="zh-CN">设定元数据...</target>
         <note>ID: ImageToolbox.SetUpMetadataLink</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.AlternateNamesHeader">
+      <trans-unit id="LanguageLookup.AlternateNamesHeader" approved="yes">
         <source xml:lang="en">Other Names</source>
         <target xml:lang="zh-CN">其他名称</target>
         <note>ID: LanguageLookup.AlternateNamesHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2" approved="yes">
         <source xml:lang="en">This list should include all the ISO-639 languages, including all the alternative names known to ethnologue.com.\n\nIf necessary, use the "Unlisted Language" option, which will be selected for you now.</source>
         <target xml:lang="zh-CN">此列表包含所有ISO-639语言，也包括ethnologue.com在录的各种语言的不同名称。请点击已经为您选中的“非列表语言”选项。</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue" approved="yes">
         <source xml:lang="en">Ethnologue.com</source>
         <target xml:lang="zh-CN">Ethlonogue.com</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
         <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
         <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
         <target xml:lang="zh-CN">关于“语言639-3代码”与“如何申请新的”</target>
         <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
         <source xml:lang="en">About The ISO Language Registry</source>
         <target xml:lang="zh-CN">关于ISO语言注册表</target>
         <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CodeHeader">
+      <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
         <source xml:lang="en">Code</source>
         <target xml:lang="zh-CN">代码</target>
         <note>ID: LanguageLookup.CodeHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryCount">
+      <trans-unit id="LanguageLookup.CountryCount" approved="yes">
         <source xml:lang="en">{0} Countries</source>
         <target xml:lang="zh-CN">{0}国家</target>
         <note>ID: LanguageLookup.CountryCount</note>
         <note>Shown when there are multiple countries and it is just confusing to list them all. {0} is a count of countries.</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.CountryHeader">
+      <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
         <source xml:lang="en">Country</source>
         <target xml:lang="zh-CN">国家</target>
         <note>ID: LanguageLookup.CountryHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
         <source xml:lang="en">You can change how the language name will be displayed here:</source>
         <target xml:lang="zh-CN">在这里改变显示的语言名称：</target>
         <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
         <source xml:lang="en">Lookup Language Code...</source>
         <target xml:lang="zh-CN">查找语言代码...</target>
         <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.LookupISOControl._searchText">
+      <trans-unit id="LanguageLookup.LookupISOControl._searchText" approved="yes">
         <source xml:lang="en">?</source>
         <target xml:lang="zh-CN">？</target>
         <note>ID: LanguageLookup.LookupISOControl._searchText</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.PrimaryNameHeader">
+      <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
         <source xml:lang="en">Name</source>
         <target xml:lang="zh-CN">名称</target>
         <note>ID: LanguageLookup.PrimaryNameHeader</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel">
+      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel" approved="yes">
         <source xml:lang="en">Show regional dialects</source>
         <target xml:lang="zh-CN">显示地区方言</target>
         <note>ID: LanguageLookup.ShowRegionalDialectsLabel</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup.UnlistedLanguage">
+      <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
         <source xml:lang="en">Unlisted Language</source>
         <target xml:lang="zh-CN">未列出语言</target>
         <note>ID: LanguageLookup.UnlistedLanguage</note>
       </trans-unit>
-      <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
         <source xml:lang="en">Can't find your language?</source>
         <target xml:lang="zh-CN">找不到你的语言？</target>
         <note>ID: LanguageLookup._cannotFindLanguageLink</note>
       </trans-unit>
-      <trans-unit id="MemoryWarning">
+      <trans-unit id="MemoryWarning" approved="yes">
         <source xml:lang="en">Unfortunately, {0} is starting to get short of memory, and may soon slow down or experience other problems. We recommend that you quit and restart it when convenient.</source>
         <target xml:lang="zh-CN">抱歉，{0}的内存不足，这将导致变慢或出现问题。请退出并重启。</target>
         <note>ID: MemoryWarning</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Creator">
+      <trans-unit id="MetadataDisplay.Creator" approved="yes">
         <source xml:lang="en">Creator: {0}</source>
         <target xml:lang="zh-CN">创作者: {0}</target>
         <note>ID: MetadataDisplay.Creator</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.CreatorLabel">
+      <trans-unit id="MetadataDisplay.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="zh-CN">创作者</target>
         <note>ID: MetadataDisplay.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.LicenseInfo">
+      <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
         <source xml:lang="en">License Info</source>
         <target xml:lang="zh-CN">许可证信息</target>
         <note>ID: MetadataDisplay.LicenseInfo</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.AttributionRequired" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You must keep the copyright and credits for authors, illustrators, etc.</source>
         <target xml:lang="zh-CN">您必须提供版权标识和作者、画家等等的姓名或名称。</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.AttributionRequired</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You are free to make commercial use of this work.</source>
         <target xml:lang="zh-CN">您可以自由地将本作品用于商业目的。</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.CommercialUseAllowed</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.Derivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work.</source>
         <target xml:lang="zh-CN">您可以自由地修改、转换或以本作品为基础进行创作。</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.Derivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may adapt and add to this work, but you may distribute the resulting work only under the same or similar license to this one.</source>
         <target xml:lang="zh-CN">您可以自由地修改、转换或以本作品为基础进行创作，但必须基于与原先许可协议相同的许可协议分拨您贡献的作品。</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.DerivativesWithShareAndShareAlike</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NoDerivatives" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not make changes or build upon this work without permission.</source>
         <target xml:lang="zh-CN">如果您修改、转换、或者基于该作品创作，您不得分发修改作品。</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NoDerivatives</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.CreativeCommons.NonCommercial" sil:dynamic="true" approved="yes">
         <source xml:lang="en">You may not use this work for commercial purposes.</source>
         <target xml:lang="zh-CN">您不得将本作品用于商业目的。</target>
         <note>ID: MetadataDisplay.Licenses.CreativeCommons.NonCommercial</note>
         <note>See http://creativecommons.org/ to find out how this is normally translated in your language. What we're aiming for here is an easy to understand summary.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true">
+      <trans-unit id="MetadataDisplay.Licenses.NullLicense" sil:dynamic="true" approved="yes">
         <source xml:lang="en">For permission to reuse, contact the copyright holder.</source>
         <target xml:lang="zh-CN">要获得再使用的允许，请联系版权所有者。</target>
         <note>ID: MetadataDisplay.Licenses.NullLicense</note>
         <note>This is used when all we have is a copyright, no other license.</note>
       </trans-unit>
-      <trans-unit id="MetadataDisplay.NoLicense">
+      <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
         <source xml:lang="en">No license specified</source>
         <target xml:lang="zh-CN">没指定许可证</target>
         <note>ID: MetadataDisplay.NoLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowCommercialUse">
+      <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
         <source xml:lang="en">Allow commercial uses of your work?</source>
         <target xml:lang="zh-CN">是否允许作品被用于商业用途？</target>
         <note>ID: MetadataEditor.AllowCommercialUse</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.AllowDerivatives">
+      <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
         <source xml:lang="en">Allow modifications of your work?</source>
         <target xml:lang="zh-CN">是否允许别人更改你的作品？</target>
         <note>ID: MetadataEditor.AllowDerivatives</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CopyrightHolder">
+      <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
         <source xml:lang="en">Copyright Holder</source>
         <target xml:lang="zh-CN">版权所有者</target>
         <note>ID: MetadataEditor.CopyrightHolder</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreativeCommons">
+      <trans-unit id="MetadataEditor.CreativeCommons" approved="yes">
         <source xml:lang="en">Creative Commons</source>
         <target xml:lang="zh-CN">知识共享</target>
         <note>ID: MetadataEditor.CreativeCommons</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CreatorLabel">
+      <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
         <source xml:lang="en">Creator</source>
         <target xml:lang="zh-CN">创作者</target>
         <note>ID: MetadataEditor.CreatorLabel</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.CustomLicense">
+      <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
         <source xml:lang="en">Custom</source>
         <target xml:lang="zh-CN">定制</target>
         <note>ID: MetadataEditor.CustomLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleNoCredit">
+      <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
         <source xml:lang="en">Copyright and License</source>
         <target xml:lang="zh-CN">版权和许可证</target>
         <note>ID: MetadataEditor.TitleNoCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.TitleWithCredit">
+      <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
         <source xml:lang="en">Credit, Copyright, and License</source>
         <target xml:lang="zh-CN">致谢，版权，和许可证</target>
         <note>ID: MetadataEditor.TitleWithCredit</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.UnknownLicense">
+      <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
         <source xml:lang="en">Contact the copyright holder for any permissions</source>
         <target xml:lang="zh-CN">想获得任何授权，请联络版权所有者</target>
         <note>ID: MetadataEditor.UnknownLicense</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.YesShareAlike">
+      <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
         <source xml:lang="en">Yes, as long as others share alike</source>
         <target xml:lang="zh-CN">同意，但是所有人都必须选择和此作品一样的版权形式</target>
         <note>ID: MetadataEditor.YesShareAlike</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.additionalRequestsLabel">
+      <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
         <source xml:lang="en">Additional Requests</source>
         <target xml:lang="zh-CN">其他要求</target>
         <note>ID: MetadataEditor.additionalRequestsLabel</note>
         <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.betterLinkLabel1">
+      <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
         <source xml:lang="en">more info</source>
         <target xml:lang="zh-CN">更多信息</target>
         <note>ID: MetadataEditor.betterLinkLabel1</note>
         <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere that defines it.</note>
       </trans-unit>
-      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
         <source xml:lang="en">Not Enforceable</source>
         <target xml:lang="zh-CN">不能执行</target>
         <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <target xml:lang="zh-CN">这也可以把普通用户不需要的按钮隐藏起来。</target>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.CtrlShiftHint">
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
         <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
         <target xml:lang="zh-CN">同时按住Ctrl和Shift键，按钮就会显示出来。</target>
         <note>ID: SettingsProtection.CtrlShiftHint</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+      <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
         <source xml:lang="en">Settings...</source>
         <target xml:lang="zh-CN">设置...</target>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
         <source xml:lang="en">Hide the button that opens settings.</source>
         <target xml:lang="zh-CN">隐藏打开设置的按钮。</target>
         <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
         <source xml:lang="en">Factory Password</source>
         <target xml:lang="zh-CN">出厂密码</target>
         <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
         <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
         <target xml:lang="zh-CN">为了阻止错误的更改导致工具失效，相关设置已经加锁。</target>
         <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
         <source xml:lang="en">Settings Protection Password</source>
         <target xml:lang="zh-CN">设置保护密码</target>
         <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox">
+      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
         <source xml:lang="en">Show Characters</source>
         <target xml:lang="zh-CN">显示字符</target>
         <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.PasswordNotice">
+      <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
         <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always google for "{1}" and "{2}".</source>
         <target xml:lang="zh-CN">这些设置的出厂密码是"{0}"。如果忘记，可以用google搜索"{1}" 和 "{2}"。</target>
         <note>ID: SettingsProtection.PasswordNotice</note>
         <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
         <source xml:lang="en">Require the factory password to get into settings.</source>
         <target xml:lang="zh-CN">需要出厂密码才能进入设置。</target>
         <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
       </trans-unit>
-      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
         <source xml:lang="en">Settings Protection</source>
         <target xml:lang="zh-CN">设置保护</target>
         <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Font">
+      <trans-unit id="WSFontControl.Font" approved="yes">
         <source xml:lang="en">&amp;Font:</source>
         <target xml:lang="zh-CN">字体</target>
         <note>ID: WSFontControl.Font</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.FontNotAvailable">
+      <trans-unit id="WSFontControl.FontNotAvailable" approved="yes">
         <source xml:lang="en">(The selected font is not available on this machine. Using default.)</source>
         <target xml:lang="zh-CN">（此机器上没有被选中的字体，正在使用默认字体。）</target>
         <note>ID: WSFontControl.FontNotAvailable</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.RightToLeftWS">
+      <trans-unit id="WSFontControl.RightToLeftWS" approved="yes">
         <source xml:lang="en">This is a &amp;right to left writing system.</source>
         <target xml:lang="zh-CN">该书写系统是从右到左的。</target>
         <note>ID: WSFontControl.RightToLeftWS</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.Size">
+      <trans-unit id="WSFontControl.Size" approved="yes">
         <source xml:lang="en">&amp;Size:</source>
         <target xml:lang="zh-CN">字体大小</target>
         <note>ID: WSFontControl.Size</note>
       </trans-unit>
-      <trans-unit id="WSFontControl.TestArea">
+      <trans-unit id="WSFontControl.TestArea" approved="yes">
         <source xml:lang="en">&amp;Test Area:</source>
         <target xml:lang="zh-CN">测试区:</target>
         <note>ID: WSFontControl.TestArea</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
         <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
         <target xml:lang="zh-CN">如果您需要的键盘不在列表中，,请单击相应链接进行设置。</target>
         <note>ID: WSKeyboardControl.KeyboardNotListed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
         <source xml:lang="en">Windows keyboard settings</source>
         <target xml:lang="zh-CN">Windows键盘设置</target>
         <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
         <source xml:lang="en">Available keyboards</source>
         <target xml:lang="zh-CN">可用键盘</target>
         <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
         <source xml:lang="en">Previously used keyboards</source>
         <target xml:lang="zh-CN">以前用过的键盘</target>
         <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
         <source xml:lang="en">Keyman Configuration</source>
         <target xml:lang="zh-CN">Keyman配置</target>
         <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
         <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
         <target xml:lang="zh-CN">没有安装Keyman 5.0或更新的版本。</target>
         <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
         <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
         <target xml:lang="zh-CN">请选择用以输入{0}文本的键盘</target>
         <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
       </trans-unit>
-      <trans-unit id="WSKeyboardControl.TestAreaCaption">
+      <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
         <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
         <target xml:lang="zh-CN">测试区(在这个区域里输入内容以测试键盘)(&amp;T)</target>
         <note>ID: WSKeyboardControl.TestAreaCaption</note>
       </trans-unit>
-      <trans-unit id="Warning">
+      <trans-unit id="Warning" approved="yes">
         <source xml:lang="en">Warning</source>
         <target xml:lang="zh-CN">警告</target>
         <note>ID: Warning</note>
       </trans-unit>
-      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption">
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption" approved="yes">
         <source xml:lang="en">Unable to connect to SLDR</source>
         <target xml:lang="zh-CN">无法连接SLDR</target>
         <note>ID: WritingSystemSetupView.UnableToConnectToSldrCaption</note>

--- a/DistFiles/localization/zh-CN/TrainingVideos.xlf
+++ b/DistFiles/localization/zh-CN/TrainingVideos.xlf
@@ -2,17 +2,17 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="TrainingVideos-en.md" datatype="html" source-language="en" target-language="zh-CN">
     <body>
-      <trans-unit id="training.videos">
+      <trans-unit id="training.videos" approved="yes">
         <source xml:lang="en">Bloom Training Videos</source>
         <target xml:lang="zh-CN">介绍Bloom使用方法的视频</target>
         <note>ID: training.videos</note>
       </trans-unit>
-      <trans-unit id="training.videos.watch">
+      <trans-unit id="training.videos.watch" approved="yes">
         <source xml:lang="en">If you are connected to the internet now, you can watch videos in your web browser:</source>
         <target xml:lang="zh-CN">已连接互联网时，可以用浏览器在线观看视频：</target>
         <note>ID: training.videos.watch</note>
       </trans-unit>
-      <trans-unit id="training.videos.all">
+      <trans-unit id="training.videos.all" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-a" html:href="http://tiny.cc/bloomVimeo">All videos</g>
         </source>
@@ -21,12 +21,12 @@
         </target>
         <note>ID: training.videos.all</note>
       </trans-unit>
-      <trans-unit id="training.videos.intro">
+      <trans-unit id="training.videos.intro" approved="yes">
         <source xml:lang="en">Introductory Videos</source>
         <target xml:lang="zh-CN">入门视频</target>
         <note>ID: training.videos.intro</note>
       </trans-unit>
-      <trans-unit id="training.videos.whofor">
+      <trans-unit id="training.videos.whofor" approved="yes">
         <source xml:lang="en">
           <g id="genid-2" ctype="x-html-a" html:href="https://vimeo.com/114043219">Bloom: Who is it for</g>
         </source>
@@ -35,7 +35,7 @@
         </target>
         <note>ID: training.videos.whofor</note>
       </trans-unit>
-      <trans-unit id="training.videos.templates">
+      <trans-unit id="training.videos.templates" approved="yes">
         <source xml:lang="en">
           <g id="genid-3" ctype="x-html-a" html:href="https://vimeo.com/114024308">Understanding Templates and Shell Books</g>
         </source>
@@ -44,7 +44,7 @@
         </target>
         <note>ID: training.videos.templates</note>
       </trans-unit>
-      <trans-unit id="training.videos.basicbook">
+      <trans-unit id="training.videos.basicbook" approved="yes">
         <source xml:lang="en">
           <g id="genid-4" ctype="x-html-a" html:href="https://vimeo.com/112825489">Using the Basic Book template</g>
         </source>
@@ -53,7 +53,7 @@
         </target>
         <note>ID: training.videos.basicbook</note>
       </trans-unit>
-      <trans-unit id="training.videos.readers">
+      <trans-unit id="training.videos.readers" approved="yes">
         <source xml:lang="en">
           <g id="genid-5" ctype="x-html-a" html:href="http://tiny.cc/usingBloomReaderTemplates">Using Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -62,12 +62,12 @@
         </target>
         <note>ID: training.videos.readers</note>
       </trans-unit>
-      <trans-unit id="training.videos.advanced">
+      <trans-unit id="training.videos.advanced" approved="yes">
         <source xml:lang="en">Advanced Topics</source>
         <target xml:lang="zh-CN">高级主题</target>
         <note>ID: training.videos.advanced</note>
       </trans-unit>
-      <trans-unit id="training.videos.formatting">
+      <trans-unit id="training.videos.formatting" approved="yes">
         <source xml:lang="en">
           <g id="genid-6" ctype="x-html-a" html:href="https://vimeo.com/117820891">Changing the format of text</g>
         </source>
@@ -76,7 +76,7 @@
         </target>
         <note>ID: training.videos.formatting</note>
       </trans-unit>
-      <trans-unit id="training.videos.custompage">
+      <trans-unit id="training.videos.custompage" approved="yes">
         <source xml:lang="en">
           <g id="genid-7" ctype="x-html-a" html:href="https://vimeo.com/116868148">Using the Custom Page template</g>
         </source>
@@ -85,7 +85,7 @@
         </target>
         <note>ID: training.videos.custompage</note>
       </trans-unit>
-      <trans-unit id="training.videos.specialcharacters">
+      <trans-unit id="training.videos.specialcharacters" approved="yes">
         <source xml:lang="en">
           <g id="genid-8" ctype="x-html-a" html:href="https://vimeo.com/117927599">Inserting special characters</g>
         </source>
@@ -94,7 +94,7 @@
         </target>
         <note>ID: training.videos.specialcharacters</note>
       </trans-unit>
-      <trans-unit id="training.videos.readertemplates">
+      <trans-unit id="training.videos.readertemplates" approved="yes">
         <source xml:lang="en">
           <g id="genid-9" ctype="x-html-a" html:href="http://tiny.cc/8vbwux">Making a set of Decodable and Leveled Reader Templates (several videos)</g>
         </source>
@@ -103,24 +103,24 @@
         </target>
         <note>ID: training.videos.readertemplates</note>
       </trans-unit>
-      <trans-unit id="training.videos.offline">
+      <trans-unit id="training.videos.offline" approved="yes">
         <source xml:lang="en">Offline Viewing</source>
         <target xml:lang="zh-CN">离线观看</target>
         <note>ID: training.videos.offline</note>
       </trans-unit>
-      <trans-unit id="training.videos.download">
+      <trans-unit id="training.videos.download" approved="yes">
         <source xml:lang="en">If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer:</source>
         <target xml:lang="zh-CN">如果您想下载这些视频，以便在没有网络时观看和分享，可以将视频下载到本地计算机：</target>
         <note>ID: training.videos.download</note>
       </trans-unit>
-      <trans-unit id="training.videos.hires">
+      <trans-unit id="training.videos.hires" approved="yes">
         <source xml:lang="en">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">High Resolution</g> (Large files)</source>
         <target xml:lang="zh-CN">
           <g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">高分辨率</g> （文件很大）</target>
         <note>ID: training.videos.hires</note>
       </trans-unit>
-      <trans-unit id="training.videos.lores">
+      <trans-unit id="training.videos.lores" approved="yes">
         <source xml:lang="en">
           <g id="genid-11" ctype="x-html-a" html:href="http://tiny.cc/bloomSDVideos">Low Resolution</g> (Smaller files)</source>
         <target xml:lang="zh-CN">

--- a/DistFiles/localization/zh-CN/bloomEpubPreview.xlf
+++ b/DistFiles/localization/zh-CN/bloomEpubPreview.xlf
@@ -2,89 +2,89 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="bloomEpubPreview-en.html" datatype="html" source-language="en" target-language="zh-CN">
     <body>
-      <trans-unit id="epubpreview.describe">
+      <trans-unit id="epubpreview.describe" approved="yes">
         <source xml:lang="en">This is an <g id="genid-1" ctype="x-html-a" html:href="https://en.wikipedia.org/wiki/ePUB">ePUB</g> (e-book) version of your book. <g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">It contains audio, so that new readers can listen as they read.</g>
       </source>
         <target xml:lang="zh-CN">这是您的书的 <g id="genid-1" ctype="x-html-a" html:href="https://en.wikipedia.org/wiki/ePUB">ePUB</g> （电子）版。 <g id="genid-2" ctype="x-html-span" html:class="showForTalkingBooks">该书含有音频，新读者可以边听边读。</g>
       </target>
         <note>ID: epubpreview.describe</note>
       </trans-unit>
-      <trans-unit id="epubpreview.recording.butnotalk">
+      <trans-unit id="epubpreview.recording.butnotalk" approved="yes">
         <source xml:lang="en">This book has some recordings, but this audio is not included in the ePUB.</source>
         <target xml:lang="zh-CN">这本书包含一些录音，但这些音频不包括在ePUB中。</target>
         <note>ID: epubpreview.recording.butnotalk</note>
       </trans-unit>
-      <trans-unit id="epubpreview.preview">
+      <trans-unit id="epubpreview.preview" approved="yes">
         <source xml:lang="en">Preview</source>
         <target xml:lang="zh-CN">预览</target>
         <note>ID: epubpreview.preview</note>
       </trans-unit>
-      <trans-unit id="epubpreview.resizing">
+      <trans-unit id="epubpreview.resizing" approved="yes">
         <source xml:lang="en">You can resize the preview by dragging the lower right corner of this simulated device. See how your book will look on screens of various sizes.</source>
         <target xml:lang="zh-CN">您可以通过拖动此模拟设备的右下角来调整预览大小。查看您的书在不同尺寸的屏幕上的样子。</target>
         <note>ID: epubpreview.resizing</note>
       </trans-unit>
-      <trans-unit id="epubpreview.readium">
+      <trans-unit id="epubpreview.readium" approved="yes">
         <source xml:lang="en">This page uses the <g id="genid-3" ctype="x-html-a" html:href="http://readium.org/">Readium</g> ePUB reader. Books will likely look different on different readers.
       </source>
         <target xml:lang="zh-CN">本页使用 <g id="genid-3" ctype="x-html-a" html:href="http://readium.org/">Readium</g> ePUB阅读器。 图书在不同阅读设备上可能看起来不同。
       </target>
         <note>ID: epubpreview.readium</note>
       </trans-unit>
-      <trans-unit id="epubpreview.talkingbookpreview">
+      <trans-unit id="epubpreview.talkingbookpreview" approved="yes">
         <source xml:lang="en">The preview here cannot yet play Talking Books. You can listen to it using Adobe's Free <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html">Digital Editions</g> e-book reader.
       </source>
         <target xml:lang="zh-CN">预览暂时无法播放有声书。 您可以使用Adobe公司出品的免费有声电子书阅读器—— <g id="genid-4" ctype="x-html-a" html:href="http://www.adobe.com/solutions/ebook/digital-editions.html">Digital Editions</g>。听
       </target>
         <note>ID: epubpreview.talkingbookpreview</note>
       </trans-unit>
-      <trans-unit id="epubpreview.ontodevice">
+      <trans-unit id="epubpreview.ontodevice" approved="yes">
         <source xml:lang="en">Getting this book onto your Device</source>
         <target xml:lang="zh-CN">将本书保存到您的设备上</target>
         <note>ID: epubpreview.ontodevice</note>
       </trans-unit>
-      <trans-unit id="epubpreview.usingdropbox">
+      <trans-unit id="epubpreview.usingdropbox" approved="yes">
         <source xml:lang="en">A handy way to get books to your phone is to set up Dropbox or similar service on both your computer and your phone/tablet. Just click Save ePUB and then choose your Dropbox folder. On your phone, open the Dropbox app and select your book. If you are using a laptop, you can also try the free <g id="genid-5" ctype="x-html-a" html:href="http://www.ushareit.com/">ShareIt</g> program to send files from your laptop to a phone or tablet.
       </source>
         <target xml:lang="zh-CN">把书发送到手机的简便方法是，在计算机和手机/平板电脑上都安装Dropbox或类似软件。 只需点击保存ePUB，然后选择Dropbox文件夹。 在手机上打开Dropbox并选取您所要的书。 如果您用的是笔记本电脑，也可以尝试用免费的 <g id="genid-5" ctype="x-html-a" html:href="http://www.ushareit.com/">ShareIt</g> 软件把文件从笔记本电脑发送到手机或平板电脑上。
       </target>
         <note>ID: epubpreview.usingdropbox</note>
       </trans-unit>
-      <trans-unit id="epubpreview.recommended.reader">
+      <trans-unit id="epubpreview.recommended.reader" approved="yes">
         <source xml:lang="en">Recommended Reader</source>
         <target xml:lang="zh-CN">推荐的阅读器</target>
         <note>ID: epubpreview.recommended.reader</note>
       </trans-unit>
-      <trans-unit id="epubpreview.gitden.okay">
+      <trans-unit id="epubpreview.gitden.okay" approved="yes">
         <source xml:lang="en">Our testing has shown <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Gitden Reader</g> to be a good choice for Android and IOS (IPhone &amp; IPad) devices.
       </source>
         <target xml:lang="zh-CN">我们的测试显示 <g id="genid-6" ctype="x-html-a" html:href="/bloom/api/help/Concepts/Gitden_Reader.htm">Gitden Reader</g> 对于搭载Android和IOS（IPhone &amp;amp; IPad）系统的设备来说是不错的选择。
       </target>
         <note>ID: epubpreview.gitden.okay</note>
       </trans-unit>
-      <trans-unit id="epubpreview.gitden.limits">
+      <trans-unit id="epubpreview.gitden.limits" approved="yes">
         <source xml:lang="en">To listen to this Talking Book using Gitden on a phone or tablet, you will need to disable Gitden's "Text To Speech" feature. Then it will show you the audio controls.</source>
         <target xml:lang="zh-CN">要在手机或平板电脑上用Gitden听有声书时，需要禁用Gitden的“文字转语音”功能,然后它会显示音频控制器。</target>
         <note>ID: epubpreview.gitden.limits</note>
       </trans-unit>
-      <trans-unit id="epubpreview.make.it.talk">
+      <trans-unit id="epubpreview.make.it.talk" approved="yes">
         <source xml:lang="en">Make it Talk</source>
         <target xml:lang="zh-CN">用它播放有声书</target>
         <note>ID: epubpreview.make.it.talk</note>
       </trans-unit>
-      <trans-unit id="epubpreview.talking.book.tool">
+      <trans-unit id="epubpreview.talking.book.tool" approved="yes">
         <source xml:lang="en">If you want to make a "Talking Book" that new readers can read-along with, use Bloom's <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">Talking Book Tool</g> to add voice recordings.
       </source>
         <target xml:lang="zh-CN">如果你想制作一本让新读者可以跟着音频一起读的“有声书”，可以用Bloom的 <g id="genid-7" ctype="x-html-a" html:href="/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Show_the_Talking_Book_Tool.htm">有声书工具</g> 来添加语音录音。
       </target>
         <note>ID: epubpreview.talking.book.tool</note>
       </trans-unit>
-      <trans-unit id="epubpreview.write.us">
+      <trans-unit id="epubpreview.write.us" approved="yes">
         <source xml:lang="en">Write to us!</source>
         <target xml:lang="zh-CN">写信给我们！</target>
         <note>ID: epubpreview.write.us</note>
       </trans-unit>
-      <trans-unit id="epubpreview.use.help.report">
+      <trans-unit id="epubpreview.use.help.report" approved="yes">
         <source xml:lang="en">Are you interested in distributing Bloom books for use on phones and other ebook readers? Is there something you would need us to do before it is useful for you? Please use the Help:Report A Problem command to send us feedback. Thanks!</source>
         <target xml:lang="zh-CN">您有兴趣传播可用于手机和其他电子书阅读器上的Bloom电子书吗？ 为了方便您更好地使用Bloom，我们可以做些什么？ 请使用“帮助：报告问题”指令给我们反馈。 谢谢！</target>
         <note>ID: epubpreview.use.help.report</note>

--- a/DistFiles/localization/zh-CN/leveledReaderInfo.xlf
+++ b/DistFiles/localization/zh-CN/leveledReaderInfo.xlf
@@ -2,59 +2,59 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="leveledReaderInfo-en.html" datatype="html" source-language="en" target-language="zh-CN">
     <body>
-      <trans-unit id="leveled.reader.vocabulary">
+      <trans-unit id="leveled.reader.vocabulary" approved="yes">
         <source xml:lang="en">Vocabulary</source>
         <target xml:lang="zh-CN">词汇</target>
         <note>ID: leveled.reader.vocabulary</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.simple">
+      <trans-unit id="leveled.reader.start.simple" approved="yes">
         <source xml:lang="en">At beginning levels, use simple words that are familiar to children. If it is possible in your language, use words with only one syllable. As children move up to higher levels, you can begin to use words with more syllables. You can begin to use less familiar words. Children should be able to guess the meaning of these less familiar words from the context of the surrounding words and sentences, as well as from the illustrations.</source>
         <target xml:lang="zh-CN">最初的几个等级要用孩子熟悉的简单词。如果在你的语言中可行的话，尽量使用单音节单词。 随着孩子的等级逐渐升高，可以开始使用有更多音节的单词, 也可以开始使用孩子不太熟悉的单词。孩子应该已经能够从上下文语境和配图中猜到词意了。</target>
         <note>ID: leveled.reader.start.simple</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.formatting">
+      <trans-unit id="leveled.reader.formatting" approved="yes">
         <source xml:lang="en">Formatting</source>
         <target xml:lang="zh-CN">字体设置</target>
         <note>ID: leveled.reader.formatting</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.start.large">
+      <trans-unit id="leveled.reader.start.large" approved="yes">
         <source xml:lang="en">Beginner readers will benefit from a larger font with clear spacing between words. Having the words or sentences in the same location on each page is also helpful. As readers progress to higher levels, font size and spacing will decrease and sentences can appear in different locations on the page.</source>
         <target xml:lang="zh-CN">对初级读者来说较大的字号和字词间距更有好处。 把词句放在每页的同样位置也很有帮助。 当读者的水平越来越高时，字号和间距会逐渐减小，句子也可以出现在页面的不同位置。</target>
         <note>ID: leveled.reader.start.large</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.increase.sizes">
+      <trans-unit id="leveled.reader.increase.sizes" approved="yes">
         <source xml:lang="en">To increase the font size, line-spacing, and word-spacing in Bloom, click in a text box and then on the grey "cog" icon in the lower left-hand corner. If you do this and then make a template book, books made with that template will also use those font settings.</source>
         <target xml:lang="zh-CN">在Bloom中需要改变字号、行间距和字词间距时，先点击文本框然后点击文本框左下角的灰色“锯齿”图案。 通过这样设置并做成的模板书，所有使用该模板制成的书都会自动采用这些字体设置。</target>
         <note>ID: leveled.reader.increase.sizes</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.predictability">
+      <trans-unit id="leveled.reader.predictability" approved="yes">
         <source xml:lang="en">Predictability</source>
         <target xml:lang="zh-CN">可预测性</target>
         <note>ID: leveled.reader.predictability</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repeat.patterns">
+      <trans-unit id="leveled.reader.repeat.patterns" approved="yes">
         <source xml:lang="en">
           <g id="genid-1" ctype="x-html-em">Predictability</g> in a text means that the reader can guess what would come next. You can increase predictability by using repeated patterns. Here are some patterns you can use:</source>
         <target xml:lang="zh-CN">
           <g id="genid-1" ctype="x-html-em"></g>文本的“可预测性”指的是读者能猜到下文会发生什么 可以通过重复来提高可预测性。下面列举了一些提高可预测性的做法：</target>
         <note>ID: leveled.reader.repeat.patterns</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.repetition">
+      <trans-unit id="leveled.reader.repetition" approved="yes">
         <source xml:lang="en">Repetition - repeating parts of the text, for example, using the same sentence with each page and just changing one word in the sentence</source>
         <target xml:lang="zh-CN">重复——重复文本中的部分内容，如每页都使用相同的句子，只改变句中的一个词。</target>
         <note>ID: leveled.reader.repetition</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.sequencing">
+      <trans-unit id="leveled.reader.sequencing" approved="yes">
         <source xml:lang="en">Sequencing - a story with a known sequence such as the days of the week or that uses numbers in a pattern</source>
         <target xml:lang="zh-CN">顺序——故事含有人们熟知的顺序，如一周的七天或有规律的数字。</target>
         <note>ID: leveled.reader.sequencing</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.building.sequence">
+      <trans-unit id="leveled.reader.building.sequence" approved="yes">
         <source xml:lang="en">Building Sequence - a story with a pattern that is repeated and added to with each new page</source>
         <target xml:lang="zh-CN">建立顺序——故事里部分内容重复出现并在每一页都加入新内容</target>
         <note>ID: leveled.reader.building.sequence</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.rhyme">
+      <trans-unit id="leveled.reader.rhyme" approved="yes">
         <source xml:lang="en">Rhyme - a story with a pattern or sequence that also includes rhyme. For example:
         <g id="genid-2" ctype="x-html-blockquote" html:class="poetry">
           <g id="genid-3" ctype="x-html-pre">Brown Bear, Brown Bear, What do you see?
@@ -78,58 +78,58 @@ Yellow Duck, Yellow Duck, What do you see?</g>
       </target>
         <note>ID: leveled.reader.rhyme</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations">
+      <trans-unit id="leveled.reader.illustrations" approved="yes">
         <source xml:lang="en">Illustration Support</source>
         <target xml:lang="zh-CN">配图</target>
         <note>ID: leveled.reader.illustrations</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.help">
+      <trans-unit id="leveled.reader.illustrations.help" approved="yes">
         <source xml:lang="en">Illustrations provide support to the story. Illustrations relate to the story in different ways at different <g id="genid-5" ctype="x-html-em">levels</g> and for different types of readers (see below). Remember that in many cultures that don't have a lot of printed material around, complex pictures may be difficult to understand.
     </source>
         <target xml:lang="zh-CN">配图能对故事起辅助作用。不同等级、不同类型的读者（见下文）对配图的需要也不尽相同。<g id="genid-5" ctype="x-html-em"> </g>切记在没有很多出版物的文化里，人们很难理解复杂的配图。</target>
         <note>ID: leveled.reader.illustrations.help</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.emergent.reader">
+      <trans-unit id="leveled.reader.illustrations.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-6" ctype="x-html-strong">Emergent Readers</g> the pictures should closely match the storyline. The reader should be able to predict the story line just by looking at the pictures. The illustrations at this level should be simple.
       </source>
         <target xml:lang="zh-CN">对<g id="genid-6" ctype="x-html-strong">萌芽读者</g>来说，配图应该和故事内容紧密结合。 让读者看见配图就能猜到故事情节。 这个等级的配图力求简单。</target>
         <note>ID: leveled.reader.illustrations.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.illustrations.early.reader">
+      <trans-unit id="leveled.reader.illustrations.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-7" ctype="x-html-strong">Early Readers</g> the pictures should offer some support to the story line. As the amount of text increases, the reader is less reliant on the pictures and gets more meaning from the text. The illustrations can be more complex.
       </source>
         <target xml:lang="zh-CN">对<g id="genid-7" ctype="x-html-strong">早期读者</g>来说，配图的作用是帮助读者理解故事情节。 随着文本长度的增加，读者对配图的依赖逐渐减少，更多从文本中理解意思。 这时的配图可以更复杂一些。</target>
         <note>ID: leveled.reader.illustrations.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.fluent.reader">
+      <trans-unit id="leveled.reader.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-8" ctype="x-html-strong">Fluent Readers</g> the pictures should offer little or no support to the story line. The reader relies more on the text than the pictures for meaning. The illustrations can be even more complex.
       </source>
         <target xml:lang="zh-CN">对<g id="genid-8" ctype="x-html-strong">流利读者</g>来说，配图不用或极少支持故事内容。 读者更多从文本中理解意思，而不是从配图理解意思。 配图可以更加复杂。</target>
         <note>ID: leveled.reader.fluent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice">
+      <trans-unit id="leveled.reader.topic.choice" approved="yes">
         <source xml:lang="en">Choice of Topic</source>
         <target xml:lang="zh-CN">话题选择</target>
         <note>ID: leveled.reader.topic.choice</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.discussion">
+      <trans-unit id="leveled.reader.topic.choice.discussion" approved="yes">
         <source xml:lang="en">Books can be on many topics. When developing books for beginning readers, choose topics that are familiar to them. Readers will be eager to read and will read more if they are reading about things they find interesting and familiar. For more experienced readers, topics can include information that the reader is not already familiar with.</source>
         <target xml:lang="zh-CN">书的话题有很多。 为新读者编书时要选择他们熟悉的话题。 读者读到自己感兴趣且熟悉的内容时，会产生更大的热情和意愿去读更多的书。对于有经验的读者，可以使用他们不熟悉的话题。</target>
         <note>ID: leveled.reader.topic.choice.discussion</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.emergent.reader">
+      <trans-unit id="leveled.reader.topic.choice.emergent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-9" ctype="x-html-strong">Emergent Readers</g> the book should be concrete, should focus on one idea/theme, and should be familiar and easy to understand.
       </source>
         <target xml:lang="zh-CN">对<g id="genid-9" ctype="x-html-strong">萌芽读者</g>来说， 内容应该具体且集中于一个话题，而且该话题必须是读者熟悉且容易理解的。</target>
         <note>ID: leveled.reader.topic.choice.emergent.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.early.reader">
+      <trans-unit id="leveled.reader.topic.choice.early.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-10" ctype="x-html-strong">Early Readers</g>, develop a story around a familiar concept but in greater depth.
       </source>
         <target xml:lang="zh-CN">对<g id="genid-10" ctype="x-html-strong">早期读者</g>来说， 可以选择他们熟悉的话题，较深入地介绍。</target>
         <note>ID: leveled.reader.topic.choice.early.reader</note>
       </trans-unit>
-      <trans-unit id="leveled.reader.topic.choice.fluent.reader">
+      <trans-unit id="leveled.reader.topic.choice.fluent.reader" approved="yes">
         <source xml:lang="en">For <g id="genid-11" ctype="x-html-strong">Fluent Readers</g> the concepts can expand beyond what is familiar, be more varied, and be abstract.
       </source>
         <target xml:lang="zh-CN">对<g id="genid-11" ctype="x-html-strong">流利读者</g>来说，话题可以超出他们熟悉的范围，更多样化、更抽象。</target>


### PR DESCRIPTION
This may be overly generous, but will allow users to see the same
translations that were available in Version3.9 that haven't been
worked on at all since then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2104)
<!-- Reviewable:end -->
