### PR TITLE
BL-6338: compute extra padding to prevent title overflow

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
@@ -101,7 +101,7 @@ mixin standard-cover-contents
 
 	+field-prototypeDeclaredExplicity("V,N1").bookTitle
 		label.bubble Book title in {lang}
-		+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style(data-book='bookTitle')
+		+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style.bloom-padForOverflow(data-book='bookTitle')
 
 	+standard-cover-image
 

--- a/src/BloomBrowserUI/utils/measureText.ts
+++ b/src/BloomBrowserUI/utils/measureText.ts
@@ -3,46 +3,27 @@
 // Bloom license.
 
 export class MeasureText {
-    // Returns the distance in pixels between the lowest descender in text and the 'bottom'
-    // of the font (as used by the browser to compute scrollHeight).
-    // This is slightly approximate since we really only want to consider the
+    // Returns an object with three measurements:
+    // actualDescent: distance in pixels between the baseline and
+    // the bottom of the lowest descender in the last line of text
+    // (This is slightly approximate since we really only want to consider the
     // part of the text that is on the last line when text is wrapped in a paragraph
     // of the specified width. We approximate this by measuring the part of the
-    // text at the end that fits in the specified width. (FontSize is in pixels.)
-    public static getExcessDescent(
+    // text at the end that fits in the specified width.) (FontSize is in pixels.)
+    // fontDescent: the descent of the font used by the browser to compute scrollHeight; we
+    // think this is the descent actually recorded in the font.
+    // layoutDescent: the distance from the baseline of the text to the bottom
+    // of an auto-sized box containing it at the specified line height.
+    // (this may actually be LESS than the height needed to really draw the descenders!)
+    public static getDescentMeasurements(
         text: string,
         fontFamily: string,
         fontSize: number,
-        width: number
+        width: number,
+        lineHeight: string
     ) {
         const t0 = performance.now();
-        // Get the real descent. This is done by drawing the text on a canvas.
-        // The code in drawText causes it to be drawn in such a position
-        // that the text baseline is aligned with the top of the canvas.
-        // Thus, whatever is drawn on the canvas is descenders.
-        // We scan to find the lowest line of pixels on which anything
-        // is drawn.
-        // This is not quite perfect, because we're drawing the whole content
-        // of the target box as a single line. We position it so that what
-        // actually gets drawn is the end of the text, but it still might
-        // include some descenders from the second-last line. It's conceivable
-        // to improve it further and figure out exactly what text is on the last
-        // line, but we decided it was not worth the effort to be that perfectionistic.
-
-        // Descenders are unlikely to be more than 1/3 of the font size,
-        // and using a smaller canvas saves memory and gives us less blank
-        // lines to scan. (Review: are there non-Roman fonts where the
-        // text is mostly descenders?)
-        const canvasHeight = fontSize / 3;
-        const testingCanvas = this.createCanvas(width, canvasHeight);
-        // The number of pixels of descent is one more than the index of
-        // the bottom line on which we found part of a descender.
-        // A small optimization is to give zero at once for empty strings.
-        const descent = text
-            ? this.getLowest(testingCanvas, text, fontFamily, fontSize) + 1
-            : 0;
-
-        // Now get the descent that the browser uses for various purposes,
+        // Get the descent that the browser uses for various purposes,
         // including painting the background of spans, and determining the
         // scrollHeight of a block of text. I _think_ it is based on the
         // descent that is recorded as a property of the font itself; we
@@ -63,6 +44,7 @@ export class MeasureText {
         div.innerText = text.substr(0, 1);
         div.style.fontFamily = fontFamily;
         div.style.fontSize = fontSize + "px";
+
         // It has to be in the document to get measured, but we don't want the
         // user to see it.
         div.style.visibility = "hidden";
@@ -72,10 +54,46 @@ export class MeasureText {
         // We don't want to put it in the document, but unless we do all its
         // measurements are zero.
         document.body.appendChild(div);
-        const outerRect = div.getBoundingClientRect();
-        const innerRect = block.getBoundingClientRect();
-        const wrongDescent = outerRect.bottom - innerRect.bottom;
+        const bottomOfTextWithDefaultLineSpace = div.getBoundingClientRect()
+            .bottom;
+        const baselineOfTextWithDefaultLineSpace = block.getBoundingClientRect()
+            .bottom;
+        const fontDescent =
+            bottomOfTextWithDefaultLineSpace -
+            baselineOfTextWithDefaultLineSpace;
+
+        div.style.lineHeight = lineHeight;
+        const bottomOfTextWithActualLineSpace = div.getBoundingClientRect()
+            .bottom;
+        const baselineOfTextWithActualLineSpace = block.getBoundingClientRect()
+            .bottom;
+        const layoutDescent =
+            bottomOfTextWithActualLineSpace - baselineOfTextWithActualLineSpace;
         document.body.removeChild(div);
+
+        // Get the real descent. This is done by drawing the text on a canvas.
+        // The code in drawText causes it to be drawn in such a position
+        // that the text baseline is aligned with the top of the canvas.
+        // Thus, whatever is drawn on the canvas is descenders.
+        // We scan to find the lowest line of pixels on which anything
+        // is drawn.
+        // This is not quite perfect, because we're drawing the whole content
+        // of the target box as a single line. We position it so that what
+        // actually gets drawn is the end of the text, but it still might
+        // include some descenders from the second-last line. It's conceivable
+        // to improve it further and figure out exactly what text is on the last
+        // line, but we decided it was not worth the effort to be that perfectionistic.
+
+        // We only need enough space to draw what the browser thinks is the descent.
+        const canvasHeight = fontDescent;
+        const testingCanvas = this.createCanvas(width, canvasHeight);
+        // The number of pixels of descent is one more than the index of
+        // the bottom line on which we found part of a descender.
+        // A small optimization is to give zero at once for empty strings.
+        const descent = text
+            ? this.getLowest(testingCanvas, text, fontFamily, fontSize) + 1
+            : 0;
+
         //document.body.removeChild(testingCanvas); // reinstate if you put it in for debugging
         const t1 = performance.now();
         console.log(
@@ -88,12 +106,37 @@ export class MeasureText {
                 " to be " +
                 descent +
                 " but estimated as " +
-                wrongDescent +
+                fontDescent +
                 " (calculation took " +
                 (t1 - t0) +
                 " ms)"
         );
-        return Math.max(wrongDescent - descent, 0);
+        return {
+            fontDescent: fontDescent,
+            actualDescent: descent,
+            layoutDescent: layoutDescent
+        };
+    }
+
+    // Same results as getDescentMeasurements(), but gets all the arguments
+    // from a given element.
+    public static getDescentMeasurementsOfBox(box: HTMLElement) {
+        const text = box.textContent ? box.textContent : "";
+        const realStyle = window.getComputedStyle(box, null);
+        // The FontFamily we get here includes quotes if there are spaces,
+        // but we don't want them for the getDescentMeasurements routine.
+        const fontFamily = realStyle
+            .getPropertyValue("font-family")
+            .replace(/"/g, "");
+        const fontSize = realStyle.getPropertyValue("font-size");
+        const lineHeight = realStyle.lineHeight;
+        return this.getDescentMeasurements(
+            text,
+            fontFamily,
+            parseInt(fontSize),
+            box.clientWidth,
+            lineHeight
+        );
     }
 
     private static createCanvas(
@@ -109,7 +152,7 @@ export class MeasureText {
         // canvas.style.position = "absolute";
         // canvas.style.left = "0";
         // canvas.style.top = "0";
-        //document.body.appendChild(canvas);
+        // document.body.appendChild(canvas);
         return canvas;
     }
 


### PR DESCRIPTION
Adds new bloom-padForOverflow property to enable this behavior

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2744)
<!-- Reviewable:end -->
