### PR TITLE
BL-6746 Correctly reference CSS files from parent directory in exports

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -1510,20 +1510,39 @@ namespace Bloom.Book
 
 			EnsureHasLinkToStyleSheet(dom, Path.GetFileName(PathToXMatterStylesheet));
 
-			// Don't use Path.DirectorySeparatorChar here...we're going to use this path in an href
-			// where it should definitely be forward slash. And it works fine in a Windows path too.
-			string autocssFilePath = "../"+"settingsCollectionStyles.css";
-			if (RobustFile.Exists(Path.Combine(_folderPath,autocssFilePath)))
-				EnsureHasLinkToStyleSheet(dom, autocssFilePath);
+			EnsureHasLocalOrParentLink(dom, "settingsCollectionStyles.css");
 
-			var customCssFilePath = "../" + "customCollectionStyles.css";
-			if (RobustFile.Exists(Path.Combine(_folderPath, customCssFilePath)))
-				EnsureHasLinkToStyleSheet(dom, customCssFilePath);
+			EnsureHasLocalOrParentLink(dom, "customCollectionStyles.css");
 
 			if (RobustFile.Exists(Path.Combine(_folderPath, "customBookStyles.css")))
 				EnsureHasLinkToStyleSheet(dom, "customBookStyles.css");
 			else
 				EnsureDoesntHaveLinkToStyleSheet(dom, "customBookStyles.css");
+		}
+
+		/// <summary>
+		/// Files like CustomCollectionStyles or settingsCollectionStyles are usually found
+		/// in the parent directory, and we want a link with href like ../CustomCollectionStyles.css.
+		/// But when publishing (e.g., to Android or Epub), we put those files in the book folder,
+		/// and the link needs to point there. In that case the file is typically found in both
+		/// places, so we preferentially link to the local one if found, though usually it isn't.
+		/// </summary>
+		/// <param name="dom"></param>
+		/// <param name="fileName"></param>
+		private void EnsureHasLocalOrParentLink(HtmlDom dom, string fileName)
+		{
+			var localPath = Path.Combine(_folderPath, fileName);
+			if (RobustFile.Exists(localPath))
+			{
+				EnsureHasLinkToStyleSheet(dom, fileName);
+				return;
+			}
+
+			// Don't use Path.DirectorySeparatorChar here...we're going to use this path in an href
+			// where it should definitely be forward slash. And it works fine in a Windows path too.
+			var parentRelativePath = "../" + fileName;
+			if (RobustFile.Exists(Path.Combine(_folderPath, parentRelativePath)))
+				EnsureHasLinkToStyleSheet(dom, parentRelativePath);
 		}
 
 		public string HandleRetiredXMatterPacks(HtmlDom dom, string nameOfXMatterPack)

--- a/src/BloomTests/Book/BookCompressorTests.cs
+++ b/src/BloomTests/Book/BookCompressorTests.cs
@@ -57,7 +57,9 @@ namespace BloomTests.Book
 				"previewMode.css",
 				"meta.json", // should be left alone
 				"readerStyles.css", // gets added
-				"Device-XMatter.css" // added when we apply this xmatter
+				"Device-XMatter.css", // added when we apply this xmatter
+				"customCollectionStyles.css", // should be moved from parent directory
+				"settingsCollectionStyles.css" // should be moved from parent directory
 			};
 
 			TestHtmlAfterCompression(kMinimumValidBookHtml,
@@ -68,6 +70,16 @@ namespace BloomTests.Book
 					File.Copy(SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "shirt.png"),
 						Path.Combine(folderPath, "thumbnail.png"));
 					File.WriteAllText(Path.Combine(folderPath, "previewMode.css"), @"This is wanted");
+					File.WriteAllText(Path.Combine(Path.GetDirectoryName(folderPath), "customCollectionStyles.css"), @"This is wanted");
+					File.WriteAllText(Path.Combine(Path.GetDirectoryName(folderPath), "settingsCollectionStyles.css"), @"This is wanted");
+				},
+				assertionsOnResultingHtmlString: html =>
+				{
+					// These two files get moved into the book folder, the links must get fixed
+					Assert.That(html, Does.Contain("href=\"customCollectionStyles.css\""));
+					Assert.That(html, Does.Contain("href=\"settingsCollectionStyles.css\""));
+					// The parent folder doesn't go with the book, so we shouldn't be referencing anything there
+					Assert.That(html, Does.Not.Contain("href=\"../"));
 				},
 				assertionsOnZipArchive: zip =>
 				{


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2947)
<!-- Reviewable:end -->
