### PR TITLE
Fix crash in opening metadata dialog for epub publishing (BL-7152)

### DIFF
--- a/src/BloomBrowserUI/publish/metadata/SubjectChooser.tsx
+++ b/src/BloomBrowserUI/publish/metadata/SubjectChooser.tsx
@@ -13,26 +13,6 @@ export interface IProps {
 }
 
 export class SubjectChooser extends React.Component<IProps> {
-    public componentDidMount() {
-        this.loadMetadata(this.props.subjects.value);
-    }
-
-    private loadMetadata(subjects: any[]) {
-        let subjectList: SubjectTreeNode[] = [];
-        if (subjects) {
-            subjects.forEach(subject => {
-                let newSubj = new SubjectTreeNode(
-                    subject["value"],
-                    subject["label"],
-                    "",
-                    true
-                );
-                subjectList.push(newSubj);
-            });
-        }
-        this.props.subjects.value = subjectList;
-    }
-
     public render() {
         SubjectTreeNode.markSelectedSubjectNodes(
             themaSubjectData,


### PR DESCRIPTION
The removed code is not needed (if it ever was) with the mobx observer
in the parent dialog.  Having it there causes a loop in change property /
render / change property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3176)
<!-- Reviewable:end -->
