### PR TITLE
Preserve zh-CN in file/folder names of translated xliff

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,6 +2,12 @@ files:
   - source: /DistFiles/localization/en/*.xlf
     translation: /DistFiles/localization/%two_letters_code%/%original_file_name%
     update_option: update_as_unapproved
+    language_mapping:
+        two_letters_code:
+            zh-CN: zh-CN
   - source: /DistFiles/localization/*/ReadMe-en.xlf
     translation: /%original_path%/ReadMe-%two_letters_code%.xlf
     update_option: update_as_unapproved
+    language_mapping:
+        two_letters_code:
+            zh-CN: zh-CN


### PR DESCRIPTION
I think I have the right syntax here.
See https://support.crowdin.com/configuration-file/#language-mapping (and examples later in the page).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2229)
<!-- Reviewable:end -->
