### PR TITLE
Fix package build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -35,6 +35,7 @@ override_dh_auto_build:
 	fi && \
 	export HOME=/tmp && \
 	. ./environ && \
+		xbuild /t:RestoreBuildTasks build/Bloom.proj && \
 		xbuild /t:SetAssemblyVersion /p:RootDir=$(shell pwd) /p:BUILD_NUMBER=$(FULL_BUILD_NUMBER) build/Bloom.proj && \
 		xbuild /p:Configuration=$(BUILD) "Bloom.sln" && \
 		xbuild /p:Configuration=$(BUILD) src/LinuxBloomLauncher/LinuxBloomLauncher.cproj


### PR DESCRIPTION
When building the debian package we need to install SIL.BuildTasks* first
before setting the assembly version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2474)
<!-- Reviewable:end -->
