### PR TITLE
[v4.2]BL-6235 Fix Music tool newPageReady()

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/music/musicToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/music/musicToolControls.tsx
@@ -1,15 +1,8 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import ToolboxToolReactAdaptor from "../toolboxToolReactAdaptor";
-import {
-    H1,
-    Div,
-    IUILanguageAwareProps,
-    Label
-} from "../../../react_components/l10n";
+import { Div, Label } from "../../../react_components/l10n";
 import { RadioGroup, Radio } from "../../../react_components/radio";
 import axios from "axios";
-import { ToolBox, ITool } from "../toolbox";
 import Slider from "rc-slider";
 import AudioRecording from "../talkingBook/audioRecording";
 import "./music.less";
@@ -56,9 +49,6 @@ export class MusicToolControls extends React.Component<{}, IMusicState> {
         this.updateBasedOnContentsOfPage();
     }
 
-    public updateMarkup() {
-        // nothing to do here.
-    }
     public getStateFromHtmlOfPage(): IMusicState {
         let audioFileName = ToolboxToolReactAdaptor.getBloomPageAttr(
             MusicToolControls.musicAttrName
@@ -153,7 +143,6 @@ export class MusicToolControls extends React.Component<{}, IMusicState> {
                         </Label>
                     </div>
                 </RadioGroup>
-
                 <div
                     className={
                         "button-label-wrapper" +
@@ -419,7 +408,7 @@ export class MusicToolAdaptor extends ToolboxToolReactAdaptor {
     public hideTool() {
         this.controlsElement.hideTool();
     }
-    public updateMarkup() {
-        this.controlsElement.updateMarkup();
+    public newPageReady() {
+        this.controlsElement.newPageReady();
     }
 }


### PR DESCRIPTION
* the switch from updateMarkup() to newPageReady() in the ITool
   interface was implemented incompletely in Music Tool

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2600)
<!-- Reviewable:end -->
