### PR TITLE
Tweak code to reduce likelihood of unreadable file (BL-7076)

### DIFF
--- a/src/BloomExe/web/controllers/SignLanguageApi.cs
+++ b/src/BloomExe/web/controllers/SignLanguageApi.cs
@@ -10,6 +10,7 @@ using System.Xml;
 using Bloom.Api;
 using Bloom.Book;
 using Bloom.Edit;
+using Gecko;
 using L10NSharp;
 using SIL.Code;
 using SIL.CommandLineProcessing;
@@ -81,9 +82,9 @@ namespace Bloom.web.controllers
 						{
 							rawVideoInput.CopyTo(rawVideoOutput);
 						}
-
-						SaveVideoFile(path, rawVideo.Path);
 					}
+					// The output stream should be closed before trying to access the newly written file.
+					SaveVideoFile(path, rawVideo.Path);
 				}
 
 				var relativePath = BookStorage.GetVideoFolderName + Path.GetFileName(path);


### PR DESCRIPTION
I haven't seen the ffmpeg failure since making this change in 70+ video recordings in two books.  I had
seen it twice today before making this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3505)
<!-- Reviewable:end -->
