### PR TITLE
BL-6323 Change size unit for CLB branding height for Simply Reading

### DIFF
--- a/src/BloomBrowserUI/branding/CLB/branding.less
+++ b/src/BloomBrowserUI/branding/CLB/branding.less
@@ -3,7 +3,10 @@
 [data-book="outside-back-cover-branding-bottom-html"] {
     flex-direction: row; // show them side-by-side
     img {
-        max-height: 20mm; // arbitrary
+        // arbitrary height; was 20mm; 4.7em is equivalent in FF, Gitden,
+        // but unlike 20mm it typically gives full-width images in
+        // Simply Reading.
+        max-height: 4.7em;
         // If the images are too wide when both are 20mm high
         // (device16x9 is perhaps the most extreme case), we want them
         // to get smaller until both fit, staying the same height as


### PR DESCRIPTION
4.7em is about the same as 20mm in FF, but Simply Reading displays the images much larger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2789)
<!-- Reviewable:end -->
