### PR TITLE
Fix two causes of thumbnail creation to fail (BL-7792)

### DIFF
--- a/src/BloomExe/BookThumbNailer.cs
+++ b/src/BloomExe/BookThumbNailer.cs
@@ -125,7 +125,8 @@ namespace Bloom
 					imageSrc = transparentImageFile;
 				using (var coverImage = PalasoImage.FromFile(imageSrc))
 				{
-					coverImage.Image = MakeImageOpaque(coverImage.Image, book.GetCoverColor());
+					if (imageSrc == transparentImageFile)
+						coverImage.Image = MakeImageOpaque(coverImage.Image, book.GetCoverColor());
 					if (options.CenterImageUsingTransparentPadding)
 						coverImage.Image = ImageUtils.CenterImageIfNecessary(new Size(size, size), coverImage.Image);
 					else

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -27,6 +27,7 @@ namespace Bloom.CollectionTab
 	{
 		private const int ButtonHeight = 112;
 		private const int ButtonWidth = 92;
+		private readonly Size MaxThumbnailSize = new Size(HtmlThumbNailer.ThumbnailOptions.DefaultHeight, HtmlThumbNailer.ThumbnailOptions.DefaultHeight);
 
 		public delegate LibraryListView Factory();//autofac uses this
 
@@ -1007,7 +1008,7 @@ namespace Bloom.CollectionTab
 					var button = FindBookButton(bookInfo);
 					if (button == null || button.IsDisposed)
 						return; // I (gjm) found that this condition occurred sometimes when testing BL-6100
-					image = ImageUtils.ResizeImageIfNecessary(button.Size, image);
+					image = ImageUtils.CenterImageIfNecessary(MaxThumbnailSize, image);
 					_bookThumbnails.Images[imageIndex] = image;
 					button.Image = IsUsableBook(button) ? image : MakeDim(image);
 				}

--- a/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
+++ b/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
@@ -340,14 +340,17 @@ namespace Bloom.ImageProcessing
 		{
 			try
 			{
+				//if it's a jpeg, we don't resize, we don't mess with transparency, nothing. These things
+				//are scary in .net. Just send the original back and wash our hands of it.
+				//If the filename extension claims to be jpeg, assume it's not lying to us and quit.
+				if (ImageUtils.HasJpegExtension(originalPath))
+					return false;
+
 				using (var originalImage = PalasoImage.FromFileRobustly(originalPath))
 				{
-					//if it's a jpeg, we don't resize, we don't mess with transparency, nothing. These things
-					//are scary in .net. Just send the original back and wash our hands of it.
+					// double check whether the file extension was misleading us...
 					if (ImageUtils.AppearsToBeJpeg(originalImage))
-					{
 						return false;
-					}
 
 					using (var processedBitmap = MakePngBackgroundTransparent(originalImage))
 					{


### PR DESCRIPTION
Very large and very small front cover images could lead to failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3443)
<!-- Reviewable:end -->
