### PR TITLE
Fix missing Music checkbox in Motion tool (BL-7826)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -274,7 +274,7 @@ div.ui-audioCurrent:not(.disableHighlight) p {
 // Animation of hiding/showing a button //
 //////////////////////////////////////////
 @anticipatedButtonLabelHeight: 57.5px; // The expected height for the English text. Ideal results would be had if this is kept up to date whenever the English string changes.
-@buttonLabelMaxHeight: 100px;
+@buttonLabelMaxHeight: 130px;
 @expandTargetProportion: unit(
     @anticipatedButtonLabelHeight / @buttonLabelMaxHeight
 );


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3473)
<!-- Reviewable:end -->
