### PR TITLE
Revert "Use custom language names consistently (BL-7832)"

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1769,32 +1769,18 @@ namespace Bloom.Book
 		/// </summary>
 		private void InjectStringListingActiveLanguagesOfBook()
 		{
-			string codeOfNationalLanguage = CollectionSettings.Language2.Iso639Code;
-			var languagesOfBook = CollectionSettings.Language1.IsCustomName ?
-				CollectionSettings.Language1.Name :
-				CollectionSettings.Language1.GetNameInLanguage(codeOfNationalLanguage);
+			string codeOfNationalLanguage = CollectionSettings.Language2Iso639Code;
+			var languagesOfBook = CollectionSettings.Language1.GetNameInLanguage(codeOfNationalLanguage);
 
 			if (MultilingualContentLanguage2 != null)
 			{
-				languagesOfBook += ", ";
-				if (MultilingualContentLanguage2 == CollectionSettings.Language2.Iso639Code)
-				{
-					languagesOfBook += CollectionSettings.Language2.IsCustomName ?
-						CollectionSettings.Language2.Name :
-						CollectionSettings.Language2.GetNameInLanguage(codeOfNationalLanguage);
-				}
-				else
-				{
-					languagesOfBook += CollectionSettings.Language3.IsCustomName ?
-						CollectionSettings.Language3.Name :
-						CollectionSettings.Language3.GetNameInLanguage(codeOfNationalLanguage);
-				}
+				languagesOfBook += ", " + ((MultilingualContentLanguage2 == CollectionSettings.Language2Iso639Code) ?
+					CollectionSettings.Language2.GetNameInLanguage(codeOfNationalLanguage) :
+					CollectionSettings.Language3.GetNameInLanguage(codeOfNationalLanguage));
 			}
 			if (MultilingualContentLanguage3 != null)
 			{
-				languagesOfBook += ", " + (CollectionSettings.Language3.IsCustomName ?
-					CollectionSettings.Language3.Name :
-					CollectionSettings.Language3.GetNameInLanguage(codeOfNationalLanguage));
+				languagesOfBook += ", " + CollectionSettings.Language3.GetNameInLanguage(codeOfNationalLanguage);
 			}
 
 			_bookData.Set("languagesOfBook", languagesOfBook, false);

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -101,9 +101,12 @@ namespace Bloom.Collection
 
 		public CollectionSettings()
 		{
-			Language1 = new WritingSystem(1);
-			Language2 = new WritingSystem(2);
-			Language3 = new WritingSystem(3);
+			//Note: I'm not convinced we actually ever rely on dynamic name lookups anymore?
+			//See: https://issues.bloomlibrary.org/youtrack/issue/BL-7832
+			Func<string> getCodeOfDefaultLanguageForNaming = ()=> Language2.Iso639Code;
+			Language1 = new WritingSystem(1, getCodeOfDefaultLanguageForNaming);
+			Language2 = new WritingSystem(2,getCodeOfDefaultLanguageForNaming);
+			Language3 = new WritingSystem(3, getCodeOfDefaultLanguageForNaming);
 			LanguagesZeroBased = new WritingSystem[3];
 			this.LanguagesZeroBased[0] = Language1;
 			this.LanguagesZeroBased[1] = Language2;
@@ -616,14 +619,8 @@ namespace Bloom.Collection
 			for (int i = 0; i < isoCodes.Length; i++)
 			{
 				var code = isoCodes[i];
-				string name;
-				if (code == Language1.Iso639Code)
-					name = Language1.Name;
-				else if (code == Language2.Iso639Code)
-					name = Language2.Name;
-				else if (code == Language3.Iso639Code)
-					name = Language3.Name;
-				else
+				string name = Language1.Name;
+				if (code != Language1Iso639Code)
 					WritingSystem.LookupIsoCode.GetBestLanguageName(code, out name);
 				string ethCode;
 				LanguageSubtag data;

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -118,11 +118,7 @@ namespace Bloom.Collection
 			string defaultFontText =
 				LocalizationManager.GetString("CollectionSettingsDialog.BookMakingTab.DefaultFontFor", "Default Font for {0}", "{0} is a language name.");
 			var lang1UiName = _collectionSettings.Language1.GetNameInLanguage(LocalizationManager.UILanguageId);
-			if (_collectionSettings.Language1.IsCustomName)
-				lang1UiName = _collectionSettings.Language1.Name;
 			var lang2UiName = _collectionSettings.Language2.GetNameInLanguage(LocalizationManager.UILanguageId);
-			if (_collectionSettings.Language2.IsCustomName)
-				lang2UiName = _collectionSettings.Language2.Name;
 			_language1Name.Text = string.Format("{0} ({1})", lang1UiName, _collectionSettings.Language1Iso639Code);
 			_language2Name.Text = string.Format("{0} ({1})", lang2UiName, _collectionSettings.Language2Iso639Code);
 			_language1FontLabel.Text = string.Format(defaultFontText, lang1UiName);
@@ -142,8 +138,6 @@ namespace Bloom.Collection
 			else
 			{
 				lang3UiName = _collectionSettings.Language3.GetNameInLanguage(LocalizationManager.UILanguageId);
-				if (_collectionSettings.Language3.IsCustomName)
-					lang3UiName = _collectionSettings.Language3.Name;
 				_language3Name.Text = string.Format("{0} ({1})", lang3UiName, _collectionSettings.Language3Iso639Code);
 				_language3FontLabel.Text = string.Format(defaultFontText, lang3UiName);
 				_removeLanguage3Link.Visible = true;
@@ -185,7 +179,6 @@ namespace Bloom.Collection
 			{
 				_collectionSettings.Language1.Iso639Code = l.LanguageTag;
 				_collectionSettings.Language1.Name = l.DesiredName;
-				_collectionSettings.Language1.IsCustomName = l.DesiredName != l.Names.FirstOrDefault();
 				ChangeThatRequiresRestart();
 			}
 		}
@@ -197,7 +190,6 @@ namespace Bloom.Collection
 			{
 				_collectionSettings.Language2Iso639Code = l.LanguageTag;
 				_collectionSettings.Language2.Name = l.DesiredName;
-				_collectionSettings.Language2.IsCustomName = l.DesiredName != l.Names.FirstOrDefault();
 				ChangeThatRequiresRestart();
 			}
 		}
@@ -210,7 +202,6 @@ namespace Bloom.Collection
 			{
 				_collectionSettings.Language3Iso639Code = l.LanguageTag;
 				_collectionSettings.Language3.Name = l.DesiredName;
-				_collectionSettings.Language3.IsCustomName = l.DesiredName != l.Names.FirstOrDefault();
 				ChangeThatRequiresRestart();
 			}
 		}

--- a/src/BloomExe/Collection/WritingSystem.cs
+++ b/src/BloomExe/Collection/WritingSystem.cs
@@ -13,10 +13,10 @@ namespace Bloom.Collection
 	public class WritingSystem
 	{
 		private readonly int _languageNumberInCollection;
-		public static LanguageLookupModel LookupIsoCode = new LanguageLookupModel() { IncludeScriptMarkers = false };
+		private readonly Func<string> _codeOfDefaultLanguageForNaming;
+		public static LanguageLookupModel LookupIsoCode = new LanguageLookupModel();
 		private string _iso639Code;
 		public string Name;
-		public bool IsCustomName;
 		public bool IsRightToLeft;
 
 		// Line breaks are always wanted only between words.  (ignoring hyphenation)
@@ -42,9 +42,13 @@ namespace Bloom.Collection
 		public decimal LineHeight;
 		public string FontName;
 
-		public WritingSystem(int languageNumberInCollection)
+		public WritingSystem(int languageNumberInCollection, Func<string> codeOfDefaultLanguageForNaming)
 		{
 			_languageNumberInCollection = languageNumberInCollection;
+
+			//Note: I'm not convinced we actually ever rely on dynamic name lookups anymore?
+			//See: https://issues.bloomlibrary.org/youtrack/issue/BL-7832
+			_codeOfDefaultLanguageForNaming = codeOfDefaultLanguageForNaming;
 		}
 
 		public string Iso639Code
@@ -52,13 +56,13 @@ namespace Bloom.Collection
 			get { return _iso639Code; }
 			set {
 				_iso639Code = value;
-				Name = GetLanguageName_NoCache("en");	// effectively what happens in palaso dialog
+				Name = GetLanguageName_NoCache(_codeOfDefaultLanguageForNaming());
 			}
 		}
 
 		public string GetNameInLanguage(string inLanguage)
 		{
-			if (!string.IsNullOrEmpty(Iso639Code) && !String.IsNullOrEmpty(Name) && IsCustomName)
+			if (!string.IsNullOrEmpty(Iso639Code) && !String.IsNullOrEmpty(Name) && inLanguage == _codeOfDefaultLanguageForNaming())
 				return Name;
 
 			return GetLanguageName_NoCache(inLanguage);
@@ -94,7 +98,6 @@ namespace Bloom.Collection
 		{
 			var pfx = "Language" + _languageNumberInCollection;
 			xml.Add(new XElement(pfx+"Name", Name));
-			xml.Add(new XElement(pfx+"IsCustomName", IsCustomName));
 			xml.Add(new XElement(pfx + "Iso639Code", Iso639Code));
 			xml.Add(new XElement($"DefaultLanguage{_languageNumberInCollection}FontName", FontName));
 			xml.Add(new XElement($"IsLanguage{_languageNumberInCollection}Rtl", IsRightToLeft));
@@ -158,33 +161,10 @@ namespace Bloom.Collection
 			{
 				Name = GetLanguageName_NoCache(languageForDefaultNameLookup=="self"?Iso639Code:languageForDefaultNameLookup);
 			}
-			IsCustomName = ReadOrComputeIsCustomName(xml, pfx+"IsCustomName");
 			LineHeight = ReadDecimal(xml, pfx+"LineHeight", 0);
 			FontName = ReadString(xml, $"DefaultLanguage{_languageNumberInCollection}FontName", GetDefaultFontName());
 			BreaksLinesOnlyAtSpaces = ReadBoolean(xml, pfx+"BreaksLinesOnlyAtSpaces", false);
 			BaseUIFontSizeInPoints = ReadInt(xml, pfx + "BaseUIFontSizeInPoints", 0 /* 0 means "default" */);
-		}
-
-		private bool ReadOrComputeIsCustomName(XElement xml, string id)
-		{
-			string s = ReadString(xml, id, null);
-			if (s != null)
-			{
-				bool b;
-				if (bool.TryParse(s, out b))
-					return b;
-			}
-			// Compute value since it wasn't stored.  Creating a LanguageLookup object is expensive enough to try obtaining
-			// the one created by LanguageLookupModel. Using LanguageLookup is only way to get the language names loaded.
-			var type = typeof(LanguageLookupModel);
-			var fieldInfo = type.GetField("_languageLookup", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-			SIL.WritingSystems.LanguageLookup lookup = null;
-			if (fieldInfo != null)
-				lookup = fieldInfo.GetValue(LookupIsoCode) as SIL.WritingSystems.LanguageLookup;
-			if (lookup == null)
-				lookup = new SIL.WritingSystems.LanguageLookup(true);
-			var language = lookup.GetLanguageFromCode(Iso639Code);
-			return Name != language.Names.FirstOrDefault();
 		}
 
 		private bool ReadBoolean(XElement xml, string id, bool defaultValue)

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -387,14 +387,32 @@ namespace Bloom.Edit
 				//_contentLanguages.Clear();		CAREFUL... the tags in the dropdown are ContentLanguage's, so changing them breaks that binding
 				if (_contentLanguages.Count() == 0)
 				{
-					_contentLanguages.Add(new ContentLanguage(_collectionSettings.Language1) { Locked = true, Selected = true });
+					_contentLanguages.Add(new ContentLanguage(_collectionSettings.Language1Iso639Code,
+															  _collectionSettings.Language1.GetNameInLanguage("en"))
+											{Locked = true, Selected = true, IsRtl = _collectionSettings.Language1.IsRightToLeft});
 
 					//NB: these won't *always* be tied to the national and regional languages, but they are for now. We would need more UI, without making for extra complexity
-					var item2 = new ContentLanguage(_collectionSettings.Language2);
+					var item2 = new ContentLanguage(_collectionSettings.Language2Iso639Code,
+													_collectionSettings.Language2.GetNameInLanguage("en"))
+									{
+										IsRtl = _collectionSettings.Language1.IsRightToLeft
+//					            		Selected =
+//					            			CurrentBook.MultilingualContentLanguage2 ==
+//					            			_librarySettings.Language2Iso639Code
+									};
 					_contentLanguages.Add(item2);
 					if (!String.IsNullOrEmpty(_collectionSettings.Language3Iso639Code))
 					{
-						var item3 = new ContentLanguage(_collectionSettings.Language3);
+						//NB: this could be the 2nd language (when the national 1 language is not selected)
+//						bool selected = CurrentBook.MultilingualContentLanguage2 ==
+//						                _librarySettings.Language3Iso639Code ||
+//						                CurrentBook.MultilingualContentLanguage3 ==
+//						                _librarySettings.Language3Iso639Code;
+						var item3 = new ContentLanguage(_collectionSettings.Language3Iso639Code,
+														_collectionSettings.Language3.GetNameInLanguage("en"))
+						{
+							IsRtl = _collectionSettings.Language3.IsRightToLeft
+						};// {Selected = selected};
 						_contentLanguages.Add(item3);
 					}
 				}
@@ -525,20 +543,15 @@ namespace Bloom.Edit
 		{
 			public readonly string Iso639Code;
 			public readonly string Name;
-			private readonly WritingSystem _ws;
 
-			public ContentLanguage(WritingSystem ws)
+			public ContentLanguage(string iso639Code, string name)
 			{
-				Iso639Code = ws.Iso639Code;
-				Name = ws.Name;
-				IsRtl = ws.IsRightToLeft;
-				_ws = ws;
+				Iso639Code = iso639Code;
+				Name = name;
 			}
 			public override string ToString()
 			{
-				if (_ws.IsCustomName)
-					return Name;
-				return _ws.GetNameInLanguage(LocalizationManager.UILanguageId);
+				return Name;
 			}
 
 			public bool Selected;


### PR DESCRIPTION
Reverts BloomBooks/BloomDesktop#3557

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3565)
<!-- Reviewable:end -->
