### PR TITLE
BL-6732 Make Copy Page handle audio and video properly

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2055,6 +2055,9 @@ namespace Bloom.Book
 			var elementOfPageBefore = FindPageDiv(pageBefore);
 			elementOfPageBefore.ParentNode.InsertAfter(newPageDiv, elementOfPageBefore);
 
+			CopyAndRenameAudioFiles(newPageDiv, templatePage.Book.FolderPath);
+			CopyAndRenameVideoFiles(newPageDiv, templatePage.Book.FolderPath);
+
 			OrderOrNumberOfPagesChanged();
 			BuildPageCache();
 			var newPage = GetPages().First(p=>p.GetDivNodeForThisPage() == newPageDiv);
@@ -2131,96 +2134,59 @@ namespace Bloom.Book
 
 		public void DuplicatePage(IPage page)
 		{
-			Guard.Against(HasFatalError, "Duplicate page failed: " + FatalErrorDescription);
-			Guard.Against(!IsEditable, "Tried to edit a non-editable book.");
-
-			var pages = GetPageElements();
-			var pageDiv = FindPageDiv(page);
-			var newpageDiv = (XmlElement) pageDiv.CloneNode(true);
-			BookStarter.SetupIdAndLineage(pageDiv, newpageDiv);
-			var body = pageDiv.ParentNode;
-			int currentPageIndex = -1;
-
-			// Have to compare Ids; can't use _pagesCache.IndexOf(page) -- (BL-467)
-			foreach (IPage cachedPage in _pagesCache)
-				if (cachedPage.Id.Equals(page.Id))
-				{
-					currentPageIndex = _pagesCache.IndexOf(cachedPage);
-					break;
-				}
-
-			// This should never happen. But just in case, don't do something we don't want to do.
-			if (currentPageIndex < 0)
-				return;
-
-			// If we copy audio markup, the new page will be linked to the SAME audio files,
-			// and the pages might well continue to share markup even when text on one of them
-			// is changed. If we WANT to copy the audio links, we need to do something like
-			// assigning a new guid each time a new recording is made, or at least if we
-			// find another sentence in the book sharing the same recording and with different
-			// text.
-			RemoveAudioMarkup(newpageDiv);
-
-			// When we copy a page with video content, it's simplest and safest to just copy and
-			// rename the video file.  If we don't do this, then deleting a page or editing a video
-			// have to be very careful not to delete or modify a video file referenced elsewhere in
-			// the book.  See https://silbloom.myjetbrains.com/youtrack/issue/BL-6536.
-			CopyAndRenameVideoFiles(newpageDiv);
-
-			body.InsertAfter(newpageDiv, pages[currentPageIndex]);
-			_storage.Dom.UpdatePageNumberAndSideClassOfPages(_collectionSettings.CharactersForDigitsForPageNumbers, _collectionSettings.IsLanguage1Rtl);
-
-			ClearPagesCache();
-			Save();
-			if (_pageListChangedEvent != null)
-				_pageListChangedEvent.Raise(null);
-
-			InvokeContentsChanged(null);
-
-			if (_pagesCache == null)
-				BuildPageCache();
-			_pageSelection.SelectPage(_pagesCache[currentPageIndex + 1]);
+			// Can be achieved by just using the current page as both the place to insert after
+			// and the template to copy.
+			// Note that Pasting a page uses the same routine; unit tests for duplicate and copy/paste
+			// take advantage of our knowledge that the code is shared so that between them they cover
+			// the important code paths. If the code stops being shared, we should extend test
+			// coverage appropriately.
+			InsertPageAfter(page, page);
 		}
 
-		private static void RemoveAudioMarkup(XmlElement newpageDiv)
+		private void CopyAndRenameAudioFiles(XmlElement newpageDiv, string sourceBookFolder)
 		{
 			foreach (var audioElement in HtmlDom.SelectAudioSentenceElements(newpageDiv).Cast<XmlElement>().ToList())
 			{
-				XmlNode after = audioElement;
-
-				string audioElementClassesValue = audioElement.GetStringAttribute("class");
-				List<string> audioElementClassList = null;
-				if (!String.IsNullOrEmpty(audioElementClassesValue))
+				// The "i" makes sure that the ID does not start with digit. It's unnecessary but harmless
+				// if it already starts with a non-digit. The JS code that usually generates these only
+				// adds it if necessary, but nothing knows enough about the nature of the IDs to make
+				// consistency about that necessary. It just needs to be unique (and a valid ID).
+				// (It would be pretty easy to make it consistent, but considerably harder to cover
+				// the new path adequately with unit tests.)
+				var id = "i" + Guid.NewGuid();
+				var oldId = audioElement.Attributes["id"]?.Value;
+				audioElement.SetAttribute("id", id);
+				if (string.IsNullOrEmpty(oldId))
+					continue;
+				var sourceAudioFilePath = Path.Combine(Path.Combine(sourceBookFolder, "audio"), oldId + ".wav");
+				var newAudioFolderPath = Path.Combine(FolderPath, "audio");
+				var newAudioFilePath = Path.Combine(newAudioFolderPath, id + ".wav");
+				Directory.CreateDirectory(newAudioFolderPath);
+				if (RobustFile.Exists(sourceAudioFilePath))
 				{
-					audioElementClassList = audioElementClassesValue.Split(HtmlDom.kHtmlClassDelimiters, StringSplitOptions.RemoveEmptyEntries).ToList();
+					RobustFile.Copy(sourceAudioFilePath, newAudioFilePath);
 				}
 
-				if (audioElementClassList != null && audioElementClassList.Contains("bloom-editable"))
+				var mp3Path = Path.ChangeExtension(sourceAudioFilePath, "mp3");
+				var newMp3Path = Path.ChangeExtension(newAudioFilePath, "mp3");
+				if (RobustFile.Exists(mp3Path))
 				{
-					// This should definitely not be deleted. Just remove the markup as best you can.
-					HtmlDom.RemoveClass(audioElement, "audio-sentence");
-				}
-				else
-				{
-					// Looks safe to remove the audio markup wrapper
-					foreach (XmlNode child in audioElement.ChildNodes)
-					{
-						audioElement.ParentNode.InsertAfter(child, after);
-						after = child;
-					}
-					audioElement.ParentNode.RemoveChild(audioElement);
+					RobustFile.Copy(mp3Path, newMp3Path);
 				}
 			}
 		}
 
-		private void CopyAndRenameVideoFiles(XmlElement newpageDiv)
+		private void CopyAndRenameVideoFiles(XmlElement newpageDiv, string sourceBookFolder)
 		{
-			foreach (var source in newpageDiv.SafeSelectNodes(".//video/source[contains(@type,'video/')]").Cast<XmlElement>().ToList())
+			foreach (var source in newpageDiv.SafeSelectNodes(".//video/source").Cast<XmlElement>().ToList())
 			{
 				var src = source.GetAttribute("src");
+				// old source may have a param, too, but we don't currently need to keep it.
+				string timings;
+				src = SignLanguageApi.StripTimingFromVideoUrl(src, out timings);
 				if (String.IsNullOrWhiteSpace(src))
 					continue;
-				var oldVideoPath = Path.Combine(FolderPath, src);
+				var oldVideoPath = Path.Combine(sourceBookFolder, src);
 				// If the video file doesn't exist, don't bother adjusting anything.
 				// If it does exist, copy it with a new name based on the current one, similarly
 				// to how we've been renaming image files that already exist in the book's folder.
@@ -2236,8 +2202,13 @@ namespace Bloom.Book
 						var newFileName = oldFileName + "-" + count.ToString(CultureInfo.InvariantCulture);
 						newVideoPath = Path.Combine(FolderPath, "video", newFileName + extension);
 					} while (RobustFile.Exists(newVideoPath));
+
+					Directory.CreateDirectory(Path.GetDirectoryName(newVideoPath));
 					RobustFile.Copy(oldVideoPath, newVideoPath, false);
-					source.SetAttribute("src", "video/" + Path.GetFileName(newVideoPath));
+					
+					source.SetAttribute("src", "video/" +
+						UrlPathString.CreateFromUnencodedString(Path.GetFileName(newVideoPath)).UrlEncoded +
+					    (string.IsNullOrEmpty(timings) ? "" : "#t=" + timings));
 				}
 			}
 		}

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -841,7 +841,7 @@ namespace BloomTests.Book
 		}
 
 		[Test]
-		public void DuplicatePage_WithAudio_OmitsAudioMarkup()
+		public void DuplicatePage_WithAudio_CopiesAudioAndAssignsNewId()
 		{
 			var book = CreateBook(); // has pages from  BookTestsBase.GetThreePageDom()
 			var original = book.GetPages().Count();
@@ -852,9 +852,33 @@ namespace BloomTests.Book
 			var sentenceSpan = pageDiv.OwnerDocument.CreateElement("span");
 			extraPara.AppendChild(sentenceSpan);
 			sentenceSpan.SetAttribute("class", "audio-sentence");
-			sentenceSpan.SetAttribute("id", Guid.NewGuid().ToString());
+			var audioId = Guid.NewGuid().ToString();
+			sentenceSpan.SetAttribute("id", audioId);
 			sentenceSpan.InnerText = "This was a sentence span";
+
+			var videoDiv = pageDiv.OwnerDocument.CreateElement("div");
+			videoDiv.SetAttribute("class", "bloom-videoContainer");
+			pageDiv.AppendChild(videoDiv);
+			var videoElt = pageDiv.OwnerDocument.CreateElement("video");
+			videoDiv.AppendChild(videoElt);
+			var sourceElt = pageDiv.OwnerDocument.CreateElement("source");
+			videoElt.AppendChild(sourceElt);
+			sourceElt.SetAttribute("src", "video/Crow.mp4"); // no timings path tested here!
+
+			var audioFolder = Path.Combine(book.FolderPath, "audio");
+			Directory.CreateDirectory(audioFolder);
+			var audioFilePath = Path.Combine(audioFolder, audioId + ".wav");
+			File.WriteAllText(audioFilePath, "This is a complete fake");
+			var mp3FilePath = Path.ChangeExtension(audioFilePath, "mp3");
+			File.WriteAllText(mp3FilePath, "This is a fake mp3");
+
+			var videoFolder = Path.Combine(book.FolderPath, "video");
+			Directory.CreateDirectory(videoFolder);
+			var videoFilePath = Path.Combine(videoFolder, "Crow.mp4");
+			File.WriteAllText(videoFilePath, "This is a fake video");
+
 			book.DuplicatePage(existingPage);
+
 			AssertPageCount(book, original + 1);
 
 			var newPage = book.GetPages().Last();
@@ -863,8 +887,121 @@ namespace BloomTests.Book
 
 			var newDivNode = newPage.GetDivNodeForThisPage();
 
-			var newFirstPara = newDivNode.ChildNodes.Cast<XmlElement>().Last();
-			Assert.That(newFirstPara.InnerXml, Is.EqualTo("This was a sentence span")); // no <span> element wrapped around it
+			var newFirstPara = newDivNode.GetElementsByTagName("p").Cast<XmlElement>().Last();
+			Assert.That(newFirstPara.InnerText, Is.EqualTo("This was a sentence span")); // kept the text
+			var newSpan = newFirstPara.GetElementsByTagName("span").Cast<XmlElement>().FirstOrDefault();
+			Assert.That(newSpan, Is.Not.Null);
+			var id = newSpan.Attributes["id"]?.Value;
+			Assert.That(id, Is.Not.Null.And.Not.Empty);
+			Assert.That(id, Is.Not.EqualTo(audioId));
+
+			var newAudioPath = Path.Combine(audioFolder, id + ".wav");
+			Assert.That(File.Exists(newAudioPath));
+			Assert.That(File.ReadAllText(newAudioPath), Is.EqualTo("This is a complete fake"));
+			var newMp3Path = Path.ChangeExtension(newAudioPath, "mp3");
+			Assert.That(File.Exists(newMp3Path));
+			Assert.That(File.ReadAllText(newMp3Path), Is.EqualTo("This is a fake mp3"));
+
+			var newVideoSrc = newDivNode.SelectSingleNode(".//source") as XmlElement;
+			var srcAttrVal = newVideoSrc?.GetAttribute("src");
+			Assert.That(srcAttrVal, Does.StartWith("video/"));
+			Assert.That(srcAttrVal, Does.Not.Contain("#").And.Not.Contain("t="));
+			Assert.That(srcAttrVal, Does.EndWith(".mp4"));
+			var fileName = srcAttrVal.Substring("video/".Length);
+			Assert.That(fileName, Is.Not.EqualTo("Crow.mp4"));
+
+			var newVideoFolder = Path.Combine(book.FolderPath, "video");
+			var newVideoPath = Path.Combine(newVideoFolder, fileName);
+			Assert.That(RobustFile.Exists(newVideoPath));
+			Assert.That(File.ReadAllText(newVideoPath), Is.EqualTo("This is a fake video"));
+		}
+
+		// If we're actually copying from another book, renaming the files is not important.
+		// But we need that when copying from the SAME book, so we always do it, and this
+		// test can cover that case also.
+		[Test]
+		public void InsertPageAfter_FromAnotherBook_WholeTextMode_CopiesAndRenamesAudioAndVideo()
+		{
+			var htmlSourceBook = @"<html><head></head><body>
+					<div class='bloom-page numberedPage bloom-nonprinting' id='page1' data-page-number='1'>
+						<div id='id1' class='bloom-editable audio-sentence'>
+							<p>Page 1 Paragraph 1 Sentence 1</p>
+							<p>Page 1 Paragraph 2 Sentence 1</p>
+						</div>
+						<div class='bloom-videoContainer'>
+							<video>
+								<source src='video/Crow.mp4#t=1.2,5.7'></source>
+							</video>
+						</div>
+					</div>
+				</body></html>";
+
+			using (var tempFolder = new SIL.TestUtilities.TemporaryFolder(_testFolder, "sourceBook"))
+			{
+				var doc = new XmlDocument();
+				doc.LoadXml(htmlSourceBook);
+				var dom = new HtmlDom(doc);
+				var storage = MakeMockStorage(tempFolder.Path, () => dom);
+				var sourceBook = new Bloom.Book.Book(storage.Object.BookInfo, storage.Object, _templateFinder.Object,
+					CreateDefaultCollectionsSettings(),
+					_pageSelection.Object, _pageListChangedEvent, new BookRefreshEvent());
+				var sourcePage = sourceBook.GetPages().Last();
+
+				var book = CreateBook(); // has pages from  BookTestsBase.GetThreePageDom()
+				var original = book.GetPages().Count();
+				var existingPage = book.GetPages().Last();
+
+				var audioFolder = Path.Combine(sourceBook.FolderPath, "audio");
+				Directory.CreateDirectory(audioFolder);
+				var audioFilePath = Path.Combine(audioFolder, "id1.wav");
+				File.WriteAllText(audioFilePath, "This is a complete fake");
+				var mp3FilePath = Path.ChangeExtension(audioFilePath, "mp3");
+				File.WriteAllText(mp3FilePath, "This is a fake mp3");
+
+				var videoFolder = Path.Combine(sourceBook.FolderPath, "video");
+				Directory.CreateDirectory(videoFolder);
+				var videoFilePath = Path.Combine(videoFolder, "Crow.mp4");
+				File.WriteAllText(videoFilePath, "This is a fake video");
+
+				book.InsertPageAfter(existingPage, sourcePage);
+
+				AssertPageCount(book, original + 1);
+
+				var newPage = book.GetPages().Last();
+				Assert.AreNotEqual(existingPage, newPage);
+				Assert.AreNotEqual(existingPage.Id, newPage.Id);
+
+				var newDivNode = newPage.GetDivNodeForThisPage();
+
+				var newTextDiv = newDivNode.ChildNodes.Cast<XmlElement>().First();
+				Assert.That(newTextDiv.InnerText, Is.EqualTo("Page 1 Paragraph 1 Sentence 1Page 1 Paragraph 2 Sentence 1")); // kept the text
+				var id = newTextDiv.Attributes["id"]?.Value;
+				Assert.That(id, Is.Not.Null.And.Not.Empty);
+				Assert.That(id, Is.Not.EqualTo("id1"));
+
+				var newAudioFolder = Path.Combine(book.FolderPath, "audio");
+				var newAudioPath = Path.Combine(newAudioFolder, id + ".wav");
+				Assert.That(File.Exists(newAudioPath));
+				Assert.That(File.ReadAllText(newAudioPath), Is.EqualTo("This is a complete fake"));
+				var newMp3Path = Path.ChangeExtension(newAudioPath, "mp3");
+				Assert.That(File.Exists(newMp3Path));
+				Assert.That(File.ReadAllText(newMp3Path), Is.EqualTo("This is a fake mp3"));
+
+				var newVideoContainer = newDivNode.GetElementsByTagName("div")[1] as XmlElement;
+				var newVideoDiv = newVideoContainer.GetElementsByTagName("video")[0] as XmlElement;
+				var newVideoSource = newVideoDiv.GetElementsByTagName("source")[0] as XmlElement;
+				var source = newVideoSource.Attributes["src"]?.Value;
+				Assert.That(source, Does.StartWith("video/"));
+				Assert.That(source, Does.EndWith(".mp4#t=1.2,5.7"));
+				var fileName = source.Substring("video/".Length, source.Length - "video/.mp4#t=1.2,5.7".Length);
+				Assert.That(fileName, Is.Not.EqualTo("Crow").And.Not.Null.And.Not.Empty);
+
+				var newVideoFolder = Path.Combine(book.FolderPath, "video");
+				var newVideoPath = Path.Combine(newVideoFolder, fileName + ".mp4");
+				Assert.That(RobustFile.Exists(newVideoPath));
+				Assert.That(File.ReadAllText(newVideoPath), Is.EqualTo("This is a fake video"));
+			}
+
 		}
 
 		[Test]
@@ -2302,48 +2439,6 @@ namespace BloomTests.Book
 
 			// Verification // 
 			Assert.AreEqual(true, result, $"ElementName: {elementName}");
-		}
-
-		[TestCase(TalkingBookApi.AudioRecordingMode.Sentence)]
-		[TestCase(TalkingBookApi.AudioRecordingMode.TextBox)]
-		public void RemoveAudioMarkup_ContainsAudioElements_AllElementsRemoved(TalkingBookApi.AudioRecordingMode audioRecordingMode)
-		{
-			string html = @"<html><head></head><body>
-					<div class='bloom-page numberedPage bloom-nonprinting' id='page1' data-page-number='1'>
-						<div class='bloom-editable'>
-							<p><span id='id1' class='audio-sentence'>Page 1 Paragraph 1 Sentence 1</span></p>
-							<p><span id='id2' class='audio-sentence'>Page 1 Paragraph 2 Sentence 1</span></p>
-						</div>
-					</div>
-				</body></html>";
-
-			if (audioRecordingMode == TalkingBookApi.AudioRecordingMode.TextBox)
-			{
-				html = @"<html><head></head><body>
-					<div class='bloom-page numberedPage bloom-nonprinting' id='page1' data-page-number='1'>
-						<div id='id1' class='bloom-editable audio-sentence'>
-							<p>Page 1 Paragraph 1 Sentence 1</p>
-							<p>Page 1 Paragraph 2 Sentence 1</p>
-						</div>
-					</div>
-				</body></html>";
-			}
-
-			_bookDom = new HtmlDom(html);
-			var book = CreateBook();
-
-			// System under test
-			var runner = new Microsoft.VisualStudio.TestTools.UnitTesting.PrivateType(typeof(global::Bloom.Book.Book));
-			runner.InvokeStatic("RemoveAudioMarkup", book.RawDom.DocumentElement);
-
-			// Test verification
-			Assert.AreEqual(0, HtmlDom.SelectAudioSentenceElements(book.RawDom.DocumentElement)?.Count ?? 0, "Count did not match expectation");
-
-			string expectedInnerHtml = "<div class=\"bloom-editable\"><p>Page 1 Paragraph 1 Sentence 1</p><p>Page 1 Paragraph 2 Sentence 1</p></div>";
-			string expectedOuterHtml = $"<div class=\"bloom-page numberedPage bloom-nonprinting\" id=\"page1\" data-page-number=\"1\">{expectedInnerHtml}</div>";
-			var page1Div = book.RawDom.SelectSingleNode("//div[@id='page1']") as XmlElement;
-			Assert.AreEqual(expectedInnerHtml, page1Div.InnerXml.Replace(" id=\"id1\"", ""), $"Inner HTML");
-			Assert.AreEqual(expectedOuterHtml, page1Div.OuterXml.Replace(" id=\"id1\"", ""), $"Outer HTML");
 		}
 
 		private const string _pathToTestVideos = "src/BloomTests/videos";


### PR DESCRIPTION
- Makes Duplicate use the same copying code as Copy/Paste page
- Makes it copy audio, but with new IDs so new page does not share with old, in case one of them is later changed (but not intending to change the other)
- Makes videos be similarly copied in Copy/Paste as well as Duplicate
- Fixes a problem where copying pages with trimmed video would either fail completely to copy the video (I think) or at least lose the timings
- Handles copying video and audio when the source is in a different book

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2951)
<!-- Reviewable:end -->
