### PR TITLE
Make metadata dialog scroll when it should (BL-6948)

### DIFF
--- a/src/BloomBrowserUI/publish/metadata/BookMetadataDialog.less
+++ b/src/BloomBrowserUI/publish/metadata/BookMetadataDialog.less
@@ -8,6 +8,9 @@
 .bookMetadataDialog {
     font-family: @ui-fonts;
     font-size: @fontSize;
+    max-height: 100vh;
+    overflow-y: scroll;
+
     // for some reason that one gets overruled by the browser, so:
     textarea {
         font-family: @ui-fonts;


### PR DESCRIPTION
This is a cherry-pick from Version4.5 (requested by John Hatton).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3072)
<!-- Reviewable:end -->
