### PR TITLE
Add autolink plugin to ckeditor (BL-6845)

### DIFF
--- a/src/BloomBrowserUI/lib/ckeditor/config.js
+++ b/src/BloomBrowserUI/lib/ckeditor/config.js
@@ -3,34 +3,38 @@
  * For licensing, see LICENSE.md or http://ckeditor.com/license
  */
 
-CKEDITOR.editorConfig = function (config) {
+CKEDITOR.editorConfig = function(config) {
     // Define changes to default configuration here.
     // For complete reference see:
     // http://docs.ckeditor.com/#!/api/CKEDITOR.config
 
     // The toolbar groups arrangement, optimized for a single toolbar row.
     config.toolbarGroups = [
-        { name: 'document', groups: ['mode', 'document', 'doctools'] },
-        { name: 'clipboard', groups: ['clipboard', 'undo'] },
-        { name: 'editing', groups: ['find', 'selection', 'spellchecker'] },
-        { name: 'forms' },
-        { name: 'basicstyles', groups: ['basicstyles', 'cleanup'] },
-        { name: 'paragraph', groups: ['list', 'indent', 'blocks', 'align', 'bidi'] },
-        { name: 'links' },
-        { name: 'insert' },
-        { name: 'styles' },
-        { name: 'colors' },
-        { name: 'tools' },
-        { name: 'others' },
-        { name: 'about' }
+        { name: "document", groups: ["mode", "document", "doctools"] },
+        { name: "clipboard", groups: ["clipboard", "undo"] },
+        { name: "editing", groups: ["find", "selection", "spellchecker"] },
+        { name: "forms" },
+        { name: "basicstyles", groups: ["basicstyles", "cleanup"] },
+        {
+            name: "paragraph",
+            groups: ["list", "indent", "blocks", "align", "bidi"]
+        },
+        { name: "links" },
+        { name: "insert" },
+        { name: "styles" },
+        { name: "colors" },
+        { name: "tools" },
+        { name: "others" },
+        { name: "about" }
     ];
 
     // The default plugins included in the basic setup define some buttons that
     // are not needed in a basic editor. They are removed here.
-    config.removeButtons = 'Cut,Copy,Paste,Undo,Redo,Anchor,Strike,Subscript,About';
+    config.removeButtons =
+        "Cut,Copy,Paste,Undo,Redo,Anchor,Strike,Subscript,About";
 
     // Dialog windows are also simplified.
-    config.removeDialogTabs = 'link:advanced';
+    config.removeDialogTabs = "link:advanced";
 
     // this aligns to tool bar with the right side fo the edit field
     config.floatSpacePreferRight = true;
@@ -40,7 +44,6 @@ CKEDITOR.editorConfig = function (config) {
 
     // Remove the annoying tooltip "Rich Text Editor, editorN".
     config.title = false;
-
 
     // See http://docs.ckeditor.com/#!/guide/dev_acf for a description of this setting.
     config.allowedContent = true;
@@ -60,7 +63,7 @@ CKEDITOR.editorConfig = function (config) {
     // but by letting people paste things that cannot be duplicated by a user doing a translation, are
     // we leading people to expect formatting in Bloom that translators will not actually be able to replicate?
     // Therefore for now we're limiting pasting to things that a translator could also do:
-    config.pasteFilter = 'p b br em i strong sup u;';
+    config.pasteFilter = "p b br em i strong sup u;";
 
     //BL-3009: don't remove empty spans, since we use <span class="bloom-linebreak"></span> when you press shift-enter.
     //http://stackoverflow.com/a/23983357/723299
@@ -72,4 +75,8 @@ CKEDITOR.editorConfig = function (config) {
     //in order to stop pictures; the on('paste') stops working if you enable this, at least for pastes that come from Word
     //CKEDITOR.config.extraPlugins  = 'pasteFromWord';
     // CKEDITOR.config.pasteFromWordPromptCleanup = true;
+
+    // Add the autolink plugin to make it easy for users to make live internet/email links in ebooks.
+    // See https://issues.bloomlibrary.org/youtrack/issue/BL-6845.
+    CKEDITOR.config.extraPlugins = "autolink";
 };

--- a/src/BloomBrowserUI/lib/ckeditor/plugins/autolink/plugin.js
+++ b/src/BloomBrowserUI/lib/ckeditor/plugins/autolink/plugin.js
@@ -1,0 +1,88 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+(function() {
+    "use strict";
+
+    // Regex by Imme Emosol.
+    var validUrlRegex = /^(https?|ftp):\/\/(-\.)?([^\s\/?\.#]+\.?)+(\/[^\s]*)?[^\s\.,]$/i,
+        // Regex by (https://www.w3.org/TR/html5/forms.html#valid-e-mail-address).
+        validEmailRegex = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
+        doubleQuoteRegex = /"/g;
+
+    CKEDITOR.plugins.add("autolink", {
+        requires: "clipboard",
+
+        init: function(editor) {
+            editor.on("paste", function(evt) {
+                var data = evt.data.dataValue;
+
+                if (
+                    evt.data.dataTransfer.getTransferType(editor) ==
+                    CKEDITOR.DATA_TRANSFER_INTERNAL
+                ) {
+                    return;
+                }
+
+                // If we found "<" it means that most likely there's some tag and we don't want to touch it.
+                if (data.indexOf("<") > -1) {
+                    return;
+                }
+
+                // Create valid email links (#1761).
+                if (data.match(validEmailRegex)) {
+                    data = data.replace(
+                        validEmailRegex,
+                        '<a href="mailto:' +
+                            data.replace(doubleQuoteRegex, "%22") +
+                            '">$&</a>'
+                    );
+                    data = tryToEncodeLink(data);
+                } else {
+                    // https://dev.ckeditor.com/ticket/13419
+                    data = data.replace(
+                        validUrlRegex,
+                        '<a href="' +
+                            data.replace(doubleQuoteRegex, "%22") +
+                            '">$&</a>'
+                    );
+                }
+
+                // If link was discovered, change the type to 'html'. This is important e.g. when pasting plain text in Chrome
+                // where real type is correctly recognized.
+                if (data != evt.data.dataValue) {
+                    evt.data.type = "html";
+                }
+
+                evt.data.dataValue = data;
+            });
+
+            function tryToEncodeLink(data) {
+                // If enabled use link plugin to encode email link.
+                if (editor.plugins.link) {
+                    var link = CKEDITOR.dom.element.createFromHtml(data),
+                        linkData = CKEDITOR.plugins.link.parseLinkAttributes(
+                            editor,
+                            link
+                        ),
+                        attributes = CKEDITOR.plugins.link.getLinkAttributes(
+                            editor,
+                            linkData
+                        );
+
+                    if (!CKEDITOR.tools.isEmpty(attributes.set)) {
+                        link.setAttributes(attributes.set);
+                    }
+
+                    if (attributes.removed.length) {
+                        link.removeAttributes(attributes.removed);
+                    }
+                    return link.getOuterHtml();
+                }
+                return data;
+            }
+        }
+    });
+})();


### PR DESCRIPTION
I used the version of the autolink plugin for ckeditor 4.10.x because it introduced email links.  I didn't use the version from 4.11.x because it changed the way it interacted with the rest of the program.

The changes in ckeditor/config.js are mostly due to VSCode prettification.  The last few lines are the only real change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3177)
<!-- Reviewable:end -->
