### PR TITLE
Show untranslated TSX strings in red, not grey (BL-6422)

### DIFF
--- a/src/BloomBrowserUI/bloomUI.less
+++ b/src/BloomBrowserUI/bloomUI.less
@@ -61,6 +61,14 @@
     display: none !important;
 }
 
+// The following is enabled for development builds and alpha builds.
+// Red on yellow background means the string has not been translated.
+body.developer .untranslated,
+body.alpha .untranslated {
+    color: darkred;
+    background-color: yellow;
+}
+
 /* all of this worked in the latest firefox, but not Bloom.
     We may want it someday, as it sure seems clearer to put
     in a ? than the black box that FF normally uses, to mean

--- a/src/BloomBrowserUI/react_components/l10n.tsx
+++ b/src/BloomBrowserUI/react_components/l10n.tsx
@@ -1,6 +1,26 @@
 import { CancelTokenStatic } from "axios";
 import * as React from "react";
 import theOneLocalizationManager from "../lib/localizationManager/localizationManager";
+import { BloomApi } from "../utils/bloomApi";
+
+export let channelName: string = ""; // ensure it's defined non-null
+BloomApi.get("/common/channel", r => {
+    channelName = r.data;
+    // Setting the class on the body element here to include the channel appears
+    // to work for the places that this code affects.  Should we want to expand
+    // marking untranslated strings visually in other places, then it would be
+    // necessary to make this assignment in C# code.  Which unfortunately would
+    // have to happen in at least half a dozen places.
+    let channelClass = channelName.toLowerCase();
+    if (channelClass.startsWith("developer/")) channelClass = "developer";
+    if (
+        document &&
+        document.body &&
+        !document.body.classList.contains(channelClass)
+    ) {
+        document.body.classList.add(channelClass);
+    }
+});
 
 // This would be used by a control that doesn't have any text of its own,
 // but has children that need to be localized.
@@ -189,7 +209,7 @@ export class LocalizableElement<
             }
         } else {
             return (
-                <span style={{ color: "grey" }}>
+                <span className="untranslated">
                     {" "}
                     {this.getOriginalStringContent()}{" "}
                 </span>

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -76,6 +76,11 @@ namespace Bloom.web.controllers
 					WorkspaceView.CheckForUpdates();
 					request.PostSucceeded();
 				}, false);
+			apiHandler.RegisterEndpointHandler("common/channel",
+				request =>
+				{
+					request.ReplyWithText(ApplicationUpdateSupport.ChannelName);
+				}, false);
 		}
 
 		private void RethinkPageAndReloadIt(ApiRequest request)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2724)
<!-- Reviewable:end -->
