### PR TITLE
Fix a failing build on Linux (20180302)

### DIFF
--- a/src/BloomTests/Book/BookCompressorTests.cs
+++ b/src/BloomTests/Book/BookCompressorTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Windows.Media;
 using Bloom;
 using Bloom.Book;
 using Bloom.Collection;


### PR DESCRIPTION
The offending using statement wasn't even used by Windows!
Linux/Mono does not have a System.Windows.Media assembly or namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2240)
<!-- Reviewable:end -->
