### PR TITLE
Use language.Name for the (up to) three chosen languages  (BL-8302)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1833,20 +1833,24 @@ namespace Bloom.Book
 		/// Bloom books can have up to 3 languages active at any time. This method pushes in a string
 		/// listing then, separated by commas. It is then usable on the front page, title page, etc.
 		/// </summary>
+		/// <remarks>
+		/// We use the name of the language assigned by the user when the language was chosen rather
+		/// than attempting to use the name in the national language (most likely getting the autonyms
+		/// from a buggy list).  This keeps things simpler and follows the principle of least surprise.
+		/// </remarks>
 		private void InjectStringListingActiveLanguagesOfBook()
 		{
-			string codeOfNationalLanguage = CollectionSettings.Language2Iso639Code;
-			var languagesOfBook = CollectionSettings.Language1.GetNameInLanguage(codeOfNationalLanguage);
+			var languagesOfBook = CollectionSettings.Language1.Name;
 
 			if (MultilingualContentLanguage2 != null)
 			{
 				languagesOfBook += ", " + ((MultilingualContentLanguage2 == CollectionSettings.Language2Iso639Code) ?
-					CollectionSettings.Language2.GetNameInLanguage(codeOfNationalLanguage) :
-					CollectionSettings.Language3.GetNameInLanguage(codeOfNationalLanguage));
+					CollectionSettings.Language2.Name :
+					CollectionSettings.Language3.Name);
 			}
 			if (MultilingualContentLanguage3 != null)
 			{
-				languagesOfBook += ", " + CollectionSettings.Language3.GetNameInLanguage(codeOfNationalLanguage);
+				languagesOfBook += ", " + CollectionSettings.Language3.Name;
 			}
 
 			_bookData.Set("languagesOfBook", languagesOfBook, false);

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -684,9 +684,9 @@ namespace Bloom.Book
 				data.WritingSystemAliases.Add("V", collectionSettings.Language1Iso639Code);
 				data.AddLanguageString("nameOfLanguage", collectionSettings.Language1.Name, "*", true);
 				data.AddLanguageString("nameOfNationalLanguage1",
-									   collectionSettings.Language2.GetNameInLanguage(collectionSettings.Language2Iso639Code), "*", true);
+									   collectionSettings.Language2.Name, "*", true);
 				data.AddLanguageString("nameOfNationalLanguage2",
-									   collectionSettings.Language3.GetNameInLanguage(collectionSettings.Language2Iso639Code), "*", true);
+									   collectionSettings.Language3.Name, "*", true);
 				data.UpdateGenericLanguageString("iso639Code", collectionSettings.Language1Iso639Code, true);
 				data.UpdateGenericLanguageString("country", collectionSettings.Country, true);
 				data.UpdateGenericLanguageString("province", collectionSettings.Province, true);
@@ -737,9 +737,9 @@ namespace Bloom.Book
 			if (code == _collectionSettings.Language1Iso639Code && !string.IsNullOrWhiteSpace(_collectionSettings.Language1.Name))
 				return _collectionSettings.Language1.Name;
 			if (code == _collectionSettings.Language2Iso639Code)
-				return _collectionSettings.Language2.GetNameInLanguage(_collectionSettings.Language2Iso639Code);
+				return _collectionSettings.Language2.Name;
 			if (code == _collectionSettings.Language3Iso639Code)
-				return _collectionSettings.Language3.GetNameInLanguage(_collectionSettings.Language2Iso639Code);
+				return _collectionSettings.Language3.Name;
 			return _collectionSettings.GetLanguageName(code, _collectionSettings.Language2Iso639Code);
 		}
 

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -531,17 +531,17 @@ namespace Bloom.Collection
 
 		private void _fontSettings1Link_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			FontSettingsLinkClicked(_collectionSettings.Language1.GetNameInLanguage(LocalizationManager.UILanguageId), 1);
+			FontSettingsLinkClicked(_collectionSettings.Language1.Name, 1);
 		}
 
 		private void _fontSettings2Link_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			FontSettingsLinkClicked(_collectionSettings.Language2.GetNameInLanguage(LocalizationManager.UILanguageId), 2);
+			FontSettingsLinkClicked(_collectionSettings.Language2.Name, 2);
 		}
 
 		private void _fontSettings3Link_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			FontSettingsLinkClicked(_collectionSettings.Language3.GetNameInLanguage(LocalizationManager.UILanguageId), 3);
+			FontSettingsLinkClicked(_collectionSettings.Language3.Name, 3);
 		}
 
 		private void FontSettingsLinkClicked(string langName, int langNum1Based)


### PR DESCRIPTION
This gives the user control over what is seen on the screen and what
is published in the book without any surprising changes in some places.
This breaks the fix for BL-7382 until the libpalaso language chooser
dialog is changed to offer autonyms instead of (or in addition to?)
English names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3668)
<!-- Reviewable:end -->
