### PR TITLE
[4.1]BL-5855 Tell handler not to do TemplateBooks

### DIFF
--- a/src/BloomExe/web/I18NHandler.cs
+++ b/src/BloomExe/web/I18NHandler.cs
@@ -42,11 +42,16 @@ namespace Bloom.Api
 							{
 								try
 								{
-									if (!d.ContainsKey(key))
-									{
-										var translation = GetTranslationDefaultMayNotBeEnglish(key, post[key]);
-										d.Add(key, translation);
-									}
+									if (d.ContainsKey(key))
+										continue;
+
+									// Now that end users can create templates, it's annoying to report that their names,
+									// page labels, and page descriptions don't have localizations.
+									if (IsTemplateBookKey(key))
+										continue;
+
+									var translation = GetTranslationDefaultMayNotBeEnglish(key, post[key]);
+									d.Add(key, translation);
 								}
 								catch (Exception error)
 								{
@@ -93,10 +98,10 @@ namespace Bloom.Api
 						}
 						else
 						{
-							if (id.StartsWith("TemplateBooks.BookName") || id.StartsWith("TemplateBooks.PageLabel") || id.StartsWith("TemplateBooks.PageDescription"))
+							// Now that end users can create templates, it's annoying to report that their names,
+							// page labels, and page descriptions don't have localizations.
+							if (IsTemplateBookKey(id))
 							{
-								// Now that end users can create templates, it's annoying to report that their names,
-								// page labels, and page descriptions don't have localizations.
 								englishText = englishText.Trim();
 							}
 							else
@@ -123,6 +128,13 @@ namespace Bloom.Api
 			}
 
 			return false;
+		}
+
+		private static bool IsTemplateBookKey(string key)
+		{
+			return key.StartsWith("TemplateBooks.BookName") ||
+			       key.StartsWith("TemplateBooks.PageLabel") ||
+			       key.StartsWith("TemplateBooks.PageDescription");
 		}
 
 		/// <summary>


### PR DESCRIPTION
* I18NHandler already didn't bother with template
   page labels and such in "translate" mode
* extend this behavior to "loadStrings" mode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2343)
<!-- Reviewable:end -->
