### PR TITLE
Disable UsbPublisherTests for Linux/Mono.

### DIFF
--- a/src/BloomTests/Publish/MockUsbPublisher.cs
+++ b/src/BloomTests/Publish/MockUsbPublisher.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !__MonoCS__
+using System;
 using System.Drawing;
 using System.IO;
 using Bloom.Book;
@@ -38,3 +39,4 @@ namespace BloomTests.Publish
 		}
 	}
 }
+#endif

--- a/src/BloomTests/Publish/UsbPublisherTests.cs
+++ b/src/BloomTests/Publish/UsbPublisherTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿#if !__MonoCS__
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -99,3 +100,4 @@ namespace BloomTests.Publish
 		}
 	}
 }
+#endif


### PR DESCRIPTION
USB publishing has not yet been implemented for Linux/Mono.
The UsbPublisher class is totally disabled from even compiling,
so its tests should be as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2267)
<!-- Reviewable:end -->
