### PR TITLE
Tweak GTK file chooser usage on Linux to ensure focus (BL-5809)

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryView.cs
+++ b/src/BloomExe/CollectionTab/LibraryView.cs
@@ -103,6 +103,19 @@ namespace Bloom.CollectionTab
 
 		private void OnMakeBloomPackButton_Click(object sender, EventArgs e)
 		{
+			// Something in the Mono runtime state machine keeps the GTK filechooser from getting the
+			// focus immediately when we invoke _collectionListView.MakeBloomPack() directly at this
+			// point.  Waiting for the next idle gets it into a state where the filechooser does receive
+			// the focus as desired.  See https://silbloom.myjetbrains.com/youtrack/issue/BL-5809.
+			if (SIL.PlatformUtilities.Platform.IsMono)
+				Application.Idle += DeferredBloompackFileChooser;
+			else
+				_collectionListView.MakeBloomPack(false);
+		}
+
+		private void DeferredBloompackFileChooser(object sender, EventArgs e)
+		{
+			Application.Idle -= DeferredBloompackFileChooser;
 			_collectionListView.MakeBloomPack(false);
 		}
 


### PR DESCRIPTION
This may look like a hack, but it works and is the only solution that
I've come up with after 2+ days of looking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2348)
<!-- Reviewable:end -->
