### PR TITLE
Restore test excluded on Linux yesterday

### DIFF
--- a/src/BloomTests/Publish/ExportEpubTests.cs
+++ b/src/BloomTests/Publish/ExportEpubTests.cs
@@ -365,7 +365,6 @@ namespace BloomTests.Publish
 		}
 
 		[Test]
-		[Platform(Exclude = "Linux", Reason = "Linux code produces strange GTK errors after passing the test.")]
 		public void BookSwitchedToDeviceXMatter()
 		{
 			var book = SetupBookLong("This is some text", "en", createPhysicalFile: true);


### PR DESCRIPTION
SIL.BuildTasks has been updated to handle the bogus error messages
this test puts out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2356)
<!-- Reviewable:end -->
