### PR TITLE
BL-6519 Fix position of branding HTML on device End page

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/Device-XMatter/Device-XMatter.less
+++ b/src/BloomBrowserUI/templates/xMatter/Device-XMatter/Device-XMatter.less
@@ -28,7 +28,7 @@ div.bloom-page.coverColor {
     // Due to the absence of the above, we need a new rule to get the branding on the bottom
     .marginBox {
         display: block;
-        img {
+        [data-book="outside-back-cover-branding-bottom-html"] {
             position: absolute;
             bottom: 0;
             left: 0;


### PR DESCRIPTION
Rule that previously positioned an image that was a direct child of margin box now needs to position the new div that is the parent of the image (or possibly other stuff).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2776)
<!-- Reviewable:end -->
