### PR TITLE
[4.5]BL-6881 Fix Talking Book Tool Play button

### DIFF
--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -471,7 +471,12 @@ namespace Bloom.Edit
 				// Delete doesn't throw if the FILE doesn't exist, but if the Directory doesn't, you're toast.
 				// And the very first time a user tries this, the audio directory probably doesn't exist...
 				if (Directory.Exists(Path.GetDirectoryName(PathToRecordableAudioForCurrentSegment)))
+				{
 					RobustFile.Delete(PathToRecordableAudioForCurrentSegment);
+					// BL-6881: "Play btn sometimes enabled after too short audio", because the .mp3 version was left behind.
+					var mp3Version = Path.ChangeExtension(PathToRecordableAudioForCurrentSegment, kPublishableExtension);
+					RobustFile.Delete(mp3Version);
+				}
 			}
 			catch (Exception error)
 			{


### PR DESCRIPTION
* In case of too short a recording, delete BOTH
   .wav and .mp3 versions of the audio.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3054)
<!-- Reviewable:end -->
