### PR TITLE
Improve xchm use for viewing help on Linux (BL-7244)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
 
 Package: bloom-desktop-alpha
 Architecture: any
-Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
+Depends: ${shlibs:Depends}, ${misc:Depends},
  mono4-sil, libgdiplus4-sil, gtk-sharp4-sil, gtklp,
  chmsee | xchm | kchmviewer, libtidy-sil,
  fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,

--- a/environ
+++ b/environ
@@ -23,15 +23,15 @@ MONO_ENV_OPTIONS="-O=-gshared"
 
 ################################################################################################
 
-# chmsee was phased out by Ubuntu in bionic (18.04)
+# chmsee was phased out by Ubuntu in bionic (18.04), and supporting libraries by disco (19.04)
 
 if [ -z "$MONO_HELP_VIEWER" ]; then
 	if [ -f /usr/bin/chmsee ]; then
 		export MONO_HELP_VIEWER=chmsee
-	elif [ -f /usr/bin/kchmviewer ]; then
-		export MONO_HELP_VIEWER=kchmviewer
 	elif [ -f /usr/bin/xchm ]; then
 		export MONO_HELP_VIEWER=xchm
+	elif [ -f /usr/bin/kchmviewer ]; then
+		export MONO_HELP_VIEWER=kchmviewer
 	fi
 fi
 

--- a/src/BloomExe/HelpLauncher.cs
+++ b/src/BloomExe/HelpLauncher.cs
@@ -79,12 +79,16 @@ namespace Bloom
 			{
 				arguments = String.Format("-showPage \"{0}\" \"{1}\"", helpTopic, helpFile);
 			}
-			else //if (helpViewer == "xchm" || helpViewer == "/usr/bin/xchm")
+			else if (helpViewer == "xchm" || helpViewer == "/usr/bin/xchm")
 			{
-				// xchm is rather dumb: it can't specify a topic on the command line.  (I did post
-				// an issue asking about this: the developer is still active to some degree.)
+				// According to the xchm developer, something like this should work:
+				// xchm file:jdk150.chm#xchm:/jdk150/api/java/applet/package-summary.html
+				arguments = String.Format("\"file:{0}#xchm:{1}\"", helpFile, helpTopic);
+			}
+			else
+			{
 				// We don't know anything about any other viewers, but assume the help file is okay.
-				arguments = String.Format ("\"{0}\"", helpFile);
+				arguments = String.Format("\"{0}\"", helpFile);
 			}
 			try
 			{


### PR DESCRIPTION
Also remove an unneeded Linux dependency.  mono4-sil and libgdiplus4-sil
provide everything mono related needed by Bloom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3279)
<!-- Reviewable:end -->
