### PR TITLE
Exclude test on Linux that causes crash (BL-4867)

### DIFF
--- a/src/BloomTests/Publish/ExportEpubTests.cs
+++ b/src/BloomTests/Publish/ExportEpubTests.cs
@@ -365,6 +365,7 @@ namespace BloomTests.Publish
 		}
 
 		[Test]
+		[Platform(Exclude = "Linux", Reason = "Linux code produces strange GTK errors after passing the test.")]
 		public void BookSwitchedToDeviceXMatter()
 		{
 			var book = SetupBookLong("This is some text", "en", createPhysicalFile: true);


### PR DESCRIPTION
The excluded test passes, but strange GTK errors it causes prevent TeamCity from calling it successful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2353)
<!-- Reviewable:end -->
