### PR TITLE
BL-5998 Fix text visibility in Export to Word

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1842,5 +1842,20 @@ namespace Bloom.Book
 			// Images in accessible epubs should have explicit empty alt attr if no useful description
 			img.SetAttribute("alt", "");
 		}
+
+		/// <summary>
+		/// Intended for Export to Word/Libre Office only. Sets an inline style to a given value, adding to what
+		/// might already be there.
+		/// </summary>
+		/// <param name="element"></param>
+		/// <param name="styleToSet"></param>
+		public static void SetInlineStyle(XmlElement element, string styleToSet)
+		{
+			var styleString = GetAttributeValue(element, "style");
+			if (!string.IsNullOrWhiteSpace(styleString))
+				styleString += " ";
+			styleString += styleToSet;
+			element.SetAttribute("style", styleString);
+		}
 	}
 }


### PR DESCRIPTION
* added an inline style attribute to each editable div
   turning display on or off depending on whether
   it had bloom-visibility-code-on or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2507)
<!-- Reviewable:end -->
