### PR TITLE
Restore the implementation of add child bubble (BL-7924)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/callout/calloutControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/callout/calloutControls.tsx
@@ -404,7 +404,9 @@ const CalloutToolControls: React.FunctionComponent = () => {
                             </MenuItem>
                         </Select>
                     </FormControl>
-                    <Button>
+                    <Button
+                        onClick={event => handleChildBubbleLinkClick(event)}
+                    >
                         <Div l10nKey="EditTab.Toolbox.ComicTool.Options.AddChildBubble">
                             Add Child Bubble
                         </Div>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3538)
<!-- Reviewable:end -->
