### PR TITLE
BL-6001 restore sample print settings

### DIFF
--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -455,7 +455,6 @@ namespace Bloom.Publish
 						_saveButton.Enabled = true;
 						_printButton.Enabled = _pdfViewer.ShowPdf(_model.PdfFilePath);
 					}
-					_pdfViewer.Visible = true;
 					break;
 				case PublishModel.DisplayModes.Printing:
 					_simpleAllPagesRadio.Enabled = false;
@@ -763,6 +762,7 @@ namespace Bloom.Publish
 				_previewBox.Image = Image.FromFile(printSettingsSampleName);
 				_previewBox.Bounds = GetPreviewBounds();
 				_previewBox.SizeMode = PictureBoxSizeMode.Zoom;
+				_previewBox.BringToFront(); // prevents BL-6001
 				_previewBox.Show();
 				if (!Settings.Default.DontShowPrintNotification)
 				{


### PR DESCRIPTION
* caused by refactor of SetDisplayMode() a few days
   ago

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2408)
<!-- Reviewable:end -->
