### PR TITLE
Fix display of image descriptions for tools (BL-6270)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
@@ -1,8 +1,11 @@
 ﻿import { ITool } from "../toolbox";
 import { ToolBox } from "../toolbox";
 import * as AudioRecorder from "./audioRecording";
+import { checkIfEnterpriseAvailable } from "../../../react_components/requiresBloomEnterprise";
 
 export default class TalkingBookTool implements ITool {
+    private enterpriseEnabled: boolean = false;
+
     public makeRootElement(): HTMLDivElement {
         throw new Error("Method not implemented.");
     }
@@ -24,9 +27,14 @@ export default class TalkingBookTool implements ITool {
     public configureElements(container: HTMLElement) {}
 
     public showTool() {
-        this.showImageDescriptionsIfAny();
         AudioRecorder.initializeTalkingBookTool();
-        AudioRecorder.theOneAudioRecorder.setupForRecording();
+        checkIfEnterpriseAvailable().then(enabled => {
+            this.enterpriseEnabled = enabled;
+            if (enabled) {
+                this.showImageDescriptionsIfAny();
+            }
+            AudioRecorder.theOneAudioRecorder.setupForRecording();
+        });
     }
 
     // Called when a new page is loaded.
@@ -55,7 +63,9 @@ export default class TalkingBookTool implements ITool {
 
     // Called whenever the user edits text.
     public updateMarkup() {
-        this.showImageDescriptionsIfAny();
+        if (this.enterpriseEnabled) {
+            this.showImageDescriptionsIfAny();
+        }
         AudioRecorder.theOneAudioRecorder.updateMarkupAndControlsToCurrentText();
     }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -524,8 +524,11 @@ function switchTool(newToolName: string): void {
         }
         if (newTool) {
             activateTool(newTool);
-            currentTool = newTool;
         }
+        // Without recording that currentTool isn't defined, then returning from
+        // More... to the same tool doesn't activate that tool.
+        // See https://issues.bloomlibrary.org/youtrack/issue/BL-6720.
+        currentTool = newTool ? newTool : undefined;
     }
 }
 


### PR DESCRIPTION
This addresses both a failure to display the image descriptions when the
image description tool is active, and displaying the image descriptions
in the talking book tool when enterprise is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2954)
<!-- Reviewable:end -->
