### PR TITLE
BL-7666 restore Reporter email functionality

### DIFF
--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -277,7 +277,7 @@ namespace Bloom.web.controllers
 			var nameString = GetNameString(firstName, lastName);
 			var obfuscatedEmail = GetObfuscatedEmail(userEmail);
 			var emailString = string.IsNullOrWhiteSpace(obfuscatedEmail) ? string.Empty : " (" + obfuscatedEmail + ")";
-			bldr.AppendLine("Error Report from " + nameString + emailString + " on " + DateTime.UtcNow.ToUniversalTime() + " (UTC)");
+			bldr.AppendLine("Error Report from " + nameString + emailString + " on " + DateTime.UtcNow.ToUniversalTime() + " UTC");
 		}
 
 		private static object GetNameString(string firstName, string lastName)


### PR DESCRIPTION
* adding "(UTC)" confused the YT code to find the
   reporter's email address in our user info string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3513)
<!-- Reviewable:end -->
