### PR TITLE
Count Bloom processes more accurately

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1299,7 +1299,7 @@ Anyone looking specifically at our issue tracking system can read what you sent 
 				var name = process.ProcessName.ToLowerInvariant();
 				// The second test prevents counting the Bloom.vshost.exe process which Visual Studio and similar tools
 				// create to speed up launching the program in debug mode. It's only useful for developers.
-				return name.Contains("bloom") && !name.Contains("vshost");
+				return name.Contains("bloom") && !name.Contains("vshost") && !name.Contains("bloomharvester");
 			}
 			catch (System.InvalidOperationException)
 			{


### PR DESCRIPTION
Previously, if the Harvester ran and then launched a Bloom subprocess which encountered an error during setup, it would erroneously complain that two Bloom processes were running. It was mistakenly counting the BloomHarvester processes as a bloom process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3508)
<!-- Reviewable:end -->
