### PR TITLE
Prevent tidy from spacing out <sup> and <sub> (BL-5974)

### DIFF
--- a/src/BloomExe/XmlHtmlConverter.cs
+++ b/src/BloomExe/XmlHtmlConverter.cs
@@ -41,7 +41,7 @@ namespace Bloom
 
 			// It also likes to insert newlines before <b>, <u>, and <i>, and convert any existing whitespace
 			// there to a space.
-			content = new Regex(@"<([ubi]|em|strong)>").Replace(content, "REMOVEWHITESPACE<$1>");
+			content = new Regex(@"<([ubi]|em|strong|sup|sub)>").Replace(content, "REMOVEWHITESPACE<$1>");
 
 			// fix for <br></br> tag doubling
 			content = content.Replace("<br></br>", "<br />");
@@ -100,7 +100,7 @@ namespace Bloom
 
 						// The regex here is mainly for the \s as a convenient way to remove whatever whitespace TIDY
 						// has inserted. It's a fringe benefit that we can use the[bi] to deal with both elements in one replace.
-						newContents = Regex.Replace(newContents, @"REMOVEWHITESPACE\s*<([biu]|em|strong)>", "<$1>");
+						newContents = Regex.Replace(newContents, @"REMOVEWHITESPACE\s*<([biu]|em|strong|sup|sub)>", "<$1>");
 
 						//In BL2250, we still had REMOVEWHITESPACE sticking around sometimes. The way we reproduced it was
 						//with <u> </u>. That is, we started with


### PR DESCRIPTION
Bloom doesn't allow users to enter these directly, but does allow them
to be pasted in.  If that happens, there's no reason why Bloom should
insert spaces in front of every <sup> or <sub> marker.