### PR TITLE
Fix unwanted Motion Book stickiness in Bloom Reader output (BL-7680)

### DIFF
--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -123,6 +123,10 @@ namespace Bloom.Publish.Android
 			apiHandler.RegisterBooleanEndpointHandler(kApiUrlPart + "motionBookMode",
 				readRequest =>
 				{
+					// If the user has taken off all possible motion, force not having motion in the
+					// Bloom Reader book.  See https://issues.bloomlibrary.org/youtrack/issue/BL-7680.
+					if (!readRequest.CurrentBook.HasMotionPages)
+						readRequest.CurrentBook.UseMotionModeInBloomReader = false;
 					return readRequest.CurrentBook.UseMotionModeInBloomReader;
 				},
 				(writeRequest, value) =>


### PR DESCRIPTION
I think this should be safe for 4.6 as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3480)
<!-- Reviewable:end -->
