### PR TITLE
Comic tool: Ctrl+drag allows drag through text box (BL-7841)

### DIFF
--- a/src/BloomBrowserUI/bookLayout/textOverPicture.less
+++ b/src/BloomBrowserUI/bookLayout/textOverPicture.less
@@ -30,11 +30,21 @@
 
 .bloom-imageContainer {
     &.grabbable {
-        cursor: grab;
+        &,
+        .bloom-textOverPicture
+            .bloom-translationGroup
+            .bloom-editable.cke_editable {
+            cursor: grab;
+        }
     }
 
     &.grabbing {
-        cursor: grabbing;
+        &,
+        .bloom-textOverPicture
+            .bloom-translationGroup
+            .bloom-editable.cke_editable {
+            cursor: grabbing;
+        }
     }
 
     .bloom-textOverPicture {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3465)
<!-- Reviewable:end -->
