### PR TITLE
BL-6095 Round 2, CheckAudioForAllText

### DIFF
--- a/src/BloomBrowserUI/publish/accessibilityCheck/accessibilityChecklist.less
+++ b/src/BloomBrowserUI/publish/accessibilityCheck/accessibilityChecklist.less
@@ -28,6 +28,19 @@
             li {
                 color: @bloom-red;
             }
+            blockquote {
+                color: darkgray;
+                width: 300px;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                margin-top: 0;
+                margin-bottom: 1em;
+                margin-left: 0;
+                &:before {
+                    content: "\201C";
+                }
+            }
         }
         // problem list
         ul {

--- a/src/BloomBrowserUI/publish/accessibilityCheck/checkItem.tsx
+++ b/src/BloomBrowserUI/publish/accessibilityCheck/checkItem.tsx
@@ -8,12 +8,16 @@ interface IProps extends IUILanguageAwareProps {
 }
 
 // Each "CheckItem" conveys the status and results of a single automated accessibility test.
-
+// this should match the struct Problem in AccessibilityCheckers.cs
+interface IProblem {
+    message: string;
+    problemText: string;
+}
 interface CheckResult {
     // this is passed, failed, unknown, or pending. Only the stylesheet cares, this code doesn't.
     resultClass: string;
     // for now, simple strings. Someday may be links to problem items.
-    problems: string[];
+    problems: IProblem[];
 }
 
 interface IState {
@@ -51,7 +55,14 @@ export class CheckItem extends React.Component<IProps, IState> {
                     {// problem descriptions are already localized by the backend
                     this.state.checkResult.problems.map((problem, index) => (
                         //react requires unique keys on each
-                        <li key={"p" + index}>{problem}</li>
+                        <li key={"p" + index}>
+                            {problem.message}
+                            {problem.problemText ? (
+                                <blockquote>{problem.problemText}</blockquote>
+                            ) : (
+                                ""
+                            )}
+                        </li>
                     ))}
                 </ul>
             </li>

--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
@@ -30,7 +30,7 @@ mixin field-ISBN
 	.ISBNContainer(data-hint="International Standard Book Number. Leave blank if you don't have one of these.")
 		span.bloom-doNotPublishIfParentOtherwiseEmpty.Credits-Page-style
 			| ISBN
-		div.bloom-translationGroup(data-default-languages="*")
+		div.bloom-translationGroup.bloom-recording-optional(data-default-languages="*")
 			div.bloom-editable(data-book="ISBN", lang="*").Credits-Page-style
 
 mixin field-acknowledgments-localizedVersion

--- a/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
+++ b/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/src/BloomTests/Book/AccessibilityCheckersTests.cs
+++ b/src/BloomTests/Book/AccessibilityCheckersTests.cs
@@ -76,7 +76,7 @@ namespace BloomTests.Book
 			Assert.AreEqual(1, results.Count(), "Should point out missing image description");
 			var expected = pageNumber ?? pageLabel;
 
-			Assert.AreEqual($"Missing image description on page {expected}", results.First());
+			Assert.AreEqual($"Missing image description on page {expected}", results.First().message);
 		}
 
 		[Test]
@@ -114,6 +114,7 @@ namespace BloomTests.Book
 		[TestCase("<p><span id='iExist' class='audio-sentence'>A flower.</span></p>")]
 		[TestCase(@"<p><span id='iExist' class='audio-sentence'>A flower.</span>
 					<span id='iExist' class='audio-sentence'>A dog.</span></p>")]
+		[TestCase(@"<label>This is bubble text</label>")]
 		public void CheckAudioForAllText_NoErrors(string content)
 		{
 			var testBook = MakeBookWithOneAudioFile($@"<div class='bloom-translationGroup'>
@@ -163,6 +164,34 @@ namespace BloomTests.Book
 								</div>");
 			var results = AccessibilityCheckers.CheckAudioForAllText(testBook);
 			Assert.Greater(results.Count(), 0, "Error should have been reported");
+		}
+
+		[Test]
+		public void CheckAudioForAllText_TextInRandomLangButVisibleAndNotRecorded_GivesError()
+		{
+			var testBook = MakeBookWithOneAudioFile($@"<div class='bloom-translationGroup'>
+										<div class='bloom-editable bloom-visibility-code-on' lang=''>
+											<p>hello</p>
+										</div>
+									</div>
+								</div>");
+			var results = AccessibilityCheckers.CheckAudioForAllText(testBook);
+			Assert.AreEqual(1,results.Count(), "The text has to be recorded because it is visible");
+		}
+
+		[Test]
+		public void CheckAudioForAllText_TextInNationalLanguageNotVisible_NotRecorded()
+		{
+			var testBook = MakeBookWithOneAudioFile($@"<div class='bloom-translationGroup'>
+										<div class='bloom-editable bloom-visibility-code-off' lang='{
+					_collectionSettings.Language2Iso639Code
+				}'>
+											<p>hello</p>
+										</div>
+									</div>
+								</div>");
+			var results = AccessibilityCheckers.CheckAudioForAllText(testBook);
+			Assert.AreEqual(0, results.Count(), "Since the text is not visible, should not give error if not recorded");
 		}
 
 		[Test]


### PR DESCRIPTION
* Filter out help bubbles
* Filter based on visibility-on instead of @lang
* Send back the text that was not recorded
* (to enable the above, switch from a simple string to a problem structure)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2493)
<!-- Reviewable:end -->
