### PR TITLE
Fix a pair of filename capitalization problems (20180413)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/music/musicToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/music/musicToolControls.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import ToolboxToolReactAdaptor from "../ToolboxToolReactAdaptor";
+import ToolboxToolReactAdaptor from "../toolboxToolReactAdaptor";
 import {
     H1,
     Div,

--- a/src/BloomBrowserUI/bookEdit/toolbox/panAndZoom/panZoomToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/panAndZoom/panZoomToolControls.tsx
@@ -10,7 +10,7 @@ import { EditableDivUtils } from "../../js/editableDivUtils";
 import { getPageFrameExports } from "../../js/bloomFrames";
 import AudioRecording from "../talkingBook/audioRecording";
 import { Checkbox } from "../../../react_components/checkbox";
-import ToolboxToolReactAdaptor from "../ToolboxToolReactAdaptor";
+import ToolboxToolReactAdaptor from "../toolboxToolReactAdaptor";
 import { MusicToolControls } from "../music/musicToolControls";
 import "./panAndZoom.less";
 


### PR DESCRIPTION
Why the conventions for filenames and class names are different in js/ts
land is beyond me.
This is a cherry-pick from master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2342)
<!-- Reviewable:end -->
