### PR TITLE
Disable Text-Over-Picture if Image Description on (BL-6192)

### DIFF
--- a/src/BloomBrowserUI/bookLayout/textOverPicture.less
+++ b/src/BloomBrowserUI/bookLayout/textOverPicture.less
@@ -58,3 +58,9 @@
         }
     }
 }
+
+.bloom-showImageDescriptions {
+    .bloom-textOverPicture {
+        display: none; // Turn this off because it's complicated to deal with these while image description tool active.  Re-positioning and shrinking the text boxes proportionally while ImageDescription tool is active is possible but hugely complicates the code... so for now, just disable it.
+    }
+}

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -197,13 +197,28 @@ namespace Bloom.Edit
 				if (targetProxy.SelfOrAncestorHasClass("bloom-textOverPicture"))
 				{
 					var deleteMessage = LocalizationManager.GetString("EditTab.DeleteTextBoxFromImage", "Delete Text Box From Image");
-					args.ContextMenu.MenuItems.Add(deleteMessage, (sender, e) => deleteTextbox_Click());
+					var menuItem = args.ContextMenu.MenuItems.Add(deleteMessage, (sender, e) => deleteTextbox_Click());
+
+					// Mostly unnecessary because targetProxy shouldn't be able to be a bloom-textOverPicture if bloom-showImageDescriptions is on,
+					// but better safe than sorry I guess.
+					if (targetProxy.SelfOrAncestorHasClass("bloom-showImageDescriptions", excludeBody: false))
+					{
+						menuItem.Enabled = false;
+					}
+
 					return false; // we don't expect to need both Add and Delete in the same place
 				}
 				if (targetProxy.SelfOrAncestorHasClass("bloom-imageContainer"))
 				{
 					var addMessage = LocalizationManager.GetString("EditTab.AddTextBoxToImage", "Add Text Box To Image");
-					args.ContextMenu.MenuItems.Add(addMessage, (sender, e) => addTextbox_Click());
+					var menuItem = args.ContextMenu.MenuItems.Add(addMessage, (sender, e) => addTextbox_Click());
+
+					// Check if the body element indicates that image descriptions are active.
+					// This will shrink the image.  Repositioning, shrinking, adding and deleting text-over-picture elements while in shrunk state is possible but massively complicates the code.
+					// So, for now just disable the text-over-picture elements and adding them.
+					if (targetProxy.SelfOrAncestorHasClass("bloom-showImageDescriptions", excludeBody: false)) {
+						menuItem.Enabled = false;
+					}
 				}
 				return false;
 			};

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -201,7 +201,7 @@ namespace Bloom.Edit
 
 					// Mostly unnecessary because targetProxy shouldn't be able to be a bloom-textOverPicture if bloom-showImageDescriptions is on,
 					// but better safe than sorry I guess.
-					if (targetProxy.SelfOrAncestorHasClass("bloom-showImageDescriptions", excludeBody: false))
+					if (targetProxy.SelfOrAncestorHasClass("bloom-showImageDescriptions"))
 					{
 						menuItem.Enabled = false;
 					}
@@ -216,7 +216,7 @@ namespace Bloom.Edit
 					// Check if the body element indicates that image descriptions are active.
 					// This will shrink the image.  Repositioning, shrinking, adding and deleting text-over-picture elements while in shrunk state is possible but massively complicates the code.
 					// So, for now just disable the text-over-picture elements and adding them.
-					if (targetProxy.SelfOrAncestorHasClass("bloom-showImageDescriptions", excludeBody: false)) {
+					if (targetProxy.SelfOrAncestorHasClass("bloom-showImageDescriptions")) {
 						menuItem.Enabled = false;
 					}
 				}

--- a/src/BloomExe/ElementProxy.cs
+++ b/src/BloomExe/ElementProxy.cs
@@ -209,14 +209,14 @@ namespace Bloom
 			return ((IList) elementClassName.Split(' ')).Contains(className);
 		}
 
-		public bool SelfOrAncestorHasClass(string className)
+		public bool SelfOrAncestorHasClass(string className, bool excludeBody = true)
 		{
 			if (HasClass(this, className))
 			{
 				return true;
 			}
 			var parent = Parent;
-			while (parent != null && parent.Name != "BODY")
+			while (parent != null && (parent.Name != "BODY" || !excludeBody))
 			{
 				if (HasClass(parent, className))
 					return true;

--- a/src/BloomExe/ElementProxy.cs
+++ b/src/BloomExe/ElementProxy.cs
@@ -209,14 +209,14 @@ namespace Bloom
 			return ((IList) elementClassName.Split(' ')).Contains(className);
 		}
 
-		public bool SelfOrAncestorHasClass(string className, bool excludeBody = true)
+		public bool SelfOrAncestorHasClass(string className)
 		{
 			if (HasClass(this, className))
 			{
 				return true;
 			}
 			var parent = Parent;
-			while (parent != null && (parent.Name != "BODY" || !excludeBody))
+			while (parent != null)
 			{
 				if (HasClass(parent, className))
 					return true;


### PR DESCRIPTION
We should review it in e2e tests that it doesn't feel overly jarring for the T.O.P. elements to disappear when you activate the toolbox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2896)
<!-- Reviewable:end -->
