### PR TITLE
BL-6796 Prevent a FF bug misplacing microphone icon in talking book

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -18,6 +18,7 @@ div.ui-audioCurrent:not(.disableHighlight) p {
         background-size: 10px 13px;
         background-position: 2px 5px;
         left: -15px;
+        top: 0; // should have no effect, but prevents a FF bug causing BL-6796
         width: 15px;
         height: 19px;
         position: absolute;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/2998)
<!-- Reviewable:end -->
