### PR TITLE
Fix BL-5824 which was using bloompack-installed customBookStyles instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ DistFiles/AdobeColorProfileEULA.htm
 DistFiles/IntegrityFailureAdvice-*.htm
 DistFiles/infoPages/TrainingVideos-*.htm
 DistFiles/localization/*.htm
+
+src/BloomBrowserUI/yarn-error\.log

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -986,10 +986,12 @@ namespace Bloom.Book
 				{
 					var file = Path.GetFileName(path);
 
-					// In BL-5824, we got bit by a design decision we made that allows stylesheets installed via bloompack
-					// to override local ones. This was done so that we could send out new custom stylesheets via webpack
-					// and have those used in all the books. Fine. But that is indiscriminate; it also was grabbing
-					// any "customBookStyles.css" from those sources and using it instead (EnhancedImageServer) and replacing that of your book (here).
+					// In BL-5824, we got bit by design decisions we made that allow stylesheets installed via bloompack and by new Bloom versions
+					// to replace local ones. This was done so that we could send out new Bloom implementation stylesheets via bloompack and in new Bloom versions
+					// and have those used in all the books. This works well for most stylesheets.
+					// But customBookStyles.css needs to be an exception; it's whole purpose is to let the local book override Bloom's normal
+					// behavior or anything in a bloompack.
+					// So customBookStyles.css is not overridden (EnhancedImageServer) or replaced (here)..
 					if (!file.ToLowerInvariant().Contains("custombookstyles"))
 					{
 						Update(file);

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -985,8 +985,15 @@ namespace Bloom.Book
 				foreach (var path in Directory.GetFiles(_folderPath, "*.css"))
 				{
 					var file = Path.GetFileName(path);
-					//if (file.ToLower().Contains("portrait") || file.ToLower().Contains("landscape"))
-					Update(file);
+
+					// In BL-5824, we got bit by a design decision we made that allows stylesheets installed via bloompack
+					// to override local ones. This was done so that we could send out new custom stylesheets via webpack
+					// and have those used in all the books. Fine. But that is indiscriminate; it also was grabbing
+					// any "customBookStyles.css" from those sources and using it instead (EnhancedImageServer) and replacing that of your book (here).
+					if (!file.ToLowerInvariant().Contains("custombookstyles"))
+					{
+						Update(file);
+					}
 				}
 			}
 

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -675,7 +675,13 @@ namespace Bloom.Api
 			{
 				_fileLocator = Program.OptimizedFileLocator;
 			}
-			var path = _fileLocator.LocateFile(fileName);
+
+			// In BL-5824, we got bit by a design decision we made that allows stylesheets installed via bloompack
+			// to override local ones. This was done so that we could send out new custom stylesheets via webpack
+			// and have those used in all the books. Fine. But that is indiscriminate; it also was grabbing
+			// any "customBookStyles.css" from those sources and using it instead (here) and replacing that of your book (in BookStorage).
+			var path = fileName.ToLowerInvariant().Contains("custombookstyles") ? localPath 
+				: _fileLocator.LocateFile(fileName);
 
 			// if still not found, and localPath is an actual file path, use it
 			if (string.IsNullOrEmpty(path) && RobustFile.Exists(localPath)) path = localPath;


### PR DESCRIPTION
In BL-5824, we got bit by a design decision we made that allows stylesheets installed via bloompack to override local ones. This was done so that we could send out new custom stylesheets via webpack and have those used in all the books. Fine. But that is indiscriminate; it also was grabbing any "customBookStyles.css" from those sources and using it instead and replacing that of your book.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2332)
<!-- Reviewable:end -->
