### PR TITLE
Add meta[@name="creator"] for use by harvester in bloomd files (BL-7409)

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -217,6 +217,19 @@ namespace Bloom.Book
 			return element;
 		}
 
+		public void AddOrReplaceMetaElement(string name, string content)
+		{
+			var meta = _dom.SelectSingleNode($"/html/head/meta[@name='{name}']") as XmlElement;
+			if (meta != null)
+			{
+				meta.SetAttribute("content", content);
+				return;
+			}
+			meta = Head.AppendChild(_dom.CreateElement("meta")) as XmlElement;
+			meta.SetAttribute("name", name);
+			meta.SetAttribute("content", content);
+		}
+
 		public void AddJavascriptFileToBody(string pathToJavascript)
 		{
 			Body.AppendChild(MakeJavascriptElement(pathToJavascript));

--- a/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
+++ b/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
@@ -26,23 +26,23 @@ namespace Bloom.Publish.Android
 
 		public static Control ControlForInvoke { get; set; }
 
-		public static void CreateBloomReaderBook(string outputPath, Book.Book book, BookServer bookServer, Color backColor, WebSocketProgress progress)
+		public static void CreateBloomDigitalBook(string outputPath, Book.Book book, BookServer bookServer, Color backColor, WebSocketProgress progress)
 		{
-			CreateBloomReaderBook(outputPath, book.FolderPath, bookServer, backColor, progress, book.CollectionSettings.HaveEnterpriseFeatures);
+			CreateBloomDigitalBook(outputPath, book.FolderPath, bookServer, backColor, progress, book.CollectionSettings.HaveEnterpriseFeatures);
 		}
 
 		// Create a BloomReader book while also creating the temporary folder for it (according to the specified parameter) and disposing of it
-		public static void CreateBloomReaderBook(string outputPath, string bookFolderPath, BookServer bookServer, Color backColor,
+		public static void CreateBloomDigitalBook(string outputPath, string bookFolderPath, BookServer bookServer, Color backColor,
 			WebSocketProgress progress, bool hasEnterpriseFeatures, string tempFolderName = "BloomReaderExport")
 		{
 			using (var temp = new TemporaryFolder(tempFolderName))
 			{
-				CreateBloomReaderBook(outputPath, bookFolderPath, bookServer, backColor, progress, temp, hasEnterpriseFeatures);
+				CreateBloomDigitalBook(outputPath, bookFolderPath, bookServer, backColor, progress, temp, hasEnterpriseFeatures);
 			}
 		}
 
 		/// <summary>
-		/// Create a BloomReader book (the zipped .bloomd file)
+		/// Create a Bloom Digital book (the zipped .bloomd file) as used by BloomReader (and Bloom Library etc)
 		/// </summary>
 		/// <param name="outputPath">The path to create the zipped .bloomd output file at</param>
 		/// <param name="bookFolderPath">The path to the input book</param>
@@ -51,11 +51,12 @@ namespace Bloom.Publish.Android
 		/// <param name="progress"></param>
 		/// <param name="tempFolder">A temporary folder. This function will not dispose of it when done</param>
 		/// <param name="hasEnterpriseFeatures"></param>
+		/// <param name="creator">value for &lt;meta name="creator" content="..."/&gt; (defaults to "bloom")</param>
 		/// <returns>Path to the unzipped .bloomd</returns>
-		public static string CreateBloomReaderBook(string outputPath, string bookFolderPath, BookServer bookServer, Color backColor,
-			WebSocketProgress progress, TemporaryFolder tempFolder, bool hasEnterpriseFeatures = false)
+		public static string CreateBloomDigitalBook(string outputPath, string bookFolderPath, BookServer bookServer, Color backColor,
+			WebSocketProgress progress, TemporaryFolder tempFolder, bool hasEnterpriseFeatures = false, string creator="bloom")
 		{
-			var modifiedBook = PrepareBookForBloomReader(bookFolderPath, bookServer, tempFolder, progress, hasEnterpriseFeatures);
+			var modifiedBook = PrepareBookForBloomReader(bookFolderPath, bookServer, tempFolder, progress, hasEnterpriseFeatures, creator);
 			// We want at least 256 for Bloom Reader, because the screens have a high pixel density. And (at the moment) we are asking for
 			// 64dp in Bloom Reader.
 
@@ -68,7 +69,7 @@ namespace Bloom.Publish.Android
 		}
 
 		public static Book.Book PrepareBookForBloomReader(string bookFolderPath, BookServer bookServer, TemporaryFolder temp,
-			WebSocketProgress progress, bool hasEnterpriseFeatures)
+			WebSocketProgress progress, bool hasEnterpriseFeatures, string creator="bloom")
 		{
 			// MakeDeviceXmatterTempBook needs to be able to copy customCollectionStyles.css etc into parent of bookFolderPath
 			// And bloom-player expects folder name to match html file name.
@@ -114,6 +115,7 @@ namespace Bloom.Publish.Android
 			modifiedBook.SetAnimationDurationsFromAudioDurations();
 
 			modifiedBook.OurHtmlDom.SetMedia("bloomReader");
+			modifiedBook.OurHtmlDom.AddOrReplaceMetaElement("bloom-digital-creator", creator);
 			EmbedFonts(modifiedBook, progress, new FontFileFinder());
 
 			var bookFile = BookStorage.FindBookHtmlInFolder(modifiedBook.FolderPath);

--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -315,7 +315,7 @@ namespace Bloom.Publish.Android
 				// wifi or usb...make the .bloomd in a temp folder.
 				using (var bloomdTempFile = TempFile.WithFilenameInTempFolder(publishedFileName))
 				{
-					BloomReaderFileMaker.CreateBloomReaderBook(bloomdTempFile.Path, book, bookServer, backColor, progress);
+					BloomReaderFileMaker.CreateBloomDigitalBook(bloomdTempFile.Path, book, bookServer, backColor, progress);
 					sendAction(publishedFileName, bloomdTempFile.Path);
 					if (confirmFunction != null && !confirmFunction(publishedFileName))
 						throw new ApplicationException("Book does not exist after write operation.");
@@ -326,7 +326,7 @@ namespace Bloom.Publish.Android
 			{
 				// save file...user has supplied name, there is no further action.
 				Debug.Assert(sendAction == null, "further actions are not supported when passing a path name");
-				BloomReaderFileMaker.CreateBloomReaderBook(destFileName, book, bookServer, backColor, progress);
+				BloomReaderFileMaker.CreateBloomDigitalBook(destFileName, book, bookServer, backColor, progress);
 				progress.Message("PublishTab.Epub.Done", "Done", useL10nIdPrefix: false);	// share message string with epub publishing
 			}
 

--- a/src/BloomTests/Publish/BloomReaderPublishTests.cs
+++ b/src/BloomTests/Publish/BloomReaderPublishTests.cs
@@ -66,7 +66,7 @@ namespace BloomTests.Publish
 
 			using (var bloomdTempFile = TempFile.WithFilenameInTempFolder(testBook.Title + BookCompressor.ExtensionForDeviceBloomBook))
 			{
-				BloomReaderFileMaker.CreateBloomReaderBook(bloomdTempFile.Path, testBook, _bookServer, Color.Azure, new NullWebSocketProgress());
+				BloomReaderFileMaker.CreateBloomDigitalBook(bloomdTempFile.Path, testBook, _bookServer, Color.Azure, new NullWebSocketProgress());
 				Assert.AreEqual(testBook.Title + BookCompressor.ExtensionForDeviceBloomBook,
 					Path.GetFileName(bloomdTempFile.Path));
 			}
@@ -1266,7 +1266,7 @@ namespace BloomTests.Publish
 
 			using (var bloomdTempFile = TempFile.WithFilenameInTempFolder(testBook.Title + BookCompressor.ExtensionForDeviceBloomBook))
 			{
-				BloomReaderFileMaker.CreateBloomReaderBook(bloomdTempFile.Path, testBook, _bookServer, Color.Azure, new NullWebSocketProgress());
+				BloomReaderFileMaker.CreateBloomDigitalBook(bloomdTempFile.Path, testBook, _bookServer, Color.Azure, new NullWebSocketProgress());
 				var zip = new ZipFile(bloomdTempFile.Path);
 				var newHtml = GetEntryContents(zip, bookFileName);
 				var paramObj = new ZipHtmlObj(zip, newHtml);
@@ -1278,7 +1278,7 @@ namespace BloomTests.Publish
 					using (var extraTempFile =
 						TempFile.WithFilenameInTempFolder(testBook.Title + "2" + BookCompressor.ExtensionForDeviceBloomBook))
 					{
-						BloomReaderFileMaker.CreateBloomReaderBook(extraTempFile.Path, testBook, _bookServer, Color.Azure, new NullWebSocketProgress());
+						BloomReaderFileMaker.CreateBloomDigitalBook(extraTempFile.Path, testBook, _bookServer, Color.Azure, new NullWebSocketProgress());
 						zip = new ZipFile(extraTempFile.Path);
 						assertionsOnRepeat(zip);
 					}


### PR DESCRIPTION
The default value is "bloom" to indicate the .bloomd was built by the
Bloom desktop app.  BloomHarvester will set the value as "harvester". (in
a separate bloom-harvester commit, of course)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3328)
<!-- Reviewable:end -->
