### PR TITLE
Remove obsolete talking book tags when making bloomd (BL-7434)

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1861,6 +1861,19 @@ namespace Bloom.Book
 			element.SetAttribute("class", newClassAttributeValue);
 		}
 
+		/// <summary>
+		/// Move the content of the element to its parent, then remove the now-empty element.
+		/// </summary>
+		public static void RemoveElementLayer(XmlElement element)
+		{
+			foreach (var node in element.ChildNodes.Cast<XmlNode>().ToList())
+			{
+				element.RemoveChild(node);
+				element.ParentNode.InsertBefore(node, element);
+			}
+			element.ParentNode.RemoveChild(element);
+		}
+
 		public static XmlNodeList SelectChildImgAndBackgroundImageElements(XmlElement element)
 		{
 			return element.SelectNodes(".//img | .//*[contains(@style,'background-image')]");

--- a/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
+++ b/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
@@ -108,6 +108,7 @@ namespace Bloom.Publish.Android
 			if (RobustFile.Exists(Path.Combine(modifiedBookFolderPath, "placeHolder.png")))
 				RobustFile.Delete(Path.Combine(modifiedBookFolderPath, "placeHolder.png"));
 			modifiedBook.Storage.CleanupUnusedAudioFiles(isForPublish: true);
+			modifiedBook.RemoveObsoleteAudioMarkup();
 			PublishHelper.SetTalkingBookFeature(modifiedBook, modifiedBook.Storage.BookInfo.MetaData);
 			modifiedBook.Storage.CleanupUnusedVideoFiles();
 			PublishHelper.SetSignLanguageFeature(modifiedBook, modifiedBook.Storage.BookInfo.MetaData);


### PR DESCRIPTION
This relieves bloom-player of slow checks for nonexistent audio files.
Note that this markup is added just by opening the Talking Book tool even
when no sound is ever recorded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3330)
<!-- Reviewable:end -->
