### PR TITLE
Set right margin in image description toolbox (BL-6893)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.less
@@ -10,6 +10,7 @@
     flex-direction: column;
     justify-content: space-between;
     padding-left: 20px;
+    padding-right: 20px;
     height: 100%; // push the help link to the bottom
     *,
     a {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3073)
<!-- Reviewable:end -->
