### PR TITLE
Preserve book title whitespace properly (BL-7558)

### DIFF
--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -1249,10 +1249,11 @@ namespace Bloom.Book
 		/// <returns></returns>
 		internal static string TextOfInnerHtml(string input)
 		{
-			// Parsing it as XML and then extracting the value removes any markup.
-			var doc = XElement.Parse("<doc>" + input + "</doc>");
-			// DataDiv can get newline between <p> and <span>, which leaves \n in place
-			// at beginning and end when an unwanted audio span is removed.  See BL-7558.
+			// Parsing it as XML and then extracting the value removes any markup.  Internal
+			// spaces might disappear if we don't preserve whitespace during the parse.
+			var doc = XElement.Parse("<doc>" + input + "</doc>", LoadOptions.PreserveWhitespace);
+			// Leading and trailing whitespace are undesireable for the title even if the user has
+			// put them in for some strange reason.  (BL-7558)
 			return doc.Value.Trim();
 		}
 

--- a/src/BloomExe/XmlHtmlConverter.cs
+++ b/src/BloomExe/XmlHtmlConverter.cs
@@ -41,9 +41,9 @@ namespace Bloom
 			//That is fixed now, but this is needed to give to clean up existing books.
 			content = content.Replace(@"REMOVEWHITESPACE", "");
 
-			// It also likes to insert newlines before <b>, <u>, and <i>, and convert any existing whitespace
-			// there to a space.
-			content = new Regex(@"<([ubi]|em|strong|sup|sub)>").Replace(content, "REMOVEWHITESPACE<$1>");
+			// tidy likes to insert newlines before <b>, <u>, <i>, and these other elements and convert any existing whitespace
+			// there to a space.  (span was found by pursuing BL-7558)
+			content = new Regex(@"<([ubi]|em|strong|sup|sub|span[^>]*)>").Replace(content, "REMOVEWHITESPACE<$1>");
 
 			// fix for <br></br> tag doubling
 			content = content.Replace("<br></br>", "<br />");
@@ -106,9 +106,9 @@ namespace Bloom
 						newContents = newContents.Replace("&nbsp;", "&#160;");
 						//REVIEW: 1) are there others? &amp; and such are fine.  2) shoul we to convert back to &nbsp; on save?
 
-						// The regex here is mainly for the \s as a convenient way to remove whatever whitespace TIDY
-						// has inserted. It's a fringe benefit that we can use the[bi] to deal with both elements in one replace.
-						newContents = Regex.Replace(newContents, @"REMOVEWHITESPACE\s*<([biu]|em|strong|sup|sub)>", "<$1>");
+						// The regex here is mainly for the \s* as a convenient way to remove whatever whitespace TIDY
+						// has inserted. It's a fringe benefit that we can use the[biu]|... to deal with all these elements in one replace.
+						newContents = Regex.Replace(newContents, @"REMOVEWHITESPACE\s*<([biu]|em|strong|sup|sub|span[^>]*)>", "<$1>");
 
 						//In BL2250, we still had REMOVEWHITESPACE sticking around sometimes. The way we reproduced it was
 						//with <u> </u>. That is, we started with

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -61,6 +61,14 @@ namespace BloomTests.Book
 		}
 
 		[Test]
+		public void TextOfInnerHtml_HandlesSpansProperly()
+		{
+			var input = "<p><strong><span class='x'>01.</span></strong> <span class='y'>The Creation</span></p>";
+			var output = BookData.TextOfInnerHtml(input);
+			Assert.That(output, Is.EqualTo("01. The Creation"));
+		}
+
+		[Test]
 		public void TextOfInnerHtml_HandlesXmlEscapesCorrectly()
 		{
 			var input = "Jack &amp; Jill like xml sequences like &amp;amp; &amp; &amp;lt; &amp; &amp;gt; for characters like &lt;&amp;&gt;";

--- a/src/BloomTests/XmlHtmlConverterTests.cs
+++ b/src/BloomTests/XmlHtmlConverterTests.cs
@@ -246,6 +246,14 @@ namespace BloomTests
 		}
 
 		[Test]
+		public void GetXmlDomFromHtml_HasSpans_PreserveSpacesBetween()
+		{
+			const string html = "<!DOCTYPE html><html><head></head><body><div><p>one <span class=\"x\">two</span> <span class=\"y\">three</span> <span class =\"z\">four</span> five</p></div></body></html>";
+			var dom = XmlHtmlConverter.GetXmlDomFromHtml(html, false);
+			Assert.That(dom.InnerXml, Does.Contain("<p>one <span class=\"x\">two</span> <span class=\"y\">three</span> <span class=\"z\">four</span> five</p>"));
+		}
+
+		[Test]
 		public void GetXmlDomFromHtml_HasEmptyParagraphs_RetainsEmptyParagraphs()
 		{
 			var pattern = "<p></p><p></p><p>a</p><p></p><p>b</p>";


### PR DESCRIPTION
libtidy introduces newlines before every span, which usually doesn't
matter a whole lot unless you really don't want them...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3371)
<!-- Reviewable:end -->
