### PR TITLE
Prevent null dereferences in recent metadata code (BL-6178)

### DIFF
--- a/src/BloomBrowserUI/publish/metadata/SubjectChooser.tsx
+++ b/src/BloomBrowserUI/publish/metadata/SubjectChooser.tsx
@@ -52,6 +52,7 @@ export default class SubjectChooser extends React.Component<IProps> {
             description: currentNode.label
         };
         let metadataSubjects: JsSubject[] = this.props.subjects.value;
+        if (!metadataSubjects) metadataSubjects = [];
         if (currentNode.checked) {
             metadataSubjects.push(currentSubject); // appends subject to the end of the array
         } else {

--- a/src/BloomBrowserUI/publish/metadata/SubjectTreeNode.ts
+++ b/src/BloomBrowserUI/publish/metadata/SubjectTreeNode.ts
@@ -50,6 +50,7 @@ export class SubjectTreeNode {
         codeValue: string,
         currentSubjects: JsSubject[]
     ): boolean {
+        if (!currentSubjects) return false;
         return currentSubjects.some(subject => subject.code == codeValue);
     }
 
@@ -60,6 +61,7 @@ export class SubjectTreeNode {
     //   2) Run a test to verify this function's correct output.
     // Therefore, when we do away with (1), we can eliminate this function.
     public static getCodeList(currentSubjects: JsSubject[]): string {
+        if (currentSubjects == null) return "";
         return currentSubjects
             .map(subject => {
                 return subject.code;

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -436,6 +436,8 @@ namespace Bloom.Publish.Epub
 		private void AddSubjects(XElement metadataElt, XNamespace dc, XNamespace opf)
 		{
 			var subjects = Book.BookInfo.MetaData.Subjects;
+			if (subjects == null)
+				return;
 			foreach (var subjectObj in subjects)
 			{
 				var code = subjectObj.code;


### PR DESCRIPTION
This may be Linux-specific behavior.  I haven't tested Windows to see
if these crashes occur there.  The fix should be safe in any case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2694)
<!-- Reviewable:end -->
