### PR TITLE
[4.1]BL-5710 Device full error rework

### DIFF
--- a/src/BloomExe/Publish/Android/usb/AndroidDeviceUsbConnection.cs
+++ b/src/BloomExe/Publish/Android/usb/AndroidDeviceUsbConnection.cs
@@ -120,7 +120,7 @@ namespace Bloom.Publish.Android.usb
 			return _device.Name;
 		}
 
-		private void Copy(Stream source, Stream destination)
+		private static void Copy(Stream source, Stream destination)
 		{
 			const int kCopyBufferSize = 262144;
 


### PR DESCRIPTION
* moved new methods down to more logical place
* renamed IsDiskFull -> IsDeviceFullOrHung
* added Win Portable Devices code for Hung device
   0x802A0006
* reworked tests to remove test interdependence
   (hopefully TC will run them okay now)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2298)
<!-- Reviewable:end -->
