### PR TITLE
Copy template's stylesheet file(s) when changing layout (BL-7170)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1397,6 +1397,7 @@ namespace Bloom.Book
 			if (!OurHtmlDom.UpdatePageToTemplate(pageDom, templatePage.GetDivNodeForThisPage(), pageId, allowDataLoss))
 				return false;
 			AddMissingStylesFromTemplatePage(templatePage);
+			CopyMissingStylesheetFiles(templatePage);
 			UpdateEditableAreasOfElement(pageDom);
 			return true;
 		}
@@ -2159,16 +2160,7 @@ namespace Bloom.Book
 			}
 
 			//similarly, if the page has stylesheet files we don't have, copy them
-			foreach(string sheetName in templatePage.Book.OurHtmlDom.GetTemplateStyleSheets())
-			{
-				var destinationPath = Path.Combine(FolderPath, sheetName);
-				if (!RobustFile.Exists(destinationPath))
-				{
-					var sourcePath = Path.Combine(templatePage.Book.FolderPath, sheetName);
-					if (RobustFile.Exists(sourcePath))
-						RobustFile.Copy(sourcePath, destinationPath);
-				}
-			}
+			CopyMissingStylesheetFiles(templatePage);
 
 			if (this.IsSuitableForMakingShells)
 			{
@@ -2190,6 +2182,26 @@ namespace Bloom.Book
 			_pageSelection.SelectPage(newPage, true);
 
 			InvokeContentsChanged(null);
+		}
+
+		/// <summary>
+		/// Copy stylesheet files referenced by the template page that this book doesn't yet have.
+		/// </summary>
+		/// <remarks>
+		/// See https://issues.bloomlibrary.org/youtrack/issue/BL-7170.
+		/// </remarks>
+		private void CopyMissingStylesheetFiles(IPage templatePage)
+		{
+			foreach (string sheetName in templatePage.Book.OurHtmlDom.GetTemplateStyleSheets())
+			{
+				var destinationPath = Path.Combine(FolderPath, sheetName);
+				if (!RobustFile.Exists(destinationPath))
+				{
+					var sourcePath = Path.Combine(templatePage.Book.FolderPath, sheetName);
+					if (RobustFile.Exists(sourcePath))
+						RobustFile.Copy(sourcePath, destinationPath);
+				}
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
The previous change copied only the reference inside the HTML file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3197)
<!-- Reviewable:end -->
