### PR TITLE
Conditionally allow the about:memory window in release builds

### DIFF
--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -556,8 +556,13 @@ namespace Bloom
 			if(FFMenuItem == null)
 				AddOpenPageInFFItem(e);
 #if DEBUG
-			AddOtherMenuItemsForDebugging(e);
+			var _addDebuggingMenuItems = true;
+#else
+			var debugBloom = Environment.GetEnvironmentVariable("DEBUGBLOOM");
+			var _addDebuggingMenuItems = !String.IsNullOrEmpty(debugBloom) && debugBloom.ToLowerInvariant() != "false" && debugBloom.ToLowerInvariant() != "no";
 #endif
+			if (_addDebuggingMenuItems)
+				AddOtherMenuItemsForDebugging(e);
 
 			e.ContextMenu.MenuItems.Add(LocalizationManager.GetString("Browser.CopyTroubleshootingInfo", "Copy Troubleshooting Information"), OnGetTroubleShootingInformation);
 		}
@@ -569,7 +574,6 @@ namespace Bloom
 				OnOpenPageInSystemBrowser);
 		}
 
-#if DEBUG
 		private void AddOtherMenuItemsForDebugging(GeckoContextMenuEventArgs e)
 		{
 			e.ContextMenu.MenuItems.Add("Open about:memory window", OnOpenAboutMemory);
@@ -618,7 +622,6 @@ namespace Bloom
 			form.Navigate("about:cache?storage=&context=");
 			form.Show();    // NOT Modal!
 		}
-#endif
 
 		public void OnGetTroubleShootingInformation(object sender, EventArgs e)
 		{


### PR DESCRIPTION
This requires setting an environment variable DEBUGBLOOM to something
other than "false" or "no" (or "").  This may help in debugging memory
leaks in Geckofx without requiring a debug build of Bloom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3401)
<!-- Reviewable:end -->
