### PR TITLE
Show page number of images with missing credits (BL-5466)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -149,10 +149,6 @@
         <source xml:lang="en">None</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.Branding.None</note>
       </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.BookMakingTab.Branding.None" sil:dynamic="true">
-        <source xml:lang="en">None</source>
-        <note>ID: CollectionSettingsDialog.BookMakingTab.Branding.None</note>
-      </trans-unit>
       <trans-unit id="CollectionSettingsDialog.BookMakingTab.DefaultFontFor">
         <source xml:lang="en">Default Font for {0}</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.DefaultFontFor</note>
@@ -1118,6 +1114,11 @@
         <source xml:lang="en">International Standard Book Number. Leave blank if you don't have one of these.</source>
         <note>ID: EditTab.FrontMatter.ISBNPrompt</note>
       </trans-unit>
+      <trans-unit id="EditTab.FrontMatter.ImageCreditMissing">
+        <source xml:lang="en"> {0} (page {1})</source>
+        <note>ID: EditTab.FrontMatter.MissingCredit</note>
+        <note>The {0} is replaced by the filename of an image.  The {1} is replaced by a reference to the first page in the book where that image occurs.</note>
+      </trans-unit>
       <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true">
         <source xml:lang="en">If you need somewhere to put more information about the book, you can use this page, which is the inside of the front cover.</source>
         <note>ID: EditTab.FrontMatter.InsideFrontCoverTextPrompt</note>
@@ -1261,11 +1262,6 @@
       <trans-unit id="EditTab.LayoutInPublishTabOnlyNotice">
         <source xml:lang="en">This option is only available in the Publish tab.</source>
         <note>ID: EditTab.LayoutInPublishTabOnlyNotice</note>
-      </trans-unit>
-      <trans-unit id="EditTab.LockBook.ToolTip" sil:dynamic="true">
-        <source xml:lang="en">This book is temporarily unlocked.</source>
-        <note>ID: EditTab.LockBook.ToolTip</note>
-        <note>Button that tells Bloom to re-lock a shell book so it can't be modified (other than translation).</note>
       </trans-unit>
       <trans-unit id="EditTab.LockBook.ToolTip" sil:dynamic="true">
         <source xml:lang="en">This book is temporarily unlocked.</source>

--- a/src/BloomExe/web/controllers/ImageApi.cs
+++ b/src/BloomExe/web/controllers/ImageApi.cs
@@ -112,12 +112,14 @@ namespace Bloom.web.controllers
 			if (missingCredits.Count > 0)
 			{
 				var missing = LocalizationManager.GetString("EditTab.FrontMatter.PasteMissingCredits", "Missing credits:");
+				var missingImage = LocalizationManager.GetString("EditTab.FrontMatter.ImageCreditMissing", " {0} (page {1})",
+					"The {0} is replaced by the filename of an image.  The {1} is replaced by a reference to the first page in the book where that image occurs.");
 				total.AppendFormat("<p>{0}", missing);
 				for (var i = 0; i < missingCredits.Count; ++i)
 				{
 					if (i > 0)
 						total.Append(",");
-					total.AppendFormat(" {0}", missingCredits[i]);
+					total.AppendFormat(missingImage, missingCredits[i], imageNameToPages[missingCredits[i]].First());
 				}
 				total.AppendFormat("</p>{0}", System.Environment.NewLine);
 			}


### PR DESCRIPTION
Also remove a pair of redundant units in Bloom.xlf while adding a new
unit to that file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2147)
<!-- Reviewable:end -->
