### PR TITLE
Fix BL-6267 textOverPicture.less, broken by BL-4972

### DIFF
--- a/src/BloomBrowserUI/bookLayout/textOverPicture.less
+++ b/src/BloomBrowserUI/bookLayout/textOverPicture.less
@@ -16,13 +16,11 @@
             content: "" !important;
         }
     }
-    .bloom-textOverPicture {
-        .ui-resizable-handle {
-            display: none !important;
-        }
-        .bloom-dragHandleTOP {
-            display: none;
-        }
+    .ui-resizable-handle {
+        display: none !important;
+    }
+    .bloom-dragHandleTOP {
+        display: none;
     }
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2602)
<!-- Reviewable:end -->
