### PR TITLE
Ensure proper floating point parsing throughout Bloom (BL-5579)

### DIFF
--- a/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
+++ b/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
@@ -184,6 +184,8 @@ namespace Bloom.CollectionCreating
 			_collectionInfo.Language1LineHeight = new decimal(0);
 			if (_fontDetails.ExtraLineHeight)
 			{
+				// The LineHeight settings from the LanguageFontDetails control are in the current culture,
+				// so we don't need to specify a culture in the TryParse.
 				double height;
 				if (double.TryParse(_fontDetails.LineHeight, out height))
 					_collectionInfo.Language1LineHeight = new decimal(height);

--- a/src/BloomExe/MiscUI/LanguageFontDetails.cs
+++ b/src/BloomExe/MiscUI/LanguageFontDetails.cs
@@ -49,14 +49,17 @@ namespace Bloom.MiscUI
 			_lineSpacingCombo.Items.Clear();
 			_lineSpacingCombo.Items.Add(defaultText);
 			_lineSpacingCombo.SelectedIndex = 0;
+			// We display the font size choices to an accuracy of 0.1 in the current culture.
 			var fontSize = 1.0;
 			while (fontSize < 2.1)
 			{
 				_lineSpacingCombo.Items.Add(fontSize.ToString("0.0"));
 				fontSize += 0.1;
 			}
-			_lineSpacingCombo.Items.Add("2.5");
-			_lineSpacingCombo.Items.Add("3.0");
+			fontSize = 2.5;
+			_lineSpacingCombo.Items.Add(fontSize.ToString("0.0"));
+			fontSize = 3.0;
+			_lineSpacingCombo.Items.Add(fontSize.ToString("0.0"));
 
 			// Make the combo box just wide enough to show its content.
 			using (var g = _lineSpacingCombo.CreateGraphics())

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -784,7 +784,7 @@ namespace Bloom.Publish.Epub
 						if(match.Success)
 						{
 							double percent;
-							if(Double.TryParse(match.Groups[1].Value, out percent))
+							if(Double.TryParse(match.Groups[1].Value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out percent))
 							{
 								mulitplier *= percent/100;
 							}

--- a/src/BloomExe/Publish/PDF/ProcessPdfWithGhostscript.cs
+++ b/src/BloomExe/Publish/PDF/ProcessPdfWithGhostscript.cs
@@ -126,18 +126,20 @@ namespace Bloom.Publish.PDF
 			}
 			if (!Directory.Exists(baseDir))
 				return null;
+			// gs9.18 works on Linux.  gs9.16 fails on Windows.  See BL-5295.
+			// We know gs9.21 works on Windows.
+			const float kMinVersion = 9.21F;
 			foreach (var versionDir in Directory.GetDirectories(baseDir))
 			{
-				// gs9.18 works on Linux.  gs9.16 fails on Windows.  See BL-5295.
-				// We know gs9.21 works on Windows.
 				var gsversion = Path.GetFileName(versionDir);
 				if (gsversion != null && gsversion.StartsWith("gs") && gsversion.Length > 2)
 				{
 					gsversion = gsversion.Substring(2);
 					float version;
-					if (float.TryParse(gsversion, out version))
+					if (float.TryParse(gsversion, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out version) ||
+						float.TryParse(gsversion, out version))		// In case it does get stored on the system in a culture-specific way.
 					{
-						if (version < 9.21F)
+						if (version < kMinVersion)
 							continue;
 						var prog = Path.Combine(versionDir, "bin", baseName + "c.exe");
 						if (File.Exists(prog))


### PR DESCRIPTION
I don't know that integer parsing is affected much by the culture
setting for simple integer values (optional sign followed by digits).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2152)
<!-- Reviewable:end -->
