### PR TITLE
Fix focus display for jquery dialogs to match React dialogs (BL-6504)

### DIFF
--- a/src/BloomBrowserUI/themes/bloom-jqueryui-theme/jquery-ui-dialog.custom.css
+++ b/src/BloomBrowserUI/themes/bloom-jqueryui-theme/jquery-ui-dialog.custom.css
@@ -75,9 +75,13 @@ div.ui-dialog div.ui-dialog-buttonset button.ui-button {
 
 div.ui-dialog div.ui-dialog-buttonset button.ui-state-hover,
 div.ui-dialog div.ui-dialog-buttonset button.ui-state-focus {
-    background: #888;
-    color: #fff;
-    border: 1px solid #666;
+    background: white;
+    color: black;
+    border: 1px solid gray;
+}
+
+div.ui-dialog div.ui-dialog-buttonset button.ui-state-focus .ui-button-text {
+    border: 1px dotted gray;
 }
 
 div.ui-dialog div.ui-dialog-buttonset button.ui-button span.ui-button-text {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2791)
<!-- Reviewable:end -->
