### PR TITLE
BL-6291 A11y Checker updates

### DIFF
--- a/src/BloomBrowserUI/publish/accessibilityCheck/accessibilityCheckScreen.tsx
+++ b/src/BloomBrowserUI/publish/accessibilityCheck/accessibilityCheckScreen.tsx
@@ -24,7 +24,7 @@ class AccessibilityCheckScreen extends React.Component<{}, IState> {
     public componentDidMount() {
         // Listen for changes to state from C#-land
         WebSocketManager.addListener("a11yChecklist", e => {
-            if (e.message === "bookSelectionChanged") this.refresh();
+            if (e.id === "bookSelectionChanged") this.refresh();
         });
         this.refresh();
     }

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Web;
 using System.Windows.Forms;
 using System.Xml;
@@ -48,6 +49,7 @@ namespace Bloom.Book
 		private readonly PageSelection _pageSelection;
 		private readonly PageListChangedEvent _pageListChangedEvent;
 		private readonly BookRefreshEvent _bookRefreshEvent;
+		private readonly BookSavedEvent _bookSavedEvent;
 		private readonly IBookStorage _storage;
 		private List<IPage> _pagesCache;
 		internal const string kIdOfBasicBook = "056B6F11-4A6C-4942-B2BC-8861E62B03B3";
@@ -72,7 +74,8 @@ namespace Bloom.Book
 		   CollectionSettings collectionSettings,
 			PageSelection pageSelection,
 			PageListChangedEvent pageListChangedEvent,
-			BookRefreshEvent bookRefreshEvent)
+			BookRefreshEvent bookRefreshEvent,
+			BookSavedEvent bookSavedEvent)
 		{
 			BookInfo = info;
 			UserPrefs = UserPrefs.LoadOrMakeNew(Path.Combine(info.FolderPath, "book.userPrefs"));
@@ -107,6 +110,8 @@ namespace Bloom.Book
 			_pageSelection = pageSelection;
 			_pageListChangedEvent = pageListChangedEvent;
 			_bookRefreshEvent = bookRefreshEvent;
+			_bookSavedEvent = bookSavedEvent;
+
 			_bookData = new BookData(OurHtmlDom,
 					_collectionSettings, UpdateImageMetadataAttributes);
 
@@ -2534,6 +2539,13 @@ namespace Bloom.Book
 				PageTemplateSource = Path.GetFileName(FolderPath);
 			}
 			_storage.Save();
+
+			// Tell the accessibility checker window (and any future subscriber) to re-compute.
+			// This Task.Delay() helps even with a delay of 0, becuase it means we get to finish with this command.
+			// I'm chooing 1 second at the moment as that feels about the longest I would want to
+			// wait to see if what I did made and accesibility check change. Of course we're *probably*
+			// ready to run this much, much sooner.
+			Task.Delay(1000).ContinueWith((task) => _bookSavedEvent.Raise(this));
 		}
 
 		/// <summary>

--- a/src/BloomExe/CLI/ChangeLayoutCommand.cs
+++ b/src/BloomExe/CLI/ChangeLayoutCommand.cs
@@ -81,7 +81,7 @@ namespace Bloom.CLI
 
 			var templateBookInfo  = new BookInfo(Path.GetDirectoryName(bookPath), true);
 			var templateBook = new Book.Book(templateBookInfo, new BookStorage(templateBookInfo.FolderPath, locator, new BookRenamedEvent(), collectionSettings),
-				null, collectionSettings, null, null, new BookRefreshEvent());
+				null, collectionSettings, null, null, new BookRefreshEvent(), new BookSavedEvent());
 
 			var pageDictionary = templateBook.GetTemplatePagesIdDictionary();
 			IPage page = null;
@@ -99,7 +99,7 @@ namespace Bloom.CLI
 				{
 					var book = new Book.Book(bookInfo,
 						new BookStorage(bookInfo.FolderPath, locator, new BookRenamedEvent(), collectionSettings),
-						null, collectionSettings, null, null, new BookRefreshEvent());
+						null, collectionSettings, null, null, new BookRefreshEvent(), new BookSavedEvent());
 					//progress.WriteMessage("Processing " + book.TitleBestForUserDisplay + " " + i + "/" + collection.GetBookInfos().Count());
 					progress.ProgressIndicator.PercentCompleted = i * 100 / collection.GetBookInfos().Count();
 

--- a/src/BloomExe/CLI/HydrateBookCommand.cs
+++ b/src/BloomExe/CLI/HydrateBookCommand.cs
@@ -57,7 +57,7 @@ namespace Bloom.CLI
 
 			var bookInfo = new BookInfo(options.Path, true);
 			var book = new Book.Book(bookInfo, new BookStorage(options.Path, locator, new BookRenamedEvent(), collectionSettings),
-				null, collectionSettings, null, null, new BookRefreshEvent());
+				null, collectionSettings, null, null, new BookRefreshEvent(), new BookSavedEvent());
 
 			if (collectionSettings.XMatterPackName == "Video")
 			{

--- a/src/BloomExe/Event.cs
+++ b/src/BloomExe/Event.cs
@@ -164,7 +164,17 @@ namespace Bloom
 
 		}
 	}
+	/// <summary>
+	/// Accessibility Checker uses this... not exactly semantic, but it does give us the hook at the right time
+	/// </summary>
+	public class BookSavedEvent : Event<Book.Book>
+	{
+		public BookSavedEvent()
+			: base("BookSavedEvent", LoggingLevel.Minor)
+		{
 
+		}
+	}
 	/// <summary>
 	/// Anything displaying a book should re-load it the current page
 	/// </summary>

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -100,6 +100,7 @@ namespace Bloom
 							typeof (LibraryClosing),
 							typeof (PageListChangedEvent), // REMOVE+++++++++++++++++++++++++++
 							typeof (BookRefreshEvent),
+							typeof (BookSavedEvent),
 							typeof (PageRefreshEvent),
 							typeof (BookDownloadStartingEvent),
 							typeof (BookSelection),

--- a/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
+++ b/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
@@ -46,15 +46,21 @@ namespace Bloom.web.controllers
 
 
 		public AccessibilityCheckApi(BloomWebSocketServer webSocketServer, BookSelection bookSelection,
-									BookRefreshEvent bookRefreshEvent, EpubMaker.Factory epubMakerFactory,
+									BookSavedEvent bookSavedEvent, EpubMaker.Factory epubMakerFactory,
 			PublishEpubApi epubApi)
 		{
 			_webSocketServer = webSocketServer;
 			_webSocketProgress = new WebSocketProgress(_webSocketServer, kWebSocketContext);
 			_epubMakerFactory = epubMakerFactory;
 			_epubApi = epubApi;
-			bookSelection.SelectionChanged += (unused1, unused2) => _webSocketServer.SendEvent(kWebSocketContext, kBookSelectionChanged);
-			bookRefreshEvent.Subscribe((book) => RefreshClient());
+			bookSelection.SelectionChanged += (unused1, unused2) =>
+			{
+				_webSocketServer.SendEvent(kWebSocketContext, kBookSelectionChanged);
+			};
+			bookSavedEvent.Subscribe((book) =>
+			{
+				RefreshClient();
+			});
 		}
 		
 		public void RegisterWithServer(EnhancedImageServer server)


### PR DESCRIPTION
1) title wasn't updating because the needed websocket event parameter changed (message --> id).
2) the checklist wasn't  auto-refreshing anymore. Created a new BookSaved event to wire to, rather than messing with the use or semantics of the existing BookRefresh event (started down the road, got very odd errors, repented).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2638)
<!-- Reviewable:end -->
