### PR TITLE
Fix CSS font selection for language names on cover (BL-7968)

### DIFF
--- a/src/BloomBrowserUI/templates/Sample Shells/The Moon and the Cap/The Moon and the Cap.htm
+++ b/src/BloomBrowserUI/templates/Sample Shells/The Moon and the Cap/The Moon and the Cap.htm
@@ -366,7 +366,7 @@
 
                         <div class="bottomRow" data-have-topic="true">
                             <div
-                                data-book="languagesOfBook"
+                                data-derived="languagesOfBook"
                                 class="coverBottomLangName Cover-Default-style"
                             >
                                 English
@@ -719,7 +719,7 @@
                     id="languageInformation"
                     class="Content-On-Title-Page-style"
                 >
-                    <div data-book="languagesOfBook" class="languagesOfBook">
+                    <div data-derived="languagesOfBook" class="languagesOfBook">
                         English
                     </div>
                     <div data-library="dialect" class="langName"></div>

--- a/src/BloomBrowserUI/templates/customXMatter/Dari-XMatter/Dari-XMatter.pug
+++ b/src/BloomBrowserUI/templates/customXMatter/Dari-XMatter/Dari-XMatter.pug
@@ -65,7 +65,7 @@ mixin afg-outsideFrontCover
 					+field-prototypeDeclaredExplicity("N1")
 						+editable(kLanguageForPrototypeOnly).Cover-Default-style(data-book='levelInformation')
 				.bottomRow
-					.coverBottomLangName.Cover-Default-style(data-book='languagesOfBook')
+					.coverBottomLangName.Cover-Default-style(data-derived='languagesOfBook')
 					+chooser-topic.coverBottomBookTopic
 
 mixin afg-titlePage
@@ -82,7 +82,7 @@ mixin afg-titlePage
 			+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Extra-On-Title-Page-style(data-book='extraTitle')
 		+underLogo
 		#languageInformation.Content-On-Title-Page-style
-		.languagesOfBook(data-book='languagesOfBook')
+		.languagesOfBook(data-derived='languagesOfBook')
 		//- review: can we get rid of these "langName" classes?
 		.langName('data-library'='dialect')
 		.langName(data-library='languageLocation').bloom-writeOnly
@@ -100,7 +100,7 @@ mixin afg-outsideBackCover
 	+page-xmatter('Outside Back Cover').cover.coverColor.outsideBackCover.bloom-backMatter(data-export='back-matter-back-cover')&attributes(attributes)#6AB1D898-9E35-498E-99D4-132B46FAFDA4
 		.ownership
 			p كتاب هاى درسى متعلق به وزارت معارف بوده خريد و فروش آن
-			p جداً ممنوع است. با متخلفين برخورد قانونى صورت مى گيرد 
+			p جداً ممنوع است. با متخلفين برخورد قانونى صورت مى گيرد
 
 doctype html
 html

--- a/src/BloomBrowserUI/templates/customXMatter/MXBBook-XMatter/MXBBook-XMatter.pug
+++ b/src/BloomBrowserUI/templates/customXMatter/MXBBook-XMatter/MXBBook-XMatter.pug
@@ -15,7 +15,7 @@ mixin mxb-titlePage
 			label.bubble Book title in {lang}
 			+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Title-Page-style(data-book='bookTitle')
 		#languageInformation.Credits-Page-style('lang'='N1')
-			.languagesOfBook(data-book='languagesOfBook')
+			.languagesOfBook(data-derived='languagesOfBook')
 			//- review: can we get rid of these "langName" classes?
 			.langName('data-library'='dialect')
 			.langName(data-library='languageLocation').bloom-writeOnly

--- a/src/BloomBrowserUI/templates/customXMatter/MXBPamphlet-XMatter/MXBPamphlet-XMatter.pug
+++ b/src/BloomBrowserUI/templates/customXMatter/MXBPamphlet-XMatter/MXBPamphlet-XMatter.pug
@@ -17,7 +17,7 @@ mixin mxb-combinedTitleCreditsPage-inside-front-cover
 			label.bubble Book title in {lang}
 			+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Title-Page-style(data-book='bookTitle')
 		#languageInformation.Credits-Page-style('lang'='N1')
-			.languagesOfBook(data-book='languagesOfBook')
+			.languagesOfBook(data-derived='languagesOfBook')
 			//- review: can we get rid of these "langName" classes?
 			.langName('data-library'='dialect')
 			.langName(data-library='languageLocation').bloom-writeOnly

--- a/src/BloomBrowserUI/templates/customXMatter/Pashti-XMatter/Pashti-XMatter.pug
+++ b/src/BloomBrowserUI/templates/customXMatter/Pashti-XMatter/Pashti-XMatter.pug
@@ -66,7 +66,7 @@ mixin afg-outsideFrontCover
 					+field-prototypeDeclaredExplicity("N1")
 						+editable(kLanguageForPrototypeOnly).Cover-Default-style(data-book='levelInformation')
 				.bottomRow
-					.coverBottomLangName.Cover-Default-style(data-book='languagesOfBook')
+					.coverBottomLangName.Cover-Default-style(data-derived='languagesOfBook')
 					+chooser-topic.coverBottomBookTopic
 
 mixin afg-titlePage
@@ -83,7 +83,7 @@ mixin afg-titlePage
 			+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Extra-On-Title-Page-style(data-book='extraTitle')
 		+underLogo
 		#languageInformation.Content-On-Title-Page-style
-		.languagesOfBook(data-book='languagesOfBook')
+		.languagesOfBook(data-derived='languagesOfBook')
 		//- review: can we get rid of these "langName" classes?
 		.langName('data-library'='dialect')
 		.langName(data-library='languageLocation').bloom-writeOnly

--- a/src/BloomBrowserUI/templates/xMatter/Video-XMatter/Video-XMatter.pug
+++ b/src/BloomBrowserUI/templates/xMatter/Video-XMatter/Video-XMatter.pug
@@ -23,7 +23,7 @@ html
 			//- 'V' means this field is only available in the vernacular
 			+field-mono-meta('V', "smallCoverCredits").smallCoverCredits.bloom-copyFromOtherLanguageIfNecessary.Cover-Default-style
 		.bottomBlock
-			.coverBottomLangName.Cover-Default-style(data-book='languagesOfBook',lang="N1")
+			.coverBottomLangName.Cover-Default-style(data-derived='languagesOfBook')
 			//+chooser-topic.coverBottomBookTopic
 
 

--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
@@ -115,7 +115,7 @@ mixin standard-cover-contents
 				+field-prototypeDeclaredExplicity("V")
 					+editable(kLanguageForPrototypeOnly).smallCoverCredits.Cover-Default-style(data-book='smallCoverCredits')
 			.bottomRow
-				.coverBottomLangName.Cover-Default-style(data-book='languagesOfBook')
+				.coverBottomLangName.Cover-Default-style(data-derived='languagesOfBook')
 				+chooser-topic.coverBottomBookTopic
 
 // Standard cover image has a (normally hidden) image description field.
@@ -211,7 +211,7 @@ mixin title-page-contents
 		+editable(kLanguageForPrototypeOnly).funding.Content-On-Title-Page-style.bloom-copyFromOtherLanguageIfNecessary(data-book='funding')
 	div.largeFlexGap
 	#languageInformation.Content-On-Title-Page-style
-	.languagesOfBook(data-book='languagesOfBook')
+	.languagesOfBook(data-derived='languagesOfBook')
 	//- review: can we get rid of these "langName" classes?
 	.langName('data-library'='dialect')
 	.langName(data-library='languageLocation').bloom-writeOnly

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -492,8 +492,8 @@ namespace Bloom.Edit
 			GetMultilingualContentLanguages(out l2, out l3);
 
 			//Reload to display these changes
+			CurrentBook.SetMultilingualContentLanguages(l2, l3);	// set langs before saving page
 			SaveNow();
-			CurrentBook.SetMultilingualContentLanguages(l2, l3);
 			CurrentBook.PrepareForEditing();
 			_view.UpdateSingleDisplayedPage(_pageSelection.CurrentSelection);
 			_view.UpdatePageList(true);//counting on this to redo the thumbnails


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3555)
<!-- Reviewable:end -->
