### PR TITLE
Fix crash in ACE by Daisy checker for bilingual books (BL-6426)

### DIFF
--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -1451,7 +1451,14 @@ namespace Bloom.Publish.Epub
 						++descCount;
 						asideNode.SetAttribute("id", figDescId);
 						var ariaAttr = img.GetAttribute("aria-describedby");
-						img.SetAttribute("aria-describedby", (string.IsNullOrWhiteSpace(ariaAttr) ? "" : ariaAttr + " ") + figDescId);
+						// ACE by Daisy cannot handle multiple ID values in the aria-describedby attribute even
+						// though the ARIA specification clearly allows this.  So for now, use only the first one.
+						// I'd prefer to use specifically the vernacular language aside if we have to choose only
+						// one, but the aside elements don't have a lang attribute (yet?).  Perhaps the aside
+						// elements are ordered such that the first one is always the vernacular.
+						// See https://silbloom.myjetbrains.com/youtrack/issue/BL-6426.
+						if (String.IsNullOrEmpty(ariaAttr))
+							img.SetAttribute("aria-describedby", figDescId);
 					}
 				}
 			}

--- a/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
+++ b/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
@@ -188,7 +188,7 @@ namespace Bloom.web.controllers
 					var randomName = Guid.NewGuid().ToString();
 					var reportDirectory = Path.Combine(reportRootDirectory, randomName);
 
-					var arguments = $"ace.js  -o \"{reportDirectory}\" \"{epubPath}\"";
+					var arguments = $"ace.js --verbose -o \"{reportDirectory}\" \"{epubPath}\"";
 					const int kSecondsBeforeTimeout = 60;
 					var progress = new NullProgress();
 					_webSocketProgress.MessageWithoutLocalizing("Running Ace by Daisy");


### PR DESCRIPTION
The real bug is in the ACE code, but this works around it until they
fix their code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2723)
<!-- Reviewable:end -->
