### PR TITLE
Factor out LanguageSpec from CollectionSettings

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -306,7 +306,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="CLI\CreateArtifactsCommand.cs" />
-    <Compile Include="Collection\LanguageSpec.cs" />
+    <Compile Include="Collection\WritingSystem.cs" />
     <Compile Include="Publish\Android\BloomReaderFileMaker.cs" />
     <Compile Include="Book\BookSelectionChangedEventArgs.cs" />
     <Compile Include="Book\QuestionGroup.cs" />

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -306,6 +306,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="CLI\CreateArtifactsCommand.cs" />
+    <Compile Include="Collection\LanguageSpec.cs" />
     <Compile Include="Publish\Android\BloomReaderFileMaker.cs" />
     <Compile Include="Book\BookSelectionChangedEventArgs.cs" />
     <Compile Include="Book\QuestionGroup.cs" />

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -374,7 +374,7 @@ namespace Bloom.Book
 		{
 			TranslationGroupManager.UpdateContentLanguageClasses(dom.RawDom, CollectionSettings, CollectionSettings.Language1Iso639Code, _bookData.MultilingualContentLanguage2,
 													 _bookData.MultilingualContentLanguage3);
-			BookInfo.IsRtl = CollectionSettings.IsLanguage1Rtl;
+			BookInfo.IsRtl = CollectionSettings.Language1.IsRightToLeft;
 
 			BookStarter.SetLanguageForElementsWithMetaLanguage(dom.RawDom, CollectionSettings);
 		}
@@ -1022,7 +1022,7 @@ namespace Bloom.Book
 			bookDOM.RemoveMetaElement("SuitableForMakingVernacularBooks", () => null,
 				val => BookInfo.IsSuitableForVernacularLibrary = val == "yes" || val == "definitely");
 
-			bookDOM.UpdatePageNumberAndSideClassOfPages(CollectionSettings.CharactersForDigitsForPageNumbers, CollectionSettings.IsLanguage1Rtl);
+			bookDOM.UpdatePageNumberAndSideClassOfPages(CollectionSettings.CharactersForDigitsForPageNumbers, CollectionSettings.Language1.IsRightToLeft);
 
 			UpdateTextsNewlyChangedToRequiresParagraph(bookDOM);
 
@@ -1077,6 +1077,10 @@ namespace Bloom.Book
 
 		/// <summary>
 		/// Write the appropriate styles to the defaultLangStyles.css file.
+		/// You would normally expect that we just write this afresh, but actually
+		/// we want to preserve font information from languages that are no longer
+		/// part of L1,L2,or L3 but are still in the book and thus may still be
+		/// rendered by Bloom Player.
 		/// </summary>
 		private void CreateOrUpdateDefaultLangStyles()
 		{
@@ -1087,7 +1091,7 @@ namespace Bloom.Book
 				// Would overwrite, but overwrite not allowed in Harvester mode.
 				return;
 			}
-			
+
 			var collectionStylesCss = CollectionSettings.GetCollectionStylesCss(false);
 			var cssBuilder = new StringBuilder(collectionStylesCss);
 			if (doesAlreadyExist)
@@ -1128,14 +1132,14 @@ namespace Bloom.Book
 			BookInfo.MetaData.PageNumberStyle = CollectionSettings.PageNumberStyle;
 			if (BookInfo.MetaData.DisplayNames == null)
 				BookInfo.MetaData.DisplayNames = new Dictionary<string,string>();
-			BookInfo.MetaData.DisplayNames[CollectionSettings.Language1Iso639Code] = CollectionSettings.Language1Name;
+			BookInfo.MetaData.DisplayNames[CollectionSettings.Language1Iso639Code] = CollectionSettings.Language1.Name;
 			if (CollectionSettings.Language2Iso639Code != CollectionSettings.Language1Iso639Code)
-				BookInfo.MetaData.DisplayNames[CollectionSettings.Language2Iso639Code] = CollectionSettings.Language2Name;
+				BookInfo.MetaData.DisplayNames[CollectionSettings.Language2Iso639Code] = CollectionSettings.Language2.Name;
 			if (!String.IsNullOrEmpty(CollectionSettings.Language3Iso639Code) &&
 				CollectionSettings.Language3Iso639Code != CollectionSettings.Language1Iso639Code &&
 				CollectionSettings.Language3Iso639Code != CollectionSettings.Language2Iso639Code)
 			{
-				BookInfo.MetaData.DisplayNames[CollectionSettings.Language3Iso639Code] = CollectionSettings.Language3Name;
+				BookInfo.MetaData.DisplayNames[CollectionSettings.Language3Iso639Code] = CollectionSettings.Language3.Name;
 			}
 			// These settings will be saved to the meta.json file the next time the book itself is saved.
 		}
@@ -1321,7 +1325,7 @@ namespace Bloom.Book
 			// worth using the fullest possible version of updating the book to bring it in line
 			// with the current orientation.
 			//BringXmatterHtmlUpToDate(bookDOM); // wipes out xmatter content!
-			//bookDOM.UpdatePageNumberAndSideClassOfPages(_collectionSettings.CharactersForDigitsForPageNumbers, _collectionSettings.IsLanguage1Rtl);
+			//bookDOM.UpdatePageNumberAndSideClassOfPages(_collectionSettings.CharactersForDigitsForPageNumbers, _collectionSettings.Language1.IsRightToLeft);
 			// // restore xmatter page content from datadiv
 			//var bd = new BookData(bookDOM, _collectionSettings, UpdateImageMetadataAttributes);
 			//bd.SynchronizeDataItemsThroughoutDOM();
@@ -1740,17 +1744,17 @@ namespace Bloom.Book
 		private void InjectStringListingActiveLanguagesOfBook()
 		{
 			string codeOfNationalLanguage = CollectionSettings.Language2Iso639Code;
-			var languagesOfBook = CollectionSettings.GetLanguage1Name(codeOfNationalLanguage);
+			var languagesOfBook = CollectionSettings.Language1.GetNameInLanguage(codeOfNationalLanguage);
 
 			if (MultilingualContentLanguage2 != null)
 			{
 				languagesOfBook += ", " + ((MultilingualContentLanguage2 == CollectionSettings.Language2Iso639Code) ?
-					CollectionSettings.GetLanguage2Name(codeOfNationalLanguage) :
-					CollectionSettings.GetLanguage3Name(codeOfNationalLanguage));
+					CollectionSettings.Language2.GetNameInLanguage(codeOfNationalLanguage) :
+					CollectionSettings.Language3.GetNameInLanguage(codeOfNationalLanguage));
 			}
 			if (MultilingualContentLanguage3 != null)
 			{
-				languagesOfBook += ", " + CollectionSettings.GetLanguage3Name(codeOfNationalLanguage);
+				languagesOfBook += ", " + CollectionSettings.Language3.GetNameInLanguage(codeOfNationalLanguage);
 			}
 
 			_bookData.Set("languagesOfBook", languagesOfBook, false);
@@ -2451,7 +2455,7 @@ namespace Bloom.Book
 
 			var pageNode = FindPageDiv(page);
 			pageNode.ParentNode.RemoveChild(pageNode);
-			Storage.Dom.UpdatePageNumberAndSideClassOfPages(CollectionSettings.CharactersForDigitsForPageNumbers, CollectionSettings.IsLanguage1Rtl);
+			Storage.Dom.UpdatePageNumberAndSideClassOfPages(CollectionSettings.CharactersForDigitsForPageNumbers, CollectionSettings.Language1.IsRightToLeft);
 
 			_pageSelection.SelectPage(pageToShowNext);
 			Save();
@@ -2463,7 +2467,7 @@ namespace Bloom.Book
 		private void OrderOrNumberOfPagesChanged()
 		{
 			OurHtmlDom.UpdatePageNumberAndSideClassOfPages(CollectionSettings.CharactersForDigitsForPageNumbers,
-				CollectionSettings.IsLanguage1Rtl);
+				CollectionSettings.Language1.IsRightToLeft);
 		}
 
 		private void ClearPagesCache()

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -644,11 +644,11 @@ namespace Bloom.Book
 //            else
 			{
 				data.WritingSystemAliases.Add("V", collectionSettings.Language1Iso639Code);
-				data.AddLanguageString("nameOfLanguage", collectionSettings.Language1Name, "*", true);
+				data.AddLanguageString("nameOfLanguage", collectionSettings.Language1.Name, "*", true);
 				data.AddLanguageString("nameOfNationalLanguage1",
-									   collectionSettings.GetLanguage2Name(collectionSettings.Language2Iso639Code), "*", true);
+									   collectionSettings.Language2.GetNameInLanguage(collectionSettings.Language2Iso639Code), "*", true);
 				data.AddLanguageString("nameOfNationalLanguage2",
-									   collectionSettings.GetLanguage3Name(collectionSettings.Language2Iso639Code), "*", true);
+									   collectionSettings.Language3.GetNameInLanguage(collectionSettings.Language2Iso639Code), "*", true);
 				data.UpdateGenericLanguageString("iso639Code", collectionSettings.Language1Iso639Code, true);
 				data.UpdateGenericLanguageString("country", collectionSettings.Country, true);
 				data.UpdateGenericLanguageString("province", collectionSettings.Province, true);
@@ -696,12 +696,12 @@ namespace Bloom.Book
 		/// <returns></returns>
 		public string PrettyPrintLanguage(string code)
 		{
-			if (code == _collectionSettings.Language1Iso639Code && !string.IsNullOrWhiteSpace(_collectionSettings.Language1Name))
-				return _collectionSettings.Language1Name;
+			if (code == _collectionSettings.Language1Iso639Code && !string.IsNullOrWhiteSpace(_collectionSettings.Language1.Name))
+				return _collectionSettings.Language1.Name;
 			if (code == _collectionSettings.Language2Iso639Code)
-				return _collectionSettings.GetLanguage2Name(_collectionSettings.Language2Iso639Code);
+				return _collectionSettings.Language2.GetNameInLanguage(_collectionSettings.Language2Iso639Code);
 			if (code == _collectionSettings.Language3Iso639Code)
-				return _collectionSettings.GetLanguage3Name(_collectionSettings.Language2Iso639Code);
+				return _collectionSettings.Language3.GetNameInLanguage(_collectionSettings.Language2Iso639Code);
 			return _collectionSettings.GetLanguageName(code, _collectionSettings.Language2Iso639Code);
 		}
 

--- a/src/BloomExe/Book/RuntimeInformationInjector.cs
+++ b/src/BloomExe/Book/RuntimeInformationInjector.cs
@@ -37,18 +37,18 @@ namespace Bloom.Book
 			dictionaryScriptElement.SetAttribute("id", "ui-dictionary");
 			var d = new Dictionary<string, string>();
 
-			d.Add(collectionSettings.Language1Iso639Code, collectionSettings.Language1Name);
+			d.Add(collectionSettings.Language1Iso639Code, collectionSettings.Language1.Name);
 			if (!String.IsNullOrEmpty(collectionSettings.Language2Iso639Code))
 				SafelyAddLanguage(d, collectionSettings.Language2Iso639Code,
-					collectionSettings.GetLanguage2Name(collectionSettings.Language2Iso639Code));
+					collectionSettings.Language2.GetNameInLanguage(collectionSettings.Language2Iso639Code));
 			if (!String.IsNullOrEmpty(collectionSettings.Language3Iso639Code))
 				SafelyAddLanguage(d, collectionSettings.Language3Iso639Code,
-					collectionSettings.GetLanguage3Name(collectionSettings.Language3Iso639Code));
+					collectionSettings.Language3.GetNameInLanguage(collectionSettings.Language3Iso639Code));
 
 			SafelyAddLanguage(d, "vernacularLang", collectionSettings.Language1Iso639Code);//use for making the vernacular the first tab
-			SafelyAddLanguage(d, "{V}", collectionSettings.Language1Name);
-			SafelyAddLanguage(d, "{N1}", collectionSettings.GetLanguage2Name(collectionSettings.Language2Iso639Code));
-			SafelyAddLanguage(d, "{N2}", collectionSettings.GetLanguage3Name(collectionSettings.Language3Iso639Code));
+			SafelyAddLanguage(d, "{V}", collectionSettings.Language1.Name);
+			SafelyAddLanguage(d, "{N1}", collectionSettings.Language2.GetNameInLanguage(collectionSettings.Language2Iso639Code));
+			SafelyAddLanguage(d, "{N2}", collectionSettings.Language3.GetNameInLanguage(collectionSettings.Language3Iso639Code));
 
 			// TODO: Eventually we need to look through all .bloom-translationGroup elements on the current page to determine
 			// whether there is text in a language not yet added to the dictionary.

--- a/src/BloomExe/Book/TranslationGroupManager.cs
+++ b/src/BloomExe/Book/TranslationGroupManager.cs
@@ -154,16 +154,16 @@ namespace Bloom.Book
 				bookData.RemoveAllForms("contentLanguage2");
 
 			bookData.Set("contentLanguage1", collectionSettings.Language1Iso639Code, false);
-			bookData.Set("contentLanguage1Rtl", collectionSettings.IsLanguage1Rtl.ToString(), false);
+			bookData.Set("contentLanguage1Rtl", collectionSettings.Language1.IsRightToLeft.ToString(), false);
 			if (oneTwoOrThreeContentLanguages > 1)
 			{
 				bookData.Set("contentLanguage2", collectionSettings.Language2Iso639Code, false);
-				bookData.Set("contentLanguage2Rtl", collectionSettings.IsLanguage2Rtl.ToString(), false);
+				bookData.Set("contentLanguage2Rtl", collectionSettings.Language2.IsRightToLeft.ToString(), false);
 			}
 			if (oneTwoOrThreeContentLanguages > 2 && !string.IsNullOrEmpty(collectionSettings.Language3Iso639Code))
 			{
 				bookData.Set("contentLanguage3", collectionSettings.Language3Iso639Code, false);
-				bookData.Set("contentLanguage3Rtl", collectionSettings.IsLanguage3Rtl.ToString(), false);
+				bookData.Set("contentLanguage3Rtl", collectionSettings.Language3.IsRightToLeft.ToString(), false);
 			}
 		}
 
@@ -266,9 +266,9 @@ namespace Bloom.Book
 		private static void UpdateRightToLeftSetting(CollectionSettings settings, XmlElement e, string lang)
 		{
 			HtmlDom.RemoveRtlDir(e);
-			if((lang == settings.Language1Iso639Code && settings.IsLanguage1Rtl) ||
-			   (lang == settings.Language2Iso639Code && settings.IsLanguage2Rtl) ||
-			   (lang == settings.Language3Iso639Code && settings.IsLanguage3Rtl))
+			if((lang == settings.Language1Iso639Code && settings.Language1.IsRightToLeft) ||
+			   (lang == settings.Language2Iso639Code && settings.Language2.IsRightToLeft) ||
+			   (lang == settings.Language3Iso639Code && settings.Language3.IsRightToLeft))
 			{
 				HtmlDom.AddRtlDir(e);
 			}

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -101,9 +101,12 @@ namespace Bloom.Collection
 
 		public CollectionSettings()
 		{
-			Language1 = new WritingSystem(1, ()=>Language2.Iso639Code);
-			Language2 = new WritingSystem(2, () => Language2.Iso639Code);
-			Language3 = new WritingSystem(3, () => Language2.Iso639Code);
+			//Note: I'm not convinced we actually ever rely on dynamic name lookups anymore?
+			//See: https://issues.bloomlibrary.org/youtrack/issue/BL-7832
+			Func<string> getCodeOfDefaultLanguageForNaming = ()=> Language2.Iso639Code;
+			Language1 = new WritingSystem(1, getCodeOfDefaultLanguageForNaming);
+			Language2 = new WritingSystem(2,getCodeOfDefaultLanguageForNaming);
+			Language3 = new WritingSystem(3, getCodeOfDefaultLanguageForNaming);
 			LanguagesZeroBased = new WritingSystem[3];
 			this.LanguagesZeroBased[0] = Language1;
 			this.LanguagesZeroBased[1] = Language2;

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -37,10 +37,10 @@ namespace Bloom.Collection
 	{
 		private const int kCurrentOneTimeCheckVersionNumber = 1; // bumping this will trigger a new one time check
 		public const string kDefaultXmatterName = "Traditional";
-		public LanguageSpec Language1;
-		public LanguageSpec Language2;
-		public LanguageSpec Language3;
-		public LanguageSpec[] LanguagesZeroBased;
+		public WritingSystem Language1;
+		public WritingSystem Language2;
+		public WritingSystem Language3;
+		public WritingSystem[] LanguagesZeroBased;
 
 		private string _signLanguageIso639Code;
 
@@ -101,10 +101,10 @@ namespace Bloom.Collection
 
 		public CollectionSettings()
 		{
-			Language1 = new LanguageSpec(1, ()=>Language2.Iso639Code);
-			Language2 = new LanguageSpec(2, () => Language2.Iso639Code);
-			Language3 = new LanguageSpec(3, () => Language2.Iso639Code);
-			LanguagesZeroBased = new LanguageSpec[3];
+			Language1 = new WritingSystem(1, ()=>Language2.Iso639Code);
+			Language2 = new WritingSystem(2, () => Language2.Iso639Code);
+			Language3 = new WritingSystem(3, () => Language2.Iso639Code);
+			LanguagesZeroBased = new WritingSystem[3];
 			this.LanguagesZeroBased[0] = Language1;
 			this.LanguagesZeroBased[1] = Language2;
 			this.LanguagesZeroBased[2] = Language3;
@@ -134,7 +134,7 @@ namespace Bloom.Collection
 			Language2 = collectionInfo.Language2;
 			Language3 = collectionInfo.Language3;
 
-			Language2.FontName = Language3.FontName = LanguageSpec.GetDefaultFontName();
+			Language2.FontName = Language3.FontName = WritingSystem.GetDefaultFontName();
 
 			
 			Country = collectionInfo.Country;
@@ -265,7 +265,7 @@ namespace Bloom.Collection
 		/// </summary>
 		public string GetLanguageName(string code, string inLanguage)
 		{
-			return LanguageSpec.LookupIsoCode.GetLocalizedLanguageName(code, inLanguage);
+			return WritingSystem.LookupIsoCode.GetLocalizedLanguageName(code, inLanguage);
 		}
 
 		public string GetSignLanguageName()
@@ -323,7 +323,7 @@ namespace Bloom.Collection
 			sb.AppendLine("/* *** DO NOT EDIT! ***   These styles are controlled by the Settings dialog box in Bloom. */");
 			sb.AppendLine("/* They may be over-ridden by rules in customCollectionStyles.css or customBookStyles.css */");
 			// note: css pseudo elements  cannot have a @lang attribute. So this is needed to show page numbers in scripts not covered by Andika New Basic.
-			LanguageSpec.AddSelectorCssRule(sb, ".numberedPage::after", Language1.FontName, Language1.IsRightToLeft, Language1.LineHeight, Language1.BreaksLinesOnlyAtSpaces, omitDirection);
+			WritingSystem.AddSelectorCssRule(sb, ".numberedPage::after", Language1.FontName, Language1.IsRightToLeft, Language1.LineHeight, Language1.BreaksLinesOnlyAtSpaces, omitDirection);
 			Language1.AddSelectorCssRule(sb, omitDirection);
 			if (Language2Iso639Code != Language1Iso639Code)
 				Language2.AddSelectorCssRule(sb, omitDirection);
@@ -469,7 +469,7 @@ namespace Bloom.Collection
 		private bool MigrateSettingsToAndikaNewBasicFont()
 		{
 			const string newFont = "Andika New Basic";
-			if (LanguageSpec.GetDefaultFontName() != newFont) // sanity check to make sure Andika New Basic is installed
+			if (WritingSystem.GetDefaultFontName() != newFont) // sanity check to make sure Andika New Basic is installed
 				return false;
 
 			const string id = "CollectionSettingsDialog.AndikaNewBasicUpdate";
@@ -673,7 +673,7 @@ namespace Bloom.Collection
 				var code = isoCodes[i];
 				string name = Language1.Name;
 				if (code != Language1Iso639Code)
-					LanguageSpec.LookupIsoCode.GetBestLanguageName(code, out name);
+					WritingSystem.LookupIsoCode.GetBestLanguageName(code, out name);
 				string ethCode;
 				LanguageSubtag data;
 				if (!StandardSubtags.RegisteredLanguages.TryGet(code.ToLowerInvariant(), out data))

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -117,8 +117,8 @@ namespace Bloom.Collection
 		{
 			string defaultFontText =
 				LocalizationManager.GetString("CollectionSettingsDialog.BookMakingTab.DefaultFontFor", "Default Font for {0}", "{0} is a language name.");
-			var lang1UiName = _collectionSettings.GetLanguage1Name(LocalizationManager.UILanguageId);
-			var lang2UiName = _collectionSettings.GetLanguage2Name(LocalizationManager.UILanguageId);
+			var lang1UiName = _collectionSettings.Language1.GetNameInLanguage(LocalizationManager.UILanguageId);
+			var lang2UiName = _collectionSettings.Language2.GetNameInLanguage(LocalizationManager.UILanguageId);
 			_language1Name.Text = string.Format("{0} ({1})", lang1UiName, _collectionSettings.Language1Iso639Code);
 			_language2Name.Text = string.Format("{0} ({1})", lang2UiName, _collectionSettings.Language2Iso639Code);
 			_language1FontLabel.Text = string.Format(defaultFontText, lang1UiName);
@@ -137,7 +137,7 @@ namespace Bloom.Collection
 			}
 			else
 			{
-				lang3UiName = _collectionSettings.GetLanguage3Name(LocalizationManager.UILanguageId);
+				lang3UiName = _collectionSettings.Language3.GetNameInLanguage(LocalizationManager.UILanguageId);
 				_language3Name.Text = string.Format("{0} ({1})", lang3UiName, _collectionSettings.Language3Iso639Code);
 				_language3FontLabel.Text = string.Format(defaultFontText, lang3UiName);
 				_removeLanguage3Link.Visible = true;
@@ -171,37 +171,37 @@ namespace Bloom.Collection
 
 		private void _language1ChangeLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			var potentiallyCustomName = _collectionSettings.Language1Name;
+			var potentiallyCustomName = _collectionSettings.Language1.Name;
 
 			var l = ChangeLanguage(_collectionSettings.Language1Iso639Code, potentiallyCustomName);
 
 			if (l != null)
 			{
-				_collectionSettings.Language1Iso639Code = l.LanguageTag;
-				_collectionSettings.Language1Name = l.DesiredName;
+				_collectionSettings.Language1.Iso639Code = l.LanguageTag;
+				_collectionSettings.Language1.Name = l.DesiredName;
 				ChangeThatRequiresRestart();
 			}
 		}
 		private void _language2ChangeLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			var potentiallyCustomName = _collectionSettings.Language2Name;
+			var potentiallyCustomName = _collectionSettings.Language2.Name;
 			var l = ChangeLanguage(_collectionSettings.Language2Iso639Code, potentiallyCustomName);
 			if (l != null)
 			{
 				_collectionSettings.Language2Iso639Code = l.LanguageTag;
-				_collectionSettings.Language2Name = l.DesiredName;
+				_collectionSettings.Language2.Name = l.DesiredName;
 				ChangeThatRequiresRestart();
 			}
 		}
 
 		private void _language3ChangeLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			var potentiallyCustomName = _collectionSettings.Language3Name;
+			var potentiallyCustomName = _collectionSettings.Language3.Name;
 			var l = ChangeLanguage(_collectionSettings.Language3Iso639Code, potentiallyCustomName);
 			if (l != null)
 			{
 				_collectionSettings.Language3Iso639Code = l.LanguageTag;
-				_collectionSettings.Language3Name = l.DesiredName;
+				_collectionSettings.Language3.Name = l.DesiredName;
 				ChangeThatRequiresRestart();
 			}
 		}
@@ -268,15 +268,15 @@ namespace Bloom.Collection
 			_collectionSettings.District = _districtText.Text.Trim();
 			if (_fontComboLanguage1.SelectedItem != null)
 			{
-				_collectionSettings.DefaultLanguage1FontName = _fontComboLanguage1.SelectedItem.ToString();
+				_collectionSettings.Language1.FontName = _fontComboLanguage1.SelectedItem.ToString();
 			}
 			if (_fontComboLanguage2.SelectedItem != null)
 			{
-				_collectionSettings.DefaultLanguage2FontName = _fontComboLanguage2.SelectedItem.ToString();
+				_collectionSettings.Language2.FontName = _fontComboLanguage2.SelectedItem.ToString();
 			}
 			if (_fontComboLanguage3.SelectedItem != null)
 			{
-				_collectionSettings.DefaultLanguage3FontName = _fontComboLanguage3.SelectedItem.ToString();
+				_collectionSettings.Language3.FontName = _fontComboLanguage3.SelectedItem.ToString();
 			}
 			if (_numberStyleCombo.SelectedItem != null)
 			{
@@ -407,11 +407,11 @@ namespace Bloom.Collection
 				_fontComboLanguage1.Items.Add(font);
 				_fontComboLanguage2.Items.Add(font);
 				_fontComboLanguage3.Items.Add(font);
-				if (font == _collectionSettings.DefaultLanguage1FontName)
+				if (font == _collectionSettings.Language1.FontName)
 					_fontComboLanguage1.SelectedIndex = _fontComboLanguage1.Items.Count-1;
-				if (font == _collectionSettings.DefaultLanguage2FontName)
+				if (font == _collectionSettings.Language2.FontName)
 					_fontComboLanguage2.SelectedIndex = _fontComboLanguage2.Items.Count - 1;
-				if (font == _collectionSettings.DefaultLanguage3FontName)
+				if (font == _collectionSettings.Language3.FontName)
 					_fontComboLanguage3.SelectedIndex = _fontComboLanguage3.Items.Count - 1;
 			}
 		}
@@ -484,19 +484,19 @@ namespace Bloom.Collection
 
 		private void _fontComboLanguage1_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			if (_fontComboLanguage1.SelectedItem.ToString().ToLowerInvariant() != _collectionSettings.DefaultLanguage1FontName.ToLower())
+			if (_fontComboLanguage1.SelectedItem.ToString().ToLowerInvariant() != _collectionSettings.Language1.FontName.ToLower())
 				ChangeThatRequiresRestart();
 		}
 
 		private void _fontComboLanguage2_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			if (_fontComboLanguage2.SelectedItem.ToString().ToLowerInvariant() != _collectionSettings.DefaultLanguage2FontName.ToLower())
+			if (_fontComboLanguage2.SelectedItem.ToString().ToLowerInvariant() != _collectionSettings.Language2.FontName.ToLower())
 				ChangeThatRequiresRestart();
 		}
 
 		private void _fontComboLanguage3_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			if (_fontComboLanguage3.SelectedItem.ToString().ToLowerInvariant() != _collectionSettings.DefaultLanguage3FontName.ToLower())
+			if (_fontComboLanguage3.SelectedItem.ToString().ToLowerInvariant() != _collectionSettings.Language3.FontName.ToLower())
 				ChangeThatRequiresRestart();
 		}
 
@@ -529,54 +529,55 @@ namespace Bloom.Collection
 
 		private void _fontSettings1Link_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			FontSettingsLinkClicked(_collectionSettings.GetLanguage1Name(LocalizationManager.UILanguageId), 1);
+			FontSettingsLinkClicked(_collectionSettings.Language1.GetNameInLanguage(LocalizationManager.UILanguageId), 1);
 		}
 
 		private void _fontSettings2Link_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			FontSettingsLinkClicked(_collectionSettings.GetLanguage2Name(LocalizationManager.UILanguageId), 2);
+			FontSettingsLinkClicked(_collectionSettings.Language2.GetNameInLanguage(LocalizationManager.UILanguageId), 2);
 		}
 
 		private void _fontSettings3Link_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			FontSettingsLinkClicked(_collectionSettings.GetLanguage3Name(LocalizationManager.UILanguageId), 3);
+			FontSettingsLinkClicked(_collectionSettings.Language3.GetNameInLanguage(LocalizationManager.UILanguageId), 3);
 		}
 
-		private void FontSettingsLinkClicked(string langName, int langNum)
-		{
+		private void FontSettingsLinkClicked(string langName, int langNum1Based)
+		{ 
+			var langSpec = _collectionSettings.LanguagesZeroBased[langNum1Based - 1];
 			using (var frm = new ScriptSettingsDialog())
 			{
 				frm.LanguageName = langName;
-				frm.LanguageRightToLeft = _collectionSettings.GetLanguageRtl(langNum);
-				frm.LanguageLineSpacing = _collectionSettings.GetLanguageLineHeight(langNum);
-				frm.BreakLinesOnlyAtSpaces = _collectionSettings.GetBreakLinesOnlyAtSpaces(langNum);
+				frm.LanguageRightToLeft = langSpec.IsRightToLeft;
+				frm.LanguageLineSpacing = langSpec.LineHeight;
+				frm.BreakLinesOnlyAtSpaces = langSpec.BreaksLinesOnlyAtSpaces;
 				frm.ShowDialog(this);
 
 				// get the changes
 				var newRtl = frm.LanguageRightToLeft;
-				var newLs = frm.LanguageLineSpacing;
+				var newLineSpacing = frm.LanguageLineSpacing;
 				var newBreak = frm.BreakLinesOnlyAtSpaces;
-
-				if (newRtl != _collectionSettings.GetLanguageRtl(langNum))
+				
+				if (newRtl != langSpec.IsRightToLeft) 
 				{
-					_collectionSettings.SetLanguageRtl(langNum, newRtl);
+					langSpec.IsRightToLeft =  newRtl;
 					ChangeThatRequiresRestart();
 				}
 
-				if (newLs != _collectionSettings.GetLanguageLineHeight(langNum))
+				if (newLineSpacing != langSpec.LineHeight)
 				{
 					// Clicking "OK" will save the values into the .bloomCollection file.  (Later when a book
 					// is edited, defaultLangStyles.css will be written out in the book's folder, which is all
 					// that is needed for this setting to take effect.)
-					_collectionSettings.SetLanguageLineHeight(langNum, newLs);
+					langSpec.LineHeight = newLineSpacing;
 				}
 
-				if (newBreak != _collectionSettings.GetBreakLinesOnlyAtSpaces(langNum))
+				if (newBreak != langSpec.BreaksLinesOnlyAtSpaces)
 				{
 					// Clicking "OK" will save the values into the .bloomCollection file.  (Later when a book
 					// is edited, defaultLangStyles.css will be written out in the book's folder, which is all
 					// that is needed for this setting to take effect.)
-					_collectionSettings.SetBreakLinesOnlyAtSpaces(langNum, newBreak);
+					langSpec.BreaksLinesOnlyAtSpaces = newBreak;
 				}
 			}
 		}

--- a/src/BloomExe/Collection/LanguageSpec.cs
+++ b/src/BloomExe/Collection/LanguageSpec.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Bloom.ToPalaso;
+using SIL.Windows.Forms.WritingSystems;
+
+namespace Bloom.Collection
+{
+	public class LanguageSpec
+	{
+		private readonly int _languageNumberInCollection;
+		private readonly Func<string> _codeOfDefaultLanguageForNaming;
+		public static LanguageLookupModel LookupIsoCode = new LanguageLookupModel();
+		private string _iso639Code;
+		public string Name;
+		public bool IsRightToLeft;
+
+		// Line breaks are always wanted only between words.  (ignoring hyphenation)
+		// Most alphabetic scripts use spaces to separate words, and line-breaks occur only
+		// at those spaces.  CJK scripts (which includes scripts outside China, Japan, and
+		// Korea) usually do not have spaces, so either line breaks are acceptable anywhere
+		// or some fancy algorithm is used to detect word boundaries. (dictionary lookup?)
+		// Some minority languages use the CJK script of the national language but also
+		// use spaces to separate words.  For these languages, proper display requires
+		// the css setting "word-break: keep-all".  This setting affects only how CJK
+		// scripts are handled with regard to line breaking.
+		// See https://silbloom.myjetbrains.com/youtrack/issue/BL-5761.
+		public bool BreaksLinesOnlyAtSpaces;
+		public int BaseUiFontSizeInPoints;
+		public decimal LineHeight;
+		public string FontName;
+
+		public LanguageSpec(int languageNumberInCollection, Func<string> codeOfDefaultLanguageForNaming)
+		{
+			_languageNumberInCollection = languageNumberInCollection;
+			_codeOfDefaultLanguageForNaming = codeOfDefaultLanguageForNaming;
+		}
+
+		public string Iso639Code
+		{
+			get { return _iso639Code; }
+			set {
+				_iso639Code = value;
+				Name = GetLanguageName_NoCache(_codeOfDefaultLanguageForNaming());
+			}
+		}
+
+		public string GetNameInLanguage(string inLanguage)
+		{
+			if (!string.IsNullOrEmpty(Iso639Code) && !String.IsNullOrEmpty(Name))
+				return Name;
+
+			return GetLanguageName_NoCache(inLanguage);
+		}
+		private string GetLanguageName_NoCache(string inLanguage)
+		{
+			try {
+				if (string.IsNullOrEmpty(Iso639Code))
+					return string.Empty;
+
+				var name = LookupIsoCode.GetLocalizedLanguageName(Iso639Code, inLanguage);
+				if (name == Iso639Code)
+				{
+					string match;
+					if (!LookupIsoCode.GetBestLanguageName(Iso639Code, out match))
+						if (!LookupIsoCode.GetBestLanguageName("en", out match))
+							return $"L{_languageNumberInCollection}-Unknown-" + Iso639Code;
+					return match;
+				}
+				return name;
+			}
+			catch (Exception)
+			{
+				return "Unknown-" + Iso639Code;
+			}
+		}
+
+		public void ChangeIsoCode(string value)
+		{
+			Iso639Code = value;
+			Name = GetLanguageName_NoCache(_codeOfDefaultLanguageForNaming());
+		}
+
+		public void SaveToXElement(XElement library)
+		{
+			var pfx = "Language" + _languageNumberInCollection;
+			library.Add(new XElement(pfx+"Name", Name));
+			library.Add(new XElement(pfx + "Iso639Code", Iso639Code));
+			library.Add(new XElement($"DefaultLanguage{_languageNumberInCollection}FontName", FontName));
+			library.Add(new XElement($"IsLanguage{_languageNumberInCollection}Rtl", IsRightToLeft));
+			library.Add(new XElement(pfx + "LineHeight", LineHeight));
+			library.Add(new XElement(pfx+"BreaksLinesOnlyAtSpaces", BreaksLinesOnlyAtSpaces));
+
+		}
+
+		public void AddSelectorCssRule(StringBuilder sb, bool omitDirection)
+		{
+			AddSelectorCssRule(sb, "[lang='" + Iso639Code + "']", FontName, IsRightToLeft, LineHeight, BreaksLinesOnlyAtSpaces, omitDirection);
+		}
+
+		public static void AddSelectorCssRule(StringBuilder sb, string selector, string fontName, bool isRtl, decimal lineHeight, bool breakOnlyAtSpaces, bool omitDirection)
+		{
+			sb.AppendLine();
+			sb.AppendLine(selector);
+			sb.AppendLine("{");
+			sb.AppendLine(" font-family: '" + fontName + "';");
+
+			// EPUBs don't handle direction: in CSS files.
+			if (!omitDirection)
+			{
+				if (isRtl)
+					sb.AppendLine(" direction: rtl;");
+				else    // Ensure proper directionality: see https://silbloom.myjetbrains.com/youtrack/issue/BL-6256.
+					sb.AppendLine(" direction: ltr;");
+			}
+			if (lineHeight > 0)
+				sb.AppendLine(" line-height: " + lineHeight.ToString(CultureInfo.InvariantCulture) + ";");
+
+			if (breakOnlyAtSpaces)
+				sb.AppendLine(" word-break: keep-all;");
+
+			sb.AppendLine("}");
+		}
+
+		/// <summary>
+		/// Read in all the persisted values of this class from an XElement
+		/// </summary>
+		/// <param name="xml"></param>
+		/// <param name="defaultLanguageCode"></param>
+		/// <param name="languageForDefaultNameLookup">a code or "self" if we should use the iso code for this spec to look it up</param>
+		public void ReadSpecFromXml(XElement xml, bool defaultToEnglishIfMissing,  string languageForDefaultNameLookup)
+		{
+			var pfx = "Language" + _languageNumberInCollection;
+			Iso639Code = ReadString(xml, $"Language{this._languageNumberInCollection}Iso639Code", defaultToEnglishIfMissing?"en":"");
+			IsRightToLeft = ReadBoolean(xml, $"IsLanguage{_languageNumberInCollection}Rtl", false);
+			
+			Name = ReadString(xml, pfx+"Name", "");
+			if (Name == "")
+			{
+				Name = GetLanguageName_NoCache(languageForDefaultNameLookup=="self"?Iso639Code:languageForDefaultNameLookup);
+			}
+
+			LineHeight = ReadDecimal(xml, pfx+"LineHeight", 0);
+
+			FontName = ReadString(xml, $"DefaultLanguage{_languageNumberInCollection}FontName", GetDefaultFontName());
+			
+			BreaksLinesOnlyAtSpaces = ReadBoolean(xml, pfx+"BreaksLinesOnlyAtSpaces", false);
+		}
+		private bool ReadBoolean(XElement library, string id, bool defaultValue)
+		{
+			string s = ReadString(library, id, defaultValue.ToString());
+			bool b;
+			bool.TryParse(s, out b);
+			return b;
+		}
+
+		private decimal ReadDecimal(XElement library, string id, decimal defaultValue)
+		{
+			var s = ReadString(library, id, defaultValue.ToString(CultureInfo.InvariantCulture));
+			decimal d;
+			// REVIEW: if we localize the display of decimal values in the line-height combo box, then this
+			// needs to handle the localized version of the number.  (This happens automatically by removing
+			// the middle two arguments.)
+			Decimal.TryParse(s, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out d);
+			return d;
+		}
+
+		private string ReadString(XElement document, string id, string defaultValue)
+		{
+			var nodes = document.Descendants(id);
+			if (nodes != null && nodes.Count() > 0)
+				return nodes.First().Value;
+			else
+			{
+				return defaultValue;
+			}
+		}
+
+		internal static string GetDefaultFontName()
+		{
+			//Since we always install Andika New Basic, let's just always use that as the default
+			//Note (BL-3674) the font installer may not have completed yet, so we don't even check to make
+			//sure it's there. It's possible that the user actually uninstalled Andika, but that's ok. Until they change to another font,
+			// they'll get a message that this font is not actually installed when they try to edit a book.
+			return "Andika New Basic";
+		}
+	}
+}

--- a/src/BloomExe/Collection/WritingSystem.cs
+++ b/src/BloomExe/Collection/WritingSystem.cs
@@ -10,7 +10,7 @@ using SIL.Windows.Forms.WritingSystems;
 
 namespace Bloom.Collection
 {
-	public class LanguageSpec
+	public class WritingSystem
 	{
 		private readonly int _languageNumberInCollection;
 		private readonly Func<string> _codeOfDefaultLanguageForNaming;
@@ -34,7 +34,7 @@ namespace Bloom.Collection
 		public decimal LineHeight;
 		public string FontName;
 
-		public LanguageSpec(int languageNumberInCollection, Func<string> codeOfDefaultLanguageForNaming)
+		public WritingSystem(int languageNumberInCollection, Func<string> codeOfDefaultLanguageForNaming)
 		{
 			_languageNumberInCollection = languageNumberInCollection;
 			_codeOfDefaultLanguageForNaming = codeOfDefaultLanguageForNaming;
@@ -85,15 +85,15 @@ namespace Bloom.Collection
 			Name = GetLanguageName_NoCache(_codeOfDefaultLanguageForNaming());
 		}
 
-		public void SaveToXElement(XElement library)
+		public void SaveToXElement(XElement xml)
 		{
 			var pfx = "Language" + _languageNumberInCollection;
-			library.Add(new XElement(pfx+"Name", Name));
-			library.Add(new XElement(pfx + "Iso639Code", Iso639Code));
-			library.Add(new XElement($"DefaultLanguage{_languageNumberInCollection}FontName", FontName));
-			library.Add(new XElement($"IsLanguage{_languageNumberInCollection}Rtl", IsRightToLeft));
-			library.Add(new XElement(pfx + "LineHeight", LineHeight));
-			library.Add(new XElement(pfx+"BreaksLinesOnlyAtSpaces", BreaksLinesOnlyAtSpaces));
+			xml.Add(new XElement(pfx+"Name", Name));
+			xml.Add(new XElement(pfx + "Iso639Code", Iso639Code));
+			xml.Add(new XElement($"DefaultLanguage{_languageNumberInCollection}FontName", FontName));
+			xml.Add(new XElement($"IsLanguage{_languageNumberInCollection}Rtl", IsRightToLeft));
+			xml.Add(new XElement(pfx + "LineHeight", LineHeight));
+			xml.Add(new XElement(pfx+"BreaksLinesOnlyAtSpaces", BreaksLinesOnlyAtSpaces));
 
 		}
 
@@ -150,17 +150,17 @@ namespace Bloom.Collection
 			
 			BreaksLinesOnlyAtSpaces = ReadBoolean(xml, pfx+"BreaksLinesOnlyAtSpaces", false);
 		}
-		private bool ReadBoolean(XElement library, string id, bool defaultValue)
+		private bool ReadBoolean(XElement xml, string id, bool defaultValue)
 		{
-			string s = ReadString(library, id, defaultValue.ToString());
+			string s = ReadString(xml, id, defaultValue.ToString());
 			bool b;
 			bool.TryParse(s, out b);
 			return b;
 		}
 
-		private decimal ReadDecimal(XElement library, string id, decimal defaultValue)
+		private decimal ReadDecimal(XElement xml, string id, decimal defaultValue)
 		{
-			var s = ReadString(library, id, defaultValue.ToString(CultureInfo.InvariantCulture));
+			var s = ReadString(xml, id, defaultValue.ToString(CultureInfo.InvariantCulture));
 			decimal d;
 			// REVIEW: if we localize the display of decimal values in the line-height combo box, then this
 			// needs to handle the localized version of the number.  (This happens automatically by removing

--- a/src/BloomExe/CollectionCreating/LanguageIdControl.cs
+++ b/src/BloomExe/CollectionCreating/LanguageIdControl.cs
@@ -27,8 +27,8 @@ namespace Bloom.CollectionCreating
 
 			if (_lookupISOControl.SelectedLanguage != null)
 			{
-				_collectionInfo.Language1Iso639Code = _lookupISOControl.SelectedLanguage.LanguageTag;
-				_collectionInfo.Language1Name = _lookupISOControl.SelectedLanguage.DesiredName;
+				_collectionInfo.Language1.Iso639Code = _lookupISOControl.SelectedLanguage.LanguageTag;
+				_collectionInfo.Language1.Name = _lookupISOControl.SelectedLanguage.DesiredName;
 				_collectionInfo.Country = _lookupISOControl.SelectedLanguage.PrimaryCountry ?? string.Empty;
 
 				//If there are multiple countries, just leave it blank so they can type something in

--- a/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
+++ b/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
@@ -134,7 +134,7 @@ namespace Bloom.CollectionCreating
 				var pattern = LocalizationManager.GetString("NewCollectionWizard.NewBookPattern", "{0} Books", "The {0} is replaced by the name of the language.");
 				// GetPathForNewSettings uses Path.Combine which can fail with certain characters that are illegal in paths, but not in language names.
 				// The characters we ran into were two pipe characters ("|") at the front of the language name.
-				var tentativeCollectionName = string.Format(pattern, _collectionInfo.Language1Name);
+				var tentativeCollectionName = string.Format(pattern, _collectionInfo.Language1.Name);
 				var sanitizedCollectionName = tentativeCollectionName.SanitizePath('.');
 				_collectionInfo.PathToSettingsFile = CollectionSettings.GetPathForNewSettings(DefaultParentDirectoryForCollections, sanitizedCollectionName);
 
@@ -178,24 +178,24 @@ namespace Bloom.CollectionCreating
 			DialogResult = DialogResult.OK;
 
 			// Collect the data from the Font and Script page.
-			_collectionInfo.DefaultLanguage1FontName = _fontDetails.SelectedFont;
-			_collectionInfo.Language1LineHeight = new decimal(0);
+			_collectionInfo.Language1.FontName = _fontDetails.SelectedFont;
+			// refactoring note: this is not needed, this will be set to zero by default:_collectionInfo.Language1LineHeight = new decimal(0);
 			if (_fontDetails.ExtraLineHeight)
 			{
 				// The LineHeight settings from the LanguageFontDetails control are in the current culture,
 				// so we don't need to specify a culture in the TryParse.
 				double height;
 				if (double.TryParse(_fontDetails.LineHeight, out height))
-					_collectionInfo.Language1LineHeight = new decimal(height);
+					_collectionInfo.Language1.LineHeight = new decimal(height);
 			}
-			_collectionInfo.IsLanguage1Rtl = _fontDetails.RightToLeft;
-			_collectionInfo.Language1BreaksLinesOnlyAtSpaces = false;
+			_collectionInfo.Language1.IsRightToLeft = _fontDetails.RightToLeft;
+			_collectionInfo.Language1.BreaksLinesOnlyAtSpaces = false;
 
 			//this both saves a step for the country with the most languages, but also helps get the order between en and tpi to what will be most useful
 			if (_collectionInfo.Country == "Papua New Guinea")
 			{
-				_collectionInfo.Language2Iso639Code = "en";
-				_collectionInfo.Language3Iso639Code = "tpi";
+				_collectionInfo.Language2.Iso639Code = "en";
+				_collectionInfo.Language3.Iso639Code = "tpi";
 			}
 			_collectionInfo.SetAnalyticsProperties();
 

--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -80,7 +80,7 @@ namespace Bloom.CollectionTab
 
 		public string LanguageName
 		{
-			get { return _collectionSettings.Language1Name; }
+			get { return _collectionSettings.Language1.Name; }
 		}
 
 		public List<BookCollection> GetBookCollections()

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -388,14 +388,14 @@ namespace Bloom.Edit
 				if (_contentLanguages.Count() == 0)
 				{
 					_contentLanguages.Add(new ContentLanguage(_collectionSettings.Language1Iso639Code,
-															  _collectionSettings.GetLanguage1Name("en"))
-											{Locked = true, Selected = true, IsRtl = _collectionSettings.IsLanguage1Rtl});
+															  _collectionSettings.Language1.GetNameInLanguage("en"))
+											{Locked = true, Selected = true, IsRtl = _collectionSettings.Language1.IsRightToLeft});
 
 					//NB: these won't *always* be tied to the national and regional languages, but they are for now. We would need more UI, without making for extra complexity
 					var item2 = new ContentLanguage(_collectionSettings.Language2Iso639Code,
-													_collectionSettings.GetLanguage2Name("en"))
+													_collectionSettings.Language2.GetNameInLanguage("en"))
 									{
-										IsRtl = _collectionSettings.IsLanguage1Rtl
+										IsRtl = _collectionSettings.Language1.IsRightToLeft
 //					            		Selected =
 //					            			CurrentBook.MultilingualContentLanguage2 ==
 //					            			_librarySettings.Language2Iso639Code
@@ -409,9 +409,9 @@ namespace Bloom.Edit
 //						                CurrentBook.MultilingualContentLanguage3 ==
 //						                _librarySettings.Language3Iso639Code;
 						var item3 = new ContentLanguage(_collectionSettings.Language3Iso639Code,
-														_collectionSettings.GetLanguage3Name("en"))
+														_collectionSettings.Language3.GetNameInLanguage("en"))
 						{
-							IsRtl = _collectionSettings.IsLanguage3Rtl
+							IsRtl = _collectionSettings.Language3.IsRightToLeft
 						};// {Selected = selected};
 						_contentLanguages.Add(item3);
 					}
@@ -1250,14 +1250,14 @@ namespace Bloom.Edit
 		public string GetFontAvailabilityMessage()
 		{
 			// REVIEW: does this ToLower() do the right thing on Linux, where filenames are case sensitive?
-			var name = _collectionSettings.DefaultLanguage1FontName.ToLowerInvariant();
+			var name = _collectionSettings.Language1.FontName.ToLowerInvariant();
 
 			if (null == FontFamily.Families.FirstOrDefault(f => f.Name.ToLowerInvariant() == name))
 			{
 				var s = LocalizationManager.GetString("EditTab.FontMissing",
 														   "The current selected " +
 														   "font is '{0}', but it is not installed on this computer. Some other font will be used.");
-				return string.Format(s, _collectionSettings.DefaultLanguage1FontName);
+				return string.Format(s, _collectionSettings.Language1.FontName);
 			}
 			return null;
 		}

--- a/src/BloomExe/MiscUI/LanguageFontDetails.cs
+++ b/src/BloomExe/MiscUI/LanguageFontDetails.cs
@@ -22,7 +22,7 @@ namespace Bloom.MiscUI
 			var fontNames = new List<string>();
 			fontNames.AddRange(Browser.NamesOfFontsThatBrowserCanRender());
 			fontNames.Sort();
-			var defaultFont = LanguageSpec.GetDefaultFontName();
+			var defaultFont = WritingSystem.GetDefaultFontName();
 			foreach (var font in fontNames)
 			{
 				_fontCombo.Items.Add(font);

--- a/src/BloomExe/MiscUI/LanguageFontDetails.cs
+++ b/src/BloomExe/MiscUI/LanguageFontDetails.cs
@@ -22,7 +22,7 @@ namespace Bloom.MiscUI
 			var fontNames = new List<string>();
 			fontNames.AddRange(Browser.NamesOfFontsThatBrowserCanRender());
 			fontNames.Sort();
-			var defaultFont = CollectionSettings.GetDefaultFontName();
+			var defaultFont = LanguageSpec.GetDefaultFontName();
 			foreach (var font in fontNames)
 			{
 				_fontCombo.Items.Add(font);

--- a/src/BloomExe/MiscUI/ProblemReporterDialog.cs
+++ b/src/BloomExe/MiscUI/ProblemReporterDialog.cs
@@ -562,11 +562,11 @@ namespace Bloom.MiscUI
 			bldr.AppendLine("Collection name: " + settings.CollectionName);
 			bldr.AppendLine("xMatter pack name: " + settings.XMatterPackName);
 			bldr.AppendLine("Language1 iso: " + settings.Language1Iso639Code + " font: " +
-			                settings.DefaultLanguage1FontName + (settings.IsLanguage1Rtl ? " RTL" : string.Empty));
+			                settings.Language1.FontName + (settings.Language1.IsRightToLeft ? " RTL" : string.Empty));
 			bldr.AppendLine("Language2 iso: " + settings.Language2Iso639Code + " font: " +
-			                settings.DefaultLanguage2FontName + (settings.IsLanguage2Rtl ? " RTL" : string.Empty));
+			                settings.Language2.FontName + (settings.Language2.IsRightToLeft ? " RTL" : string.Empty));
 			bldr.AppendLine("Language3 iso: " + settings.Language3Iso639Code + " font: " +
-			                settings.DefaultLanguage3FontName + (settings.IsLanguage3Rtl ? " RTL" : string.Empty));
+			                settings.Language3.FontName + (settings.Language3.IsRightToLeft ? " RTL" : string.Empty));
 		}
 
 		private void GetAdditionalFileInfo(StringBuilder bldr)

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -858,7 +858,7 @@ namespace Bloom.Publish.Epub
 			// These IDs must match the corresponding ones in the manifest, since the spine
 			// doesn't indicate where to actually find the content.
 			var spineElt = new XElement(opf + "spine");
-			if(this.Book.CollectionSettings.IsLanguage1Rtl)
+			if(this.Book.CollectionSettings.Language1.IsRightToLeft)
 			{
 				spineElt.SetAttributeValue("page-progression-direction","rtl");
 			}
@@ -919,11 +919,11 @@ namespace Bloom.Publish.Epub
 			// REVIEW: is BODY always ltr, or should it be the same as Language1?  Having BODY be ltr for a book in Arabic or Hebrew
 			// seems counterintuitive even if all the div elements are marked correctly.
 			_directionSettings.Add("body", "ltr");
-			_directionSettings.Add(this.Book.CollectionSettings.Language1Iso639Code, this.Book.CollectionSettings.IsLanguage1Rtl ? "rtl" : "ltr");
+			_directionSettings.Add(this.Book.CollectionSettings.Language1Iso639Code, this.Book.CollectionSettings.Language1.IsRightToLeft ? "rtl" : "ltr");
 			if (!_directionSettings.ContainsKey(this.Book.CollectionSettings.Language2Iso639Code))
-				_directionSettings.Add(this.Book.CollectionSettings.Language2Iso639Code, this.Book.CollectionSettings.IsLanguage2Rtl ? "rtl" : "ltr");
+				_directionSettings.Add(this.Book.CollectionSettings.Language2Iso639Code, this.Book.CollectionSettings.Language2.IsRightToLeft ? "rtl" : "ltr");
 			if (!String.IsNullOrEmpty(this.Book.CollectionSettings.Language3Iso639Code) && !_directionSettings.ContainsKey(this.Book.CollectionSettings.Language3Iso639Code))
-				_directionSettings.Add(this.Book.CollectionSettings.Language3Iso639Code, this.Book.CollectionSettings.IsLanguage3Rtl ? "rtl" : "ltr");
+				_directionSettings.Add(this.Book.CollectionSettings.Language3Iso639Code, this.Book.CollectionSettings.Language3.IsRightToLeft ? "rtl" : "ltr");
 		}
 
 		private void SetDirAttributes(HtmlDom pageDom)

--- a/src/BloomExe/Publish/Epub/PublishEpubApi.cs
+++ b/src/BloomExe/Publish/Epub/PublishEpubApi.cs
@@ -112,7 +112,7 @@ namespace Bloom.Publish.Epub
 			{
 				{
 					string suggestedName = string.Format("{0}-{1}.epub", Path.GetFileName(_bookSelection.CurrentSelection.FolderPath),
-						_collectionSettings.GetLanguage1Name("en"));
+						_collectionSettings.Language1.GetNameInLanguage("en"));
 					using (var dlg = new DialogAdapters.SaveFileDialogAdapter())
 					{
 						if (!string.IsNullOrEmpty(_lastDirectory) && Directory.Exists(_lastDirectory))

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -245,7 +245,7 @@ namespace Bloom.Publish
 				}
 				if (pageRemoved)
 				{
-					dom.UpdatePageNumberAndSideClassOfPages(settings.CharactersForDigitsForPageNumbers, settings.IsLanguage1Rtl);
+					dom.UpdatePageNumberAndSideClassOfPages(settings.CharactersForDigitsForPageNumbers, settings.Language1.IsRightToLeft);
 					return true;
 				}
 			}

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -157,7 +157,7 @@ namespace Bloom.Publish
 
 		private bool LayoutPagesForRightToLeft
 		{
-			get { return _collectionSettings.IsLanguage1Rtl;  }
+			get { return _collectionSettings.Language1.IsRightToLeft;  }
 
 		}
 

--- a/src/BloomExe/WebLibraryIntegration/BookDownloadSupport.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookDownloadSupport.cs
@@ -35,12 +35,13 @@ namespace Bloom.WebLibraryIntegration
 					Path.GetFileName(downloadFolder));
 				var settings = new NewCollectionSettings()
 				{
-					Language1Iso639Code = "en",
-					Language1Name = "English",
+			
 					IsSourceCollection = true,
 					PathToSettingsFile = pathToSettingsFile
 					// All other defaults are fine
 				};
+				settings.Language1.Iso639Code = "en";
+				settings.Language1.Name = "English";
 				CollectionSettings.CreateNewCollection(settings);
 			}
 		}

--- a/src/BloomExe/web/ReadersApi.cs
+++ b/src/BloomExe/web/ReadersApi.cs
@@ -52,7 +52,7 @@ namespace Bloom.Api
 		{
 			apiHandler.RegisterEndpointHandler("collection/defaultFont", request =>
 			{
-				var bookFontName = request.CurrentCollectionSettings.DefaultLanguage1FontName;
+				var bookFontName = request.CurrentCollectionSettings.Language1.FontName;
 				if(String.IsNullOrEmpty(bookFontName))
 					bookFontName = "sans-serif";
 				request.ReplyWithText(bookFontName);
@@ -347,19 +347,24 @@ namespace Bloom.Api
 		private static string GetReaderSettings(CollectionSettings currentCollectionSettings)
 		{
 			var settingsPath = DecodableReaderToolSettings.GetReaderToolsSettingsFilePath(currentCollectionSettings);
-
+			var settings = "";
 			// if file exists, return current settings
 			if (RobustFile.Exists(settingsPath))
 			{
 				var result = RobustFile.ReadAllText(settingsPath, Encoding.UTF8);
 				if (!string.IsNullOrWhiteSpace(result))
-					return result;
+					settings = result;
 			}
 
+			if (settings.Length > 0)
+			{
+				return settings;
+			}
 			// file does not exist, so make a new one
 			// The literal string here defines our default reader settings for a collection.
 			var settingsString = "{\"letters\":\"a b c d e f g h i j k l m n o p q r s t u v w x y z\","
-				+ "\"moreWords\":\"\","
+				+ $"'lang:\"{currentCollectionSettings.Language1Iso639Code}\"'"
+			                     + "\"moreWords\":\"\","
 				+ "\"stages\":[{\"letters\":\"\",\"sightWords\":\"\"}],"
 				+ "\"levels\":[{\"maxWordsPerSentence\":2,\"maxWordsPerPage\":2,\"maxWordsPerBook\":20,\"maxUniqueWordsPerBook\":0,\"thingsToRemember\":[]},"
 					+ "{\"maxWordsPerSentence\":5,\"maxWordsPerPage\":5,\"maxWordsPerBook\":23,\"maxUniqueWordsPerBook\":8,\"thingsToRemember\":[]},"
@@ -384,7 +389,7 @@ namespace Bloom.Api
 			var sb = new StringBuilder();
 			var str = LocalizationManager.GetString("EditTab.Toolbox.DecodableReaderTool.LetterWordReportMessage",
 				"The following is a generated report of the decodable stages for {0}.  You can make any changes you want to this file, but Bloom will not notice your changes.  It is just a report.");
-			sb.AppendLineFormat(str, CurrentBook.CollectionSettings.Language1Name);
+			sb.AppendLineFormat(str, CurrentBook.CollectionSettings.Language1.Name);
 
 			var idx = 1;
 			foreach (var stage in settings.stages)
@@ -427,7 +432,7 @@ namespace Bloom.Api
 		{
 			// insert LangName and LangID if missing
 			if (jsonString.Contains("\"LangName\":\"\""))
-				jsonString = jsonString.Replace("\"LangName\":\"\"", "\"LangName\":\"" + CurrentBook.CollectionSettings.Language1Name + "\"");
+				jsonString = jsonString.Replace("\"LangName\":\"\"", "\"LangName\":\"" + CurrentBook.CollectionSettings.Language1.Name + "\"");
 
 			if (jsonString.Contains("\"LangID\":\"\""))
 				jsonString = jsonString.Replace("\"LangID\":\"\"", "\"LangID\":\"" + CurrentBook.CollectionSettings.Language1Iso639Code + "\"");

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -29,18 +29,21 @@ namespace BloomTests.Book
 		{
 			_collectionSettings = new CollectionSettings(new NewCollectionSettings()
 			{
-				PathToSettingsFile = CollectionSettings.GetPathForNewSettings(new TemporaryFolder("BookDataTests").Path, "test"),
-				Language1Iso639Code = "xyz",
-				Language2Iso639Code = "en",
-				Language3Iso639Code = "fr"
+				PathToSettingsFile =
+					CollectionSettings.GetPathForNewSettings(new TemporaryFolder("BookDataTests").Path, "test"),
 			});
+			_collectionSettings.Language1.Iso639Code = "xyz";
+			_collectionSettings.Language2.Iso639Code = "en";
+			_collectionSettings.Language3.Iso639Code = "fr";
 			ErrorReport.IsOkToInteractWithUser = false;
 
 			LocalizationManager.UseLanguageCodeFolders = true;
 			var localizationDirectory = FileLocationUtilities.GetDirectoryDistributedWithApplication("localization");
-			_localizationManager = LocalizationManager.Create(TranslationMemory.XLiff, "fr", "Bloom", "Bloom", "1.0.0", localizationDirectory, "SIL/Bloom",
+			_localizationManager = LocalizationManager.Create(TranslationMemory.XLiff, "fr", "Bloom", "Bloom", "1.0.0",
+				localizationDirectory, "SIL/Bloom",
 				null, "");
-			_palasoLocalizationManager = LocalizationManager.Create(TranslationMemory.XLiff, "fr", "Palaso","Palaso", "1.0.0", localizationDirectory, "SIL/Palaso",
+			_palasoLocalizationManager = LocalizationManager.Create(TranslationMemory.XLiff, "fr", "Palaso", "Palaso",
+				"1.0.0", localizationDirectory, "SIL/Palaso",
 				null, "");
 		}
 
@@ -71,9 +74,11 @@ namespace BloomTests.Book
 		[Test]
 		public void TextOfInnerHtml_HandlesXmlEscapesCorrectly()
 		{
-			var input = "Jack &amp; Jill like xml sequences like &amp;amp; &amp; &amp;lt; &amp; &amp;gt; for characters like &lt;&amp;&gt;";
+			var input =
+				"Jack &amp; Jill like xml sequences like &amp;amp; &amp; &amp;lt; &amp; &amp;gt; for characters like &lt;&amp;&gt;";
 			var output = BookData.TextOfInnerHtml(input);
-			Assert.That(output, Is.EqualTo("Jack & Jill like xml sequences like &amp; & &lt; & &gt; for characters like <&>"));
+			Assert.That(output,
+				Is.EqualTo("Jack & Jill like xml sequences like &amp; & &lt; & &gt; for characters like <&>"));
 		}
 
 		[Test]
@@ -89,9 +94,9 @@ namespace BloomTests.Book
 		[Test]
 		public void MakeLanguageUploadData_FindsOverriddenNames()
 		{
-			_collectionSettings.Language1Name = "Cockney";
+			_collectionSettings.Language1.Name = "Cockney";
 			// Note: no current way of overriding others; verify they aren't changed.
-			var results = _collectionSettings.MakeLanguageUploadData(new[] { "en", "tpi", "xyz" });
+			var results = _collectionSettings.MakeLanguageUploadData(new[] {"en", "tpi", "xyz"});
 			Assert.That(results.Length, Is.EqualTo(3), "should get one result per input");
 			VerifyLangData(results[0], "en", "English", "eng");
 			VerifyLangData(results[1], "tpi", "Tok Pisin", "tpi");
@@ -105,36 +110,36 @@ namespace BloomTests.Book
 			Assert.That(lang.EthnologueCode, Is.EqualTo(ethCode));
 		}
 
-	   [Test]
+		[Test]
 		public void SuckInDataFromEditedDom_NoDataDIvTitleChanged_NewTitleInCache()
-	   {
-		   HtmlDom bookDom = new HtmlDom(@"<html ><head></head><body>
+		{
+			HtmlDom bookDom = new HtmlDom(@"<html ><head></head><body>
 				<div class='bloom-page' id='guid2'>
 					<textarea lang='xyz' data-book='bookTitle'>original</textarea>
 				</div>
 			 </body></html>");
-		   var data = new BookData(bookDom, _collectionSettings, null);
-		   Assert.AreEqual("original", data.GetVariableOrNull("bookTitle", "xyz"));
+			var data = new BookData(bookDom, _collectionSettings, null);
+			Assert.AreEqual("original", data.GetVariableOrNull("bookTitle", "xyz"));
 
 
-		   HtmlDom editedPageDom = new HtmlDom(@"<html ><head></head><body>
+			HtmlDom editedPageDom = new HtmlDom(@"<html ><head></head><body>
 				<div class='bloom-page' id='guid2'>
 					<textarea lang='xyz' data-book='bookTitle'>changed</textarea>
 				</div>
 			 </body></html>");
 
-		   data.SuckInDataFromEditedDom(editedPageDom);
+			data.SuckInDataFromEditedDom(editedPageDom);
 
-		   Assert.AreEqual("changed", data.GetVariableOrNull("bookTitle", "xyz"));
-	   }
+			Assert.AreEqual("changed", data.GetVariableOrNull("bookTitle", "xyz"));
+		}
 
 		/// <summary>
 		/// Regression test: the difference between this situation (had a value before) and the one where this is newly discovered was the source of a bug
 		/// </summary>
-	   [Test]
-	   public void SuckInDataFromEditedDom_HasDataDivWithOldTitleThenTitleChanged_NewTitleInCache()
-	   {
-		   HtmlDom bookDom = new HtmlDom(@"<html ><head></head><body>
+		[Test]
+		public void SuckInDataFromEditedDom_HasDataDivWithOldTitleThenTitleChanged_NewTitleInCache()
+		{
+			HtmlDom bookDom = new HtmlDom(@"<html ><head></head><body>
 				<div id='bloomDataDiv'>
 						<div data-book='bookTitle' lang='xyz'>original</div>
 				</div>
@@ -143,18 +148,18 @@ namespace BloomTests.Book
 				</div>
 			 </body></html>");
 
-		   var data = new BookData(bookDom, _collectionSettings, null);
-		   Assert.AreEqual("original", data.GetVariableOrNull("bookTitle", "xyz"));
+			var data = new BookData(bookDom, _collectionSettings, null);
+			Assert.AreEqual("original", data.GetVariableOrNull("bookTitle", "xyz"));
 
-		   HtmlDom editedPageDom = new HtmlDom(@"<html ><head></head><body>
+			HtmlDom editedPageDom = new HtmlDom(@"<html ><head></head><body>
 				<div class='bloom-page' id='guid2'>
 					<textarea lang='xyz' data-book='bookTitle'>changed</textarea>
 				</div>
 			 </body></html>");
 
-		   data.SuckInDataFromEditedDom(editedPageDom);
+			data.SuckInDataFromEditedDom(editedPageDom);
 
-		   Assert.AreEqual("changed", data.GetVariableOrNull("bookTitle", "xyz"));
+			Assert.AreEqual("changed", data.GetVariableOrNull("bookTitle", "xyz"));
 		}
 
 		// BRANDING-RELATED TESTS
@@ -459,7 +464,8 @@ namespace BloomTests.Book
 				data.MergeBrandingSettings(tempFolder.Path);
 				var metadata = BookCopyrightAndLicense.GetMetadata(bookDom);
 
-				Assert.AreEqual($"Copyright © {DateTime.Now.Year.ToString()} Chewtoys International", metadata.CopyrightNotice);
+				Assert.AreEqual($"Copyright © {DateTime.Now.Year.ToString()} Chewtoys International",
+					metadata.CopyrightNotice);
 			}
 		}
 
@@ -467,7 +473,8 @@ namespace BloomTests.Book
 		[TestCase("copyright", "Copyright © 2012, test")]
 		[TestCase("licenseNotes", "Some extra notes")]
 		[TestCase("licenseUrl", "http://creativecommons.org/licenses/by-nd/3.0/bynd/")]
-		public void MergeSettings_HasCopyrightAlready_CustomBrandingStuffIgnored(string dataDivName, string dataDivContent)
+		public void MergeSettings_HasCopyrightAlready_CustomBrandingStuffIgnored(string dataDivName,
+			string dataDivContent)
 		{
 			HtmlDom bookDom = new HtmlDom(@"<html ><head></head><body>
 				<div id='bloomDataDiv'>
@@ -505,8 +512,10 @@ namespace BloomTests.Book
 				if (dataDivName == "licenseUrl")
 				{
 					Assert.That(metadata.License, Is.InstanceOf<CreativeCommonsLicense>());
-					Assert.That(metadata.License.Url, Is.EqualTo("http://creativecommons.org/licenses/by-nd/3.0/bynd/"));
-				} else if (dataDivName == "copyright")
+					Assert.That(metadata.License.Url,
+						Is.EqualTo("http://creativecommons.org/licenses/by-nd/3.0/bynd/"));
+				}
+				else if (dataDivName == "copyright")
 				{
 					Assert.That(metadata.License, Is.InstanceOf<NullLicense>());
 				}
@@ -518,12 +527,13 @@ namespace BloomTests.Book
 				if (dataDivName == "licenseNotes")
 					Assert.That(metadata.License.RightsStatement, Is.EqualTo("Some extra notes"));
 				else
-				Assert.That(metadata.License.RightsStatement, Is.Null.Or.Empty);
+					Assert.That(metadata.License.RightsStatement, Is.Null.Or.Empty);
 			}
 		}
 
 		[Test]
-		public void SuckInDataFromEditedDom_XmatterPageAttributeAddedToXmatterPage_XmatterPageAttributeAddedToBookDataAndDataDiv()
+		public void
+			SuckInDataFromEditedDom_XmatterPageAttributeAddedToXmatterPage_XmatterPageAttributeAddedToBookDataAndDataDiv()
 		{
 			HtmlDom bookDom = new HtmlDom(@"<html><head></head><body>
 				<div id='bloomDataDiv'>
@@ -545,17 +555,20 @@ namespace BloomTests.Book
 
 			data.SuckInDataFromEditedDom(editedPageDom);
 
-			Assert.AreEqual("SoundTrack0.mp3", data.GetXmatterPageDataAttributeValue("frontCover", "data-backgroundaudio"));
+			Assert.AreEqual("SoundTrack0.mp3",
+				data.GetXmatterPageDataAttributeValue("frontCover", "data-backgroundaudio"));
 			Assert.AreEqual("0.21", data.GetXmatterPageDataAttributeValue("frontCover", "data-backgroundaudiovolume"));
 
 			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath(
 				"//div[@id='bloomDataDiv']/div[@data-xmatter-page='frontCover' " +
-				"and @data-backgroundaudio='SoundTrack0.mp3' and @data-backgroundaudiovolume='0.21' and not(text())]", 1);
+				"and @data-backgroundaudio='SoundTrack0.mp3' and @data-backgroundaudiovolume='0.21' and not(text())]",
+				1);
 		}
 
 		//[Test] TODO - this test doesn't work because SuckInDataFromEditedDom first updates the page from the data div before updating the data div from the page.
 		// I couldn't get it worked out, but the production code does do things correctly. I attempted to add this test for BL-5409.
-		public void SuckInDataFromEditedDom_XmatterPageAttributeUpdatedInXmatterPage_XmatterPageAttributeUpdatedInBookDataAndDataDiv()
+		public void
+			SuckInDataFromEditedDom_XmatterPageAttributeUpdatedInXmatterPage_XmatterPageAttributeUpdatedInBookDataAndDataDiv()
 		{
 			HtmlDom bookDom = new HtmlDom(@"<html><head></head><body>
 				<div id='bloomDataDiv'>
@@ -567,7 +580,8 @@ namespace BloomTests.Book
 			 </body></html>");
 
 			var data = new BookData(bookDom, _collectionSettings, null);
-			Assert.AreEqual("SoundTrack0.mp3", data.GetXmatterPageDataAttributeValue("frontCover", "data-backgroundaudio"));
+			Assert.AreEqual("SoundTrack0.mp3",
+				data.GetXmatterPageDataAttributeValue("frontCover", "data-backgroundaudio"));
 			Assert.AreEqual("0.21", data.GetXmatterPageDataAttributeValue("frontCover", "data-backgroundaudiovolume"));
 
 			HtmlDom editedPageDom = new HtmlDom(@"<html><head></head><body>
@@ -581,18 +595,20 @@ namespace BloomTests.Book
 
 			data.SuckInDataFromEditedDom(editedPageDom);
 
-			Assert.AreEqual("SoundTrack2.mp3", data.GetXmatterPageDataAttributeValue("frontCover", "data-backgroundaudio"));
+			Assert.AreEqual("SoundTrack2.mp3",
+				data.GetXmatterPageDataAttributeValue("frontCover", "data-backgroundaudio"));
 			Assert.AreEqual("0.99", data.GetXmatterPageDataAttributeValue("frontCover", "data-backgroundaudiovolume"));
 
 			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath(
 				"//div[@id='bloomDataDiv']/div[@data-xmatter-page='frontCover' " +
-				"and @data-backgroundaudio='SoundTrack2.mp3' and @data-backgroundaudiovolume='0.99' and not(text())]", 1);
+				"and @data-backgroundaudio='SoundTrack2.mp3' and @data-backgroundaudiovolume='0.99' and not(text())]",
+				1);
 		}
 
 		[Test]
 		public void UpdateFieldsAndVariables_CustomLibraryVariable_CopiedToOtherElement()
 		{
-			var dom=new HtmlDom(@"<html ><head></head><body>
+			var dom = new HtmlDom(@"<html ><head></head><body>
 				<div class='bloom-page' id='guid3'>
 					<p>
 						<textarea lang='xyz' id='copyOfVTitle'  data-book='bookTitle'>tree</textarea>
@@ -617,7 +633,9 @@ namespace BloomTests.Book
 				</body></html>");
 			var data = new BookData(dom, _collectionSettings, null);
 			data.UpdateVariablesAndDataDivThroughDOM();
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-book='bookTitle' and @lang='"+_collectionSettings.Language1Iso639Code+"' and text()='the title']",1);
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath(
+				"//div[@data-book='bookTitle' and @lang='" + _collectionSettings.Language1Iso639Code +
+				"' and text()='the title']", 1);
 		}
 
 		[Test]
@@ -625,7 +643,8 @@ namespace BloomTests.Book
 		{
 			var dom = new HtmlDom(@"<html><head></head><body>
 				<div id='bloomDataDiv'>
-					<div data-xmatter-page='frontCover' " + HtmlDom.musicAttrName + "='audio/SoundTrack1.mp3' " + HtmlDom.musicVolumeName + @"='0.17'></div>
+					<div data-xmatter-page='frontCover' " + HtmlDom.musicAttrName + "='audio/SoundTrack1.mp3' " +
+			                      HtmlDom.musicVolumeName + @"='0.17'></div>
 				</div>
 				<div id='firstPage' class='bloom-page' data-xmatter-page='frontCover'>1st page</div>
 				</body></html>");
@@ -633,7 +652,8 @@ namespace BloomTests.Book
 			data.UpdateVariablesAndDataDivThroughDOM();
 			AssertThatXmlIn.Dom(dom.RawDom)
 				.HasSpecifiedNumberOfMatchesForXpath("//div[@id='firstPage' and @data-xmatter-page='frontCover' and @"
-					+ HtmlDom.musicAttrName + "='audio/SoundTrack1.mp3' and @" + HtmlDom.musicVolumeName + "='0.17']", 1);
+				                                     + HtmlDom.musicAttrName + "='audio/SoundTrack1.mp3' and @" +
+				                                     HtmlDom.musicVolumeName + "='0.17']", 1);
 		}
 
 		[Test]
@@ -649,7 +669,7 @@ namespace BloomTests.Book
 						<p class='centered' lang='xyz' data-book='bookTitle' id='P1'>originalButNoExactlyCauseItShouldn'tMatter</p>
 				</div>
 			 </body></html>");
-			var data = new BookData(dom,  _collectionSettings, null);
+			var data = new BookData(dom, _collectionSettings, null);
 			var textarea1 = dom.SelectSingleNodeHonoringDefaultNS("//textarea[@data-book='bookTitle' and @lang='xyz']");
 			textarea1.InnerText = "peace & quiet";
 			data.SynchronizeDataItemsThroughoutDOM();
@@ -674,15 +694,18 @@ namespace BloomTests.Book
 					</p>
 				</div>
 			 </body></html>");
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//textarea[@lang='en' and @id='1' and text()='EnglishTitle']", 1);
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//textarea[@lang='xyz'  and @id='2' and text()='xyzTitle']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//textarea[@lang='en' and @id='1' and text()='EnglishTitle']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//textarea[@lang='xyz'  and @id='2' and text()='xyzTitle']", 1);
 			var textarea2 = dom.SelectSingleNodeHonoringDefaultNS("//textarea[@id='2']");
 			textarea2.InnerText = "newXyzTitle";
-			var data = new BookData(dom, new CollectionSettings() { Language1Iso639Code = "etr" }, null);
+			var data = new BookData(dom, CreateCollection(Language1Iso639Code: "etr"), null);
 			data.SynchronizeDataItemsThroughoutDOM();
 			var textarea3 = dom.SelectSingleNodeHonoringDefaultNS("//textarea[@id='3']");
 			Assert.AreEqual("newXyzTitle", textarea3.InnerText);
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//textarea[@id='1' and text()='EnglishTitle']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//textarea[@id='1' and text()='EnglishTitle']", 1);
 		}
 
 		[Test]
@@ -701,11 +724,13 @@ namespace BloomTests.Book
 					</p>
 				</div>
 			 </body></html>");
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//textarea[@lang='en' and @id='1' and text()='EnglishTitle']", 1);
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//textarea[@lang='xyz'  and @id='2' and text()='xyzTitle']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//textarea[@lang='en' and @id='1' and text()='EnglishTitle']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//textarea[@lang='xyz'  and @id='2' and text()='xyzTitle']", 1);
 			var textarea1 = dom.SelectSingleNodeHonoringDefaultNS("//textarea[@id='1']");
 			textarea1.InnerText = "newEnglishTitle";
-			var data = new BookData(dom,   new CollectionSettings(){Language1Iso639Code = "etr"}, null);
+			var data = new BookData(dom, CreateCollection(Language1Iso639Code: "etr"), null);
 			data.SynchronizeDataItemsThroughoutDOM();
 			var textarea2 = dom.SelectSingleNodeHonoringDefaultNS("//textarea[@id='2']");
 			Assert.AreEqual("xyzTitle", textarea2.InnerText);
@@ -730,48 +755,43 @@ namespace BloomTests.Book
 					</div>
 				</div>
 				</body></html>");
-			var collectionSettings = new CollectionSettings()
-				{
-					Language1Iso639Code = "etr"
-				};
-			var data = new BookData(dom,   collectionSettings, null);
+			var collectionSettings = CreateCollection(Language1Iso639Code: "etr");
+			var data = new BookData(dom, collectionSettings, null);
 			data.SynchronizeDataItemsThroughoutDOM();
-			XmlElement nationalTitle = (XmlElement)dom.SelectSingleNodeHonoringDefaultNS("//h2[@data-book='bookTitle']");
+			XmlElement nationalTitle =
+				(XmlElement) dom.SelectSingleNodeHonoringDefaultNS("//h2[@data-book='bookTitle']");
 			Assert.AreEqual("Vaccinations", nationalTitle.InnerText);
 
 			//now switch the national language to Tok Pisin
 
 			collectionSettings.Language2Iso639Code = "tpi";
 			data.SynchronizeDataItemsThroughoutDOM();
-			nationalTitle = (XmlElement)dom.SelectSingleNodeHonoringDefaultNS("//h2[@data-book='bookTitle']");
+			nationalTitle = (XmlElement) dom.SelectSingleNodeHonoringDefaultNS("//h2[@data-book='bookTitle']");
 			Assert.AreEqual("Tambu Sut", nationalTitle.InnerText);
 		}
 
-        [Test]
-        public void UpdateFieldsAndVariables_OneLabelPreserved_DuplicatesRemovedNotAdded()
-        {
-            var dom = new HtmlDom(@"<html ><head></head><body>
+		[Test]
+		public void UpdateFieldsAndVariables_OneLabelPreserved_DuplicatesRemovedNotAdded()
+		{
+			var dom = new HtmlDom(@"<html ><head></head><body>
 				<div class='bloom-page titlePage'>
 						<div id='target' class='bloom-content1' data-book='insideBackCover'>
 							<label class='bubble'>Some more space to put things</label><label class='bubble'>Some more space to put things</label>Here is the content
 						</div>
 				</div>
 				</body></html>");
-            var collectionSettings = new CollectionSettings()
-            {
-                Language1Iso639Code = "etr"
-            };
-            var data = new BookData(dom, collectionSettings, null);
-            data.SynchronizeDataItemsThroughoutDOM();
-            XmlElement target = (XmlElement)dom.SelectSingleNodeHonoringDefaultNS("//div[@id='target']");
+			var collectionSettings = CreateCollection(Language1Iso639Code: "etr");
+			var data = new BookData(dom, collectionSettings, null);
+			data.SynchronizeDataItemsThroughoutDOM();
+			XmlElement target = (XmlElement) dom.SelectSingleNodeHonoringDefaultNS("//div[@id='target']");
 
-            // It's expected that the surviving label goes at the end.
-            Assert.That(target.InnerText, Is.EqualTo("Here is the contentSome more space to put things"));
-            XmlElement label = (XmlElement)target.SelectSingleNodeHonoringDefaultNS("//label");
-            Assert.That(label.InnerText, Is.EqualTo("Some more space to put things"));
-        }
+			// It's expected that the surviving label goes at the end.
+			Assert.That(target.InnerText, Is.EqualTo("Here is the contentSome more space to put things"));
+			XmlElement label = (XmlElement) target.SelectSingleNodeHonoringDefaultNS("//label");
+			Assert.That(label.InnerText, Is.EqualTo("Some more space to put things"));
+		}
 
-        [Test]
+		[Test]
 		public void GetMultilingualContentLanguage_ContentLanguageSpecifiedInHtml_ReadsIt()
 		{
 			var dom = new HtmlDom(@"<html ><head></head><body>
@@ -780,11 +800,12 @@ namespace BloomTests.Book
 						<div data-book='contentLanguage3'>es</div>
 				</div>
 				</body></html>");
-			var collectionSettings = new CollectionSettings();
-			var data = new BookData(dom,   collectionSettings, null);
+			var collectionSettings = CreateCollection();
+			var data = new BookData(dom, collectionSettings, null);
 			Assert.AreEqual("fr", data.MultilingualContentLanguage2);
 			Assert.AreEqual("es", data.MultilingualContentLanguage3);
 		}
+
 		[Test]
 		public void SetMultilingualContentLanguage_ContentLanguageSpecifiedInHtml_ReadsIt()
 		{
@@ -793,34 +814,41 @@ namespace BloomTests.Book
 						<div data-book='contentLanguage2'>fr</div>
 				</div>
 				</body></html>");
-			var collectionSettings = new CollectionSettings();
-			var data = new BookData(dom,   collectionSettings, null);
+			var collectionSettings = CreateCollection();
+			var data = new BookData(dom, collectionSettings, null);
 			data.SetMultilingualContentLanguages("en", "de");
 			Assert.AreEqual("en", data.MultilingualContentLanguage2);
 			Assert.AreEqual("de", data.MultilingualContentLanguage3);
 		}
+
 		[Test]
 		public void UpdateVariablesAndDataDivThroughDOM_NewLangAdded_AddedToDataDiv()
 		{
-			var dom = new HtmlDom(@"<html><head></head><body><div data-book='someVariable' lang='en'>hi</div></body></html>");
+			var dom = new HtmlDom(
+				@"<html><head></head><body><div data-book='someVariable' lang='en'>hi</div></body></html>");
 
 			var e = dom.RawDom.CreateElement("div");
 			e.SetAttribute("data-book", "someVariable");
 			e.SetAttribute("lang", "fr");
 			e.InnerText = "bonjour";
 			dom.RawDom.SelectSingleNode("//body").AppendChild(e);
-			var data = new BookData(dom,   new CollectionSettings(), null);
+			var data = new BookData(dom, CreateCollection(), null);
 			data.UpdateVariablesAndDataDivThroughDOM();
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//body/div[1][@id='bloomDataDiv']", 1);//NB microsoft uses 1 as the first. W3c uses 0.
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='someVariable' and @lang='en' and text()='hi']", 1);
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='someVariable' and @lang='fr' and text()='bonjour']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//body/div[1][@id='bloomDataDiv']",
+					1); //NB microsoft uses 1 as the first. W3c uses 0.
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath(
+				"//div[@id='bloomDataDiv']/div[@data-book='someVariable' and @lang='en' and text()='hi']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath(
+				"//div[@id='bloomDataDiv']/div[@data-book='someVariable' and @lang='fr' and text()='bonjour']", 1);
 		}
 
 		[Test]
 		public void UpdateVariablesAndDataDivThroughDOM_HasDataLibraryValues_LibraryValuesNotPutInDataDiv()
 		{
-			var dom = new HtmlDom(@"<html><head></head><body><div data-book='someVariable' lang='en'>hi</div><div data-collection='user' lang='en'>john</div></body></html>");
-			var data = new BookData(dom,   new CollectionSettings(), null);
+			var dom = new HtmlDom(
+				@"<html><head></head><body><div data-book='someVariable' lang='en'>hi</div><div data-collection='user' lang='en'>john</div></body></html>");
+			var data = new BookData(dom, CreateCollection(), null);
 			data.UpdateVariablesAndDataDivThroughDOM();
 			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//div[@id='bloomDataDiv']/div[@data-book='user']");
 			AssertThatXmlIn.Dom(dom.RawDom).HasNoMatchForXpath("//div[@id='bloomDataDiv']/div[@data-collection]");
@@ -830,10 +858,14 @@ namespace BloomTests.Book
 		public void UpdateVariablesAndDataDivThroughDOM_DoesNotExist_MakesOne()
 		{
 			var dom = new HtmlDom(@"<html><head></head><body><div data-book='someVariable'>world</div></body></html>");
-			var data = new BookData(dom,   new CollectionSettings(), null);
+			var data = new BookData(dom, CreateCollection(), null);
 			data.UpdateVariablesAndDataDivThroughDOM();
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//body/div[1][@id='bloomDataDiv']", 1);//NB microsoft uses 1 as the first. W3c uses 0.
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='someVariable' and text()='world']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//body/div[1][@id='bloomDataDiv']",
+					1); //NB microsoft uses 1 as the first. W3c uses 0.
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath(
+					"//div[@id='bloomDataDiv']/div[@data-book='someVariable' and text()='world']", 1);
 		}
 
 		[Test]
@@ -847,11 +879,15 @@ namespace BloomTests.Book
 			e.InnerText = "anything";
 			dom.RawDom.SelectSingleNode("//body").AppendChild(e);
 
-			var data = new BookData(dom, new CollectionSettings(), null);
+			var data = new BookData(dom, CreateCollection(), null);
 			data.UpdateVariablesAndDataDivThroughDOM();
 
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//body/div[1][@id='bloomDataDiv']", 1);//NB microsoft uses 1 as the first. W3c uses 0.
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-xmatter-page='frontCover' and @data-someattribute='someValue' and not(text())]", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//body/div[1][@id='bloomDataDiv']",
+					1); //NB microsoft uses 1 as the first. W3c uses 0.
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath(
+				"//div[@id='bloomDataDiv']/div[@data-xmatter-page='frontCover' and @data-someattribute='someValue' and not(text())]",
+				1);
 		}
 
 		//[Test] TODO - this test doesn't work because UpdateVariablesAndDataDivThroughDOM first updates the page from the data div before updating the data div from the page.
@@ -863,14 +899,19 @@ namespace BloomTests.Book
 				<div class='bloom-page' data-xmatter-page='frontCover' data-someattribute='someValue'>anything</div>
 				</body></html>");
 
-			var e = (XmlElement)dom.RawDom.SelectSingleNode("//body/div[@class='bloom-page' and @data-xmatter-page='frontCover']");
+			var e = (XmlElement) dom.RawDom.SelectSingleNode(
+				"//body/div[@class='bloom-page' and @data-xmatter-page='frontCover']");
 			e.SetAttribute("data-someattribute", "someOtherValue");
 
-			var data = new BookData(dom, new CollectionSettings(), null);
+			var data = new BookData(dom, CreateCollection(), null);
 			data.UpdateVariablesAndDataDivThroughDOM();
 
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//body/div[1][@id='bloomDataDiv']", 1);//NB microsoft uses 1 as the first. W3c uses 0.
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-xmatter-page='frontCover' and @data-someattribute='someOtherValue' and not(text())]", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//body/div[1][@id='bloomDataDiv']",
+					1); //NB microsoft uses 1 as the first. W3c uses 0.
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath(
+				"//div[@id='bloomDataDiv']/div[@data-xmatter-page='frontCover' and @data-someattribute='someOtherValue' and not(text())]",
+				1);
 		}
 
 		//[Test] TODO - this test doesn't work because UpdateVariablesAndDataDivThroughDOM first updates the page from the data div before updating the data div from the page.
@@ -882,14 +923,19 @@ namespace BloomTests.Book
 				<div class='bloom-page' data-xmatter-page='frontCover' data-someattribute='someValue'>anything</div>
 				</body></html>");
 
-			var e = (XmlElement)dom.RawDom.SelectSingleNode("//body/div[@class='bloom-page' and @data-xmatter-page='frontCover']");
+			var e = (XmlElement) dom.RawDom.SelectSingleNode(
+				"//body/div[@class='bloom-page' and @data-xmatter-page='frontCover']");
 			e.RemoveAttribute("data-someattribute");
 
-			var data = new BookData(dom, new CollectionSettings(), null);
+			var data = new BookData(dom, CreateCollection(), null);
 			data.UpdateVariablesAndDataDivThroughDOM();
 
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//body/div[1][@id='bloomDataDiv']", 1);//NB microsoft uses 1 as the first. W3c uses 0.
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-xmatter-page='frontCover' and not(@data-someattribute) and not(text())]", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//body/div[1][@id='bloomDataDiv']",
+					1); //NB microsoft uses 1 as the first. W3c uses 0.
+			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath(
+				"//div[@id='bloomDataDiv']/div[@data-xmatter-page='frontCover' and not(@data-someattribute) and not(text())]",
+				1);
 		}
 
 
@@ -897,18 +943,25 @@ namespace BloomTests.Book
 		public void SetMultilingualContentLanguages_HasTrilingualLanguages_AddsToDataDiv()
 		{
 			var dom = new HtmlDom(@"<html><head></head><body></body></html>");
-			var data = new BookData(dom,  new CollectionSettings(), null);
+			var data = new BookData(dom, CreateCollection(), null);
 			data.SetMultilingualContentLanguages("okm", "kbt");
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='contentLanguage2' and text()='okm']", 1);
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='contentLanguage3' and text()='kbt']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath(
+					"//div[@id='bloomDataDiv']/div[@data-book='contentLanguage2' and text()='okm']", 1);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath(
+					"//div[@id='bloomDataDiv']/div[@data-book='contentLanguage3' and text()='kbt']", 1);
 		}
+
 		[Test]
 		public void SetMultilingualContentLanguages_ThirdContentLangTurnedOff_RemovedFromDataDiv()
 		{
-			var dom = new HtmlDom(@"<html><head><div id='bloomDataDiv'><div data-book='contentLanguage2'>xyz</div><div data-book='contentLanguage3'>kbt</div></div></head><body></body></html>");
-			var data = new BookData(dom,  new CollectionSettings(), null);
-			data.SetMultilingualContentLanguages(null,null);
-			AssertThatXmlIn.Dom(dom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='contentLanguage3']", 0);
+			var dom = new HtmlDom(
+				@"<html><head><div id='bloomDataDiv'><div data-book='contentLanguage2'>xyz</div><div data-book='contentLanguage3'>kbt</div></div></head><body></body></html>");
+			var data = new BookData(dom, CreateCollection(), null);
+			data.SetMultilingualContentLanguages(null, null);
+			AssertThatXmlIn.Dom(dom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='contentLanguage3']", 0);
 		}
 
 
@@ -919,39 +972,43 @@ namespace BloomTests.Book
 		[TestCase("", "the province", "the district", "the district, the province")]
 		[TestCase("", "", "the district", "the district")]
 		[TestCase("", "the province", "", "the province")]
-		public void Constructor_CollectionSettingsHasVariousLocationFields_LanguageLocationFilledCorrect(string country, string province, string district, string expected)
+		public void Constructor_CollectionSettingsHasVariousLocationFields_LanguageLocationFilledCorrect(string country,
+			string province, string district, string expected)
 		{
 			var dom = new HtmlDom();
-			var data = new BookData(dom, new CollectionSettings(){Country=country, Province = province, District= district}, null);
+			var data = new BookData(dom,
+				new CollectionSettings() {Country = country, Province = province, District = district}, null);
 			Assert.AreEqual(expected, data.GetVariableOrNull("languageLocation", "*"));
-		  }
+		}
 
-		/*    data.AddLanguageString("*", "nameOfLanguage", collectionSettings.Language1Name, true);
+		/*    data.AddLanguageString("*", "nameOfLanguage", collectionSettings.Language1.Name, true);
 				data.AddLanguageString("*", "nameOfNationalLanguage1",
-									   collectionSettings.GetLanguage2Name(collectionSettings.Language2Iso639Code), true);
+									   collectionSettings.Language2.GetNameInLanguage(collectionSettings.Language2Iso639Code), true);
 				data.AddLanguageString("*", "nameOfNationalLanguage2",
-									   collectionSettings.GetLanguage3Name(collectionSettings.Language2Iso639Code), true);
+									   collectionSettings.Language3.GetNameInLanguage(collectionSettings.Language2Iso639Code), true);
 				data.AddGenericLanguageString("iso639Code", collectionSettings.Language1Iso639Code, true);*/
 
 		[Test]
 		public void Constructor_CollectionSettingsHasISO639Code_iso639CodeFilledIn()
 		{
 			var dom = new HtmlDom();
-			var data = new BookData(dom, new CollectionSettings() { Language1Iso639Code = "xyz" }, null);
+			var data = new BookData(dom, CreateCollection(Language1Iso639Code: "xyz"), null);
 			Assert.AreEqual("xyz", data.GetVariableOrNull("iso639Code", "*"));
 		}
+
 		[Test]
 		public void Constructor_CollectionSettingsHasISO639Code_DataSetContainsProperV()
 		{
 			var dom = new HtmlDom();
-			var data = new BookData(dom, new CollectionSettings() { Language1Iso639Code = "xyz" }, null);
+			var data = new BookData(dom, CreateCollection(Language1Iso639Code: "xyz"), null);
 			Assert.AreEqual("xyz", data.GetWritingSystemCodes()["V"]);
 		}
+
 		[Test]
 		public void Constructor_CollectionSettingsHasLanguage1Name_LanguagenameOfNationalLanguage1FilledIn()
 		{
 			var dom = new HtmlDom();
-			var data = new BookData(dom, new CollectionSettings() { Language1Name = "foobar" }, null);
+			var data = new BookData(dom, CreateCollection(Language1Name: "foobar"), null);
 			Assert.AreEqual("foobar", data.GetVariableOrNull("nameOfLanguage", "*"));
 		}
 
@@ -961,14 +1018,15 @@ namespace BloomTests.Book
 		public void Constructor_CollectionSettingsHasLanguage2Iso639Code_nameOfNationalLanguage1FilledIn()
 		{
 			var dom = new HtmlDom();
-			var data = new BookData(dom, new CollectionSettings() { Language2Iso639Code = "tpi" }, null);
+			var data = new BookData(dom, CreateCollection(Language2Iso639Code: "tpi"), null);
 			Assert.AreEqual("Tok Pisin", data.GetVariableOrNull("nameOfNationalLanguage1", "*"));
 		}
+
 		[Test]
 		public void Constructor_CollectionSettingsHasLanguage3Iso639Code_nameOfNationalLanguage2FilledIn()
 		{
 			var dom = new HtmlDom();
-			var data = new BookData(dom, new CollectionSettings() { Language3Iso639Code = "tpi" }, null);
+			var data = new BookData(dom, CreateCollection(Language3Iso639Code: "tpi"), null);
 			Assert.AreEqual("Tok Pisin", data.GetVariableOrNull("nameOfNationalLanguage2", "*"));
 		}
 
@@ -976,11 +1034,11 @@ namespace BloomTests.Book
 		public void Set_DidNotHaveForm_Added()
 		{
 			var htmlDom = new HtmlDom();
-			var data = new BookData(htmlDom, new CollectionSettings(), null);
+			var data = new BookData(htmlDom, CreateCollection(), null);
 			data.Set("1", "one", "en");
 			Assert.AreEqual("one", data.GetVariableOrNull("1", "en"));
-			AssertThatXmlIn.Dom(htmlDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='en']",1);
-			var roundTripData = new BookData(htmlDom, new CollectionSettings(), null);
+			AssertThatXmlIn.Dom(htmlDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='en']", 1);
+			var roundTripData = new BookData(htmlDom, CreateCollection(), null);
 			var t = roundTripData.GetVariableOrNull("1", "en");
 			Assert.AreEqual("one", t);
 		}
@@ -989,10 +1047,10 @@ namespace BloomTests.Book
 		public void Set_AddTwoForms_BothAdded()
 		{
 			var htmlDom = new HtmlDom();
-			var data = new BookData(htmlDom, new CollectionSettings(), null);
+			var data = new BookData(htmlDom, CreateCollection(), null);
 			data.Set("1", "one", "en");
 			data.Set("1", "uno", "es");
-			var roundTripData = new BookData(htmlDom, new CollectionSettings(), null);
+			var roundTripData = new BookData(htmlDom, CreateCollection(), null);
 			Assert.AreEqual("one", roundTripData.GetVariableOrNull("1", "en"));
 			Assert.AreEqual("uno", roundTripData.GetVariableOrNull("1", "es"));
 		}
@@ -1001,12 +1059,12 @@ namespace BloomTests.Book
 		public void Set_DidHaveForm_StillJustOneCopy()
 		{
 			var htmlDom = new HtmlDom();
-			var data = new BookData(htmlDom, new CollectionSettings(), null);
+			var data = new BookData(htmlDom, CreateCollection(), null);
 			data.Set("1", "one", "en");
 			data.Set("1", "one", "en");
 			Assert.AreEqual("one", data.GetVariableOrNull("1", "en"));
 			AssertThatXmlIn.Dom(htmlDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='en']", 1);
-			var roundTripData = new BookData(htmlDom, new CollectionSettings(), null);
+			var roundTripData = new BookData(htmlDom, CreateCollection(), null);
 			var t = roundTripData.GetVariableOrNull("1", "en");
 			Assert.AreEqual("one", t);
 		}
@@ -1015,12 +1073,12 @@ namespace BloomTests.Book
 		public void Set_EmptyString_Removes()
 		{
 			var htmlDom = new HtmlDom();
-			var data = new BookData(htmlDom, new CollectionSettings(), null);
+			var data = new BookData(htmlDom, CreateCollection(), null);
 			data.Set("1", "one", "en");
 			data.Set("1", "", "en");
 			Assert.AreEqual(null, data.GetVariableOrNull("1", "en"));
 			AssertThatXmlIn.Dom(htmlDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='en']", 0);
-			var roundTripData = new BookData(htmlDom, new CollectionSettings(), null);
+			var roundTripData = new BookData(htmlDom, CreateCollection(), null);
 			Assert.IsNull(roundTripData.GetVariableOrNull("1", "en"));
 		}
 
@@ -1028,12 +1086,12 @@ namespace BloomTests.Book
 		public void Set_Null_Removes()
 		{
 			var htmlDom = new HtmlDom();
-			var data = new BookData(htmlDom, new CollectionSettings(), null);
+			var data = new BookData(htmlDom, CreateCollection(), null);
 			data.Set("1", "one", "en");
 			data.Set("1", null, "en");
 			Assert.AreEqual(null, data.GetVariableOrNull("1", "en"));
 			AssertThatXmlIn.Dom(htmlDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='en']", 0);
-			var roundTripData = new BookData(htmlDom, new CollectionSettings(), null);
+			var roundTripData = new BookData(htmlDom, CreateCollection(), null);
 			Assert.IsNull(roundTripData.GetVariableOrNull("1", "en"));
 		}
 
@@ -1041,10 +1099,10 @@ namespace BloomTests.Book
 		public void RemoveSingleForm_HasForm_Removed()
 		{
 			var htmlDom = new HtmlDom();
-			var data = new BookData(htmlDom, new CollectionSettings(), null);
-			data.Set("1","one","en");
-			var data2 = new BookData(htmlDom, new CollectionSettings(), null);
-			data2.RemoveSingleForm("1","en");
+			var data = new BookData(htmlDom, CreateCollection(), null);
+			data.Set("1", "one", "en");
+			var data2 = new BookData(htmlDom, CreateCollection(), null);
+			data2.RemoveSingleForm("1", "en");
 			Assert.IsNull(data2.GetVariableOrNull("1", "en"));
 		}
 
@@ -1052,11 +1110,11 @@ namespace BloomTests.Book
 		public void RemoveDataDivVariableForOneLanguage_DoesNotHaveForm_OK()
 		{
 			var htmlDom = new HtmlDom();
-			var data = new BookData(htmlDom, new CollectionSettings(), null);
+			var data = new BookData(htmlDom, CreateCollection(), null);
 			data.RemoveSingleForm("1", "en");
 			Assert.AreEqual(null, data.GetVariableOrNull("1", "en"));
 			AssertThatXmlIn.Dom(htmlDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@lang='en']", 0);
-			var roundTripData = new BookData(htmlDom, new CollectionSettings(), null);
+			var roundTripData = new BookData(htmlDom, CreateCollection(), null);
 			Assert.IsNull(roundTripData.GetVariableOrNull("1", "en"));
 		}
 
@@ -1064,9 +1122,9 @@ namespace BloomTests.Book
 		public void RemoveDataDivVariableForOneLanguage_WasLastForm_WholeElementRemoved()
 		{
 			var htmlDom = new HtmlDom();
-			var data = new BookData(htmlDom, new CollectionSettings(), null);
-			data.Set("1","one","en");
-			var roundTripData = new BookData(htmlDom, new CollectionSettings(), null);
+			var data = new BookData(htmlDom, CreateCollection(), null);
+			data.Set("1", "one", "en");
+			var roundTripData = new BookData(htmlDom, CreateCollection(), null);
 			roundTripData.RemoveSingleForm("1", "en");
 			Assert.IsNull(roundTripData.GetVariableOrNull("1", "en"));
 
@@ -1077,13 +1135,13 @@ namespace BloomTests.Book
 		public void RemoveDataDivVariableForOneLanguage_WasTwoForms_OtherRemains()
 		{
 			var htmlDom = new HtmlDom();
-			var data = new BookData(htmlDom, new CollectionSettings(), null);
+			var data = new BookData(htmlDom, CreateCollection(), null);
 			data.Set("1", "one", "en");
 			data.Set("1", "uno", "es");
-			var roundTripData = new BookData(htmlDom, new CollectionSettings(), null);
+			var roundTripData = new BookData(htmlDom, CreateCollection(), null);
 			roundTripData.RemoveSingleForm("1", "en");
 			Assert.IsNull(roundTripData.GetVariableOrNull("1", "en"));
-			Assert.AreEqual("uno",roundTripData.GetVariableOrNull("1","es"));
+			Assert.AreEqual("uno", roundTripData.GetVariableOrNull("1", "es"));
 		}
 
 
@@ -1091,21 +1149,21 @@ namespace BloomTests.Book
 		public void Set_CalledTwiceWithDIfferentLangs_HasBoth()
 		{
 			var htmlDom = new HtmlDom();
-			var data = new BookData(htmlDom, new CollectionSettings(), null);
+			var data = new BookData(htmlDom, CreateCollection(), null);
 			data.Set("1", "one", "en");
 			data.Set("1", "uno", "es");
-			Assert.AreEqual(2,data.GetMultiTextVariableOrEmpty("1").Forms.Count());
+			Assert.AreEqual(2, data.GetMultiTextVariableOrEmpty("1").Forms.Count());
 		}
 
 		[Test]
 		public void UpdateVariablesAndDataDivThroughDOM_VariableIsNull_DataDivForItRemoved()
 		{
 			var htmlDom = new HtmlDom();
-			var data = new BookData(htmlDom, new CollectionSettings(), null);
-			data.Set("1","one","en");
+			var data = new BookData(htmlDom, CreateCollection(), null);
+			data.Set("1", "one", "en");
 			data.Set("1", null, "es");
 			data.UpdateVariablesAndDataDivThroughDOM();
-			AssertThatXmlIn.Dom(htmlDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("html/body/div/div[@lang='en']",1);
+			AssertThatXmlIn.Dom(htmlDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("html/body/div/div[@lang='en']", 1);
 			AssertThatXmlIn.Dom(htmlDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("html/body/div/div[@lang='es']", 0);
 		}
 
@@ -1113,7 +1171,8 @@ namespace BloomTests.Book
 		public void PrettyPrintLanguage_DoesNotModifyUnknownCodes()
 		{
 			var htmlDom = new HtmlDom();
-			var settingsettings = new CollectionSettings() { Language1Iso639Code = "pdc", Language1Name = "German, Kludged" };
+			var settingsettings =
+				CreateCollection(Language1Iso639Code: "pdc", Language1Name: "German, Kludged");
 			var data = new BookData(htmlDom, settingsettings, null);
 			Assert.That(data.PrettyPrintLanguage("xyz"), Is.EqualTo("xyz"));
 		}
@@ -1122,7 +1181,8 @@ namespace BloomTests.Book
 		public void PrettyPrintLanguage_AdjustsLang1()
 		{
 			var htmlDom = new HtmlDom();
-			var settingsettings = new CollectionSettings() {Language1Iso639Code = "pdc", Language1Name = "German, Kludged"};
+			var settingsettings =
+				CreateCollection(Language1Iso639Code: "pdc", Language1Name: "German, Kludged");
 			var data = new BookData(htmlDom, settingsettings, null);
 			Assert.That(data.PrettyPrintLanguage("pdc"), Is.EqualTo("German, Kludged"));
 		}
@@ -1131,8 +1191,13 @@ namespace BloomTests.Book
 		public void PrettyPrintLanguage_AdjustsKnownLanguages_German()
 		{
 			var htmlDom = new HtmlDom();
-			var settingsettings = new CollectionSettings() { Language1Iso639Code = "pdc", Language1Name = "German, Kludged", Language2Iso639Code = "de", Language3Iso639Code = "fr"};
-			var data = new BookData(htmlDom, settingsettings, null);
+			var settings = CreateCollection(
+				Language1Name: "German, Kludged",
+				Language1Iso639Code: "pdc",
+				Language2Iso639Code: "de",
+				Language3Iso639Code: "fr"
+			);
+			var data = new BookData(htmlDom, settings, null);
 			Assert.That(data.PrettyPrintLanguage("de"), Is.EqualTo("Deutsch"));
 			Assert.That(data.PrettyPrintLanguage("fr"), Is.EqualTo("français"));
 			Assert.That(data.PrettyPrintLanguage("en"), Is.EqualTo("English"));
@@ -1143,8 +1208,13 @@ namespace BloomTests.Book
 		public void PrettyPrintLanguage_AdjustsKnownLanguages_English()
 		{
 			var htmlDom = new HtmlDom();
-			var settingsettings = new CollectionSettings() { Language1Iso639Code = "pdc", Language1Name = "German, Kludged", Language2Iso639Code = "en", Language3Iso639Code = "fr"};
-			var data = new BookData(htmlDom, settingsettings, null);
+			var settings = CreateCollection(
+				Language1Iso639Code: "pdc",
+				Language1Name: "German, Kludged",
+				Language2Iso639Code: "en",
+				Language3Iso639Code: "fr"
+			);
+			var data = new BookData(htmlDom, settings, null);
 			Assert.That(data.PrettyPrintLanguage("de"), Is.EqualTo("German"));
 			Assert.That(data.PrettyPrintLanguage("fr"), Is.EqualTo("French"));
 			Assert.That(data.PrettyPrintLanguage("en"), Is.EqualTo("English"));
@@ -1174,17 +1244,20 @@ namespace BloomTests.Book
 			TestTopicHandling("Health", "en", "Health", "x", "y", "z", "Should use English");
 			TestTopicHandling("Health", "en", "Health", "en", "fr", "es", "Should use lang1");
 			TestTopicHandling("NoTopic", "", "", "en", "fr", "es", "'No Topic' should give no @lang and no text");
-			TestTopicHandling("Bogus", "en", "Bogus", "z", "fr", "es", "Unrecognized topic should give topic in English");
+			TestTopicHandling("Bogus", "en", "Bogus", "z", "fr", "es",
+				"Unrecognized topic should give topic in English");
 		}
-		private void TestTopicHandling(string topicKey, string expectedLanguage, string expectedTranslation, string lang1, string lang2, string lang3, string description)
+
+		private void TestTopicHandling(string topicKey, string expectedLanguage, string expectedTranslation,
+			string lang1, string lang2, string lang3, string description)
 		{
-			_collectionSettings.Language1Iso639Code = lang1;
-			_collectionSettings.Language2Iso639Code = lang2;
-			_collectionSettings.Language3Iso639Code = lang3;
+			_collectionSettings.Language1.Iso639Code = lang1;
+			_collectionSettings.Language2.Iso639Code = lang2;
+			_collectionSettings.Language3.Iso639Code = lang3;
 
 			var bookDom = new HtmlDom(@"<html><body>
 				<div id='bloomDataDiv'>
-						<div data-book='topic' lang='en'>"+topicKey+@"</div>
+						<div data-book='topic' lang='en'>" + topicKey + @"</div>
 				</div>
 				<div id='somePage'>
                     <div id='test' data-derived='topic'>
@@ -1199,13 +1272,15 @@ namespace BloomTests.Book
 				{
 					AssertThatXmlIn.Dom(bookDom.RawDom)
 						.HasSpecifiedNumberOfMatchesForXpath(
-							"//div[@id='test' and @data-derived='topic' and not(@lang) and text()='" + expectedTranslation + "']", 1);
+							"//div[@id='test' and @data-derived='topic' and not(@lang) and text()='" +
+							expectedTranslation + "']", 1);
 				}
 				else
 				{
 					AssertThatXmlIn.Dom(bookDom.RawDom)
 						.HasSpecifiedNumberOfMatchesForXpath(
-							"//div[@id='test' and @data-derived='topic' and @lang='" + expectedLanguage + "' and text()='" +
+							"//div[@id='test' and @data-derived='topic' and @lang='" + expectedLanguage +
+							"' and text()='" +
 							expectedTranslation + "']", 1);
 				}
 			}
@@ -1230,7 +1305,8 @@ namespace BloomTests.Book
 			 </body></html>");
 			var data = new BookData(bookDom, _collectionSettings, null);
 			data.SynchronizeDataItemsThroughoutDOM();
-			AssertThatXmlIn.Dom(bookDom.RawDom).HasNoMatchForXpath("//div[@id='bloomDataDiv']/div[@data-book='topic' and @lang='fr']");
+			AssertThatXmlIn.Dom(bookDom.RawDom)
+				.HasNoMatchForXpath("//div[@id='bloomDataDiv']/div[@data-book='topic' and @lang='fr']");
 		}
 
 		[Test]
@@ -1243,9 +1319,12 @@ namespace BloomTests.Book
 			 </body></html>");
 			var data = new BookData(bookDom, _collectionSettings, null);
 			data.SynchronizeDataItemsThroughoutDOM();
-			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-derived='topic' and @lang='en']/p", 0);
-			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='bloomDataDiv']/div[@data-book='topic' and @lang='en' and text()='Health']", 1);
+			AssertThatXmlIn.Dom(bookDom.RawDom)
+				.HasSpecifiedNumberOfMatchesForXpath("//div[@data-derived='topic' and @lang='en']/p", 0);
+			AssertThatXmlIn.Dom(bookDom.RawDom).HasSpecifiedNumberOfMatchesForXpath(
+				"//div[@id='bloomDataDiv']/div[@data-book='topic' and @lang='en' and text()='Health']", 1);
 		}
+
 		private bool AndikaNewBasicIsInstalled()
 		{
 			const string fontToCheck = "andika new basic";
@@ -1276,11 +1355,11 @@ namespace BloomTests.Book
 			// Verify
 			var oneTimeCheckVersion = _collectionSettings.OneTimeCheckVersionNumber;
 			Assert.That(Convert.ToInt32(oneTimeCheckVersion).Equals(1));
-			var font1 = _collectionSettings.DefaultLanguage1FontName;
+			var font1 = _collectionSettings.Language1.FontName;
 			Assert.That(font1.Equals("Andika New Basic"));
-			var font2 = _collectionSettings.DefaultLanguage1FontName;
+			var font2 = _collectionSettings.Language1.FontName;
 			Assert.That(font2.Equals("Andika New Basic"));
-			var font3 = _collectionSettings.DefaultLanguage1FontName;
+			var font3 = _collectionSettings.Language1.FontName;
 			Assert.That(font3.Equals("Andika New Basic"));
 		}
 
@@ -1294,7 +1373,7 @@ namespace BloomTests.Book
 			_collectionSettings.Load();
 
 			// Verify
-			var font1 = _collectionSettings.DefaultLanguage1FontName;
+			var font1 = _collectionSettings.Language1.FontName;
 			var oneTimeCheckVersion = _collectionSettings.OneTimeCheckVersionNumber;
 			Assert.That(Convert.ToInt32(oneTimeCheckVersion).Equals(1));
 			Assert.That(font1.Equals("Andika New Basic"));
@@ -1310,7 +1389,7 @@ namespace BloomTests.Book
 			_collectionSettings.Load();
 
 			// Verify
-			var font1 = _collectionSettings.DefaultLanguage1FontName;
+			var font1 = _collectionSettings.Language1.FontName;
 			var oneTimeCheckVersion = _collectionSettings.OneTimeCheckVersionNumber;
 			Assert.That(Convert.ToInt32(oneTimeCheckVersion).Equals(1));
 			Assert.That(font1.Equals("Andika"));
@@ -1332,8 +1411,8 @@ namespace BloomTests.Book
 				<DefaultLanguage1FontName>Andika</DefaultLanguage1FontName>
 				<DefaultLanguage2FontName>Andika</DefaultLanguage2FontName>
 				<DefaultLanguage3FontName>Andika</DefaultLanguage3FontName>
-				<IsLanguage1Rtl>false</IsLanguage1Rtl>
-				<IsLanguage2Rtl>false</IsLanguage2Rtl>
+				<Language1.IsRightToLeft>false</Language1.IsRightToLeft>
+				<Language2.IsRightToLeft>false</Language2.IsRightToLeft>
 				<IsLanguage3Rtl>true</IsLanguage3Rtl>
 				<IsSourceCollection>False</IsSourceCollection>
 				<XMatterPack>Factory</XMatterPack>
@@ -1353,8 +1432,8 @@ namespace BloomTests.Book
 				<DefaultLanguage2FontName>Andika New Basic</DefaultLanguage2FontName>
 				<DefaultLanguage3FontName>Andika New Basic</DefaultLanguage3FontName>
 				<OneTimeCheckVersionNumber>1</OneTimeCheckVersionNumber>
-				<IsLanguage1Rtl>false</IsLanguage1Rtl>
-				<IsLanguage2Rtl>false</IsLanguage2Rtl>
+				<Language1.IsRightToLeft>false</Language1.IsRightToLeft>
+				<Language2.IsRightToLeft>false</Language2.IsRightToLeft>
 				<IsLanguage3Rtl>true</IsLanguage3Rtl>
 				<IsSourceCollection>False</IsSourceCollection>
 				<XMatterPack>Factory</XMatterPack>
@@ -1374,8 +1453,8 @@ namespace BloomTests.Book
 				<DefaultLanguage2FontName>Andika</DefaultLanguage2FontName>
 				<DefaultLanguage3FontName>Andika</DefaultLanguage3FontName>
 				<OneTimeCheckVersionNumber>1</OneTimeCheckVersionNumber>
-				<IsLanguage1Rtl>false</IsLanguage1Rtl>
-				<IsLanguage2Rtl>false</IsLanguage2Rtl>
+				<Language1.IsRightToLeft>false</Language1.IsRightToLeft>
+				<Language2.IsRightToLeft>false</Language2.IsRightToLeft>
 				<IsLanguage3Rtl>true</IsLanguage3Rtl>
 				<IsSourceCollection>False</IsSourceCollection>
 				<XMatterPack>Factory</XMatterPack>
@@ -1392,11 +1471,13 @@ namespace BloomTests.Book
 			// The old xpath used in most of these tests was getting datadiv results, not bloom-page results,
 			// but the messages on most Asserts made it clear it was supposed to be testing the bloom-page contents.
 			// This xpath tests the bloom-page contents, not the datadiv
-			return "//div[@id='originalContributions']/div[@data-book='originalContributions' and @lang='" + lang + "']";
+			return "//div[@id='originalContributions']/div[@data-book='originalContributions' and @lang='" + lang +
+			       "']";
 		}
 
 		[Test]
-		public void SynchronizeDataItemsThroughoutDOM_HasOnlyEnglishContributorsButEnglishIsLang3_CopiesEnglishIntoNationalLanguageSlot()
+		public void
+			SynchronizeDataItemsThroughoutDOM_HasOnlyEnglishContributorsButEnglishIsLang3_CopiesEnglishIntoNationalLanguageSlot()
 		{
 			var dom = new HtmlDom(@"<html ><head></head><body>
 				<div id='bloomDataDiv'>
@@ -1409,23 +1490,26 @@ namespace BloomTests.Book
 					</div>
 				</div>
 				</body></html>");
-			var collectionSettings = new CollectionSettings()
-				{
-					  Language1Iso639Code = "etr",
-					  Language2Iso639Code = "fr"
-				};
+			var collectionSettings = CreateCollection(
+
+				Language1Iso639Code: "etr",
+				Language2Iso639Code: "fr"
+			);
 			var data = new BookData(dom, collectionSettings, null);
 			data.SynchronizeDataItemsThroughoutDOM();
 			var englishContributions = dom.SelectSingleNodeHonoringDefaultNS(GetXpathForContributionsInLang("en"));
-			Assert.AreEqual("the contributions", englishContributions.InnerText, "Should copy English into body of course, as normal");
+			Assert.AreEqual("the contributions", englishContributions.InnerText,
+				"Should copy English into body of course, as normal");
 			var frenchContributions = dom.SelectSingleNodeHonoringDefaultNS(GetXpathForContributionsInLang("fr"));
-			Assert.AreEqual("the contributions", frenchContributions.InnerText, "Should copy English into French Contributions becuase it's better than just showing nothing");
+			Assert.AreEqual("the contributions", frenchContributions.InnerText,
+				"Should copy English into French Contributions becuase it's better than just showing nothing");
 		}
 
 
 
 		[Test]
-		public void SynchronizeDataItemsThroughoutDOM_HasOnlyEnglishContributorsInDataDivButFrenchInBody_DoesNotCopyEnglishIntoFrenchSlot()
+		public void
+			SynchronizeDataItemsThroughoutDOM_HasOnlyEnglishContributorsInDataDivButFrenchInBody_DoesNotCopyEnglishIntoFrenchSlot()
 		{
 			var dom = new HtmlDom(@"<html ><head></head><body>
 				<div id='bloomDataDiv'>
@@ -1438,19 +1522,20 @@ namespace BloomTests.Book
 					</div>
 				</div>
 				</body></html>");
-			var collectionSettings = new CollectionSettings()
-			{
-				Language1Iso639Code = "etr",
-				Language2Iso639Code = "fr"
-			};
+			var collectionSettings = CreateCollection(
+				Language1Iso639Code: "etr",
+				Language2Iso639Code: "fr"
+			);
 			var data = new BookData(dom, collectionSettings, null);
 			data.SynchronizeDataItemsThroughoutDOM();
 			var frenchContributions = dom.SelectSingleNodeHonoringDefaultNS(GetXpathForContributionsInLang("fr"));
-			Assert.AreEqual("les contributeurs", frenchContributions.InnerText, "Should not touch existing French Contributions");
+			Assert.AreEqual("les contributeurs", frenchContributions.InnerText,
+				"Should not touch existing French Contributions");
 		}
 
 		[Test]
-		public void SynchronizeDataItemsThroughoutDOM_HasFrenchAndEnglishContributorsInDataDiv_DoesNotCopyEnglishIntoFrenchSlot()
+		public void
+			SynchronizeDataItemsThroughoutDOM_HasFrenchAndEnglishContributorsInDataDiv_DoesNotCopyEnglishIntoFrenchSlot()
 		{
 			var dom = new HtmlDom(@"<html ><head></head><body>
 				<div id='bloomDataDiv'>
@@ -1464,17 +1549,19 @@ namespace BloomTests.Book
 					</div>
 				</div>
 				</body></html>");
-			var collectionSettings = new CollectionSettings()
-			{
-				Language1Iso639Code = "xyz",
-				Language2Iso639Code = "fr"
-			};
+			var collectionSettings = CreateCollection(
+
+				Language1Iso639Code: "xyz",
+				Language2Iso639Code: "fr"
+			);
 			var data = new BookData(dom, collectionSettings, null);
 			data.SynchronizeDataItemsThroughoutDOM();
 			var frenchContributions = dom.SelectSingleNodeHonoringDefaultNS(GetXpathForContributionsInLang("fr"));
-			Assert.AreEqual("les contributeurs", frenchContributions.InnerText, "Should use the French, not the English even though the French in the body was empty");
+			Assert.AreEqual("les contributeurs", frenchContributions.InnerText,
+				"Should use the French, not the English even though the French in the body was empty");
 			var vernacularContributions = dom.SelectSingleNodeHonoringDefaultNS(GetXpathForContributionsInLang("xyz"));
-			Assert.AreEqual("", vernacularContributions.InnerText, "Should not copy Edolo into Vernacular Contributions. Only national language fields get this treatment");
+			Assert.AreEqual("", vernacularContributions.InnerText,
+				"Should not copy Edolo into Vernacular Contributions. Only national language fields get this treatment");
 		}
 
 		[Test]
@@ -1493,17 +1580,18 @@ namespace BloomTests.Book
 					</div>
 				</div>
 				</body></html>");
-			var collectionSettings = new CollectionSettings
-			{
-					  Language1Iso639Code = "xyz",
-					  Language2Iso639Code = "fr"
-			};
+			var collectionSettings = CreateCollection(
+				Language1Iso639Code: "xyz",
+				Language2Iso639Code: "fr"
+			);
 			var data = new BookData(dom, collectionSettings, null);
 			data.SynchronizeDataItemsThroughoutDOM();
 			var frenchContributions = dom.SelectSingleNodeHonoringDefaultNS(GetXpathForContributionsInLang("fr"));
-			Assert.AreEqual("the contributions", frenchContributions.InnerText, "Should copy Edolo into French Contributions because it's better than just showing nothing");
+			Assert.AreEqual("the contributions", frenchContributions.InnerText,
+				"Should copy Edolo into French Contributions because it's better than just showing nothing");
 			var vernacularContributions = dom.SelectSingleNodeHonoringDefaultNS(GetXpathForContributionsInLang("xyz"));
-			Assert.AreEqual("", vernacularContributions.InnerText, "Should not copy Edolo into Vernacular Contributions. Only national language fields get this treatment");
+			Assert.AreEqual("", vernacularContributions.InnerText,
+				"Should not copy Edolo into Vernacular Contributions. Only national language fields get this treatment");
 		}
 
 		[Test]
@@ -1522,17 +1610,19 @@ namespace BloomTests.Book
 					</div>
 				</div>
 				</body></html>");
-			var collectionSettings = new CollectionSettings()
-			{
-				Language1Iso639Code = "xyz",
-				Language2Iso639Code = "en"
-			};
+			var collectionSettings = CreateCollection(
+
+				Language1Iso639Code: "xyz",
+				Language2Iso639Code: "en"
+			);
 			var data = new BookData(dom, collectionSettings, null);
 			data.SynchronizeDataItemsThroughoutDOM();
 			var englishContributions = dom.SelectSingleNodeHonoringDefaultNS(GetXpathForContributionsInLang("en"));
-			Assert.AreEqual("les contributeurs", englishContributions.InnerText, "Should copy French into English Contributions because it's better than just showing nothing");
+			Assert.AreEqual("les contributeurs", englishContributions.InnerText,
+				"Should copy French into English Contributions because it's better than just showing nothing");
 			var vernacularContributions = dom.SelectSingleNodeHonoringDefaultNS(GetXpathForContributionsInLang("xyz"));
-			Assert.AreEqual("", vernacularContributions.InnerText, "Should not copy Edolo into Vernacular Contributions. Only national language fields get this treatment");
+			Assert.AreEqual("", vernacularContributions.InnerText,
+				"Should not copy Edolo into Vernacular Contributions. Only national language fields get this treatment");
 		}
 
 		[TestCase("", ExpectedResult = true)]
@@ -1553,10 +1643,7 @@ namespace BloomTests.Book
 
 		private static string NewLines
 		{
-			get
-			{
-				return Environment.NewLine + "  " + Environment.NewLine + "  " + Environment.NewLine;
-			}
+			get { return Environment.NewLine + "  " + Environment.NewLine + "  " + Environment.NewLine; }
 		}
 
 		// A separate test was required, since I wanted to use Environment.NewLine and the
@@ -1587,7 +1674,7 @@ namespace BloomTests.Book
 				</body></html>");
 			var data = new BookData(dom, _collectionSettings, null);
 			data.SynchronizeDataItemsThroughoutDOM();
-			var foo = (XmlElement)dom.SelectSingleNodeHonoringDefaultNS("//*[@id='foo']");
+			var foo = (XmlElement) dom.SelectSingleNodeHonoringDefaultNS("//*[@id='foo']");
 			Assert.That(foo.InnerXml, Contains.Substring("<label>some label</label>"));
 		}
 
@@ -1615,6 +1702,49 @@ namespace BloomTests.Book
 			dataPage = data.GetXmatterPageDataAttributeValue("outsideBackCover", "data-page");
 			Assert.That(pageNumber, Is.EqualTo(""));
 			Assert.That(dataPage, Is.EqualTo("required singleton"));
+		}
+
+
+		public static CollectionSettings CreateCollection(string Language1Iso639Code = null,
+			string Language1Name = null,
+			string Language2Iso639Code = null,
+			string Language2Name = null,
+			string Language3Iso639Code = null,
+			string Language3Name = null
+		)
+		{
+			var c = new CollectionSettings();
+			if (Language1Iso639Code != null)
+			{
+				c.Language1.Iso639Code = Language1Iso639Code;
+			}
+
+			if (Language1Name != null)
+			{
+				c.Language1.Name = Language1Name;
+			}
+
+			if (Language2Iso639Code != null)
+			{
+				c.Language2.Iso639Code = Language2Iso639Code;
+			}
+
+			if (Language2Name != null)
+			{
+				c.Language2.Name = Language2Name;
+			}
+
+			if (Language3Iso639Code != null)
+			{
+				c.Language3.Iso639Code = Language3Iso639Code;
+			}
+
+			if (Language3Name != null)
+			{
+				c.Language3.Name = Language3Name;
+			}
+
+			return c;
 		}
 	}
 }

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -1411,8 +1411,8 @@ namespace BloomTests.Book
 				<DefaultLanguage1FontName>Andika</DefaultLanguage1FontName>
 				<DefaultLanguage2FontName>Andika</DefaultLanguage2FontName>
 				<DefaultLanguage3FontName>Andika</DefaultLanguage3FontName>
-				<Language1.IsRightToLeft>false</Language1.IsRightToLeft>
-				<Language2.IsRightToLeft>false</Language2.IsRightToLeft>
+				<IsLanguage1Rtl>false</IsLanguage1Rtl>
+				<IsLanguage2Rtl>false</IsLanguage2Rtl>
 				<IsLanguage3Rtl>true</IsLanguage3Rtl>
 				<IsSourceCollection>False</IsSourceCollection>
 				<XMatterPack>Factory</XMatterPack>
@@ -1432,8 +1432,8 @@ namespace BloomTests.Book
 				<DefaultLanguage2FontName>Andika New Basic</DefaultLanguage2FontName>
 				<DefaultLanguage3FontName>Andika New Basic</DefaultLanguage3FontName>
 				<OneTimeCheckVersionNumber>1</OneTimeCheckVersionNumber>
-				<Language1.IsRightToLeft>false</Language1.IsRightToLeft>
-				<Language2.IsRightToLeft>false</Language2.IsRightToLeft>
+				<IsLanguage1Rtl>false</IsLanguage1Rtl>
+				<IsLanguage2Rtl>false</IsLanguage2Rtl>
 				<IsLanguage3Rtl>true</IsLanguage3Rtl>
 				<IsSourceCollection>False</IsSourceCollection>
 				<XMatterPack>Factory</XMatterPack>
@@ -1453,8 +1453,8 @@ namespace BloomTests.Book
 				<DefaultLanguage2FontName>Andika</DefaultLanguage2FontName>
 				<DefaultLanguage3FontName>Andika</DefaultLanguage3FontName>
 				<OneTimeCheckVersionNumber>1</OneTimeCheckVersionNumber>
-				<Language1.IsRightToLeft>false</Language1.IsRightToLeft>
-				<Language2.IsRightToLeft>false</Language2.IsRightToLeft>
+				<IsLanguage1Rtl>false</IsLanguage1Rtl>
+				<IsLanguage2Rtl>false</IsLanguage2Rtl>
 				<IsLanguage3Rtl>true</IsLanguage3Rtl>
 				<IsSourceCollection>False</IsSourceCollection>
 				<XMatterPack>Factory</XMatterPack>

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -1393,7 +1393,7 @@ namespace BloomTests.Book
 					</body>
 				</html>");
 			var book = CreateBook();
-			book.CollectionSettings.Language1Name = "My Language Name";
+			book.CollectionSettings.Language1.Name = "My Language Name";
 			book.BringBookUpToDate(new NullProgress());
 			AssertThatXmlIn.Dom(book.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-book='languagesOfBook' and text()='My Language Name' and not(@lang='en')]", 3);
 		}
@@ -1464,15 +1464,15 @@ namespace BloomTests.Book
 									</head><body></body></html>");
 			var book = CreateBook();
 			Assert.That(book.BookInfo.IsRtl, Is.False);
-			var old = _collectionSettings.IsLanguage1Rtl;
+			var old = _collectionSettings.Language1.IsRightToLeft;
 			try
 			{
-				_collectionSettings.IsLanguage1Rtl = true;
+				_collectionSettings.Language1.IsRightToLeft = true;
 				book.BringBookUpToDate(new NullProgress());
 			}
 			finally
 			{
-				_collectionSettings.IsLanguage1Rtl = old;
+				_collectionSettings.Language1.IsRightToLeft = old;
 			}
 			Assert.That(book.BookInfo.IsRtl, Is.True);
 		}

--- a/src/BloomTests/Collection/CollectionSettingsTests.cs
+++ b/src/BloomTests/Collection/CollectionSettingsTests.cs
@@ -45,9 +45,9 @@ namespace BloomTests.Collection
 			const string collectionName = "test";
 			var settings = CreateCollectionSettings(_folder.Path, collectionName);
 			settings.Language1Iso639Code = "fr";
-			Assert.AreEqual("French", settings.GetLanguage1Name("en"));
+			Assert.AreEqual("French", settings.Language1.GetNameInLanguage("en"));
 			settings.Language1Iso639Code = "en";
-			Assert.AreEqual("English", settings.GetLanguage1Name("en"));
+			Assert.AreEqual("English", settings.Language1.GetNameInLanguage("en"));
 		}
 
 		[Test]

--- a/src/BloomTests/Publish/ExportEpubTests.cs
+++ b/src/BloomTests/Publish/ExportEpubTests.cs
@@ -566,7 +566,7 @@ namespace BloomTests.Publish
 		public void LeftToRight_SpineDoesNotDeclareDirection()
 		{
 			var book = SetupBook("This is some text", "xyz");
-			book.CollectionSettings.IsLanguage1Rtl = false;
+			book.CollectionSettings.Language1.IsRightToLeft = false;
 			MakeEpub("output", "SpineDoesNotDeclareDirection", book);
 			AssertThatXmlIn.String(_manifestContent).HasSpecifiedNumberOfMatchesForXpath("//spine[not(@page-progression-direction)]", 1);
 			;
@@ -576,7 +576,7 @@ namespace BloomTests.Publish
 		public void RightToLeft_SpineDeclaresRtlDirection()
 		{
 			var book = SetupBook("This is some text", "xyz");
-			book.CollectionSettings.IsLanguage1Rtl = true;
+			book.CollectionSettings.Language1.IsRightToLeft = true;
 			MakeEpub("output", "SpineDeclaresRtlDirection", book);
 			AssertThatXmlIn.String(_manifestContent).HasSpecifiedNumberOfMatchesForXpath("//spine[@page-progression-direction='rtl']", 1);;
 		}


### PR DESCRIPTION
Factor out Language info to LanguageSpec, leading to a huge reduction in duplication and other unneeded code in CollectionSettings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3445)
<!-- Reviewable:end -->
