### PR TITLE
Fix dropdown menus to stay up for Linux/Gnome (BL-6107)

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -111,8 +111,36 @@ namespace Bloom.Edit
 			_cutButton.ImageAttributes.SetColorMatrix(colorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
 			_pasteButton.ImageAttributes.SetColorMatrix(colorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
 			_copyButton.ImageAttributes.SetColorMatrix(colorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Bitmap);
+
+			// Prevent the layout choices and book language dropdown menus from closing
+			// immediately in Linux/Gnome (default for ubuntu 18.04 aka bionic).
+			_layoutChoices.DropDown.Closing += DropDown_Closing;
+			_contentLanguagesDropdown.DropDown.Closing += DropDown_Closing;
 #endif
 		}
+
+#if __MonoCS__
+		/// <summary>
+		/// Prevent the book language and layout dropdown menus from closing prematurely.
+		/// This is a big problem for Gnome, which is the default window manager in Ubuntu 18.04.
+		/// Clicking outside the menu will no longer automatically close the menu with this fix.
+		/// </summary>
+		/// <remarks>
+		/// See https://silbloom.myjetbrains.com/youtrack/issue/BL-6107.
+		/// See also WorkspaceView.DropDown_Closing (UI language menu dropdown).
+		/// </remarks>
+		void DropDown_Closing(object sender, ToolStripDropDownClosingEventArgs e)
+		{
+			//Console.WriteLine("DEBUG DropDown_Closing: reason = {0}", e.CloseReason.ToString());
+			if (e.CloseReason == ToolStripDropDownCloseReason.AppFocusChange)
+				e.Cancel = true;
+		}
+
+		// We could use the _*Choices.DropDown.MouseLeave events to close the dropdown menus,
+		// but that's as abnormal as the current behavior of not closing when clicking outside
+		// the menu.  The current behavior has already been around for the UI language dropdown
+		// menu for some time, so users may well have seen it before.
+#endif
 
 		/// <summary>
 		/// Might add a menu item to the Gecko context menu.

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -305,6 +305,7 @@ namespace Bloom.Workspace
 			_uiLanguageMenu.DropDown.Closing += DropDown_Closing;
 			// one side-effect of the above is if the _uiLanguageMenu dropdown is open, a click on the _helpMenu won't close it
 			_helpMenu.Click += (sender, args) => _uiLanguageMenu.DropDown.Close(ToolStripDropDownCloseReason.ItemClicked);
+			_helpMenu.DropDown.Closing += DropDown_Closing;
 
 			// Removing this for now (BL-5111)
 			//_uiLanguageMenu.DropDownItems.Add(new ToolStripSeparator());
@@ -331,6 +332,8 @@ namespace Bloom.Workspace
 					e.Cancel = true;
 					break;
 				case ToolStripDropDownCloseReason.AppClicked:
+					if (sender == _helpMenu.DropDown)
+						break;
 					// "reason" is AppClicked, but is it legit?
 					// Every other time we get AppClicked even if we are just hovering over the help menu.
 					var mousePos = _helpMenu.Owner.PointToClient(MousePosition);


### PR DESCRIPTION
This perhaps should be considered for backporting to 4.2 or even 4.1.