### PR TITLE
Minimally fix Bloom to compile/run with mono5-sil

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Standards-Version: 3.9.7
 Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
  wget, unzip, desktop-file-utils, curl,
  optipng, libsndfile1,
- mono4-sil, libgdiplus4-sil,
+ mono5-sil, libgdiplus5-sil,
  libenchant-dev, libxklavier-dev, libdconf-dev,
  libicu-dev,
  libgtk2.0-cil (>= 2.12.10), libgtk2.0-dev (>= 2.14), libasound2-dev,
@@ -18,7 +18,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
 Package: bloom-desktop-alpha
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
- mono4-sil, libgdiplus4-sil, gtk-sharp4-sil, gtklp,
+ mono5-sil, libgdiplus5-sil, gtk-sharp5-sil, gtklp,
  chmsee | xchm | kchmviewer, libtidy-sil,
  fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,
  optipng, libsndfile1,

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-export MONO_PREFIX = /opt/mono4-sil
+export MONO_PREFIX = /opt/mono5-sil
 export BUILD = Release
 
 PACKAGE = bloom-desktop-alpha
@@ -98,11 +98,11 @@ override_dh_auto_install:
 # Don't export any assemblies to other packages
 override_dh_makeclilibs:
 
-# Include mono4-sil in shlib dirs searched
+# Include mono5-sil in shlib dirs searched
 override_dh_shlibdeps:
 	dh_shlibdeps -l$(MONO_PREFIX)/lib --exclude=Firefox
 
-# Include mono4-sil in cli dirs searched
+# Include mono5-sil in cli dirs searched
 # Trying to process connections.dll now crashes on jenkins instead of merely complaining.
 # The -X (--exclude) option doesn't seem to work for dh_clideps to skip connections.dll.
 override_dh_clideps:

--- a/environ
+++ b/environ
@@ -1,13 +1,13 @@
 # Environment settings for running programs with the SIL version of mono
 # Set MONO_ENVIRON to this file's pathname, then run, for example,
-#    /opt/mono4-sil/bin/mono --debug Bloom.exe
-# These setting assume that the packaged SIL Mono is installed in /opt/mono4-sil.
+#    /opt/mono5-sil/bin/mono --debug Bloom.exe
+# These setting assume that the packaged SIL Mono is installed in /opt/mono5-sil.
 # Note that this file is intended to be "sourced", not "executed".
 
 # the sourcing script should cd/pushd to the directory containing this script
 BASE="$(pwd)"
 [ -z "$BUILD" ] && BUILD=Debug
-[ -z "$MONO_PREFIX" ] && MONO_PREFIX=/opt/mono4-sil
+[ -z "$MONO_PREFIX" ] && MONO_PREFIX=/opt/mono5-sil
 
 # Dependency locations
 # Search for xulrunner and geckofx, select the best, and add its location to LD_LIBRARY_PATH.
@@ -54,10 +54,10 @@ fi
 if [ "$RUNMODE" = "PACKAGE" -o "$RUNMODE" = "INSTALLED" ]
 then
 	# Add packaged mono items to paths
-	PATH="/opt/mono4-sil/bin:${PATH}"
-	LD_LIBRARY_PATH="/opt/mono4-sil/lib:${LD_LIBRARY_PATH}"
-	PKG_CONFIG_PATH="/opt/mono4-sil/lib/pkgconfig:${PKG_CONFIG_PATH}"
-	MONO_GAC_PREFIX="/opt/mono4-sil:/usr"
+	PATH="/opt/mono5-sil/bin:${PATH}"
+	LD_LIBRARY_PATH="/opt/mono5-sil/lib:${LD_LIBRARY_PATH}"
+	PKG_CONFIG_PATH="/opt/mono5-sil/lib/pkgconfig:${PKG_CONFIG_PATH}"
+	MONO_GAC_PREFIX="/opt/mono5-sil:/usr"
 else
 	# Add locally-built mono items to paths
 	# We also add the default values for PKG_CONFIG_PATH - MonoDevelop resets the PKG_CONFIG_PATH
@@ -97,3 +97,6 @@ export HGRCPATH=
 
 #sets keyboard input method to none
 unset XMODIFIERS
+
+# prevent crash due to incompatible Gtk/mono5 problem (TEMPORARY HACK)
+export USE_GTK_DIALOGS=0

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -57,6 +57,9 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>TRACE</DefineConstants>
     <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+    <DefineConstants>__MonoCS__</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>WinExe</OutputType>

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -80,6 +80,9 @@
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
     <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+    <DefineConstants>__MonoCS__</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">


### PR DESCRIPTION
This is needed for the upcoming Ubuntu LTS release (20.04 / focal).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3648)
<!-- Reviewable:end -->
