### PR TITLE
Fix BL-6135 Video import button on frame doesn't match Bloom UI

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1935,10 +1935,6 @@
         <note>ID: EditTab.UnlockBook.ToolTip</note>
         <note>Button that tells Bloom to temporarily unlock a shell book for editing other than translation.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Video.ChangeVideo" sil:dynamic="true">
-        <source xml:lang="en">Change Video</source>
-        <note>ID: EditTab.Video.ChangeVideo</note>
-      </trans-unit>
       <trans-unit id="Errors.BookProblem">
         <source xml:lang="en">Bloom had a problem showing this book. This doesn't mean your work is lost, but it does mean that something is out of date, is missing, or has gone wrong.</source>
         <note>ID: Errors.BookProblem</note>

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -136,13 +136,12 @@ div.hoverUp {
         background-color: @ChangeImageButtonColor;
         background-image: url("../img/changeButton.svg");
     }
-    &.changeVideoButton {
+    &.importVideoButtonOverlay {
         right: 0;
         top: 0;
         background-color: @ChangeImageButtonColor;
-        // Currently this image is a duplicate of changeButton. Eventually we may come up with
-        // something different, so I gave it a name of its own.
-        background-image: url("../img/changeVideoButton.svg");
+        background-image: url("../img/importVideoButtonOverlay.svg");
+        background-size: 40px 40px;
     }
     &.pasteImageButton {
         right: 0;

--- a/src/BloomBrowserUI/bookEdit/img/importVideoButtonOverlay.svg
+++ b/src/BloomBrowserUI/bookEdit/img/importVideoButtonOverlay.svg
@@ -14,8 +14,8 @@
    viewBox="0 0 40 40.000001"
    id="svg3987"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="ImportVideo.svg">
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   sodipodi:docname="changeVideoButton.svg">
   <defs
      id="defs3989" />
   <sodipodi:namedview
@@ -25,16 +25,16 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="573.5"
-     inkscape:cy="331.79665"
+     inkscape:zoom="11.313708"
+     inkscape:cx="48.238961"
+     inkscape:cy="19.222142"
      inkscape:document-units="px"
-     inkscape:current-layer="layer1"
+     inkscape:current-layer="g1851"
      showgrid="false"
-     inkscape:window-width="1920"
-     inkscape:window-height="1148"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-width="1823"
+     inkscape:window-height="1177"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
      inkscape:window-maximized="1"
      inkscape:snap-page="true"
      inkscape:snap-global="true"
@@ -49,7 +49,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -66,10 +66,10 @@
          inkscape:connector-curvature="0"
          id="path1828"
          d="m -179.72441,63.643478 -4.16101,0 0,6.336705 6.4149,0 0,-3.835374"
-         style="fill:none;stroke:#59b4d3;stroke-width:0.58302855;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         style="fill:none;stroke:#000000;stroke-width:0.58302855;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="cccccccccssccccc"
-         style="fill:#59b4d3;fill-opacity:1;stroke:#59b4d3;stroke-width:0.19434284;stroke-linecap:round;stroke-opacity:1"
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.19434284;stroke-linecap:round;stroke-opacity:1"
          id="path4-2"
          d="m -176.88813,62.77335 -4.69367,4.569999 0,-1.881151 c -9.3e-4,-0.379392 -0.56965,-0.379392 -0.57058,0 l 0,2.565739 c -0.002,0.01897 -0.002,0.03808 0,0.05705 l 0,0.08557 0.0207,0.0641 0.0789,0.02147 2.75167,0 c 0.38039,0 0.38039,-0.57049 0,-0.57049 l -1.88154,0 0.94855,-0.932793 3.74513,-3.580157 c 0.19792,-0.263879 -0.25824,-0.556301 -0.3994,-0.399343 z"
          data-name="Path"

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -70,7 +70,11 @@ function SetupVideoContainer(
     //   if Enterprise features are enabled.
     if (isEnterpriseEnabled) {
         theOneLocalizationManager
-            .asyncGetText("EditTab.Video.ChangeVideo", "Change Video", "")
+            .asyncGetText(
+                "EditTab.Toolbox.SignLanguage.ImportVideo",
+                "Import Video",
+                ""
+            )
             .done(function(changeVideoText) {
                 $(containerDiv)
                     .mouseenter(function() {
@@ -81,7 +85,7 @@ function SetupVideoContainer(
                         // The code that executes when this button is clicked is currently C#.
                         // See EditingView._browser1_OnBrowserClick for the start of the chain.
                         $this.prepend(
-                            "<button class='changeVideoButton imageButton " +
+                            "<button class='importVideoButtonOverlay imageButton " +
                                 buttonModifier +
                                 "' title='" +
                                 changeVideoText +
@@ -109,9 +113,11 @@ function SetupVideoContainer(
                     .mouseleave(function() {
                         var $this = $(this);
                         $this.removeClass("hoverUp");
-                        $this.find(".changeVideoButton").each(function() {
-                            $(this).remove();
-                        });
+                        $this
+                            .find(".importVideoButtonOverlay")
+                            .each(function() {
+                                $(this).remove();
+                            });
                     });
             });
     }

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -589,7 +589,7 @@ namespace Bloom.Edit
 				OnCopyImage(ge);
 			if(target.ClassName.Contains("editMetadataButton"))
 				OnEditImageMetdata(ge);
-			if (target.ClassName.Contains("changeVideoButton"))
+			if (target.ClassName.Contains("importVideoButtonOverlay"))
 				_signLanguageApi.OnChangeVideo(ge);
 
 			var anchor = target as GeckoAnchorElement;


### PR DESCRIPTION
I also joined up the previously separate "Change Video" and "Import Video" strings, removing the former from the English tsx.
Also changed the name of the icon to help differentiate it from the one on the toolbox.
This will probably need special attention merging into 4.4/master as image files have moved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2619)
<!-- Reviewable:end -->
