### PR TITLE
Avoid showing script markers in language tags during lookup (BL-7641)

### DIFF
--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -251,6 +251,10 @@ namespace Bloom.Collection
 				// Following should be consistent with LanguageIdControl constructor.
 				dlg.UseSimplifiedChinese();
 
+				// Avoid showing gratuitous script markers in language tags.
+				// See https://issues.bloomlibrary.org/youtrack/issue/BL-7641.
+				dlg.IncludeScriptMarkers = false;
+
 				if (DialogResult.OK != dlg.ShowDialog())
 				{
 					return null;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3519)
<!-- Reviewable:end -->
