### PR TITLE
BL-5745 More effectively suppress Axios errors after page unloads

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -889,19 +889,6 @@ interface String {
     startsWith(string): boolean;
 }
 
-export function setZoom(newScale: string) {
-    $("div#page-scaling-container").attr(
-        "style",
-        "transform: scale(" + newScale + "); transform-origin: top left;"
-    );
-    // Save changes, so TextOverPicture draggables work correctly.
-    BloomApi.post("common/saveChangesAndRethinkPageEvent");
-}
-
-// This is used to keep wheel zooming messages from happening too fast.
-// The program will crash otherwise, at least on Linux.
-var wheelZoomOkay: boolean = true;
-
 // ---------------------------------------------------------------------------------
 // called inside document ready function
 // ---------------------------------------------------------------------------------

--- a/src/BloomBrowserUI/publish/epub/epubPublishUI.tsx
+++ b/src/BloomBrowserUI/publish/epub/epubPublishUI.tsx
@@ -46,6 +46,10 @@ class EpubPublishUI extends React.Component<
         BloomApi.postData("publish/epub/updatePreview", this.state);
     }
 
+    public componentDidMount() {
+        window.addEventListener("beforeunload", this.componentCleanup);
+    }
+
     // Apparently, we have to rely on the window event when closing or refreshing the page.
     // componentWillUnmount will not get called in those cases.
     public componentWillUnmount() {

--- a/src/BloomBrowserUI/utils/WebSocketManager.ts
+++ b/src/BloomBrowserUI/utils/WebSocketManager.ts
@@ -87,7 +87,6 @@ export default class WebSocketManager {
             );
             webSocket.close();
             WebSocketManager.socketMap[clientContext] = null;
-            BloomApi.NotifyPageClosing();
         }
     }
     /**

--- a/src/BloomBrowserUI/utils/bloomApi.ts
+++ b/src/BloomBrowserUI/utils/bloomApi.ts
@@ -212,3 +212,5 @@ export class BloomApi {
         }
     }
 }
+
+window.addEventListener("beforeunload", () => BloomApi.NotifyPageClosing());


### PR DESCRIPTION
Also restores a change lost in a recent merge, and fixes another missing beforeunload

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2581)
<!-- Reviewable:end -->
