### PR TITLE
Fix initialization error in WritingSystem (BL-7832)

### DIFF
--- a/src/BloomExe/Collection/WritingSystem.cs
+++ b/src/BloomExe/Collection/WritingSystem.cs
@@ -201,6 +201,8 @@ namespace Bloom.Collection
 				if (!LookupIsoCode.AreLanguagesLoaded)
 					LookupIsoCode.LoadLanguages();
 			}
+			if (String.IsNullOrWhiteSpace(Iso639Code))
+				return false;	// undefined (probably language3)
 			var language = LookupIsoCode.LanguageLookup.GetLanguageFromCode(Iso639Code);
 			return Name != language.Names.FirstOrDefault();
 		}


### PR DESCRIPTION
IsCustomName should default to false like IsLanguageRTL if the language
is essentially undefined in the .bloomCollection file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3570)
<!-- Reviewable:end -->
