### PR TITLE
Branding alt texts: fix unit tests (BL-6787)

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using System.Web;
 using System.Xml;
 using System.Xml.Xsl;
+using Bloom.Publish.Epub;
 using Bloom.web.controllers;
 using DesktopAnalytics;
 using Gecko;
@@ -2143,7 +2144,7 @@ namespace Bloom.Book
 		}
 
 		// Make the image's alt attr match the image description for the specified language.
-		// If we don't have one, make the alt attr exactly an empty string.
+		// If we don't have one, make the alt attr exactly an empty string (except branding images may be allowed to have custom alt text).
 		private static void SetImageAltAttrFromDescription(XmlElement img, string descriptionLang)
 		{
 			var parent = img.ParentNode as XmlElement;
@@ -2176,7 +2177,7 @@ namespace Bloom.Book
 				}
 			}
 
-			if (IsPlaceholderImageAltText(img))
+			if (!EpubMaker.IsBranding(img) || IsPlaceholderImageAltText(img))
 			{
 				// Images in accessible epubs should have explicit empty alt attr if no useful description
 				img.SetAttribute("alt", "");

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -1059,7 +1059,7 @@ namespace Bloom.Publish.Epub
 			}
 		}
 
-		private static bool IsBranding(XmlElement element)
+		public static bool IsBranding(XmlElement element)
 		{
 			if (element == null)
 			{

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -131,6 +131,12 @@ namespace BloomTests.Book
 							<img class='licenseImage' src='license.png' data-derived='licenseImage' alt='License image'></img>
 						</div>
 					</div>
+					<div data-book='title-page-branding-bottom-html'>
+						<div class='marginBox'>
+							<img src='imageWithCustomAlt.svg' type='image/svg' alt='Custom Alt'></img>
+							<img src='title-page.svg' type='image/svg' alt='This picture, title-page.svg,  is missing or was loading too slowly'></img>
+						</div>
+					</div>
 					<div class='bloom-page numberedPage customPage A5Portrait'>
 						<div class='marginBox'>
 							<img src='junk' alt = 'more junk'></img>
@@ -150,7 +156,13 @@ namespace BloomTests.Book
 			foreach (XmlElement img in images)
 			{
 				Assert.That(img.Attributes["alt"], Is.Not.Null);
-				Assert.That(img.Attributes["alt"].Value, Is.EqualTo(""));
+
+				string expectedAltText = "";
+				if (img.Attributes["src"].Value == "imageWithCustomAlt.svg")
+				{
+					expectedAltText = "Custom Alt";
+				}
+				Assert.That(img.Attributes["alt"].Value, Is.EqualTo(expectedAltText));
 			}
 		}
 

--- a/src/BloomTests/Publish/ExportEpubTests.cs
+++ b/src/BloomTests/Publish/ExportEpubTests.cs
@@ -98,7 +98,7 @@ namespace BloomTests.Publish
 			var assertThatPageOneData = AssertThatXmlIn.String(_page1Data);
 			assertThatPageOneData.HasNoMatchForXpath("//xhtml:div[contains(@class,'bloom-imageDescription')]", _ns);
 			assertThatPageOneData.HasSpecifiedNumberOfMatchesForXpath("//xhtml:div[@class='marginBox']/xhtml:div/xhtml:aside[.='This describes image 1']", _ns, 1);
-			assertThatPageOneData.HasSpecifiedNumberOfMatchesForXpath("//xhtml:img[@class='branding' and @alt='' and @role='presentation']", _ns, 1);
+			assertThatPageOneData.HasSpecifiedNumberOfMatchesForXpath("//xhtml:img[@class='branding' and (@alt='' or @alt='Logo of the book sponsors') and @role='presentation']", _ns, 1);
 		}
 
 		[TestCase(TalkingBookApi.AudioRecordingMode.Sentence)]


### PR DESCRIPTION
Also change code such that only allows the alt text to be preserved on branding images

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2987)
<!-- Reviewable:end -->
