### PR TITLE
Monodevelop 7.4 puts debugging options in a .user file

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -37,13 +37,6 @@
     <Optimize>false</Optimize>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>6</LangVersion>
-    <EnvironmentVariables>
-      <EnvironmentVariables>
-        <Variable name="DISPLAY" value=":2" />
-        <Variable name="FEEDBACK" value="off" />
-        <Variable name="MONO_PREFIX" value="/opt/mono4-sil" />
-      </EnvironmentVariables>
-    </EnvironmentVariables>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>..\..\output\Release\</OutputPath>


### PR DESCRIPTION
These should never have been stored in the .csproj file itself, but
that's what earlier versions of Monodevelop did.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2308)
<!-- Reviewable:end -->
