### PR TITLE
Warn user about damaged (no id) audio elements (BL-6832)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1771,6 +1771,16 @@ namespace Bloom.Book
 			return true;
 		}
 
+		public bool HasBrokenAudioSentenceElements()
+		{
+			foreach (var divPage in RawDom.SafeSelectNodes("/html/body/div").Cast<XmlElement>())
+			{
+				if (HtmlDom.HasAudioSentenceElementsWithoutId(divPage))
+					return true;
+			}
+			return false;
+		}
+
 		/// <summary>
 		/// Determines whether the book references an existing image file other than
 		/// branding, placeholder, or license images.

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1873,6 +1873,14 @@ namespace Bloom.Book
 			return element.SafeSelectNodes("descendant-or-self::node()[contains(@class,'audio-sentence') and @recordingmd5]");
 		}
 
+		public static bool HasAudioSentenceElementsWithoutId(XmlElement element)
+		{
+			// It's unexpected for a book to have nodes with class audio-sentence and no id to link them to a file, but
+			// if they do occur, it's better to ignore them than for other code to crash when looking for the ID.
+			var nodes = element.SafeSelectNodes("descendant-or-self::node()[contains(@class,'audio-sentence') and string-length(@id) = 0]");
+			return nodes?.Count >= 1;
+		}
+
 		public bool DoesContainNarrationAudioRecordedUsingWholeTextBox()
 		{
 			var nodes = _dom.SafeSelectNodes("//*[@data-audiorecordingmode='TextBox']");

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -111,6 +111,15 @@ namespace Bloom.Publish
 				_currentlyLoadedBook = BookSelection.CurrentSelection;
 				// In case we have any new settings since the last time we were in the Edit tab (BL-3881)
 				_currentlyLoadedBook.BringBookUpToDate(new NullProgress());
+				// Alert the user if the audio in this book has been damaged by hand-editing.
+				if (_currentlyLoadedBook.HasBrokenAudioSentenceElements())
+				{
+					string shortMsg = L10NSharp.LocalizationManager.GetString(@"PublishTab.Audio.ElementsMissingId",
+						"Some audio elements are missing ids",
+						@"Message briefly displayed to the user in a toast");
+					var longMsg = "This book has elements marked audio-sentence that have no IDs. Usually this means that the book has been edited using some other program than Bloom.";
+					NonFatalProblem.Report(ModalIf.None, PassiveIf.All, shortMsg, longMsg);
+				}
 			}
 			return _currentlyLoadedBook;
 		}

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -2531,6 +2531,113 @@ namespace BloomTests.Book
 			Assert.That(audioSpans[0].InnerText, Is.EqualTo("Page 1 Paragraph 2 Sentence 1"));
 		}
 
+		[Test]
+		public void HasAudioSentenceElementsWithoutId_HandlesEmptyId()
+		{
+			string html = @"<html><head></head><body>
+					<div class='bloom-page numberedPage bloom-nonprinting' id='page1' data-page-number='1'>
+						<div class='bloom-editable'>
+							<p><span id='id1' class='audio-sentence'>Page 1 Paragraph 1 Sentence 1</span></p>
+							<p><span id='id2' class='audio-sentence'>Page 1 Paragraph 2 Sentence 1</span></p>
+							<p><span id='' class='audio-sentence'>Page 1 Paragraph 3 Sentence 1</span></p>
+						</div>
+					</div>
+				</body></html>";
+
+			var dom = new HtmlDom(html);
+			var hasMissingId = HtmlDom.HasAudioSentenceElementsWithoutId(dom.Body);
+			Assert.That(hasMissingId, Is.True);
+		}
+
+		[Test]
+		public void HasAudioSentenceElementsWithoutId_HandlesDivEmptyId()
+		{
+			string html = @"<html><head></head><body>
+					<div class='bloom-page numberedPage bloom-nonprinting' id='page1' data-page-number='1'>
+						<div class='bloom-editable audio-sentence' id=''>
+							<p><span id='id1' class='audio-sentence'>Page 1 Paragraph 1 Sentence 1</span></p>
+							<p><span id='id2' class='audio-sentence'>Page 1 Paragraph 2 Sentence 1</span></p>
+							<p><span id='id3' class='audio-sentence'>Page 1 Paragraph 3 Sentence 1</span></p>
+						</div>
+					</div>
+				</body></html>";
+
+			var dom = new HtmlDom(html);
+			var hasMissingId = HtmlDom.HasAudioSentenceElementsWithoutId(dom.Body);
+			Assert.That(hasMissingId, Is.True);
+		}
+
+		[Test]
+		public void HasAudioSentenceElementsWithoutId_HandlesMissingId()
+		{
+			string html = @"<html><head></head><body>
+					<div class='bloom-page numberedPage bloom-nonprinting' id='page1' data-page-number='1'>
+						<div class='bloom-editable'>
+							<p><span id='id1' class='audio-sentence'>Page 1 Paragraph 1 Sentence 1</span></p>
+							<p><span id='id2' class='audio-sentence'>Page 1 Paragraph 2 Sentence 1</span></p>
+							<p><span class='audio-sentence'>Page 1 Paragraph 3 Sentence 1</span></p>
+						</div>
+					</div>
+				</body></html>";
+
+			var dom = new HtmlDom(html);
+			var hasMissingId = HtmlDom.HasAudioSentenceElementsWithoutId(dom.Body);
+			Assert.That(hasMissingId, Is.True);
+		}
+
+		[Test]
+		public void HasAudioSentenceElementsWithoutId_HandlesDivMissingId()
+		{
+			string html = @"<html><head></head><body>
+					<div class='bloom-page numberedPage bloom-nonprinting' id='page1' data-page-number='1'>
+						<div class='bloom-editable audio-sentence'>
+							<p><span id='id1' class='audio-sentence'>Page 1 Paragraph 1 Sentence 1</span></p>
+							<p><span id='id2' class='audio-sentence'>Page 1 Paragraph 2 Sentence 1</span></p>
+							<p><span id='id3' class='audio-sentence'>Page 1 Paragraph 3 Sentence 1</span></p>
+						</div>
+					</div>
+				</body></html>";
+
+			var dom = new HtmlDom(html);
+			var hasMissingId = HtmlDom.HasAudioSentenceElementsWithoutId(dom.Body);
+			Assert.That(hasMissingId, Is.True);
+		}
+
+		[Test]
+		public void HasAudioSentenceElementsWithoutId_HandlesIdsAllThere()
+		{
+			string html = @"<html><head></head><body>
+					<div class='bloom-page numberedPage bloom-nonprinting' id='page1' data-page-number='1'>
+						<div class='bloom-editable'>
+							<p><span id='id1' class='audio-sentence'>Page 1 Paragraph 1 Sentence 1</span></p>
+							<p><span id='id2' class='audio-sentence'>Page 1 Paragraph 2 Sentence 1</span></p>
+							<p><span id='id3' class='audio-sentence'>Page 1 Paragraph 3 Sentence 1</span></p>
+						</div>
+					</div>
+				</body></html>";
+
+			var dom = new HtmlDom(html);
+			var hasMissingId = HtmlDom.HasAudioSentenceElementsWithoutId(dom.Body);
+			Assert.That(hasMissingId, Is.False);
+		}
+
+		[Test]
+		public void HasAudioSentenceElementsWithoutId_HandlesDivIdsAllThere()
+		{
+			string html = @"<html><head></head><body>
+					<div class='bloom-page numberedPage bloom-nonprinting' id='page1' data-page-number='1'>
+						<div class='bloom-editable audio-sentence' id='id0'>
+							<p><span id='id1' class='audio-sentence'>Page 1 Paragraph 1 Sentence 1</span></p>
+							<p><span id='id2' class='audio-sentence'>Page 1 Paragraph 2 Sentence 1</span></p>
+							<p><span id='id3' class='audio-sentence'>Page 1 Paragraph 3 Sentence 1</span></p>
+						</div>
+					</div>
+				</body></html>";
+
+			var dom = new HtmlDom(html);
+			var hasMissingId = HtmlDom.HasAudioSentenceElementsWithoutId(dom.Body);
+			Assert.That(hasMissingId, Is.False);
+		}
 
 #if UserControlledTemplate
 		[Test]


### PR DESCRIPTION
The warning occurs each time the user loads the book for publishing as
a toast.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3046)
<!-- Reviewable:end -->
