### PR TITLE
Handle customized language names more consistently (BL-7832)

### DIFF
--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -619,8 +619,14 @@ namespace Bloom.Collection
 			for (int i = 0; i < isoCodes.Length; i++)
 			{
 				var code = isoCodes[i];
-				string name = Language1.Name;
-				if (code != Language1Iso639Code)
+				string name;
+				if (code == Language1.Iso639Code)
+					name = Language1.Name;
+				else if (code == Language2.Iso639Code)
+					name = Language2.Name;
+				else if (code == Language3.Iso639Code)
+					name = Language3.Name;
+				else
 					WritingSystem.LookupIsoCode.GetBestLanguageName(code, out name);
 				string ethCode;
 				LanguageSubtag data;

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -117,8 +117,8 @@ namespace Bloom.Collection
 		{
 			string defaultFontText =
 				LocalizationManager.GetString("CollectionSettingsDialog.BookMakingTab.DefaultFontFor", "Default Font for {0}", "{0} is a language name.");
-			var lang1UiName = _collectionSettings.Language1.GetNameInLanguage(LocalizationManager.UILanguageId);
-			var lang2UiName = _collectionSettings.Language2.GetNameInLanguage(LocalizationManager.UILanguageId);
+			var lang1UiName = _collectionSettings.Language1.UiName;
+			var lang2UiName = _collectionSettings.Language2.UiName;
 			_language1Name.Text = string.Format("{0} ({1})", lang1UiName, _collectionSettings.Language1Iso639Code);
 			_language2Name.Text = string.Format("{0} ({1})", lang2UiName, _collectionSettings.Language2Iso639Code);
 			_language1FontLabel.Text = string.Format(defaultFontText, lang1UiName);
@@ -137,7 +137,7 @@ namespace Bloom.Collection
 			}
 			else
 			{
-				lang3UiName = _collectionSettings.Language3.GetNameInLanguage(LocalizationManager.UILanguageId);
+				lang3UiName = _collectionSettings.Language3.UiName;
 				_language3Name.Text = string.Format("{0} ({1})", lang3UiName, _collectionSettings.Language3Iso639Code);
 				_language3FontLabel.Text = string.Format(defaultFontText, lang3UiName);
 				_removeLanguage3Link.Visible = true;
@@ -179,6 +179,7 @@ namespace Bloom.Collection
 			{
 				_collectionSettings.Language1.Iso639Code = l.LanguageTag;
 				_collectionSettings.Language1.Name = l.DesiredName;
+				_collectionSettings.Language1.IsCustomName = l.DesiredName != l.Names.FirstOrDefault();
 				ChangeThatRequiresRestart();
 			}
 		}
@@ -190,6 +191,7 @@ namespace Bloom.Collection
 			{
 				_collectionSettings.Language2Iso639Code = l.LanguageTag;
 				_collectionSettings.Language2.Name = l.DesiredName;
+				_collectionSettings.Language2.IsCustomName = l.DesiredName != l.Names.FirstOrDefault();
 				ChangeThatRequiresRestart();
 			}
 		}
@@ -202,6 +204,7 @@ namespace Bloom.Collection
 			{
 				_collectionSettings.Language3Iso639Code = l.LanguageTag;
 				_collectionSettings.Language3.Name = l.DesiredName;
+				_collectionSettings.Language3.IsCustomName = l.DesiredName != l.Names.FirstOrDefault();
 				ChangeThatRequiresRestart();
 			}
 		}

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -387,32 +387,14 @@ namespace Bloom.Edit
 				//_contentLanguages.Clear();		CAREFUL... the tags in the dropdown are ContentLanguage's, so changing them breaks that binding
 				if (_contentLanguages.Count() == 0)
 				{
-					_contentLanguages.Add(new ContentLanguage(_collectionSettings.Language1Iso639Code,
-															  _collectionSettings.Language1.GetNameInLanguage("en"))
-											{Locked = true, Selected = true, IsRtl = _collectionSettings.Language1.IsRightToLeft});
+					_contentLanguages.Add(new ContentLanguage(_collectionSettings.Language1) { Locked = true, Selected = true });
 
 					//NB: these won't *always* be tied to the national and regional languages, but they are for now. We would need more UI, without making for extra complexity
-					var item2 = new ContentLanguage(_collectionSettings.Language2Iso639Code,
-													_collectionSettings.Language2.GetNameInLanguage("en"))
-									{
-										IsRtl = _collectionSettings.Language1.IsRightToLeft
-//					            		Selected =
-//					            			CurrentBook.MultilingualContentLanguage2 ==
-//					            			_librarySettings.Language2Iso639Code
-									};
+					var item2 = new ContentLanguage(_collectionSettings.Language2);
 					_contentLanguages.Add(item2);
 					if (!String.IsNullOrEmpty(_collectionSettings.Language3Iso639Code))
 					{
-						//NB: this could be the 2nd language (when the national 1 language is not selected)
-//						bool selected = CurrentBook.MultilingualContentLanguage2 ==
-//						                _librarySettings.Language3Iso639Code ||
-//						                CurrentBook.MultilingualContentLanguage3 ==
-//						                _librarySettings.Language3Iso639Code;
-						var item3 = new ContentLanguage(_collectionSettings.Language3Iso639Code,
-														_collectionSettings.Language3.GetNameInLanguage("en"))
-						{
-							IsRtl = _collectionSettings.Language3.IsRightToLeft
-						};// {Selected = selected};
+						var item3 = new ContentLanguage(_collectionSettings.Language3);
 						_contentLanguages.Add(item3);
 					}
 				}
@@ -543,15 +525,18 @@ namespace Bloom.Edit
 		{
 			public readonly string Iso639Code;
 			public readonly string Name;
+			private readonly WritingSystem _ws;
 
-			public ContentLanguage(string iso639Code, string name)
+			public ContentLanguage(WritingSystem ws)
 			{
-				Iso639Code = iso639Code;
-				Name = name;
+				Iso639Code = ws.Iso639Code;
+				Name = ws.Name;
+				IsRtl = ws.IsRightToLeft;
+				_ws = ws;
 			}
 			public override string ToString()
 			{
-				return Name;
+				return _ws.UiName;
 			}
 
 			public bool Selected;


### PR DESCRIPTION
A customized name will always be used, in the UI and published material.
A non-customized name will depend (in theory) on the context, the UI
language, and the national language for the collection.  In practice at
the moment, we have only possibly custom names, English names, and the
name of the language in itself (autonym).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3566)
<!-- Reviewable:end -->
