### PR TITLE
BL-7666 Get stack trace working

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryBookView.cs
+++ b/src/BloomExe/CollectionTab/LibraryBookView.cs
@@ -235,7 +235,7 @@ namespace Bloom.CollectionTab
 		{
 			if (GetAnchorHref(e).EndsWith("ReportProblem"))
 			{
-				ProblemReportApi.ShowProblemDialog(_previewBrowser, "nonfatal");
+				ProblemReportApi.ShowProblemDialog(_previewBrowser, null, "", "nonfatal");
 			}
 		}
 

--- a/src/BloomExe/FatalExceptionHandler.cs
+++ b/src/BloomExe/FatalExceptionHandler.cs
@@ -94,7 +94,7 @@ namespace Bloom
 
 		protected override bool DisplayError(Exception exception)
 		{
-			ProblemReportApi.ShowProblemDialog(Form.ActiveForm, exception);
+			ProblemReportApi.ShowProblemDialog(Form.ActiveForm, exception, "", "fatal");
 			return true;
 		}
 	}

--- a/src/BloomExe/InstallerSupport.cs
+++ b/src/BloomExe/InstallerSupport.cs
@@ -250,7 +250,7 @@ namespace Bloom
 				var exception =
 					new FileNotFoundException(
 						"Bloom was not able to find some of its files. The shortcut icon you clicked on may be out of date. Try deleting it and reinstalling Bloom");
-				ProblemReportApi.ShowProblemDialog(null, exception);
+				ProblemReportApi.ShowProblemDialog(null, exception, "", "fatal");
 				// Not sure these lines are reachable. Just making sure.
 				Application.Exit();
 				return;

--- a/src/BloomExe/NonFatalProblem.cs
+++ b/src/BloomExe/NonFatalProblem.cs
@@ -90,7 +90,7 @@ namespace Bloom
 						{
 							// N.B.: We should be more careful than ever about when we want 'showSendReport' to be 'true',
 							// since this new "nonfatal" UI doesn't have a "Cancel" button.
-							ProblemReportApi.ShowProblemDialog(Form.ActiveForm, exception, "nonfatal");
+							ProblemReportApi.ShowProblemDialog(Form.ActiveForm, exception, fullDetailedMessage, "nonfatal");
 						}
 						else
 						{

--- a/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookTransfer.cs
@@ -234,7 +234,7 @@ namespace Bloom.WebLibraryIntegration
 					progressDialog.ProgressStateResult.ExceptionThatWasEncountered != null)
 				{
 					var exc = progressDialog.ProgressStateResult.ExceptionThatWasEncountered;
-					ProblemReportApi.ShowProblemDialog(null, exc);
+					ProblemReportApi.ShowProblemDialog(null, exc, "", "fatal");
 				}
 			}
 		}

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -902,7 +902,7 @@ namespace Bloom.Workspace
 			// To test the old ErrorReport.NotifyUserOfProblem, uncomment this next line.
 			// ErrorReport.NotifyUserOfProblem(new ApplicationException("internal exception message"), "My main message");
 
-			ProblemReportApi.ShowProblemDialog(this);
+			ProblemReportApi.ShowProblemDialog(this, null);
 		}
 
 		public void SetStateOfNonPublishTabs(bool enable)


### PR DESCRIPTION
* uses SIL.ExceptionHelper to get the same exception
   information we got with the old dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3520)
<!-- Reviewable:end -->
