### PR TITLE
Preserve generated xliff files better when building Bloom

### DIFF
--- a/DistFiles/localization/en/IntegrityFailureAdvice.xlf
+++ b/DistFiles/localization/en/IntegrityFailureAdvice.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="IntegrityFailureAdvice-en.md" datatype="html" source-language="en">
     <body>

--- a/DistFiles/localization/en/bloomEpubPreview.xlf
+++ b/DistFiles/localization/en/bloomEpubPreview.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/TR/html" xmlns:sil="http://sil.org/software/XLiff">
   <file original="bloomEpubPreview-en.html" datatype="html" source-language="en">
     <body>

--- a/src/BloomBrowserUI/gulpfile.js
+++ b/src/BloomBrowserUI/gulpfile.js
@@ -263,9 +263,9 @@ gulp.task('createXliffFiles', function() {
             var xliffFile = getXliffFilename(file.path);
             var cmd = "";
             if (IsLinux)
-                cmd = "/opt/mono4-sil/bin/mono ../../lib/dotnet/HtmlXliff.exe --extract";
+                cmd = "/opt/mono4-sil/bin/mono ../../lib/dotnet/HtmlXliff.exe --extract --preserve";
             else
-                cmd = "..\\..\\lib\\dotnet\\HtmlXliff.exe --extract";
+                cmd = "..\\..\\lib\\dotnet\\HtmlXliff.exe --extract --preserve";
             cmd = cmd + " -o \"" + xliffFile + "\"";
             cmd = cmd + " \"" + file.path + "\"";
             console.log("Extracting " + xliffFile + " from " + file.path);


### PR DESCRIPTION
It might be worth cherry-picking this at least to Version4.1 to reduce annoyance to programmers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2156)
<!-- Reviewable:end -->
