### PR TITLE
Fix reporting audio error in book to cover electronic pubs (BL-6832)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1781,6 +1781,18 @@ namespace Bloom.Book
 			return false;
 		}
 
+		public void ReportIfBrokenAudioSentenceElements()
+		{
+			if (HasBrokenAudioSentenceElements())
+			{
+				string shortMsg = L10NSharp.LocalizationManager.GetString(@"PublishTab.Audio.ElementsMissingId",
+					"Some audio elements are missing ids",
+					@"Message briefly displayed to the user in a toast");
+				var longMsg = "This book has elements marked audio-sentence that have no IDs. Usually this means that the book has been edited using some other program than Bloom.";
+				NonFatalProblem.Report(ModalIf.None, PassiveIf.All, shortMsg, longMsg);
+			}
+		}
+
 		/// <summary>
 		/// Determines whether the book references an existing image file other than
 		/// branding, placeholder, or license images.

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -111,15 +111,6 @@ namespace Bloom.Publish
 				_currentlyLoadedBook = BookSelection.CurrentSelection;
 				// In case we have any new settings since the last time we were in the Edit tab (BL-3881)
 				_currentlyLoadedBook.BringBookUpToDate(new NullProgress());
-				// Alert the user if the audio in this book has been damaged by hand-editing.
-				if (_currentlyLoadedBook.HasBrokenAudioSentenceElements())
-				{
-					string shortMsg = L10NSharp.LocalizationManager.GetString(@"PublishTab.Audio.ElementsMissingId",
-						"Some audio elements are missing ids",
-						@"Message briefly displayed to the user in a toast");
-					var longMsg = "This book has elements marked audio-sentence that have no IDs. Usually this means that the book has been edited using some other program than Bloom.";
-					NonFatalProblem.Report(ModalIf.None, PassiveIf.All, shortMsg, longMsg);
-				}
 			}
 			return _currentlyLoadedBook;
 		}

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -532,6 +532,7 @@ namespace Bloom.Publish
 
 		private void ShowHtmlPanel(string pathToHtml)
 		{
+			_model.BookSelection.CurrentSelection.ReportIfBrokenAudioSentenceElements();
 			Logger.WriteEvent("Entering Publish Screen: "+ pathToHtml);
 			_workingIndicator.Visible = false;
 			_printButton.Enabled = false;


### PR DESCRIPTION
This will complain when the epub view opens or when the the user sends/saves a Bloom Reader book.  (The adjusted fix on 4.6 will complain when the Android view opens by tying in to the preview update.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3051)
<!-- Reviewable:end -->
