### PR TITLE
Display proper names for multilingual books (BL-6830)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1703,7 +1703,9 @@ namespace Bloom.Book
 
 			if (MultilingualContentLanguage2 != null)
 			{
-				languagesOfBook += ", " + _collectionSettings.GetLanguage2Name(codeOfNationalLanguage);
+				languagesOfBook += ", " + ((MultilingualContentLanguage2 == _collectionSettings.Language2Iso639Code) ?
+					_collectionSettings.GetLanguage2Name(codeOfNationalLanguage) :
+					_collectionSettings.GetLanguage3Name(codeOfNationalLanguage));
 			}
 			if (MultilingualContentLanguage3 != null)
 			{


### PR DESCRIPTION
This includes allowing the book title in the 3rd language.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3182)
<!-- Reviewable:end -->
