### PR TITLE
BL-5647, BL-5630 toolbox tools being cut off

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/panAndZoom/panZoomToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/panAndZoom/panZoomToolControls.tsx
@@ -163,8 +163,8 @@ export class PanAndZoomTool implements ITool {
     }
     hideTool() {
         const page = this.getPage();
-        page.getElementById("animationStart").remove();
-        page.getElementById("animationEnd").remove();
+        this.removeElt(page.getElementById("animationStart"));
+        this.removeElt(page.getElementById("animationEnd"));
         // enhance: if more than one image...do what??
         const firstImage = this.getFirstImage();
         if (!firstImage) {


### PR DESCRIPTION
This fixes at least one thing that could cause it...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2200)
<!-- Reviewable:end -->
