### PR TITLE
Fix a couple of spots disposing of GeckoWebBrowser objects (20190916)

### DIFF
--- a/src/BloomExe/Edit/Configurator.cs
+++ b/src/BloomExe/Edit/Configurator.cs
@@ -148,8 +148,7 @@ namespace Bloom.Edit
 			Cursor.Current = Cursors.WaitCursor;
 			try
 			{
-				browser.DocumentCompleted -= browser_DocumentNavigated;
-				browser.DocumentCompleted += browser_DocumentNavigated;
+				browser.DocumentCompleted += browser_DocumentCompleted;
 
 				_isolator.Navigate(browser, url);
 
@@ -174,11 +173,13 @@ namespace Bloom.Edit
 			}
 			finally
 			{
+				// Ensure this doesn't get added multiple times, or fire on a disposed browser.
+				browser.DocumentCompleted -= browser_DocumentCompleted;
 				Cursor.Current = Cursors.Default;
 			}
 		}
 
-		void browser_DocumentNavigated(object sender, EventArgs e)
+		void browser_DocumentCompleted(object sender, EventArgs e)
 		{
 			((GeckoWebBrowser)sender).Tag = sender;
 		}

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -146,6 +146,12 @@ namespace Bloom.Publish
 			// if it is active, is removed (hence deactivated) and disposed.
 			SetDisplayMode(PublishModel.DisplayModes.WaitForUserToChooseSomething);
 			// This is only supposed to be active in one mode of PublishView.
+			if (_htmlControl != null)
+			{
+				Controls.Remove(_htmlControl);
+				_htmlControl.Dispose();
+				_htmlControl = null;
+			}
 			Browser.SuppressJavaScriptErrors = false;
 			Browser.ClearCache(); // of anything used in publish mode; may help free memory.
 			PublishHelper.Cancel();


### PR DESCRIPTION
I also renamed an event handler method that didn't match the event name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3389)
<!-- Reviewable:end -->
