### PR TITLE
BL-5489 Cover credits should be centered.

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-common.less
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-common.less
@@ -168,7 +168,6 @@
 
             .creditsRow {
                 .bloom-editable.smallCoverCredits {
-                    display: inherit;
                     text-align: center;
                     line-height: 1.7em;
                     min-height: 1.7em;

--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
@@ -111,7 +111,7 @@ mixin standard-cover-contents
 			// because it is never empty
 			.creditsRow(data-hint='You may use this space for author/illustrator, or anything else.')
 				+field-prototypeDeclaredExplicity("V")
-					+editable(kLanguageForPrototypeOnly).Cover-Default-style(data-book='smallCoverCredits')
+					+editable(kLanguageForPrototypeOnly).smallCoverCredits.Cover-Default-style(data-book='smallCoverCredits')
 			.bottomRow
 				.coverBottomLangName.Cover-Default-style(data-book='languagesOfBook')
 				+chooser-topic.coverBottomBookTopic


### PR DESCRIPTION
This was broken back in 3.9, I think.  Let's test it in 4.1 then cherry pick to 4.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2169)
<!-- Reviewable:end -->
