### PR TITLE
Drag icon works after resize (BL-8066)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -90,13 +90,27 @@ export function GetButtonModifier(container) {
 
 //Bloom "imageContainer"s are <div>'s with wrap an <img>, and automatically proportionally resize
 //the img to fit the available space
+//Precondition: containerDiv must be just a single HTMLElement
 function SetupImageContainer(containerDiv) {
+    // Initialize the value of the hoverUp class.
+    // the hoverup class should be present whenever the mouse is over the containerDiv.
+    // This is usually achieved by mouseenter/mouseleave event handlers,
+    // but mouseenter won't trigger if the mouse starts off over the image container when the page is loaded
+    // That case is extremely commonplace when adding comic bubbles, because that needs to reload the page.
+    // (It is also possible to trigger even when opening up a new page, but probably less likely to happen accidentally)
+    if (containerDiv.matches(":hover")) {
+        containerDiv.classList.add("hoverUp");
+    } else {
+        containerDiv.classList.remove("hoverUp");
+    }
+
     $(containerDiv)
         .mouseenter(function() {
             var $this = $(this);
             var img = $this.find("img");
             if (img.length === 0)
                 //TODO check for bloom-backgroundImage to make sure this isn't just a case of a missing <img>
+                // TODO: Looks like assigning an HTMLElement to a JQuery. I'd rather we not do this, although I think we manage to $() wrap our way out of this mess later.
                 img = containerDiv; //using a backgroundImage
 
             var buttonModifier = GetButtonModifier($this);

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -1137,7 +1137,7 @@ export class BubbleManager {
         // I tried to do without this... it didn't work. This causes page changes to get saved and fills
         // things in for editing.
         // It causes EditingModel.RethinkPageAndReloadIt() to get run... which eventually causes
-        // makeTextOverPictureBoxDraggableClickableAndResizable to get called by bloomEditing.ts.
+        // makeTOPBoxesDraggableClickableAndResizable to get called by bloomEditing.ts.
         BloomApi.postThatMightNavigate("common/saveChangesAndRethinkPageEvent");
     }
 
@@ -1340,22 +1340,37 @@ export class BubbleManager {
             const imagePos = imageContainer[0].getBoundingClientRect();
             const wrapperBoxRectangle = thisTOPBox[0].getBoundingClientRect();
 
-            // Add the dragHandles. The visible one has a zindex below the canvas. The transparent one is above.
+            // Add the dragHandles (if needed). The visible one has a zindex below the canvas. The transparent one is above.
             // The 'mouseover' event listener below will make sure the .ui-draggable-handle class
             // on the transparent one is set to the right state depending on whether the visible handle
             // is occluded or not.
-            thisTOPBox.append(
-                "<img class='bloom-ui bloom-dragHandle visible' src='/bloom/bookEdit/img/dragHandle.svg'/>"
-            );
-            thisTOPBox.append(
-                "<img class='bloom-ui bloom-dragHandle transparent' src='/bloom/bookEdit/img/dragHandle.svg'/>"
-            );
+            const visibleHandles = thisTOPBox.find(".bloom-dragHandle.visible");
+            if (visibleHandles.length == 0) {
+                // Not added yet. Let's create it
+                thisTOPBox.append(
+                    "<img class='bloom-ui bloom-dragHandle visible' src='/bloom/bookEdit/img/dragHandle.svg'/>"
+                );
+            }
 
             // Save the dragHandle that's above the canvas and setup the 'mouseover' event to determine if we
             // should be able to drag with it or not.
-            const transparentHandle = thisTOPBox.find(
+            let transparentHandle: HTMLElement;
+            const transparentHandles = thisTOPBox.find(
                 ".bloom-dragHandle.transparent"
-            )[0];
+            );
+            if (transparentHandles.length == 0) {
+                // Not added yet. Let's create it
+                thisTOPBox.append(
+                    "<img class='bloom-ui bloom-dragHandle transparent' src='/bloom/bookEdit/img/dragHandle.svg'/>"
+                );
+                transparentHandle = thisTOPBox.find(
+                    ".bloom-dragHandle.transparent"
+                )[0];
+            } else {
+                // No need to append it again. Just use the existing one.
+                transparentHandle = transparentHandles[0];
+            }
+
             transparentHandle.addEventListener("mouseover", event => {
                 this.setDraggableStateOnDragHandles(
                     imageContainer[0],


### PR DESCRIPTION
The problem seems to be that we re-added duplicate drag handles. I think only the first one gets the event listener, but probably the last one is the one that gets the mouse events. So the listener isn't fired.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3707)
<!-- Reviewable:end -->
