### PR TITLE
BL-8009 set state to highlight refresh icon

### DIFF
--- a/src/BloomBrowserUI/bloomMaterialUITheme.js
+++ b/src/BloomBrowserUI/bloomMaterialUITheme.js
@@ -9,6 +9,7 @@ import { createMuiTheme } from "@material-ui/core/styles";
 const bloomBlue = "#1d94a4";
 const bloomPurple = "#96668f";
 const kDialogTopBottomGray = "#F1F3F4";
+const kRefreshIconColor = "#988b8b";
 // the value that gets us to the 4.5 AA ratio depends on the background.
 // So the "aside"/features right-panel color effects this.
 //const AACompliantBloomBlue = "#177c8a";
@@ -21,7 +22,8 @@ const theme = createMuiTheme({
     palette: {
         primary: { main: bloomBlue },
         secondary: { main: bloomPurple },
-        warning: { main: "#F3AA18" }
+        warning: { main: "#F3AA18" },
+        text: { secondary: kRefreshIconColor }
     },
     typography: {
         fontSize: 12,

--- a/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
@@ -54,6 +54,7 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
         useL10n("Creating Digital Book", "PublishTab.Android.Creating")
     );
     const [closePending, setClosePending] = useState(false);
+    const [highlightRefresh, setHighlightRefresh] = useState(false);
     const [progressState, setProgressState] = useState(ProgressState.Working);
     const [bookUrl, setBookUrl] = useState(
         inStorybookMode
@@ -125,6 +126,7 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
                             bookUrl
                         }
                         showRefresh={true}
+                        highlightRefreshIcon={highlightRefresh}
                         onRefresh={() => props.onReset()}
                     />
                 </PreviewPanel>
@@ -138,7 +140,9 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
                         }}
                     />
                     <ThumbnailGroup onChange={() => props.onReset()} />
-                    <PublishLanguagesGroup />
+                    <PublishLanguagesGroup
+                        onChange={() => setHighlightRefresh(true)}
+                    />
                     <HelpGroup>
                         <HelpLink
                             l10nKey="PublishTab.Android.AboutBookFeatures"

--- a/src/BloomBrowserUI/publish/commonPublish/DeviceAndControls.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/DeviceAndControls.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import "./DeviceFrame.less";
 import { useState, useEffect } from "react";
-import { Div } from "../../react_components/l10nComponents";
+import { useL10n } from "../../react_components/l10nHooks";
+import { useTheme, Theme, Typography } from "@material-ui/core";
+import IconButton from "@material-ui/core/IconButton";
+import RefreshIcon from "@material-ui/icons/Refresh";
 
 /*
   Example usage:
@@ -16,12 +19,15 @@ export const DeviceAndControls: React.FunctionComponent<{
     url: string;
     iframeClass?: string;
     showRefresh?: boolean;
+    highlightRefreshIcon?: boolean;
     onRefresh?: () => void;
 }> = props => {
     const [landscape, setLandscape] = useState(props.defaultLandscape);
+    const theme: Theme = useTheme();
     useEffect(() => {
         setLandscape(props.defaultLandscape);
     }, [props]);
+    const refreshText = useL10n("Refresh", "Common.Refresh");
 
     return (
         <div className="deviceAndControls">
@@ -60,10 +66,28 @@ export const DeviceAndControls: React.FunctionComponent<{
                     }
                     onClick={() => props.onRefresh && props.onRefresh()}
                 >
-                    <div className="refresh-icon" />
-                    <Div className="refresh" l10nKey="Common.Refresh">
-                        Refresh
-                    </Div>
+                    <IconButton
+                        aria-label="refresh preview"
+                        className="refresh-icon"
+                    >
+                        <RefreshIcon
+                            fontSize="large"
+                            htmlColor={
+                                props.highlightRefreshIcon
+                                    ? theme.palette.primary.main
+                                    : theme.palette.text.secondary
+                            }
+                        />
+                    </IconButton>
+                    <Typography
+                        color={
+                            props.highlightRefreshIcon
+                                ? "primary"
+                                : "textSecondary"
+                        }
+                    >
+                        {refreshText}
+                    </Typography>
                 </div>
             )}
         </div>

--- a/src/BloomBrowserUI/publish/commonPublish/DeviceFrame.less
+++ b/src/BloomBrowserUI/publish/commonPublish/DeviceFrame.less
@@ -41,23 +41,10 @@
         flex-direction: row;
         cursor: pointer;
         .refresh-icon {
+            padding: 0;
             height: 1.7em;
             width: 1.7em;
-            background-image: url("../../images/Ic_refresh_48px.svg");
-            margin-top: -4px;
-            background-size: 1.7em;
-            background-repeat: none;
-            // coverts black in SVG to roughly 152,139,139 as used for text.
-            // see https://codepen.io/sosuke/pen/Pjoqqp
-            filter: invert(65%) sepia(3%) saturate(836%) hue-rotate(314deg)
-                brightness(87%) contrast(83%);
-        }
-        .refresh {
-            color: rgb(
-                152,
-                139,
-                139
-            ); // also explicit in the svg; should this be some Bloom pallette color?
+            margin-top: -8px;
         }
         &.with-orientation-buttons {
             transform: translate(-332px, 420px); // portrait, rotation buttons

--- a/src/BloomBrowserUI/publish/stories.tsx
+++ b/src/BloomBrowserUI/publish/stories.tsx
@@ -89,8 +89,24 @@ storiesOf("Publish/DeviceFrame", module)
             Portrait
         </DeviceAndControls>
     ))
-    .add("DeviceFrame Landscape only", () => (
-        <DeviceAndControls defaultLandscape={true} canRotate={false} url="">
+    .add("DeviceFrame Landscape only with Refresh button", () => (
+        <DeviceAndControls
+            defaultLandscape={true}
+            canRotate={false}
+            url=""
+            showRefresh={true}
+        >
+            Landscape
+        </DeviceAndControls>
+    ))
+    .add("DeviceFrame Landscape only with highlighted Refresh button", () => (
+        <DeviceAndControls
+            defaultLandscape={true}
+            canRotate={false}
+            url=""
+            showRefresh={true}
+            highlightRefreshIcon={true}
+        >
             Landscape
         </DeviceAndControls>
     ))


### PR DESCRIPTION
* if PublishLanguagesGroup changes
* currently Feature and thumbnail color changes refresh
   automatically and Language checkbox changes don't
* this change just highlights the refresh button and label
   if a Language checkbox has changed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3628)
<!-- Reviewable:end -->
