### PR TITLE
Fix a hanging bug for mono5-sil in NewCollectionWizard (BL-8253)

### DIFF
--- a/src/BloomExe/CollectionCreating/NewCollectionWizard.Designer.cs
+++ b/src/BloomExe/CollectionCreating/NewCollectionWizard.Designer.cs
@@ -42,7 +42,7 @@ namespace Bloom.CollectionCreating
             this._languageLocationPage = new Bloom.Wizard.WizardAdapterPage();
 			this._languageFontPage = new Bloom.Wizard.WizardAdapterPage();
             this._finishPage = new Bloom.Wizard.WizardAdapterPage();
-			this.betterLabel1 = new SIL.Windows.Forms.Widgets.BetterLabel();
+			this.betterLabel1 = new SIL.Windows.Forms.Widgets.HtmlLabel();
             this._collectionNamePage = new Bloom.Wizard.WizardAdapterPage();
             this._collectionNameProblemPage = new Bloom.Wizard.WizardAdapterPage();
 			this._welcomeHtml = new SIL.Windows.Forms.Widgets.HtmlLabel();
@@ -143,9 +143,7 @@ namespace Bloom.CollectionCreating
 			this.betterLabel1.Enabled = false;
 			this.betterLabel1.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.betterLabel1.Location = new System.Drawing.Point(120, 60);
-			this.betterLabel1.Multiline = true;
 			this.betterLabel1.Name = "betterLabel1";
-			this.betterLabel1.ReadOnly = true;
 			this.betterLabel1.Size = new System.Drawing.Size(631, 23);
 			this.betterLabel1.TabIndex = 0;
 			this.betterLabel1.TabStop = false;
@@ -256,7 +254,7 @@ namespace Bloom.CollectionCreating
 		private Bloom.Wizard.WizardAdapterPage _languageFontPage;
 		private Bloom.MiscUI.LanguageFontDetails _fontDetails;
 		private LanguageLocationControl _languageLocationControl;
-		private SIL.Windows.Forms.Widgets.BetterLabel betterLabel1;
+		private SIL.Windows.Forms.Widgets.HtmlLabel betterLabel1;
         private Bloom.Wizard.WizardAdapterPage _welcomePage;
 		private SIL.Windows.Forms.Widgets.HtmlLabel _welcomeHtml;
 	}

--- a/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
+++ b/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
@@ -234,7 +234,10 @@ namespace Bloom.CollectionCreating
 			var pattern = LocalizationManager.GetString("NewCollectionWizard.FinishPageContent",
 				"OK, that's all we need to get started with your new '{0}' collection.\r\nClick on the 'Finish' button.",
 				"{0} is the name of the new collection");
-			betterLabel1.Text = String.Format(pattern, Path.GetFileNameWithoutExtension(_collectionInfo.PathToSettingsFile));
+			// Convert newlines into HTML <br/>, handling messy \r\n or \n or \r
+			var pieces = pattern.Split(new[]{'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
+			var format = string.Join("<br/>", pieces);
+			betterLabel1.HTML = String.Format(format, Path.GetFileNameWithoutExtension(_collectionInfo.PathToSettingsFile));
 		}
 	}
 


### PR DESCRIPTION
Replacing a SIL.WF.BetterLabel with a SIL.WF.HtmlLabel works to prevent
the wizard dialog from getting stuck during initialization.  (I think
having translators continue to deal with newlines in the string is okay
compared to having them try to deal with <br/> elements.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3656)
<!-- Reviewable:end -->
