### PR TITLE
BL-5772 Area outside picture in pan/zoom animation should be black

### DIFF
--- a/src/BloomBrowserUI/bookLayout/bookFeatures.less
+++ b/src/BloomBrowserUI/bookLayout/bookFeatures.less
@@ -44,7 +44,11 @@
         visibility: hidden;
     }
     .bloom-imageContainer {
-        background-color:white; // prevent transparency from leaking through
+        // in full-screenpicture mode, the original imageContainer becomes the
+        // frame, and its background color provides the black bars around the
+        // animation. A new div is inserted which wraps the animation and provides
+        // the white background in case the image is partly transparent.
+        background-color:black;
         position: fixed;
         left: 0;
         top: 0;


### PR DESCRIPTION
A bloom player change should be merged first to make the background of the animation itself white!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2290)
<!-- Reviewable:end -->
