### PR TITLE
[4.1]BL-5855 Prevent forgetting page label change

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -640,6 +640,8 @@ function SetupElements(container) {
     ConstrainContentsOfPageLabel(container);
 }
 
+const pageLabelL18nPrefix = "TemplateBooks.PageLabel.";
+
 function ConstrainContentsOfPageLabel(container) {
     var pageLabel = <HTMLDivElement>document.getElementsByClassName("pageLabel")[0];
     if (!pageLabel)
@@ -649,6 +651,12 @@ function ConstrainContentsOfPageLabel(container) {
         pageLabel.innerText = pageLabel.innerText.split(/[\/\\*:?"<>|]/).join("");
         // characters that mess something else up, found through experimentation
         pageLabel.innerText = pageLabel.innerText.split(/[#%\r\n]/).join("");
+        // update data-i18n attribute to prevent this change being forgotton on reload; BL-5855
+        var localizationAttr = pageLabel.getAttribute("data-i18n");
+        if (localizationAttr.startsWith(pageLabelL18nPrefix)) {
+            localizationAttr = pageLabelL18nPrefix + pageLabel.innerText;
+            pageLabel.setAttribute("data-i18n", localizationAttr);
+        }
     });
 }
 
@@ -661,9 +669,9 @@ function AddXMatterLabelAfterPageLabel(container) {
     xMatterLabel = xMatterLabel.replace(new RegExp("\"", "g"), ""); //No idea why the quotes are still in there at this point.
     if (xMatterLabel === "" || xMatterLabel === "none")
         return;
-    theOneLocalizationManager.asyncGetText("TemplateBooks.PageLabel." + xMatterLabel, xMatterLabel, "")
+    theOneLocalizationManager.asyncGetText(pageLabelL18nPrefix + xMatterLabel, xMatterLabel, "")
         .done(function (xMatterLabelTranslation) {
-            theOneLocalizationManager.asyncGetText("TemplateBooks.PageLabel.FrontBackMatter", "Front/Back Matter", "")
+            theOneLocalizationManager.asyncGetText(pageLabelL18nPrefix + "FrontBackMatter", "Front/Back Matter", "")
                 .done(function (frontBackTranslation) {
                     $(pageLabel).attr("data-after-content", xMatterLabelTranslation + " " + frontBackTranslation);
                 });


### PR DESCRIPTION
* was due to not updating the data-i18n attribute
* another possible solution would be to delete the
   attribute when changing the page label on the 
   premise that we don't want to try localizing random
   template page labels from the user... but we might
   want to and they may change it back to something
   we already know how to localize.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2331)
<!-- Reviewable:end -->
