### PR TITLE
Add original-book-source-url to the book metadata json (BL-6981)

### DIFF
--- a/src/BloomExe/Book/BookInfo.cs
+++ b/src/BloomExe/Book/BookInfo.cs
@@ -809,7 +809,8 @@ namespace Bloom.Book
 						province = ProvinceName,
 						district = DistrictName,
 						features = Features,
-						internetLimits = InternetLimits
+						internetLimits = InternetLimits,
+						originalBookSourceUrl = OriginalBookSourceUrl
 						// Other fields are not needed by the web site and we don't expect they will be.
 					});
 			}
@@ -1118,6 +1119,13 @@ namespace Bloom.Book
 		/// </summary>
 		[JsonProperty("use-original-copyright")]
 		public bool UseOriginalCopyright { get; set; }
+
+		/// <summary>
+		/// The URL the source of this book was downloaded from before conversion to Bloom source format.
+		/// This is set by RoseGarden, but expected to be empty for books that originate in Bloom.
+		/// </summary>
+		[JsonProperty("original-book-source-url")]
+		public string OriginalBookSourceUrl { get; set; }
 	}
 
 	/// <summary>


### PR DESCRIPTION
This is needed for RoseGarden output to help users trace the origin of
converted books.  An entry needs to be made in the book table in Parse.com
for production eventually, and maybe for the sandbox/next.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3611)
<!-- Reviewable:end -->
