### PR TITLE
Fix cover image descriptions to use ImageDescriptionEdit-style (BL-7039)

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
@@ -125,7 +125,17 @@ mixin standard-cover-contents
 mixin standard-cover-image
 	.bloom-imageContainer
 		img(data-book="coverImage", src="placeHolder.png")
-		+field("auto").bloom-imageDescription.bloom-trailingElement.normal-style(data-book="coverImageDescription")
+		+field-cover-image("auto").bloom-imageDescription.bloom-trailingElement(data-book="coverImageDescription")
+
+mixin field-cover-image(languages)
+	-requireOneArgument('field', arguments);
+	.bloom-translationGroup(data-default-languages=languages)&attributes(attributes)
+		+editable-cover-image(kLanguageForPrototypeOnly)
+
+mixin editable-cover-image(language)
+	- requireOneArgument('editable', arguments)
+	.bloom-editable.ImageDescriptionEdit-style(lang=language, contenteditable="true")&attributes(attributes)
+
 
 mixin factoryStandard-outsideFrontCover
 	// FRONT COVER

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -964,6 +964,7 @@ namespace Bloom.Book
 			var licenseMetadata = GetLicenseMetadata();
 			BringXmatterHtmlUpToDate(bookDOM);
 			RepairBrokenSmallCoverCredits(bookDOM);
+			RepairCoverImageDescriptions(bookDOM);
 
 			progress.WriteStatus("Repair page label localization");
 			RepairPageLabelLocalization(bookDOM);
@@ -1174,6 +1175,36 @@ namespace Bloom.Book
 				var imgNode = imgNodes[0];
 				coverImageElement.InnerText = (imgNode.Attributes == null || imgNode.Attributes["src"] == null) ?
 					string.Empty : HttpUtility.UrlDecode(imgNode.Attributes["src"].Value);
+			}
+		}
+
+		/// <summary>
+		/// Repair the cover image descriptions to use ImageDescriptionEdit-style instead of normal-style.
+		/// </summary>
+		/// <remarks>
+		/// See https://issues.bloomlibrary.org/youtrack/issue/BL-7039.
+		/// </remarks>
+		internal static void RepairCoverImageDescriptions(HtmlDom bookDOM)
+		{
+			if (bookDOM?.Body == null)
+				return;		// must be a test running...
+			var dataDiv = bookDOM.Body.SelectSingleNode("div[@id='bloomDataDiv']");
+			if (dataDiv == null)
+				return;		// must be a test running...
+			var coverImageDiv = dataDiv.SelectSingleNode("div[@data-book='coverImageDescription' and @lang='*']");
+			if (coverImageDiv == null)
+				return;		// must be a test running...  or a very old book?
+			var coverImageDescriptionDivs = coverImageDiv.SafeSelectNodes("div[contains(@class,'bloom-editable')]");
+			foreach (XmlNode descriptionDiv in coverImageDescriptionDivs)
+			{
+				//XmlElement descriptionDiv = xnode as XmlElement;
+				var classAttr = descriptionDiv.Attributes["class"].Value;
+				if (classAttr.Contains("normal-style"))
+					classAttr = classAttr.Replace("normal-style","").Replace("  ", " ");
+				if (!classAttr.Contains("ImageDescriptionEdit-style"))
+					classAttr = classAttr + " ImageDescriptionEdit-style";
+				if (classAttr != descriptionDiv.Attributes["class"].Value)
+					descriptionDiv.Attributes["class"].Value = classAttr;
 			}
 		}
 

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -2365,6 +2365,91 @@ namespace BloomTests.Book
 			Assert.That(audioSpans[0].InnerText, Is.EqualTo("Page 1 Paragraph 2 Sentence 1"));
 		}
 
+		[Test]
+		public void RepairCoverImageDescriptions_ReplacesIncorrectStyle()
+		{
+			string html = @"<html><head></head><body>
+	<div id='bloomDataDiv'>
+		<div data-book='coverImageDescription' lang='*'>
+			<div data-languagetipcontent='English' aria-label='false' role='textbox' spellcheck='true' tabindex='0' class='bloom-editable normal-style bloom-content1 bloom-visibility-code-on' lang='en' contenteditable='true'>
+				<p>musical score in artistic waves</p>
+			</div>
+			<div style='' class='bloom-editable normal-style' lang='z' contenteditable='true'></div>
+			<div data-languagetipcontent='español' style='' class='bloom-editable normal-style bloom-contentNational2' lang='es' contenteditable='true'></div>
+			<div data-languagetipcontent='français' aria-label='false' role='textbox' spellcheck='true' tabindex='0' style='' class='bloom-editable normal-style bloom-contentNational1' lang='fr' contenteditable='true'>
+				<p></p>
+			</div>
+		</div>
+		<div class='bloom-page' id='guid1'>
+			<div class='bloom-editable bloom-content1' contenteditable='true'></div>
+			<div class='bloom-editable bloom-content2' contenteditable='true'></div>
+			<div class='bloom-editable bloom-content3' contenteditable='true'></div>
+		</div>
+	</div>
+</body></html>";
+			var dom = new HtmlDom(html);
+
+			// The old xmatter incorrectly inserted the class 'normal-style' to image description divs for the cover page.
+			// Verify this old (incorrect) data setup.
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(@class, 'bloom-editable')]", 4);
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(@class, 'normal-style')]", 4);
+			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(@class, 'ImageDescriptionEdit-style')]");
+
+			// SUT
+			Bloom.Book.Book.RepairCoverImageDescriptions(dom);
+
+			// Verify that the class 'normal-style' has been replaced by the class "ImageDescriptionEdit-style' in all of
+			// the image description divs for the cover page.
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(@class, 'bloom-editable')]", 4);
+			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(@class, 'normal-style')]");
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(concat(' ',@class,' '), ' ImageDescriptionEdit-style ')]", 4);
+		}
+
+		[Test]
+		public void RepairCoverImageDescriptions_InsertsMissingStyle()
+		{
+			string html = @"<html><head></head><body>
+	<div id='bloomDataDiv'>
+		<div data-book='coverImageDescription' lang='*'>
+			<div data-languagetipcontent='English' aria-label='false' role='textbox' spellcheck='true' tabindex='0' class='bloom-editable bloom-content1 bloom-visibility-code-on' contenteditable='true' lang='en'>
+				<p></p>
+			</div>
+			<div data-languagetipcontent='español' style='' aria-label='false' role='textbox' spellcheck='true' tabindex='0' class='bloom-editable bloom-contentNational2' contenteditable='true' lang='es'>
+				<p></p>
+			</div>
+			<div data-languagetipcontent='français' style='' aria-label='false' role='textbox' spellcheck='true' tabindex='0' class='bloom-editable bloom-contentNational1' contenteditable='true' lang='fr'>
+				<p></p>
+			</div>
+			<div style='' class='bloom-editable' contenteditable='true' lang='z'>
+				<p></p>
+			</div>
+		</div>
+		<div class='bloom-page' id='guid1'>
+			<div class='bloom-editable bloom-content1' contenteditable='true'></div>
+			<div class='bloom-editable bloom-content2' contenteditable='true'></div>
+			<div class='bloom-editable bloom-content3' contenteditable='true'></div>
+		</div>
+	</div>
+</body></html>";
+			var dom = new HtmlDom(html);
+
+			// The old xmatter did not insert the class 'ImageDescriptionEdit-style' to image description divs for the cover page.
+			// Repair should handle cases where 'normal-style' is also missing.  Verify the (incorrect) data setup for the test.
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(@class, 'bloom-editable')]", 4);
+			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(@class, 'normal-style')]");
+			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(@class, 'ImageDescriptionEdit-style')]");
+
+			// SUT
+			Bloom.Book.Book.RepairCoverImageDescriptions(dom);
+
+			// Verify that the class "ImageDescriptionEdit-style' has been inserted in all of the image description divs for the
+			// cover page, and that 'normal-style' still does not exist.
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(@class, 'bloom-editable')]", 4);
+			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(@class, 'normal-style')]");
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='coverImageDescription']/div[contains(concat(' ',@class,' '), ' ImageDescriptionEdit-style ')]", 4);
+		}
+
+
 
 #if UserControlledTemplate
 		[Test]


### PR DESCRIPTION
This change is on Version4.4 as requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3118)
<!-- Reviewable:end -->
