### PR TITLE
Two adjustments to epub metadata dialog (BL-6946/6947)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -188,7 +188,7 @@
         <note>ID: BookMetadata.a11yLevelAAA</note>
       </trans-unit>
       <trans-unit id="BookMetadata.alternativeText" sil:dynamic="true">
-        <source xml:lang="en">Alternative text</source>
+        <source xml:lang="en">Has Image Descriptions</source>
         <note>ID: BookMetadata.alternativeText</note>
       </trans-unit>
       <trans-unit id="BookMetadata.author" sil:dynamic="true">
@@ -234,10 +234,6 @@
       <trans-unit id="BookMetadata.signLanguage" sil:dynamic="true">
         <source xml:lang="en">Sign Language</source>
         <note>ID: BookMetadata.signLanguage</note>
-      </trans-unit>
-      <trans-unit id="BookMetadata.soundHazard" sil:dynamic="true">
-        <source xml:lang="en">Sound Hazard</source>
-        <note>ID: BookMetadata.soundHazard</note>
       </trans-unit>
       <trans-unit id="BookMetadata.subjects" sil:dynamic="true">
         <source xml:lang="en">Subjects</source>

--- a/src/BloomBrowserUI/publish/metadata/BookMetadataTable.tsx
+++ b/src/BloomBrowserUI/publish/metadata/BookMetadataTable.tsx
@@ -149,29 +149,32 @@ export default class BookMetadataTable extends React.Component<IProps> {
         return (
             <div>
                 {/* from https://www.w3.org/wiki/WebSchemas/Accessibility*/}
-                {[
-                    "flashingHazard",
-                    "motionSimulationHazard",
-                    "soundHazard"
-                ].map(hazardName => {
-                    return (
-                        <StringListCheckbox
-                            key={hazardName}
-                            l10nKey={"BookMetadata." + hazardName}
-                            alreadyLocalized={true}
-                            list={this.props.metadata.hazards.value}
-                            itemName={hazardName}
-                            tristateItemOffName={
-                                "no" + this.capitalizeFirstChar(hazardName)
-                            }
-                            onChange={list =>
-                                (this.props.metadata.hazards.value = list)
-                            }
-                        >
-                            {this.props.translatedControlStrings[hazardName]}
-                        </StringListCheckbox>
-                    );
-                })}
+                {/* "Sound Hazard" is too hard to explain (BL-6947) */}
+                {["flashingHazard", "motionSimulationHazard"].map(
+                    hazardName => {
+                        return (
+                            <StringListCheckbox
+                                key={hazardName}
+                                l10nKey={"BookMetadata." + hazardName}
+                                alreadyLocalized={true}
+                                list={this.props.metadata.hazards.value}
+                                itemName={hazardName}
+                                tristateItemOffName={
+                                    "no" + this.capitalizeFirstChar(hazardName)
+                                }
+                                onChange={list =>
+                                    (this.props.metadata.hazards.value = list)
+                                }
+                            >
+                                {
+                                    this.props.translatedControlStrings[
+                                        hazardName
+                                    ]
+                                }
+                            </StringListCheckbox>
+                        );
+                    }
+                )}
             </div>
         );
     }

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -562,22 +562,17 @@ namespace Bloom.Publish.Epub
 			if (!string.IsNullOrEmpty(metadata.Hazards))
 			{
 				var hazards = metadata.Hazards.Split(',');
-				if (hazards.All(haz => haz.StartsWith("no")))
+				// "none" is recommended instead of listing all 3 noXXXHazard values separately.
+				// But since we don't know anything about sound, we can't use it.  (BL-6947)
+				foreach (var hazard in hazards)
 				{
-					// "none" is recommended instead of listing all 3 noXXXHazard values separately
-					metadataElt.Add(new XElement(opf + "meta", new XAttribute("property", "schema:accessibilityHazard"), "none"));
-				}
-				else
-				{
-					foreach (var hazard in hazards)
-					{
-						metadataElt.Add(new XElement(opf + "meta", new XAttribute("property", "schema:accessibilityHazard"), hazard));
-					}
+					metadataElt.Add(new XElement(opf + "meta", new XAttribute("property", "schema:accessibilityHazard"), hazard));
 				}
 			}
 			else
 			{
-				metadataElt.Add(new XElement(opf + "meta", new XAttribute("property", "schema:accessibilityHazard"), "none"));
+				// report that we don't know anything.
+				metadataElt.Add(new XElement(opf + "meta", new XAttribute("property", "schema:accessibilityHazard"), "unknown"));
 			}
 
 			metadataElt.Add(new XElement(opf + "meta", new XAttribute("property", "schema:accessibilitySummary"),

--- a/src/BloomExe/web/controllers/BookMetadataApi.cs
+++ b/src/BloomExe/web/controllers/BookMetadataApi.cs
@@ -71,8 +71,7 @@ namespace Bloom.web.controllers
 					{
 						flashingHazard = LocalizationManager.GetString("BookMetadata.flashingHazard", "Flashing Hazard"),
 						motionSimulationHazard = LocalizationManager.GetString("BookMetadata.motionSimulationHazard", "Motion Simulation Hazard"),
-						soundHazard = LocalizationManager.GetString("BookMetadata.soundHazard", "Sound Hazard"),
-						alternativeText = LocalizationManager.GetString("BookMetadata.alternativeText", "Alternative Text"),
+						alternativeText = LocalizationManager.GetString("BookMetadata.alternativeText", "Has Image Descriptions"),
 						signLanguage = LocalizationManager.GetString("BookMetadata.signLanguage", "Sign Language"),
 					};
 					var blob = new


### PR DESCRIPTION
1) rename "Alternative Text" to "Has Image Descriptions" (BL-6946)
2) remove "Sound Hazard" since it's too difficult to explain (BL-6947)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3076)
<!-- Reviewable:end -->
