### PR TITLE
Fix Bl-6569 Toolbox loads tool contents into header

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -891,9 +891,13 @@ function loadToolboxTool(
         toolboxElt.append(content);
     } else {
         let insertBefore = toolboxElt
-            .children()
+            .children() // children() includes both the headers and the contents of the tools
+            .filter(".ui-accordion-header") // we only want to sort this into the headers...
             .filter(function() {
-                return $(this).text() > label;
+                // Note that we aren't (as of 4.4) setting the "locale" of the browser to match the
+                // UI language. In my tests, it's stuck at "en-US" (navigator.language). But if we ever do
+                // set this, then this will do a better job of ordering. Meanwhile, no worse.
+                return label.localeCompare($(this).text()) < 0;
             })
             .first();
         if (insertBefore.length === 0) {

--- a/src/BloomBrowserUI/react_components/l10n.tsx
+++ b/src/BloomBrowserUI/react_components/l10n.tsx
@@ -202,7 +202,7 @@ export class LocalizableElement<
             l10nClass = "translated";
             text = this.state.translation;
         }
-        return <span className={l10nClass}> {text} </span>;
+        return <span className={l10nClass}>{text}</span>;
     }
 
     public getLocalizedTooltip(controlIsEnabled: boolean): string {


### PR DESCRIPTION
The problem was that the newly added tool was looking for the alphabetically correct place to live, but was looking not just at the tool headers, but also their contents.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2812)
<!-- Reviewable:end -->
