### PR TITLE
Add @types/node to package.json

### DIFF
--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -49,6 +49,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.3.0",
         "@fortawesome/react-fontawesome": "^0.1.2",
         "@types/markdown-it": "^0.0.5",
+        "@types/node": "^10.12.10",
         "@types/rc-slider": "^8.2.2",
         "@types/react-select": "^2.0.2",
         "@types/react-table": "^6.7.12",


### PR DESCRIPTION
We don't want this moving forward, but has been implied until recently,
and proving impossible to fix "correctly" with tsc 2.9.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2922)
<!-- Reviewable:end -->
