### PR TITLE
BL-6527 Restore style of Bloom UI links in hint bubbles

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/BloomHintBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/js/BloomHintBubbles.ts
@@ -443,7 +443,11 @@ export default class BloomHintBubbles {
                     functionCall = "javascript:" + functionCall + ";";
 
                 whatToSay =
-                    "<a href='" + functionCall + "'>" + whatToSay + "</a>";
+                    "<a class='ui-link' href='" +
+                    functionCall +
+                    "'>" +
+                    whatToSay +
+                    "</a>";
             }
             whatToSay =
                 whatToSay +
@@ -470,7 +474,13 @@ export default class BloomHintBubbles {
             );
             if (linkTarget.indexOf("(") > 0)
                 linkTarget = "javascript:" + linkTarget + ";";
-            return "<br><a href='" + linkTarget + "'>" + linkText + "</a>";
+            return (
+                "<br><a class='ui-link' href='" +
+                linkTarget +
+                "'>" +
+                linkText +
+                "</a>"
+            );
         }
         return "";
     }

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -641,9 +641,10 @@ h2 {
 }
 
 // if brandings (or anything else) has hyperlinks, we default to not showing ugly blue underlines in print.
-// those could be re-enabled for digital products
-a:link,
-a:visited {
+// those could be re-enabled for digital products. The ui-link class is used to suppress this
+// for links we want in the Bloom ui, such as in hint bubbles.
+a:not(.ui-link):link,
+a:not(.ui-link):visited {
     color: unset;
     text-decoration: unset;
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2783)
<!-- Reviewable:end -->
