### PR TITLE
BL-6130 Fix Ally Checker link

### DIFF
--- a/src/BloomBrowserUI/react_components/link.tsx
+++ b/src/BloomBrowserUI/react_components/link.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { ILocalizationProps, LocalizableElement } from "./l10n";
 
 interface ILinkProps extends ILocalizationProps {
@@ -14,7 +13,9 @@ export class Link extends LocalizableElement<ILinkProps, {}> {
         return (
             <a
                 id={"" + this.props.id}
-                href={this.props.href}
+                // href must be defined in order to maintain normal link UI
+                // I tried to do like the 'id' attribute above, but it caused an error.
+                href={this.props.href ? this.props.href : ""}
                 onClick={this.props.onClick}
             >
                 {this.getLocalizedContent()}


### PR DESCRIPTION
* normal link UI (pointer cursor and underscore)
   go away if 'href' is undefined on Link
* but putting in href="dummy" causes an error
   when the image server can't find a file "dummy"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2547)
<!-- Reviewable:end -->
