### PR TITLE
BL-7130 Resize some thumbs to fit buttons

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -7,10 +7,10 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Bloom.Book;
 using Bloom.Collection;
+using Bloom.ImageProcessing;
 using Bloom.Properties;
 using Bloom.ToPalaso;
 using Bloom.web;
@@ -1001,10 +1001,11 @@ namespace Bloom.CollectionTab
 				var imageIndex = _bookThumbnails.Images.IndexOfKey(bookInfo.Id);
 				if (imageIndex > -1)
 				{
-					_bookThumbnails.Images[imageIndex] = image;
 					var button = FindBookButton(bookInfo);
 					if (button == null || button.IsDisposed)
 						return; // I (gjm) found that this condition occurred sometimes when testing BL-6100
+					image = ImageUtils.ResizeImageIfNecessary(button.Size, image);
+					_bookThumbnails.Images[imageIndex] = image;
 					button.Image = IsUsableBook(button) ? image : MakeDim(image);
 				}
 			}

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
@@ -346,6 +347,37 @@ namespace Bloom.ImageProcessing
 				return false;
 			}
 			return true;
+		}
+
+		public static Image ResizeImageIfNecessary(Size maxSize, Image image)
+		{
+			// from https://www.c-sharpcorner.com/article/resize-image-in-c-sharp/
+			var desiredHeight = maxSize.Height;
+			var desiredWidth = maxSize.Width;
+			if (image.Height <= desiredHeight && image.Width <= desiredWidth)
+				return image; // We are already within parameters
+
+			// Try resizing to width of button first
+			var newHeight = image.Height * desiredWidth / image.Width;
+			var newWidth = desiredWidth;
+			if (newHeight > desiredHeight)
+			{
+				// Resize to height of button instead
+				newWidth = image.Width * desiredHeight / image.Height;
+				newHeight = desiredHeight;
+			}
+
+			var newImage = new Bitmap(newWidth, newHeight);
+			using (var graphic = Graphics.FromImage(newImage))
+			{
+				// I tried using HighSpeed settings in here with no appreciable difference in loading speed.
+				graphic.InterpolationMode = InterpolationMode.HighQualityBicubic;
+				graphic.SmoothingMode = SmoothingMode.HighQuality;
+				graphic.PixelOffsetMode = PixelOffsetMode.HighQuality;
+				graphic.CompositingQuality = CompositingQuality.HighQuality;
+				graphic.DrawImage(image, 0, 0, desiredWidth, newHeight);
+			}
+			return newImage;
 		}
 	}
 }


### PR DESCRIPTION
* Device 16 x 9 Landscape was producing odd buttons

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3139)
<!-- Reviewable:end -->
