### PR TITLE
Sort sight words found in sample texts by frequency properly (BL-6264)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -657,6 +657,14 @@ export class ReaderToolsModel {
 
         for (let i = 0; i < words.length; i++) {
             const dw = new DataWord(words[i]);
+            // Ensure a proper count for sight words found in the sample text data.
+            // See https://silbloom.myjetbrains.com/youtrack/issue/BL-6264.
+            const possibleCount = this.allWords[words[i]];
+            if (possibleCount) {
+                dw.Count = possibleCount;
+            } else {
+                dw.Count = 0; // Not found in sample text data.
+            }
             dw.isSightWord = true;
             returnVal.push(dw);
         }


### PR DESCRIPTION
Note that sight words not found in the sample text will now sort at the
end of the frequency list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2837)
<!-- Reviewable:end -->
