### PR TITLE
BL-6897 Fix selectability

### DIFF
--- a/src/BloomBrowserUI/bloomUI.less
+++ b/src/BloomBrowserUI/bloomUI.less
@@ -107,3 +107,17 @@ input[type="checkbox"]:indeterminate::after {
     //color: gray;
 }
 */
+
+// Don't let uneditable text be selected (BL-6788/6897).
+// See https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting.
+* {
+    -moz-user-select: none; // Firefox
+    -ms-user-select: none; // Edge/Internet Explorer
+    user-select: none; // Chrome
+}
+
+[contenteditable="true"] * {
+    -moz-user-select: text; // Firefox
+    -ms-user-select: text; // Edge/Internet Explorer
+    user-select: text; // Chrome
+}

--- a/src/BloomBrowserUI/collection/enterpriseSettings.less
+++ b/src/BloomBrowserUI/collection/enterpriseSettings.less
@@ -6,11 +6,6 @@
     padding: 0px 4px 0px 4px;
     font-family: @ui-fonts;
     font-size: @ui-font-size;
-    // Don't let uneditable text be selected (https://issues.bloomlibrary.org/youtrack/issue/BL-6788).
-    // See https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting.
-    -moz-user-select: none; // Firefox
-    -ms-user-select: none; // Edge/Internet Explorer
-    user-select: none; // Chrome
 
     #enterpriseMain,
     #communityMain {


### PR DESCRIPTION
* any code that uses bloomUI.less should work now
* if an element is a child of an element with
   attribute contenteditable="true" it will be selectable
   otherwise not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3031)
<!-- Reviewable:end -->
