### PR TITLE
Fix Linux package dependencies (20190927)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
 
 Package: bloom-desktop
 Architecture: any
-Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
+Depends: ${shlibs:Depends}, ${misc:Depends},
  mono4-sil, libgdiplus4-sil, gtk-sharp4-sil, gtklp,
  chmsee, libtidy-sil,
  fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,


### PR DESCRIPTION
For some reason, the xenial package was being built with unobtainable
dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3397)
<!-- Reviewable:end -->
