### PR TITLE
Fix Bloom 4.7 to compile/run with mono5-sil (cherry-picks from master)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Standards-Version: 3.9.7
 Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
  wget, unzip, desktop-file-utils, curl,
  optipng, libsndfile1,
- mono4-sil, libgdiplus4-sil,
+ mono5-sil, libgdiplus5-sil,
  libenchant-dev, libxklavier-dev, libdconf-dev,
  libicu-dev,
  libgtk2.0-cil (>= 2.12.10), libgtk2.0-dev (>= 2.14), libasound2-dev,
@@ -18,7 +18,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
 Package: bloom-desktop-beta
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
- mono4-sil, libgdiplus4-sil, gtk-sharp4-sil, gtklp,
+ mono5-sil, libgdiplus5-sil, gtk-sharp5-sil, gtklp,
  chmsee | xchm | kchmviewer, libtidy-sil,
  fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,
  optipng, libsndfile1,

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-export MONO_PREFIX = /opt/mono4-sil
+export MONO_PREFIX = /opt/mono5-sil
 export BUILD = Release
 
 PACKAGE = bloom-desktop-beta
@@ -98,11 +98,11 @@ override_dh_auto_install:
 # Don't export any assemblies to other packages
 override_dh_makeclilibs:
 
-# Include mono4-sil in shlib dirs searched
+# Include mono5-sil in shlib dirs searched
 override_dh_shlibdeps:
 	dh_shlibdeps -l$(MONO_PREFIX)/lib --exclude=Firefox
 
-# Include mono4-sil in cli dirs searched
+# Include mono5-sil in cli dirs searched
 # Trying to process connections.dll now crashes on jenkins instead of merely complaining.
 # The -X (--exclude) option doesn't seem to work for dh_clideps to skip connections.dll.
 override_dh_clideps:

--- a/environ
+++ b/environ
@@ -1,13 +1,13 @@
 # Environment settings for running programs with the SIL version of mono
 # Set MONO_ENVIRON to this file's pathname, then run, for example,
-#    /opt/mono4-sil/bin/mono --debug Bloom.exe
-# These setting assume that the packaged SIL Mono is installed in /opt/mono4-sil.
+#    /opt/mono5-sil/bin/mono --debug Bloom.exe
+# These setting assume that the packaged SIL Mono is installed in /opt/mono5-sil.
 # Note that this file is intended to be "sourced", not "executed".
 
 # the sourcing script should cd/pushd to the directory containing this script
 BASE="$(pwd)"
 [ -z "$BUILD" ] && BUILD=Debug
-[ -z "$MONO_PREFIX" ] && MONO_PREFIX=/opt/mono4-sil
+[ -z "$MONO_PREFIX" ] && MONO_PREFIX=/opt/mono5-sil
 
 # Dependency locations
 # Search for xulrunner and geckofx, select the best, and add its location to LD_LIBRARY_PATH.
@@ -16,7 +16,6 @@ BASE="$(pwd)"
 
 GDK_SHARP=/usr/lib/cli/gdk-sharp-2.0
 
-MONO_RUNTIME=v4.0.30319
 MONO_PATH="${GDK_SHARP}:${GECKOFX}"
 MONO_DEBUG=explicit-null-checks
 MONO_ENV_OPTIONS="-O=-gshared"
@@ -54,10 +53,10 @@ fi
 if [ "$RUNMODE" = "PACKAGE" -o "$RUNMODE" = "INSTALLED" ]
 then
 	# Add packaged mono items to paths
-	PATH="/opt/mono4-sil/bin:${PATH}"
-	LD_LIBRARY_PATH="/opt/mono4-sil/lib:${LD_LIBRARY_PATH}"
-	PKG_CONFIG_PATH="/opt/mono4-sil/lib/pkgconfig:${PKG_CONFIG_PATH}"
-	MONO_GAC_PREFIX="/opt/mono4-sil:/usr"
+	PATH="/opt/mono5-sil/bin:${PATH}"
+	LD_LIBRARY_PATH="/opt/mono5-sil/lib:${LD_LIBRARY_PATH}"
+	PKG_CONFIG_PATH="/opt/mono5-sil/lib/pkgconfig:${PKG_CONFIG_PATH}"
+	MONO_GAC_PREFIX="/opt/mono5-sil:/usr"
 else
 	# Add locally-built mono items to paths
 	# We also add the default values for PKG_CONFIG_PATH - MonoDevelop resets the PKG_CONFIG_PATH
@@ -83,7 +82,7 @@ MONO_MWF_SCALING=disable
 export \
 	PATH LD_LIBRARY_PATH PKG_CONFIG_PATH LD_PRELOAD \
 	MONO_PATH \
-	MONO_RUNTIME MONO_PREFIX MONO_GAC_PREFIX \
+	MONO_PREFIX MONO_GAC_PREFIX \
 	MONO_TRACE_LISTENER MONO_IOMAP MONO_MWF_SCALING \
 	MONO_DEBUG MONO_ENV_OPTIONS
 

--- a/src/BloomBrowserUI/gulpfile.js
+++ b/src/BloomBrowserUI/gulpfile.js
@@ -87,7 +87,7 @@ var paths = {
 var allXliffFiles = globule.find(paths.xliff);
 // Check for the existence of the SIL mono, which flags we're on Linux
 // and need to use it to execute HtmlXliff.exe
-var IsLinux = globule.find(["/opt/mono4-sil/**/mono"]).length > 0;
+var IsLinux = globule.find(["/opt/mono5-sil/**/mono"]).length > 0;
 
 gulp.task("less", function() {
     var less = require("gulp-less");
@@ -283,7 +283,7 @@ gulp.task("translateHtmlFiles", function() {
                     var cmd = "";
                     if (IsLinux)
                         cmd =
-                            "/opt/mono4-sil/bin/mono --debug ../../lib/dotnet/HtmlXliff.exe --inject";
+                            "/opt/mono5-sil/bin/mono --debug ../../lib/dotnet/HtmlXliff.exe --inject";
                     else cmd = "..\\..\\lib\\dotnet\\HtmlXliff.exe --inject";
                     cmd = cmd + ' -x "' + xliffFile + '"';
                     cmd = cmd + ' -o "' + outfile + '"';
@@ -313,7 +313,7 @@ gulp.task("createXliffFiles", function() {
                 var cmd = "";
                 if (IsLinux)
                     cmd =
-                        "/opt/mono4-sil/bin/mono --debug ../../lib/dotnet/HtmlXliff.exe --extract --preserve";
+                        "/opt/mono5-sil/bin/mono --debug ../../lib/dotnet/HtmlXliff.exe --extract --preserve";
                 else
                     cmd =
                         "..\\..\\lib\\dotnet\\HtmlXliff.exe --extract --preserve";

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -57,6 +57,9 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>TRACE</DefineConstants>
     <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+    <DefineConstants>__MonoCS__</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -292,7 +295,7 @@
       <HintPath>..\..\lib\dotnet\YouTrackSharp.dll</HintPath>
     </Reference>
     <Reference Include="DialogAdapters">
-      <HintPath>..\..\lib\dotnet\DialogAdapters.dll</HintPath>
+      <HintPath>..\..\packages\DialogAdapters.0.1.4.30000\lib\net45\DialogAdapters.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -1244,7 +1247,7 @@
     <None Include="Resources\cutDisable16x16.png" />
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="IWshRuntimeLibrary">
+    <COMReference Include="IWshRuntimeLibrary" Condition="'$(OS)'=='Windows_NT'">
       <Guid>{F935DC20-1CF0-11D0-ADB9-00C04FD58A0B}</Guid>
       <VersionMajor>1</VersionMajor>
       <VersionMinor>0</VersionMinor>

--- a/src/BloomExe/Collection/ScriptSettingsDialog.Designer.cs
+++ b/src/BloomExe/Collection/ScriptSettingsDialog.Designer.cs
@@ -170,7 +170,7 @@
 			// flowLayoutPanel1
 			// 
 			this.flowLayoutPanel1.AutoSize = true;
-			this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+			this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowOnly;
 			this.flowLayoutPanel1.Controls.Add(this._languageNameLabel);
 			this.flowLayoutPanel1.Controls.Add(this.tableLayoutPanel1);
 			this.flowLayoutPanel1.Controls.Add(this._okButton);

--- a/src/BloomExe/CollectionCreating/NewCollectionWizard.Designer.cs
+++ b/src/BloomExe/CollectionCreating/NewCollectionWizard.Designer.cs
@@ -42,7 +42,7 @@ namespace Bloom.CollectionCreating
             this._languageLocationPage = new Bloom.Wizard.WizardAdapterPage();
 			this._languageFontPage = new Bloom.Wizard.WizardAdapterPage();
             this._finishPage = new Bloom.Wizard.WizardAdapterPage();
-			this.betterLabel1 = new SIL.Windows.Forms.Widgets.BetterLabel();
+			this._finalMessage = new SIL.Windows.Forms.Widgets.HtmlLabel();
             this._collectionNamePage = new Bloom.Wizard.WizardAdapterPage();
             this._collectionNameProblemPage = new Bloom.Wizard.WizardAdapterPage();
 			this._welcomeHtml = new SIL.Windows.Forms.Widgets.HtmlLabel();
@@ -127,7 +127,7 @@ namespace Bloom.CollectionCreating
 			//
 			// _finishPage
 			//
-			this._finishPage.Controls.Add(this.betterLabel1);
+			this._finishPage.Controls.Add(this._finalMessage);
 			this._finishPage.IsFinishPage = true;
 			this._finishPage.Name = "_finishPage";
 			this._finishPage.Size = new System.Drawing.Size(637, 310);
@@ -137,19 +137,17 @@ namespace Bloom.CollectionCreating
 			//
 			// betterLabel1
 			//
-			this.betterLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+			this._finalMessage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.betterLabel1.BorderStyle = System.Windows.Forms.BorderStyle.None;
-			this.betterLabel1.Enabled = false;
-			this.betterLabel1.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.betterLabel1.Location = new System.Drawing.Point(120, 60);
-			this.betterLabel1.Multiline = true;
-			this.betterLabel1.Name = "betterLabel1";
-			this.betterLabel1.ReadOnly = true;
-			this.betterLabel1.Size = new System.Drawing.Size(631, 23);
-			this.betterLabel1.TabIndex = 0;
-			this.betterLabel1.TabStop = false;
-			this.betterLabel1.Text = "<Text>";
+			this._finalMessage.BorderStyle = System.Windows.Forms.BorderStyle.None;
+			this._finalMessage.Enabled = false;
+			this._finalMessage.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this._finalMessage.Location = new System.Drawing.Point(120, 60);
+			this._finalMessage.Name = "_finalMessage";
+			this._finalMessage.Size = new System.Drawing.Size(631, 23);
+			this._finalMessage.TabIndex = 0;
+			this._finalMessage.TabStop = false;
+			this._finalMessage.Text = "<Text>";
 			//
 			// _collectionNamePage
 			//
@@ -256,7 +254,7 @@ namespace Bloom.CollectionCreating
 		private Bloom.Wizard.WizardAdapterPage _languageFontPage;
 		private Bloom.MiscUI.LanguageFontDetails _fontDetails;
 		private LanguageLocationControl _languageLocationControl;
-		private SIL.Windows.Forms.Widgets.BetterLabel betterLabel1;
+		private SIL.Windows.Forms.Widgets.HtmlLabel _finalMessage;
         private Bloom.Wizard.WizardAdapterPage _welcomePage;
 		private SIL.Windows.Forms.Widgets.HtmlLabel _welcomeHtml;
 	}

--- a/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
+++ b/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
@@ -234,7 +234,10 @@ namespace Bloom.CollectionCreating
 			var pattern = LocalizationManager.GetString("NewCollectionWizard.FinishPageContent",
 				"OK, that's all we need to get started with your new '{0}' collection.\r\nClick on the 'Finish' button.",
 				"{0} is the name of the new collection");
-			betterLabel1.Text = String.Format(pattern, Path.GetFileNameWithoutExtension(_collectionInfo.PathToSettingsFile));
+			// Convert newlines into HTML <br/>, handling messy \r\n or \n or \r
+			var pieces = pattern.Split(new[]{'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
+			var format = string.Join("<br/>", pieces);
+			_finalMessage.HTML = String.Format(format, Path.GetFileNameWithoutExtension(_collectionInfo.PathToSettingsFile));
 		}
 	}
 

--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -24,6 +24,7 @@
     <package id="SourceMapDotNet" version="1.0.5478.26629" targetFramework="net461" />
     <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
     <package id="TechTalk.JiraRestClient.RestSharp105" version="2.3.0.1" targetFramework="net461" />
+    <package id="DialogAdapters" version="0.1.4.30000" targetFramework="net461" />
     <!-- Linux specific packages.  Changes above this line must be copied to ../packages.config -->
     <package id="Geckofx45.32.Linux" version="45.0.23.0" targetFramework="net461" />
     <package id="Geckofx45.64.Linux" version="45.0.23.0" targetFramework="net461" />

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -7,6 +7,7 @@
   <package id="CommandLineParser" version="2.5.0" targetFramework="net461" />
   <package id="DeltaCompressionDotNet" version="1.1.0" targetFramework="net461" />
   <package id="DesktopAnalytics" version="1.2.4.11" targetFramework="net461" />
+  <package id="DialogAdapters" version="0.1.4.30000" targetFramework="net461" />
   <package id="EasyHttp" version="1.6.86.0" targetFramework="net461" />
   <package id="Fleck" version="0.14.0.59" targetFramework="net461" />
   <package id="Glob" version="0.4.0" targetFramework="net461" />

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -80,6 +80,9 @@
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
     <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
+    <DefineConstants>__MonoCS__</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">

--- a/src/LinuxBloomLauncher/BloomLauncher.c
+++ b/src/LinuxBloomLauncher/BloomLauncher.c
@@ -155,7 +155,7 @@ static gchar ** GetArgvForBloom(int argcOrig, char ** argvOrig)
 
 	// On Linux, mono is the program that is running: Bloom.exe is just data for the program
 	// Bloom uses the debugged version of Mono 4.6.1 packaged by SIL/LSDev.
-	argvNew[0] = g_strdup("/opt/mono4-sil/bin/mono");
+	argvNew[0] = g_strdup("/opt/mono5-sil/bin/mono");
 	// Sacrifice line numbers in stack dumps for speed -- often don't see them anyway.
 	// If we do reinstate the "--debug", then the "+ 2" and "1 new" above need to be
 	// incremented, and the "[1]", "[i+1]", and "[argcOrig+1]" below need to be incremented.
@@ -245,14 +245,14 @@ static gchar ** GetEnvpForBloom()
 	//printf("LD_PRELOAD=%s\n", preload);
 
 	/* also set MONO_PREFIX, other MONO related values, and PATH */
-	envp = g_environ_setenv(envp, "MONO_PREFIX", g_strdup("/opt/mono4-sil"), true);
+	envp = g_environ_setenv(envp, "MONO_PREFIX", g_strdup("/opt/mono5-sil"), true);
 	envp = g_environ_setenv(envp, "MONO_RUNTIME", g_strdup("v4.0.30319"), true);
 	envp = g_environ_setenv(envp, "MONO_DEBUG", g_strdup("explicit-null-checks"), true);
 	envp = g_environ_setenv(envp, "MONO_ENV_OPTIONS", g_strdup("-O=-gshared"), true);
 	envp = g_environ_setenv(envp, "MONO_TRACE_LISTENER", g_strdup("Console.Out"), true);
 	envp = g_environ_setenv(envp, "MONO_MWF_SCALING", g_strdup("disable"), true);
 	envp = g_environ_setenv(envp, "MONO_PATH", g_strconcat(programDirectory, ":/usr/lib/cli/gdk-sharp-2.0", NULL), true);
-	envp = g_environ_setenv(envp, "MONO_GAC_PREFIX", g_strdup("/opt/mono4-sil:/usr"), true);
+	envp = g_environ_setenv(envp, "MONO_GAC_PREFIX", g_strdup("/opt/mono5-sil:/usr"), true);
 
 	const char * pathOld = g_environ_getenv(envp, "PATH");
 	const char * path;


### PR DESCRIPTION
This is needed for the upcoming Ubuntu LTS release (20.04 / focal).  I've tested this by opening every dialog and menu that I could access and by creating a book (with multiple content pages) for every standard template except Template Maker.  I also tried all of the tools in editing at least one book.  Everything I tried seemed to work okay, or at least as well as under mono4-sil.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3665)
<!-- Reviewable:end -->
