### PR TITLE
Update TS to use arrow functions, part 1 (BL-6401)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -25,14 +25,14 @@ export default class OverflowChecker {
         if (editablePageElements.length > 30) return;
 
         //Add the handler so that when the elements change, we test for overflow
-        editablePageElements.on("keyup paste", function(e) {
+        editablePageElements.on("keyup paste", e => {
             // BL-2892 There's no guarantee that the paste target isn't inside one of the editablePageElements
             // If we allow an embedded paste target (e.g. <p>) to get tested for overflow, it will overflow artificially.
             const target = $(e.target).closest(editablePageElements)[0];
             // Give the browser time to get the pasted text into the DOM first, before testing for overflow
             // GJM -- One place I read suggested that 0ms would work, it just needs to delay one 'cycle'.
             //        At first I was concerned that this might slow typing, but it doesn't seem to.
-            setTimeout(function() {
+            setTimeout(() => {
                 OverflowChecker.MarkOverflowInternal(target);
 
                 //REVIEW: why is this here, in the overflow detection?

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowSpec.ts
@@ -89,7 +89,7 @@ function RunAncestorMarginTest(index: number, value: HTMLElement) {
 }
 
 // Uses jasmine-query-1.3.1.js
-describe("Overflow Tests", function() {
+describe("Overflow Tests", () => {
     jasmine.getFixtures().fixturesPath = "base/bookEdit/OverflowChecker";
 
     // these tests are only reliable when tested with Firefox
@@ -98,7 +98,7 @@ describe("Overflow Tests", function() {
         return;
     }
 
-    it("Check test page for Self overflows", function() {
+    it("Check test page for Self overflows", () => {
         loadFixtures("OverflowFixture.html");
         expect($("#jasmine-fixtures")).toBeTruthy();
         if (window.console && window.console.log) {
@@ -108,7 +108,7 @@ describe("Overflow Tests", function() {
         $(".myTest").each((index, element) => RunTest(index, element));
     });
 
-    it("Check test page for Margin overflows", function() {
+    it("Check test page for Margin overflows", () => {
         loadFixtures("OverflowMarginFixture.html");
         expect($("#jasmine-fixtures")).toBeTruthy();
         if (window.console && window.console.log) {
@@ -120,7 +120,7 @@ describe("Overflow Tests", function() {
         );
     });
 
-    it("Check test page for Fixed Ancestor overflows", function() {
+    it("Check test page for Fixed Ancestor overflows", () => {
         loadFixtures("OverflowAncestorFixture.html");
         expect($("#jasmine-fixtures")).toBeTruthy();
         if (window.console && window.console.log) {

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditorSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditorSpec.ts
@@ -149,9 +149,9 @@ function HasRuleMatchingThisSelector(selector: string): boolean {
     return count > 0;
 }
 
-describe("StyleEditor", function() {
+describe("StyleEditor", () => {
     // most perplexingly, jasmine doesn't reset the dom between tests
-    beforeEach(function() {
+    beforeEach(() => {
         $('style[title="userModifiedStyles"]').remove();
         $("body").html("");
     });
@@ -174,7 +174,7 @@ describe("StyleEditor", function() {
     //  expect(GetUserModifiedStyleSheet()).not.toBeNull();
     //});
 
-    it("MakeBigger creates a style for the correct class if it is missing", function() {
+    it("MakeBigger creates a style for the correct class if it is missing", () => {
         $("body").append(
             "<div id='testTarget' class='ignore foo-style ignoreMeToo '></div>"
         );
@@ -195,7 +195,7 @@ describe("StyleEditor", function() {
     //note originally i was just letting everything be changeable, regardless. The problem is that then things like title
     //and subtitle were getting conflated. So that is a future enhancement; for now, I'm keeping things simple by saying
     //I have to have an explict x-style in the @class, except in the special case of known legacy pages, which all started with the same bit of guid
-    it("MakeBigger does nothing if no x-style classes, and ancestor is not a known old-format basic-book page", function() {
+    it("MakeBigger does nothing if no x-style classes, and ancestor is not a known old-format basic-book page", () => {
         $("body").append(
             "<div class='bloom-page' data-pagelineage='123-blah-blah'><div id='testTarget'>i don't want to get bigger</div></div>"
         );
@@ -204,7 +204,7 @@ describe("StyleEditor", function() {
     });
 
     // Handle books created with the original (0.9) version of "Basic Book", which lacked "x-style" but had all pages starting with an id of 5dcd48df (so we can detect them)
-    it("MakeBigger adds normal-style if there are no x-style classes, but ancestor is a known old-format basic-book page", function() {
+    it("MakeBigger adds normal-style if there are no x-style classes, but ancestor is a known old-format basic-book page", () => {
         $("body").append(
             "<div  class='bloom-page'  data-pagelineage='5dcd48df-blah-blah'><div id='testTarget'>i want to get bigger</div></div>"
         );
@@ -212,7 +212,7 @@ describe("StyleEditor", function() {
         expect(GetRuleForNormalStyle()).not.toBeNull();
     });
 
-    it("MakeBigger can add a new rule without removing other rules", function() {
+    it("MakeBigger can add a new rule without removing other rules", () => {
         $("body").append(
             "<div id='testTarget' class='blah-style'></div><div id='testTarget2' class='normal-style'></div>"
         );
@@ -221,7 +221,7 @@ describe("StyleEditor", function() {
         expect(GetRuleForNormalStyle()).not.toBeNull();
     });
 
-    it("MakeBigger doesn't make a duplicate style if there is already one there", function() {
+    it("MakeBigger doesn't make a duplicate style if there is already one there", () => {
         $("body").append(
             "<div id='testTarget' class='ignore foo-style ignoreMeToo '></div>"
         );
@@ -240,7 +240,7 @@ describe("StyleEditor", function() {
         expect(count).toBe(1);
     });
 
-    it("When the element has an @lang, MakeBigger adds rules that only affect the given language", function() {
+    it("When the element has an @lang, MakeBigger adds rules that only affect the given language", () => {
         $("body").append(
             "<div id='testTarget' class='foo-style' lang='xyz'></div><div id='testTarget2' class='normal-style'></div>"
         );
@@ -256,7 +256,7 @@ describe("StyleEditor", function() {
         expect(count).toBe(1);
     });
 
-    it("When the element does not have @lang, MakeBigger adds rules that apply only when there is no @lang", function() {
+    it("When the element does not have @lang, MakeBigger adds rules that apply only when there is no @lang", () => {
         $("body").append(
             "<div id='testTarget' class='foo-style' lang='xyz'></div><div id='testTarget2' class='normal-style'></div>"
         );
@@ -267,7 +267,7 @@ describe("StyleEditor", function() {
         );
     });
 
-    it("When the element has an @lang, and already has a rule, MakeBigger replaces the existing rule", function() {
+    it("When the element has an @lang, and already has a rule, MakeBigger replaces the existing rule", () => {
         $("head").append(
             "<style title='userModifiedStyles'>.foo-style[lang='xyz']{ font-size: 8pt ! important; }</style>"
         );
@@ -287,7 +287,7 @@ describe("StyleEditor", function() {
         expect(GetFontSizeRuleByLang("xyz")).toBe(10);
     });
 
-    it("When the element does not have @lang, ChangeSizeAbsolute adds rules that apply only when there is no @lang", function() {
+    it("When the element does not have @lang, ChangeSizeAbsolute adds rules that apply only when there is no @lang", () => {
         $("body").append(
             "<div id='testTarget' class='foo-style'></div><div id='testTarget2' class='normal-style' lang='xyz'></div>"
         );
@@ -299,7 +299,7 @@ describe("StyleEditor", function() {
         if (rule != null) expect(ParseRuleForFontSize(rule.cssText)).toBe(20);
     });
 
-    it("When the element has an @lang, and already has a rule, ChangeSizeAbsolute replaces the existing rule", function() {
+    it("When the element has an @lang, and already has a rule, ChangeSizeAbsolute replaces the existing rule", () => {
         $("head").append(
             "<style title='userModifiedStyles'>.foo-style[lang='xyz']{ font-size: 8pt ! important; }</style>"
         );
@@ -319,7 +319,7 @@ describe("StyleEditor", function() {
         expect(GetFontSizeRuleByLang("xyz")).toBe(20);
     });
 
-    it("When the element has an @lang, but no existing rule, ChangeSizeAbsolute adds rules that only affect the given language", function() {
+    it("When the element has an @lang, but no existing rule, ChangeSizeAbsolute adds rules that only affect the given language", () => {
         $("body").append(
             "<div id='testTarget' class='foo-style' lang='xyz'></div><div id='testTarget2' class='normal-style'></div>"
         );
@@ -336,7 +336,7 @@ describe("StyleEditor", function() {
         expect(GetFontSizeRuleByLang("xyz")).toBe(20);
     });
 
-    it("If a 'default-style' slips through, make it 'normal-style'", function() {
+    it("If a 'default-style' slips through, make it 'normal-style'", () => {
         $("body").append(
             "<div id='testTarget' class='foo-style' lang='xyz'></div><div id='testTarget2' class='default-style'></div>"
         );
@@ -345,7 +345,7 @@ describe("StyleEditor", function() {
         expect(GetRuleForNormalStyle()).not.toBeNull();
     });
 
-    it("If a 'coverTitle' slips through, make it 'Title-On-Cover-style'", function() {
+    it("If a 'coverTitle' slips through, make it 'Title-On-Cover-style'", () => {
         $("body").append(
             "<div id='testTarget' class='foo-style' lang='xyz'></div><div id='testTarget2' class='coverTitle'></div>"
         );
@@ -354,7 +354,7 @@ describe("StyleEditor", function() {
         expect(GetRuleForCoverTitleStyle()).not.toBeNull();
     });
 
-    it("MakeSmaller has no effect if it will be smaller than 7pt", function() {
+    it("MakeSmaller has no effect if it will be smaller than 7pt", () => {
         $("body").append(
             "<div id='testTarget' class='blah-style'></div><div id='testTarget2' class='foo-style' lang='xyz'></div>"
         );
@@ -364,7 +364,7 @@ describe("StyleEditor", function() {
         expect(GetFontSizeRuleByLang("xyz")).toBe(8);
     });
 
-    it("When the element has a size rule in 'em's, MakeSmaller is still limited to bigger than 6pt font", function() {
+    it("When the element has a size rule in 'em's, MakeSmaller is still limited to bigger than 6pt font", () => {
         $("head").append(
             "<style title='userModifiedStyles'>.foo-style[lang='xyz']{ font-size: 0.6em ! important; }</style>"
         );
@@ -384,7 +384,7 @@ describe("StyleEditor", function() {
         expect(GetFontSizeRuleByLang("xyz")).toBe(0.6); // 0.6em -> 8pt -> smaller is 6pt (not allowed; remains 0.6em)
     });
 
-    it("When the element has a size rule in enough 'em's, MakeSmaller will still work", function() {
+    it("When the element has a size rule in enough 'em's, MakeSmaller will still work", () => {
         $("head").append(
             "<style title='userModifiedStyles'>.foo-style[lang='xyz']{ font-size: 0.8em ! important; }</style>"
         );

--- a/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.ts
+++ b/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.ts
@@ -91,7 +91,7 @@ export default class TextBoxProperties {
                     dialogElement.css("opacity", 1.0);
                     if (!noFormatChange) {
                         // Hook up change event handlers
-                        $("#language-group").change(function() {
+                        $("#language-group").change(() => {
                             propDlg.changeLanguageGroup();
                         });
                         new WebFXTabPane($("#tabRoot").get(0), false);
@@ -111,7 +111,7 @@ export default class TextBoxProperties {
                         dialogElement.draggable("enable");
 
                         $("html").off("click.dialogElement");
-                        $("html").on("click.dialogElement", function(event) {
+                        $("html").on("click.dialogElement", event => {
                             if (
                                 event.target !== dialogElement.get(0) &&
                                 dialogElement.has(event.target).length === 0 &&
@@ -124,9 +124,7 @@ export default class TextBoxProperties {
                                 event.preventDefault();
                             }
                         });
-                        dialogElement.on("click.dialogElement", function(
-                            event
-                        ) {
+                        dialogElement.on("click.dialogElement", event => {
                             // this stops an event inside the dialog from propagating to the html element, which would close the dialog
                             event.stopPropagation();
                         });
@@ -466,7 +464,7 @@ export default class TextBoxProperties {
         //     items.push(current.toString());
         // }
 
-        items.sort(function(a, b) {
+        items.sort((a, b) => {
             return a.label.toLowerCase().localeCompare(b.label.toLowerCase());
         });
 

--- a/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxPropertiesSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxPropertiesSpec.ts
@@ -3,10 +3,10 @@
 import TextBoxProperties from "./TextBoxProperties";
 "use strict";
 
-describe("TextBoxProperties", function() {
+describe("TextBoxProperties", () => {
     var dialog;
     // most perplexingly, jasmine doesn't reset the dom between tests
-    beforeEach(function() {
+    beforeEach(() => {
         $("body").html("");
         $("body").append(
             '<div id="testTarget" class="bloom-translationGroup"></div>'
@@ -14,7 +14,7 @@ describe("TextBoxProperties", function() {
         dialog = new TextBoxProperties("");
     });
 
-    it("changeBackground, to none, css set properly", function() {
+    it("changeBackground, to none, css set properly", () => {
         // this div represents the button used to select the 'none' background option
         $("body").append(
             '<div id="background-none" class="selectedIcon"></div>'
@@ -24,7 +24,7 @@ describe("TextBoxProperties", function() {
         expect($("#testTarget").hasClass("bloom-background-none")).toBeTruthy();
     });
 
-    it("changeBackground, to gray, css set properly", function() {
+    it("changeBackground, to gray, css set properly", () => {
         // this div represents the button used to select the 'gray' background option
         $("body").append(
             '<div id="background-gray" class="selectedIcon"></div>'
@@ -34,7 +34,7 @@ describe("TextBoxProperties", function() {
         expect($("#testTarget").hasClass("bloom-background-gray")).toBeTruthy();
     });
 
-    it("changeBorder, nothing to something, no sides selected, css classes set properly and border side buttons selected", function() {
+    it("changeBorder, nothing to something, no sides selected, css classes set properly and border side buttons selected", () => {
         $("#testTarget").addClass("bloom-borderstyle-black");
         $("#testTarget").addClass("bloom-top-border-off");
         $("#testTarget").addClass("bloom-right-border-off");
@@ -94,7 +94,7 @@ describe("TextBoxProperties", function() {
         // expect($('#testTarget').css('box-sizing')).toBe('border-box');
     });
 
-    it("changeBorder, something to nothing, css classes set properly and border side buttons deselected", function() {
+    it("changeBorder, something to nothing, css classes set properly and border side buttons deselected", () => {
         $("#testTarget").addClass("bloom-borderstyle-black");
 
         // this div represents the buttons used to select border styles
@@ -128,7 +128,7 @@ describe("TextBoxProperties", function() {
         expect($("#borderleft").hasClass("selectedIcon")).toBeFalsy();
     });
 
-    it("changeBorder, change border style with only some sides, css classes set properly and border side buttons unchanged", function() {
+    it("changeBorder, change border style with only some sides, css classes set properly and border side buttons unchanged", () => {
         $("#testTarget").addClass("bloom-borderstyle-black");
         $("#testTarget").addClass("bloom-right-border-off");
         $("#testTarget").addClass("bloom-left-border-off");
@@ -167,7 +167,7 @@ describe("TextBoxProperties", function() {
         expect($("#borderleft").hasClass("selectedIcon")).toBeTruthy();
     });
 
-    it("changeBorder, deselect bottom side, border style unchanged and bottom border turned off", function() {
+    it("changeBorder, deselect bottom side, border style unchanged and bottom border turned off", () => {
         $("#testTarget").addClass("bloom-borderstyle-black-round");
 
         // these divs represent the buttons used to select border styles
@@ -203,7 +203,7 @@ describe("TextBoxProperties", function() {
         ).toBeTruthy();
     });
 
-    it("changeBorder, deselect last side, css classes set properly and border set to none", function() {
+    it("changeBorder, deselect last side, css classes set properly and border set to none", () => {
         $("#testTarget").addClass("bloom-borderstyle-black-round");
         $("#testTarget").addClass("bloom-top-border-off");
         $("#testTarget").addClass("bloom-right-border-off");

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -210,7 +210,7 @@ export default class BloomField {
             .filter(function() {
                 return this.localName.toLowerCase() != "div";
             })
-            .each(function() {
+            .each(() => {
                 //divToProtect.removeChild(this);
             });
         //also remove any raw text nodes, which you can only get at with "contents"
@@ -223,7 +223,7 @@ export default class BloomField {
                     this.textContent.trim().length > 0
                 );
             })
-            .each(function() {
+            .each(() => {
                 // divToProtect.removeChild(this);
             });
 

--- a/src/BloomBrowserUI/bookEdit/editablePage.ts
+++ b/src/BloomBrowserUI/bookEdit/editablePage.ts
@@ -99,7 +99,7 @@ window["PasteImageCredits"] = () => {
     EditableDivUtils.pasteImageCredits();
 };
 
-$(document).ready(function() {
+$(document).ready(() => {
     $("body")
         .find("*[data-i18n]")
         .localize();

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.ts
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.ts
@@ -23,7 +23,7 @@ const kWebsocketContext = "pageThumbnailList";
 let thumbnailTimerInterval = 200; // yes, this actually is not a constant!
 let listenerFunction;
 
-$(window).ready(function() {
+$(window).ready(() => {
     $(".gridly").gridly({
         base: 35, // px
         gutter: 10, // px

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.ts
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.ts
@@ -127,7 +127,7 @@ export default class BloomSourceBubbles {
 
         // First, sort the divs (and/or textareas) alphabetically by language code
         let items = $this.find("textarea, div");
-        items.sort(function(a, b) {
+        items.sort((a, b) => {
             //nb: Jan 2012: we modified "jquery.easytabs.js" to target @lang attributes, rather than ids.  If that change gets lost,
             //it's just a one-line change.
             const keyA = $(a).attr("lang");
@@ -434,7 +434,7 @@ export default class BloomSourceBubbles {
                     },
                     hide: hideEvents ? hideEventsStr : hideEvents,
                     events: {
-                        show: function(event, api) {
+                        show: (event, api) => {
                             // don't need to do this if there is only one editable area
                             const $body: JQuery = $("body");
                             if (
@@ -469,7 +469,7 @@ export default class BloomSourceBubbles {
                                 $tip.attr("data-max-height", maxHeight);
                             }
                         },
-                        render: function(event, api) {
+                        render: (event, api) => {
                             api.elements.tooltip.keydown(kevent => {
                                 // When the user types <Control-A> inside a source bubble, we don't
                                 // want the whole page selected.  We want just the current text of
@@ -551,7 +551,7 @@ export default class BloomSourceBubbles {
             $(elt).focus(event => {
                 // reset tool tips that may be expanded
                 const $body = $("body");
-                $body.find(".qtip").each(function(idx, obj) {
+                $body.find(".qtip").each((idx, obj) => {
                     const $thisTip = $(obj);
                     $thisTip.addClass("passive-bubble");
                     const maxHeight = $thisTip.attr("data-max-height");

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/SourceBubblesSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/SourceBubblesSpec.ts
@@ -4,15 +4,15 @@
 import BloomSourceBubbles from "./BloomSourceBubbles";
 "use strict";
 
-describe("SourceBubbles", function() {
+describe("SourceBubbles", () => {
     // reset fixture
-    beforeEach(function() {
+    beforeEach(() => {
         $("body").html("");
     });
-    afterEach(function() {
+    afterEach(() => {
         $("body").html("");
     });
-    it("Run MakeSourceTextDivForGroup with pre-defined settings", function() {
+    it("Run MakeSourceTextDivForGroup with pre-defined settings", () => {
         // TODO: Testing is a bit hampered by not being able (currently) to put test values
         // into the cSharpDependencyInjector version of GetSettings(). Someday it might
         // be worth modifying that file so that tests can setup their own values for:
@@ -64,7 +64,7 @@ describe("SourceBubbles", function() {
         expect(result.find("div").length).toBe(3);
     });
 
-    it("Run CreateDropdownIfNecessary with pre-defined settings", function() {
+    it("Run CreateDropdownIfNecessary with pre-defined settings", () => {
         var testHtml = $(
             [
                 "<div id='testTarget' class='bloom-translationGroup'>",
@@ -123,7 +123,7 @@ describe("SourceBubbles", function() {
         expect(topLevelDivs.length).toBe(3);
     });
 
-    it("CreateDropdownIfNecessary doesn't if doesn't need to", function() {
+    it("CreateDropdownIfNecessary doesn't if doesn't need to", () => {
         var testHtml = $(
             [
                 "<div id='testTarget' class='bloom-translationGroup'>",

--- a/src/BloomBrowserUI/bookPreview/bookPreview.ts
+++ b/src/BloomBrowserUI/bookPreview/bookPreview.ts
@@ -17,7 +17,7 @@ $.fn.CenterVerticallyInParent = function() {
     });
 };
 
-$(document).ready(function() {
+$(document).ready(() => {
     $("textarea").focus(function() {
         $(this).attr("readonly", "readonly");
     });

--- a/src/BloomBrowserUI/collection/enterpriseSettings.tsx
+++ b/src/BloomBrowserUI/collection/enterpriseSettings.tsx
@@ -510,6 +510,6 @@ export class EnterpriseSettings extends React.Component<{}, IState> {
 }
 
 // allow plain 'ol javascript in the html to connect up react
-(window as any).connectEnterpriseSettingsScreen = function(element) {
+(window as any).connectEnterpriseSettingsScreen = element => {
     ReactDOM.render(<EnterpriseSettings />, element);
 };

--- a/src/BloomBrowserUI/lib/errorHandler.ts
+++ b/src/BloomBrowserUI/lib/errorHandler.ts
@@ -57,13 +57,13 @@ export function reportPreliminaryError(message: string, stack: string) {
 // Using our own api to report the errors also makes us independent of GeckoFx's
 // way of dealing with unhandled exceptions, and helps us distinguish thrown
 // from unhandled ones, which some Gecko45 reporting doesn't.
-window.onerror = function(msg, url, line, col, error) {
+window.onerror = (msg, url, line, col, error) => {
     // Make a preliminary report, which will be discarded if the stack conversion succeeds.
     reportPreliminaryError(msg.toString(), error.stack);
     // Try to make the report using source stack.
     StackTrace.fromError(error).then(stackframes => {
         var stringifiedStack = stackframes
-            .map(function(sf) {
+            .map(sf => {
                 return sf.toString();
             })
             .join("\n");

--- a/src/BloomBrowserUI/lib/localizationManager/localizationManager.ts
+++ b/src/BloomBrowserUI/lib/localizationManager/localizationManager.ts
@@ -59,7 +59,7 @@ export class LocalizationManager {
         };
         if (keyValuePairs) ajaxSettings["data"] = keyValuePairs;
 
-        $.ajax(ajaxSettings).done(function(data) {
+        $.ajax(ajaxSettings).done(data => {
             theOneLocalizationManager.dictionary = $.extend(
                 theOneLocalizationManager.dictionary,
                 data
@@ -377,10 +377,7 @@ export class LocalizationManager {
      * @returns {String}
      */
     public simpleDotNetFormat(format: string, args: string[]) {
-        return format.replace(/{(\d+)}/g, function(
-            match: string,
-            index: number
-        ) {
+        return format.replace(/{(\d+)}/g, (match: string, index: number) => {
             return typeof args[index] !== "undefined" ? args[index] : match;
         });
     }

--- a/src/BloomBrowserUI/lib/localizationManager/localizationManagerSpec.ts
+++ b/src/BloomBrowserUI/lib/localizationManager/localizationManagerSpec.ts
@@ -1,18 +1,16 @@
 /// <reference path="localizationManager.ts" />
 ///<reference path="../../typings/bundledFromTSC.d.ts"/>
-import theOneLocalizationManager from './localizationManager';
+import theOneLocalizationManager from "./localizationManager";
 
 "use strict";
 
-describe("localizationManager", function () {
-        beforeEach(function () {
+describe("localizationManager", () => {
+    beforeEach(() => {});
 
-        });
-
-        /* This doesn't work. The old version would never fail, because it didn't actually account for how to hancdle
+    /* This doesn't work. The old version would never fail, because it didn't actually account for how to handle
         async calls. I've adjusted it to be apparently correct, but now we run into the problem that the method under
         test here actually fails in some non-understoodway.  See BL-3554.
-        
+
             it("asyncGetTextInLang returns English if in a unit test environment", function (done) {
                     theOneLocalizationManager.asyncGetTextInLang('theKey','someEnglishWord', 'fr').done(result => {
                             expect(result).toBe('someEnglishWord');


### PR DESCRIPTION
I'm using the tslint.json setting suggested by Andrew to find the places to fix.  The setting itself will be part of the last PR for this issue.  (I anticipate 2-3 more PRs given the number of affected files.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2870)
<!-- Reviewable:end -->
