### PR TITLE
Text-over-pic: Prevent ImageDesc tool activation from messing up TOP elements (bl-6721)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -1066,8 +1066,11 @@ export default class StyleEditor {
                             const buttonIds = this.getButtonIds();
                             for (let i = 0; i < buttonIds.length; i++) {
                                 const button = $("#" + buttonIds[i]);
-                                button.click(function() {
-                                    this.buttonClick(this);
+
+                                // Note: Use arrow function so that "this" refers to the right thing.
+                                // Otherwise, clicking on Gear Icon's Bold All/Italics All/etc. will throw exception because "this" doesn't refer to the right thing.
+                                button.click(() => {
+                                    this.buttonClick(button);
                                 });
                                 button.addClass("propButton");
                             }

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -35,15 +35,6 @@ export default class BloomField {
 
         BloomField.MakeShiftEnterInsertLineBreak(bloomEditableDiv);
 
-        // Things assume that the editable will definitely contain one paragraph.
-        // If it doesn't, subtle weird things can happen.
-        // 1) For example, if a text-over-picture element does not contain a paragraph, you often can't type directly into the box immediately.
-        //    (you need to switch focus to a different text box then switch focus back to the text-over-picture)
-        // 2) Text-over-picture elements with no paragraph, only a span containing two words on exactly one line will get messed up by CKEditor when the page is saved (including some tool activations may trigger saves)
-        // 3) Some styling rules (e.g. indentation) assume it is in paragraphs and probably won't be applied immediately.
-        // 4) probably others
-        BloomField.ModifyForParagraphMode(bloomEditableDiv);
-
         //For future: this works, but we need more time to think about it. BloomField.MakeTabEnterTabElement(bloomEditableDiv);
 
         /*  The following is assumed to not be needed currently (3.9)... probably not needed
@@ -52,7 +43,7 @@ export default class BloomField {
             kinds of low-level html editor methods working right, so it
             makes sense to leave them here in case we have analogous situations come up.
 
-            BloomField.ModifyForParagraphMode(bloomEditableDiv);
+            BloomField.EnsureParagraphsPresent(bloomEditableDiv);
             $(bloomEditableDiv).blur(function () {
                 BloomField.ModifyForParagraphMode(this);
             });
@@ -62,6 +53,17 @@ export default class BloomField {
             BloomField.PrepareNonParagraphField(bloomEditableDiv);
             BloomField.ManageWhatHappensIfTheyDeleteEverythingNonParagraph(bloomEditableDiv);
         */
+
+        // What this does is mostly redundant with things CkEditor does, but in some cases CkEditor inserts more paragraphs than we want when we start out with none. See BL-6721"
+        //
+        // Things assume that the editable will definitely contain one paragraph.
+        // If it doesn't, subtle weird things can happen.
+        // 1) For example, if a text-over-picture element does not contain a paragraph, you often can't type directly into the box immediately.
+        //    (you need to switch focus to a different text box then switch focus back to the text-over-picture)
+        // 2) Text-over-picture elements with no paragraph, only a span containing two words on exactly one line will get messed up by CKEditor when the page is saved (including some tool activations may trigger saves)
+        // 3) Some styling rules (e.g. indentation) assume it is in paragraphs and probably won't be applied immediately.
+        // 4) probably others
+        BloomField.EnsureParagraphsPresent(bloomEditableDiv);
     }
 
     private static MakeTabEnterTabElement(field: HTMLElement) {
@@ -345,7 +347,7 @@ export default class BloomField {
     //      text doesn't get any of the formatting assigned to paragraphs)
     // 2) when this field was already used by the user, and then later switched to paragraph mode.
     // 3) corner cases that aren't handled by as-you-edit events. E.g., pressing "ctrl+a DEL"
-    private static ModifyForParagraphMode(field: HTMLElement) {
+    private static EnsureParagraphsPresent(field: HTMLElement) {
         BloomField.ConvertTopLevelTextNodesToParagraphs(field);
         $(field)
             .find("br")
@@ -398,7 +400,7 @@ export default class BloomField {
 
         $(field).keyup(e => {
             if ($(this).find("p").length === 0) {
-                BloomField.ModifyForParagraphMode(field);
+                BloomField.EnsureParagraphsPresent(field);
 
                 // Now put the cursor in the paragraph, *after* the character they may have just typed or the
                 // text they just pasted.

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -35,7 +35,14 @@ export default class BloomField {
 
         BloomField.MakeShiftEnterInsertLineBreak(bloomEditableDiv);
 
-        BloomField.EnsureEditableContainsParagraph(bloomEditableDiv);
+        // Things assume that the editable will definitely contain one paragraph.
+        // If it doesn't, subtle weird things can happen.
+        // 1) For example, if a text-over-picture element does not contain a paragraph, you often can't type directly into the box immediately.
+        //    (you need to switch focus to a different text box then switch focus back to the text-over-picture)
+        // 2) Text-over-picture elements with no paragraph, only a span containing two words on exactly one line will get messed up by CKEditor when the page is saved (including some tool activations may trigger saves)
+        // 3) Some styling rules (e.g. indentation) assume it is in paragraphs and probably won't be applied immediately.
+        // 4) probably others
+        BloomField.ModifyForParagraphMode(bloomEditableDiv);
 
         //For future: this works, but we need more time to think about it. BloomField.MakeTabEnterTabElement(bloomEditableDiv);
 
@@ -537,23 +544,6 @@ export default class BloomField {
                 }
             }
         });
-    }
-
-    // Things assume that the editable will definitely contain one paragraph.
-    // If it doesn't, subtle weird things can happen.
-    // 1) For example, if a text-over-picture element does not contain a paragraph, you often can't type directly into the box immediately.
-    //    (you need to switch focus to a different text box then switch focus back to the text-over-picture)
-    // 2) Text-over-picture elements with no paragraph, only a span containing two words on exactly one line will get messed up by CKEditor when the page is saved (including some tool activations may trigger saves)
-    // 3) Some styling rules (e.g. indentation) assume it is in paragraphs and probably won't be applied immediately.
-    // 4) probably others
-    private static EnsureEditableContainsParagraph(
-        bloomEditableDiv: HTMLElement
-    ) {
-        const paragraphElements = bloomEditableDiv.getElementsByTagName("p");
-        if (!paragraphElements || paragraphElements.length <= 0) {
-            const newParagraphNode = document.createElement("P");
-            bloomEditableDiv.appendChild(newParagraphNode);
-        }
     }
 }
 enum CursorPosition {

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -34,7 +34,10 @@ export default class BloomField {
         );
 
         BloomField.MakeShiftEnterInsertLineBreak(bloomEditableDiv);
-        //For furture: this works, but we need more time to think about it. BloomField.MakeTabEnterTabElement(bloomEditableDiv);
+
+        BloomField.EnsureEditableContainsParagraph(bloomEditableDiv);
+
+        //For future: this works, but we need more time to think about it. BloomField.MakeTabEnterTabElement(bloomEditableDiv);
 
         /*  The following is assumed to not be needed currently (3.9)... probably not needed
             since we added ckeditor.
@@ -534,6 +537,23 @@ export default class BloomField {
                 }
             }
         });
+    }
+
+    // Things assume that the editable will definitely contain one paragraph.
+    // If it doesn't, subtle weird things can happen.
+    // 1) For example, if a text-over-picture element does not contain a paragraph, you often can't type directly into the box immediately.
+    //    (you need to switch focus to a different text box then switch focus back to the text-over-picture)
+    // 2) Text-over-picture elements with no paragraph, only a span containing two words on exactly one line will get messed up by CKEditor when the page is saved (including some tool activations may trigger saves)
+    // 3) Some styling rules (e.g. indentation) assume it is in paragraphs and probably won't be applied immediately.
+    // 4) probably others
+    private static EnsureEditableContainsParagraph(
+        bloomEditableDiv: HTMLElement
+    ) {
+        const paragraphElements = bloomEditableDiv.getElementsByTagName("p");
+        if (!paragraphElements || paragraphElements.length <= 0) {
+            const newParagraphNode = document.createElement("P");
+            bloomEditableDiv.appendChild(newParagraphNode);
+        }
     }
 }
 enum CursorPosition {

--- a/src/BloomBrowserUI/bookEdit/editablePage.ts
+++ b/src/BloomBrowserUI/bookEdit/editablePage.ts
@@ -16,13 +16,17 @@ import {
     pageSelectionChanging,
     pageUnloading,
     disconnectForGarbageCollection,
-    makeElement
+    makeElement,
+    SetupElements,
+    attachToCkEditor
 } from "./js/bloomEditing";
 export {
     pageSelectionChanging,
     pageUnloading,
     disconnectForGarbageCollection,
-    makeElement
+    makeElement,
+    SetupElements,
+    attachToCkEditor
 };
 import { origamiCanUndo, origamiUndo } from "./js/origami";
 export { origamiCanUndo, origamiUndo };

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -959,8 +959,8 @@ export function bootstrap() {
         ".bloom-content3[contenteditable='true'],.bloom-contentNational1[contenteditable='true']";
     $("div.bloom-page")
         .find(complicatedFind)
-        .each(function() {
-            attachToCkEditor(this);
+        .each((index: number, element: Element) => {
+            attachToCkEditor(element);
         });
 
     // We want to do this as late in the page setup process as possible because a

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -949,8 +949,6 @@ export function bootstrap() {
         // So for now, we just going to say that you don't get ckeditor inside fields that have an embedded image.
         return;
     }
-    // Map from ckeditor id strings to the div the ckeditor is wrapping.
-    const mapCkeditDiv = new Object();
 
     // attach ckeditor to the contenteditable="true" class="bloom-content1"
     // also to contenteditable="true" and class="bloom-content2" or class="bloom-content3"
@@ -1114,6 +1112,10 @@ export function attachToCkEditor(element) {
     // Map from ckeditor id strings to the div the ckeditor is wrapping.
     const mapCkeditDiv = new Object();
 
+    if (!element) {
+        return;
+    }
+
     // attach ckeditor to the contenteditable="true" class="bloom-content1"
     // also to contenteditable="true" and class="bloom-content2" or class="bloom-content3"
     // but skip any element with class="bloom-userCannotModifyStyles" (which might be on the translationGroup)
@@ -1126,10 +1128,6 @@ export function attachToCkEditor(element) {
         return;
 
     if ($(element).css("cursor") === "not-allowed") return;
-
-    if (!element) {
-        return;
-    }
 
     const ckedit = CKEDITOR.inline(element);
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
@@ -324,8 +324,8 @@ export class ImageDescriptionAdapter extends ToolboxToolReactAdaptor {
                             "common/requestTranslationGroups",
                             result => {
                                 if (result) {
-                                    this.postRequestTranslationGroupsFinishedCallback(
-                                        result,
+                                    this.appendTranslationGroup(
+                                        result.data,
                                         container
                                     );
                                 }
@@ -339,10 +339,7 @@ export class ImageDescriptionAdapter extends ToolboxToolReactAdaptor {
 
     // Adds a new bloom-translationGroup
     // This function is meant to get called after we send a request to C# land to figure out what kind of bloom-editables/languages we need inside this translation group
-    private postRequestTranslationGroupsFinishedCallback(
-        result,
-        container: Element
-    ) {
+    private appendTranslationGroup(innerHtml, container: Element) {
         // Fill the interior of the new element with the HTML we get back from the API call.
 
         // from somewhere else I (John Thomson) copied this as a typical default set of classes for a translation group,
@@ -361,8 +358,8 @@ export class ImageDescriptionAdapter extends ToolboxToolReactAdaptor {
         const newElementHtmlSuffix = "</div>";
 
         let newElementHtmlInterior: string = "";
-        if (result && result.data) {
-            newElementHtmlInterior = result.data;
+        if (innerHtml) {
+            newElementHtmlInterior = innerHtml;
         }
         const newElementHtml =
             newElementHtmlPrefix +

--- a/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
@@ -339,6 +339,7 @@ export class ImageDescriptionAdapter extends ToolboxToolReactAdaptor {
 
     // Adds a new bloom-translationGroup
     // This function is meant to get called after we send a request to C# land to figure out what kind of bloom-editables/languages we need inside this translation group
+    // The container must be inside the (editing) page iFrame (because this relies on getPageFromExports()
     private appendTranslationGroup(innerHtml, container: Element) {
         // Fill the interior of the new element with the HTML we get back from the API call.
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
@@ -378,12 +378,11 @@ export class ImageDescriptionAdapter extends ToolboxToolReactAdaptor {
         // This is necessary for the data-language tooltip to appear, probably among other things.
         getPageFrameExports().SetupElements(container);
 
-        const newEditables = $(newTg).find(".bloom-editable");
-        for (let i = 0; i < newEditables.length; ++i) {
-            const newEditable = newEditables[i];
-
-            // Attaching CKEditor is necessary for range select formatting to work.
-            getPageFrameExports().attachToCkEditor(newEditable);
-        }
+        $(newTg)
+            .find(".bloom-editable")
+            .each((index, newEditable) => {
+                // Attaching CKEditor is necessary for range select formatting to work.
+                getPageFrameExports().attachToCkEditor(newEditable);
+            });
     }
 }

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1337,7 +1337,7 @@ namespace Bloom.Book
 			var dataBookElements = RawDom.SafeSelectNodes("//div[@id='bloomDataDiv']/div[@data-book]");
 			return dataBookElements.Cast<XmlElement>()
 				.Select(node => node.GetOptionalStringAttribute("lang", null))
-				.Where(lang => !String.IsNullOrEmpty(lang) && (lang != "*" || lang != "z"))
+				.Where(lang => !String.IsNullOrEmpty(lang) && (lang != "*" && lang != "z"))
 				.Distinct()
 				.ToList();
 		}

--- a/src/BloomExe/Book/TranslationGroupManager.cs
+++ b/src/BloomExe/Book/TranslationGroupManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -73,6 +73,33 @@ namespace Bloom.Book
 			}
 		}
 
+		public static string PrepareDefaultTranslationGroups(XmlNode pageOrDocumentNode, Book currentBook)
+		{
+			XmlDocument ownerDocument = pageOrDocumentNode.OwnerDocument;
+			if (ownerDocument == null)
+			{
+				if (pageOrDocumentNode is XmlDocument)
+				{
+					ownerDocument = pageOrDocumentNode as XmlDocument;
+				}
+				else
+				{
+					return "";
+				}
+			}
+
+			var wrapper = ownerDocument.CreateElement("div");
+			var containerElement = ownerDocument.CreateElement("div");
+			containerElement.SetAttribute("class", "bloom-translationGroup");
+			wrapper.AppendChild(containerElement);
+
+			PrepareElementsInPageOrDocument(containerElement, currentBook.CollectionSettings);
+
+			TranslationGroupManager.UpdateContentLanguageClasses(wrapper, currentBook.CollectionSettings, currentBook.CollectionSettings.Language1Iso639Code,
+				currentBook.MultilingualContentLanguage2, currentBook.MultilingualContentLanguage3);
+
+			return containerElement.InnerXml;			
+		}
 
 		/// <summary>
 		/// This is used when a book is first created from a source; without it, if the shell maker left the book as trilingual when working on it,

--- a/src/BloomExe/Book/TranslationGroupManager.cs
+++ b/src/BloomExe/Book/TranslationGroupManager.cs
@@ -98,7 +98,7 @@ namespace Bloom.Book
 			TranslationGroupManager.UpdateContentLanguageClasses(wrapper, currentBook.CollectionSettings, currentBook.CollectionSettings.Language1Iso639Code,
 				currentBook.MultilingualContentLanguage2, currentBook.MultilingualContentLanguage3);
 
-			return containerElement.InnerXml;			
+			return containerElement.InnerXml;
 		}
 
 		/// <summary>

--- a/src/BloomExe/Book/TranslationGroupManager.cs
+++ b/src/BloomExe/Book/TranslationGroupManager.cs
@@ -73,10 +73,15 @@ namespace Bloom.Book
 			}
 		}
 
-		public static string PrepareDefaultTranslationGroups(XmlNode pageOrDocumentNode, Book currentBook)
+		/// <summary>
+		/// Returns the sequence of bloom-editable divs that would normally be created as the content of an empty bloom-translationGroup,
+		/// given the current collection and book settings, with the classes that would normally be set on them prior to editing to make the right ones visible etc.
+		/// </summary>
+		public static string GetDefaultTranslationGroupContent(XmlNode pageOrDocumentNode, Book currentBook)
 		{
-			XmlDocument ownerDocument = pageOrDocumentNode.OwnerDocument;
-			if (ownerDocument == null)
+			// First get a XMLDocument so that we can start creating elements using it.
+			XmlDocument ownerDocument = pageOrDocumentNode?.OwnerDocument;
+			if (ownerDocument == null)	// the OwnerDocument child can be null if pageOrDocumentNode is a document itself
 			{
 				if (pageOrDocumentNode is XmlDocument)
 				{
@@ -88,9 +93,13 @@ namespace Bloom.Book
 				}
 			}
 
-			var wrapper = ownerDocument.CreateElement("div");
+			// We want to use the usual routines that insert the required bloom-editables and classes into existing translation groups.
+			// To make this work we make a temporary translation group
+			// Since one of the routines expects the TG to be a descendant of the element passed to it, we make another layer of temporary wrapper around the translation group as well
 			var containerElement = ownerDocument.CreateElement("div");
 			containerElement.SetAttribute("class", "bloom-translationGroup");
+
+			var wrapper = ownerDocument.CreateElement("div");
 			wrapper.AppendChild(containerElement);
 
 			PrepareElementsInPageOrDocument(containerElement, currentBook.CollectionSettings);

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1088,6 +1088,12 @@ namespace Bloom.Edit
 			}
 		}
 
+		internal void RequestTranslationGroups(ApiRequest request)
+		{
+			string translationGroupHtml = TranslationGroupManager.PrepareDefaultTranslationGroups(_domForCurrentPage.RawDom, CurrentBook); ;
+			request.ReplyWithHtml(translationGroupHtml);
+		}
+		
 		public void ChangePicture(GeckoHtmlElement img, PalasoImage imageInfo, IProgress progress)
 		{
 			try

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1090,7 +1090,7 @@ namespace Bloom.Edit
 
 		internal void RequestTranslationGroups(ApiRequest request)
 		{
-			string translationGroupHtml = TranslationGroupManager.PrepareDefaultTranslationGroups(_domForCurrentPage.RawDom, CurrentBook);
+			string translationGroupHtml = TranslationGroupManager.GetDefaultTranslationGroupContent(_domForCurrentPage.RawDom, CurrentBook);
 			request.ReplyWithHtml(translationGroupHtml);
 		}
 		

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1090,7 +1090,7 @@ namespace Bloom.Edit
 
 		internal void RequestTranslationGroups(ApiRequest request)
 		{
-			string translationGroupHtml = TranslationGroupManager.PrepareDefaultTranslationGroups(_domForCurrentPage.RawDom, CurrentBook); ;
+			string translationGroupHtml = TranslationGroupManager.PrepareDefaultTranslationGroups(_domForCurrentPage.RawDom, CurrentBook);
 			request.ReplyWithHtml(translationGroupHtml);
 		}
 		

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -51,6 +51,7 @@ namespace Bloom.web.controllers
 			apiHandler.RegisterEndpointHandler("common/error", HandleJavascriptError, false);
 			apiHandler.RegisterEndpointHandler("common/preliminaryError", HandlePreliminaryJavascriptError, false);
 			apiHandler.RegisterEndpointHandler("common/saveChangesAndRethinkPageEvent", RethinkPageAndReloadIt, true);
+			apiHandler.RegisterEndpointHandler("common/requestTranslationGroups", RequestTranslationGroups, true);
 			apiHandler.RegisterEndpointHandler("common/showInFolder", HandleShowInFolderRequest, true);
 			// Used when something in JS land wants to copy text to or from the clipboard. For POST, the text to be put on the
 			// clipboard is passed as the 'text' property of a JSON requestData.
@@ -153,6 +154,11 @@ namespace Bloom.web.controllers
 		private void RethinkPageAndReloadIt(ApiRequest request)
 		{
 			Model.RethinkPageAndReloadIt(request);
+		}
+
+		private void RequestTranslationGroups(ApiRequest request)
+		{
+			Model.RequestTranslationGroups(request);
 		}
 
 		/// <summary>

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -1219,5 +1219,30 @@ p {
 			AssertThatXmlIn.Dom(pageDom.RawDom).HasSpecifiedNumberOfMatchesForXpath(thirdTextXpath, 1);
 			AssertThatXmlIn.Dom(pageDom.RawDom).HasSpecifiedNumberOfMatchesForXpath(fourthTextXpath, 1);
 		}
+
+		// Tests that "", "*", and "z" are properly filtered.
+		[Test]
+		public void GatherDataBookLanguages_ContainsLangsWildcardAndZ_RemovesUnnecessaryLangs()
+		{
+			var dom = new HtmlDom(
+				@"<html><body><div>
+					<div id='bloomDataDiv'>
+						<div data-book='styleNumberSequence' lang=''>0</div>
+						<div data-book='styleNumberSequence' lang='*'>0</div>
+						<div data-book='styleNumberSequence' lang='z'>0</div>
+						<div data-book='styleNumberSequence' lang='en'>0</div>
+						<div data-book='styleNumberSequence' lang='es'>0</div>
+						<div data-book='styleNumberSequence' lang='zh-CN'>0</div>
+						<div data-book='styleNumberSequence' lang='zh-TW'>0</div>
+					</div>
+				</div></body></html>");
+
+			var result = dom.GatherDataBookLanguages();
+
+			Assert.AreEqual(4, result.Count, "Count");
+			Assert.IsFalse(result.Contains(""), "Unexpected item \"\" found");
+			Assert.IsFalse(result.Contains("*"), "Unexpected item \"*\" found");
+			Assert.IsFalse(result.Contains("z"), "Unexpected item \"z\" found");
+		}
 	}
 }


### PR DESCRIPTION
- Prevent ImageDesc tool activation from messing up text-over-picture elements
- Fix problem where text-over-picture elements often lose focus
- Fix bug where bloom-editable's format all (from gear icon)  e.g. bold all, italic all, underline all were throwing exceptions
- Fix bug in GatherDataBookLanguages where "*" and "z" were not properly removed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2930)
<!-- Reviewable:end -->
