### PR TITLE
BL-6036 Indicate if we changed recording device as we started recording

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -329,6 +329,9 @@ export default class AudioRecording {
             .post("/bloom/api/audio/startRecord?id=" + id)
             .then(result => {
                 this.setStatus("record", Status.Active);
+                // The active device MIGHT have changed, if the user unplugged since we
+                // chose it.
+                this.updateInputDeviceDisplay();
             })
             .catch(error => {
                 toastr.error(error.statusText);


### PR DESCRIPTION
(Typically because the selected device has been unplugged...or because of a bug in libpalaso.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2514)
<!-- Reviewable:end -->
