### PR TITLE
Don't let uneditable text in Enterprise tab be selected (BL-6788)

### DIFF
--- a/src/BloomBrowserUI/collection/enterpriseSettings.less
+++ b/src/BloomBrowserUI/collection/enterpriseSettings.less
@@ -6,6 +6,11 @@
     padding: 0px 4px 0px 4px;
     font-family: @ui-fonts;
     font-size: @ui-font-size;
+    // Don't let uneditable text be selected (https://issues.bloomlibrary.org/youtrack/issue/BL-6788).
+    // See https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting.
+    -moz-user-select: none; // Firefox
+    -ms-user-select: none; // Edge/Internet Explorer
+    user-select: none; // Chrome
 
     #enterpriseMain,
     #communityMain {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3001)
<!-- Reviewable:end -->
