### PR TITLE
BL-6117 Let Ace-by-Daisy checker make its own epub as needed

### DIFF
--- a/src/BloomBrowserUI/publish/accessibilityCheck/accessibilityCheckScreen.tsx
+++ b/src/BloomBrowserUI/publish/accessibilityCheck/accessibilityCheckScreen.tsx
@@ -21,7 +21,7 @@ class AccessibilityCheckScreen extends React.Component<{}, IState> {
     public componentDidMount() {
         // Listen for changes to state from C#-land
         WebSocketManager.addListener("a11yChecklist", event => {
-            this.refresh();
+            if (event.data === "bookSelectionChanged") this.refresh();
         });
         this.refresh();
     }

--- a/src/BloomBrowserUI/publish/accessibilityCheck/accessibilityChecklist.tsx
+++ b/src/BloomBrowserUI/publish/accessibilityCheck/accessibilityChecklist.tsx
@@ -33,7 +33,12 @@ export class AccessibilityChecklist extends React.Component<
     // a function that causes it to refresh.
     private subscribeChildToRefreshEvent(childRefreshFunction) {
         WebSocketManager.addListener("a11yChecklist", event => {
-            childRefreshFunction();
+            if (
+                event.data === "bookSelectionChanged" ||
+                event.data === "bookContentsMayHaveChanged"
+            ) {
+                childRefreshFunction();
+            }
         });
     }
 

--- a/src/BloomBrowserUI/publish/accessibilityCheck/checkItem.tsx
+++ b/src/BloomBrowserUI/publish/accessibilityCheck/checkItem.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { IUILanguageAwareProps } from "../../react_components/l10n";
 import axios from "axios";
-import WebSocketManager from "../../utils/WebSocketManager";
+
 interface IProps extends IUILanguageAwareProps {
     apiCheckName: string;
     label: string;

--- a/src/BloomBrowserUI/publish/accessibilityCheck/daisyChecks.less
+++ b/src/BloomBrowserUI/publish/accessibilityCheck/daisyChecks.less
@@ -12,11 +12,29 @@
         padding: 1em;
         font-size: 14pt;
     }
+    #progress-box {
+        padding: 10px;
+    }
+    #report {
+        display: flex;
+        flex-direction: column;
+        #refresh {
+            margin-left: auto;
+            margin-right: 30px;
+            margin-top: 10px;
+            color: @bloom-blue;
+            &:before {
+                content: "⟳";
+                font-size: 18px;
+                font-weight: bold;
+            }
+        }
 
-    iframe {
-        margin: 0;
-        width: 100%;
-        height: unset;
-        flex: 1;
+        iframe {
+            margin: 0;
+            width: 100%;
+            height: unset;
+            flex: 1;
+        }
     }
 }

--- a/src/BloomBrowserUI/publish/epub/epubPublishUI.tsx
+++ b/src/BloomBrowserUI/publish/epub/epubPublishUI.tsx
@@ -169,7 +169,6 @@ class EpubPublishUI extends React.Component<IUILanguageAwareProps, IState> {
                         <Link
                             id="a11yCheckerLink"
                             l10nKey="AccessibilityCheck.ShowAccessibilityChecker"
-                            href=""
                             onClick={() =>
                                 axios.post(
                                     "/bloom/api/accessibilityCheck/showAccessibilityChecker"

--- a/src/BloomBrowserUI/react_components/link.tsx
+++ b/src/BloomBrowserUI/react_components/link.tsx
@@ -13,7 +13,11 @@ interface ILinkProps extends ILocalizationProps {
 export class Link extends LocalizableElement<ILinkProps, {}> {
     public render() {
         return (
-            <a id={"" + this.props.id} href={this.props.href} onClick={this.props.onClick}>
+            <a
+                id={"" + this.props.id}
+                href={this.props.href}
+                onClick={this.props.onClick}
+            >
                 {this.getLocalizedContent()}
             </a>
         );

--- a/src/BloomBrowserUI/react_components/progressBox.tsx
+++ b/src/BloomBrowserUI/react_components/progressBox.tsx
@@ -18,7 +18,10 @@ interface IProgressState {
 
 // Note that this component does not do localization; we expect the progress messages
 // to already be localized when they are sent over the websocket.
-export default class ProgressBox extends React.Component<IProgressBoxProps, IProgressState> {
+export default class ProgressBox extends React.Component<
+    IProgressBoxProps,
+    IProgressState
+> {
     constructor(props: IProgressBoxProps) {
         super(props);
         let self = this;
@@ -28,36 +31,39 @@ export default class ProgressBox extends React.Component<IProgressBoxProps, IPro
             var e = JSON.parse(event.data);
             if (e.id === "progress") {
                 if (e.style) {
-                    self.setState({
-                        progress:
-                            self.state.progress +
-                            "<span style='" +
-                            e.style +
-                            "'>" +
-                            e.payload +
-                            "</span><br/>"
-                    });
+                    this.writeLine(
+                        `<span style='${e.style}'>${e.payload}</span>`
+                    );
                 } else {
-                    self.setState({
-                        progress: self.state.progress + e.payload + "<br/>"
-                    });
+                    this.writeLine(e.payload);
                 }
                 this.tryScrollToBottom();
             }
         });
         if (props.onReadyToReceive) {
-            WebSocketManager.notifyReady(props.lifetimeLabel, props.onReadyToReceive);
+            WebSocketManager.notifyReady(
+                props.lifetimeLabel,
+                props.onReadyToReceive
+            );
         }
     }
 
-    tryScrollToBottom() {
+    public write(htmlToAdd: string) {
+        this.setState({
+            progress: this.state.progress + htmlToAdd
+        });
+    }
+    public writeLine(htmlToAdd: string) {
+        this.write(htmlToAdd + "<br/>");
+    }
+
+    private tryScrollToBottom() {
         // Must be done AFTER painting once, so we
         // get a real current scroll height.
         let progressDiv = document.getElementById("progress-box");
 
         // in my testing in FF, this worked the first time
-        if (progressDiv)
-            progressDiv.scrollTop = progressDiv.scrollHeight;
+        if (progressDiv) progressDiv.scrollTop = progressDiv.scrollHeight;
         // but there apparently have been times when the div wasn't around
         // yet, so we do this:
         else {
@@ -67,9 +73,12 @@ export default class ProgressBox extends React.Component<IProgressBoxProps, IPro
         }
     }
 
-    render() {
+    public render() {
         return (
-            <div id="progress-box" dangerouslySetInnerHTML={{ __html: this.state.progress }} />
+            <div
+                id="progress-box"
+                dangerouslySetInnerHTML={{ __html: this.state.progress }}
+            />
         );
     }
 }

--- a/src/BloomExe/Publish/Android/usb/UsbPublisher.cs
+++ b/src/BloomExe/Publish/Android/usb/UsbPublisher.cs
@@ -55,9 +55,9 @@ namespace Bloom.Publish.Android.usb
 					// on another thread.
 					_connectionHandler = new BackgroundWorker();
 				}
-				_progress.Message(id: "LookingForDevice",
-					message: "Looking for an Android device connected by USB cable and set up for MTP...",
-					comment: "This is a progress message; MTP is an acronym for the system that allows computers to access files on devices.");
+				_progress.Message(idSuffix: "LookingForDevice",
+					comment: "This is a progress message; MTP is an acronym for the system that allows computers to access files on devices.",
+					message: "Looking for an Android device connected by USB cable and set up for MTP...");
 
 				_androidDeviceUsbConnection.OneReadyDeviceFound = HandleFoundAReadyDevice;
 				_androidDeviceUsbConnection.OneReadyDeviceNotFound = HandleFoundOneNonReadyDevice;
@@ -84,15 +84,15 @@ namespace Bloom.Publish.Android.usb
 
 		public void Stop()
 		{
-			_progress.Message(id: "Stopped", message: "Stopped");
+			_progress.Message(idSuffix: "Stopped", message: "Stopped");
 			_androidDeviceUsbConnection.StopFindingDevice();
 		}
 
 		private void UsbFailConnect(Exception e)
 		{
 			Stop();
-			_progress.Message(id: "UnableToConnect",
-				message: "Unable to connect to any Android device which has Bloom Reader.");
+			_progress.Message(idSuffix: "UnableToConnect",
+				 message: "Unable to connect to any Android device which has Bloom Reader.");
 
 			_progress.ErrorWithoutLocalizing("\tTechnical details to share with the development team: " + e);
 			Logger.WriteError(e);
@@ -101,7 +101,7 @@ namespace Bloom.Publish.Android.usb
 
 		private void HandleFoundAReadyDevice(Book.Book book, Color backColor)
 		{
-			_progress.MessageWithParams(id: "Connected",
+			_progress.MessageWithParams(idSuffix: "Connected",
 				message: "Connected to {0} via USB...",
 				comment: "{0} is a the name of the device Bloom connected to",
 				parameters: _androidDeviceUsbConnection.GetDeviceName());
@@ -126,13 +126,13 @@ namespace Bloom.Publish.Android.usb
 					// I made this "running" instead of "installed" because I'm assuming
 					// we wouldn't get a bloom directory just from installing. We don't actually need it to be
 					// running, but this keeps the instructions simple.
-					_progress.Message(id: "DeviceWithoutBloomReader",
+					_progress.Message(idSuffix: "DeviceWithoutBloomReader",
 						message: "The following devices are connected but do not seem to have Bloom Reader running:");
 					foreach (var deviceName in deviceNames)
 						_progress.MessageWithoutLocalizing($"\t{deviceName}");
 					break;
 				case DeviceNotFoundReportType.MoreThanOneReadyDevice:
-					_progress.Message(id: "MoreThanOne",
+					_progress.Message(idSuffix: "MoreThanOne",
 						message: "The following connected devices all have Bloom Reader installed. Please connect only one of these devices.");
 					foreach (var deviceName in deviceNames)
 						_progress.MessageWithoutLocalizing($"\t{deviceName}");
@@ -204,7 +204,7 @@ namespace Bloom.Publish.Android.usb
 			}
 			else
 			{
-				_progress.Error(id: "FailureToSend",
+				_progress.Error(idSuffix: "FailureToSend",
 					message: "An error occurred and the book was not sent to your Android device.");
 				if (e != null)
 				{

--- a/src/BloomExe/Publish/Android/wifi/WiFiAdvertiser.cs
+++ b/src/BloomExe/Publish/Android/wifi/WiFiAdvertiser.cs
@@ -57,7 +57,7 @@ namespace Bloom.Publish.Android.wifi
 
 		private void Work()
 		{
-			_progress.Message(id:"beginAdvertising", message:"Advertising book to Bloom Readers on local network...");
+			_progress.Message(idSuffix: "beginAdvertising", message: "Advertising book to Bloom Readers on local network...");
 			try
 			{
 				while (true)
@@ -72,7 +72,7 @@ namespace Bloom.Publish.Android.wifi
 			}
 			catch (ThreadAbortException)
 			{
-				_progress.Message(id: "Stopped", message: "Stopped Advertising.");
+				_progress.Message(idSuffix: "Stopped", message: "Stopped Advertising.");
 				_client.Close();
 			}
 			catch (Exception error)

--- a/src/BloomExe/Publish/Android/wifi/WiFiPublisher.cs
+++ b/src/BloomExe/Publish/Android/wifi/WiFiPublisher.cs
@@ -73,7 +73,7 @@ namespace Bloom.Publish.Android.wifi
 				// just ignore the request.
 				catch (Exception ex) when (ex is JsonReaderException || ex is JsonSerializationException)
 				{
-					_progress.Error(id: "BadBookRequest",
+					_progress.Error(idSuffix: "BadBookRequest",
 						message: "Got a book request we could not process. Possibly the device is running an incompatible version of BloomReader?");
 
 					//this is too technical/hard to translate
@@ -92,10 +92,10 @@ namespace Bloom.Publish.Android.wifi
 			PublishToAndroidApi.CheckBookLayout(book, _progress);
 			_wifiAdvertiser.Start();
 
-			_progress.Message(id: "WifiInstructions1",
-				message:"On the Android, run Bloom Reader, open the menu and choose 'Receive Books from computer'.");
-			_progress.Message(id: "WifiInstructions2",
-				message:"You can do this on as many devices as you like. Make sure each device is connected to the same network as this computer.");
+			_progress.Message(idSuffix: "WifiInstructions1",
+				message: "On the Android, run Bloom Reader, open the menu and choose 'Receive Books from computer'.");
+			_progress.Message(idSuffix: "WifiInstructions2",
+				message: "You can do this on as many devices as you like. Make sure each device is connected to the same network as this computer.");
 		}
 
 		public void Stop()
@@ -210,7 +210,7 @@ namespace Bloom.Publish.Android.wifi
 					_wifiSender.UploadDataAsync(new Uri(androidHttpAddress + "/putfile?path=" + Uri.EscapeDataString(publishedFileName)), File.ReadAllBytes(bloomDPath));
 				},
 				_progress,
-				(publishedFileName, bookTitle) => _progress.GetMessageWithParams(id: "Sending",
+				(publishedFileName, bookTitle) => _progress.GetMessageWithParams(idSuffix: "Sending",
 					comment: "{0} is the name of the book, {1} is the name of the device",
 					message: "Sending \"{0}\" to device {1}",
 					parameters: new object[] { bookTitle, androidName }),
@@ -242,7 +242,7 @@ namespace Bloom.Publish.Android.wifi
 			{
 				// This method is called on a background thread in response to receiving a request from Bloom Reader.
 				// Exceptions somehow get discarded, so there is no point in letting them propagate further.
-				_progress.Error(id: "Failed",
+				_progress.Error(idSuffix: "Failed",
 					message: "There was an error while sending the book. Possibly the device was disconnected? If you can't see a "
 					         + "reason for this the following may be helpful to report to the developers:");
 				_progress.Exception(e);

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -70,6 +70,8 @@ namespace Bloom.Publish.Epub
 	/// </summary>
 	public class EpubMaker : IDisposable
 	{
+		public delegate EpubMaker Factory();// autofac uses this
+
 		public const string kEPUBExportFolder = "ePUB export";
 		protected const string kEpubNamespace = "http://www.idpf.org/2007/ops";
 
@@ -194,6 +196,7 @@ namespace Bloom.Publish.Epub
 			if(!string.IsNullOrEmpty(BookInStagingFolder))
 				return; //already staged
 
+			progress.Message("BuildingEPub", comment:"Shown in a progress box when Bloom is starting to creat an epub", message:"Building Epub");
 			if (String.IsNullOrEmpty(Book.CollectionSettings.Language3Iso639Code))
 				_langsForLocalization = new string[] { Book.CollectionSettings.Language1Iso639Code, Book.CollectionSettings.Language2Iso639Code };
 			else
@@ -1511,15 +1514,16 @@ namespace Bloom.Publish.Epub
 			if(string.IsNullOrEmpty (BookInStagingFolder)) {
 				StageEpub(progress);
 			}
-			FinishEpub (destinationEpubPath);
+			ZipAndSaveEpub (destinationEpubPath, progress);
 		}
 
 		/// <summary>
 		/// Finish publishing an ePUB that has been staged, by zipping it into the desired final file.
 		/// </summary>
 		/// <param name="destinationEpubPath"></param>
-		public void FinishEpub (string destinationEpubPath)
+		public void ZipAndSaveEpub (string destinationEpubPath, IWebSocketProgress progress)
 		{
+			progress.Message("Saving", comment:"Shown in a progress box when Bloom is saving an epub", message:"Saving");
 			var zip = new BloomZipFile (destinationEpubPath);
 			foreach (var file in Directory.GetFiles (BookInStagingFolder))
 				zip.AddTopLevelFile (file);
@@ -1760,7 +1764,7 @@ namespace Bloom.Publish.Epub
 			_browser.WebBrowser.NavigationError += (object sender, Gecko.Events.GeckoNavigationErrorEventArgs e) => done = true;
 			_browser.Navigate (normalDom, source: "epub");
 			while (!done) {
-				Application.DoEvents ();
+				Application.DoEvents (); // NOTE: this has bad consequences all down the line. See BL-6122.
 				Application.RaiseIdle (new EventArgs ()); // needed on Linux to avoid deadlock starving browser navigation
 			}
 

--- a/src/BloomExe/web/WebSocketProgress.cs
+++ b/src/BloomExe/web/WebSocketProgress.cs
@@ -34,14 +34,14 @@ namespace Bloom.web
 		{
 			MessageWithoutLocalizing($"<span style='color:red'>{message}</span>", args);
 		}
-		public void Error(string id, string message)
+		public void Error(string idSuffix, string message)
 		{
-			ErrorWithoutLocalizing(LocalizationManager.GetDynamicString(appId: "Bloom", id: _l10IdPrefix + id, englishText: message));
+			ErrorWithoutLocalizing(LocalizationManager.GetDynamicString(appId: "Bloom", id: _l10IdPrefix + idSuffix, englishText: message));
 		}
 
 		public void MessageWithoutLocalizing(string message, params object[] args)
 		{
-			_bloomWebSocketServer.Send("progress", message);
+			_bloomWebSocketServer.Send("progress", String.Format(message, args));
 		}
 
 		public void MessageWithStyleWithoutLocalizing(string message, string style)
@@ -49,53 +49,57 @@ namespace Bloom.web
 			_bloomWebSocketServer.Send("progress", message, style);
 		}
 
-		public void Message(string id, string message, string comment = null)
+		public void Message(string idSuffix, string comment, string message)
 		{
-			MessageWithoutLocalizing(LocalizationManager.GetDynamicString(appId: "Bloom", id: _l10IdPrefix + id, englishText: message, comment: comment));
+			MessageWithoutLocalizing(LocalizationManager.GetDynamicString(appId: "Bloom", id: _l10IdPrefix + idSuffix, englishText: message, comment: comment));
+		}
+		public void Message(string idSuffix, string message)
+		{
+			MessageWithoutLocalizing(LocalizationManager.GetDynamicString(appId: "Bloom", id: _l10IdPrefix + idSuffix, englishText: message));
 		}
 
 		// Use with care: if the first parameter is a string, you can leave out one of the earlier arguments with no compiler warning.
-		public void MessageWithParams(string id, string comment, string message, params object[] parameters)
+		public void MessageWithParams(string idSuffix, string comment, string message, params object[] parameters)
 		{
-			var formatted = GetMessageWithParams(id, comment, message, parameters);
+			var formatted = GetMessageWithParams(idSuffix, comment, message, parameters);
 			MessageWithoutLocalizing(formatted);
 		}
 
 		// Use with care: if the first parameter is a string, you can leave out one of the earlier arguments with no compiler warning.
-		public void ErrorWithParams(string id, string comment, string message, params object[] parameters)
+		public void ErrorWithParams(string idSuffix, string comment, string message, params object[] parameters)
 		{
-			var formatted = GetMessageWithParams(id, comment, message, parameters);
+			var formatted = GetMessageWithParams(idSuffix, comment, message, parameters);
 			ErrorWithoutLocalizing(formatted);
 		}
 
 		// Use with care: if the first parameter is a string, you can leave out one of the earlier arguments with no compiler warning.
-		public void MessageWithColorAndParams(string id, string comment, string color, string message, params object[] parameters)
+		public void MessageWithColorAndParams(string idSuffix, string comment, string color, string message, params object[] parameters)
 		{
-			var formatted = GetMessageWithParams(id, comment, message, parameters);
+			var formatted = GetMessageWithParams(idSuffix, comment, message, parameters);
 			MessageWithoutLocalizing("<span style='color:" + color + "'>" + formatted + "</span>");
 		}
 
 		// Use with care: if the first parameter is a string, you can leave out one of the earlier arguments with no compiler warning.
-		public string GetMessageWithParams(string id, string comment, string message, params object[] parameters)
+		public string GetMessageWithParams(string idSuffix, string comment, string message, params object[] parameters)
 		{
 			Debug.Assert(message.Contains("{0}"));
-			var localized = LocalizationManager.GetDynamicString(appId: "Bloom", id: _l10IdPrefix + id, englishText: message,
+			var localized = LocalizationManager.GetDynamicString(appId: "Bloom", id: _l10IdPrefix + idSuffix, englishText: message,
 				comment: comment);
 			var formatted = String.Format(localized, parameters);
 			return formatted;
 		}
 
-		public void MessageUsingTitle(string id, string message, string bookTitle)
+		public void MessageUsingTitle(string idSuffix, string message, string bookTitle)
 		{
-			var formatted = GetTitleMessage(id, message, bookTitle);
+			var formatted = GetTitleMessage(idSuffix, message, bookTitle);
 			MessageWithoutLocalizing(formatted);
 		}
 
-		public string GetTitleMessage(string id, string message, string bookTitle)
+		public string GetTitleMessage(string idSuffix, string message, string bookTitle)
 		{
 			Debug.Assert(message.Contains("{0}"));
 			Debug.Assert(!message.Contains("{1}"));
-			var localized = LocalizationManager.GetDynamicString(appId: "Bloom", id: _l10IdPrefix + id, englishText: message,
+			var localized = LocalizationManager.GetDynamicString(appId: "Bloom", id: _l10IdPrefix + idSuffix, englishText: message,
 				comment: "{0} is a book title");
 			var formatted = String.Format(localized, bookTitle);
 			return formatted;
@@ -114,6 +118,7 @@ namespace Bloom.web
 	{
 		void MessageWithoutLocalizing(string message, params object[] args);
 		void ErrorWithoutLocalizing(string message, params object[] args);
+		void Message(string idSuffix, string comment, string message);
 		void MessageWithParams(string id, string comment, string message, params object[] parameters);
 		void ErrorWithParams(string id, string comment, string message, params object[] parameters);
 		void MessageWithColorAndParams(string id, string comment, string color, string message, params object[] parameters);
@@ -127,6 +132,10 @@ namespace Bloom.web
 		}
 
 		public void ErrorWithoutLocalizing(string message, params object[] args)
+		{
+		}
+
+		public void Message(string id, string comment, string message)
 		{
 		}
 

--- a/src/BloomExe/web/controllers/ApiRequest.cs
+++ b/src/BloomExe/web/controllers/ApiRequest.cs
@@ -110,9 +110,18 @@ namespace Bloom.Api
 			_requestInfo.ReplyWithImage(imagePath);
 		}
 
+		/// <summary>
+		/// Use this one in cases where the error has already been output to a progress box,
+		/// and repeating the error is just noise.
+		/// </summary>
+		public void Failed()
+		{
+			_requestInfo.ContentType = "text/plain";
+			_requestInfo.WriteError(503);
+		}
+
 		public void Failed(string text)
 		{
-			//Debug.WriteLine(this.Requestinfo.LocalPathWithoutQuery+": "+text);
 			_requestInfo.ContentType = "text/plain";
 			_requestInfo.WriteError(503, text);
 		}

--- a/src/BloomTests/Book/BookCompressorTests.cs
+++ b/src/BloomTests/Book/BookCompressorTests.cs
@@ -715,6 +715,11 @@ namespace BloomTests.Book
 				ErrorsNotLocalized.Add(message);
 			}
 
+			public void Message(string idSuffix, string comment, string message)
+			{
+				MessagesNotLocalized.Add(string.Format(message));
+			}
+
 			public void MessageWithParams(string id, string comment, string message, params object[] parameters)
 			{
 				MessagesNotLocalized.Add(string.Format(message, parameters));


### PR DESCRIPTION
Also:
Added a manual refresh button
Simplified state down to just the report, since we can use progress for everything else.
Expanded but simplified error reporting when trying to find and run node/npm/ace-by-daisy.
Make web socket message be able to have a simple message  without parameters.
normalized the order of arguments in these websocket messaging.
Changed the localization id parameter from "id" to "idSuffix" to help us remember that in this context, some parent has already set up most of the id.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2505)
<!-- Reviewable:end -->
