### PR TITLE
BL-6195 Prevent searching installed folders for certain files

### DIFF
--- a/src/BloomExe/Book/BloomReaderFileMaker.cs
+++ b/src/BloomExe/Book/BloomReaderFileMaker.cs
@@ -25,9 +25,12 @@ namespace Bloom.Book
 		public static Book PrepareBookForBloomReader(Book book, BookServer bookServer, TemporaryFolder temp, Color backColor,
 			IWebSocketProgress progress)
 		{
-			var modifiedBook = BookCompressor.MakeDeviceXmatterTempBook(book, bookServer, temp.FolderPath);
+			// MakeDeviceXmatterTempBook needs to be able to copy customCollectionStyles.css etc into parent of bookFolderPath
+			var bookFolderPath = Path.Combine(temp.FolderPath, "PlaceForBook");
+			Directory.CreateDirectory(bookFolderPath);
+			var modifiedBook = BookCompressor.MakeDeviceXmatterTempBook(book, bookServer, bookFolderPath);
 
-			var jsonPath = Path.Combine(temp.FolderPath, QuestionFileName);
+			var jsonPath = Path.Combine(bookFolderPath, QuestionFileName);
 			var questionPages = modifiedBook.RawDom.SafeSelectNodes(
 				"//html/body/div[contains(@class, 'bloom-page') and contains(@class, 'questions')]");
 			var questions = new List<QuestionGroup>();

--- a/src/BloomExe/Book/BookCompressor.cs
+++ b/src/BloomExe/Book/BookCompressor.cs
@@ -38,7 +38,7 @@ namespace Bloom.Book
 				// We want at least 256 for Bloom Reader, because the screens have a high pixel density. And (at the moment) we are asking for
 				// 64dp in Bloom Reader.
 
-				MakeSizedThumbnail(modifiedBook, backColor, temp.FolderPath, 256);
+				MakeSizedThumbnail(modifiedBook, backColor, modifiedBook.FolderPath, 256);
 
 				CompressDirectory(outputPath, modifiedBook.FolderPath, "", reduceImages: true, omitMetaJson: false, wrapWithFolder: false,
 					pathToFileForSha: BookStorage.FindBookHtmlInFolder(book.FolderPath));
@@ -56,9 +56,24 @@ namespace Bloom.Book
 			// else, BR shows a default thumbnail for the book
 		}
 
+		/// <summary>
+		/// tempFolderPath is where to put the book. Note that a few files (e.g., customCollectionStyles.css)
+		/// are copied into its parent in order to be in the expected location relative to the book,
+		/// so that needs to be a folder we can write in.
+		/// </summary>
+		/// <param name="book"></param>
+		/// <param name="bookServer"></param>
+		/// <param name="tempFolderPath"></param>
+		/// <returns></returns>
 		public static Book MakeDeviceXmatterTempBook(Book book, BookServer bookServer, string tempFolderPath)
 		{
 			BookStorage.CopyDirectory(book.FolderPath, tempFolderPath);
+			// We will later copy these into the book's own folder and adjust the style sheet refs.
+			// But in some cases (at least, where the book's primary stylesheet does not provide
+			// the information SizeAndOrientation.GetLayoutChoices() is looking for), we need them
+			// to exist in the originally expected lcoation: the book's parent directory for
+			// BringBookUpToDate to succeed.
+			BookStorage.CopyCollectionStyles(book.FolderPath, Path.GetDirectoryName(tempFolderPath));
 			var bookInfo = new BookInfo(tempFolderPath, true);
 			bookInfo.XMatterNameOverride = "Device";
 			var modifiedBook = bookServer.GetBookFromBookInfo(bookInfo);

--- a/src/BloomExe/Collection/BrandingProject.cs
+++ b/src/BloomExe/Collection/BrandingProject.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using L10NSharp;
+using SIL.IO;
 
 namespace Bloom.Collection
 {
@@ -20,7 +21,7 @@ namespace Bloom.Collection
 		public string Key;
 		public static IEnumerable<BrandingProject> GetProjectChoices()
 		{
-			var brandingDirectory = BloomFileLocator.GetDirectoryDistributedWithApplication("branding");
+			var brandingDirectory = FileLocationUtilities.GetDirectoryDistributedWithApplication("branding");
 			foreach (var brandDirectory in Directory.GetDirectories(brandingDirectory))
 			{
 				var brand = new BrandingProject {Key = Path.GetFileName(brandDirectory)};

--- a/src/BloomExe/Edit/LameEncoder.cs
+++ b/src/BloomExe/Edit/LameEncoder.cs
@@ -68,7 +68,7 @@ namespace Bloom.Edit
 			if (RobustFile.Exists("/usr/bin/lame"))
 				return "/usr/bin/lame";
 #else
-			return BloomFileLocator.GetFileDistributedWithApplication("lame.exe");
+			return FileLocationUtilities.GetFileDistributedWithApplication("lame.exe");
 #endif
 			return string.Empty;
 		}

--- a/src/BloomExe/Registration/LicenseDialog.cs
+++ b/src/BloomExe/Registration/LicenseDialog.cs
@@ -42,7 +42,7 @@ namespace Bloom.Registration
 			_licenseBrowser.Size = new Size(_acceptButton.Right - 12, _acceptButton.Top - 24);
 			Controls.Add(_licenseBrowser);
 			var locale = CultureInfo.CurrentUICulture.Name;
-			string licenseFilePath = BloomFileLocator.GetFileDistributedWithApplication(licenseHtmlFile);
+			string licenseFilePath = FileLocationUtilities.GetFileDistributedWithApplication(licenseHtmlFile);
 			var localizedLicenseFilePath = licenseFilePath.Substring(0, licenseFilePath.Length - 3) + "-" + locale + ".htm";
 			if (RobustFile.Exists(localizedLicenseFilePath))
 				licenseFilePath = localizedLicenseFilePath;

--- a/src/BloomTests/BloomFileLocatorTests.cs
+++ b/src/BloomTests/BloomFileLocatorTests.cs
@@ -132,7 +132,7 @@ namespace BloomTests
 		[Test]
 		public void GetBestLocalizedFile_EnglishIsCurrentLang_GetEnglishOne()
 		{
-			var englishPath = BloomFileLocator.DirectoryOfTheApplicationExecutable.CombineForPath(
+			var englishPath = FileLocationUtilities.DirectoryOfTheApplicationExecutable.CombineForPath(
 				"../browser/templates/xMatter/Traditional-XMatter/description-en.txt");
 			var bestLocalizedFile = BloomFileLocator.GetBestLocalizedFile(englishPath);
 			Assert.AreEqual(englishPath, bestLocalizedFile);
@@ -142,7 +142,7 @@ namespace BloomTests
 		public void GetBestLocalizedFile_DontHaveThatTranslation_GetEnglishOne()
 		{
 			LocalizationManager.SetUILanguage("gd", false);
-			var englishPath = BloomFileLocator.DirectoryOfTheApplicationExecutable.CombineForPath(
+			var englishPath = FileLocationUtilities.DirectoryOfTheApplicationExecutable.CombineForPath(
 				"../browser/templates/xMatter/Traditional-XMatter/description-en.txt");
 			var bestLocalizedFile = BloomFileLocator.GetBestLocalizedFile(englishPath);
 			Assert.AreEqual(englishPath, bestLocalizedFile);
@@ -152,7 +152,7 @@ namespace BloomTests
 		public void GetBestLocalizedFile_HaveFrench_FindsIt()
 		{
 			LocalizationManager.SetUILanguage("fr", false);
-			var englishPath = BloomFileLocator.DirectoryOfTheApplicationExecutable.CombineForPath(
+			var englishPath = FileLocationUtilities.DirectoryOfTheApplicationExecutable.CombineForPath(
 				"../browser/templates/xMatter/Traditional-XMatter/description-en.txt");
 			var bestLocalizedFile = BloomFileLocator.GetBestLocalizedFile(englishPath);
 			Assert.IsTrue(bestLocalizedFile.Contains("-fr"));

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -19,7 +19,7 @@ namespace BloomTests.Book
 	[TestFixture]
 	public class BookStarterTests
 	{
-		private FileLocator _fileLocator;
+		private BloomFileLocator _fileLocator;
 		private BookStarter _starter;
 		private TemporaryFolder _shellCollectionFolder;
 		private TemporaryFolder _projectFolder;


### PR DESCRIPTION
Things like customCollectionStyles.css should not be looked for in arbitrary installed collections.
Also ensures that MakeDeviceXmatterTempBook copies the proper ones of these into a parent folder

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2579)
<!-- Reviewable:end -->
