### PR TITLE
Fix BL-5419, accented chars from book-download url from FF was mangled

### DIFF
--- a/src/BloomExe/WebLibraryIntegration/BloomLinkArgs.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomLinkArgs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Web;
 using SIL.Network;
 
 namespace Bloom.WebLibraryIntegration
@@ -63,9 +64,9 @@ namespace Bloom.WebLibraryIntegration
 			var parts = qparams[0].Split('=');
 			if (parts.Length != 2 || parts[0] != kOrderFile)
 				throw new ArgumentException(String.Format("badly formed BloomLinkArgs URL string: {0}", url));
-			OrderUrl = HttpUtilityFromMono.UrlDecode(parts[1]);
+			OrderUrl = HttpUtility.UrlDecode(parts[1]);
 			if (qparams.Length > 1 && qparams[1].StartsWith("title="))
-				Title = HttpUtilityFromMono.UrlDecode(qparams[1].Substring("title=".Length));
+				Title = HttpUtility.UrlDecode(qparams[1].Substring("title=".Length));
 			else
 			{
 				// Make up a title from the book order. This should be obsolete once all instances of Bloom Library

--- a/src/BloomTests/WebLibraryIntegration/BloomLinkArgsTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BloomLinkArgsTests.cs
@@ -27,5 +27,29 @@ namespace BloomTests.WebLibraryIntegration
 			Assert.That(args.OrderUrl, Is.EqualTo("somepath/whatever=.BookOrder"));
 			Assert.That(args.Title, Is.EqualTo("whatever="));
 		}
+
+		//BL-5419
+		[Test]
+		public void BloomLinkArgs_WithSpanishFromFirefox_DoesNotMangle()
+		{
+			var url =
+				"bloom://localhost/order?orderFile=BloomLibraryBooks/chris_hurst%40sil.org%2f2bc65ef6-9c84-4b3a-af69-fcc6ed2682b4%2fComo+la+hormigita+salvó+al+pájaro+blanco%2fYanda+’Yar+Tururuwa+ta+Gode+wa+Farar+Tsuntsuwa.BloomBookOrder&title=Como%20la%20hormigita%20salvó%20al%20pájaro%20blanco%0A";
+			var args = new BloomLinkArgs(url);
+			//Assert.That(args.OrderUrl, Is.EqualTo("somepath/whatever=.BookOrder"));
+			Assert.True(args.OrderUrl.Contains("pájaro"));
+			Assert.True(args.Title.Contains("pájaro"));
+		}
+
+		//BL-5419. Chrome was ok, becuase it encoded the accented characters
+		[Test]
+		public void BloomLinkArgs_WithSpanishFromChrome_DoesNotMangle()
+		{
+			var url =
+				"bloom://localhost/order?orderFile=BloomLibraryBooks/chris_hurst%40sil.org%2f2bc65ef6-9c84-4b3a-af69-fcc6ed2682b4%2fComo+la+hormigita+salv%c3%b3+al+p%c3%a1jaro+blanco%2fYanda+%e2%80%99Yar+Tururuwa+ta+Gode+wa+Farar+Tsuntsuwa.BloomBookOrder&title=Como%20la%20hormigita%20salv%C3%B3%20al%20p%C3%A1jaro%20blanco%0A";
+			var args = new BloomLinkArgs(url);
+			//Assert.That(args.OrderUrl, Is.EqualTo("somepath/whatever=.BookOrder"));
+			Assert.True(args.OrderUrl.Contains("pájaro"));
+			Assert.True(args.Title.Contains("pájaro"));
+		}
 	}
 }


### PR DESCRIPTION
Just switched to the urldecode available with .net.