### PR TITLE
BL-5538 Fix margins and other layout of Publish to Android view

### DIFF
--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageControls/pageControls.less
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageControls/pageControls.less
@@ -17,7 +17,7 @@
 
 // This div that React inserts is just inside of the root and becomes
 // the real parent of all the content.
-div[data-reactroot] {
+#pageControlsRoot {
     height: 100%;
     display: flex;
     flex-direction: column;

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageControls/pageControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageControls/pageControls.tsx
@@ -78,7 +78,7 @@ class PageControls extends React.Component<{}, IPageControlsState> {
 
     render() {
         return (
-            <div>
+            <div id="pageControlsRoot">
                 <div>
                     <BloomButton
                         l10nKey="EditTab.AddPageDialog.AddPageButton"

--- a/src/BloomBrowserUI/publish/android/androidPublishUI.less
+++ b/src/BloomBrowserUI/publish/android/androidPublishUI.less
@@ -28,7 +28,7 @@ body {
 
 // This is the div that react inserts and which becomes the real parent of all the content.
 // We make it flex so that we can make the progress panel grow to fill the available space.
-#AndroidPublishUI [data-reactroot]{
+#androidPublishReactRoot {
   height: 100%;
    display:flex;
    flex-direction: column;

--- a/src/BloomBrowserUI/publish/android/androidPublishUI.tsx
+++ b/src/BloomBrowserUI/publish/android/androidPublishUI.tsx
@@ -107,7 +107,7 @@ class AndroidPublishUI extends React.Component<IUILanguageAwareProps, IComponent
 
 
         return (
-            <div>
+            <div id="androidPublishReactRoot">
                 <H1 className="media-heading" l10nKey="PublishTab.Android.Media"
                     l10nComment="A heading in the Publish to Android screen.">
                     Media


### PR DESCRIPTION
I think this was broken because we upgraded to a later React which no longer sets data-reactRoot on its root element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2129)
<!-- Reviewable:end -->
