### PR TITLE
Fix broken Sign Language tool display (BL-6569)

### DIFF
--- a/src/BloomBrowserUI/react_components/l10n.tsx
+++ b/src/BloomBrowserUI/react_components/l10n.tsx
@@ -202,7 +202,7 @@ export class LocalizableElement<
             l10nClass = "translated";
             text = this.state.translation;
         }
-        return <span className={l10nClass}>{text}</span>;
+        return <span className={l10nClass}> {text} </span>;
     }
 
     public getLocalizedTooltip(controlIsEnabled: boolean): string {


### PR DESCRIPTION
This reverts what I thought was an innocuous change last week.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2803)
<!-- Reviewable:end -->
