### PR TITLE
Don't embed fonts we know are not used in the published book (BL-7998)

### DIFF
--- a/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
+++ b/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
@@ -312,11 +312,7 @@ namespace Bloom.Publish.Android
 		public static void EmbedFonts(Book.Book book, WebSocketProgress progress, IFontFinder fontFileFinder)
 		{
 			const string defaultFont = "Andika New Basic"; // already in BR, don't need to embed or make rule.
-			// The 'false' here says to ignore all but the first font face in CSS's ordered lists of desired font faces.
-			// If someone is publishing an Epub, they should have that font showing. For one thing, this makes it easier
-			// for us to not embed fonts we don't want/ need.For another, it makes it less likely that an epub will look
-			// different or have glyph errors when shown on a machine that does have that primary font.
-			var fontsWanted = EpubMaker.GetFontsUsed(book.FolderPath, false).ToList();
+			var fontsWanted = book.GetFontsUsedInBook().ToList();	// filters out fonts used only for unused langs and custom styles
 			fontsWanted.Remove(defaultFont);
 			fontFileFinder.NoteFontsWeCantInstall = true;
 			var filesToEmbed = new List<string>();

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -1809,11 +1809,7 @@ namespace Bloom.Publish.Epub
 		/// </summary>
 		private void EmbedFonts()
 		{
-			// The 'false' here says to ignore all but the first font face in CSS's ordered lists of desired font faces.
-			// If someone is publishing an Epub, they should have that font showing. For one thing, this makes it easier
-			// for us to not embed fonts we don't want/ need.For another, it makes it less likely that an epub will look
-			// different or have glyph errors when shown on a machine that does have that primary font.
-			var fontsWanted = GetFontsUsed (Book.FolderPath, false);
+			var fontsWanted = Book.GetFontsUsedInBook();	// filters out fonts used only for unused langs and custom styles
 			var fontFileFinder = new FontFileFinder ();
 			var filesToEmbed = fontsWanted.SelectMany (fontFileFinder.GetFilesForFont).ToArray ();
 			foreach (var file in filesToEmbed) {
@@ -1856,26 +1852,6 @@ namespace Bloom.Publish.Epub
 
 			sb.AppendLine(
 				$"@font-face {{font-family:'{name}'; font-weight:{weight}; font-style:{style}; src:url('{fullRelativePath}') format('{format}');}}");
-		}
-
-		/// <summary>
-		/// First step of embedding fonts: determine what are used in the document.
-		/// Eventually we may load each page into a DOM and use JavaScript to ask each
-		/// bit of text what actual font and face it is using.
-		/// For now we examine the stylesheets and collect the font families they mention.
-		/// </summary>
-		/// <param name="bookPath"></param>
-		/// <param name="includeFallbackFonts"></param>
-		/// <returns></returns>
-		public static IEnumerable<string> GetFontsUsed (string bookPath, bool includeFallbackFonts)
-		{
-			var result = new HashSet<string> ();
-			// Css for styles are contained in the actual html
-			foreach (var ss in Directory.EnumerateFiles (bookPath, "*.*").Where (f => f.EndsWith (".css") || f.EndsWith (".htm") || f.EndsWith (".html"))) {
-				var root = RobustFile.ReadAllText (ss, Encoding.UTF8);
-				HtmlDom.FindFontsUsedInCss (root, result, includeFallbackFonts);
-			}
-			return result;
 		}
 
 		const double mmPerInch = 25.4;


### PR DESCRIPTION
I applied this to epubs as well as bloomds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3563)
<!-- Reviewable:end -->
