### PR TITLE
Preserve registration across versions even when FEEDBACK is off (BL-7…

### DIFF
--- a/src/BloomExe/Registration/RegistrationDialog.cs
+++ b/src/BloomExe/Registration/RegistrationDialog.cs
@@ -77,6 +77,17 @@ namespace Bloom.Registration
 
 		public static bool ShouldWeShowRegistrationDialog()
 		{
+			// Allow registration information to be copied from version to version even if
+			// the user has set the FEEDBACK environment variable.  If the user does register, or
+			// use an email address in a feedback form, we want to preserve that information!
+			// See https://issues.bloomlibrary.org/youtrack/issue/BL-7956.
+			if (SIL.Windows.Forms.Registration.Registration.Default.NeedUpgrade)
+			{
+				//see http://stackoverflow.com/questions/3498561/net-applicationsettingsbase-should-i-call-upgrade-every-time-i-load
+				SIL.Windows.Forms.Registration.Registration.Default.Upgrade();
+				SIL.Windows.Forms.Registration.Registration.Default.NeedUpgrade = false;
+				SIL.Windows.Forms.Registration.Registration.Default.Save();
+			}
 			//there is no point registering if we are are developer/tester
 			string feedbackSetting = System.Environment.GetEnvironmentVariable("FEEDBACK");
 			if (!string.IsNullOrEmpty(feedbackSetting) && feedbackSetting.ToLowerInvariant() != "yes" &&
@@ -86,15 +97,6 @@ namespace Bloom.Registration
 			if (!_haveRegisteredLaunch)//in case the client app calls this more then once during a single run (like Bloom does when opening a different collection)
 			{
 				_haveRegisteredLaunch=true;
-
-				if (SIL.Windows.Forms.Registration.Registration.Default.NeedUpgrade)
-				{
-					//see http://stackoverflow.com/questions/3498561/net-applicationsettingsbase-should-i-call-upgrade-every-time-i-load
-					SIL.Windows.Forms.Registration.Registration.Default.Upgrade();
-					SIL.Windows.Forms.Registration.Registration.Default.NeedUpgrade = false;
-					SIL.Windows.Forms.Registration.Registration.Default.Save();
-				}
-
 				SIL.Windows.Forms.Registration.Registration.Default.LaunchCount++;
 				SIL.Windows.Forms.Registration.Registration.Default.Save();
 			}


### PR DESCRIPTION
…956)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3560)
<!-- Reviewable:end -->
