### PR TITLE
AutoSegment: Fix exception if text contains parentheses (BL-6769)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -1809,6 +1809,14 @@ export default class AudioRecording {
             const fragment = textFragments[i];
             if (this.isRecordable(fragment)) {
                 const newId = this.createValidXhtmlUniqueId();
+
+                // Sometimes extraneous newlines can be injected (by CKEditor?). They may get removed later (maybe after the CKEditor reloads when the text box's underlying HTML is modified???)
+                // However, some processing needs the text immediately, and others are after the text is cleaned.
+                // In order to reconcile the two, just fix the text immediately.
+                fragment.text = fragment.text
+                    .replace(/\r/g, "")
+                    .replace(/\n/g, "");
+
                 fragmentObjects.push(
                     new AudioTextFragment(fragment.text, newId)
                 );

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -617,6 +617,7 @@
     </Compile>
     <Compile Include="ApplicationUpdateSupport.cs" />
     <Compile Include="UpdateVersionTable.cs" />
+    <Compile Include="Utils\TextUtils.cs" />
     <Compile Include="WebLibraryIntegration\BookDownloadSupport.cs" />
     <Compile Include="WebLibraryIntegration\IProgressDialog.cs" />
     <Compile Include="web\controllers\AudioSegmentationApi.cs" />

--- a/src/BloomExe/Utils/TextUtils.cs
+++ b/src/BloomExe/Utils/TextUtils.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bloom.Utils
+{
+	public static class TextUtils
+	{
+		// Removes trailing newline characters of both varieties, both \r and \n
+		public static string TrimEndNewlines(string text)
+		{
+			int index = text.Length - 1;
+			while (text[index] == '\r' || text[index] == '\n')
+			{
+				--index;
+			}
+
+			string cleaned = text.Substring(0, index + 1);
+			return cleaned;
+		}
+	}
+}

--- a/src/BloomExe/web/controllers/AudioSegmentationApi.cs
+++ b/src/BloomExe/web/controllers/AudioSegmentationApi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Bloom.Api;
 using Bloom.Book;
+using Bloom.Utils;
 using Newtonsoft.Json;
 using SIL.Reporting;
 
@@ -223,8 +224,8 @@ namespace Bloom.web.controllers
 			string textFragmentsFilename =  $"{directoryName}/{requestParameters.audioFilenameBase}_fragments.txt";
 			string audioTimingsFilename = $"{directoryName}/{requestParameters.audioFilenameBase}_timings.{kTimingsOutputFormat}";
 
-			audioTextFragments = audioTextFragments.Where(obj => !String.IsNullOrWhiteSpace(obj.fragmentText));	// Remove entries containing only whitespace
-			var fragmentList = audioTextFragments.Select(obj => obj.fragmentText);
+			audioTextFragments = audioTextFragments.Where(obj => !String.IsNullOrWhiteSpace(obj.fragmentText)); // Remove entries containing only whitespace
+			var fragmentList = audioTextFragments.Select(obj => TextUtils.TrimEndNewlines(obj.fragmentText));
 			var idList = audioTextFragments.Select(obj => obj.id).ToList();
 
 			try

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -222,6 +222,7 @@
     <Compile Include="ToPalaso\MostRecentPathsTests.cs" />
     <Compile Include="ToPalaso\ProgresDialogTests.cs" />
     <Compile Include="UpdateVersionTableTests.cs" />
+    <Compile Include="Utils\TextUtilsTests.cs" />
     <Compile Include="WebLibraryIntegration\BloomLinkArgsTests.cs" />
     <Compile Include="WebLibraryIntegration\BloomParseClientTests.cs" />
     <Compile Include="WebLibraryIntegration\BloomS3ClientTests.cs" />

--- a/src/BloomTests/Utils/TextUtilsTests.cs
+++ b/src/BloomTests/Utils/TextUtilsTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace BloomTests.Utils
+{
+	[TestFixture]
+	public class TextUtilsTests
+	{
+		[TestCase("John 3:16 (NIV)")]
+		public void TrimEndNewlines_ValidInput_NoChangeInOutput(string input)
+		{
+			TrimEndNewlinesRunner(input, input);
+		}
+
+		[TestCase("John 3:16 (NIV)\n\n\n", "John 3:16 (NIV)")]
+		[TestCase("John 3:16 (NIV)\r\r\r", "John 3:16 (NIV)")]
+		[TestCase("John 3:16 (NIV)\r\n\r\n\r\n", "John 3:16 (NIV)")]
+		public void TrimEndNewlines_InvalidInput_InvalidCharsRemoved(string input, string expected)
+		{
+			TrimEndNewlinesRunner(input, expected);
+		}
+
+		private void TrimEndNewlinesRunner(string input, string expected)
+		{
+			string observed = Bloom.Utils.TextUtils.TrimEndNewlines(input);
+			Assert.That(observed.Equals(expected, StringComparison.Ordinal), $"{observed} does not equal {expected}");
+		}
+
+	}
+}


### PR DESCRIPTION
Related to https://issues.bloomlibrary.org/youtrack/issue/BL-6769
Typing parenthesis into a text box seems to temporarily inject extraneous newline characters.
This causes 2 problems:
1) Aeneas thinks there are more fragments than the bloom code thinks there are.
2) The sentenceToId mapping doesn't work properly because the newline characters get automatically cleaned at a later point in time... and at some points in time we save the version without cleaning, and others we look it up post-cleaning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3012)
<!-- Reviewable:end -->
