### PR TITLE
BL-6979 Abort creating book preview data when obsolete

### DIFF
--- a/src/BloomBrowserUI/utils/WebSocketManager.ts
+++ b/src/BloomBrowserUI/utils/WebSocketManager.ts
@@ -40,7 +40,13 @@ export default class WebSocketManager {
             //here we're passing "socketName" in the "subprotocol" parameter, just for ease of identifying
             //sockets on the server side when debugging.
 
-            // Enhance: This needs a try/catch or something. What is the plan if the constructor throws an exception?
+            // I tried a lot of error handling here: catching any exception in the constructor, attaching
+            // onerror and onclose handlers to the new socket...and we still get notifications sent to the unhandled
+            // error hook, when a connection is refused, as it is if the page we're trying to set up
+            // a socket for has already been navigated away from. Apparently there's a browser spec that
+            // says clients should purposely make it difficult for Javascript to explore what's going
+            // wrong when a socket can't be opened. So instead those errors are suppressed
+            // in Browser.ReportJavascriptError.
             WebSocketManager.socketMap[clientContext] = new WebSocket(
                 "ws://127.0.0.1:" + websocketPort.toString(),
                 clientContext

--- a/src/BloomExe/BookThumbNailer.cs
+++ b/src/BloomExe/BookThumbNailer.cs
@@ -27,6 +27,11 @@ namespace Bloom
 			_thumbnailProvider = thumbNailer;
 		}
 
+		public void CancelOrder(Guid requestId)
+		{
+			_thumbnailProvider.CancelOrder(requestId);
+		}
+
 		public HtmlThumbNailer HtmlThumbNailer { get { return _thumbnailProvider;} }
 
 		private void GetThumbNailOfBookCover(Book.Book book, HtmlThumbNailer.ThumbnailOptions thumbnailOptions, Action<Image> callback, Action<Exception> errorCallback, bool async)
@@ -74,12 +79,13 @@ namespace Bloom
 		/// </summary>
 		/// <param name="book"></param>
 		/// <param name="height">Optional parameter. If unspecified, use defaults</param>
-		public void MakeThumbnailOfCover(Book.Book book, int height = -1)
+		public void MakeThumbnailOfCover(Book.Book book, int height = -1, Guid requestId = new Guid())
 		{
 			HtmlThumbNailer.ThumbnailOptions options = new HtmlThumbNailer.ThumbnailOptions
 			{
 				//since this is destined for HTML, it's much easier to handle if there is no pre-padding
-				CenterImageUsingTransparentPadding = false
+				CenterImageUsingTransparentPadding = false,
+				RequestId = requestId
 			};
 
 			if (height != -1)

--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -145,11 +145,18 @@ namespace Bloom.Publish.Android
 					// another background one and return before the preview is ready. But in case something in C#
 					// might one day kick of a new preview, or we find we do need a background thread,
 					// I've made it a websocket broadcast when it is ready.
+					// If we've already left the publish tab...we can get a few of these requests queued up when
+					// a tester rapidly toggles between views...abandon the attempt
+					if (!PublishHelper.InPublishTab)
+					{
+						request.Failed("aborted, no longer in publish tab");
+						return;
+					}
 					PreviewUrl = StageBloomD(request.CurrentBook, _bookServer, _progress, _thumbnailBackgroundColor);
 					_webSocketServer.SendString(kWebSocketContext, kWebsocketEventId_Preview, PreviewUrl);
 					request.PostSucceeded();
 				}
-			}, true);
+			}, false);
 
 
 			apiHandler.RegisterEndpointHandler(kApiUrlPart + "thumbnail", request =>

--- a/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
@@ -752,7 +752,7 @@ namespace Bloom.WebLibraryIntegration
 
 				var publishModel = new PublishModel(bookSelection, new PdfMaker(), currentEditableCollectionSelection, context.Settings, server, _thumbnailer);
 				publishModel.PageLayout = book.GetLayout();
-				var view = new PublishView(publishModel, new SelectedTabChangedEvent(), new LocalizationChangedEvent(), this, null, null, null, null);
+				var view = new PublishView(publishModel, new SelectedTabChangedEvent(), new LocalizationChangedEvent(), this, null, null, null, null, null);
 				var blPublishModel = new BloomLibraryPublishModel(this, book);
 				string dummy;
 


### PR DESCRIPTION
Various attempts to prevent errors when rapidly switching among publish tabs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3111)
<!-- Reviewable:end -->
