### PR TITLE
BL-5736 Enable Variants and Scripts

### DIFF
--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -158,6 +158,8 @@ namespace Bloom.Collection
 			{
 				//at this point, we don't let them customize the national languages
 				dlg.IsDesiredLanguageNameFieldVisible = potentiallyCustomName != null;
+				dlg.IsShowRegionalDialectsCheckBoxVisible = true;
+				dlg.IsScriptAndVariantLinkVisible = true;
 
 				var language = new LanguageInfo() { LanguageTag = iso639Code};
 				if (!string.IsNullOrEmpty(potentiallyCustomName))

--- a/src/BloomExe/CollectionCreating/LanguageIdControl.cs
+++ b/src/BloomExe/CollectionCreating/LanguageIdControl.cs
@@ -17,6 +17,7 @@ namespace Bloom.CollectionCreating
 
 			// Following should be consistent with CollectionSettingsDialog.ChangeLanguage()
 			_lookupISOControl.UseSimplifiedChinese();
+			_lookupISOControl.IsScriptAndVariantLinkVisible = true;
 		}
 
 		private void OnLookupISOControlReadinessChanged(object sender, EventArgs e)
@@ -47,6 +48,7 @@ namespace Bloom.CollectionCreating
 			_collectionInfo = collectionInfo;
 			_lookupISOControl.ReadinessChanged += OnLookupISOControlReadinessChanged;
 		}
+
 		public void NowVisible()
 		{
 			_setNextButtonState(this, _lookupISOControl.SelectedLanguage != null);


### PR DESCRIPTION
* Bloom side
* update LanguageIdControl and
   Collection Settings dialog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2362)
<!-- Reviewable:end -->
