### PR TITLE
BL-5972 restore language labels for image descriptions

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -211,9 +211,13 @@ function AddEditKeyHandlers(container) {
     // so that it can be caught even when the focus isn't on the browser
 }
 
-// Add little language tags
+// Add little language tags. (At one point we limited this to visible .bloom-editable divs,
+// probably as an optimzation since there can be other-language divs present but hidden.
+// But there may be yet others that are not visible when we run this but which soon will be,
+// such as image descriptions. We don't seem to need the optimization, so let's just do
+// them all.)
 function AddLanguageTags(container) {
-    $(container).find(".bloom-editable:visible[contentEditable=true]").each(function () {
+    $(container).find(".bloom-editable[contentEditable=true]").each(function () {
         var $this = $(this);
 
         // If this DIV already had a language tag, remove the content in case we decide the situation has changed.

--- a/src/BloomBrowserUI/bookLayout/textOverPicture.less
+++ b/src/BloomBrowserUI/bookLayout/textOverPicture.less
@@ -6,7 +6,7 @@
 @DragHandleBackgroundColor: transparent;
 
 // Don't show text over picture borders or resizing handles unless hovering over the image
-.bloom-imageContainer:not(.hoverUp) {
+.bloom-imageContainer:not(.hoverUp) .bloom-textOverPicture {
     .bloom-editable {
         border: none;
         // keeps text from jumping when switching between hover/nothover states


### PR DESCRIPTION
Some other subtleties were being hidden, too, on the assumption that these were text-over-picture blocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2390)
<!-- Reviewable:end -->
