### PR TITLE
[4.1]BL-5620 Fix Big Book problem

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1022,7 +1022,7 @@ namespace Bloom.Book
 			}
 		}
 
-		private static void RemoveImgTagInDataDiv(HtmlDom bookDom)
+		internal static void RemoveImgTagInDataDiv(HtmlDom bookDom)
 		{
 			// BL-4586 Some old books ended up with background-image urls containing XML img tags
 			// in the HTML-encoded string. This happened because the coverImage data-book element

--- a/src/BloomExe/Book/BookStarter.cs
+++ b/src/BloomExe/Book/BookStarter.cs
@@ -144,6 +144,15 @@ namespace Bloom.Book
 
 			XMatterHelper.RemoveExistingXMatter(storage.Dom);
 
+			// BL-4586 Some old books ended up with background-image urls containing XML img tags
+			// in the HTML-encoded string. This happened because the coverImage data-book element
+			// contained an img tag instead of a bare filename.
+			// Normally such a thing would get fixed on loading the book, but if the "old book" in question
+			// is a shell downloaded from BloomLibrary.org, Bloom is not allowed to modify the book,
+			// so if such a thing exists in this copied book here we will strip it out and replace it with the
+			// filename in the img src attribute.
+			Book.RemoveImgTagInDataDiv(storage.Dom);
+
 			bookData.RemoveAllForms("ISBN");//ISBN number of the original doesn't apply to derivatives
 
 			var sizeAndOrientation = Layout.FromDomAndChoices(storage.Dom, Layout.A5Portrait, _fileLocator);


### PR DESCRIPTION
* When a shell book has an <img> tag in the data div
   (see BL-4586), making a new book will have a
   problem without this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2203)
<!-- Reviewable:end -->
