### PR TITLE
AutoSplit 4.5: Special Highlight after finish (BL-7000)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -26,6 +26,24 @@ div.ui-audioCurrent:not(.disableHighlight) p {
         content: " ";
     }
 }
+.ui-audioCurrent.bloom-postAudioSplit[data-audiorecordingmode="TextBox"]:not(.disableHighlight) {
+    // Special higlighting after the Split button completes to show it completed.
+    span:nth-child(3n + 1) {
+        background-color: #bfedf3;
+    }
+    span:nth-child(3n + 2) {
+        background-color: #7fdae6;
+    }
+    span:nth-child(3n + 3) {
+        background-color: #29c2d6;
+    }
+
+    p {
+        // Override the normal yellow highlight so it doesn't clash with the ones we just added
+        background: none;
+    }
+}
+
 .ui-audioBody {
     padding-left: 15px;
     padding-right: 15px;

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -808,6 +808,8 @@ export default class AudioRecording {
             }
         }
 
+        this.clearAudioSplit();
+
         axios
             .post("/bloom/api/audio/startRecord?id=" + id)
             .then(result => {
@@ -1178,6 +1180,8 @@ export default class AudioRecording {
                     toastr.error(error.statusText);
                 });
         }
+
+        this.clearAudioSplit();
         this.updatePlayerStatus();
         this.changeStateAndSetExpectedAsync("record");
     }
@@ -1248,6 +1252,8 @@ export default class AudioRecording {
             // Enhance: Maybe could be Play if the current sentence already has text available?
             // Enhance: Maybe this function could have a Fallback optional parameter. And it would try to set Play, but switch to Record if not available.
             this.changeStateAndSetExpectedAsync("record");
+
+            this.clearAudioSplit();
         } else {
             // From Sentence -> TextBox, we don't convert the playback mode.
             // (since until/unless the user actually makes a new whole-text-box recording, we actually still have by-sentence recordings we can play)
@@ -2976,6 +2982,8 @@ export default class AudioRecording {
                 allowUpdateOfCurrent
             );
 
+            this.markAudioSplit();
+
             // Now that we're all done with use sentenceToIdListMap, clear it out so that there's no potential for accidental re-use
             this.sentenceToIdListMap = {};
             this.changeStateAndSetExpectedAsync("next");
@@ -3012,6 +3020,20 @@ export default class AudioRecording {
             if (element) {
                 element.classList.remove("cursor-progress");
             }
+        }
+    }
+
+    private markAudioSplit() {
+        const currentTextBox = this.getCurrentTextBox();
+        if (currentTextBox) {
+            currentTextBox.classList.add("bloom-postAudioSplit");
+        }
+    }
+
+    private clearAudioSplit() {
+        const currentTextBox = this.getCurrentTextBox();
+        if (currentTextBox) {
+            currentTextBox.classList.remove("bloom-postAudioSplit");
         }
     }
 


### PR DESCRIPTION
When Split is done, add a special 3-way alternating highlight to visually indicate that Split has finished.
Clear the split when the user starts a new recording, clears (deletes) the recordings for the text box, or changes the recording mode.

Don't clear if the user types, nor on book close/save.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3088)
<!-- Reviewable:end -->
