### PR TITLE
Use "import" to import JSON in typescript

### DIFF
--- a/src/BloomBrowserUI/json.d.ts
+++ b/src/BloomBrowserUI/json.d.ts
@@ -1,0 +1,5 @@
+// This declaration allows JSON data to be imported by TypeScript, albeit in an untyped way.
+declare module "*.json" {
+    const value: any;
+    export default value;
+}

--- a/src/BloomBrowserUI/publish/metadata/SubjectTreeNode.ts
+++ b/src/BloomBrowserUI/publish/metadata/SubjectTreeNode.ts
@@ -3,7 +3,10 @@
 // (Subjects from Thema are organized as a hierarchical tree but their JSON file is a flat list).
 // Qualifier subjects were removed (all those with codes starting with a number)
 // The Children related subjects were moved to the top of the list.
-export const themaSubjectData: SubjectTreeNode[] = require("./ThemaData.json");
+import * as themaData from "./ThemaData.json";
+export const themaSubjectData: SubjectTreeNode[] = <SubjectTreeNode[]>(
+    (<unknown>themaData)
+);
 
 // A SubjectTreeNode represents the data from one node of the Thema based subject tree
 // in a form usable by the react-dropdown-tree-select component.


### PR DESCRIPTION
This removes the implicit need for "@types/node" in package.json.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2919)
<!-- Reviewable:end -->
