### PR TITLE
Fix originalTitle to handle HTML special chars in title (BL-8221)

### DIFF
--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -1450,18 +1450,21 @@ namespace Bloom.Book
 				// We just need to make the info, if any, consistent wit the bookdata
 				if (info != null)
 				{
-					info.OriginalTitle = GetVariableOrNull("originalTitle","*");
+					string encodedTitle = GetVariableOrNull("originalTitle","*"); 
+					info.OriginalTitle = HttpUtility.HtmlDecode(encodedTitle);
 				}
 			} else
 			{
-				string originalTitle =
-					BookData.TextOfInnerHtml(title?.TextAlternatives.GetExactAlternative(_collectionSettings.Language1Iso639Code));
+				string encodedOriginalTitle = title?.TextAlternatives.GetExactAlternative(_collectionSettings.Language1Iso639Code);
+				string decodedOriginalTitle = BookData.TextOfInnerHtml(encodedOriginalTitle);
 
-				_dataset.UpdateGenericLanguageString("originalTitle", originalTitle, false);
+				// _dataset.TextVariables is expected to contain an ENCODED string!
+				// info.OriginalTitle is expected to contain a DECODED string
+				_dataset.UpdateGenericLanguageString("originalTitle", encodedOriginalTitle, false);
 				UpdateSingleTextVariableInDataDiv("originalTitle", _dataset.TextVariables["originalTitle"].TextAlternatives);
 				if (info != null)
 				{
-					info.OriginalTitle = originalTitle;
+					info.OriginalTitle = decodedOriginalTitle;
 				}
 			}
 		}


### PR DESCRIPTION
Previously, it would throw nasty exceptions that crashed the program without saving the book if the book contained "invalid xml" (not properly encoded)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3712)
<!-- Reviewable:end -->
