### PR TITLE
[WIP?] Move all less->css processing to webpack (BL-6270)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -140,7 +140,7 @@ div.hoverUp {
         left: 0;
         bottom: 0;
         background-color: @bloom-blue;
-        background-image: url("../img/ImageDescriptionImageOverlayButton.svg");
+        background-image: url("../../images/ImageDescriptionImageOverlayButton.svg");
         // sorry, this background-size is kinda arbitrary, and "49px 40px" works at full size, but if we ever make these
         //buttons shrink as the image container shrinks, this will still work.
         background-size: 63%;

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -12,7 +12,7 @@ span.ui-audioCurrent:not(.disableHighlight) {
     background: @highlightColor;
 
     &:before {
-        background-image: url(currentTextIndicator.svg);
+        background-image: url("currentTextIndicator.svg");
         background-repeat: no-repeat;
         background-size: 10px 13px;
         background-position: 2px 5px;
@@ -69,15 +69,15 @@ span.ui-audioCurrent:not(.disableHighlight) {
         }
     }
     #audio-play {
-        background-image: url(audio/play_enabled.svg);
+        background-image: url("../../../images/play_enabled.svg");
         height: 45px;
         width: 45px; // visually same width as record button
 
         &.expected {
-            background-image: url(audio/play_expected.svg);
+            background-image: url("play_expected.svg");
         }
         &.active {
-            background-image: url(audio/play_active.svg);
+            background-image: url("play_active.svg");
         }
     }
     .audio-about {
@@ -137,23 +137,23 @@ span.ui-audioCurrent:not(.disableHighlight) {
         }
     }
     #audio-next {
-        background-image: url(audio/next_enabled.svg);
+        background-image: url("next_enabled.svg");
         &.expected {
-            background-image: url(audio/next_expected.svg);
+            background-image: url("next_expected.svg");
         }
     }
     #audio-prev {
-        background-image: url(audio/prev_enabled.svg);
+        background-image: url("prev_enabled.svg");
     }
     #audio-listen {
         margin-left: 2px; // visually centered
-        background-image: url(audio/listen_enabled.svg);
+        background-image: url("listen_enabled.svg");
         &.active {
-            background-image: url(audio/listen_active.svg);
+            background-image: url("listen_active.svg");
         }
     }
     #audio-clear {
-        background-image: url(audio/clear_enabled.svg);
+        background-image: url("clear_enabled.svg");
     }
     .button-label-wrapper {
         margin-top: 10px;

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -484,7 +484,8 @@ h2 {
         width: 100%;
         height: 100%;
         &.bloom-noVideoSelected {
-            background: url("video-placeholder.svg") no-repeat center;
+            background: url("../templates/template books/video-placeholder.svg")
+                no-repeat center;
             background-size: contain;
         }
 

--- a/src/BloomBrowserUI/cleanupCss.js
+++ b/src/BloomBrowserUI/cleanupCss.js
@@ -1,0 +1,224 @@
+// Remove unwanted bundle (and css) files produced by processing less into css.
+// Also rename css files that are supposed to have hyphens or spaces in their names
+// move all of the css files to where we want them in the folder structure.
+// (The last two steps will not be needed once mini-css-extract-plugin allows a function
+// for determining the output file path.  The first step would still be nice.)
+//
+// NOTE: This is not called by webpack watch when recompiling one of the less files.
+// The result of the recompilation accumulates in output/browser/styles with the names
+// given by the original webpack processing.  Running this explicitly won't help because
+// of the check for a specific output file to determine whether to proceed.
+// I suppose the cleanupAndRename method could be revised to use the Promise and timeout
+// functionality instead of the simple fs.existsSync method, but I'm not sure it's worth
+// the effort.
+
+const fs = require("fs");
+const path = require("path");
+const outputDir = "../../output/browser";
+
+// This method is derived from the third answer at
+// https://stackoverflow.com/questions/26165725/nodejs-check-file-exists-if-not-wait-till-it-exist
+function checkExistsWithTimeout(path, timeout) {
+    return new Promise((resolve, reject) => {
+        const timeoutTimerId = setTimeout(handleTimeout, timeout);
+        const interval = 500; // check every half-second
+        let intervalCount = -1;
+
+        function handleTimeout() {
+            clearTimeout(timerId);
+            const error = new Error("check for " + path + " timed out");
+            error.name = "PATH_CHECK_TIMED_OUT";
+            reject(error);
+        }
+
+        function handleInterval() {
+            fs.access(path, err => {
+                ++intervalCount;
+                if (err) {
+                    let intervalTimerId = setTimeout(handleInterval, interval);
+                } else {
+                    clearTimeout(timeoutTimerId);
+                    resolve({ path: path, time: intervalCount * interval });
+                }
+            });
+        }
+
+        handleInterval(); // test for path immediately.
+    });
+}
+
+function removeWithTimeout(filepath) {
+    checkExistsWithTimeout(filepath, 5000)
+        .then(function(response) {
+            fs.unlinkSync(response.path);
+            let message = "removed " + filepath;
+            if (response.time != 0) {
+                message = message + " after " + response.time + " msec";
+            }
+            console.log(message);
+        })
+        .catch(function(error) {
+            console.log(error);
+        });
+}
+
+function renameWithTimeout(oldpath, newpath) {
+    checkExistsWithTimeout(oldpath, 5000)
+        .then(function(response) {
+            // ensure no problems with existing files or missing directories
+            if (fs.existsSync(newpath)) {
+                fs.unlinkSync(newpath);
+            } else {
+                const newdir = path.dirname(newpath);
+                if (!fs.existsSync(newdir)) {
+                    fs.mkdirSync(newdir);
+                }
+            }
+            fs.renameSync(oldpath, newpath);
+            let message = "renamed " + oldpath + " to " + newpath;
+            if (response.time != 0) {
+                message = message + " after " + response.time + " msec";
+            }
+            console.log(message);
+        })
+        .catch(function(error) {
+            console.log(error);
+        });
+}
+
+// Remove the unwanted javascript bundle produced by webpack and move the
+// generated css file to the desired location.  The latter won't be needed
+// once mini-css-extract-plugin allows us to use a function for the output
+// filename instead of its current limited choices.
+function cleanupAndRename(bundleName, pathAndBasename) {
+    // Delete the .js bundle that we don't need or want.
+    let unwanted = outputDir + "/" + bundleName + ".js";
+    removeWithTimeout(unwanted);
+    removeWithTimeout(unwanted + ".map");
+
+    let oldpath = outputDir + "/styles/" + bundleName + ".css";
+    let newpath = outputDir + "/" + pathAndBasename + ".css";
+    renameWithTimeout(oldpath, newpath);
+    renameWithTimeout(oldpath + ".map", newpath + ".map");
+}
+
+function removeBundleCss(bundleName) {
+    let unwanted = outputDir + "/styles/" + bundleName + ".css";
+    removeWithTimeout(unwanted);
+    removeWithTimeout(unwanted + ".map");
+}
+
+function cleanupAll() {
+    cleanupAndRename("page_chooser", "pageChooser/page-chooser");
+    cleanupAndRename("rc_slider_bloom", "bookEdit/css/rc-slider-bloom");
+
+    cleanupAndRename(
+        "Basic_Book",
+        "templates/template books/Basic Book/Basic Book"
+    );
+    cleanupAndRename("Big_Book", "templates/template books/Big Book/Big Book");
+    cleanupAndRename(
+        "Decodable_Reader",
+        "templates/template books/Decodable Reader/Decodable Reader"
+    );
+
+    cleanupAndRename(
+        "Device_XMatter",
+        "templates/xMatter/Device-XMatter/Device-XMatter"
+    );
+    cleanupAndRename(
+        "Factory_XMatter",
+        "templates/xMatter/Factory-XMatter/Factory-XMatter"
+    );
+    cleanupAndRename(
+        "SIL_Cameroon_XMatter",
+        "templates/xMatter/SIL-Cameroon-Mothballed/SIL-Cameroon-XMatter"
+    );
+    cleanupAndRename(
+        "SuperPaperSaver_XMatter",
+        "templates/xMatter/SuperPaperSaver-XMatter/SuperPaperSaver-XMatter"
+    );
+    cleanupAndRename(
+        "TemplateStarter_XMatter",
+        "templates/xMatter/TemplateStarter-XMatter/TemplateStarter-XMatter"
+    );
+    cleanupAndRename(
+        "Traditional_XMatter",
+        "templates/xMatter/Traditional-XMatter/Traditional-XMatter"
+    );
+    cleanupAndRename(
+        "Video_XMatter",
+        "templates/xMatter/Video-XMatter/Video-XMatter"
+    );
+    cleanupAndRename(
+        "MXBBook_XMatter",
+        "templates/customXMatter/MXBBook-XMatter/MXBBook-XMatter"
+    );
+    cleanupAndRename(
+        "MBXPamphlet_XMatter",
+        "templates/customXMatter/MXBPamphlet-XMatter/MXBPamphlet-XMatter"
+    );
+    cleanupAndRename(
+        "Dari_XMatter",
+        "templates/customXMatter/Dari-XMatter/Dari-XMatter"
+    );
+    cleanupAndRename(
+        "Pashti_XMatter",
+        "templates/customXMatter/Pashti-XMatter/"
+    );
+
+    cleanupAndRename(
+        "ArithmeticTemplate",
+        "templates/template books/Arithmetic Template/ArithmeticTemplate"
+    );
+    cleanupAndRename(
+        "audioRecording",
+        "bookEdit/toolbox/talkingBook/audioRecording"
+    );
+    cleanupAndRename("baseEPUB", "publish/epub/baseEPUB");
+    cleanupAndRename("basePage", "bookLayout/basePage");
+    cleanupAndRename("bloomDialog", "bookEdit/css/bloomDialog");
+    cleanupAndRename(
+        "bookSettings",
+        "bookEdit/toolbox/bookSettings/bookSettings"
+    );
+    cleanupAndRename(
+        "configuration",
+        "templates/template books/Wall Calendar/configuration"
+    );
+    cleanupAndRename("editMode", "bookEdit/css/editMode");
+    cleanupAndRename("editPaneGlobal", "bookEdit/css/editPaneGlobal");
+    cleanupAndRename("languageDisplay", "bookLayout/languageDisplay");
+    cleanupAndRename("motion", "bookEdit/toolbox/motion/motion");
+    cleanupAndRename("music", "bookEdit/toolbox/music/music");
+    cleanupAndRename("origami", "bookEdit/css/origami");
+    cleanupAndRename("origamiEditing", "bookEdit/css/origamiEditing");
+    cleanupAndRename(
+        "pageControls",
+        "bookEdit/pageThumbnailList/pageControls/pageControls"
+    );
+    cleanupAndRename(
+        "pageThumbnailList",
+        "bookEdit/pageThumbnailList/pageThumbnailList"
+    );
+    cleanupAndRename("previewMode", "bookPreview/previewMode");
+    cleanupAndRename(
+        "readerSetup",
+        "bookEdit/toolbox/readers/readerSetup/readerSetup"
+    );
+    cleanupAndRename("readerStyles", "publish/android/readerStyles");
+    cleanupAndRename("readerTools", "bookEdit/toolbox/readerTools");
+    cleanupAndRename("Special", "templates/template books/Special/Special");
+    cleanupAndRename("toolbox", "bookEdit/toolbox/toolbox");
+    cleanupAndRename("topicChooser", "bookEdit/TopicChooser/topicChooser");
+    cleanupAndRename(
+        "wallCalendar",
+        "templates/template books/Wall Calendar/wallCalendar"
+    );
+
+    // A pair of regular javascript bundles are producing css output: remove this unwanted css.
+    removeBundleCss("pageControlsBundle");
+    removeBundleCss("toolboxBundle");
+}
+
+cleanupAll();

--- a/src/BloomBrowserUI/gulpfile.js
+++ b/src/BloomBrowserUI/gulpfile.js
@@ -54,7 +54,7 @@ var paths = {
         "!../../DistFiles/ReleaseNotes.md",
         "!../../DistFiles/ffmpeg/*.md"
     ],
-    less: ["./**/*.less", "!./node_modules/**/*.less"],
+    //less: ["./**/*.less", "!./node_modules/**/*.less"],
     pug: ["./**/*.pug", "!./node_modules/**/*.pug", "!./**/*mixins.pug"],
     //typescript: ['./**/*.ts','!./**/*.d.ts', '!./**/node_modules/**/*.*'],
 
@@ -87,24 +87,24 @@ var allXliffFiles = globule.find(paths.xliff);
 // and need to use it to execute HtmlXliff.exe
 var IsLinux = globule.find(["/opt/mono4-sil/**/mono"]).length > 0;
 
-gulp.task("less", function() {
-    var less = require("gulp-less");
-    return gulp
-        .src(paths.less)
-        .pipe(debug({ title: "less:" }))
-        .pipe(sourcemaps.init())
-        .pipe(
-            less()
-                // Without this, the task will happily go on its merry way and you have to
-                // scroll up through the log messages to know if there was any problem at all.
-                .on("error", function(error) {
-                    console.error(error.message);
-                    process.exit(1);
-                })
-        )
-        .pipe(sourcemaps.write(outputDir))
-        .pipe(gulp.dest(outputDir)); //drop all css's into the same dirs.
-});
+// gulp.task("less", function() {
+//     var less = require("gulp-less");
+//     return gulp
+//         .src(paths.less)
+//         .pipe(debug({ title: "less:" }))
+//         .pipe(sourcemaps.init())
+//         .pipe(
+//             less()
+//                 // Without this, the task will happily go on its merry way and you have to
+//                 // scroll up through the log messages to know if there was any problem at all.
+//                 .on("error", function(error) {
+//                     console.error(error.message);
+//                     process.exit(1);
+//                 })
+//         )
+//         .pipe(sourcemaps.write(outputDir))
+//         .pipe(gulp.dest(outputDir)); //drop all css's into the same dirs.
+// });
 
 gulp.task("pug", function() {
     var pug = require("gulp-pug");
@@ -158,18 +158,18 @@ gulp.task("copy", function() {
 });
 
 gulp.task("watchInner", function() {
-    watch(
-        paths.less,
-        batch(function(events, done) {
-            gulp.start("copy", done);
-        })
-    );
-    watch(
-        paths.less,
-        batch(function(events, done) {
-            gulp.start("less", done);
-        })
-    );
+    // watch(
+    //     paths.less,
+    //     batch(function(events, done) {
+    //         gulp.start("copy", done);
+    //     })
+    // );
+    // watch(
+    //     paths.less,
+    //     batch(function(events, done) {
+    //         gulp.start("less", done);
+    //     })
+    // );
     watch(
         paths.pug,
         batch(function(events, done) {
@@ -203,7 +203,7 @@ gulp.task("watchInner", function() {
 });
 
 gulp.task("watchlp", function() {
-    runSequence(["less", "pug", "pugLRT"], "watchInner");
+    runSequence([/*"less",*/ "pug", "pugLRT"], "watchInner");
 });
 
 gulp.task("watch", function() {
@@ -359,7 +359,7 @@ gulp.task("default", function(callback) {
         "clean",
         "copy",
         [
-            "less",
+            // "less",
             "pug",
             "pugLRT",
             "markdownHelp",

--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -99,6 +99,7 @@
         "markdown-it": "^8.4.1",
         "markdown-it-attrs": "^1.2.1",
         "markdown-it-container": "^2.0.0",
+        "mini-css-extract-plugin": "^0.4.2",
         "path": "^0.12.7",
         "prettier": "latest",
         "pretty-quick": "^1.6.0",
@@ -113,6 +114,7 @@
         "typescript": "^2.8.1",
         "webpack": "^4.6.0",
         "webpack-cli": "^2.1.2",
+        "webpack-shell-plugin-next": "^0.6.4",
         "webpack-stream": "^4.0.3"
     }
 }

--- a/src/BloomBrowserUI/templates/customXMatter/Dari-XMatter/Dari-XMatter.less
+++ b/src/BloomBrowserUI/templates/customXMatter/Dari-XMatter/Dari-XMatter.less
@@ -1,6 +1,6 @@
 @import "../../xMatter/bloom-xmatter-common.less";
 
-@XMatterPackName: "Afghanistan";
+@XMatterPackName: "Dari";
 
 .printInfo {
     height: 5em;

--- a/src/BloomBrowserUI/templates/customXMatter/Dari-XMatter/Dari-XMatter.pug
+++ b/src/BloomBrowserUI/templates/customXMatter/Dari-XMatter/Dari-XMatter.pug
@@ -100,15 +100,15 @@ mixin afg-outsideBackCover
 	+page-xmatter('Outside Back Cover').cover.coverColor.outsideBackCover.bloom-backMatter(data-export='back-matter-back-cover')&attributes(attributes)#6AB1D898-9E35-498E-99D4-132B46FAFDA4
 		.ownership
 			p كتاب هاى درسى متعلق به وزارت معارف بوده خريد و فروش آن
-			p جداً ممنوع است. با متخلفين برخورد قانونى صورت مى گيرد 
+			p جداً ممنوع است. با متخلفين برخورد قانونى صورت مى گيرد
 
 doctype html
 html
 	head
 		meta(charset='UTF-8')
 		meta(name='BloomFormatVersion', content='2.0')
-		title Afghanistan Front & Back Matter
-		+stylesheets('Afghanistan-XMatter.css')
+		title Dari Front & Back Matter
+		+stylesheets('Dari-XMatter.css')
 	body
 		+afg-outsideFrontCover
 		+standard-blankInsideFrontCover

--- a/src/BloomBrowserUI/templates/customXMatter/Pashti-XMatter/Pashti-XMatter.less
+++ b/src/BloomBrowserUI/templates/customXMatter/Pashti-XMatter/Pashti-XMatter.less
@@ -1,6 +1,6 @@
 @import "../../xMatter/bloom-xmatter-common.less";
 
-@XMatterPackName: "Afghanistan";
+@XMatterPackName: "Pashti";
 
 .printInfo {
     height: 5em;

--- a/src/BloomBrowserUI/templates/customXMatter/Pashti-XMatter/Pashti-XMatter.pug
+++ b/src/BloomBrowserUI/templates/customXMatter/Pashti-XMatter/Pashti-XMatter.pug
@@ -109,7 +109,7 @@ html
 		meta(charset='UTF-8')
 		meta(name='BloomFormatVersion', content='2.0')
 		title Afghanistan Front & Back Matter
-		+stylesheets('Afghanistan-XMatter.css')
+		+stylesheets('Pashti-XMatter.css')
 	body
 		+afg-outsideFrontCover
 		+standard-blankInsideFrontCover

--- a/src/BloomBrowserUI/webpack.config.js
+++ b/src/BloomBrowserUI/webpack.config.js
@@ -1,8 +1,8 @@
 ﻿var path = require("path");
 var webpack = require("webpack");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const ShellPlugin = require("webpack-shell-plugin-next");
 var node_modules = path.resolve(__dirname, "node_modules");
-var pathToReact = path.resolve(node_modules, "react/dist/react.js");
-var pathToReactDom = path.resolve(node_modules, "react-dom/dist/react-dom.js");
 var pathToOriginalJavascriptFilesInLib = path.resolve(__dirname, "lib");
 var pathToBookEditJS = path.resolve(__dirname, "bookEdit/js");
 var pathToOriginalJavascriptFilesInModified_Libraries = path.resolve(
@@ -12,7 +12,8 @@ var pathToOriginalJavascriptFilesInModified_Libraries = path.resolve(
 var globule = require("globule");
 
 //note: if you change this, change it in gulpfile.js & karma.conf.js as well
-var outputDir = "../../output/browser";
+const outputDir = "../../output/browser";
+const stylesDir = outputDir + "/styles";
 
 // Because our output directory does not have the same parent as our node_modules, we
 // need to resolve the babel related presets (and plugins).  This mapping function was
@@ -55,8 +56,69 @@ module.exports = {
             "./lib/**/*Spec.js",
             "./publish/**/*Spec.ts",
             "./publish/**/*Spec.js"
-        ])
-        //             testBundle: globule.find(["./**/*Spec.ts", "./**/*Spec.js", "!./node_modules/**"])//This slowed down webpack a ton, becuase the way it works is that it 1st it finds it all, then it excludes node_modules
+        ]),
+        // These are referenced in pug files.
+        audioRecording: "./bookEdit/toolbox/talkingBook/audioRecording.less",
+        basePage: "./bookLayout/basePage.less",
+        bloomDialog: "./bookEdit/css/bloomDialog.less",
+        bookSettings: "./bookEdit/toolbox/bookSettings/bookSettings.less",
+        editMode: "./bookEdit/css/editMode.less",
+        editPaneGlobal: "./bookEdit/css/editPaneGlobal.less",
+        motion: "./bookEdit/toolbox/motion/motion.less",
+        music: "./bookEdit/toolbox/music/music.less",
+        page_chooser: "./pageChooser/page-chooser.less",
+        pageControls:
+            "./bookEdit/pageThumbnailList/pageControls/pageControls.less",
+        pageThumbnailList:
+            "./bookEdit/pageThumbnailList/pageThumbnailList.less",
+        rc_slider_bloom: "./bookEdit/css/rc-slider-bloom.less",
+        readerSetup: "./bookEdit/toolbox/readers/readerSetup/readerSetup.less",
+        readerTools: "./bookEdit/toolbox/readerTools.less",
+        toolbox: "./bookEdit/toolbox/toolbox.less",
+        // These are used programmatically by C# code.
+        baseEPUB: "./publish/epub/baseEPUB.less",
+        languageDisplay: "./bookLayout/languageDisplay.less",
+        origami: "./bookEdit/css/origami.less",
+        origamiEditing: "./bookEdit/css/origamiEditing.less",
+        previewMode: "./bookPreview/previewMode.less",
+        readerStyles: "./publish/android/readerStyles.less",
+        previewMode: "./bookPreview/previewMode.less",
+        topicChooser: "./bookEdit/TopicChooser/topicChooser.less",
+        // referenced by Book Template and XMatter pug files
+        ArithmeticTemplate:
+            "./templates/template books/Arithmetic Template/ArithmeticTemplate.less",
+        Basic_Book: "./templates/template books/Basic Book/Basic Book.less",
+        Big_Book: "./templates/template books/Big Book/Big Book.less",
+        Decodable_Reader:
+            "./templates/template books/Decodable Reader/Decodable Reader.less",
+        Special: "./templates/template books/Special/Special.less",
+        configuration:
+            "./templates/template books/Wall Calendar/configuration.less",
+        wallCalendar:
+            "./templates/template books/Wall Calendar/wallCalendar.less",
+        Device_XMatter:
+            "./templates/xMatter/Device-XMatter/Device-XMatter.less",
+        Factory_XMatter:
+            "./templates/xMatter/Factory-XMatter/Factory-XMatter.less",
+        SIL_Cameroon_XMatter:
+            "./templates/xMatter/SIL-Cameroon-Mothballed/SIL-Cameroon-XMatter.less",
+        // The pug file uses Traditional-XMatter.css instead of SIL-PNG-XMatter.css.
+        // SIL_PNG_XMatter: "./templates/xMatter/SIL-PNG-XMatter/SIL-PNG-XMatter.less",
+        SuperPaperSaver_XMatter:
+            "./templates/xMatter/SuperPaperSaver-XMatter/SuperPaperSaver-XMatter.less",
+        TemplateStarter_XMatter:
+            "./templates/xMatter/TemplateStarter-XMatter/TemplateStarter-XMatter.less",
+        Traditional_XMatter:
+            "./templates/xMatter/Traditional-XMatter/Traditional-XMatter.less",
+        Video_XMatter: "./templates/xMatter/Video-XMatter/Video-XMatter.less",
+        MXBBook_XMatter:
+            "./templates/customXMatter/MXBBook-XMatter/MXBBook-XMatter.less",
+        MBXPamphlet_XMatter:
+            "./templates/customXMatter/MXBPamphlet-XMatter/MXBPamphlet-XMatter.less",
+        Dari_XMatter:
+            "./templates/customXMatter/Dari-XMatter/Dari-XMatter.less",
+        Pashti_XMatter:
+            "./templates/customXMatter/Pashti-XMatter/Pashti-XMatter.less"
     },
 
     output: {
@@ -90,7 +152,7 @@ module.exports = {
             pathToBookEditJS,
             pathToOriginalJavascriptFilesInModified_Libraries
         ],
-        extensions: [".js", ".jsx", ".ts", ".tsx"] //We may need to add .less here... otherwise maybe it will ignore them unless they are require()'d
+        extensions: [".js", ".jsx", ".ts", ".tsx", ".less"] //We may need to add .less here... otherwise maybe it will ignore them unless they are require()'d
     },
     plugins: [
         //answer on various legacy issues: http://stackoverflow.com/questions/28969861/managing-jquery-plugin-dependency-in-webpack?lq=1
@@ -99,6 +161,17 @@ module.exports = {
             $: "jquery",
             jQuery: "jquery",
             "window.jQuery": "jquery"
+        }),
+        new MiniCssExtractPlugin({
+            filename: "styles/[name].css",
+            chunkFilename: "styles/[id].css"
+        }),
+        new ShellPlugin({
+            onBuildEnd: {
+                scripts: ["node cleanupCss.js"],
+                blocking: false,
+                parallel: false
+            }
         })
     ],
     optimization: {
@@ -187,8 +260,81 @@ module.exports = {
                 ]
             },
             {
+                test: /\.less$/,
+                include: [
+                    path.resolve(__dirname, "bookEdit/css/bloomDialog.less"),
+                    path.resolve(__dirname, "bookEdit/css/editMode.less"),
+                    path.resolve(__dirname, "bookEdit/css/editPaneGlobal.less"),
+                    path.resolve(
+                        __dirname,
+                        "bookEdit/css/rc-slider-bloom.less"
+                    ),
+                    path.resolve(
+                        __dirname,
+                        "bookEdit/pageThumbnailList/pageControls/pageControls.less"
+                    ),
+                    path.resolve(
+                        __dirname,
+                        "bookEdit/pageThumbnailList/pageThumbnailList.less"
+                    ),
+                    path.resolve(
+                        __dirname,
+                        "bookEdit/toolbox/bookSettings/bookSettings.less"
+                    ),
+                    path.resolve(
+                        __dirname,
+                        "bookEdit/toolbox/motion/motion.less"
+                    ),
+                    path.resolve(
+                        __dirname,
+                        "bookEdit/toolbox/music/music.less"
+                    ),
+                    path.resolve(
+                        __dirname,
+                        "bookEdit/toolbox/readers/readerSetup/readerSetup.less"
+                    ),
+                    path.resolve(
+                        __dirname,
+                        "bookEdit/toolbox/readerTools.less"
+                    ),
+                    path.resolve(
+                        __dirname,
+                        "bookEdit/toolbox/talkingBook/audioRecording.less"
+                    ),
+                    path.resolve(__dirname, "bookEdit/toolbox/toolbox.less"),
+                    path.resolve(__dirname, "bookLayout/basePage.less"),
+                    path.resolve(__dirname, "pageChooser/page-chooser.less"),
+                    path.resolve(__dirname, "publish/epub/baseEPUB.less"),
+                    path.resolve(
+                        __dirname,
+                        "bookEdit/TopicChooser/topicChooser.less"
+                    ),
+                    path.resolve(__dirname, "bookPreview/previewMode.less"),
+                    path.resolve(__dirname, "bookEdit/css/origami.less"),
+                    path.resolve(__dirname, "bookEdit/css/origamiEditing.less"),
+                    path.resolve(__dirname, "bookLayout/languageDisplay.less"),
+                    path.resolve(__dirname, "bookPreview/previewMode.less"),
+                    path.resolve(
+                        __dirname,
+                        "publish/android/readerStyles.less"
+                    ),
+                    path.resolve(__dirname, "templates/")
+                ],
+                use: [
+                    {
+                        loader: MiniCssExtractPlugin.loader
+                    },
+                    {
+                        loader: "css-loader" // translates CSS into CommonJS
+                    },
+                    {
+                        loader: "less-loader" // compiles Less to CSS
+                    }
+                ]
+            },
+            {
                 // this allows things like background-image: url("myComponentsButton.svg") and have the resulting path look for the svg in the stylesheet's folder
-                test: /\.(svg|jpg|png)$/,
+                test: /\.(svg|jpg|png|gif)$/,
                 use: {
                     loader: "file-loader"
                 }


### PR DESCRIPTION
I'm not sure this is worth merging before the output files can be placed correctly
to begin with.  The new cleanCss.js file is not called by webpack --watch, but
only by webpack for a complete build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2693)
<!-- Reviewable:end -->
