### PR TITLE
[4.1]BL-5940 Fix curly brace issue

### DIFF
--- a/src/BloomExe/Book/BookStarter.cs
+++ b/src/BloomExe/Book/BookStarter.cs
@@ -54,7 +54,7 @@ namespace Bloom.Book
 
 			// We use the "initial name" to make the initial copy, and it gives us something
 			//to name the folder and file until such time as the user enters a title in for the book.
-			string initialBookName = GetInitialName(sourceBookFolder, parentCollectionPath);
+			string initialBookName = GetInitialName(parentCollectionPath);
 			var newBookFolder = Path.Combine(parentCollectionPath, initialBookName);
 			CopyFolder(sourceBookFolder, newBookFolder);
 			//if something bad happens from here on out, we need to delete that folder we just made
@@ -509,7 +509,7 @@ namespace Bloom.Book
 			}
 		}
 
-		private string GetInitialName(string sourcePath, string parentCollectionPath)
+		private string GetInitialName(string parentCollectionPath)
 		{
 			var name = BookStorage.SanitizeNameForFileSystem(UntitledBookName);
 			return BookStorage.GetUniqueFolderName(parentCollectionPath, name);

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -1213,6 +1213,11 @@ namespace Bloom.Book
 			dangerousCharacters.AddRange(PathUtilities.GetInvalidOSIndependentFileNameChars());
 			// NBSP also causes problems.  See https://issues.bloomlibrary.org/youtrack/issue/BL-5212.
 			dangerousCharacters.Add('\u00a0');
+			// Curly braces cause problems in PDF generation (BL-5940).
+			// Interestingly enough, this fixes the problem, but still allows braces in the title to show in the book.
+			// It just keeps them out of the filename.
+			dangerousCharacters.Add('{');
+			dangerousCharacters.Add('}');
 			//dangerousCharacters.Add('.'); Moved this to a trim because SHRP uses names like "SHRP 2.3" (term 2, week 3)
 			foreach (char c in dangerousCharacters)
 			{


### PR DESCRIPTION
* removes curly braces from filename, but leaves
   them in the displayed/printed title
* also removed an unused parameter in BookStarter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2370)
<!-- Reviewable:end -->
