### PR TITLE
BL-6365 simplify height rules for bloom-editable to fix title problem

### DIFF
--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -134,7 +134,13 @@ textarea,
     line-height: @defaultLineHeight;
     min-height: @defaultLineHeight + 0.3em;
     width: 100%;
-    height: 100%;
+    // We want the bloom-editables to fill the containing bloom-translationGroup,
+    // so that the boxes around them give an idea of how much space is available
+    // when the translationGroup has a fixed size. This pair of properties allows
+    // each bloom-editable to grow proportionally to fill the space (including
+    // filling it all if there is only one).
+    height: auto;
+    flex-grow: 1;
     // visible .bloom-editables are made display:flex rather than display:none
     // to allow for possible vertical alignment options. Once using display:flex,
     // the direction must be column, or paragraphs arrange in a row.
@@ -500,16 +506,6 @@ h2 {
     .bloom-translationGroup {
         height: ~"calc(100% - 2px)";
         width: ~"calc(100% - 2px)"; //the -1 lets our border fall jus inside the marginbox border. Undesirable in terms of layout, but visually it looks a lot better in the editor
-    }
-    /* other rules normally make bloom-editable divs height: 100%. That won't work for a bilingual or trilingual block.
-    This rule makes them start out the size they need to be, then whatever space is left over is divided between them.
-    */
-    &.bloom-bilingual,
-    &.bloom-trilingual {
-        .bloom-editable {
-            height: auto;
-            flex-grow: 1;
-        }
     }
 
     .split-pane-component {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2690)
<!-- Reviewable:end -->
