### PR TITLE
Increase timespan for failing unit test (20190318)

### DIFF
--- a/src/BloomTests/WebLibraryIntegration/BookTransferDupIdTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BookTransferDupIdTests.cs
@@ -83,7 +83,7 @@ namespace BloomTests.WebLibraryIntegration
 			_guid1 = Guid.NewGuid().ToString();
 			_guid2 = Guid.NewGuid().ToString();
 			var book3Time = new DateTime(2019,3,5,15,33,30);
-			var smallSpan = new TimeSpan(10); // only 1 microsecond! (100ns is too short for Linux file timestamps)
+			var smallSpan = new TimeSpan(10000); // only 1 millisecond! (100ns is too short for Linux file timestamps)
 			SetupMetaData(bookFolder1, _guid1, book3Time + smallSpan);
 			SetupMetaData(bookFolder2, _guid1, book3Time + smallSpan + smallSpan);
 			SetupMetaData(bookFolder3, _guid1, book3Time);


### PR DESCRIPTION
1 microsecond worked locally, but not on TeamCity. Try 1 millisecond.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3082)
<!-- Reviewable:end -->
