### PR TITLE
Ensure image description tool stay open for a11y checking (BL-6228)

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1404,6 +1404,8 @@ namespace Bloom.Edit
 					// See https://silbloom.myjetbrains.com/youtrack/issue/BL-6228. This control can lose/regain
 					// focus erratically on Linux, so we don't want this save on its LostFocus event.
 					_model.SaveNow();
+					// Restore any tool state removed by CleanHtmlAndCopyToPageDom(), which is called by _model.SaveNow().
+					RunJavaScript("if (typeof(FrameExports) !=='undefined') {FrameExports.getToolboxFrameExports().applyToolboxStateToPage();}");
 				};
 			}
 		}


### PR DESCRIPTION
Saving the page removes any tool's HTML from the book's page.  It needs
to be restored for seamless operation between the main window and the
a11y checking window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2630)
<!-- Reviewable:end -->
