### PR TITLE
Narration highlight backward compatibility fix  (BL-7182)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -989,7 +989,20 @@ export default class AudioRecording {
             const currentTextBox = this.getCurrentTextBox();
             if (currentTextBox) {
                 currentTextBox.classList.remove("bloom-postAudioSplit");
-                this.elementsToPlayConsecutivelyStack.push(currentTextBox);
+
+                const audioSegments = this.getAudioSegmentsWithinElement(
+                    currentTextBox
+                );
+
+                if (audioSegments && audioSegments.length > 0) {
+                    // This text box is in 4.5 Format (Hard Split) where it contains audio-sentence elements within it
+                    this.elementsToPlayConsecutivelyStack = jQuery
+                        .makeArray(audioSegments)
+                        .reverse();
+                } else {
+                    // Nope, no audio-sentence elements within it. Uses 4.6 Format (Soft Split)
+                    this.elementsToPlayConsecutivelyStack.push(currentTextBox);
+                }
             }
         } else {
             const currentHighlight = this.getCurrentHighlight();


### PR DESCRIPTION
Fixes backward compatibility issues with playing a book in 4.6 that was created using 4.5 and Hard Split.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3219)
<!-- Reviewable:end -->
