### PR TITLE
Add common/debugMessage API for Javascript debugging

### DIFF
--- a/src/BloomBrowserUI/utils/bloomApi.ts
+++ b/src/BloomBrowserUI/utils/bloomApi.ts
@@ -226,6 +226,14 @@ export class BloomApi {
             successCallback
         );
     }
+
+    // This is useful for debugging TypeScript code, especially on Linux.  I wouldn't necessarily expect
+    // to see it used anywhere in code that gets submitted and merged.
+    public static postDebugMessage(message: string): void {
+        BloomApi.postDataWithConfig("common/debugMessage", message, {
+            headers: { "Content-Type": "text/plain" }
+        });
+    }
 }
 
 window.addEventListener("beforeunload", () => BloomApi.NotifyPageClosing());

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -89,6 +89,15 @@ namespace Bloom.web.controllers
 				{
 					request.ReplyWithText(ApplicationUpdateSupport.ChannelName);
 				}, false);
+			// This is useful for debugging TypeScript code, especially on Linux.  I wouldn't necessarily expect
+			// to see it used anywhere in code that gets submitted and merged.
+			apiHandler.RegisterEndpointHandler ("common/debugMessage",
+				request =>
+				{
+					var message = request.RequiredPostString();
+					Debug.WriteLine("FROM JS: " + message);
+					request.PostSucceeded();
+				}, false);
 		}
 
 		// Request from javascript to open the folder containing the specified file,


### PR DESCRIPTION
This is especially useful on Linux, where we can't get a Debug window
from inside Bloom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2960)
<!-- Reviewable:end -->
