### PR TITLE
Keep InvalidCastException from crashing bulk upload

### DIFF
--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -782,8 +782,17 @@ namespace Bloom
 
 		public static void ClearCache()
 		{
-			var instance = Xpcom.CreateInstance<nsICacheStorageService>("@mozilla.org/netwerk/cache-storage-service;1");
-			instance.Clear();
+			try
+			{
+				var instance = Xpcom.CreateInstance<nsICacheStorageService>("@mozilla.org/netwerk/cache-storage-service;1");
+				instance.Clear();
+			}
+			catch (InvalidCastException e)
+			{
+				// For some reason, Release builds (only) sometimes run into this when uploading.
+				// Don't let it stop us just to clear a cache.
+				Logger.WriteError(e);
+			}
 		}
 
 		public void SetEditDom(HtmlDom editDom)


### PR DESCRIPTION
* only seems to occur with Release builds
* only seems to occur when doing a bulk upload

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3108)
<!-- Reviewable:end -->
