### PR TITLE
Update TS to use arrow functions, part 3 (BL-6401)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/ReadersSynphonyWrapperSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/ReadersSynphonyWrapperSpec.ts
@@ -1,16 +1,16 @@
 import ReadersSynphonyWrapper from "./ReadersSynphonyWrapper";
 import { ReaderStage } from "./ReaderSettings";
 
-describe("ReadersSynphonyWrapper tests", function() {
-    it("loads a file with a specified name", function() {
+describe("ReadersSynphonyWrapper tests", () => {
+    it("loads a file with a specified name", () => {
         // Todo PhilH: this test should load a data file and check that the expected stages are present
         expect(true).toBe(true);
     });
-    it("initially has empty list of stages", function() {
+    it("initially has empty list of stages", () => {
         var api = new ReadersSynphonyWrapper();
         expect(api.getStages()).toEqual([]);
     });
-    it("remembers added stages", function() {
+    it("remembers added stages", () => {
         var api = new ReadersSynphonyWrapper();
         var stage1 = new ReaderStage("1");
         api.AddStage(stage1);
@@ -23,8 +23,8 @@ describe("ReadersSynphonyWrapper tests", function() {
     });
 });
 
-describe("Stage tests", function() {
-    it("remembers its name", function() {
+describe("Stage tests", () => {
+    it("remembers its name", () => {
         var stage = new ReaderStage("X");
         expect(stage.getName()).toBe("X");
     });

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/decodableReader/decodableReaderToolboxTool.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/decodableReader/decodableReaderToolboxTool.ts
@@ -63,7 +63,7 @@ export class DecodableReaderToolboxTool implements ITool {
         // invoke function when a bloom-editable element loses focus.
         $(container)
             .find(".bloom-editable")
-            .focusout(function() {
+            .focusout(() => {
                 getTheOneReaderToolsModel().doMarkup();
             });
 
@@ -75,25 +75,27 @@ export class DecodableReaderToolboxTool implements ITool {
 
         $(container)
             .find(".bloom-editable")
-            .keydown(function(e): boolean {
-                if ((e.keyCode == 90 || e.keyCode == 89) && e.ctrlKey) {
-                    // ctrl-z or ctrl-Y
-                    if (
-                        getTheOneReaderToolsModel().currentMarkupType !==
-                        MarkupType.None
-                    ) {
-                        e.preventDefault();
-                        if (e.shiftKey || e.keyCode == 89) {
-                            // ctrl-shift-z or ctrl-y
-                            getTheOneReaderToolsModel().redo();
-                        } else {
-                            getTheOneReaderToolsModel().undo();
+            .keydown(
+                (e): boolean => {
+                    if ((e.keyCode == 90 || e.keyCode == 89) && e.ctrlKey) {
+                        // ctrl-z or ctrl-Y
+                        if (
+                            getTheOneReaderToolsModel().currentMarkupType !==
+                            MarkupType.None
+                        ) {
+                            e.preventDefault();
+                            if (e.shiftKey || e.keyCode == 89) {
+                                // ctrl-shift-z or ctrl-y
+                                getTheOneReaderToolsModel().redo();
+                            } else {
+                                getTheOneReaderToolsModel().undo();
+                            }
+                            return false;
                         }
-                        return false;
                     }
+                    return true;
                 }
-                return true;
-            });
+            );
     }
 
     // Some things were impossible to do i18n on via the jade/pug

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/directoryWatcher.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/directoryWatcher.ts
@@ -67,7 +67,7 @@ export class DirectoryWatcher {
     private restartTimer(self): void {
         if (self.run === true) {
             if (self.refreshInterval > 0) {
-                setTimeout(function() {
+                setTimeout(() => {
                     self.checkNow(self);
                 }, self.refreshInterval * 1000);
             }
@@ -86,7 +86,7 @@ export class DirectoryWatcher {
             ajaxSettings["data"] = postKeyValueDataObject;
 
         // we are expecting the value returned in 'data' to be either 'yes' or 'no'
-        $.ajax(ajaxSettings).done(function(data) {
+        $.ajax(ajaxSettings).done(data => {
             self.ifChangedFireEvents(data, self);
         });
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/jquery.div-columns.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/jquery.div-columns.ts
@@ -18,7 +18,7 @@ interface JQueryStatic {
  * Use an 'Immediately Invoked Function Expression' to make this compatible with jQuery.noConflict().
  * @param {jQuery} $
  */
-(function($) {
+($ => {
     $.extend({
         /**
          * Set the width of the column (div) to be a multiple of the min-width.
@@ -26,7 +26,7 @@ interface JQueryStatic {
          * will line up correctly.
          * @param {String} cssClassName
          */
-        divsToColumns: function(cssClassName) {
+        divsToColumns: cssClassName => {
             var div = $("div." + cssClassName + ":first");
             if (div.length === 0) return;
 
@@ -39,7 +39,7 @@ interface JQueryStatic {
                 return this.offsetWidth > minWidth;
             });
 
-            elements.css("width", function() {
+            elements.css("width", () => {
                 var w = this.offsetWidth;
                 var i = Math.ceil(w / minWidth);
                 w = minWidth * i + (i - 1) * (marginLeft + marginRight);
@@ -53,10 +53,10 @@ interface JQueryStatic {
          * @param {String} cssClassName
          * @param {String} longestWord
          */
-        divsToColumnsBasedOnLongestWord: function(
+        divsToColumnsBasedOnLongestWord: (
             cssClassName: string,
             longestWord: string
-        ) {
+        ) => {
             var div = $("div." + cssClassName + ":first");
             if (div.length === 0) return;
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
@@ -15,7 +15,7 @@ import "./bloomSynphonyExtensions.js"; //add several functions to LanguageData
  * Use an 'Immediately Invoked Function Expression' to make this compatible with jQuery.noConflict().
  * @param {jQuery} $
  */
-(function($) {
+($ => {
     var cssSentenceTooLong = "sentence-too-long";
     var cssSightWord = "sight-word";
     var cssWordNotFound = "word-not-found";
@@ -42,7 +42,7 @@ import "./bloomSynphonyExtensions.js"; //add several functions to LanguageData
         // initialize words per page
         var totalWordCount = 0;
 
-        var checkLeaf = function(leaf) {
+        var checkLeaf = leaf => {
             stashNonTextUIElementsInEditBox(leaf);
             // split into sentences
             var fragments = theOneLibSynphony.stringToSentences($(leaf).html());
@@ -86,7 +86,7 @@ import "./bloomSynphonyExtensions.js"; //add several functions to LanguageData
             restoreNonTextUIElementsInEditBox(leaf);
         };
 
-        var checkRoot = function(root) {
+        var checkRoot = root => {
             var children = root.children();
             var processedChild = false; // Did we find a significant child?
             for (var i = 0; i < children.length; i++) {
@@ -225,13 +225,13 @@ import "./bloomSynphonyExtensions.js"; //add several functions to LanguageData
             if (!fragments || fragments.length === 0) return;
 
             // remove inter-sentence space
-            fragments = fragments.filter(function(frag) {
+            fragments = fragments.filter(frag => {
                 return frag.isSentence;
             });
 
             var subMax = Math.max.apply(
                 Math,
-                fragments.map(function(frag) {
+                fragments.map(frag => {
                     return frag.wordCount();
                 })
             );
@@ -256,7 +256,7 @@ import "./bloomSynphonyExtensions.js"; //add several functions to LanguageData
             );
 
             // remove inter-sentence space
-            fragments = fragments.filter(function(frag) {
+            fragments = fragments.filter(frag => {
                 return frag.isSentence;
             });
 
@@ -321,7 +321,7 @@ import "./bloomSynphonyExtensions.js"; //add several functions to LanguageData
          * @param {String[]} desiredGPCs
          * @returns {String}
          */
-        markupGraphemes: function(word, gpcForm, desiredGPCs) {
+        markupGraphemes: (word, gpcForm, desiredGPCs) => {
             // for backward compatibility
             if (Array.isArray(word)) return oldMarkup(word, gpcForm);
 
@@ -349,22 +349,22 @@ import "./bloomSynphonyExtensions.js"; //add several functions to LanguageData
     });
 
     $.extend({
-        cssSentenceTooLong: function() {
+        cssSentenceTooLong: () => {
             return cssSentenceTooLong;
         }
     });
     $.extend({
-        cssSightWord: function() {
+        cssSightWord: () => {
             return cssSightWord;
         }
     });
     $.extend({
-        cssWordNotFound: function() {
+        cssWordNotFound: () => {
             return cssWordNotFound;
         }
     });
     $.extend({
-        cssPossibleWord: function() {
+        cssPossibleWord: () => {
             return cssPossibleWord;
         }
     });

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.io.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.io.ts
@@ -207,7 +207,7 @@ function getChangedSettings(): ReaderSettings {
     );
 
     // remove empty lines from the more words list
-    moreWords = _.filter(moreWords, function(a: string) {
+    moreWords = _.filter(moreWords, (a: string) => {
         return a.trim() !== "";
     });
     settings.moreWords = moreWords.join(" ");

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
@@ -37,7 +37,7 @@ function process_UI_Message(event: MessageEvent): void {
                     "format_not_supported"
                 );
                 let foundNotSupported: boolean = false;
-                files.forEach(function(element, index, array) {
+                files.forEach((element, index, array) => {
                     const filenameComponents: string[] = element.split(".");
                     if (filenameComponents.length < 2) {
                         array[index] =
@@ -100,7 +100,7 @@ function process_UI_Message(event: MessageEvent): void {
             }
 
             // handle the beforeActivate event
-            tabs.on("tabsbeforeactivate", function(event, ui) {
+            tabs.on("tabsbeforeactivate", (event, ui) => {
                 tabBeforeActivate(ui);
             });
 
@@ -158,7 +158,7 @@ export function displayLetters(): void {
     let letters: string[] = cleanSpaceDelimitedList(
         (<HTMLInputElement>document.getElementById("dls_letters")).value.trim()
     ).split(" ");
-    letters = letters.filter(function(n) {
+    letters = letters.filter(n => {
         return n !== "";
     });
 
@@ -344,7 +344,7 @@ export function selectLetters(tr: HTMLTableRowElement) {
     let stage_letters: string[] = (<HTMLTableCellElement>(
         tr.cells[1]
     )).innerHTML.split(" ");
-    const current: JQuery = letters.filter(function(index, element) {
+    const current: JQuery = letters.filter((index, element) => {
         return stage_letters.indexOf((<HTMLElement>element).innerHTML) > -1;
     });
 
@@ -358,7 +358,7 @@ export function selectLetters(tr: HTMLTableRowElement) {
                 );
             })
     );
-    const previous = letters.filter(function(index, element) {
+    const previous = letters.filter((index, element) => {
         return stage_letters.indexOf((<HTMLElement>element).innerHTML) > -1;
     });
 
@@ -418,20 +418,17 @@ export function selectLevel(tr: HTMLTableRowElement) {
 
 // prevent pasting anything but plain text into the contenteditable children of the argument
 export function forcePlainTextPaste(parent: NodeSelector): void {
-    [].forEach.call(
-        parent.querySelectorAll('[contenteditable="true"]'),
-        function(el) {
-            el.addEventListener(
-                "paste",
-                function(e) {
-                    e.preventDefault();
-                    const text = e.clipboardData.getData("text/plain");
-                    document.execCommand("insertHTML", false, text);
-                },
-                false
-            );
-        }
-    );
+    [].forEach.call(parent.querySelectorAll('[contenteditable="true"]'), el => {
+        el.addEventListener(
+            "paste",
+            e => {
+                e.preventDefault();
+                const text = e.clipboardData.getData("text/plain");
+                document.execCommand("insertHTML", false, text);
+            },
+            false
+        );
+    });
 }
 
 function getCellInnerHTML(tr: HTMLTableRowElement, cellIndex: number): string {
@@ -460,7 +457,7 @@ function displayAllowedWordsForSelectedStage(wordsStr: string): void {
     let longestWord: string = "";
     let longestWordLength: number = 0;
 
-    _.each(words, function(w: string) {
+    _.each(words, (w: string) => {
         result += '<div class="book-font word">' + w + "</div>";
 
         if (w.length > longestWordLength) {
@@ -489,8 +486,8 @@ function displayWordsForSelectedStage(wordsStr: string): void {
     let words: DataWord[] = <DataWord[]>_.toArray(wordsObj);
 
     // add sight words
-    _.each(sightWords, function(sw: string) {
-        let word: DataWord = _.find(words, function(w: DataWord) {
+    _.each(sightWords, (sw: string) => {
+        let word: DataWord = _.find(words, (w: DataWord) => {
             return w.Name === sw;
         });
 
@@ -510,7 +507,7 @@ function displayWordsForSelectedStage(wordsStr: string): void {
     });
 
     // sort the list
-    words = _.sortBy(words, function(w) {
+    words = _.sortBy(words, w => {
         return w.Name;
     });
 
@@ -518,7 +515,7 @@ function displayWordsForSelectedStage(wordsStr: string): void {
     let longestWord: string = "";
     let longestWordLength: number = 0;
 
-    _.each(words, function(w: DataWord) {
+    _.each(words, (w: DataWord) => {
         if (!w.html) w.html = $.markupGraphemes(w.Name, w.GPCForm, desiredGPCs);
         result += '<div class="book-font word">' + w.html + "</div>";
 
@@ -731,8 +728,7 @@ function resetStageDetail(): void {
     (<HTMLElement>document.getElementById("rs-matching-words")).innerHTML = "";
     (<HTMLInputElement>(
         document.getElementById("setup-stage-sight-words")
-    )).value =
-        "";
+    )).value = "";
     $(".rs-letters")
         .removeClass("current-letter")
         .removeClass("previous-letter")
@@ -801,7 +797,7 @@ function storeThingsToRemember(): void {
         .split("</li>");
 
     // remove blank lines
-    vals = vals.filter(function(e) {
+    vals = vals.filter(e => {
         const x = e.trim();
         return x.length > 0 && x !== "&nbsp;";
     });
@@ -872,37 +868,37 @@ function firstSetupLetters(): boolean {
  */
 function attachEventHandlers(): void {
     if (typeof $ === "function") {
-        $("#open-text-folder").onSafe("click", function() {
+        $("#open-text-folder").onSafe("click", () => {
             BloomApi.post("readers/ui/openTextsFolder");
             return false;
         });
 
-        $("#setup-add-stage").onSafe("click", function() {
+        $("#setup-add-stage").onSafe("click", () => {
             addNewStage();
             return false;
         });
 
-        $("#define-sight-words").onSafe("click", function() {
+        $("#define-sight-words").onSafe("click", () => {
             alert("What are sight words?");
             return false;
         });
 
-        $("#setup-stage-sight-words").onSafe("keyup", function() {
+        $("#setup-stage-sight-words").onSafe("keyup", () => {
             updateSightWords(this);
             requestWordsForSelectedStage();
         });
 
-        $("#setup-remove-stage").onSafe("click", function() {
+        $("#setup-remove-stage").onSafe("click", () => {
             removeStage();
             return false;
         });
 
-        $("#setup-add-level").onSafe("click", function() {
+        $("#setup-add-level").onSafe("click", () => {
             addNewLevel();
             return false;
         });
 
-        $("#setup-remove-level").onSafe("click", function() {
+        $("#setup-remove-level").onSafe("click", () => {
             removeLevel();
             return false;
         });
@@ -930,11 +926,11 @@ function attachEventHandlers(): void {
                 .html(this.value);
         });
 
-        $('input[name="words-or-letters"]').onSafe("change", function() {
+        $('input[name="words-or-letters"]').onSafe("change", () => {
             enableSampleWords();
         });
 
-        $("#setup-choose-allowed-words-file").onSafe("click", function() {
+        $("#setup-choose-allowed-words-file").onSafe("click", () => {
             BloomApi.get("readers/ui/chooseAllowedWordsListFile", result => {
                 const fileName = result.data;
                 if (fileName) setAllowedWordsFile(fileName);
@@ -947,7 +943,7 @@ function attachEventHandlers(): void {
             return false;
         });
 
-        $("#remove-allowed-word-file").onSafe("click", function() {
+        $("#remove-allowed-word-file").onSafe("click", () => {
             setAllowedWordsFile("");
 
             // hide stale controls
@@ -1104,7 +1100,7 @@ function wordListChangedCallback() {
 
 import { getToolboxFrameExports } from "../../../js/bloomFrames";
 
-$(document).ready(function() {
+$(document).ready(() => {
     attachEventHandlers();
     $("body")
         .find("*[data-i18n]")

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetupDialog.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetupDialog.ts
@@ -45,7 +45,7 @@ export function showSetupDialog(showWhat) {
     theOneLocalizationManager.loadStrings(
         getSettingsDialogLocalizedStrings(),
         null,
-        function() {
+        () => {
             var title;
             if (showWhat == "stages")
                 title = theOneLocalizationManager.getText(
@@ -81,7 +81,7 @@ export function showSetupDialog(showWhat) {
                                 "Help"
                             ),
                             class: "left-button",
-                            click: function() {
+                            click: () => {
                                 settingsFrameWindow().postMessage("Help", "*");
                             }
                         },
@@ -90,7 +90,7 @@ export function showSetupDialog(showWhat) {
                                 "Common.OK",
                                 "OK"
                             ),
-                            click: function() {
+                            click: () => {
                                 settingsFrameWindow().postMessage("OK", "*");
                             }
                         },
@@ -100,7 +100,7 @@ export function showSetupDialog(showWhat) {
                                 "Common.Cancel",
                                 "Cancel"
                             ),
-                            click: function() {
+                            click: () => {
                                 //nb: the element pointed to here by setupDialogElement is the same as "this"
                                 //however, the jquery that you'd get by saying $(this) is *not* the same one as
                                 //that stored in setupDialogElement. Ref BL-3331.
@@ -108,13 +108,13 @@ export function showSetupDialog(showWhat) {
                             }
                         }
                     },
-                    close: function() {
+                    close: () => {
                         // $(this).remove(); uses the wrong document (see https://silbloom.myjetbrains.com/youtrack/issue/BL-3962)
                         // the following derives from http://stackoverflow.com/questions/2864740/jquery-how-to-completely-remove-a-dialog-on-close
                         setupDialogElement.dialog("destroy").remove();
                         fireCSharpEvent("setModalStateEvent", "false");
                     },
-                    open: function() {
+                    open: () => {
                         $("#synphonyConfig").css("overflow", "hidden");
                         $('button span:contains("Help")').prepend(
                             '<i class="fa fa-question-circle"></i> '

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools.ts
@@ -158,37 +158,37 @@ export function beginInitializeDecodableReaderTool(): JQueryPromise<void> {
     // load synphony settings and then finish init
     return beginLoadSynphonySettings().then(() => {
         // use the off/on pattern so the event is not added twice if the tool is closed and then reopened
-        $("#incStage").onSafe("click.readerTools", function() {
+        $("#incStage").onSafe("click.readerTools", () => {
             getTheOneReaderToolsModel().incrementStage();
         });
 
-        $("#decStage").onSafe("click.readerTools", function() {
+        $("#decStage").onSafe("click.readerTools", () => {
             getTheOneReaderToolsModel().decrementStage();
         });
 
-        $("#sortAlphabetic").onSafe("click.readerTools", function() {
+        $("#sortAlphabetic").onSafe("click.readerTools", () => {
             getTheOneReaderToolsModel().sortAlphabetically();
         });
 
-        $("#sortLength").onSafe("click.readerTools", function() {
+        $("#sortLength").onSafe("click.readerTools", () => {
             getTheOneReaderToolsModel().sortByLength();
         });
 
-        $("#sortFrequency").onSafe("click.readerTools", function() {
+        $("#sortFrequency").onSafe("click.readerTools", () => {
             getTheOneReaderToolsModel().sortByFrequency();
         });
 
         getTheOneReaderToolsModel().updateControlContents();
         $("#toolbox").accordion("refresh");
 
-        $(window).resize(function() {
+        $(window).resize(() => {
             resizeWordList(false);
         });
 
-        setTimeout(function() {
+        setTimeout(() => {
             resizeWordList();
         }, 200);
-        setTimeout(function() {
+        setTimeout(() => {
             $.divsToColumns("letter");
         }, 100);
     });
@@ -197,11 +197,11 @@ export function beginInitializeDecodableReaderTool(): JQueryPromise<void> {
 export function beginInitializeLeveledReaderTool(): JQueryPromise<void> {
     // load synphony settings
     return beginLoadSynphonySettings().then(() => {
-        $("#incLevel").onSafe("click.readerTools", function() {
+        $("#incLevel").onSafe("click.readerTools", () => {
             getTheOneReaderToolsModel().incrementLevel();
         });
 
-        $("#decLevel").onSafe("click.readerTools", function() {
+        $("#decLevel").onSafe("click.readerTools", () => {
             getTheOneReaderToolsModel().decrementLevel();
         });
 
@@ -273,7 +273,7 @@ function initializeSynphony(settingsFileContent: string): void {
  */
 function beginSetTextsList(textsList: string): Promise<void> {
     return getTheOneReaderToolsModel().beginSetTextsList(
-        textsList.split(/\r/).filter(function(e) {
+        textsList.split(/\r/).filter(e => {
             return e ? true : false;
         })
     );
@@ -478,7 +478,7 @@ export function resizeWordList(startTimeout: boolean = true): void {
     }
 
     if (startTimeout)
-        setTimeout(function() {
+        setTimeout(() => {
             resizeWordList();
         }, 500);
 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -514,12 +514,12 @@ export class ReaderToolsModel {
         // locale the browser thinks is current. When we implement ldml-dependent sorting we can improve this.
         switch (this.sort) {
             case SortType.alphabetic:
-                words.sort(function(a: DataWord, b: DataWord) {
+                words.sort((a: DataWord, b: DataWord) => {
                     return a.Name.localeCompare(b.Name);
                 });
                 break;
             case SortType.byLength:
-                words.sort(function(a: DataWord, b: DataWord) {
+                words.sort((a: DataWord, b: DataWord) => {
                     if (a.Name.length === b.Name.length) {
                         return a.Name.localeCompare(b.Name);
                     }
@@ -527,7 +527,7 @@ export class ReaderToolsModel {
                 });
                 break;
             case SortType.byFrequency:
-                words.sort(function(a: DataWord, b: DataWord) {
+                words.sort((a: DataWord, b: DataWord) => {
                     const aFreq = a.Count;
                     const bFreq = b.Count;
                     if (aFreq === bFreq) {
@@ -603,7 +603,7 @@ export class ReaderToolsModel {
         const allLetters = this.synphony.source.letters.split(" ");
 
         // Sort our letters based on the order they were entered
-        letters.sort(function(a, b) {
+        letters.sort((a, b) => {
             return allLetters.indexOf(a) - allLetters.indexOf(b);
         });
 
@@ -713,9 +713,7 @@ export class ReaderToolsModel {
         const sightWords = this.getSightWordsAsObjects(stageNumber);
         const stageWords = this.getStageWords();
 
-        return _.uniq(stageWords.concat(sightWords), false, function(
-            w: DataWord
-        ) {
+        return _.uniq(stageWords.concat(sightWords), false, (w: DataWord) => {
             return w.Name;
         });
     }
@@ -1104,7 +1102,7 @@ export class ReaderToolsModel {
             );
 
             // remove inter-sentence space
-            fragments = fragments.filter(function(frag) {
+            fragments = fragments.filter(frag => {
                 return frag.isSentence;
             });
 
@@ -1124,7 +1122,7 @@ export class ReaderToolsModel {
             );
 
             // remove inter-sentence space
-            fragments = fragments.filter(function(frag) {
+            fragments = fragments.filter(frag => {
                 return frag.isSentence;
             });
 
@@ -1149,7 +1147,7 @@ export class ReaderToolsModel {
             );
 
             // remove inter-sentence space
-            fragments = fragments.filter(function(frag) {
+            fragments = fragments.filter(frag => {
                 return frag.isSentence;
             });
 
@@ -1174,7 +1172,7 @@ export class ReaderToolsModel {
             );
 
             // remove inter-sentence space
-            fragments = fragments.filter(function(frag) {
+            fragments = fragments.filter(frag => {
                 return frag.isSentence;
             });
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsSpec.ts
@@ -5,10 +5,10 @@ import {
 import { getTheOneReaderToolsModel } from "./readerToolsModel";
 import ReadersSynphonyWrapper from "./ReadersSynphonyWrapper";
 
-describe("Bloom Edit Controls tests", function() {
+describe("Bloom Edit Controls tests", () => {
     var classValues;
 
-    beforeEach(function() {
+    beforeEach(() => {
         //noinspection JSUndeclaredVariable
         //reviewslog: this is not allowed: theOneLanguageDataInstance = null;
         ResetLanguageDataInstance();
@@ -73,19 +73,19 @@ describe("Bloom Edit Controls tests", function() {
             decLevel: "something",
             incLevel: "something"
         };
-        getTheOneReaderToolsModel().setElementAttribute = function(
+        getTheOneReaderToolsModel().setElementAttribute = (
             elementId,
             attrName,
             val
-        ) {
+        ) => {
             classValues[elementId] = val;
         };
 
         //noinspection JSUnusedLocalSymbols
-        getTheOneReaderToolsModel().getElementAttribute = function(
+        getTheOneReaderToolsModel().getElementAttribute = (
             elementId,
             attrName
-        ) {
+        ) => {
             var result = classValues[elementId];
             if (result) {
                 return result;
@@ -95,7 +95,7 @@ describe("Bloom Edit Controls tests", function() {
     });
 
     /* skipping until we figure out how to make work with localization See BL-3554
-        it("increments stage to limit on stage right button", function() {
+        it("increments stage to limit on stage right button", () => {
                 getTheOneReaderToolsModel().incrementStage();
 
 //        setTimeout(function(){
@@ -114,7 +114,7 @@ describe("Bloom Edit Controls tests", function() {
 */
 
     /* skipping until we figure out how to make work with localization See BL-3554
-         it("decrements stage to 1 on stage left button", function() {
+         it("decrements stage to 1 on stage left button", () => {
                 getTheOneReaderToolsModel().setStageNumber(3);
                 (<any>getTheOneReaderToolsModel().updateElementContent).calls.reset();
                 getTheOneReaderToolsModel().decrementStage();
@@ -129,7 +129,7 @@ describe("Bloom Edit Controls tests", function() {
                 expect(getTheOneReaderToolsModel().updateElementContent).not.toHaveBeenCalled();
         });
 */
-    it("increments level to limit on level right button", function() {
+    it("increments level to limit on level right button", () => {
         getTheOneReaderToolsModel().incrementLevel();
         expect(
             getTheOneReaderToolsModel().updateElementContent
@@ -149,7 +149,7 @@ describe("Bloom Edit Controls tests", function() {
     });
 
     /* skipping until we figure out how to make work with localization See BL-3554
-        it("decrements level to 1 on level left button", function() {
+        it("decrements level to 1 on level left button", () => {
                 getTheOneReaderToolsModel().setLevelNumber(3);
                 (<any>getTheOneReaderToolsModel().updateElementContent).calls.reset();
                 getTheOneReaderToolsModel().decrementLevel();
@@ -165,7 +165,7 @@ describe("Bloom Edit Controls tests", function() {
         });
 */
     /* skipping until we figure out how to make work with localization See BL-3554
-        it("setting stage updates stage button visibility", function() {
+        it("setting stage updates stage button visibility", () => {
                 getTheOneReaderToolsModel().setStageNumber(3);
                 expect(getTheOneReaderToolsModel().getElementAttribute("decStage", "class")).toBe("something");
                 expect(getTheOneReaderToolsModel().getElementAttribute("incStage", "class")).toBe("something disabledIcon");
@@ -188,7 +188,7 @@ describe("Bloom Edit Controls tests", function() {
         });
 */
 
-    it("updates level button visibility when setting level", function() {
+    it("updates level button visibility when setting level", () => {
         getTheOneReaderToolsModel().setLevelNumber(3);
         expect(
             getTheOneReaderToolsModel().getElementAttribute("decLevel", "class")
@@ -230,7 +230,7 @@ describe("Bloom Edit Controls tests", function() {
         ).toBe("something disabledIcon");
     });
 
-    it("updates content of level element when setting level", function() {
+    it("updates content of level element when setting level", () => {
         getTheOneReaderToolsModel().setLevelNumber(3);
         expect(
             getTheOneReaderToolsModel().updateElementContent
@@ -238,7 +238,7 @@ describe("Bloom Edit Controls tests", function() {
     });
 
     /* skipping due to mistery. See BL-3554
-        it("sorts word list correctly when sort buttons clicked", function() {
+        it("sorts word list correctly when sort buttons clicked", () => {
 
                 getTheOneReaderToolsModel().setStageNumber(2);
                 getTheOneReaderToolsModel().ckEditorLoaded = true; // some things only happen once the editor is loaded; pretend it is.
@@ -274,7 +274,7 @@ describe("Bloom Edit Controls tests", function() {
         });
         */
 
-    it("sets selected class when sort button clicked", function() {
+    it("sets selected class when sort button clicked", () => {
         classValues.sortAlphabetic = "sortItem sortIconSelected";
         classValues.sortLength = "sortItem";
         classValues.sortFrequency = "sortItem";
@@ -339,7 +339,7 @@ describe("Bloom Edit Controls tests", function() {
         ).toBe("sortItem sortIconSelected");
     });
 
-    it("updates word list on init", function() {
+    it("updates word list on init", () => {
         getTheOneReaderToolsModel().ckEditorLoaded = true; // some things only happen once the editor is loaded; pretend it is.
         getTheOneReaderToolsModel().updateControlContents();
         expect(
@@ -350,7 +350,7 @@ describe("Bloom Edit Controls tests", function() {
         );
     });
 
-    it("updates stage count and buttons on init", function() {
+    it("updates stage count and buttons on init", () => {
         getTheOneReaderToolsModel().updateControlContents();
         expect(
             getTheOneReaderToolsModel().updateElementContent
@@ -360,7 +360,7 @@ describe("Bloom Edit Controls tests", function() {
         ).toBe("something disabledIcon");
     });
 
-    it("updates level buttons on init", function() {
+    it("updates level buttons on init", () => {
         getTheOneReaderToolsModel().updateControlContents();
         expect(
             getTheOneReaderToolsModel().updateElementContent
@@ -370,14 +370,14 @@ describe("Bloom Edit Controls tests", function() {
         ).toBe("something disabledIcon");
     });
 
-    it("updates stage label on init", function() {
+    it("updates stage label on init", () => {
         getTheOneReaderToolsModel().updateControlContents();
         expect(
             getTheOneReaderToolsModel().updateElementContent
         ).toHaveBeenCalledWith("stageNumber", "1");
     });
 
-    it("sets level max values on init", function() {
+    it("sets level max values on init", () => {
         getTheOneReaderToolsModel().updateControlContents();
         expect(
             getTheOneReaderToolsModel().updateElementContent
@@ -400,7 +400,7 @@ describe("Bloom Edit Controls tests", function() {
         ).toBe("");
     });
 
-    it("updates max values when level changes", function() {
+    it("updates max values when level changes", () => {
         getTheOneReaderToolsModel().incrementLevel();
         expect(
             getTheOneReaderToolsModel().updateElementContent

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools_libSynphonySpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools_libSynphonySpec.ts
@@ -6,7 +6,7 @@ import {
 import * as _ from "underscore";
 import ReadersSynphonyWrapper from "./ReadersSynphonyWrapper";
 
-describe("readerTools-libSynphony tests", function() {
+describe("readerTools-libSynphony tests", () => {
     function generateTestData() {
         //reviewslog this wasn't allowed  theOneLanguageDataInstance = null;
         ResetLanguageDataInstance();
@@ -75,19 +75,19 @@ describe("readerTools-libSynphony tests", function() {
     var divTextEntry2;
     var divTextEntry3;
 
-    beforeEach(function() {
+    beforeEach(() => {
         divTextEntry1 = addDiv("text_entry1");
         divTextEntry2 = addDiv("text_entry2");
         divTextEntry3 = addDiv("text_entry3");
     });
 
-    afterEach(function() {
+    afterEach(() => {
         document.body.removeChild(divTextEntry1);
         document.body.removeChild(divTextEntry2);
         document.body.removeChild(divTextEntry3);
     });
 
-    it("addWordsFromFile", function() {
+    it("addWordsFromFile", () => {
         getTheOneReaderToolsModel().clearForTest();
         var fileContents = "The cat sat on the mat. The rat sat on the cat.";
 
@@ -102,7 +102,7 @@ describe("readerTools-libSynphony tests", function() {
         });
     });
 
-    it("addWordsFromFile properly handles paragraphs", function() {
+    it("addWordsFromFile properly handles paragraphs", () => {
         getTheOneReaderToolsModel().clearForTest();
         var fileContents = "one\r\ntwo\nthree four five.\r\n six. seven";
 
@@ -119,7 +119,7 @@ describe("readerTools-libSynphony tests", function() {
     });
 
     /* skipping See BL-3554
-                it("addWordsToSynphony", function() {
+                it("addWordsToSynphony", () => {
 
                         generateTestData();
                         var synphony = getTheOneReaderToolsModel().synphony;
@@ -141,7 +141,7 @@ describe("readerTools-libSynphony tests", function() {
     /**
      * Test for BL-223, div displaying markup if there is no text
      */
-    it("markupEndsWithBreakTag", function() {
+    it("markupEndsWithBreakTag", () => {
         generateTestData();
 
         var knownGraphemes = [
@@ -204,7 +204,7 @@ describe("readerTools-libSynphony tests", function() {
         );
     });
 
-    it("sightWordOnlyStages", function() {
+    it("sightWordOnlyStages", () => {
         generateSightWordsOnlyTestData();
 
         var knownGraphemes = [];

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -276,7 +276,7 @@ export default class AudioRecording {
         var divs = this.getPage().find(
             ":not(.bloom-noAudio) > " + kBloomEditableTextBoxSelector
         );
-        return divs.filter(":visible").filter(function(idx, elt) {
+        return divs.filter(":visible").filter((idx, elt) => {
             return theOneLibSynphony
                 .stringToSentences(elt.innerHTML)
                 .some(frag => {

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -111,7 +111,7 @@ export class ToolBox {
 
             $(container)
                 .find(".bloom-editable")
-                .keydown(function(event) {
+                .keydown(event => {
                     //don't do markup on cursor keys
                     if (event.keyCode >= 37 && event.keyCode <= 40) {
                         // this is check is another workaround for one scenario of BL-3490, but one that, as far as I can tell makes sense.
@@ -121,7 +121,7 @@ export class ToolBox {
                     }
                     handleKeyboardInput();
                 })
-                .on("compositionend", function(argument) {
+                .on("compositionend", argument => {
                     // Keyman (and other IME's?) don't send keydown events, but do send compositionend events
                     // See https://silbloom.myjetbrains.com/youtrack/issue/BL-5440.
                     handleKeyboardInput();
@@ -193,7 +193,7 @@ export class ToolBox {
         // It seems (see BL-5330) that the toolbox code is loaded into the edit document as well as the
         // toolbox one. Nothing outside toolbox imports it directly, so it must be some indirect link.
         // It's important that this function is only hooked up to the real toolbox instance.
-        $(parent.window.document).ready(function() {
+        $(parent.window.document).ready(() => {
             $(parent.window.document)
                 .find("#pure-toggle-right")
                 .change(function() {
@@ -206,7 +206,7 @@ export class ToolBox {
             axios
                 .all([this.getShowAdvancedFeatures(), this.getEnabledTools()])
                 .then(
-                    axios.spread(function(showAdvancedFeatures, enabledTools) {
+                    axios.spread((showAdvancedFeatures, enabledTools) => {
                         // Both requests are complete
                         // remove the experimental tools if the user doesn't want them
                         showExperimentalTools =
@@ -246,7 +246,7 @@ export class ToolBox {
                         // which means putting it last in the array.
                         toolsToLoad.push("settings");
                         $("#toolbox").hide();
-                        const loadNextTool = function() {
+                        const loadNextTool = () => {
                             if (toolsToLoad.length === 0) {
                                 $("#toolbox").accordion({
                                     heightStyle: "fill"
@@ -256,7 +256,7 @@ export class ToolBox {
                                     .localize(); // run localization
 
                                 // Now bind the window's resize function to the toolbox resizer
-                                $(window).bind("resize", function() {
+                                $(window).bind("resize", () => {
                                     clearTimeout(resizeTimer); // resizeTimer variable is defined outside of ready function
                                     resizeTimer = setTimeout(
                                         resizeToolbox,
@@ -623,7 +623,7 @@ function setCurrentTool(toolID: string) {
     // the active tool (if it's already the one we want, typically the first), so we can't rely on
     // the activate event happening in the initial call. Instead, we make SURE to call it for the
     // tool we are making active.
-    toolbox.onSafe("accordionactivate.toolbox", function(event, ui) {
+    toolbox.onSafe("accordionactivate.toolbox", (event, ui) => {
         let newToolName = "";
         if (ui.newHeader.attr("data-toolId")) {
             newToolName = ui.newHeader.attr("data-toolId").toString();
@@ -739,7 +739,7 @@ function handleKeyboardInput(): void {
     //  this.keypressTimer.clearTimeout();
     //}
     if (keypressTimer) clearTimeout(keypressTimer);
-    keypressTimer = setTimeout(function() {
+    keypressTimer = setTimeout(() => {
         // This happens 500ms after the user stops typing.
         const page: HTMLIFrameElement = <HTMLIFrameElement>(
             parent.window.document.getElementById("page")

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolboxBootstrap.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolboxBootstrap.ts
@@ -54,7 +54,7 @@ export function applyToolboxStateToPage() {
     applyToolboxStateToUpdatedPage();
 }
 
-$(document).ready(function() {
+$(document).ready(() => {
     getTheOneToolbox().initialize();
 });
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolboxSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolboxSpec.ts
@@ -1,7 +1,7 @@
 import { removeCommentsFromEditableHtml } from "./toolbox";
 
-describe("toolbox tests", function() {
-    it("removeCommentsFromEditableHtml removes comments correctly including ones with new lines", function() {
+describe("toolbox tests", () => {
+    it("removeCommentsFromEditableHtml removes comments correctly including ones with new lines", () => {
         var p = document.createElement("p");
         var span1 = document.createElement("span");
         span1.appendChild(document.createTextNode("text"));

--- a/src/BloomBrowserUI/tslint.json
+++ b/src/BloomBrowserUI/tslint.json
@@ -7,6 +7,10 @@
         },
         "prefer-const": {
             "severity": "warning"
+        },
+        "only-arrow-functions": {
+            "options": "allow-declarations",
+            "severity": "error"
         }
     },
     "extends": [


### PR DESCRIPTION
This is the final set of files, including the change to tslint.json to
detect places where arrow functions should be used.  Note that tslint
ignores function declarations whose body already uses a this variable
different than the this in the outer scope.  These places may warrant a
second round of fixes, but will require much more thought and care.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2873)
<!-- Reviewable:end -->
