### PR TITLE
Another fix for ePUB branding with multiple images (BL-5495)

### DIFF
--- a/src/BloomBrowserUI/ePUB/baseEPUB.less
+++ b/src/BloomBrowserUI/ePUB/baseEPUB.less
@@ -62,7 +62,7 @@ div.bloom-editable {
     }
     img.branding {
         // allow for more than one image
-        display: flow;
+        display: inline-block;
         // place the image(s) at the bottom of the page
         position: fixed;
         bottom: 10px;


### PR DESCRIPTION
This approach shouldn't be as experimental, but seems to work just
as well in the emulator and Gitden readers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2130)
<!-- Reviewable:end -->
