### PR TITLE
BL-6220 Clean up Epub preview and ACE generation

### DIFF
--- a/src/BloomBrowserUI/publish/epub/epubPublishUI.tsx
+++ b/src/BloomBrowserUI/publish/epub/epubPublishUI.tsx
@@ -154,6 +154,7 @@ class EpubPublishUI extends React.Component<
                         <ApiBackedCheckbox
                             apiEndpoint="publish/epub/removeFontSizesSetting"
                             l10nKey="PublishTab.Epub.RemoveFontSizes"
+                            priorClickAction={() => this.abortPreview()}
                         >
                             Use ePUB reader's text size
                         </ApiBackedCheckbox>
@@ -186,11 +187,16 @@ class EpubPublishUI extends React.Component<
     // (e.g., the implemented but not shipped "links" option)
     private setPublishRadio(val: string) {
         this.setState({ howToPublishImageDescriptions: val });
+        this.abortPreview();
         BloomApi.postDataWithConfig(
             "publish/epub/imageDescriptionSetting",
             val,
             { headers: { "Content-Type": "application/json" } }
         );
+    }
+
+    private abortPreview() {
+        BloomApi.post("publish/epub/abortPreview");
     }
 }
 

--- a/src/BloomBrowserUI/react_components/apiBackedCheckbox.tsx
+++ b/src/BloomBrowserUI/react_components/apiBackedCheckbox.tsx
@@ -10,6 +10,8 @@ interface IProps extends ILocalizationProps {
     // The parent can give us this function which we use to subscribe to refresh events
     // See notes in accessibiltiyChecklist for a thorough discussion.
     subscribeToRefresh?: (queryData: () => void) => void;
+    // Extra function to call before posting apiEndpoint.
+    priorClickAction?: () => void;
 }
 interface IState {
     checked: boolean;
@@ -42,6 +44,9 @@ export class ApiBackedCheckbox extends React.Component<IProps, IState> {
                 l10nKey={this.props.l10nKey}
                 onCheckChanged={c => {
                     this.setState({ checked: c });
+                    if (this.props.priorClickAction) {
+                        this.props.priorClickAction();
+                    }
                     BloomApi.postDataWithConfig(this.props.apiEndpoint, c, {
                         headers: { "Content-Type": "application/json" }
                     });

--- a/src/BloomBrowserUI/react_components/link.tsx
+++ b/src/BloomBrowserUI/react_components/link.tsx
@@ -4,7 +4,7 @@ import { ILocalizationProps, LocalizableElement } from "./l10n";
 interface ILinkProps extends ILocalizationProps {
     id?: string;
     href?: string;
-    onClick?: any;
+    onClick?: any; // overrides following any href.
 }
 
 // A normal html anchor element that is localizable.
@@ -16,7 +16,16 @@ export class Link extends LocalizableElement<ILinkProps, {}> {
                 // href must be defined in order to maintain normal link UI
                 // I tried to do like the 'id' attribute above, but it caused an error.
                 href={this.props.href ? this.props.href : ""}
-                onClick={this.props.onClick}
+                onClick={e => {
+                    if (this.props.onClick) {
+                        // If we have an onClick we don't expect to also have an href.
+                        // In which case the code above will provide an empty href.
+                        // The default behaviour will navigate to the top of the page,
+                        // causing the whole react page to reload. So prevent that default.
+                        e.preventDefault();
+                        this.props.onClick();
+                    }
+                }}
             >
                 {this.getLocalizedContent()}
             </a>

--- a/src/BloomBrowserUI/react_components/progressBox.tsx
+++ b/src/BloomBrowserUI/react_components/progressBox.tsx
@@ -39,10 +39,14 @@ export default class ProgressBox extends React.Component<
                 this.tryScrollToBottom();
             }
         });
-        if (props.onReadyToReceive) {
+    }
+
+    public componentDidMount() {
+        //alert("constructing progress box for " + this.props.clientContext);
+        if (this.props.onReadyToReceive) {
             WebSocketManager.notifyReady(
-                props.clientContext,
-                props.onReadyToReceive
+                this.props.clientContext,
+                this.props.onReadyToReceive
             );
         }
     }

--- a/src/BloomExe/Publish/Epub/EpubPublishUiSettings.cs
+++ b/src/BloomExe/Publish/Epub/EpubPublishUiSettings.cs
@@ -24,6 +24,11 @@ namespace Bloom.Publish.Epub
 			       && other.removeFontSizes == this.removeFontSizes;
 		}
 
+		public EpubPublishUiSettings Clone()
+		{
+			return (EpubPublishUiSettings) MemberwiseClone();
+		}
+
 		public override int GetHashCode()
 		{
 			return howToPublishImageDescriptions.GetHashCode() ^ removeFontSizes.GetHashCode();

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -514,6 +514,7 @@ namespace Bloom.Publish
 					// we'll lose them for all the other JS code in this pane. But I don't have a better solution.
 					// We still get them in the output window, in case we really want to look for one.
 					Browser.SuppressJavaScriptErrors = true;
+					PublishEpubApi.ControlForInvoke = ParentForm; // something created on UI thread that won't go away
 					ShowHtmlPanel(BloomFileLocator.GetBrowserFile(false, "publish", "epub", "epubPublishUI.html"));
 					break;
 			}

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -36,7 +36,6 @@ namespace Bloom.Workspace
 		private readonly SelectedTabChangedEvent _selectedTabChangedEvent;
 		private readonly LocalizationChangedEvent _localizationChangedEvent;
 		private readonly ProblemReporterDialog.Factory _problemReportDialogFactory;
-		private readonly PublishEpubApi _epubApi;
 #if CHORUS
 			private readonly ChorusSystem _chorusSystem;
 #else
@@ -80,8 +79,7 @@ namespace Bloom.Workspace
 							LocalizationChangedEvent localizationChangedEvent,
 							ProblemReporterDialog.Factory problemReportDialogFactory,
 							//ChorusSystem chorusSystem,
-							LocalizationManager localizationManager,
-							PublishEpubApi epubApi
+							LocalizationManager localizationManager
 
 			)
 		{
@@ -93,7 +91,6 @@ namespace Bloom.Workspace
 			_problemReportDialogFactory = problemReportDialogFactory;
 			//_chorusSystem = chorusSystem;
 			_localizationManager = localizationManager;
-			_epubApi = epubApi;
 			_model.UpdateDisplay += new System.EventHandler(OnUpdateDisplay);
 			InitializeComponent();
 
@@ -539,7 +536,6 @@ namespace Bloom.Workspace
 
 		private void SelectPage(Control view)
 		{
-			_epubApi.MainPageChanged();
 			CurrentTabView = view as IBloomTabArea;
 			// Warn the user if we're starting to use too much memory.
 			SIL.Windows.Forms.Reporting.MemoryManagement.CheckMemory(false, "switched page in workspace", true);

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -67,12 +67,22 @@ namespace Bloom.Api
 		/// Making it true can kill performance if you don't need it (BL-3452), and complicates exception handling and problem reporting (BL-4679).
 		/// There's also danger of deadlock if something in the UI thread is somehow waiting for this request to complete.
 		/// But, beware of race conditions or anything that manipulates UI controls if you make it false.</param>
-		public void RegisterEndpointHandler(string pattern, EndpointHandler handler, bool handleOnUiThread)
+		/// <param name="requiresSync">True if the handler wants the server to ensure no other thread is doing an api
+		/// call while this one is running. This is our default behavior, ensuring that no API request can interfere with any
+		/// other in any unexpected way...essentially all Bloom's data is safe from race conditions arising from
+		/// server threads manipulating things on background threads. However, it makes it impossible for a new
+		/// api call to interrupt a previous one. For example, when one api call is creating an epub preview
+		/// and we get a new one saying we need to abort that (because one of the property buttons has changed),
+		/// the epub that is being generated is obsolete and we want the new api call to go ahead so it can set a flag 
+		/// to abort the one in progress. To avoid race conditions, api calls that set requiresSync false should be kept small
+		/// and simple and be very careful about touching objects that other API calls might interact with.</param>
+		public void RegisterEndpointHandler(string pattern, EndpointHandler handler, bool handleOnUiThread, bool requiresSync = true)
 		{
 			_endpointRegistrations[pattern.ToLowerInvariant().Trim(new char[] {'/'})] = new EndpointRegistration()
 			{
 				Handler = handler,
-				HandleOnUIThread = handleOnUiThread
+				HandleOnUIThread = handleOnUiThread,
+				RequiresSync = requiresSync
 			};
 		}
 
@@ -80,7 +90,7 @@ namespace Bloom.Api
 		/// Handle simple boolean reads/writes
 		/// </summary>
 		public void RegisterBooleanEndpointHandler(string pattern, Func<ApiRequest, bool> readAction, Action<ApiRequest, bool> writeAction,
-			bool handleOnUiThread)
+			bool handleOnUiThread, bool requiresSync = true)
 		{
 			RegisterEndpointHandler(pattern, request =>
 			{
@@ -93,14 +103,14 @@ namespace Bloom.Api
 					writeAction(request, request.RequiredPostBooleanAsJson());
 					request.PostSucceeded();
 				}
-			}, handleOnUiThread);
+			}, handleOnUiThread, requiresSync);
 		}
 
 		/// <summary>
 		/// Handle enum reads/writes
 		/// </summary>
 		public void RegisterEnumEndpointHandler<T>(string pattern, Func<ApiRequest, T> readAction, Action<ApiRequest, T> writeAction,
-			bool handleOnUiThread)
+			bool handleOnUiThread, bool requiresSync = true)
 		{
 			Debug.Assert(typeof(T).IsEnum, "Type passed to RegisterEnumEndpointHandler is not an Enum.");
 			RegisterEndpointHandler(pattern, request =>
@@ -114,7 +124,7 @@ namespace Bloom.Api
 					writeAction(request, request.RequiredPostEnumAsJson<T>());
 					request.PostSucceeded();
 				}
-			}, handleOnUiThread);
+			}, handleOnUiThread, requiresSync);
 		}
 
 		// We use two different locks to synchronize access to the methods of this class.
@@ -247,18 +257,26 @@ namespace Bloom.Api
 							pair.Key.ToLower()
 						).Success))
 				{
-					// A single synchronization object won't do, because when processing a request to create a thumbnail,
-					// we have to load the HTML page the thumbnail is based on. If the page content somehow includes
-					// an api request (api/branding/image is one example), that request will deadlock if the
-					// api/pageTemplateThumbnail request already has the main lock.
-					// To the best of my knowledge, there's no shared data between the thumbnailing process and any
-					// other api requests, so it seems safe to have one lock that prevents working on multiple
-					// thumbnails at the same time, and one that prevents working on other api requests at the same time.
-					var syncOn = SyncObj;
-					if (localPath.ToLowerInvariant().StartsWith("api/pagetemplatethumbnail"))
-						syncOn = ThumbnailSyncObj;
-					lock(syncOn)
+					if (pair.Value.RequiresSync)
 					{
+						// A single synchronization object won't do, because when processing a request to create a thumbnail,
+						// we have to load the HTML page the thumbnail is based on. If the page content somehow includes
+						// an api request (api/branding/image is one example), that request will deadlock if the
+						// api/pageTemplateThumbnail request already has the main lock.
+						// To the best of my knowledge, there's no shared data between the thumbnailing process and any
+						// other api requests, so it seems safe to have one lock that prevents working on multiple
+						// thumbnails at the same time, and one that prevents working on other api requests at the same time.
+						var syncOn = SyncObj;
+						if (localPath.ToLowerInvariant().StartsWith("api/pagetemplatethumbnail"))
+							syncOn = ThumbnailSyncObj;
+						lock (syncOn)
+						{
+							return ApiRequest.Handle(pair.Value, info, CurrentCollectionSettings, _bookSelection.CurrentSelection);
+						}
+					}
+					else
+					{
+						// Up to api's that request no sync to do things right!
 						return ApiRequest.Handle(pair.Value, info, CurrentCollectionSettings, _bookSelection.CurrentSelection);
 					}
 				}

--- a/src/BloomExe/web/controllers/ApiRequest.cs
+++ b/src/BloomExe/web/controllers/ApiRequest.cs
@@ -16,6 +16,7 @@ namespace Bloom.Api
 	{
 		public bool HandleOnUIThread = true;
 		public EndpointHandler Handler;
+		public bool RequiresSync = true; // set false if handler does its own thread-handling.
 	}
 
 


### PR DESCRIPTION
- Remove use of background worker for making epubs, since creation is already on a background (server) thread
- making the epub is now a single step
- Use checksum to reliably tell whether we need to regenerate the epub
- Save the PublishView's Form rather than retrieving Form.ActiveForm
- Fix a problem in Link.tsx that caused excessive page  refreshes (and extra epub creation)
- Fix a glitch that could make epub generation fail to terminate
- Added support for api handlers that deal with their own threading issues (so changing a setting can abort preview creation)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2591)
<!-- Reviewable:end -->
