### PR TITLE
Fix Forward compatibility for narration audio (BL-6559)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -200,6 +200,10 @@ export default class AudioRecording {
                 .first()
                 .attr("data-audioRecordingMode");
             doWhenRecordingModeIsKnown(audioRecordingModeStr);
+        } else if (this.getPage().find("span.audio-sentence")) {
+            // This may happen when loading books from 4.3 or earlier that already have text recorded,
+            // and is especially important if the collection default is set to anything other than Sentence.
+            doWhenRecordingModeIsKnown(AudioRecordingMode.Sentence);
         } else {
             // We are not sure what it should be.
             // So, check what the collection default has to say


### PR DESCRIPTION
Fixes a problem where a book has audio recorded in 4.3, and is then loaded it in 4.4 while the collection default was set to TextBox.   The book will now correctly detect the pre-existing mode. Previously the wrong mode was detected and the existing audio would not play

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2829)
<!-- Reviewable:end -->
