### PR TITLE
Fix (hopefully) failing UsbPublisher tests

### DIFF
--- a/src/BloomTests/Publish/MockUsbPublisher.cs
+++ b/src/BloomTests/Publish/MockUsbPublisher.cs
@@ -8,7 +8,7 @@ using Bloom.web;
 
 namespace BloomTests.Publish
 {
-	class MockUsbPublisher : UsbPublisher
+	public class MockUsbPublisher : UsbPublisher
 	{
 		const int HR_ERROR_DISK_FULL = unchecked((int)0x80070070);
 

--- a/src/BloomTests/Publish/UsbPublisherTests.cs
+++ b/src/BloomTests/Publish/UsbPublisherTests.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Windows.Forms;
 using Bloom;
 using Bloom.Book;
@@ -14,7 +15,8 @@ using SIL.IO;
 namespace BloomTests.Publish
 {
 	[TestFixture]
-	class UsbPublisherTests : BookTestsBase
+	[Apartment(ApartmentState.STA)] // otherwise the 2 tests can collide
+	public class UsbPublisherTests : BookTestsBase
 	{
 		private static BookSelection s_bookSelection;
 		private BookServer _bookServer;
@@ -47,8 +49,8 @@ namespace BloomTests.Publish
 
 		public override void TearDown()
 		{
-			_spy.Reset();
 			base.TearDown();
+			_spy.Reset();
 		}
 
 		private WebSocketProgress CreateWebSocketProgress()


### PR DESCRIPTION
I believe the TearDown method from one test was running during the other test and messing up the state. I've set the class to STA apartment type (there's only 2 tests).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2268)
<!-- Reviewable:end -->
