### PR TITLE
BL-6167 Img tag in datadiv kills Paste Credits

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1812,7 +1812,14 @@ namespace Bloom.Book
 		public static string GetNumberOrLabelOfPageWhereElementLives(XmlElement childElement)
 		{
 			var pageElement = childElement.SelectSingleNode("ancestor-or-self::div[contains(@class,'bloom-page')]") as XmlElement;
-			// optional becuase unit tests might be missing data-page-number
+			if (pageElement == null)
+			{
+#if DEBUG
+				throw new ApplicationException("Don't feed non-page images to this method!");
+#endif
+				return "unknown";
+			}
+			// optional because unit tests might be missing data-page-number
 			var pageNumber = pageElement.GetOptionalStringAttribute("data-page-number","unknown");
 			if (
 				// front matter won't have a pageNumber

--- a/src/BloomExe/web/controllers/ImageApi.cs
+++ b/src/BloomExe/web/controllers/ImageApi.cs
@@ -256,6 +256,8 @@ namespace Bloom.web.controllers
 			var imageNameToPages = new Dictionary<string, List<string>>();
 			foreach (XmlElement img in HtmlDom.SelectChildImgAndBackgroundImageElements(domBody as XmlElement))
 			{
+				if (IsElementNotInAPage(img))
+					continue;
 				var name = HtmlDom.GetImageElementUrl(img).PathOnly.NotEncoded;
 				var pageNum = HtmlDom.GetNumberOrLabelOfPageWhereElementLives(img);
 				if (string.IsNullOrWhiteSpace(pageNum))
@@ -274,6 +276,11 @@ namespace Bloom.web.controllers
 				}
 			}
 			return imageNameToPages;
+		}
+
+		private static bool IsElementNotInAPage(XmlElement element)
+		{
+			return !(element.SelectSingleNode("ancestor-or-self::div[contains(@class,'bloom-page')]") is XmlElement);
 		}
 
 		/// <summary>

--- a/src/BloomTests/web/controllers/ImageApiTests.cs
+++ b/src/BloomTests/web/controllers/ImageApiTests.cs
@@ -307,6 +307,24 @@ namespace BloomTests.web.controllers
 		}
 
 		[Test]
+		public void GetFilteredImageNameToPagesDictionary_WorksWithBishmallahImageInDataDiv()
+		{
+			const string xhtml = @"
+<body>
+	<div id=""bloomDataDiv"">
+		<div lang=""*"" data-book=""bishmallah"">
+			<img alt="""" src=""myBishmallahImage.png""/>
+		</div>
+	</div>
+</body>";
+
+			var dom = new XmlDocument();
+			dom.LoadXml(xhtml);
+			var imageNameToPages = _apiObject.GetFilteredImageNameToPagesDictionary(dom.SelectSingleNode("//body"));
+			Assert.AreEqual(0, imageNameToPages.Keys.Count, "Unique image is not on a bloom-page");
+		}
+
+		[Test]
 		public void CollectFormattedCredits_SingleCredit_Works()
 		{
 			_creditsToFormat.Add("my credit", new List<string> {"Front Cover", "2"});


### PR DESCRIPTION
* instead of returning a page label, will return a
   data-book name (e.g. 'bishmallah')

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2546)
<!-- Reviewable:end -->
