### PR TITLE
Get proper screenshots for error reports (BL-8348)

### DIFF
--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -279,8 +279,10 @@ namespace Bloom.web.controllers
 						var screenshot = new Bitmap(bounds.Width, bounds.Height);
 						using (var g = Graphics.FromImage(screenshot))
 						{
-							g.CopyFromScreen(controlForScreenshotting.PointToScreen(new Point(bounds.Left, bounds.Top)), Point.Empty,
-								bounds.Size);
+							if (controlForScreenshotting.Parent == null)
+								g.CopyFromScreen(bounds.Left, bounds.Top, 0, 0, bounds.Size);	// bounds already in screen coords
+							else
+								g.CopyFromScreen(controlForScreenshotting.PointToScreen(new Point(bounds.Left, bounds.Top)), Point.Empty, bounds.Size);
 						}
 
 						_screenshotTempFile = TempFile.WithFilename(ScreenshotName);


### PR DESCRIPTION
I tested this on both Windows and Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3689)
<!-- Reviewable:end -->
