### PR TITLE
Ensure checking for overwrites on file saves

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -197,6 +197,7 @@ namespace Bloom.CollectionTab
 			{
 				dlg.FileName = Path.GetFileNameWithoutExtension(SelectedBook.GetPathHtmlFile())+".xml";
 				dlg.InitialDirectory = SelectedBook.FolderPath;
+				dlg.OverwritePrompt = true;
 				if(DialogResult.OK == dlg.ShowDialog())
 				{
 					try

--- a/src/BloomExe/Publish/Android/file/FilePublisher.cs
+++ b/src/BloomExe/Publish/Android/file/FilePublisher.cs
@@ -31,6 +31,7 @@ namespace Bloom.Publish.Android.file
 					dlg.InitialDirectory = Settings.Default.BloomDeviceFileExportFolder;
 					//(otherwise leave to default save location)
 				}
+				dlg.OverwritePrompt = true;
 				if (DialogResult.OK == dlg.ShowDialog())
 				{
 					Settings.Default.BloomDeviceFileExportFolder = Path.GetDirectoryName(dlg.FileName);

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -380,6 +380,7 @@ namespace Bloom.Publish
 					rgb = rgb.Replace("|", "");
 					swopv2 = swopv2.Replace("|", "");
 					dlg.Filter = String.Format("{0}|*.pdf|{1}|*.pdf", rgb, swopv2);
+					dlg.OverwritePrompt = true;
 					if (DialogResult.OK == dlg.ShowDialog())
 					{
 						_lastDirectory = Path.GetDirectoryName(dlg.FileName);
@@ -631,6 +632,7 @@ namespace Bloom.Publish
 													 _collectionSettings.GetLanguage1Name("en"));
 				dlg.FileName = suggestedName;
 				dlg.Filter = "EPUB|*.epub";
+				dlg.OverwritePrompt = true;
 				if (DialogResult.OK == dlg.ShowDialog())
 				{
 					_lastDirectory = Path.GetDirectoryName(dlg.FileName);


### PR DESCRIPTION
This may have been an oversight when we changed to using Gtk file
dialogs on Linux.  Two of six places had this already.  (One of
these changes is in essentially dead code.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2379)
<!-- Reviewable:end -->
