### PR TITLE
Back out dysfunctional high DPI fix

### DIFF
--- a/src/BloomExe/app.config
+++ b/src/BloomExe/app.config
@@ -128,9 +128,4 @@ that is bundled with the nuget package under the tools folder.-->
         <add key="AWSProfileName" value="" />
         <add key="CoreProductName" value="Bloom" />
     </appSettings>
-    <!-- Recommended in https://docs.microsoft.com/en-us/dotnet/framework/winforms/high-dpi-support-in-windows-forms
-    to improve handling of high-dpi monitors in Windows 10. -->
-    <System.Windows.Forms.ApplicationConfigurationSection>
-        <add key="DpiAwareness" value="PerMonitorV2" />
-    </System.Windows.Forms.ApplicationConfigurationSection>
 </configuration>


### PR DESCRIPTION
The fix targets .Net 4.7 which we don't use in Bloom.  It doesn't work on
Windows and it crashes the program on Linux.  (See the Remarks section in
https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/winforms/.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2513)
<!-- Reviewable:end -->
