### PR TITLE
Fix misspelled "Big Book.html" (BL-5620)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -795,8 +795,8 @@ namespace Bloom.Book
 					_pageMigrations["d31c38d8-c1cb-4eb9-951b-d2840f6a8bdb"] = new GuidAndPath() { Guid = "a31c38d8-c1cb-4eb9-951b-d2840f6a8bdb", Path = "Basic Book/Basic Book.html" }; // Just Text
 					_pageMigrations["FD115DFF-0415-4444-8E76-3D2A18DBBD27"] = new GuidAndPath() { Guid = "aD115DFF-0415-4444-8E76-3D2A18DBBD27", Path = "Basic Book/Basic Book.html" }; // Picture & Word
 					// Big book [see commit 7bfefd0dbc9faf8930c4926b0156e44d3447e11b]
-					_pageMigrations["AF708725-E961-44AA-9149-ADF66084A04F"] = new GuidAndPath() { Guid = "adcd48df-e9ab-4a07-afd4-6a24d0398385", Path = "Big Book/BigBook.html" }; // Just a Picture
-					_pageMigrations["D9A55EB6-43A8-4C6A-8891-2C1CDD95772C"] = new GuidAndPath() { Guid = "a31c38d8-c1cb-4eb9-951b-d2840f6a8bdb", Path = "Big Book/BigBook.html" }; // Just Text
+					_pageMigrations["AF708725-E961-44AA-9149-ADF66084A04F"] = new GuidAndPath() { Guid = "adcd48df-e9ab-4a07-afd4-6a24d0398385", Path = "Big Book/Big Book.html" }; // Just a Picture
+					_pageMigrations["D9A55EB6-43A8-4C6A-8891-2C1CDD95772C"] = new GuidAndPath() { Guid = "a31c38d8-c1cb-4eb9-951b-d2840f6a8bdb", Path = "Big Book/Big Book.html" }; // Just Text
 					// Decodable reader [see commit 7bfefd0dbc9faf8930c4926b0156e44d3447e11b]
 					_pageMigrations["f95c0314-ce47-4b47-a638-06325ad1a963"] = new GuidAndPath() { Guid = "adcd48df-e9ab-4a07-afd4-6a24d0398382", Path = "Decodable Reader/Decodable Reader.html" }; // Basic Text and Picture
 					_pageMigrations["c0847f89-b58a-488a-bbee-760ce4a13567"] = new GuidAndPath() { Guid = "adcd48df-e9ab-4a07-afd4-6a24d0398383", Path = "Decodable Reader/Decodable Reader.html" }; // Picture in Middle

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -625,7 +625,7 @@ namespace Bloom.Book
 			}
 
 			//ok, so maybe they changed the name of the folder and not the htm. Can we find a *single* html doc?
-			// BL-3572 when the only file in the directory is "BigBook.html", it matches both filters in Windows (tho' not in Linux?)
+			// BL-3572 when the only file in the directory is "Big Book.html", it matches both filters in Windows (tho' not in Linux?)
 			// so Union works better here. (And we'll change the name of the book too.)
 			var candidates = new List<string>(Directory.GetFiles(folderPath, "*.htm").Union(Directory.GetFiles(folderPath, "*.html")));
 			var decoyMarkers = new string[] {"configuration",

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -319,8 +319,8 @@ namespace BloomTests.Book
 		[Test]
 		public void PathToExistingHtml_WorksWithFullHtmlName()
 		{
-			var filenameOnly = "BigBook";
-			var fullFilename = "BigBook.html";
+			var filenameOnly = "Big Book";
+			var fullFilename = "Big Book.html";
 			var storage = GetInitialStorageWithDifferentFileName(filenameOnly);
 			var oldFullPath = Path.Combine(storage.FolderPath, filenameOnly + ".htm");
 			var newFullPath = Path.Combine(storage.FolderPath, fullFilename);


### PR DESCRIPTION
The change in Book.cs is crucial.  The other changes are cosmetic for consistency.