### PR TITLE
Revert "fix" to br tags

### DIFF
--- a/src/BloomExe/XmlHtmlConverter.cs
+++ b/src/BloomExe/XmlHtmlConverter.cs
@@ -383,7 +383,7 @@ namespace Bloom
 
 			html = RestoreSvgs(html, removedSvgs);
 
-			html = html.Replace(BrPlaceholder, "<br/>");
+			html = html.Replace(BrPlaceholder, "<br>");
 			html = RemoveFillerInEmptyElements(html);
 			return html;
 		}


### PR DESCRIPTION
* valid html uses < br >, which isn't valid xml
* I had wanted to be able to validate the .htm files with Notepad++ xml validation...
  apparently not a good idea here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2443)
<!-- Reviewable:end -->
