### PR TITLE
Test TeamCity setup for detecting test failures on Linux (20190930)

### DIFF
--- a/src/BloomTests/BloomFileLocatorTests.cs
+++ b/src/BloomTests/BloomFileLocatorTests.cs
@@ -56,6 +56,14 @@ namespace BloomTests
 			_otherFilesForTestingFolder.Dispose();
 		}
 
+		[Test]
+		public void THISTESTSHOULDALWAYSFAIL()
+		{
+			var Truth = true;
+			var Lie = false;
+			Assert.That(Truth, Is.EqualTo(Lie), "This test is supposed to fail...");
+		}
+
 		/// <summary>
 		/// This factory CSS is also found in various factory templates.
 		/// </summary>


### PR DESCRIPTION
The current (possibly temporary) setup apparently handles the problem of
false positives for test failure.  This (extremely temporary) hack tests
whether that setup correctly handles true test failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3399)
<!-- Reviewable:end -->
