### PR TITLE
[4.2]BL-5842 Allow Picture Dict page in AddPage

### DIFF
--- a/src/BloomBrowserUI/templates/template books/Picture Dictionary/Picture Dictionary.pug
+++ b/src/BloomBrowserUI/templates/template books/Picture Dictionary/Picture Dictionary.pug
@@ -10,6 +10,18 @@ mixin field-classOnChild(internalClass)
 		block
 		+editable(kLanguageForPrototypeOnly)(class=internalClass)
 
+mixin pictureDictionary-pageContents
+	.pageLabel Picture Dictionary Page
+	.pageDescription A page with six placeholders for a picture and a word
+	.marginBox
+		+field-classOnChild('picturePageTitle-style').domain
+			label.placeholder The title
+		+repeat(6)
+			.wordAndPicture.bloom-draggable.bloom-resizable
+				+image
+				+field-classOnChild('pictureCaption-style').wordsDiv
+					label.placeholder caption
+
 doctype html
 
 html
@@ -34,17 +46,6 @@ html
 			+bookVariable-topic('th', 'พจนานุกรม')
 			+bookVariable-topic('es', 'Diccionario')
 		.bloom-page.numberedPage.images6.A5Portrait.pictureDictionaryPage#7E5B8274-C7BD-4471-B54D-50CF09E4D899
-			.pageLabel Picture Dictionary Page
-			.pageDescription A page with six placeholders for a picture and a word
-			.marginBox
-				+field-classOnChild('picturePageTitle-style').domain
-					label.placeholder The title
-				+repeat(6)
-					.wordAndPicture.bloom-draggable.bloom-resizable
-						+image
-						+field-classOnChild('pictureCaption-style').wordsDiv
-							label.placeholder caption
-
-		+standardPage-JustPicture
-		+standardPage-JustText
-		+standardPage-Custom
+			+pictureDictionary-pageContents
+		.bloom-page.numberedPage.images6.A5Portrait.pictureDictionaryPage#73747D25-B856-4910-ABFD-888F1644D980(data-page='extra')
+			+pictureDictionary-pageContents


### PR DESCRIPTION
* only if we created the book with Pict Dict template
* kluge: added an extra copy of template page
   (different Guid) that has data-page='extra'
* removed pages from template that are already
   in Basic Book

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2391)
<!-- Reviewable:end -->
