### PR TITLE
Fix books with duplicated language divs in translation groups (BL-6923)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -806,6 +806,32 @@ namespace Bloom.Book
 		}
 
 		/// <summary>
+		/// Fix errors that users have encountered.  For now, this is only a duplication of language div elements
+		/// inside of translationGroup divs.
+		/// </summary>
+		/// <remarks>
+		/// See https://issues.bloomlibrary.org/youtrack/issue/BL-6923.
+		/// </remarks>
+		private void FixErrorsEncounteredByUsers(HtmlDom bookDOM)
+		{
+			foreach (
+				XmlElement groupElement in
+				bookDOM.Body.SafeSelectNodes("descendant::*[contains(@class,'bloom-translationGroup')]"))
+			{
+				// Even though the user only had duplicate vernacular divs, let's check all three
+				// languages just to be safe.
+				var lang1 = CollectionSettings.Language1Iso639Code;
+				TranslationGroupManager.FixDuplicateLanguageDivs(groupElement, lang1);
+				var lang2 = CollectionSettings.Language2Iso639Code;
+				if (!String.IsNullOrEmpty(lang2) && lang2 != lang1)
+					TranslationGroupManager.FixDuplicateLanguageDivs(groupElement, lang2);
+				var lang3 = CollectionSettings.Language3Iso639Code;
+				if (!String.IsNullOrEmpty(lang3) && lang3 != lang2 && lang3 != lang1)
+					TranslationGroupManager.FixDuplicateLanguageDivs(groupElement, lang3);
+			}
+		}
+
+		/// <summary>
 		/// For Bloom Reader books (and ePUBs), we need to copy the collection level settings files
 		/// to go with the book.  Since these end up in the zip file with the book files, the link
 		/// references to them need to be adjusted to use the current directory, not the parent
@@ -948,6 +974,7 @@ namespace Bloom.Book
 			}
 			RemoveObsoleteSoundAttributes(bookDOM);
 			BringBookInfoUpToDate(oldMetaData);
+			FixErrorsEncounteredByUsers(bookDOM);
 		}
 
 		// Some books got corrupted with CKE temp data, possibly before we prevented this happening when

--- a/src/BloomTests/Book/TranslationGroupManagerTests.cs
+++ b/src/BloomTests/Book/TranslationGroupManagerTests.cs
@@ -459,5 +459,89 @@ namespace BloomTests.Book
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[contains(@class, 'normal-style') and contains(@class, 'bloom-translationGroup')]", 0);
 			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-translationGroup']", 1);
 		}
+
+		[Test]
+		public void FixDuplicateLanguageDivs_HandlesEmptyDivs()
+		{
+			var contents = @"<div class='bloom-page' >
+			<div class='bloom-translationGroup normal-style'>
+				<div class='bloom-editable' data-languagetipcontent='First' lang='xyz'></div>
+				<div class='bloom-editable' lang='en'></div>
+				<div class='bloom-editable' lang='fr'></div>
+				<div class='bloom-editable' data-languagetipcontent='Second' lang='xyz'></div>
+			</div>
+		</div>";
+			var dom = new XmlDocument();
+			dom.LoadXml(contents);
+			TranslationGroupManager.FixDuplicateLanguageDivs((XmlElement)dom.SafeSelectNodes("//div[contains(@class,'bloom-translationGroup')]")[0], "xyz");
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[contains(@class, 'bloom-translationGroup')]", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable']", 3);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='xyz']", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='en']", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='fr']", 1);
+		}
+
+		[Test]
+		public void FixDuplicateLanguageDivs_HandlesEmptySecondDiv()
+		{
+			var contents = @"<div class='bloom-page' >
+			<div class='bloom-translationGroup normal-style'>
+				<div class='bloom-editable' data-languagetipcontent='First' lang='xyz'>Xyz text</div>
+				<div class='bloom-editable' lang='en'>English text</div>
+				<div class='bloom-editable' lang='fr'>French text</div>
+				<div class='bloom-editable' data-languagetipcontent='Second' lang='xyz'></div>
+			</div>
+		</div>";
+			var dom = new XmlDocument();
+			dom.LoadXml(contents);
+			TranslationGroupManager.FixDuplicateLanguageDivs((XmlElement)dom.SafeSelectNodes("//div[contains(@class,'bloom-translationGroup')]")[0], "xyz");
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[contains(@class, 'bloom-translationGroup')]", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable']", 3);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='xyz' and contains(., 'Xyz text')]", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='en']", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='fr']", 1);
+		}
+
+		[Test]
+		public void FixDuplicateLanguageDivs_HandlesEmptyFirstDiv()
+		{
+			var contents = @"<div class='bloom-page' >
+			<div class='bloom-translationGroup normal-style'>
+				<div class='bloom-editable' data-languagetipcontent='First' lang='xyz'></div>
+				<div class='bloom-editable' lang='en'>English text</div>
+				<div class='bloom-editable' lang='fr'>French text</div>
+				<div class='bloom-editable' data-languagetipcontent='Second' lang='xyz'>Xyz text</div>
+			</div>
+		</div>";
+			var dom = new XmlDocument();
+			dom.LoadXml(contents);
+			TranslationGroupManager.FixDuplicateLanguageDivs((XmlElement)dom.SafeSelectNodes("//div[contains(@class,'bloom-translationGroup')]")[0], "xyz");
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[contains(@class, 'bloom-translationGroup')]", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable']", 3);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='xyz' and contains(., 'Xyz text')]", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='en']", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='fr']", 1);
+		}
+
+		[Test]
+		public void FixDuplicateLanguageDivs_HandlesNonemptyDivs()
+		{
+			var contents = @"<div class='bloom-page' >
+			<div class='bloom-translationGroup normal-style'>
+				<div class='bloom-editable' data-languagetipcontent='First' lang='xyz'>First Xyz text</div>
+				<div class='bloom-editable' lang='en'>English text</div>
+				<div class='bloom-editable' lang='fr'>French text</div>
+				<div class='bloom-editable' data-languagetipcontent='Second' lang='xyz'>Second Xyz text</div>
+			</div>
+		</div>";
+			var dom = new XmlDocument();
+			dom.LoadXml(contents);
+			TranslationGroupManager.FixDuplicateLanguageDivs((XmlElement)dom.SafeSelectNodes("//div[contains(@class,'bloom-translationGroup')]")[0], "xyz");
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[contains(@class, 'bloom-translationGroup')]", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable']", 3);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='xyz' and contains(., 'First Xyz text"+ System.Environment.NewLine +"Second Xyz text')]", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='en']", 1);
+			AssertThatXmlIn.Dom(dom).HasSpecifiedNumberOfMatchesForXpath("//div[@class='bloom-editable' and @lang='fr']", 1);
+		}
 	}
 }


### PR DESCRIPTION
This repairs damaged books, but doesn't address the cause.  I have been
unable to reproduce the original bug that resulted in the duplicate divs.

Even if we want to press on to try to find out what caused the duplication,
this is useful for repairing books that have gotten into a bad state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3059)
<!-- Reviewable:end -->
