### PR TITLE
Fix LinuxBloomLauncher to use mono5-sil instead of mono4-sil (BL-8253)

### DIFF
--- a/src/LinuxBloomLauncher/BloomLauncher.c
+++ b/src/LinuxBloomLauncher/BloomLauncher.c
@@ -155,7 +155,7 @@ static gchar ** GetArgvForBloom(int argcOrig, char ** argvOrig)
 
 	// On Linux, mono is the program that is running: Bloom.exe is just data for the program
 	// Bloom uses the debugged version of Mono 4.6.1 packaged by SIL/LSDev.
-	argvNew[0] = g_strdup("/opt/mono4-sil/bin/mono");
+	argvNew[0] = g_strdup("/opt/mono5-sil/bin/mono");
 	// Sacrifice line numbers in stack dumps for speed -- often don't see them anyway.
 	// If we do reinstate the "--debug", then the "+ 2" and "1 new" above need to be
 	// incremented, and the "[1]", "[i+1]", and "[argcOrig+1]" below need to be incremented.
@@ -245,14 +245,14 @@ static gchar ** GetEnvpForBloom()
 	//printf("LD_PRELOAD=%s\n", preload);
 
 	/* also set MONO_PREFIX, other MONO related values, and PATH */
-	envp = g_environ_setenv(envp, "MONO_PREFIX", g_strdup("/opt/mono4-sil"), true);
+	envp = g_environ_setenv(envp, "MONO_PREFIX", g_strdup("/opt/mono5-sil"), true);
 	envp = g_environ_setenv(envp, "MONO_RUNTIME", g_strdup("v4.0.30319"), true);
 	envp = g_environ_setenv(envp, "MONO_DEBUG", g_strdup("explicit-null-checks"), true);
 	envp = g_environ_setenv(envp, "MONO_ENV_OPTIONS", g_strdup("-O=-gshared"), true);
 	envp = g_environ_setenv(envp, "MONO_TRACE_LISTENER", g_strdup("Console.Out"), true);
 	envp = g_environ_setenv(envp, "MONO_MWF_SCALING", g_strdup("disable"), true);
 	envp = g_environ_setenv(envp, "MONO_PATH", g_strconcat(programDirectory, ":/usr/lib/cli/gdk-sharp-2.0", NULL), true);
-	envp = g_environ_setenv(envp, "MONO_GAC_PREFIX", g_strdup("/opt/mono4-sil:/usr"), true);
+	envp = g_environ_setenv(envp, "MONO_GAC_PREFIX", g_strdup("/opt/mono5-sil:/usr"), true);
 
 	const char * pathOld = g_environ_getenv(envp, "PATH");
 	const char * path;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3649)
<!-- Reviewable:end -->
