### PR TITLE
Fix BL-6740 Overlay and Help link interaction

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.less
@@ -9,28 +9,19 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    // All the layers down to .imageDescriptionTool have to be 100%
-    // to allow it to stretch and put Help at the bottom
-    height: 100%;
+    padding-left: 20px;
+    height: 100%; // push the help link to the bottom
     *,
     a {
         color: @bloom-toolboxWhite;
     }
 }
 
-.imageToolInternalWrapper {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-}
-
 .imgDescLabelBlock {
-    margin: 20px;
+    // no: creates a scroll-bar, bizarrely... margin-top: 2em;
+    margin-bottom: 2em;
 }
 
-.imageDescriptionCheck {
-    margin-left: 20px;
-}
 @playVideoIconWidth: 16px;
 @playVideoIconMargin: 5px;
 
@@ -48,15 +39,4 @@
 .wrapPlayVideo {
     display: flex;
     flex-direction: row;
-}
-
-// By default help has a large margin. In this tool we want it fixed at the bottom,
-// so it's in a FLEX box that distributes any spare space to keep it there.
-// We need a rather specific rule to override the default one.
-.toolboxRoot {
-    .imageDescriptionTool {
-        .helpLinkWrapper {
-            margin-bottom: 0;
-        }
-    }
 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
@@ -8,7 +8,7 @@ import ToolboxToolReactAdaptor from "../toolboxToolReactAdaptor";
 import { Label } from "../../../react_components/l10n";
 import { Checkbox } from "../../../react_components/checkbox";
 import Link from "../../../react_components/link";
-import HelpLink from "../../../react_components/helpLink";
+import { ToolBottomHelpLink } from "../../../react_components/helpLink";
 import {
     RequiresBloomEnterpriseWrapper,
     checkIfEnterpriseAvailable
@@ -89,7 +89,7 @@ export class ImageDescriptionToolControls extends React.Component<
                         (this.state.enabled ? "" : " disabled")
                     }
                 >
-                    <div className="imageDescriptionToolInternalWrapper">
+                    <div className="topGroup">
                         <div className="imgDescLabelBlock">
                             <Label l10nKey="EditTab.Toolbox.ImageDescriptionTool.LearnToMake">
                                 Learn to make effective image descriptions:
@@ -140,14 +140,8 @@ export class ImageDescriptionToolControls extends React.Component<
                         </div>
                         {this.createCheckboxes()}
                     </div>
-                    <div className="helpLinkWrapper imgDescLabelBlock">
-                        <HelpLink
-                            helpId="Tasks/Edit_tasks/Image_Description_Tool/Image_Description_Tool_overview.htm"
-                            l10nKey="Common.Help"
-                        >
-                            Help
-                        </HelpLink>
-                    </div>
+                    {/* the flex box will then push this to the bottom */}
+                    <ToolBottomHelpLink helpId="Tasks/Edit_tasks/Image_Description_Tool/Image_Description_Tool_overview.htm" />
                 </div>
             </RequiresBloomEnterpriseWrapper>
         );

--- a/src/BloomBrowserUI/bookEdit/toolbox/impairmentVisualizer/impairmentVisualizer.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/impairmentVisualizer/impairmentVisualizer.tsx
@@ -8,7 +8,7 @@ import "./impairmentVisualizer.less";
 import { RequiresBloomEnterpriseWrapper } from "../../../react_components/requiresBloomEnterprise";
 import { RadioGroup, Radio } from "../../../react_components/radio";
 import { deuteranopia, tritanopia, achromatopsia } from "color-blind";
-import HelpLink from "../../../react_components/helpLink";
+import { ToolBottomHelpLink } from "../../../react_components/helpLink";
 
 interface IState {
     kindOfColorBlindness: string;
@@ -88,14 +88,8 @@ export class ImpairmentVisualizerControls extends React.Component<{}, IState> {
                             </Radio>
                         </RadioGroup>
                     </div>
-                    <div className="helpLinkWrapper">
-                        <HelpLink
-                            l10nKey="Common.Help"
-                            helpId="Tasks/Edit_tasks/Impairment_Visualizer/Impairment_Visualizer_overview.htm"
-                        >
-                            Help
-                        </HelpLink>
-                    </div>{" "}
+
+                    <ToolBottomHelpLink helpId="Tasks/Edit_tasks/Impairment_Visualizer/Impairment_Visualizer_overview.htm" />
                 </div>
             </RequiresBloomEnterpriseWrapper>
         );

--- a/src/BloomBrowserUI/bookEdit/toolbox/motion/motionTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/motion/motionTool.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Div } from "../../../react_components/l10n";
-import { HelpLink } from "../../../react_components/helpLink";
+import { ToolBottomHelpLink } from "../../../react_components/helpLink";
 // These are for Motion:
 import { EditableDivUtils } from "../../js/editableDivUtils";
 import { getPageFrameExports } from "../../js/bloomFrames";
@@ -971,7 +971,8 @@ export class MotionTool extends ToolboxToolReactAdaptor {
         if (!page) return;
         (page.getElementsByClassName(
             "bloom-page"
-        )[0] as HTMLElement).style.visibility = "";
+        )[0] as HTMLElement).style.visibility =
+            "";
         // stop the animation itself by removing the root elements it adds.
         this.removeElt(this.animationStyleElement);
         this.animationStyleElement = null;
@@ -1178,12 +1179,7 @@ export class MotionControl extends React.Component<IMotionProps, IMotionState> {
                     </div>
                 </div>
                 <div className="helpLinkWrapper">
-                    <HelpLink
-                        helpId="Tasks/Edit_tasks/Motion_Tool/Motion_Tool_overview.htm"
-                        l10nKey="Common.Help"
-                    >
-                        Help
-                    </HelpLink>
+                    <ToolBottomHelpLink helpId="Tasks/Edit_tasks/Motion_Tool/Motion_Tool_overview.htm" />
                 </div>
                 <audio id="pzMusicPlayer" preload="none" />
             </div>

--- a/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
@@ -11,7 +11,7 @@ import {
     BloomEnterpriseAvailableContext
 } from "../../../react_components/requiresBloomEnterprise";
 import { BloomApi } from "../../../utils/bloomApi";
-import { HelpLink } from "../../../react_components/helpLink";
+import { ToolBottomHelpLink } from "../../../react_components/helpLink";
 import { UrlUtils } from "../../../utils/urlUtils";
 import { Expandable } from "../../../react_components/expandable";
 import theOneLocalizationManager from "../../../lib/localizationManager/localizationManager";
@@ -305,14 +305,7 @@ export class SignLanguageToolControls extends React.Component<
                                     {videoStats}
                                 </Expandable>
                             </div>
-                            <div className="helpLinkWrapper">
-                                <HelpLink
-                                    l10nKey="Common.Help"
-                                    helpId="Tasks/Edit_tasks/Sign_Language_Tool/Sign_Language_Tool_overview.htm"
-                                >
-                                    Help
-                                </HelpLink>
-                            </div>
+                            <ToolBottomHelpLink helpId="Tasks/Edit_tasks/Sign_Language_Tool/Sign_Language_Tool_overview.htm" />
                         </div>
                     )}
                 </BloomEnterpriseAvailableContext.Consumer>

--- a/src/BloomBrowserUI/react_components/helpLink.tsx
+++ b/src/BloomBrowserUI/react_components/helpLink.tsx
@@ -3,13 +3,17 @@ import { ILocalizationProps, LocalizableElement } from "./l10n";
 
 interface IHelpLinkProps extends ILocalizationProps {
     helpId: string;
+    style?: React.CSSProperties;
 }
 
 // just an html anchor that knows how to localize and how turn a Bloom help id into a url
 export class HelpLink extends LocalizableElement<IHelpLinkProps, {}> {
     public render() {
         return (
-            <a href={"/bloom/api/help/" + this.props.helpId}>
+            <a
+                style={this.props.style}
+                href={"/bloom/api/help/" + this.props.helpId}
+            >
                 {this.getLocalizedContent()}
             </a>
         );
@@ -17,3 +21,18 @@ export class HelpLink extends LocalizableElement<IHelpLinkProps, {}> {
 }
 
 export default HelpLink;
+
+// A common help link is just called "help" and that has a high zindex so that it is usable even when the tool is disabled by an overlay
+export class ToolBottomHelpLink extends React.Component<{ helpId: string }> {
+    public render() {
+        return (
+            <HelpLink
+                style={{ zIndex: 100 }}
+                l10nKey="Common.Help"
+                helpId={this.props.helpId}
+            >
+                Help
+            </HelpLink>
+        );
+    }
+}

--- a/src/BloomBrowserUI/react_components/requiresBloomEnterprise.less
+++ b/src/BloomBrowserUI/react_components/requiresBloomEnterprise.less
@@ -33,7 +33,7 @@
     top: 0;
     left: 0;
     right: 0;
-    bottom: 25pt; // allow space for the tool's Help link to remain exposed and active
+    bottom: 0;
     background-color: fade(
         @bloom-blue,
         50%


### PR DESCRIPTION
This simplifies a lot of  code by have a dedicated component for the help. That component positions itself on top of the overlay that disables all of its peers. Also removes some seemingly needless wrappers, classes, and css rules I ran into along the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2953)
<!-- Reviewable:end -->
