### PR TITLE
Bl 6035 remove title attribute rework

### DIFF
--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -1783,7 +1783,9 @@ namespace Bloom.Publish.Epub
 				}
 				else
 				{
-					img.RemoveAttribute("title");	// We don't want this tooltip in published books.
+					var parent = img.ParentNode as XmlElement;
+					parent.RemoveAttribute("title");	// We don't want this in published books.
+					img.RemoveAttribute("title");	// We don't want this in published books.  (probably doesn't exist)
 					img.RemoveAttribute("type");	// This is invalid, but has appeared for svg branding images.
 				}
 			}


### PR DESCRIPTION
The title attribute is actually on the parent div, not on the img element itself.  Oops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2461)
<!-- Reviewable:end -->
