### PR TITLE
Fix language tip 1) in wrong position & 2) moves unexpectedly (BL-8151)

### DIFF
--- a/src/BloomBrowserUI/bookLayout/bubble.less
+++ b/src/BloomBrowserUI/bookLayout/bubble.less
@@ -242,18 +242,23 @@
 // different bubble shapes require different positioning of the affordances
 [data-bubble] {
     .bloom-dragHandle {
-        right: 100% + 1px;
+        right: calc(100% + 1px);
     }
     #formatButton {
-        right: 100% + 2px;
+        right: calc(100% + 2px);
     }
     // we need to push the label left-ward to get out of the way of the fat part of the bubble
     [data-languageTipContent]:after {
-        right: 100% + 10px !important;
+        right: calc(100% + 10px) !important;
     }
 }
-[data-bubble*="caption"] {
+[data-bubble*="`caption`"] {
     [data-languageTipContent]:after {
-        right: 100% + 2px !important;
+        right: calc(100% + 2px) !important;
+    }
+}
+[data-bubble*="`style`:`none`"] {
+    [data-languageTipContent]:after {
+        right: calc(100% + 1px) !important;
     }
 }

--- a/src/BloomBrowserUI/bookLayout/bubble.less
+++ b/src/BloomBrowserUI/bookLayout/bubble.less
@@ -241,24 +241,20 @@
 
 // different bubble shapes require different positioning of the affordances
 [data-bubble] {
+    // These happen to be multiples of 1.4 is because they are 1% increments of 140px (the default text box width)
     .bloom-dragHandle {
-        right: calc(100% + 1px);
+        right: calc(100% + 1.4px);
     }
     #formatButton {
-        right: calc(100% + 2px);
+        right: calc(100% + 2.8px);
     }
     // we need to push the label left-ward to get out of the way of the fat part of the bubble
     [data-languageTipContent]:after {
-        right: calc(100% + 10px) !important;
+        right: calc(100% + 14px) !important;
     }
 }
-[data-bubble*="`caption`"] {
+[data-bubble*="caption"] {
     [data-languageTipContent]:after {
-        right: calc(100% + 2px) !important;
-    }
-}
-[data-bubble*="`style`:`none`"] {
-    [data-languageTipContent]:after {
-        right: calc(100% + 1px) !important;
+        right: calc(100% + 2.8px) !important;
     }
 }


### PR DESCRIPTION
Even though the old code says it's (100% + 1px) away, the preprocessor actually calculates this as 101% away (this isn't a unit conversion it can handle at compile time). So the amount we positioned them away from the left edge was actually based on percentages of the width, not the fixed number! :(
We want to change that to a fixed number instead (so that the tip does not move as the bubble size changes), but keep them at the same initial position *handwave*. But when determining where the old behavior's position is thorny because it's based on a percentage of the width. So we need to assume a certain width of the text box.
The most reasonable assumption seems to be to use the default text box width, which is 140.
That means that for text boxes which are of the default width, there will be no change in initial position.
But for non-default-widths, these language tip positions will be slightly different than before, unfortunately. (That's the bugfix... when you resize the bubble to a non-default size, the language tip position no longer changes)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3625)
<!-- Reviewable:end -->
