### PR TITLE
Prevent cover image description audio when unwanted (BL-7839)

### DIFF
--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -1310,11 +1310,17 @@ namespace Bloom.Publish.Epub
 					description.ParentNode.RemoveChild(description);
 				}
 			}
+			else if (PublishImageDescriptions == BookInfo.HowToPublishImageDescriptions.None)
+			{
+				// This ensures that we get rid of audio as well as the text display.
+				// See https://issues.bloomlibrary.org/youtrack/issue/BL-7839.
+				var imageDescriptions = bookDom.SafeSelectNodes("//div[contains(@class, 'bloom-imageDescription')]");
+				foreach (XmlElement description in imageDescriptions)
+				{
+					description.ParentNode.RemoveChild(description);
+				}
+			}
 			// code to handle HowToPublishImageDescriptions.Links was removed from Bloom 4.6 on June 28, 2019.
-			// If HowToPublishImageDescriptions.None, leave alone, and they will be invisible, but not deleted.
-			// This allows the image description audio to play even when the description isn't displayed in
-			// written form (BL-7237).  (For broken readers, the text might still be visible, but then it's
-			// likely the audio wouldn't play anyway.)
 		}
 
 		/// <summary>

--- a/src/BloomTests/Publish/EPubMakerTests.cs
+++ b/src/BloomTests/Publish/EPubMakerTests.cs
@@ -167,7 +167,7 @@ namespace BloomTests.Publish
 		}
 
 		[Test]
-		public void HandleImageDescriptions_HowTo_None_LeavesDescriptionAlone()
+		public void HandleImageDescriptions_HowTo_None_RemovesDescription()
 		{
 			string inputImageHtml = "<img src='a.png'/>";
 			var htmlDom = new HtmlDom($@"<html><body>
@@ -194,28 +194,11 @@ namespace BloomTests.Publish
 			Assert.That(divImage.GetAttribute("class"), Is.EqualTo("bloom-imageContainer"));
 			var imgNodes = divImage.SafeSelectNodes("./*");
 			Assert.That(imgNodes, Is.Not.Null);
-			Assert.That(imgNodes.Count, Is.EqualTo(2));
+			Assert.That(imgNodes.Count, Is.EqualTo(1));
 
 			var img = imgNodes[0] as System.Xml.XmlElement;
 			Assert.That(img.LocalName, Is.EqualTo("img"));
 			Assert.That(img.GetAttribute("alt"), Is.EqualTo("This is a test."));
-
-			var div = imgNodes[1] as System.Xml.XmlElement;
-			Assert.That(div.LocalName, Is.EqualTo("div"));
-			Assert.That(div.GetAttribute("class"), Is.EqualTo("bloom-translationGroup bloom-imageDescription"));
-			var divDescList = div.SafeSelectNodes("./*");
-			Assert.That(divDescList, Is.Not.Null);
-			Assert.That(divDescList.Count, Is.EqualTo(1));
-			var divDesc = divDescList[0] as System.Xml.XmlElement;
-			Assert.That(divDesc.LocalName, Is.EqualTo("div"));
-			Assert.That(divDesc.GetAttribute("lang"), Is.EqualTo("en"));
-			var paraNodes = divDesc.SafeSelectNodes("./*");
-			Assert.That(paraNodes, Is.Not.Null);
-			Assert.That(paraNodes.Count, Is.EqualTo(1));
-			var para = paraNodes[0] as System.Xml.XmlElement;
-			Assert.That(para.LocalName, Is.EqualTo("p"));
-			Assert.That(para.InnerText, Is.EqualTo("This is a test."));
-			Assert.That(para.InnerXml, Is.EqualTo("This is a test."));
 		}
 
 		private void HandleImageDescriptions(HtmlDom htmlDom, BookInfo.HowToPublishImageDescriptions howTo = BookInfo.HowToPublishImageDescriptions.None)


### PR DESCRIPTION
Should this be considered for cherry-picking to 4.6?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3515)
<!-- Reviewable:end -->
