### PR TITLE
Fix uses of UrlPathString.NotEncoded for filepaths (BL-4816)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2652,7 +2652,7 @@ namespace Bloom.Book
 					{
 						var bookFolderName = Path.GetFileName(bookInfo.FolderPath);
 						var path = HtmlDom.GetImageElementUrl(img);
-						var pathRelativeToFolioFolder = "../" + bookFolderName + "/" + path.NotEncoded;
+						var pathRelativeToFolioFolder = "../" + bookFolderName + "/" + path.NotEncoded;	// want query as well as filepath
 						//NB: URLEncode would replace spaces with '+', which is ok in the parameter section, but not the URL
 						//So we are using UrlPathEncode
 
@@ -3009,7 +3009,7 @@ namespace Bloom.Book
 			if (coverImgElt == null)
 				return null;
 			var coverImageUrl = HtmlDom.GetImageElementUrl(coverImgElt);
-			var coverImageFileName = coverImageUrl.NotEncoded;
+			var coverImageFileName = coverImageUrl.PathOnly.NotEncoded;
 			if (string.IsNullOrEmpty(coverImageFileName))
 				return null;
 			var coverImagePath = Path.Combine(StoragePageFolder, coverImageFileName);
@@ -3068,7 +3068,7 @@ namespace Bloom.Book
 			}
 			foreach (XmlElement div in page.SafeSelectNodes(".//div[contains(@class, 'bloom-imageContainer')]"))
 			{
-				var imgUrl = HtmlDom.GetImageElementUrl(div).NotEncoded;
+				var imgUrl = HtmlDom.GetImageElementUrl(div).PathOnly.NotEncoded;
 				// Actually getting a background img url is a good indication that it's one we want.
 				if (!string.IsNullOrEmpty(imgUrl) && imgUrl != "placeHolder.png")
 					return true;

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -499,7 +499,7 @@ namespace Bloom.Book
 			{
 				// Reference: BL-3235
 				//remove the url path encoding
-				form = UrlPathString.CreateFromUrlEncodedString(form).NotEncoded;
+				form = UrlPathString.CreateFromUrlEncodedString(form).NotEncoded;	// want query as well as filepath
 				//switch to html/xml encoding
 				form = HttpUtility.HtmlEncode(form);
 			}

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1815,10 +1815,6 @@ namespace Bloom.Book
 		/// adding the supplied params. If urlEncodePath is true, we will take the encoded path version
 		/// of the url argument. Caller is responsible to encode the paramString if necessary.
 		/// </summary>
-		/// <param name="url"></param>
-		/// <param name="srcElement"></param>
-		/// <param name="urlEncodePath"></param>
-		/// <param name="encodedParamString"></param>
 		public static void SetSrcOfVideoElement(UrlPathString url, ElementProxy srcElement, bool urlEncodePath, string encodedParamString = "")
 		{
 			if (encodedParamString == null)
@@ -1826,7 +1822,7 @@ namespace Bloom.Book
 			if (!string.IsNullOrEmpty(encodedParamString) && !(encodedParamString.StartsWith("?")))
 				encodedParamString = "?" + encodedParamString;
 			srcElement.SetAttribute("src",
-				(urlEncodePath ? url.UrlEncodedForHttpPath : url.NotEncoded) + encodedParamString);
+				(urlEncodePath ? url.PathOnly.UrlEncodedForHttpPath : url.PathOnly.NotEncoded) + encodedParamString);
 		}
 
 		public static string RemoveClass(string className, string input)

--- a/src/BloomExe/Book/ImageUpdater.cs
+++ b/src/BloomExe/Book/ImageUpdater.cs
@@ -121,12 +121,7 @@ namespace Bloom.Book
 		{
 			//see also PageEditingModel.UpdateMetadataAttributesOnImage(), which does the same thing but on the browser dom
 			var url = HtmlDom.GetImageElementUrl(new ElementProxy(imgElement));
-			var end = url.NotEncoded.IndexOf('?');
-			string fileName = url.NotEncoded;
-			if (end > 0)
-			{
-				fileName = fileName.Substring(0, end);
-			}
+			string fileName = url.PathOnly.NotEncoded;
 			if (fileName.ToLowerInvariant() == "placeholder.png" || fileName.ToLowerInvariant() == "license.png")
 				return;
 			if (string.IsNullOrEmpty(fileName))

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -678,7 +678,7 @@ namespace Bloom.Edit
 			var imageElement = GetImageNode(ge);
 			if(imageElement == null)
 				return;
-			string fileName = HtmlDom.GetImageElementUrl(imageElement).NotEncoded;
+			string fileName = HtmlDom.GetImageElementUrl(imageElement).PathOnly.NotEncoded;
 
 			var imageInfo = ImageUpdater.GetImageInfoSafelyFromFilePath(_model.CurrentBook.FolderPath, fileName);
 			if (imageInfo == null)
@@ -883,10 +883,10 @@ namespace Bloom.Edit
 			if(imageElement != null)
 			{
 				var url = HtmlDom.GetImageElementUrl(imageElement);
-				if(String.IsNullOrEmpty(url.NotEncoded))
+				if(String.IsNullOrEmpty(url.PathOnly.NotEncoded))
 					return false;
 
-				var path = Path.Combine(bookFolderPath, url.NotEncoded);
+				var path = Path.Combine(bookFolderPath, url.PathOnly.NotEncoded);
 				try
 				{
 					using(var image = PalasoImage.FromFileRobustly(path))
@@ -986,7 +986,7 @@ namespace Bloom.Edit
 			var imageElement = GetImageNode(ge);
 			if(imageElement == null)
 				return;
-			string currentPath = HtmlDom.GetImageElementUrl(imageElement).NotEncoded;
+			string currentPath = HtmlDom.GetImageElementUrl(imageElement).PathOnly.NotEncoded;
 
 			if(!CheckIfLockedAndWarn(currentPath))
 				return;

--- a/src/BloomExe/Edit/PageEditingModel.cs
+++ b/src/BloomExe/Edit/PageEditingModel.cs
@@ -43,7 +43,7 @@ namespace Bloom.Edit
 		{
 			if (src!=null)
 			{
-				var path = Path.Combine(bookFolderPath, src.NotEncoded);
+				var path = Path.Combine(bookFolderPath, src.PathOnly.NotEncoded);
 				if (path == imageInfo.OriginalFilePath)
 					return true;
 			}

--- a/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
+++ b/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
@@ -154,7 +154,7 @@ namespace Bloom.Publish.Android
 			var folderPath = Path.GetDirectoryName(bookFile);
 			foreach (var imgElt in dom.SafeSelectNodes("//img[@src]").Cast<XmlElement>().ToArray())
 			{
-				var file = UrlPathString.CreateFromUrlEncodedString(imgElt.Attributes["src"].Value).NotEncoded.Split('?')[0];
+				var file = UrlPathString.CreateFromUrlEncodedString(imgElt.Attributes["src"].Value).PathOnly.NotEncoded;
 				if (!File.Exists(Path.Combine(folderPath, file)))
 				{
 					imgElt.ParentNode.RemoveChild(imgElt);

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -1478,7 +1478,7 @@ namespace Bloom.Publish.Epub
 		{
 			isBrandingFile = false;
 			var url = HtmlDom.GetImageElementUrl(img);
-			if (url == null || url.PathOnly == null || String.IsNullOrEmpty(url.NotEncoded))
+			if (url == null || String.IsNullOrEmpty(url.PathOnly.NotEncoded))
 				return null; // very weird, but all we can do is ignore it.
 			// Notice that we use only the path part of the url. For some unknown reason, some bloom books
 			// (e.g., El Nino in the library) have a query in some image sources, and at least some ePUB readers
@@ -1496,7 +1496,7 @@ namespace Bloom.Publish.Epub
 		private string FindVideoFileIfPossible(XmlElement vid)
 		{
 			var url = HtmlDom.GetVideoElementUrl(vid);
-			if (url == null || url.PathOnly == null || String.IsNullOrEmpty(url.NotEncoded))
+			if (url == null || String.IsNullOrEmpty(url.PathOnly.NotEncoded))
 				return null;
 			return url.PathOnly.NotEncoded;
 		}

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -494,7 +494,7 @@ namespace Bloom.Api
 			string modPath = localPath;
 			string path = null;
 			var urlPath = UrlPathString.CreateFromUrlEncodedString(modPath);
-			var tempPath = urlPath.NotEncoded;
+			var tempPath = urlPath.PathOnly.NotEncoded;
 			if (RobustFile.Exists(tempPath))
 				modPath = tempPath;
 			try

--- a/src/BloomExe/web/controllers/SignLanguageApi.cs
+++ b/src/BloomExe/web/controllers/SignLanguageApi.cs
@@ -381,14 +381,14 @@ namespace Bloom.web.controllers
 			var fileName = request.Parameters.Get("source");
 			timings = new[] {0.0m, 0.0m};
 
-			string rawTimings = UrlPathString.CreateFromUrlEncodedString(request.Parameters.Get("timings")).NotEncoded;
+			string rawTimings = UrlPathString.CreateFromUrlEncodedString(request.Parameters.Get("timings")).NotEncoded;	// UrlPathString used only for decoding
 
 			videoFilePath = Path.Combine(CurrentBook.FolderPath, fileName);
 			// Some callers need this file to exist, others don't, but decoding is required for all.
 			if (!RobustFile.Exists(videoFilePath) && Regex.IsMatch(fileName, "%[0-9A-Fa-f][0-9A-Fa-f]"))
 			{
 				videoFilePath = Path.Combine(CurrentBook.FolderPath,
-					UrlPathString.CreateFromUrlEncodedString(fileName).NotEncoded);
+					UrlPathString.CreateFromUrlEncodedString(fileName).NotEncoded);	// UrlPathString used only for decoding
 			}
 
 			if (forEditing && WarnIfVideoCantChange(videoFilePath))
@@ -555,7 +555,7 @@ namespace Bloom.web.controllers
 
 			// Check for valid video file to match url
 			var urlWithoutPrefix = UrlPathString.CreateFromUrlEncodedString(videoUrl.Substring(6)); // grab everything after 'video/'
-			var originalVideoFilePath = Path.Combine(videoFolder, urlWithoutPrefix.NotEncoded);
+			var originalVideoFilePath = Path.Combine(videoFolder, urlWithoutPrefix.NotEncoded);	// any query already removed
 			if (!RobustFile.Exists(originalVideoFilePath))
 				return string.Empty;
 


### PR DESCRIPTION
This is needed if we ever want to add query markup to image URLs for
transparency (or other effects).  Doing so would make books incompatible
with earlier versions of Bloom.  This fix prepares for a possible future
enhancement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3236)
<!-- Reviewable:end -->
