### PR TITLE
Update Geckofx60 and add some explicit garbage collection (20191018)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -119,14 +119,14 @@
     <Reference Include="Geckofx-Core" Condition="'$(OS)'!='Windows_NT'">
       <HintPath>..\..\output\$(Configuration)\Geckofx-Core.dll</HintPath>
     </Reference>
-    <Reference Include="Geckofx-Core, Version=60.0.39.0, Culture=neutral, PublicKeyToken=3209ac31600d1857, processorArchitecture=x86" Condition="'$(OS)'=='Windows_NT'">
-      <HintPath>..\..\packages\Geckofx60.32.60.0.39\lib\net45\Geckofx-Core.dll</HintPath>
+    <Reference Include="Geckofx-Core, Version=60.0.42.0, Culture=neutral, PublicKeyToken=3209ac31600d1857, processorArchitecture=x86" Condition="'$(OS)'=='Windows_NT'">
+      <HintPath>..\..\packages\Geckofx60.32.60.0.42\lib\net45\Geckofx-Core.dll</HintPath>
     </Reference>
     <Reference Include="Geckofx-Winforms" Condition="'$(OS)'!='Windows_NT'">
       <HintPath>..\..\output\$(Configuration)\Geckofx-Winforms.dll</HintPath>
     </Reference>
-    <Reference Include="Geckofx-Winforms, Version=60.0.39.0, Culture=neutral, PublicKeyToken=3209ac31600d1857, processorArchitecture=x86" Condition="'$(OS)'=='Windows_NT'">
-      <HintPath>..\..\packages\Geckofx60.32.60.0.39\lib\net45\Geckofx-Winforms.dll</HintPath>
+    <Reference Include="Geckofx-Winforms, Version=60.0.42.0, Culture=neutral, PublicKeyToken=3209ac31600d1857, processorArchitecture=x86" Condition="'$(OS)'=='Windows_NT'">
+      <HintPath>..\..\packages\Geckofx60.32.60.0.42\lib\net45\Geckofx-Winforms.dll</HintPath>
     </Reference>
     <Reference Include="Glob, Version=0.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Glob.0.4.0\lib\net46\Glob.dll</HintPath>
@@ -1316,7 +1316,7 @@ cp -p "$(SolutionDir)lib/dotnet/GeckofxHtmlToPdf.exe.config" "$(OutDir)BloomPdfM
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="BeforeBuild" Condition="'$(OS)'=='Windows_NT'">
     <Exec Command="mkdir $(OutDir)Firefox" Condition="!Exists('$(OutDir)Firefox')" />
-    <Exec Command="copy /Y $(SolutionDir)packages\Geckofx60.32.60.0.39\content\Firefox\*.* $(OutDir)Firefox" />
+    <Exec Command="copy /Y $(SolutionDir)packages\Geckofx60.32.60.0.42\content\Firefox\*.* $(OutDir)Firefox" />
   </Target>
   <!-- these operations cannot all be done BeforeBuild, because the nuget download occurs as part of Build after BeforeBuild -->
   <Target Name="BeforeResolveReferences" Condition="'$(OS)'!='Windows_NT'">
@@ -1325,7 +1325,7 @@ cp -p "$(SolutionDir)lib/dotnet/GeckofxHtmlToPdf.exe.config" "$(OutDir)BloomPdfM
     <!-- copy the appropriate Geckofx60 files to the output directory, first creating it if necessary -->
     <Exec Command="mkdir -p $(OutDir)" />
     <Exec Command="rm -rf $(OutDir)Firefox" />
-    <Exec Command="find $(SolutionDir)packages/Geckofx60.64.Linux.60.0.39 -name 'Geckofx-*.*' -exec cp -pvn '{}' $(OutDir) ';' &amp;&amp; find $(SolutionDir)packages/Geckofx60.64.Linux.60.0.39 -name Firefox* -type d -exec cp -pRvn '{}' $(OutDir)/Firefox ';';" />
+    <Exec Command="find $(SolutionDir)packages/Geckofx60.64.Linux.60.0.42 -name 'Geckofx-*.*' -exec cp -pvn '{}' $(OutDir) ';' &amp;&amp; find $(SolutionDir)packages/Geckofx60.64.Linux.60.0.42 -name Firefox* -type d -exec cp -pRvn '{}' $(OutDir)/Firefox ';';" />
   </Target>
   <ItemGroup>
     <BasicBookCssFiles Include="..\..\DistFiles\factoryCollections\Templates\Basic Book\*.css" />
@@ -1433,13 +1433,13 @@ cp -p "$(SolutionDir)lib/dotnet/GeckofxHtmlToPdf.exe.config" "$(OutDir)BloomPdfM
     <Copy SourceFiles="@(BloomPdfMakerArgs)" DestinationFolder="$(OutDir)" />
     <Copy SourceFiles="@(IccFiles)" DestinationFolder="$(OutDir)/ColorProfiles" />
   </Target>
-  <Import Project="..\..\packages\Geckofx60.32.60.0.39\build\Geckofx60.32.targets" Condition="Exists('..\..\packages\Geckofx60.32.60.0.39\build\Geckofx60.32.targets')" />
-  <Import Project="../../packages/Geckofx60.64.Linux.60.0.39/build/Geckofx60.64.Linux.targets" Condition="Exists('../../packages/Geckofx60.64.Linux.60.0.39/build/Geckofx60.64.Linux.targets')" />
+  <Import Project="..\..\packages\Geckofx60.32.60.0.42\build\Geckofx60.32.targets" Condition="Exists('..\..\packages\Geckofx60.32.60.0.42\build\Geckofx60.32.targets')" />
+  <Import Project="../../packages/Geckofx60.64.Linux.60.0.42/build/Geckofx60.64.Linux.targets" Condition="Exists('../../packages/Geckofx60.64.Linux.60.0.42/build/Geckofx60.64.Linux.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="'$(OS)'=='Windows_NT' AND !Exists('..\..\packages\Geckofx60.32.60.0.39\build\Geckofx60.32.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Geckofx60.32.60.0.39\build\Geckofx60.32.targets'))" />
-    <Error Condition="'$(OS)'!='Windows_NT' AND !Exists('../../packages/Geckofx60.64.Linux.60.0.39/build/Geckofx60.64.Linux.targets')" Text="$([System.String]::Format('$(ErrorText)', '../../packages/Geckofx60.64.Linux.60.0.39/build/Geckofx60.64.Linux.targets'))" />
+    <Error Condition="'$(OS)'=='Windows_NT' AND !Exists('..\..\packages\Geckofx60.32.60.0.42\build\Geckofx60.32.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Geckofx60.32.60.0.42\build\Geckofx60.32.targets'))" />
+    <Error Condition="'$(OS)'!='Windows_NT' AND !Exists('../../packages/Geckofx60.64.Linux.60.0.42/build/Geckofx60.64.Linux.targets')" Text="$([System.String]::Format('$(ErrorText)', '../../packages/Geckofx60.64.Linux.60.0.42/build/Geckofx60.64.Linux.targets'))" />
   </Target>
 </Project>

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -569,6 +569,9 @@ namespace Bloom.Edit
 			ChangingPages = false;
 			_model.DocumentCompleted();
 			_browser1.Focus(); //fix BL-3078 No Initial Insertion Point when any page shown
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			MemoryService.MinimizeHeap(true);
 #if MEMORYCHECK
 			// Check memory for the benefit of developers.
 			SIL.Windows.Forms.Reporting.MemoryManagement.CheckMemory(false, "EditingView - display page updated", false);

--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -26,7 +26,7 @@
     <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
     <package id="TechTalk.JiraRestClient.RestSharp105" version="2.3.0.1" targetFramework="net461" />
     <!-- Linux specific packages.  Changes above this line must be copied to ../packages.config -->
-    <!--package id="Geckofx60.32.Linux" version="60.0.36" targetFramework="net461" /-->
-    <package id="Geckofx60.64.Linux" version="60.0.39" targetFramework="net461" />
+    <!--package id="Geckofx60.32.Linux" version="60.0.42" targetFramework="net461" /-->
+    <package id="Geckofx60.64.Linux" version="60.0.42" targetFramework="net461" />
     <package id="SharpFont" version="3.1.0" targetFramework="net461" />
 </packages>

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -27,5 +27,5 @@
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
   <package id="TechTalk.JiraRestClient.RestSharp105" version="2.3.0.1" targetFramework="net461" />
   <!-- Windows specific packages.  Changes above this line must be copied to Linux/packages.config -->
-  <package id="Geckofx60.32" version="60.0.39" targetFramework="net461" />
+  <package id="Geckofx60.32" version="60.0.42" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
The new Geckofx60 package fixes the worst of the Gecko window/memory leaks
that I've observed.  Memory consumption is now on a par with Geckofx45 in
initial testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3406)
<!-- Reviewable:end -->
