### PR TITLE
Fix startup error when user defines coverColor (BL-6923)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2364,7 +2364,8 @@ namespace Bloom.Book
 				return HtmlDom.AddEmptyUserModifiedStylesNode(headElement);
 
 			var coverColorElement = HtmlDom.GetCoverColorStyleElement(headElement);
-			if (coverColorElement == null)
+			// If the user defines the cover color, the two elements could end up being the same.
+			if (coverColorElement == null || coverColorElement == userStyleElement)
 				return userStyleElement;
 
 			// We have both style elements. Make sure they're in the right order.


### PR DESCRIPTION
Not reported in issue, but the problem occurs with the reported book.  This is a cherry-pick from 4.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3062)
<!-- Reviewable:end -->
