### PR TITLE
Suppress ACE/Daisy errors on branding images

### DIFF
--- a/src/BloomBrowserUI/branding/CLB/branding.json
+++ b/src/BloomBrowserUI/branding/CLB/branding.json
@@ -3,8 +3,7 @@
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content":
-                "<img src='clb.png'/><img src='BloomWithTaglineAgainstLight.svg'/>",
+            "content": "<img class='branding' src='clb.png'/><img class='branding' src='BloomWithTaglineAgainstLight.svg'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/Default/branding.json
+++ b/src/BloomBrowserUI/branding/Default/branding.json
@@ -3,7 +3,7 @@
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='BloomWithTaglineAgainstLight.svg'/>",
+            "content": "<img class='branding' src='BloomWithTaglineAgainstLight.svg'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/GRN-REACH/branding.json
+++ b/src/BloomBrowserUI/branding/GRN-REACH/branding.json
@@ -9,14 +9,13 @@
         {
             "data-book": "licenseNotes",
             "lang": "*",
-            "content":
-                "Translations—If you create a translation of this work, please add the following disclaimer along with the attribution: This translation was not created by USAID and should not be considered an official USAID translation. USAID shall not be liable for any content or error in this translation.<br/>Adaptations—If you create an adaptation of this work, please add the following disclaimer along with the attribution: This is an adaptation of an original work by USAID. Views and opinions expressed in the adaptation are the sole responsibility of the author or authors of the adaptation and are not endorsed by USAID.",
+            "content": "Translations—If you create a translation of this work, please add the following disclaimer along with the attribution: This translation was not created by USAID and should not be considered an official USAID translation. USAID shall not be liable for any content or error in this translation.<br/>Adaptations—If you create an adaptation of this work, please add the following disclaimer along with the attribution: This is an adaptation of an original work by USAID. Views and opinions expressed in the adaptation are the sole responsibility of the author or authors of the adaptation and are not endorsed by USAID.",
             "condition": "ifAllCopyrightEmpty"
         },
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='grn-reach-logos.png'/>",
+            "content": "<img class='branding' src='grn-reach-logos.png'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/Juarez-Guatemala/branding.json
+++ b/src/BloomBrowserUI/branding/Juarez-Guatemala/branding.json
@@ -4,8 +4,7 @@
             "data-book": "credits-page-branding-top-html",
             "lang": "*",
             // note: we want the text to adopt the same styling as the other Spanish on the credits page, so we give this the right style and @lang attribute:
-            "content":
-                "<img src='GuatemalaMOE-USAID.png'/><div class='Credits-Page-style' lang='es'><p>Este libro fue realizado gracias al apoyo del Pueblo de los Estados Unidos de América a través de la Agencia de los Estados Unidos de América para el Desarrollo Internacional (USAID, por sus siglas en inglés).</p> <p>El contenido de este material es responsabilidad exclusiva de los autores y el mismo no necesariamente refleja la perspectiva de USAID ni del Gobierno de los Estados Unidos de América.</p></div>",
+            "content": "<img class='branding' src='GuatemalaMOE-USAID.png'/><div class='Credits-Page-style' lang='es'><p>Este libro fue realizado gracias al apoyo del Pueblo de los Estados Unidos de América a través de la Agencia de los Estados Unidos de América para el Desarrollo Internacional (USAID, por sus siglas en inglés).</p> <p>El contenido de este material es responsabilidad exclusiva de los autores y el mismo no necesariamente refleja la perspectiva de USAID ni del Gobierno de los Estados Unidos de América.</p></div>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/Local-Community/branding.json
+++ b/src/BloomBrowserUI/branding/Local-Community/branding.json
@@ -3,14 +3,13 @@
         {
             "data-book": "title-page-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='BloomLocal.svg'/>",
+            "content": "<img class='branding' src='BloomLocal.svg'/>",
             "condition": "always"
         },
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content":
-                "<p>This book was created with Bloom Enterprise features freely enabled in order to support projects funded by the local community.</p><img src='Bloom Against Light HD.png'/>",
+            "content": "<p>This book was created with Bloom Enterprise features freely enabled in order to support projects funded by the local community.</p><img class='branding' src='Bloom Against Light HD.png'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/PNG-RISE/branding.json
+++ b/src/BloomBrowserUI/branding/PNG-RISE/branding.json
@@ -10,14 +10,14 @@
         {
             "data-book": "title-page-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='title-page.png'/>",
+            "content": "<img class='branding' src='title-page.png'/>",
             "condition": "always"
         },
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
             // only one of these will be visible
-            "content": "<img class='portraitOnly' src='backPortrait.svg'/><img class='landscapeOnly' src='backLandscape.svg'/>",
+            "content": "<img class='portraitOnly branding' src='backPortrait.svg'/><img class='landscapeOnly branding' src='backLandscape.svg'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/Papua-Literacy/branding.json
+++ b/src/BloomBrowserUI/branding/Papua-Literacy/branding.json
@@ -3,7 +3,7 @@
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='back.png'/>",
+            "content": "<img class='branding' src='back.png'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/RBI-BookBoost-pilot/branding.json
+++ b/src/BloomBrowserUI/branding/RBI-BookBoost-pilot/branding.json
@@ -3,8 +3,7 @@
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content":
-                "<p>This product is made possible through the generous support of the All Children Reading: A Grand Challenge for Development (ACR GCD) Partners (the United States Agency for International Development (USAID), World Vision, and the Australian Government) and Pearson. It was prepared by Resources for the Blind, Inc. and does not necessarily reflect the views of Pearson and the ACR GCD Partners.</p><p/><img src='RBI-BookBoost-pilot-back.png'/>",
+            "content": "<p>This product is made possible through the generous support of the All Children Reading: A Grand Challenge for Development (ACR GCD) Partners (the United States Agency for International Development (USAID), World Vision, and the Australian Government) and Pearson. It was prepared by Resources for the Blind, Inc. and does not necessarily reflect the views of Pearson and the ACR GCD Partners.</p><p/><img class='branding' src='RBI-BookBoost-pilot-back.png'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/SIL-International/branding.json
+++ b/src/BloomBrowserUI/branding/SIL-International/branding.json
@@ -3,13 +3,13 @@
         {
             "data-book": "title-page-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='SILInternationalBlack.svg'/>",
+            "content": "<img class='branding' src='SILInternationalBlack.svg'/>",
             "condition": "always"
         },
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='BloomWithTaglineGrey.svg'/>",
+            "content": "<img class='branding' src='BloomWithTaglineGrey.svg'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/SIL-LEAD/branding.json
+++ b/src/BloomBrowserUI/branding/SIL-LEAD/branding.json
@@ -3,20 +3,19 @@
         {
             "data-book": "credits-page-branding-bottom-html",
             "lang": "*",
-            "content":
-                "<h4>Please visit or contact us at:</h4><p>Website: <a href='https://www.sil-lead.org'>www.sil-lead.org</a></p><p>Facebook: <a href='https://www.facebook.com/sillead/'>www.facebook.com/sillead/</a></p><p>YouTube: <a href='https://www.youtube.com/silleadinc'>www.youtube.com/silleadinc</a></p><p>Email: <a href='mailto:bloomhelp@sil-lead.org'>bloomhelp@sil-lead.org</a></p>",
+            "content": "<h4>Please visit or contact us at:</h4><p>Website: <a href='https://www.sil-lead.org'>www.sil-lead.org</a></p><p>Facebook: <a href='https://www.facebook.com/sillead/'>www.facebook.com/sillead/</a></p><p>YouTube: <a href='https://www.youtube.com/silleadinc'>www.youtube.com/silleadinc</a></p><p>Email: <a href='mailto:bloomhelp@sil-lead.org'>bloomhelp@sil-lead.org</a></p>",
             "condition": "always"
         },
         {
             "data-book": "title-page-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='SILLEAD.svg'/>",
+            "content": "<img class='branding' src='SILLEAD.svg'/>",
             "condition": "always"
         },
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='back.svg'/>",
+            "content": "<img class='branding' src='back.svg'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/SIL-PNG/branding.json
+++ b/src/BloomBrowserUI/branding/SIL-PNG/branding.json
@@ -3,13 +3,13 @@
         {
             "data-book": "title-page-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='silpng.svg'/>",
+            "content": "<img class='branding' src='silpng.svg'/>",
             "condition": "always"
         },
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='back-cover-outside.svg'/>",
+            "content": "<img class='branding' src='back-cover-outside.svg'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/Suluh-INOVASI/branding.json
+++ b/src/BloomBrowserUI/branding/Suluh-INOVASI/branding.json
@@ -9,14 +9,13 @@
         {
             "data-book": "title-page-branding-bottom-html",
             "lang": "*",
-            "content":
-                "<div class='titlePageBrandingNotice'>Program ini didukung oleh INOVASI bekerjasama dengan SULUH INSAN LESTARI</div>",
+            "content": "<div class='titlePageBrandingNotice'>Program ini didukung oleh INOVASI bekerjasama dengan SULUH INSAN LESTARI</div>",
             "condition": "always"
         },
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='Suluh-INOVASI-back.png'/>",
+            "content": "<img class='branding' src='Suluh-INOVASI-back.png'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/Test/branding.json
+++ b/src/BloomBrowserUI/branding/Test/branding.json
@@ -3,37 +3,32 @@
         {
             "data-book": "credits-page-branding-top-html",
             "lang": "*",
-            "content":
-                "<img src='butterfly.png'/><div class='standout'>This should show at the top of the credits page underneath a butterfly.</div>",
+            "content": "<img class='branding' src='butterfly.png'/><div class='standout'>This should show at the top of the credits page underneath a butterfly.</div>",
             "condition": "always"
         },
         {
             "data-book": "credits-page-branding-bottom-html",
             "lang": "*",
-            "content":
-                "<div  class='standout'>This should show at the bottom of the credits page. The image below should be a caterpillar in a5landscape, but butterfly in a5portrait, switched by styles in branding.css</div><img class='portrait' src='butterfly.png'/><img class='landscape' src='caterpillar.png'/>",
+            "content": "<div  class='standout'>This should show at the bottom of the credits page. The image below should be a caterpillar in a5landscape, but butterfly in a5portrait, switched by styles in branding.css</div><img class='portrait branding' src='butterfly.png'/><img class='landscape branding' src='caterpillar.png'/>",
             "condition": "always"
         },
         {
             "data-book": "title-page-branding-bottom-html",
             "lang": "*",
-            "content":
-                "<img src='butterfly.png'/><div class='standout'>This should show at the bottom of the title page, underneath a butterfly. This is a hyperlink but it should not be underlined: <a href='https://bloomlibrary.org'>https://bloomlibrary.org</a></div>",
+            "content": "<img class='branding' src='butterfly.png'/><div class='standout'>This should show at the bottom of the title page, underneath a butterfly. This is a hyperlink but it should not be underlined: <a href='https://bloomlibrary.org'>https://bloomlibrary.org</a></div>",
             "condition": "always"
         },
 
         {
             "data-book": "outside-back-cover-branding-top-html",
             "lang": "*",
-            "content":
-                "<img src='butterfly.png'/><div class='standout'>This text should show at the top of the outer back cover, underneath a butterfly.</div>",
+            "content": "<img class='branding' src='butterfly.png'/><div class='standout'>This text should show at the top of the outer back cover, underneath a butterfly.</div>",
             "condition": "always"
         },
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content":
-                "<div class='standout'>This should show at the bottom of the outside back cover page, above some soccer balls...<img src='WideSoccerBalls.png'/>.. and then the Bloom logo:<img src='Bloom Against Light HD.png'/></div>",
+            "content": "<div class='standout'>This should show at the bottom of the outside back cover page, above some soccer balls...<img class='branding' src='WideSoccerBalls.png'/>.. and then the Bloom logo:<img class='branding' src='Bloom Against Light HD.png'/></div>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/ToMasewalTlahtol/branding.json
+++ b/src/BloomBrowserUI/branding/ToMasewalTlahtol/branding.json
@@ -3,13 +3,13 @@
         {
             "data-book": "credits-page-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='ToMasewalTlahtol.svg'/>",
+            "content": "<img class='branding' src='ToMasewalTlahtol.svg'/>",
             "condition": "always"
         },
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='back-cover-outside.svg'/>",
+            "content": "<img class='branding' src='back-cover-outside.svg'/>",
             "condition": "always"
         }
     ]

--- a/src/BloomBrowserUI/branding/UBB-GMIT/branding.json
+++ b/src/BloomBrowserUI/branding/UBB-GMIT/branding.json
@@ -3,13 +3,13 @@
         {
             "data-book": "credits-page-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='ubb-gmit.png'/>",
+            "content": "<img class='branding' src='ubb-gmit.png'/>",
             "condition": "always"
         },
         {
             "data-book": "outside-back-cover-branding-bottom-html",
             "lang": "*",
-            "content": "<img src='back-cover-outside.svg'/>",
+            "content": "<img class='branding' src='back-cover-outside.svg'/>",
             "condition": "always"
         }
     ]


### PR DESCRIPTION
Add the "branding" class to the images loaded from the presets.  This will cause EpubMaker::HandleImageDescriptions() to set role=presentation which will tell ACE/Daisy to ignore it.  It will also cause empty alt text to be assigned instead of removing the alt text attribute.

Just going with the simpler fix for now, but it is not defensive. We could also add some code to try to ensure that the .branding class is added to images when the BradningSettings presets are loaded from disk.

We could also add non-empty alt text, which was talked about in the card, but for now I leave that off until further discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2980)
<!-- Reviewable:end -->
