### PR TITLE
Fix yellow crash caused by publishing with no cover image (BL-7329)

### DIFF
--- a/src/BloomExe/Book/BookCompressor.cs
+++ b/src/BloomExe/Book/BookCompressor.cs
@@ -240,7 +240,7 @@ namespace Bloom.Book
 			var transparentImageFiles = new List<string>();
 			foreach (var div in xmlDom.SafeSelectNodes("//div[contains(concat(' ',@class,' '),' coverColor ')]//div[contains(@class,'bloom-imageContainer')]").Cast<XmlElement>())
 			{
-				var style = div.GetStringAttribute("style");
+				var style = div.GetAttribute("style");
 				if (!String.IsNullOrEmpty(style) && style.Contains(kBackgroundImage))
 				{
 					System.Diagnostics.Debug.Assert(div.GetStringAttribute("class").Contains("bloom-backgroundImage"));


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3284)
<!-- Reviewable:end -->
