### PR TITLE
Rule used to hide stuff during overflow calc was not specific enough

### DIFF
--- a/src/BloomBrowserUI/bookLayout/textOverPicture.less
+++ b/src/BloomBrowserUI/bookLayout/textOverPicture.less
@@ -123,12 +123,16 @@
                     line-height: 1.3em;
                 }
             }
-
             // Allows the format gear and language tip to be suppressed by adding a class
+            // (currently, during overflow testing). Don't normally like !important,
+            // but the rules this has to override are complex and trying to make this
+            // rule always more specific means breaking it up and putting it in multiple
+            // places (and is bug prone, if we change the other visibility rules).
+            // We absolutely want these hidden during overflow calculations!
             .bloom-editable.disableTOPControls {
                 #formatButton,
                 &:after {
-                    display: none;
+                    display: none !important;
                 }
             }
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3453)
<!-- Reviewable:end -->
