### PR TITLE
Fix sources of recursive problem report dialogs (20191218)

### DIFF
--- a/src/BloomExe/web/RequestInfo.cs
+++ b/src/BloomExe/web/RequestInfo.cs
@@ -258,10 +258,12 @@ namespace Bloom.Api
 
 		public void ReplyWithImage(string path, string originalPath = null)
 		{
-			var pos = path.LastIndexOf('.');
-			if(pos > 0)
-				_actualContext.Response.ContentType = BloomServer.GetContentType(path.Substring(pos));
-
+			if (path != null)
+			{
+				var pos = path.LastIndexOf('.');
+				if (pos > 0)
+					_actualContext.Response.ContentType = BloomServer.GetContentType(path.Substring(pos));
+			}
 			ReplyWithFileContent(path, originalPath);
 		}
 

--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -47,7 +47,10 @@ namespace Bloom.web.controllers
 			apiHandler.RegisterEndpointHandler("problemReport/screenshot",
 				(ApiRequest request) =>
 				{
-					request.ReplyWithImage(_screenshotTempFile?.Path);
+					if (_screenshotTempFile == null)
+						request.Failed();
+					else
+						request.ReplyWithImage(_screenshotTempFile.Path);
 				}, true);
 
 			// ProblemDialog.tsx uses this endpoint to get the name of the book.


### PR DESCRIPTION
These spots both had problems with failed screenshots.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3551)
<!-- Reviewable:end -->
