### PR TITLE
Add gtk-sharp4-sil as dependency for Bloom 4.2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
 Package: bloom-desktop
 Architecture: any
 Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
- mono4-sil, libgdiplus4-sil, gtklp,
+ mono4-sil, libgdiplus4-sil, gtk-sharp4-sil, gtklp,
  chmsee, libtidy-sil,
  fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,
  optipng, libsndfile1,


### PR DESCRIPTION
THIS SHOULD NOT BE MERGED TO Version4.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2751)
<!-- Reviewable:end -->
