### PR TITLE
Use import to load JSON data in TypeScript

### DIFF
--- a/src/BloomBrowserUI/publish/metadata/SubjectTreeNode.ts
+++ b/src/BloomBrowserUI/publish/metadata/SubjectTreeNode.ts
@@ -3,7 +3,10 @@
 // (Subjects from Thema are organized as a hierarchical tree but their JSON file is a flat list).
 // Qualifier subjects were removed (all those with codes starting with a number)
 // The Children related subjects were moved to the top of the list.
-export const themaSubjectData: SubjectTreeNode[] = require("./ThemaData.json");
+import * as themaData from "./ThemaData.json";
+export const themaSubjectData: SubjectTreeNode[] = <SubjectTreeNode[]>(
+    (<unknown>themaData)
+);
 
 // A SubjectTreeNode represents the data from one node of the Thema based subject tree
 // in a form usable by the react-dropdown-tree-select component.

--- a/src/BloomBrowserUI/tsconfig.json
+++ b/src/BloomBrowserUI/tsconfig.json
@@ -7,7 +7,9 @@
         "lib": ["dom", "es5", "scripthost", "es2017.object"],
         "experimentalDecorators": true,
         "alwaysStrict": true,
-        "noImplicitReturns": true
+        "noImplicitReturns": true,
+        "outDir": "../../output/browser",
+        "resolveJsonModule": true
     },
     "exclude": ["node_modules", "typings"]
 }


### PR DESCRIPTION
The require function used before is defined by node, which we don't
want to depend on in our TS code.  (we were unaware of this before it
broke yesterday.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2921)
<!-- Reviewable:end -->
