### PR TITLE
Update node.js to 8.10.0, the latest LTS version (BL-5777)

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -22,16 +22,37 @@ Each time code is checked in, an automatic build begins on our [TeamCity build s
 
 ## Building Web Source Code ##
 
-You'll need [nodejs](https://nodejs.org/en/) installed. On windows, the degree of [nesting inside of node_modules](https://github.com/Microsoft/nodejstools/issues/69) becomes a problem, but this is helped by NPM versions >= 3. To get a newish NPM, you should install a newish [nodejs](https://nodejs.org/en/), e.g. 5.4 or greater.
+You'll need [nodejs](https://nodejs.org/en/) installed.  As time goes on, the required version of nodejs changes.  Bloom 4.1 (and several earlier versions of Bloom) builds with nodejs 6.10.1.  Bloom 4.2 (and later versions of Bloom) builds with nodejs 8.10.0.  To make this feasible, we use [nvm-windows](https://github.com/coreybutler/nvm-windows) on Windows and [nvm](https://github.com/creationix/nvm) on Linux to install and manage which version of nodejs is active for the build process.  To install nvm on Windows, go to  [nvm-windows releases](https://github.com/coreybutler/nvm-windows/releases) and download the latest nvm-setup.zip file.  Unzip the downloaded file and run the nvm-setup.exe program to install nvm.  Once nvm has been installed for windows, run these commands in a command window to install the needed versions of nodejs.  This needs to be done only once.
+
+    nvm install 6.10.1
+    nvm install 8.10.0
+    nvm ls
+
+To install nvm (and the needed versions of nodejs) on Linux, run these commands in a bash shell window.  Again, this needs to be done only once.  (The version of nvm may change over time.  Check the [nvm home page](https://github.com/creationix/nvm#install-script) for exact details.)
+
+    wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm as a shell function
+    command -v nvm                                   # This should respond with "nvm"
+    nvm install 6.10.1
+    nvm install 8.10.0
+    nvm ls
 
 This will build and test the Typescript, javascript, less, and pug:
 
     cd src/BloomBrowserUI
+    nvm use 8.10.0    # or 6.10.1 if building Bloom 4.1 or earlier
     npm install
     npm run build
     npm test
 
-Here npm is really just running some gulp scripts, defined in gulpfile.js. Note that when you're using Visual Studio, the "Task Runner Explorer" can be used to start those gulp tasks, and VS should run the "default" gulp task each time it does a build. To make it run this each time you do a "run", though, make sure you've turned off this option:
+To help keep all of these commands straight, a shell script named npm-build.sh is stored in the build folder (alongside the getDependencies shell scripts).  It can run either on Linux or in the git bash shell on Windows.  The command you type is very simple:
+
+    build/npm-build.sh
+
+There are command line options to disable either the 'npm install' and 'npm test' commands if all you want to do is build.  (--skip-install and --skip-test are the verbose forms of those options.)
+
+'npm run build' is really just running some gulp scripts, defined in gulpfile.js. Note that when you're using Visual Studio, the "Task Runner Explorer" can be used to start those gulp tasks, and VS should run the "default" gulp task each time it does a build. To make it run this each time you do a "run", though, make sure you've turned off this option:
 
     Tools:Options:Projects and Solutions:Build and Run:Only build startup projects and dependencies on Run
 

--- a/build/npm-build.sh
+++ b/build/npm-build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -i
+set -e
+cd "$(dirname "$0")/../src/BloomBrowserUI"
+
+NPMSKIPINSTALL=false
+NPMSKIPTEST=false
+while (( "$#" )); do
+    case "$1" in
+	"-i"|"--skip-install")
+	    NPMSKIPINSTALL=true
+	    ;;
+	"-t"|"--skip-test")
+	    NPMSKIPTEST=true;
+	    ;;
+	*) echo "Usage: npm-build.sh [options]";
+	   echo "  -i|--skip-install - skip 'npm install' before building"
+	   echo "  -t|--skip-test    - skip 'npm test' after building"
+	   exit 1;
+	   ;;
+    esac
+    shift
+done
+
+# nvm-windows modifies the environment in such a way that neither bash scripts
+# nor batch files can find npm after "nvm use" is called.  This requires nvm
+# to run in a subshell for the sake of Windows.
+if [ "$OS" = "Windows_NT" ]; then
+    (nvm ls | grep '\* 8\.10\.0') || (nvm use 8.10.0)
+else
+    (nvm current | grep '8\.10\.0') || nvm use 8.10.0
+fi
+
+if [ "$NPMSKIPINSTALL" != "true" ]; then npm install; fi
+npm run build
+if [ "$NPMSKIPTEST" != "true" ]; then npm test; fi

--- a/debian/rules
+++ b/debian/rules
@@ -25,13 +25,13 @@ override_dh_auto_build:
 	build/getDependencies-Linux.sh
 	# This seems to be the only reliable way to get the version of nodejs/npm that we need.
 	if [ "`uname -m`" = "x86_64" ]; then \
-	    wget https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-x64.tar.xz && \
-	    tar xf node-v6.10.1-linux-x64.tar.xz && \
-	    export PATH="`pwd`/node-v6.10.1-linux-x64/bin:$$PATH"; \
+	    wget https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-x64.tar.xz && \
+	    tar xf node-v8.10.0-linux-x64.tar.xz && \
+	    export PATH="`pwd`/node-v8.10.0-linux-x64/bin:$$PATH"; \
 	else \
-	    wget https://nodejs.org/dist/v6.10.1/node-v6.10.1-linux-x86.tar.xz && \
-	    tar xf node-v6.10.1-linux-x86.tar.xz && \
-	    export PATH="`pwd`/node-v6.10.1-linux-x86/bin:$$PATH"; \
+	    wget https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-x86.tar.xz && \
+	    tar xf node-v8.10.0-linux-x86.tar.xz && \
+	    export PATH="`pwd`/node-v8.10.0-linux-x86/bin:$$PATH"; \
 	fi && \
 	export HOME=/tmp && \
 	. ./environ && \

--- a/src/BloomBrowserUI/.npmrc
+++ b/src/BloomBrowserUI/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -7,7 +7,7 @@
         "test": "test"
     },
     "engines": {
-        "node": "~6.10.1"
+        "node": "~8.10.0"
     },
     "scripts": {
         "test": "karma start --browsers Firefox",


### PR DESCRIPTION
This merge requires the affected TeamCity builds to switch to using node 8.10.0 before it will build on them.  The packaging builds on Jenkins will build okay since the code checked in here changes that behavior for those builds.

The new package-lock.json may or may not need to be checked in.  The discussion about it was not unanimous by any means.

Do not merge this if you aren't will to modify the TeamCity builds.  Of course, if you don't modify those builds first, how will you know it works?  We have a chicken and egg problem in one sense...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2313)
<!-- Reviewable:end -->
