### PR TITLE
BL-6307 Use param instead of rename to defeat caching

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
@@ -12,6 +12,7 @@ import {
 import { BloomApi } from "../../../utils/bloomApi";
 import { HelpLink } from "../../../react_components/helpLink";
 import { Link } from "../../../react_components/link";
+import { UrlUtils } from "../../../utils/UrlUtils";
 
 // The recording process can be in one of these states:
 // idle...the initial state, returned to when stopped; top label shows "Start Recording"; stop button and second label hidden
@@ -631,7 +632,7 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
         return ToolBox.getPage().getElementsByClassName(classes);
     }
 
-    public static getSelectedVideoPath(): string {
+    public static getSelectedVideoPathAndTiming(): string {
         const containers = this.getVideoContainers(true);
         if (containers.length == 0) {
             return null;
@@ -646,6 +647,14 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
             return null;
         }
         return sources[0].getAttribute("src");
+    }
+
+    public static getSelectedVideoPath(): string {
+        // strip off the ?now= param we sometimes use to prevent use of cached old versions,
+        // and the #t= fragment used to trim videos.
+        return UrlUtils.extractPathComponent(
+            SignLanguageTool.getSelectedVideoPathAndTiming()
+        );
     }
 
     public detachFromPage() {
@@ -783,18 +792,25 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
         stats.startSeconds = start;
         stats.endSeconds = end;
         this.reactControls.setState({ videoStatistics: stats });
-        BloomApi.get("toolbox/fileExists?filename=" + src, result => {
-            const fileExists: boolean = result.data;
-            if (fileExists) {
-                this.reactControls.getVideoStatsFromFile();
-                SignLanguageTool.setCurrentVideoPoint(
-                    parseFloat(
-                        this.reactControls.state.videoStatistics.startSeconds
-                    )
-                );
+        BloomApi.get(
+            // extractPathComponent doesn't unencode the path, so if needed this
+            // URL should already be %encoded. But video filenames in Bloom are currently
+            // all GUIDs, even for imported videos, so this isn't really an issue.
+            "toolbox/fileExists?filename=" + UrlUtils.extractPathComponent(src),
+            result => {
+                const fileExists: boolean = result.data;
+                if (fileExists) {
+                    this.reactControls.getVideoStatsFromFile();
+                    SignLanguageTool.setCurrentVideoPoint(
+                        parseFloat(
+                            this.reactControls.state.videoStatistics
+                                .startSeconds
+                        )
+                    );
+                }
+                this.reactControls.setState({ haveRecording: fileExists });
             }
-            this.reactControls.setState({ haveRecording: fileExists });
-        });
+        );
         BloomApi.get(
             "toolbox/fileExists?filename=" + src.replace(".mp4", ".orig"),
             result => {

--- a/src/BloomBrowserUI/utils/urlUtils.ts
+++ b/src/BloomBrowserUI/utils/urlUtils.ts
@@ -1,0 +1,27 @@
+// Utility functions related to URLs
+
+export class UrlUtils {
+    // input may have ? followed by params.
+    // input may have # followed by fragment (after params, if at all).
+    // strip them off.
+    // Does not encode or decode; assumes any ? or # that is not a delimiter is %encoded
+    // Currently intended for relative URLs; hence, does not handle leading elements before path.
+    public static extractPathComponent(combined: string) {
+        if (!combined) {
+            return null;
+        }
+        // (I) tried  return new URL(combined).pathname;, but URL is 'unavailable' according to debugger.)
+
+        const paramIndex = combined.indexOf("?");
+        if (paramIndex >= 0) {
+            return combined.substring(0, paramIndex); // also removes fragment if any
+        }
+
+        const hashIndex = combined.indexOf("#");
+        if (hashIndex >= 0) {
+            return combined.substring(0, hashIndex);
+        }
+
+        return combined;
+    }
+}

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1775,11 +1775,23 @@ namespace Bloom.Book
 					videoContainer.GetAttribute("class")));
 		}
 
-		public static void SetSrcOfVideoElement(UrlPathString url, ElementProxy srcElement, bool urlEncode = true)
+		/// <summary>
+		/// Set the src attribute of the element to the path indicated by the url argument, optionally
+		/// adding the supplied params. If urlEncodePath is true, we will take the encoded path version
+		/// of the url argument. Caller is responsible to encode the paramString if necessary.
+		/// </summary>
+		/// <param name="url"></param>
+		/// <param name="srcElement"></param>
+		/// <param name="urlEncodePath"></param>
+		/// <param name="encodedParamString"></param>
+		public static void SetSrcOfVideoElement(UrlPathString url, ElementProxy srcElement, bool urlEncodePath, string encodedParamString = "")
 		{
-			// Encoding this can break links within epubs.
+			if (encodedParamString == null)
+				encodedParamString = "";
+			if (!string.IsNullOrEmpty(encodedParamString) && !(encodedParamString.StartsWith("?")))
+				encodedParamString = "?" + encodedParamString;
 			srcElement.SetAttribute("src",
-				urlEncode ? url.UrlEncodedForHttpPath : url.NotEncoded); // We need the fwd slash to come through unencoded
+				(urlEncodePath ? url.UrlEncodedForHttpPath : url.NotEncoded) + encodedParamString);
 		}
 
 		public static string RemoveClass(string className, string input)

--- a/src/BloomExe/Edit/PageEditingModel.cs
+++ b/src/BloomExe/Edit/PageEditingModel.cs
@@ -23,7 +23,7 @@ namespace Bloom.Edit
 			var isSameFile = IsSameFilePath(bookFolderPath, HtmlDom.GetImageElementUrl(imgOrDivWithBackgroundImage), imageInfo);
 			var imageFileName = ImageUtils.ProcessAndSaveImageIntoFolder(imageInfo, bookFolderPath, isSameFile);
 			HtmlDom.SetImageElementUrl(imgOrDivWithBackgroundImage,
-				UrlPathString.CreateFromUnencodedString(imageFileName));
+				UrlPathString.CreateFromUnencodedString(imageFileName, true));
 			UpdateMetadataAttributesOnImage(imgOrDivWithBackgroundImage, imageInfo);
 		}
 


### PR DESCRIPTION
Also deals with problems in "Show in Folder" caused by adding timing fragment to URI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2863)
<!-- Reviewable:end -->
