### PR TITLE
[4.1]BL-5910 Repair Quiz pages

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1143,6 +1143,26 @@ namespace Bloom.Book
 			node.InnerXml = node.InnerXml.Replace(kBR, "<br/>");
 		}
 
+		internal static void StripUnwantedTagsPreservingText(XmlDocument dom, XmlNode element, string[] tagsToPreserve)
+		{
+			if (element.HasChildNodes)
+			{
+				var countOfChildren = element.ChildNodes.Count;
+				for (var i = 0; i < countOfChildren; i++)
+				{
+					var childNode = element.ChildNodes[i];
+					if (childNode is XmlText)
+						continue;
+
+					StripUnwantedTagsPreservingText(dom, childNode, tagsToPreserve);
+				}
+			}
+			if (tagsToPreserve.Contains(element.Name))
+				return;
+			var replacementNode = dom.CreateTextNode(element.InnerText);
+			element.ParentNode.ReplaceChild(replacementNode, element);
+		}
+
 		/// <summary>
 		/// Blindly merge the classes from the source into the target.
 		/// </summary>

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -1044,6 +1044,87 @@ namespace BloomTests.Book
 		}
 
 		[Test]
+		public void BringBookUpToDate_RepairQuestionsPages_DoesNotMessUpGoodPages()
+		{
+			const string xpathQuestionsPrefix = "//div[contains(@class,'questions')]";
+			_bookDom = new HtmlDom(@"
+				<html>
+					<head />
+					<body>
+						<div class='bloom-page questions'>
+							<div class='marginBox'>
+								<div>
+									<div class='quizInstructions'>Some gobbledy-gook</div>
+								</div>
+								<div>
+									<div class='bloom-translationGroup quiz-style quizContents bloom-noAudio bloom-userCannotModifyStyles'>
+										<div class='bloom-editable bloom-content1 bloom-contentNational1' contenteditable='true' lang='en'>
+											My test question. <br/>
+											<p>‌Answer 1 </p>
+											<p>‌*Answer 2 </p>
+											<p>‌</p>
+											<p>‌Second test question </p>
+											<p>‌*Some right answer </p>
+											<p>‌Some wrong answer </p>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</body>
+				</html>");
+
+			var book = CreateBook();
+
+			book.BringBookUpToDate(new NullProgress());
+			AssertThatXmlIn.Dom(book.RawDom).HasSpecifiedNumberOfMatchesForXpath(xpathQuestionsPrefix + "//div[contains(@class,'bloom-noAudio') and contains(@class,'bloom-userCannotModifyStyles')]", 1);
+			AssertThatXmlIn.Dom(book.RawDom).HasSpecifiedNumberOfMatchesForXpath(xpathQuestionsPrefix + "//div//p", 6);
+			AssertThatXmlIn.Dom(book.RawDom).HasSpecifiedNumberOfMatchesForXpath(xpathQuestionsPrefix + "//div//br", 1);
+		}
+
+		[Test]
+		public void BringBookUpToDate_RepairQuestionsPages_Works()
+		{
+			const string xpathQuestionsPrefix = "//div[contains(@class,'questions')]";
+			_bookDom = new HtmlDom(@"
+				<html>
+					<head />
+					<body>
+						<div class='bloom-page questions'>
+							<div class='marginBox'>
+								<div>
+									<div class='quizInstructions'>Some gobbledy-gook</div>
+								</div>
+								<div>
+									<div class='bloom-translationGroup quiz-style quizContents'>
+										<div class='bloom-editable bloom-content1 bloom-contentNational1' contenteditable='true' lang='en'>
+											<h1>My test question.</h1> <br/>
+											<p>‌Answer 1 </p>
+											<p>‌*Ans<span class='audio-sentence'>wer 2</span></p>
+											<p>‌</p>
+											<p>‌Second test question <em>weird stuff!</em></p>
+											<p>*Some right answer</p>
+											<p><span data-duration='1.600227' id='i125f143d-7c30-44c1-8d23-0e000f484e08' class='audio-sentence' recordingmd5='undefined'>My test text.</span></p>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</body>
+				</html>");
+
+			var book = CreateBook();
+
+			book.BringBookUpToDate(new NullProgress());
+			AssertThatXmlIn.Dom(book.RawDom).HasSpecifiedNumberOfMatchesForXpath(xpathQuestionsPrefix + "//div[contains(@class,'bloom-noAudio') and contains(@class,'bloom-userCannotModifyStyles')]", 1);
+			AssertThatXmlIn.Dom(book.RawDom).HasNoMatchForXpath(xpathQuestionsPrefix + "//div//span");
+			AssertThatXmlIn.Dom(book.RawDom).HasNoMatchForXpath(xpathQuestionsPrefix + "//div//em");
+			AssertThatXmlIn.Dom(book.RawDom).HasNoMatchForXpath(xpathQuestionsPrefix + "//div//h1");
+			AssertThatXmlIn.Dom(book.RawDom).HasSpecifiedNumberOfMatchesForXpath(xpathQuestionsPrefix + "//div//p[.='‌*Answer 2']", 1);
+			AssertThatXmlIn.Dom(book.RawDom).HasSpecifiedNumberOfMatchesForXpath(xpathQuestionsPrefix + "//div//p[.='My test text.']", 1);
+		}
+
+		[Test]
 		public void BringBookUpToDate_LanguagesOfBookUpdated()
 		{
 			_bookDom = new HtmlDom(@"

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -866,5 +866,35 @@ namespace BloomTests.Book
 			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath($"//div[@id='12' and @data-page-number='{page12Number}']", 1);
 
 		}
+
+		[Test]
+		public void StripUnwantedTagsPreservingText_StripsEmbeddedSpan()
+		{
+			var tagsToPreserve = new[] { "div", "p", "br" };
+			var dom = new HtmlDom(@"<html><head></head><body>
+						<div id='testthiselement'>
+							<div class='bloom-editable bloom-content1 bloom-contentNational1' contenteditable='true' lang='en'>
+								<h1>My test question.</h1> <br/>
+								<p>‌Answer 1 </p>
+								<p>‌*Ans<span class='audio-sentence'>wer 2</span></p>
+								<p>‌</p>
+								<p>‌Second test question <em>weird stuff!</em></p>
+								<p>‌*Some right answer </p>
+								<p><span data-duration='1.600227' id='i125f143d-7c30-44c1-8d23-0e000f484e08' class='audio-sentence' recordingmd5='undefined'>My test text.</span></p>
+							</div>
+						</div>
+				</body></html>");
+			var testableElement = dom.SelectSingleNode("//div[@id='testthiselement']");
+
+			// SUT
+			HtmlDom.StripUnwantedTagsPreservingText(dom.RawDom, testableElement, tagsToPreserve);
+
+			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//span");
+			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//h1");
+			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//em");
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//p[.='‌*Some right answer ']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//p[.='‌*Answer 2']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//p[.='My test text.']", 1);
+		}
 	}
 }


### PR DESCRIPTION
* left over from when the Talking Book tool
   allowed recording these pages
* adds 2 classes that are needed
* only preserves div, p, and br tags in quizContents

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2357)
<!-- Reviewable:end -->
