### PR TITLE
BL-6099 Use .bak if .htm is missing

### DIFF
--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -171,13 +171,22 @@ namespace Bloom.Collection
 			_bookInfos.Add(bookInfo);
 		}
 
+		private bool BackupFileExists(string folderPath)
+		{
+			var bakFiles = Directory.GetFiles(folderPath, BookStorage.BackupFilename);
+			return bakFiles.Length == 1 && RobustFile.Exists(bakFiles[0]);
+		}
+
 		private void AddBookInfo(string folderPath)
 		{
 			try
 			{
 				//this is handy when windows explorer won't let go of the thumbs.db file, but we want to delete the folder
-				if (Directory.GetFiles(folderPath, "*.htm").Length == 0 && Directory.GetFiles(folderPath, "*.html").Length == 0)
-					return;
+				if (Directory.GetFiles(folderPath, "*.htm").Length == 0 &&
+					Directory.GetFiles(folderPath, "*.html").Length == 0 &&
+					// BL-6099: don't hide the book if we at least have a valid backup file
+					!BackupFileExists(folderPath))
+						return;
 				var bookInfo = new BookInfo(folderPath, Type == CollectionType.TheOneEditableCollection);
 
 				_bookInfos.Add(bookInfo);

--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -134,9 +134,9 @@ namespace Bloom.CollectionTab
 
 		private IEnumerable<BookCollection> GetBookCollectionsOnce()
 		{
-			var editableCllection = _bookCollectionFactory(_pathToLibrary, BookCollection.CollectionType.TheOneEditableCollection);
-			_currentEditableCollectionSelection.SelectCollection(editableCllection);
-			yield return editableCllection;
+			var editableCollection = _bookCollectionFactory(_pathToLibrary, BookCollection.CollectionType.TheOneEditableCollection);
+			_currentEditableCollectionSelection.SelectCollection(editableCollection);
+			yield return editableCollection;
 
 			foreach (var bookCollection in _sourceCollectionsList.GetSourceCollectionsFolders())
 				yield return _bookCollectionFactory(bookCollection, BookCollection.CollectionType.SourceCollection);


### PR DESCRIPTION
* fixed a couple of typos
* cached PathToExistingHtml
* books with only .bak file will now show in collection
* when such a book is selected,
   ExpensiveInitialization will try to restore the backup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2498)
<!-- Reviewable:end -->
