### PR TITLE
Fix button label word wrapping (BL-5506)

### DIFF
--- a/DistFiles/localization/es/Bloom.xlf
+++ b/DistFiles/localization/es/Bloom.xlf
@@ -1702,11 +1702,11 @@ Luego suelte la tecla que apretó para mostrar esta lista.</target>
           <target xml:lang="es-ES">Cortar (tCtrl+X)</target>
         </alt-trans>
       </trans-unit>
-      <trans-unit id="EditTab.DeletePageButton">
+      <trans-unit id="EditTab.DeletePageButton" approved="yes">
         <source xml:lang="en">Remove Page</source>
         <note>ID: EditTab.DeletePageButton</note>
         <note xml:lang="en">OLD TEXT (before 3.9): Remove\n  Page</note>
-        <target xml:lang="es-ES" state="translated">Eliminar página</target>
+        <target xml:lang="es-ES">Eliminar página</target>
         <alt-trans>
           <target xml:lang="es-ES">Eliminar\n página</target>
         </alt-trans>
@@ -1758,11 +1758,11 @@ Luego suelte la tecla que apretó para mostrar esta lista.</target>
         <note>This is for the 4-button panel that pops up when the user selects more than one character in a textbox.</note>
         <target xml:lang="es-ES">Subrayado</target>
       </trans-unit>
-      <trans-unit id="EditTab.DuplicatePageButton">
+      <trans-unit id="EditTab.DuplicatePageButton" approved="yes">
         <source xml:lang="en">Duplicate Page</source>
         <note>ID: EditTab.DuplicatePageButton</note>
         <note xml:lang="en">OLD TEXT (before 3.9): Duplicate\n  Page</note>
-        <target xml:lang="es-ES" state="translated">Duplicar página</target>
+        <target xml:lang="es-ES">Duplicar página</target>
         <alt-trans>
           <target xml:lang="es-ES">Duplicar\n  Página</target>
         </alt-trans>

--- a/src/BloomExe/Edit/EditingView.Designer.cs
+++ b/src/BloomExe/Edit/EditingView.Designer.cs
@@ -197,6 +197,7 @@
 			this._duplicatePageButton.Text = "Duplicate\r\n   Page";
 			this._duplicatePageButton.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
 			this._duplicatePageButton.TextDropShadow = false;
+			this._duplicatePageButton.TextWordWrap = true;
 			this._betterToolTip1.SetToolTip(this._duplicatePageButton, "Insert a new page which is a duplicate of this one");
 			this._betterToolTip1.SetToolTipWhenDisabled(this._duplicatePageButton, "This page cannot be duplicated");
 			this._duplicatePageButton.UseVisualStyleBackColor = false;
@@ -239,6 +240,7 @@
 			this._deletePageButton.Text = "Remove\r\n  Page";
 			this._deletePageButton.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
 			this._deletePageButton.TextDropShadow = false;
+			this._deletePageButton.TextWordWrap = true;
 			this._betterToolTip1.SetToolTip(this._deletePageButton, "Remove this page from the book");
 			this._betterToolTip1.SetToolTipWhenDisabled(this._deletePageButton, "This page cannot be removed");
 			this._deletePageButton.UseVisualStyleBackColor = false;


### PR DESCRIPTION
Also approve a pair of Spanish translations that only changed the inter-word spacing to remove a newline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2131)
<!-- Reviewable:end -->
