### PR TITLE
Fix unit tests with a hack (BL-7300)

### DIFF
--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -273,6 +273,14 @@ namespace Bloom.Publish.Epub
 				// But don't have time for now.
 				_book = PublishHelper.MakeDeviceXmatterTempBook(_book.FolderPath, _bookServer, tempBookPath, _omittedPageLabels);
 			}
+			else if (Program.RunningUnitTests)
+			{
+				// HACK alert!
+				// Previous to BL-7300, EpubMaker called FixDivOrdering directly, so unit tests ordered them correctly.
+				// The code for BL-7300 moved the call into BringBookUpToDate which is called by MakeDeviceXmatterTempBook above.
+				// Since unit tests do not call MakeDeviceXmatterTempBook, we need to fix the ordering directly.
+				_book.OurHtmlDom.FixDivOrdering();
+			}
 
 			// The readium control remembers the current page for each book.
 			// So it is useful to have a unique name for each one.


### PR DESCRIPTION
Ok, so this is obviously less than ideal.
(I think) the real solution is to have the unit tests actually call MakeDeviceXmatterTempBook, but someone in the past decided this was too hard at that time.
But we have broken tests now... (my fault for not checking before making the previous PR).
So we probably need to merge this and make a card which I will pick up to get the tests running MakeDeviceXmatterTempBook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3315)
<!-- Reviewable:end -->
