### PR TITLE
Fix Bloom Linux package dependencies for Geckofx60 (20191119)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
  libenchant-dev, libxklavier-dev, libdconf-dev,
  libicu-dev,
  libgtk3.0-cil, libgtk-3-dev, libasound2-dev,
+ libgtk2.0-cil, libgtk2.0-dev,
  icu-devtools | libicu-dev (<< 52)
 
 Package: bloom-desktop-alpha
@@ -21,6 +22,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
  mono4-sil, libgdiplus4-sil, gtk-sharp4-sil, gtklp,
  libgtk-3-0, libgtk3.0-cil,
+ libgtk2.0-0, libgtk2.0-cil,
  chmsee | xchm | kchmviewer, libtidy-sil,
  fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,
  optipng, libsndfile1,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3464)
<!-- Reviewable:end -->
