### PR TITLE
Fix Linux to not complain about command errors (BL-6769)

### DIFF
--- a/src/BloomExe/web/controllers/AudioSegmentationApi.cs
+++ b/src/BloomExe/web/controllers/AudioSegmentationApi.cs
@@ -79,7 +79,7 @@ namespace Bloom.web.controllers
 
 		public bool AreAutoSegmentDependenciesMet(out string message)
 		{
-			if (DoesCommandCauseError("WHERE python", kWorkingDirectory))   // TODO: Linux compatability. Also more below.   Maybe use "locate" command on Linux?
+			if (DoesCommandCauseError("WHERE python", kWorkingDirectory))   // TODO: Linux compatability. Also more below.   Probably use "which" command on Linux.
 			{
 				message = "Python";
 				return false;
@@ -114,6 +114,12 @@ namespace Bloom.web.controllers
 		// Returns true if the command returned with an error
 		protected bool DoesCommandCauseError(string commandString, string workingDirectory, out string standardOutput, out string standardError, params int[] errorCodesToIgnore)
 		{
+			if (SIL.PlatformUtilities.Platform.IsLinux)
+			{
+				standardOutput = "";
+				standardError = "";
+				return true;	// TODO: Linux compatibility.
+			}
 			if (!String.IsNullOrEmpty(workingDirectory))
 			{
 				commandString = $"cd \"{workingDirectory}\" && {commandString}";


### PR DESCRIPTION
This is a temporary fix until we have time for a proper Linux
implementation.  Without it, annoying yellow crash dialogs always pop
up on Linux when editing a page with the Talking Book tool open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3034)
<!-- Reviewable:end -->
