### PR TITLE
Add Reader-related data-book values

### DIFF
--- a/src/BloomBrowserUI/templates/template books/Decodable Reader/Decodable Reader.pug
+++ b/src/BloomBrowserUI/templates/template books/Decodable Reader/Decodable Reader.pug
@@ -17,7 +17,7 @@ html
 		+stylesheets('Basic Book.css')
 		+stylesheet('Decodable Reader.css')
 		+standardStyles
-	body
+	body.decodable-reader
 		+dataDiv
 			+bookVariable-title('en', 'Decodable Reader')
 

--- a/src/BloomBrowserUI/templates/template books/Leveled Reader/Leveled Reader.pug
+++ b/src/BloomBrowserUI/templates/template books/Leveled Reader/Leveled Reader.pug
@@ -15,7 +15,7 @@ html
 		title 'Leveled Reader'
 		+stylesheets('Basic Book.css')
 		+standardStyles
-	body
+	body.leveled-reader
 		+dataDiv
 			+bookVariable-title('en', 'Leveled Reader')
 			+bookVariable-title('id', 'Pembaca diratakan')

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2589,7 +2589,7 @@ namespace Bloom.Book
 				// The main condition for being able to just write the page is that no shareable data on the
 				// page changed during editing. If that's so we can skip this step.
 				if (needToDoFullSave)
-					_bookData.SuckInDataFromEditedDom(editedPageDom); //this will do an updatetitle
+					_bookData.SuckInDataFromEditedDom(editedPageDom, BookInfo); //this will do an updatetitle
 
 				// When the user edits the styles on a page, the new or modified rules show up in a <style/> element with title "userModifiedStyles".
 				// Here we copy that over to the book DOM.


### PR DESCRIPTION
Gives the leveled and decodable reader templates body classes to identify books from these sources. (But no data migration from ones previously created.)
Adds data-book values levelOrStageNumber and decodableStageLetters. These will be added automatically to existing books IFF they have the required body class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3667)
<!-- Reviewable:end -->
