### PR TITLE
BL-6698 Don't use missing-localization spans in options

### DIFF
--- a/src/BloomBrowserUI/react_components/l10n.tsx
+++ b/src/BloomBrowserUI/react_components/l10n.tsx
@@ -190,6 +190,11 @@ export class LocalizableElement<
     }
 
     public getLocalizedContent(): JSX.Element {
+        const parts = this.getLocalizedContentAndClass();
+        return <span className={parts.l10nClass}>{parts.text}</span>;
+    }
+
+    private getLocalizedContentAndClass(): { text: string; l10nClass: string } {
         let l10nClass = "untranslated";
         let text = this.getOriginalStringContent();
         if (this.props.alreadyLocalized) {
@@ -202,7 +207,13 @@ export class LocalizableElement<
             l10nClass = "translated";
             text = this.state.translation;
         }
-        return <span className={l10nClass}>{text}</span>;
+        return { text: text, l10nClass: l10nClass };
+    }
+
+    // Should return the same text that getLocalizedContent would wrap in a span
+    public getPlainLocalizedContent(): string {
+        const parts = this.getLocalizedContentAndClass();
+        return parts.text;
     }
 
     public getLocalizedTooltip(controlIsEnabled: boolean): string {

--- a/src/BloomBrowserUI/react_components/option.tsx
+++ b/src/BloomBrowserUI/react_components/option.tsx
@@ -8,11 +8,15 @@ interface IOptionProps extends ILocalizationProps {
 }
 
 // An <option> element that is localizable.
+// We normally use getLocalizedContent, which returns a span with a class that
+// we use to indicate localization problems. However, option is not allowed
+// to contain HTML markup, only text, so trying to put a span in it has weird
+// results...we get [object Object] instead of anything sensible.
 export default class Option extends LocalizableElement<IOptionProps, {}> {
     public render() {
         return (
             <option className={this.props.className} value={this.props.value}>
-                {this.getLocalizedContent()}
+                {this.getPlainLocalizedContent()}
             </option>
         );
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2893)
<!-- Reviewable:end -->
