### PR TITLE
[4.1]BL-5575 Comprehension Quiz

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -350,6 +350,8 @@ function SetupElements(container) {
     });
 
     //Convert Standard Format Markers in the pasted text to html spans
+    // Also (see BL-5575), if the parent div has .bloom-userCannotModifyStyles,
+    // only allow plain text paste.
     $(container).find("div.bloom-editable").on("paste", function (e) {
         var theEvent = e.originalEvent as ClipboardEvent;
         if (!theEvent.clipboardData)
@@ -359,6 +361,12 @@ function SetupElements(container) {
         if (s == null || s === "")
             return;
 
+        if ($(this).parent().hasClass("bloom-userCannotModifyStyles")) {
+            e.preventDefault();
+            document.execCommand("insertText", false, s);
+            //NB: odd that this doesn't work?! document.execCommand("paste", false, s);
+            return;
+        }
         var re = new RegExp("\\\\v\\s(\\d+)", "g");
         var matches = re.exec(s);
         if (matches == null) {
@@ -725,11 +733,12 @@ export function bootstrap() {
     }
     // attach ckeditor to the contenteditable="true" class="bloom-content1"
     // also to contenteditable="true" and class="bloom-content2" or class="bloom-content3"
-    // but skip any element with class="bloom-userCannotModifyStyles"
+    // but skip any element with class="bloom-userCannotModifyStyles" (which might be on the translationGroup)
     var complicatedFind = ".bloom-content1[contenteditable='true'],.bloom-content2[contenteditable='true'],";
     complicatedFind += ".bloom-content3[contenteditable='true'],.bloom-contentNational1[contenteditable='true']";
     $("div.bloom-page").find(complicatedFind).each(function () {
-        if ($(this).hasClass("bloom-userCannotModifyStyles"))
+        if ($(this).hasClass("bloom-userCannotModifyStyles") ||
+            $(this).parent().hasClass("bloom-userCannotModifyStyles"))
             return; // equivalent to 'continue'
 
         if ($(this).css("cursor") === "not-allowed")

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -157,8 +157,9 @@ export default class AudioRecording {
 
     // We only do recording in editable divs in the main content language.
     // This should NOT restrict to ones that already contain audio-sentence spans.
+    // BL-5575 But we don't (at this time) want to record comprehension questions.
     private getRecordableDivs(): JQuery {
-        return this.getPage().find('div.bloom-editable.bloom-content1');
+        return this.getPage().find(':not(.bloom-noAudio) > div.bloom-editable.bloom-content1');
     }
 
     private getAudioElements(): JQuery {
@@ -446,6 +447,11 @@ export default class AudioRecording {
 
     public updateMarkupAndControlsToCurrentText() {
         var editable = this.getRecordableDivs();
+        if (editable.length === 0) {
+            // no editable text on this page.
+            this.changeStateAndSetExpected('');
+            return;
+        }
         this.makeSentenceSpans(editable);
         // For displaying the qtip, restrict the editable divs to the ones that have
         // audio sentences.

--- a/src/BloomBrowserUI/templates/template books/Multimedia/Multimedia.pug
+++ b/src/BloomBrowserUI/templates/template books/Multimedia/Multimedia.pug
@@ -59,4 +59,4 @@ html
 				.split-pane-divider.vertical-divider
 				.split-pane-component.position-right
 					.split-pane-component-inner.adding
-						+field("auto").quiz-style.quizContents
+						+field("auto").quiz-style.quizContents.bloom-userCannotModifyStyles.bloom-noAudio

--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -20,7 +20,6 @@ using SIL.IO;
 using SIL.Reporting;
 using SIL.Windows.Forms.Miscellaneous;
 using L10NSharp;
-using SIL.Xml;
 
 namespace Bloom
 {
@@ -889,7 +888,7 @@ namespace Bloom
 		}
 
 		/// <summary>
-		/// What's going on here: the browser is just /editting displaying a copy of one page of the document.
+		/// What's going on here: the browser is just editing/displaying a copy of one page of the document.
 		/// So we need to copy any changes back to the real DOM.
 		/// </summary>
 		private void LoadPageDomFromBrowser()
@@ -906,9 +905,7 @@ namespace Bloom
 				else
 				{
 					// Assume _editDom corresponds to a frame called 'page' in the root. This may eventually need to be more configurable.
-					if (_browser.Window == null || _browser.Window.Document == null)
-						return;
-					var frameElement = _browser.Window.Document.GetElementById("page") as GeckoIFrameElement;
+					var frameElement = _browser.Window?.Document?.GetElementById("page") as GeckoIFrameElement;
 					if (frameElement == null)
 						return;
 					// contentDocument = frameElement.ContentDocument; unreliable in Gecko45


### PR DESCRIPTION
* Fixed Talking Book Tool and Comprehension Quiz
   so that the contents are not recordable
* fixed TBT so Record is not active on 1st page
   display if no recordable divs (part of BL-5457)
* added bloom-userCannotModifyStyles to comp
   question translationGroup
* made paste in context of userCannotModStyles
   only paste text (no html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2234)
<!-- Reviewable:end -->
