### PR TITLE
Allow text box audio recording in xmatter

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -678,6 +678,14 @@ namespace Bloom.Book
 				BloomReaderMinVersion = "1.0",
 				XPath = "//*[@data-audiorecordingmode='TextBox']"
 			},
+			new Feature() {FeatureId = "wholeTextBoxAudioInXmatter",
+				// technically could be in back matter, but typically back matter has no recordable text,
+				// and xmatter seems too technical a term for end users to see.
+				FeaturePhrase = "Whole Text Box Audio in Front/Back Matter",
+				BloomDesktopMinVersion = "4.7",
+				BloomReaderMinVersion = "1.0",
+				XPath = "//div[@data-xmatter-page]//*[@data-audiorecordingmode='TextBox']"
+			},
 			new Feature() {FeatureId = "comical-1",
 				FeaturePhrase = "Support for Comics",
 				BloomDesktopMinVersion = "4.7",

--- a/src/BloomExe/web/controllers/AudioSegmentationApi.cs
+++ b/src/BloomExe/web/controllers/AudioSegmentationApi.cs
@@ -164,7 +164,7 @@ namespace Bloom.web.controllers
 					RedirectStandardError = true,
 				},
 			};
-			if (!string.IsNullOrEmpty(workingDirectory))
+			if (!string.IsNullOrEmpty(workingDirectory) && Directory.Exists(workingDirectory))
 				process.StartInfo.WorkingDirectory = workingDirectory;
 			process.Start();
 			process.WaitForExit();

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -228,7 +228,7 @@ namespace BloomTests.Book
 			var textarea1 = dom.SelectSingleNodeHonoringDefaultNS("//textarea[@id='2' and @lang='xyz']");
 			textarea1.InnerText = "peace";
 			book.BringBookUpToDate(new NullProgress());
-			var textarea2 = dom.SelectSingleNodeHonoringDefaultNS("//textarea[@id='copyOfVTitle'  and @lang='xyz']");
+			var textarea2 = dom.SelectSingleNodeHonoringDefaultNS("//textarea[@idc='copyOfVTitle'  and @lang='xyz']");
 			Assert.AreEqual("peace", textarea2.InnerText);
 		}
 

--- a/src/BloomTests/Book/BookTestsBase.cs
+++ b/src/BloomTests/Book/BookTestsBase.cs
@@ -224,7 +224,7 @@ namespace BloomTests.Book
 						<textarea id='6' lang='xyz'>original2</textarea>
 					</p>
 					<p>
-						<textarea lang='xyz' id='copyOfVTitle'  data-book='bookTitle'>tree</textarea>
+						<textarea lang='xyz' idc='copyOfVTitle'  data-book='bookTitle'>tree</textarea>
 						<textarea lang='xyz' id='aa'  data-collection='testLibraryVariable'>aa</textarea>
 					   <textarea lang='xyz' id='bb'  data-collection='testLibraryVariable'>bb</textarea>
 

--- a/src/BloomTests/Book/DataSetTests.cs
+++ b/src/BloomTests/Book/DataSetTests.cs
@@ -155,6 +155,61 @@ namespace BloomTests.Book
 			Assert.That(first.SameAs(second), Is.True);
 		}
 
+		[Test]
+		public void SameAs_OneHasAttrVals_False()
+		{
+			var first = MakeComplexDataSet();
+			var second = MakeComplexDataSet();
+			DataSetElementValue dsv2 = second.TextVariables["one"];
+			dsv2.SetAttributeList("fr", null);
+			Assert.That(first.SameAs(second), Is.False);
+			Assert.That(second.SameAs(first), Is.False);
+		}
+
+		[Test]
+		public void SameAs_OneHasMoreAttrVals_False()
+		{
+			var first = MakeComplexDataSet();
+			var second = MakeComplexDataSet();
+			DataSetElementValue dsv2 = second.TextVariables["one"];
+			dsv2.SetAttributeList("fr", MakeList("attr1", "val1fr"));
+			Assert.That(first.SameAs(second), Is.False);
+			Assert.That(second.SameAs(first), Is.False);
+		}
+
+		[Test]
+		public void SameAs_OneHasDifferentAttrVals_False()
+		{
+			var first = MakeComplexDataSet();
+			var second = MakeComplexDataSet();
+			DataSetElementValue dsv2 = second.TextVariables["one"];
+			dsv2.SetAttributeList("fr", MakeList("attr1", "val1fr", "attr4", "val4modifed"));
+			Assert.That(first.SameAs(second), Is.False);
+			Assert.That(second.SameAs(first), Is.False);
+		}
+
+		[Test]
+		public void SameAs_OneHasDifferentAttrOrder_True()
+		{
+			var first = MakeComplexDataSet();
+			var second = MakeComplexDataSet();
+			DataSetElementValue dsv2 = second.TextVariables["one"];
+			dsv2.SetAttributeList("fr", MakeList("attr4", "val4", "attr1", "val1fr"));
+			Assert.That(first.SameAs(second), Is.True);
+			Assert.That(second.SameAs(first), Is.True);
+		}
+
+		[Test]
+		public void SameAs_OneHasDifferentAttrKeys_False()
+		{
+			var first = MakeComplexDataSet();
+			var second = MakeComplexDataSet();
+			DataSetElementValue dsv2 = second.TextVariables["one"];
+			dsv2.SetAttributeList("fr", MakeList("attr1", "val1fr", "attrModified", "val4"));
+			Assert.That(first.SameAs(second), Is.False);
+			Assert.That(second.SameAs(first), Is.False);
+		}
+
 		private static DataSet MakeComplexDataSet()
 		{
 			var ds = new DataSet();
@@ -164,7 +219,23 @@ namespace BloomTests.Book
 			var values = new HashSet<KeyValuePair<string, string>>();
 			values.Add(new KeyValuePair<string, string>("key", "value"));
 			ds.UpdateXmatterPageDataAttributeSet("one", values);
+			DataSetElementValue dsv = ds.TextVariables["one"];
+			dsv.SetAttributeList("en", MakeList("attr1", "val1", "attr2", "val2"));
+			dsv.SetAttributeList("de", MakeList("attr1", "val1de", "attr3", "val3de"));
+			DataSetElementValue dsv2 = ds.TextVariables["one"];
+			dsv2.SetAttributeList("fr", MakeList("attr1", "val1fr", "attr4", "val4"));
 			return ds;
+		}
+
+		static List<Tuple<string, string>> MakeList(params string[] args)
+		{
+			var result = new List<Tuple<string, string>>();
+			Assert.That(args.Length %2, Is.EqualTo(0));
+			for (var i = 0; i < args.Length / 2; i++)
+			{
+				result.Add(Tuple.Create(args[i * 2], args[i * 2 + 1]));
+			}
+			return result;
 		}
 	}
 }


### PR DESCRIPTION
Includes a major change that, by default, saves attributes along with content of elements that get copied to data-div.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3523)
<!-- Reviewable:end -->
