### PR TITLE
Fix thumbnailer problem

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -987,6 +987,8 @@ namespace Bloom.CollectionTab
 				{
 					_bookThumbnails.Images[imageIndex] = image;
 					var button = FindBookButton(bookInfo);
+					if (button == null || button.IsDisposed)
+						return; // I (gjm) found that this condition occurred sometimes when testing BL-6100
 					button.Image = IsUsableBook(button) ? image : MakeDim(image);
 				}
 			}


### PR DESCRIPTION
* I found this condition occurred from time to time
   when doing a lot of quick duplicating of pages and
   moving from book to book. (testing BL-6100)
* It's not too serious as it only green screen's on
   a Debug build, but hey, might as well stop it from
   throwing an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2545)
<!-- Reviewable:end -->
