### PR TITLE
BL-8115 fix cover color changing regex to be general

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2139,20 +2139,35 @@ namespace Bloom.Book
 		/// <param name="color"></param>
 		public void SetCoverColor(string color)
 		{
+			if (SetCoverColorInternal(color))
+			{
+				Save();
+				ContentsChanged?.Invoke(this, new EventArgs());	
+			}
+		}
+
+		/// <summary>
+		/// Internal method is testable
+		/// </summary>
+		/// <param name="color"></param>
+		/// <returns>true if a change was made</returns>
+		internal bool SetCoverColorInternal(string color)
+		{
 			foreach (XmlElement stylesheet in RawDom.SafeSelectNodes("//style"))
 			{
 				string content = stylesheet.InnerXml;
 				var regex =
-					new Regex(@"(DIV.(coverColor\s*TEXTAREA|bloom-page.coverColor)\s*{\s*background-color:\s*)(#[0-9a-fA-F]*)");
-				if (regex.IsMatch(content))
-				{
-					var newContent = regex.Replace(content, "$1" + color);
-					stylesheet.InnerXml = newContent;
-					Save();
-					ContentsChanged?.Invoke(this, new EventArgs());
-					return;
-				}
+					new Regex(
+						@"(DIV.(coverColor\s*TEXTAREA|bloom-page.coverColor)\s*{\s*background-color:\s*)(#[0-9a-fA-F]*)",
+						RegexOptions.IgnoreCase);
+				if (!regex.IsMatch(content))
+					continue;
+				var newContent = regex.Replace(content, "$1" + color);
+				stylesheet.InnerXml = newContent;
+				return true;
 			}
+
+			return false;
 		}
 
 		/// <summary>

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -43,6 +43,60 @@ namespace BloomTests.Book
 		}
 
 		[Test]
+		public void SetCoverColor_WorksWithCaps()
+		{
+			var newValue = "#777777";
+			SetDom("",
+				@"<style type='text/css'>
+				</style>
+				<style type='text/css'>
+					DIV.coverColor  TEXTAREA {
+						background-color: #B2CC7D !important;
+					}
+					DIV.bloom-page.coverColor {
+						background-color: #B2CC7D !important;
+					}
+				</style>
+				<style type='text/css'>
+				</style>");
+			var book = CreateBook();
+			var dom = book.RawDom;
+			book.SetCoverColorInternal(newValue);
+			var coverColorText = dom.SafeSelectNodes("//style[text()]")[0].InnerText;
+			var first = coverColorText.IndexOf(newValue, StringComparison.InvariantCulture);
+			var last = coverColorText.LastIndexOf(newValue, StringComparison.InvariantCulture);
+			Assert.That(first > 0);
+			Assert.That(last > 0 && last != first);
+		}
+
+		[Test]
+		public void SetCoverColor_WorksWithLowercase()
+		{
+			var newValue = "#777777";
+			SetDom("",
+				@"<style type='text/css'>
+				</style>
+				<style type='text/css'>
+					div.coverColor  textarea {
+						background-color: #B2CC7D !important;
+					}
+					div.bloom-page.coverColor {
+						background-color: #B2CC7D !important;
+					}
+				</style>
+				<style type='text/css'>
+				</style>");
+			var book = CreateBook();
+			var dom = book.RawDom;
+			book.SetCoverColorInternal(newValue);
+			var coverColorText = dom.SafeSelectNodes("//style[text()]")[0].InnerText;
+			var first = coverColorText.IndexOf(newValue, StringComparison.InvariantCulture);
+			var last = coverColorText.LastIndexOf(newValue, StringComparison.InvariantCulture);
+			Assert.That(first > 0);
+			Assert.That(last > 0 && last != first);
+		}
+
+		[Test]
 		public void BringBookUpToDate_EmbeddedXmlImgTagRemoved()
 		{
 			// Some older books had XML img tags inside the coverImage data-book value. This resulted in an


### PR DESCRIPTION
* our code linters keep the .htm files in our code base from
   using capital letters for html tags like DIV, so they won't
   work on Moon & Cap, e.g.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3631)
<!-- Reviewable:end -->
