### PR TITLE
Exclude Windows-specific tests that often fail on Linux

### DIFF
--- a/src/BloomTests/UpdateVersionTableTests.cs
+++ b/src/BloomTests/UpdateVersionTableTests.cs
@@ -86,6 +86,7 @@ namespace BloomTests
 			Assert.IsTrue(e  == WebExceptionStatus.NameResolutionFailure || e == WebExceptionStatus.ProtocolError );
 		}
 		[Test]
+		[Platform(Exclude = "Linux", Reason = "Windows-specific, fails on Linux without special access setup")]
 		public void FileForThisChannelIsMissing_ErrorIsCorrect()
 		{
 			var t = new UpdateVersionTable { URLOfTable = "http://bloomlibrary.org/channels/UpgradeTableSomethingBogus.txt"};
@@ -144,6 +145,7 @@ namespace BloomTests
 		}
 
 		[Test]
+		[Platform(Exclude = "Linux", Reason = "Windows-specific, fails on Linux without special access setup")]
 		public void LookupURLOfUpdate_CanReadTableForAlphaFromServer()
 		{
 			var t = new UpdateVersionTable();
@@ -156,6 +158,7 @@ namespace BloomTests
 		}
 
 		[Test]
+		[Platform(Exclude = "Linux", Reason = "Windows-specific, fails on Linux without special access setup")]
 		public void LookupURLOfUpdateInternal_NotBehindCaptivePortal_Works()
 		{
 			var t = new UpdateVersionTable();


### PR DESCRIPTION
These are now failing on TeamCity as well as my local Linux machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2816)
<!-- Reviewable:end -->
