### PR TITLE
BL-5844 Add chakma page numbering

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1477,13 +1477,18 @@ namespace Bloom.Book
 			if(string.IsNullOrEmpty(charactersForDigits))
 				return postiveInteger.ToString(CultureInfo.InvariantCulture);
 
-			Debug.Assert(charactersForDigits.Length==10);
-
+			// normal charactersForDigits.length gives 20 for chakma's 10 characters... I gather because it is converted to utf 16  and then
+			// those bytes are counted? Here's all the info:
+			// "In short, the length of a string is actually a ridiculously complex question and calculating it can take a lot of CPU time as well as data tables."
+			// https://stackoverflow.com/questions/26975736/why-is-the-length-of-this-string-longer-than-the-number-of-characters-in-it
+			var infoOnDigitsCharacters = new StringInfo(charactersForDigits);
+			Debug.Assert(infoOnDigitsCharacters.LengthInTextElements == 10);
+			
 			return String.Join("", postiveInteger.ToString(CultureInfo.InvariantCulture)
 				.Select(x =>
 				{
 					if ("1234567890".Contains(x.ToString()))
-						return charactersForDigits.Substring(x - '0', 1);
+						return infoOnDigitsCharacters.SubstringByTextElements(x - '0', 1);
 					else
 						return x.ToString();
 				}));

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -422,6 +422,9 @@ namespace Bloom.Collection
 				sb.AppendLine("/* These styles are controlled by the Settings dialog box in Bloom. */");
 				sb.AppendLine("/* They many be over-ridden by rules in customCollectionStyles.css or customBookStyles.css */");
 				AddFontCssRule(sb, "BODY", GetDefaultFontName(), false, 0);
+				// note: css pseudo elements  cannot have a @lang attribute. So this is needed to show page numbers in scripts
+				// not covered by Andika New Basic.
+				AddFontCssRule(sb, ".numberedPage::after", DefaultLanguage1FontName, IsLanguage1Rtl, Language1LineHeight);
 				AddFontCssRule(sb, "[lang='" + Language1Iso639Code + "']", DefaultLanguage1FontName, IsLanguage1Rtl, Language1LineHeight);
 				AddFontCssRule(sb, "[lang='" + Language2Iso639Code + "']", DefaultLanguage2FontName, IsLanguage2Rtl, Language2LineHeight);
 				if (!string.IsNullOrEmpty(Language3Iso639Code))

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -64,6 +64,7 @@ namespace Bloom.Collection
 				{ "Bengali", "০১২৩৪৫৬৭৮৯"}, // from bn-BD
 				{ "Cambodian", "០១២៣៤៥៦៧៨៩"}, // from km-KH
 				{ "Khmer", "០១២៣៤៥៦៧៨៩"}, // from km-KH"
+				{ "Chakma", "𑄶𑄷𑄸𑄹𑄺𑄻𑄼𑄽𑄾𑄿" }, // see https://codepoints.net/search?sc=Cakm
 				{ "Cjk-Decimal", "〇一二三四五六七八九"},// haven't found a culture for this
 				{ "Decimal", "" },
 				{ "Devanagari", "०१२३४५६७८९"}, // from hi-IN
@@ -850,10 +851,15 @@ namespace Bloom.Collection
 				string info;
 				if(CssNumberStylesToCultureOrDigits.TryGetValue(PageNumberStyle, out info))
 				{
-					if (info.Length == 10) // string of digits
+					// normal info.length gives 20 for chakma's 10 characters... I gather because it is converted to utf 16  and then
+					// those bytes are counted? Here's all the info:
+					// "In short, the length of a string is actually a ridiculously complex question and calculating it can take a lot of CPU time as well as data tables."
+					// https://stackoverflow.com/questions/26975736/why-is-the-length-of-this-string-longer-than-the-number-of-characters-in-it
+					var infoOnDigitsCharacters = new StringInfo(info);
+					if (infoOnDigitsCharacters.LengthInTextElements == 10) // string of digits
 						return info; //we've just listed the digits out, no need to look up a culture
 
-					if(info.Length == 5) // Microsoft culture code
+					if(infoOnDigitsCharacters.LengthInTextElements == 5) // Microsoft culture code
 					{
 						try
 						{

--- a/src/BloomExe/Collection/CollectionSettingsDialog.Designer.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.Designer.cs
@@ -307,6 +307,7 @@ namespace Bloom.Collection
 			this._numberStyleCombo.Name = "_numberStyleCombo";
 			this._numberStyleCombo.Size = new System.Drawing.Size(189, 25);
 			this._numberStyleCombo.TabIndex = 35;
+			this._numberStyleCombo.SelectedIndexChanged += new System.EventHandler(this._numberStyleCombo_SelectedIndexChanged);
 			// 
 			// label3
 			// 

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -520,5 +520,10 @@ namespace Bloom.Collection
 		{
 			Process.Start("http://bit.ly/2zTQHfM");
 		}
+
+		private void _numberStyleCombo_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			ChangeThatRequiresRestart();
+		}
 	}
 }


### PR DESCRIPTION
Also force restart when you change the numbering.
Currently requires a custom font rule to actually see the numbers:

    /* Required for Bloom version 4.1 to show page numbers in Chakma */
    .numberedPage::after{
        font-family: "RibengUni";
    }

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2323)
<!-- Reviewable:end -->
