### PR TITLE
[4.2]BL-5931 Fix Publish - SaveButton l18n

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2897,10 +2897,6 @@ Do you want to go ahead?</note>
         <source xml:lang="en">Uploading {0}</source>
         <note>ID: PublishTab.Upload.UploadingStatus</note>
       </trans-unit>
-      <trans-unit id="PublishView._saveButton">
-        <source xml:lang="en">Save stub</source>
-        <note>ID: PublishView._saveButton</note>
-      </trans-unit>
       <trans-unit id="ReaderSetup.AddLevel" sil:dynamic="true">
         <source xml:lang="en">Add Level</source>
         <note>ID: ReaderSetup.AddLevel</note>

--- a/src/BloomExe/Publish/PublishView.Designer.cs
+++ b/src/BloomExe/Publish/PublishView.Designer.cs
@@ -116,6 +116,7 @@ namespace Bloom.Publish
 			this._saveButton.Image = global::Bloom.Properties.Resources.Usb;
 			this._L10NSharpExtender.SetLocalizableToolTip(this._saveButton, null);
 			this._L10NSharpExtender.SetLocalizationComment(this._saveButton, null);
+			this._L10NSharpExtender.SetLocalizationPriority(this._saveButton, L10NSharp.LocalizationPriority.NotLocalizable);
 			this._L10NSharpExtender.SetLocalizingId(this._saveButton, "PublishView._saveButton");
 			this._saveButton.Location = new System.Drawing.Point(139, 0);
 			this._saveButton.Name = "_saveButton";


### PR DESCRIPTION
* there are 2 items that should be localized
** PublishTab.SaveButton
** PublishTab.SaveEpub
* we just make sure the L10NSharpExtender uses
   one of these (they actually get set elsewhere)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2402)
<!-- Reviewable:end -->
