### PR TITLE
Fix metadata editable text fields to show text properly (BL-6350)

### DIFF
--- a/src/BloomBrowserUI/publish/metadata/BookMetadataDialog.less
+++ b/src/BloomBrowserUI/publish/metadata/BookMetadataDialog.less
@@ -31,7 +31,13 @@
                 padding: 0;
 
                 & > * {
-                    padding: 7px 5px;
+                    padding-right: 5px; // sets padding-left as well
+                }
+                & > :not(textarea) {
+                    // We want vertical padding if it's not a textarea which either has some internal
+                    // table related spacing or is more limited vertically to begin with.
+                    // See https://silbloom.myjetbrains.com/youtrack/issue/BL-6350.
+                    padding-top: 7px; // sets padding-bottom as well
                 }
                 & > textarea {
                     height: 2em;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2682)
<!-- Reviewable:end -->
