### PR TITLE
Fix audio level meter to use the background of its parent

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -104,8 +104,9 @@ div.ui-audioCurrent:not(.disableHighlight) p {
         margin-bottom: 5px;
     }
     .ui-audioInput,
-    div.ui-audioMeter {
+    .ui-audioMeter {
         display: inline-block;
+        background-color: @bloom-panelBackground;
     }
     .ui-audioInputGroup {
         margin-top: 5px;

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -881,8 +881,11 @@ export default class AudioRecording {
         // Erase the whole canvas
         var height = 15;
         var width = 80;
-        var toolboxBackgroundColor = "#404040"; // should match value in audioRecording.less
-        ctx.fillStyle = toolboxBackgroundColor;
+
+        ctx.fillStyle = window.getComputedStyle(
+            this.levelCanvas.parentElement!
+        ).backgroundColor!;
+
         ctx.fillRect(0, 0, width, height);
 
         // Draw the appropriate number and color of bars


### PR DESCRIPTION
Follow-on to BL-5996

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2950)
<!-- Reviewable:end -->
