### PR TITLE
Prevent double paste when text contains standard format verse marker (BL-7052)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -152,10 +152,12 @@ export default class BloomField {
         (<any>bloomEditableDiv).bloomCkEditor = ckeditor;
     }
 
-    private static convertStandardFormatVerseMarkersToSuperscript(
+    // Not private so we can unit test it. It is too difficult to get the actual paste
+    // event to get fired and handled correctly in tests.
+    public static convertStandardFormatVerseMarkersToSuperscript(
         inputText: any
     ): any {
-        const re = new RegExp("\\\\v\\s(\\d+)", "g");
+        const re = /\\v\s(\d+)/g;
         const matches = re.exec(inputText);
         if (matches == null) {
             //just let it paste

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -113,8 +113,11 @@ export default class BloomField {
         //     alert(event.data.dataValue);
         // });
         ckeditor.on("paste", event => {
-            var endMkr = "";
-            let paras = event.data.dataValue.match(/<p>/g);
+            event.data.dataValue = this.convertStandardFormatVerseMarkersToSuperscript(
+                event.data.dataValue
+            );
+
+            const paras = event.data.dataValue.match(/<p>/g);
             if (!paras) {
                 // Enhance: should we remove the probable <span> and just leave the text?
                 // But it might be carrying some important style info.
@@ -124,6 +127,7 @@ export default class BloomField {
             // This prevents a typically unwanted extra line break being inserted before the
             // start of the material copied. Without the <p> wrapper, that material just
             // gets inserted into the current paragraph.
+            let endMkr = "";
             if (paras.length === 1) {
                 // Unwrapping the one and only <p> will leave no break between what used to be that
                 // paragraph and the following text, which should now start a new paragraph.
@@ -146,6 +150,20 @@ export default class BloomField {
         // This makes it easy to find the right editor instance. There may be some ckeditor built-in way, but
         // I wasn't able to find one.
         (<any>bloomEditableDiv).bloomCkEditor = ckeditor;
+    }
+
+    private static convertStandardFormatVerseMarkersToSuperscript(
+        inputText: any
+    ): any {
+        const re = new RegExp("\\\\v\\s(\\d+)", "g");
+        const matches = re.exec(inputText);
+        if (matches == null) {
+            //just let it paste
+            return inputText;
+        } else {
+            // Use <sup> because that is what ckeditor uses
+            return inputText.replace(re, "<sup>$1</sup>");
+        }
     }
 
     private static MakeShiftEnterInsertLineBreak(field: HTMLElement) {

--- a/src/BloomBrowserUI/bookEdit/bloomField/bloomFieldSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/bloomFieldSpec.ts
@@ -1,4 +1,4 @@
-/// <reference path="BloomField.ts" />
+///<reference path="BloomField.ts" />
 ///<reference path="../../typings/bundledFromTSC.d.ts"/>
 import BloomField from "./BloomField";
 
@@ -8,15 +8,29 @@ function WireUp() {
     });
 }
 
-/* this doesn't work since we retired the bloom-requiresParagraph tag and started using ckeditor.
-    However, if you look in a browser, it does in fact get a paragraph.
-describe("bloomField", function () {
-    beforeEach(function () {
-        $('body').html('<head></head><div class="bloom-requiresParagraph"><div id="simple" contenteditable="true" class="bloom-editable"></div></div>');
+describe("BloomField", () => {
+    beforeEach(() => {
+        $("body").html(
+            '<head></head><div id="simple" contenteditable="true" class="bloom-editable"></div>'
+        );
     });
 
-    it("Putting cursor in a bloom-requiresParagraph field creates a <p>", function () {
-        WireUp();
-        expect($('div p').length).toBeGreaterThan(0);
+    it("convertStandardFormatVerseMarkersToSuperscript creates superscript when text includes SFM verse marker", () => {
+        const result = BloomField.convertStandardFormatVerseMarkersToSuperscript(
+            "A \\v 2 B C \\v 3 D E."
+        );
+        expect(result).toBe("A <sup>2</sup> B C <sup>3</sup> D E.");
     });
-});*/
+
+    it("convertStandardFormatVerseMarkersToSuperscript does not create superscript when text doesn't include SFM verse marker", () => {
+        const result = BloomField.convertStandardFormatVerseMarkersToSuperscript(
+            "A v 2 B C \\v D E."
+        );
+        expect(result).toBe("A v 2 B C \\v D E.");
+    });
+
+    it("bloom-editable div creates a <p>", () => {
+        WireUp();
+        expect($("div p").length).toBeGreaterThan(0);
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -173,9 +173,7 @@ function AddEditKeyHandlers(container) {
                 document.execCommand(
                     "insertHTML",
                     false,
-                    "<span class='superscript'>" +
-                        document.getSelection() +
-                        "</span>"
+                    "<sup>" + document.getSelection() + "</sup>"
                 );
             }
         });
@@ -490,16 +488,6 @@ export function SetupElements(container) {
                 document.execCommand("insertText", false, s);
                 //NB: odd that this doesn't work?! document.execCommand("paste", false, s);
                 return;
-            }
-            const re = new RegExp("\\\\v\\s(\\d+)", "g");
-            const matches = re.exec(s);
-            if (matches == null) {
-                //just let it paste
-            } else {
-                e.preventDefault();
-                const x = s.replace(re, "<span class='superscript'>$1</span>");
-                document.execCommand("insertHtml", false, x);
-                //NB: this would undo, but it doesn't work document.execCommand("paste", false, x);
             }
         });
 

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -452,6 +452,8 @@ label.bubble,
 label.placeholder {
     display: none;
 }
+// Previously (<= 4.5), we used to use this class to do superscripting. Now we use <sup> to be consistent with ckeditor.
+// But we have to keep this styling here for legacy books.
 .superscript {
     vertical-align: super;
     font-size: 80%;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3192)
<!-- Reviewable:end -->
