### PR TITLE
Image Description: Mitigate CKEditor messing up text-over-pic (BL-6721)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -1066,8 +1066,11 @@ export default class StyleEditor {
                             const buttonIds = this.getButtonIds();
                             for (let i = 0; i < buttonIds.length; i++) {
                                 const button = $("#" + buttonIds[i]);
-                                button.click(function() {
-                                    this.buttonClick(this);
+
+                                // Note: Use arrow function so that "this" refers to the right thing.
+                                // Otherwise, clicking on Gear Icon's Bold All/Italics All/etc. will throw exception because "this" doesn't refer to the right thing.
+                                button.click(() => {
+                                    this.buttonClick(button);
                                 });
                                 button.addClass("propButton");
                             }


### PR DESCRIPTION
Extraneous newlines will be inserted by CKEditor into text-over-picture elements containing 2+ words on a single line when image description is activated for the first time on the page, which will trigger an overflow warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2924)
<!-- Reviewable:end -->
