### PR TITLE
Fix javascript error handler to not swallow errors (BL-7085)

### DIFF
--- a/src/BloomBrowserUI/lib/errorHandler.ts
+++ b/src/BloomBrowserUI/lib/errorHandler.ts
@@ -10,7 +10,7 @@ import Axios from "axios";
 // This function is shared by code that wants to report errors but for some
 // reason shouldn't do so by throwing.
 export function reportError(message: string, stack: string) {
-    if (typeof (window as any).__karma__) {
+    if ((window as any).__karma__) {
         console.log(
             "skipping post to common/error because in unit tests: \r\n" +
                 message +


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3127)
<!-- Reviewable:end -->
