### PR TITLE
Remove white background for Device16x9Landscape (BL-6496)

### DIFF
--- a/src/BloomBrowserUI/bookLayout/device.less
+++ b/src/BloomBrowserUI/bookLayout/device.less
@@ -44,9 +44,6 @@
     //TODO: This is only for videos
     // Why is this not used for Device16x9Portrait too?!
     background-color: black;
-    img {
-        background-color: white;
-    } // so that transparent images show
 }
 
 .Device16x9Landscape,


### PR DESCRIPTION
I don't know how to enable PictureStoryLandscape to test still having the white background there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2771)
<!-- Reviewable:end -->
