### PR TITLE
BL-6808 stop treating element with no ID as audio span

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1815,7 +1815,9 @@ namespace Bloom.Book
 
 		public static XmlNodeList SelectAudioSentenceElements(XmlElement element)
 		{
-			return element.SafeSelectNodes("descendant-or-self::node()[contains(@class,'audio-sentence')]");
+			// It's unexpected for a book to have nodes with class audio-sentence and no id to link them to a file, but
+			// if they do occur, it's better to ignore them than for other code to crash when looking for the ID.
+			return element.SafeSelectNodes("descendant-or-self::node()[contains(@class,'audio-sentence') and string-length(@id) > 0]");
 		}
 
 		public static XmlNodeList SelectAudioSentenceElementsWithDataDuration(XmlElement element)

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -2346,6 +2346,25 @@ namespace BloomTests.Book
 			Assert.AreEqual(expectedOuterHtml, page1Div.OuterXml.Replace(" id=\"id1\"", ""), $"Outer HTML");
 		}
 
+		[Test]
+		public void SelectAudioSentenceElements_SentenceWithNoId_SkipsIt()
+		{
+			string html = @"<html><head></head><body>
+					<div class='bloom-page numberedPage bloom-nonprinting' id='page1' data-page-number='1'>
+						<div class='bloom-editable'>
+							<p><span class='audio-sentence'>Page 1 Paragraph 1 Sentence 1</span></p>
+							<p><span id='id2' class='audio-sentence'>Page 1 Paragraph 2 Sentence 1</span></p>
+							<p><span id='' class='audio-sentence'>Page 1 Paragraph 3 Sentence 1</span></p>
+						</div>
+					</div>
+				</body></html>";
+
+			var dom = new HtmlDom(html);
+			var audioSpans = HtmlDom.SelectAudioSentenceElements(dom.Body);
+			Assert.That(audioSpans, Has.Count.EqualTo(1));
+			Assert.That(audioSpans[0].InnerText, Is.EqualTo("Page 1 Paragraph 2 Sentence 1"));
+		}
+
 
 #if UserControlledTemplate
 		[Test]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2991)
<!-- Reviewable:end -->
