### PR TITLE
BL-7666 fix comma in user information

### DIFF
--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -274,8 +274,21 @@ namespace Bloom.web.controllers
 		{
 			var firstName = SIL.Windows.Forms.Registration.Registration.Default.FirstName;
 			var lastName = SIL.Windows.Forms.Registration.Registration.Default.Surname;
-			bldr.AppendLine("Error Report from " + lastName + ", " + firstName + " (" + GetObfuscatedEmail(userEmail) + ") on " + DateTime.UtcNow.ToUniversalTime());
+			var nameString = GetNameString(firstName, lastName);
+			var obfuscatedEmail = GetObfuscatedEmail(userEmail);
+			var emailString = string.IsNullOrWhiteSpace(obfuscatedEmail) ? string.Empty : " (" + obfuscatedEmail + ")";
+			bldr.AppendLine("Error Report from " + nameString + emailString + " on " + DateTime.UtcNow.ToUniversalTime() + " (UTC)");
 		}
+
+		private static object GetNameString(string firstName, string lastName)
+		{
+			return !string.IsNullOrWhiteSpace(firstName) && !string.IsNullOrWhiteSpace(lastName)
+				? lastName + ", " + firstName
+				: string.IsNullOrWhiteSpace(lastName) && string.IsNullOrWhiteSpace(firstName) ?
+					"unknown" :
+					(lastName + firstName).Trim();
+		}
+
 
 		private static void GetStandardErrorReportingProperties(StringBuilder bldr, bool appendLog)
 		{


### PR DESCRIPTION
* there will be a comma only if both first and last name
   contain something
* the parentheses around the email address will only
   appear if there is an email address

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3507)
<!-- Reviewable:end -->
