### PR TITLE
Fix bug where non-HTML files match FindBookHtml()

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -1383,7 +1383,14 @@ namespace Bloom.Book
 			//ok, so maybe they changed the name of the folder and not the htm. Can we find a *single* html doc?
 			// BL-3572 when the only file in the directory is "Big Book.html", it matches both filters in Windows (tho' not in Linux?)
 			// so Union works better here. (And we'll change the name of the book too.)
-			var candidates = new List<string>(Directory.GetFiles(folderPath, "*.htm").Union(Directory.GetFiles(folderPath, "*.html")));
+			var candidates = new List<string>(
+				Directory.GetFiles(folderPath)
+
+				// Although GetFiles supports simple pattern matching, it doesn't support enforcing end-of-string matches...
+				// So let's do the filtering this way instead, to make sure we don't get any extensions that start with "htm" but aren't exact matches.
+				.Where(name => name.EndsWith(".htm") || name.EndsWith(".html"))
+				);
+
 			var decoyMarkers = new[] {"configuration",
 				PrefixForCorruptHtmFiles, // Used to rename corrupt htm files before restoring backup
 				"_conflict", // owncloud

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -998,7 +998,7 @@ namespace BloomTests.Book
 		[TestCase("foo", "foo.html")] //normal case
 		[TestCase("foobar", "foo.html")] //changed folder name
 		[TestCase("foo", "foo.html", "bar.html")] //use folder name to decide (not sure this is good idea, but it's in existing code)
-		[TestCase("foobar", "foo.html", "foo.htm.bak")]
+		[TestCase("foobar", "foo.html", "foo.htm.bak", "foo.htmbak")]
 		[TestCase("foobar", "foo.html", "foo_conflict.htm")] //own cloud
 		[TestCase("foobar", "foo.html", "foo_conflict.htm", "foo_conflict2.htm")] //two conflict files
 		[TestCase("foobar", "foo.html", "foo (Scott's conflicted copy 2009-10-15).htm")] //dropbox


### PR DESCRIPTION
Fix bug where non-HTML files match FindBookHtml()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3655)
<!-- Reviewable:end -->
