### PR TITLE
[4.4]BL-6561 Don't close ePUB metadata dlg on click

### DIFF
--- a/src/BloomBrowserUI/publish/metadata/BookMetadataDialog.tsx
+++ b/src/BloomBrowserUI/publish/metadata/BookMetadataDialog.tsx
@@ -63,7 +63,7 @@ export default class BookMetadataDialog extends React.Component<{}, IState> {
                     ariaHideApp={false} //we're not trying to make Bloom work with screen readers
                     className="bookMetadataDialog"
                     isOpen={this.state.isOpen}
-                    shouldCloseOnOverlayClick={true}
+                    shouldCloseOnOverlayClick={false}
                     onRequestClose={() => this.handleCloseModal(false)}
                 >
                     <Div


### PR DESCRIPTION
* now user must use OK or Cancel buttons, or hit Esc
   to close the dialog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2799)
<!-- Reviewable:end -->
