### PR TITLE
BL-6818 Repair epub preview after recent changes

### DIFF
--- a/src/BloomBrowserUI/publish/android/androidFrame.less
+++ b/src/BloomBrowserUI/publish/android/androidFrame.less
@@ -67,7 +67,8 @@
 // the wrapper around the preview that looks like a phone's shell.
 // The first group of settings (not inside .device-square) are for the
 // old ePUB preview, the others for the new android one.
-.device {
+.device,
+#device {
     height: 800px;
     width: 400px;
     padding-left: 30px;
@@ -76,6 +77,10 @@
     //border: 5px solid white;
     border-radius: 38px;
     background-color: @preview-border;
+    #epubPublishUI & {
+        // temporary override for old preview
+        background-color: #404040;
+    }
     box-shadow: 0px 0px 50px 10px rgba(0, 0, 0, 0.1);
     .device-square & {
         height: @small-device-size;
@@ -102,7 +107,8 @@
 // again we have legacy version for ePUB and the new versions below in .device-square.
 @speakerlength : 80px;
 @speakerwidth: 10px;
-.device:before {
+.device:before,
+#device:before {
     width: @speakerlength;
     height: @speakerwidth;
     top: 35px;
@@ -113,7 +119,8 @@
 
 //the bottom 'button' (looks like phone home button) is the "after" rule
 // This is only for the legacy ePUB version.
-.device:after {
+.device:after,
+#device:after {
     width: @CircleDiameter;
     height: @CircleDiameter;
     border-radius: 50%;
@@ -172,7 +179,9 @@
 }
 
 .device:before,
-.device:after {
+.device:after,
+#device:before,
+#device:after {
     content: "";
     position: absolute;
 }

--- a/src/BloomBrowserUI/publish/sectionScreen.less
+++ b/src/BloomBrowserUI/publish/sectionScreen.less
@@ -156,3 +156,11 @@ html.publishTabScreen {
         font-size: 12pt;
     }
 }
+
+html.publishTabScreen #epubPublishUI .preview-section {
+    // For now, with the old device preview, we don't want this section growing.
+    // The phone preview grows with it and gets a weird aspect ratio.
+    flex-grow: 0;
+    // and the section doesn't need to be wide enough for a landscape option and controls
+    width: 400px;
+}

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -251,7 +251,10 @@ namespace Bloom.Publish
 				if (disposing)
 				{
 					if (_browser != null)
-						_browser.Dispose();
+					{
+						_browser.Invoke((Action) (() => _browser.Dispose()));
+					}
+
 					_browser = null;
 				}
 				_isDisposed = true;


### PR DESCRIPTION
The Dispose fix restores the ability to open the epub preview in Firefox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3037)
<!-- Reviewable:end -->
