### PR TITLE
BL-7074 Use CSS instead of DOM manipulation

### DIFF
--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
@@ -37,6 +37,16 @@ body {
     flex: 1 1 auto;
     overflow-y: auto; // so it will scroll, if it needs to, instead of growing
     cursor: default;
+    .pageContainer {
+        // BL-7074 Keep SL books from eating up memory by not displaying videos in page thumb images.
+        .bloom-videoContainer {
+            background: center no-repeat
+                url("../../templates/template books/Sign Language/video-placeholder.svg");
+            video {
+                display: none;
+            }
+        }
+    }
 }
 
 .pageContainer {

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -250,36 +250,12 @@ namespace Bloom.Api
 			{
 				_keyToCurrentPage = key;
 			}
-
-			// If we are creating a page thumbnail and we have videos,
-			// replace them with our standard video placeholder image.
-			if (source == BloomServer.SimulatedPageFileSource.Thumb ||
-			    source == BloomServer.SimulatedPageFileSource.Pagelist ||
-			    source == BloomServer.SimulatedPageFileSource.Epub)
-			{
-				ReplaceAnyVideoElementsWithPlaceholder(dom);
-			}
 			var html5String = TempFileUtils.CreateHtml5StringFromXml(dom.RawDom);
 			lock (_urlToSimulatedPageContent)
 			{
 				_urlToSimulatedPageContent[key] = html5String;
 			}
 			return new SimulatedPageFile {Key = url};
-		}
-
-		private const string vidPlaceHolderDivContents =
-			@"<img src='video-placeholder.svg' />";
-
-		private static void ReplaceAnyVideoElementsWithPlaceholder(HtmlDom dom)
-		{
-			var vidNodes = dom.SafeSelectNodes("//div[contains(concat(' ', @class, ' '), ' bloom-videoContainer ')]");
-			foreach (XmlNode vidNode in vidNodes)
-			{
-				var placeHolderNode = dom.RawDom.CreateElement("div");
-				placeHolderNode.InnerXml = vidPlaceHolderDivContents;
-				placeHolderNode.SetAttribute("class", "bloom-imageContainer");
-				vidNode.ParentNode.ReplaceChild(placeHolderNode, vidNode);
-			}
 		}
 
 		internal static void RemoveSimulatedPageFile(string key)


### PR DESCRIPTION
* page list thumbnail images will use the
   video-placeholder image instead of capturing
   an image from the video

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3148)
<!-- Reviewable:end -->
