### PR TITLE
BL-6023 Fix Story Primer Word Find js errors

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -798,7 +798,7 @@ export function bootstrap() {
     complicatedFind += ".bloom-content3[contenteditable='true'],.bloom-contentNational1[contenteditable='true']";
     $("div.bloom-page").find(complicatedFind).each(function () {
         if ($(this).hasClass("bloom-userCannotModifyStyles") ||
-            $(this).parent().hasClass("bloom-userCannotModifyStyles"))
+            $(this).parentsUntil(".marginBox").hasClass("bloom-userCannotModifyStyles"))
             return; // equivalent to 'continue'
 
         if ($(this).css("cursor") === "not-allowed")


### PR DESCRIPTION
* Word Find had bloom-userCannotModifyStyles
   on a table element several layers above the
   bloom-translationGroup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2437)
<!-- Reviewable:end -->
