### PR TITLE
Prevent some javascript errors which cause TeamCity test failures when using Geckofx60

### DIFF
--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -24,6 +24,7 @@ using Bloom.Collection;
 using Bloom.Edit;
 using Bloom.Publish.Epub;
 using Bloom.Properties;
+using Bloom.Publish;
 using Bloom.Publish.Android;
 using Bloom.web;
 using SIL.PlatformUtilities;
@@ -279,6 +280,18 @@ namespace Bloom.Api
 				var placeHolderNode = dom.RawDom.CreateElement("div");
 				placeHolderNode.InnerXml = vidPlaceHolderDivContents;
 				placeHolderNode.SetAttribute("class", "bloom-imageContainer");
+
+				// When we get to this point and we are creating an epub, we have already generated the
+				// temporary IDs needed to determine element visibility. We need to maintain the ID
+				// so we don't try to look up IDs in the dom which don't exist and throw a js error.
+				var vidNodeIdAttribute = vidNode.Attributes["id"];
+				if (vidNodeIdAttribute != null)
+				{
+					var vidNodeId = vidNodeIdAttribute.Value;
+					if (!string.IsNullOrEmpty(vidNodeId) && vidNodeId.StartsWith(PublishHelper.kTempIdMarker))
+						placeHolderNode.SetAttribute("id", vidNodeId);
+				}
+
 				vidNode.ParentNode.ReplaceChild(placeHolderNode, vidNode);
 			}
 		}

--- a/src/BloomTests/Publish/BloomReaderPublishTests.cs
+++ b/src/BloomTests/Publish/BloomReaderPublishTests.cs
@@ -670,7 +670,9 @@ namespace BloomTests.Publish
 		private void NewQuizTestActionsOnFolderBeforeCompressing(string bookFolderPath)
 		{
 			// This file gets placed in the real book's folder after adding a quiz in edit mode, so we mock that process.
-			RobustFile.WriteAllText(Path.Combine(bookFolderPath, PublishHelper.kSimpleComprehensionQuizJs), "not the real file's contents");
+			// But the code which puts an epub into a real browser to determine visibility of elements will actually
+			// try to run this, so it needs to be something which won't throw a javascript error.
+			RobustFile.WriteAllText(Path.Combine(bookFolderPath, PublishHelper.kSimpleComprehensionQuizJs), "//not the real file's contents");
 		} 
 
 		[Test]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3377)
<!-- Reviewable:end -->
