### PR TITLE
BL-6288 Show correct content for publish PDF in other orientation

### DIFF
--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -161,20 +161,13 @@ namespace Bloom.Publish
 		{
 			PdfFilePath = GetPdfPath(Path.GetFileName(_currentlyLoadedBook.FolderPath));
 
-			var dom = BookSelection.CurrentSelection.GetDomForPrinting(BookletPortion, _currentBookCollectionSelection.CurrentSelection, _bookServer);
+			var orientationChanging = BookSelection.CurrentSelection.GetLayout().SizeAndOrientation.IsLandScape !=
+			                          PageLayout.SizeAndOrientation.IsLandScape;
+			var dom = BookSelection.CurrentSelection.GetDomForPrinting(BookletPortion, _currentBookCollectionSelection.CurrentSelection,
+				_bookServer, orientationChanging, PageLayout);
 
 			AddStylesheetClasses(dom.RawDom);
 
-			//we do this now becuase the publish ui allows the user to select a different layout for the pdf than what is in the book file
-			SizeAndOrientation.UpdatePageSizeAndOrientationClasses(dom.RawDom, PageLayout);
-
-			if (BookSelection.CurrentSelection.GetLayout().SizeAndOrientation.IsLandScape !=
-			    PageLayout.SizeAndOrientation.IsLandScape)
-			{
-				// Need to update the xmatter in the print dom...it may use different images.
-				// Make sure we do this AFTER setting PageOrientation in Dom.
-				BookSelection.CurrentSelection.UpdateBrandingForCurrentOrientation(dom);
-			}
 			PageLayout.UpdatePageSplitMode(dom.RawDom);
 
 			XmlHtmlConverter.MakeXmlishTagsSafeForInterpretationAsHtml(dom.RawDom);

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -408,7 +408,9 @@ namespace Bloom.Publish
 			_model.PageLayout = ((Layout)item.Tag);
 			ClearRadioButtons();
 			UpdateDisplay();
-			SetDisplayMode(PublishModel.DisplayModes.WaitForUserToChooseSomething);
+			// A side effect of UpdateDisplay will select the appropriate radio button,
+			// since we haven't changed the display mode. If the selected button is a PDF
+			// one, that will trigger regenerating the PDF.
 		}
 
 		private void OnSinglePageModeChanged(object sender, EventArgs e)

--- a/src/BloomExe/web/EnhancedImageServer.cs
+++ b/src/BloomExe/web/EnhancedImageServer.cs
@@ -43,6 +43,9 @@ namespace Bloom.Api
 
 		public CollectionSettings CurrentCollectionSettings { get; set; }
 
+		// This is useful for debugging.
+		public static Dictionary<string, string> SimulatedPageContent => _urlToSimulatedPageContent;
+
 		/// <summary>
 		/// This is only used in a few special cases where we need one to pass as an argument but it won't be fully used.
 		/// </summary>


### PR DESCRIPTION
Also BL-6251, make PDF be displayed after regenerating it after changing layout in publish tab

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2627)
<!-- Reviewable:end -->
