### PR TITLE
Fix BL-8051 don't let iframes break book

### DIFF
--- a/src/BloomExe/XmlHtmlConverter.cs
+++ b/src/BloomExe/XmlHtmlConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -305,6 +305,13 @@ namespace Bloom
 				if (string.IsNullOrEmpty(node.InnerText) && node.ChildNodes.Count == 0)
 				{
 					node.InnerText = " ";
+				}
+			}
+			foreach (XmlElement node in dom.SafeSelectNodes("//iframe"))
+			{
+				if (!node.HasChildNodes)
+				{
+					node.AppendChild(node.OwnerDocument.CreateTextNode("Must have a closing tag in HTML"));
 				}
 			}
 		}


### PR DESCRIPTION
Previously code emitted <Iframe..../> which isn't valid html5 and which kills the rest of the book. Change  to emit

`<iframe...>Must have a closing tag in HTM</iframe>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3587)
<!-- Reviewable:end -->
