### PR TITLE
Fix bug in displaying zoom control on Linux (BL-8360)

### DIFF
--- a/src/BloomExe/Workspace/ZoomControl.cs
+++ b/src/BloomExe/Workspace/ZoomControl.cs
@@ -14,6 +14,15 @@ namespace Bloom.Workspace
 		public ZoomControl()
 		{
 			InitializeComponent();
+			if (SIL.PlatformUtilities.Platform.IsLinux)
+			{
+				// Work around a bug in Mono 5 (and Mono 6?).
+				// See https://issues.bloomlibrary.org/youtrack/issue/BL-8360.
+				this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+				this._minusButton.Location = new System.Drawing.Point(0, -8);	// restore original locations
+				this._percentLabel.Location = new System.Drawing.Point(20, 4);
+				this._plusButton.Location = new System.Drawing.Point(58, -8);
+			}
 			Zoom = 100;
 			_plusButton.ForeColor = Color.FromKnownColor(KnownColor.MenuText);
 			_plusButton.FlatAppearance.MouseOverBackColor = SystemColors.GradientActiveCaption;


### PR DESCRIPTION
The bug is apparently in the mono 5 runtime library.  We just work around
it in Bloom code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3695)
<!-- Reviewable:end -->
