### PR TITLE
Redo handling lang attributes and css for collection settings (BL-7343)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1069,15 +1069,6 @@ namespace Bloom.Book
 				RobustFile.Copy(Path.Combine(Path.GetDirectoryName(FolderPath), kCustomStyles), Path.Combine(FolderPath, kCustomStyles), true);
 			// Update book settings from collection settings
 			UpdateCollectionSettingsInBookMetaData();
-			// Set primary book language attributes.
-			foreach (XmlElement body in bookDom.SafeSelectNodes("//body"))
-			{
-				body.SetAttribute("lang", CollectionSettings.Language1Iso639Code);
-			}
-			foreach (XmlElement pageDiv in bookDom.SafeSelectNodes("//div[contains(@class,'bloom-page')]"))
-			{
-				pageDiv.SetAttribute("lang", CollectionSettings.Language1Iso639Code);
-			}
 		}
 
 		private void CreateOrUpdateDefaultLangStyles()
@@ -1111,6 +1102,8 @@ namespace Bloom.Book
 					}
 					if (copyCurrentRule)
 						cssBuilder.AppendLine(cssLines[index]);
+					if (line == "}")
+						copyCurrentRule = false;
 				}
 			}
 			RobustFile.WriteAllText(path, cssBuilder.ToString());

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -521,6 +521,8 @@ namespace Bloom.Collection
 			var sb = new StringBuilder();
 			sb.AppendLine("/* *** DO NOT EDIT! ***   These styles are controlled by the Settings dialog box in Bloom. */");
 			sb.AppendLine("/* They may be over-ridden by rules in customCollectionStyles.css or customBookStyles.css */");
+			// note: css pseudo elements  cannot have a @lang attribute. So this is needed to show page numbers in scripts not covered by Andika New Basic.
+			AddSelectorCssRule(sb, ".numberedPage::after", DefaultLanguage1FontName, IsLanguage1Rtl, Language1LineHeight, Language1BreaksLinesOnlyAtSpaces, omitDirection);
 			AddSelectorCssRule(sb, "[lang='" + Language1Iso639Code + "']", DefaultLanguage1FontName, IsLanguage1Rtl, Language1LineHeight, Language1BreaksLinesOnlyAtSpaces, omitDirection);
 			if (Language2Iso639Code != Language1Iso639Code)
 				AddSelectorCssRule(sb, "[lang='" + Language2Iso639Code + "']", DefaultLanguage2FontName, IsLanguage2Rtl, Language2LineHeight, Language2BreaksLinesOnlyAtSpaces, omitDirection);


### PR DESCRIPTION
This applies to uploading to BloomLibrary and to creating BloomPacks, and
is needed for backward compatibility with Bloom 4.5 and earlier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3324)
<!-- Reviewable:end -->
