### PR TITLE
Talking Book: Fix bug where blue split highlight removed (BL-7548)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -34,7 +34,10 @@ div.ui-audioCurrent:not(.disableHighlight) p {
     }
 }
 .ui-audioCurrent.bloom-postAudioSplit[data-audiorecordingmode="TextBox"]:not(.disableHighlight) {
-    // Special higlighting after the Split button completes to show it completed.
+    // Special highlighting after the Split button completes to show it completed.
+    // Note: This highlighting is expected to persist across sessions, but to be hidden (displayed with the yellow color) while each segment is playing.
+    //       This is accomplished because this rule temporarily drops out of effect when .ui-audioCurrent is moved to the span as that segment plays.
+    //       (The rule requires a span BELOW the .ui-audioCurrent, so it drops out of effect the span IS the .ui-audioCurrent).
     span:nth-child(3n + 1) {
         background-color: #bfedf3;
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -988,8 +988,6 @@ export default class AudioRecording {
         if (this.audioRecordingMode == AudioRecordingMode.TextBox) {
             const currentTextBox = this.getCurrentTextBox();
             if (currentTextBox) {
-                currentTextBox.classList.remove("bloom-postAudioSplit");
-
                 const audioSegments = this.getAudioSegmentsWithinElement(
                     currentTextBox
                 );


### PR DESCRIPTION
Fix problem where the class responsible for enabling the highlights is removed when playing the audio happens (and never added back on either).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3346)
<!-- Reviewable:end -->
