### PR TITLE
Fix invalid state for Talking Book after changing tools (BL-6655)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -200,7 +200,7 @@ export default class AudioRecording {
                 .first()
                 .attr("data-audioRecordingMode");
             doWhenRecordingModeIsKnown(audioRecordingModeStr);
-        } else if (this.getPage().find("span.audio-sentence")) {
+        } else if (this.getPage().find("span.audio-sentence").length > 0) {
             // This may happen when loading books from 4.3 or earlier that already have text recorded,
             // and is especially important if the collection default is set to anything other than Sentence.
             doWhenRecordingModeIsKnown(AudioRecordingMode.Sentence);
@@ -324,7 +324,7 @@ export default class AudioRecording {
         changeTo: JQuery,
         checking?: boolean
     ): void {
-        if (current) {
+        if (current && current.length > 0) {
             current
                 .removeClass("ui-audioCurrent")
                 .removeClass("disableHighlight");
@@ -740,6 +740,14 @@ export default class AudioRecording {
     public newPageReady() {
         // FYI, it is possible for newPageReady to be called without updateMarkup() being called. (e.g. when opening the toolbox with an empty text box)
         this.initializeForMarkup();
+    }
+
+    // Should be called when whatever tool uses this is about to be hidden (e.g., changing tools or closing toolbox)
+    public hideTool() {
+        this.stopListeningForLevels();
+
+        // Need to clear out any state. The next time this tool gets reopened, there is no guarantee that it will be reopened in the same context.
+        this.audioRecordingMode = AudioRecordingMode.Unknown;
     }
 
     // Called on initial setup and on toolbox updateMarkup(), including when a new page is created with Talking Book tab open

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
@@ -38,7 +38,7 @@ export default class TalkingBookTool implements ITool {
 
     public hideTool() {
         if (AudioRecorder && AudioRecorder.theOneAudioRecorder) {
-            AudioRecorder.theOneAudioRecorder.stopListeningForLevels();
+            AudioRecorder.theOneAudioRecorder.hideTool();
         }
     }
 


### PR DESCRIPTION
When the talking book tool is closed/switched to a new tool, it previously maintained its state. When it reopened, the state was no longer valid. now we cleanup the state when the tool is closed.
Also, this exposed a problem where it was never looking up the collection default setting, so I fixed that too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2835)
<!-- Reviewable:end -->
