### PR TITLE
Remove (un)decodable markup when closing tool (BL-6485)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -737,7 +737,9 @@ export class ReaderToolsModel {
         }
 
         // if no change, return now
-        if (!newMarkupType) return false;
+        // Note that an enum value of 0 is not "truthy".
+        // See https://silbloom.myjetbrains.com/youtrack/issue/BL-6485.
+        if (!newMarkupType && newMarkupType !== MarkupType.None) return false;
         let didMarkup = false;
 
         if (newMarkupType !== this.currentMarkupType) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2766)
<!-- Reviewable:end -->
