### PR TITLE
Display cover image properly for Motion Books (BL-5770)

### DIFF
--- a/src/BloomBrowserUI/bookLayout/bookFeatures.less
+++ b/src/BloomBrowserUI/bookLayout/bookFeatures.less
@@ -53,6 +53,10 @@
         left: 0;
         top: 0;
 
+        // These two lines are needed to make the cover image display properly
+        width: 100%;
+        margin-top: 0;
+
         &[class*="Device16x9Landscape"] {
             width: @Device16x9Landscape-Width;
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2374)
<!-- Reviewable:end -->
