### PR TITLE
ABC-BARMM changes

### DIFF
--- a/src/BloomBrowserUI/branding/BARMM/branding.json
+++ b/src/BloomBrowserUI/branding/BARMM/branding.json
@@ -3,7 +3,8 @@
         {
             "data-book": "licenseUrl",
             "lang": "*",
-            "content": "http://creativecommons.org/licenses/by-nc/4.0/"
+            "content": "http://creativecommons.org/licenses/by-nc/4.0/",
+            "condition": "always"
         },
         {
             "data-book": "cover-branding-bottom-html",

--- a/src/BloomBrowserUI/templates/bloom-foundation-mixins.pug
+++ b/src/BloomBrowserUI/templates/bloom-foundation-mixins.pug
@@ -84,8 +84,8 @@ mixin field-withSampleText
 		+editable(kLanguageForPrototypeOnly)
 			block
 
-//- Sometimes, especially when we're just jade-ifying some existing html with existing css,
-//- we need to put attributes directly on the prototyp div instide of a translation group.
+//- Sometimes, especially when we're just pug-ifying some existing html with existing css,
+//- we need to put attributes directly on the prototype div inside of a translation group.
 //- This one lets us do that
 mixin field-prototypeDeclaredExplicity(languages)
 	- requireOneArgument('field-prototypeDeclaredExplicity', arguments);

--- a/src/BloomBrowserUI/templates/xMatter/ABC-Reader-XMatter/ABC-Reader-XMatter.less
+++ b/src/BloomBrowserUI/templates/xMatter/ABC-Reader-XMatter/ABC-Reader-XMatter.less
@@ -2,58 +2,59 @@
 
 @XMatterPackName: "ABC Reader";
 
-// [data-book="smallCoverCredits"],
-// [data-book="funding"] {
-//     display: none !important;
-// }
-
 @circleDiameter: 80px;
 @creditsLineSpacing: 14px;
 
-body.leveled-reader .numberCircle {
-    background-color: #ba0c2f;
-}
-body.decodable-reader .numberCircle {
-    background-color: rgb(0, 47, 108);
-}
-
-body:not(.decodable-reader) {
-    .decodableStageLettersRow {
-        display: none !important; // for decodable only
-    }
-    &:not(.leveled-reader) {
+body {
+    &.leveled-reader {
+        .numberLabel::before {
+            content: "Level";
+        }
         .numberCircle {
-            display: none !important;
+            background-color: #ba0c2f;
+        }
+    }
+    &.decodable-reader {
+        .numberLabel::before {
+            content: "Stage";
+        }
+        .numberCircle {
+            background-color: rgb(0, 47, 108);
+        }
+    }
+    &:not(.decodable-reader) {
+        .decodableStageLettersRow {
+            display: none !important; // for decodable only
+        }
+        &:not(.leveled-reader) {
+            .numberCircle {
+                display: none !important;
+            }
         }
     }
 }
 
-body.leveled-reader {
-    .numberLabel::before {
-        content: "Level";
-    }
-}
-body.decodable-reader {
-    .numberLabel::before {
-        content: "Stage";
-    }
-}
-body
-// working very hard to get this one to win over any user attempts to change it.
-// might be a mistake, if they have a good reason to change it. But at the moment I don't know
-// of a way for the xmatter to supply a different default for .Title-On-Cover style, or to introduce
-// a new alternative style for this field.
-    .Title-On-Cover-style.bloom-content1.bloom-contentNational1.bloom-visibility-code-on {
-    font-size: 36pt !important;
-}
 .cover {
     .titleAndNumberCircle {
         display: flex;
         flex-direction: row;
-        flex: 0 0 auto; //this is normally on the title itself, but we're wrapping it
+        justify-content: space-between;
         .bookTitle {
-            //flex-grow: 1;
-            width: calc(100% - @circleDiameter);
+            flex: unset; // Unhelpful value inherited from Traditional xmatter
+            min-width: 75%;
+            .bloom-editable {
+                // Ideally the customer would like the title left-justified (as here) if there is a number
+                // circle display, but centered if there is no circle (neither Decodable or Leveled reader).
+                // Unfortunately, I haven't figured out how to change 'text-align' based on another element's
+                // css display value.
+                text-align: start;
+            }
+            // It took some doing to figure out the specificity to overrule Bloom "normal" 250% title rule
+            // and yet still allow the user-adjustable inline style to work. This should set titles
+            // to default to 36pt unless overridden by the user.
+            .Title-On-Cover-style[data-book="bookTitle"] {
+                font-size: 36pt;
+            }
         }
     }
 
@@ -62,9 +63,6 @@ body
         margin-top: -19px;
         width: @circleDiameter;
         height: @circleDiameter;
-        //margin-left: auto;
-        position: absolute;
-        right: 0;
 
         border-radius: 50%;
         color: white;
@@ -89,8 +87,7 @@ body
             margin-bottom: 0;
         }
     }
-    [data-book="readerDescription"] {
-        text-align: center;
+    .descriptionAndTopicRow {
         font-weight: bold;
     }
     .branding {
@@ -112,9 +109,6 @@ body
     [data-book="bookTitle"] {
         font-size: 28pt;
     }
-    [data-book="readerDescription"] {
-        text-align: center;
-    }
     .levelOrStageAndNumberRow {
         display: flex;
         flex-direction: row;
@@ -125,11 +119,28 @@ body
         flex-direction: row;
         justify-content: center;
     }
-    .readerDescription {
+    .descriptionAndTopicRow {
         margin-top: auto; // push to bottom
         margin-bottom: 1em;
     }
 }
+
+.descriptionAndTopicRow {
+    display: flex;
+    flex-direction: row;
+    flex: 0 0 auto;
+    justify-content: space-between;
+    .readerDescription {
+        min-width: 50%;
+        text-align: start;
+        margin-right: 20px; // in case we get really big descriptions and topics and they run into each other
+    }
+    .abcTopic {
+        min-width: 25%;
+        text-align: end;
+    }
+}
+
 #stageInformation {
     margin: 10px;
     border: solid thin black;
@@ -144,9 +155,6 @@ body
             display: flex;
             flex-direction: row;
             margin-bottom: @creditsLineSpacing;
-        }
-        [data-book="readerDescription"] {
-            text-align: left;
         }
         .bloom-translationGroup {
             margin-bottom: @creditsLineSpacing;

--- a/src/BloomBrowserUI/templates/xMatter/ABC-Reader-XMatter/ABC-Reader-Xmatter.pug
+++ b/src/BloomBrowserUI/templates/xMatter/ABC-Reader-XMatter/ABC-Reader-Xmatter.pug
@@ -1,11 +1,21 @@
 extends ../Traditional-XMatter/Traditional-XMatter.pug
 
+mixin nonStandardTopic
+	//- e.g. "Cooking", but in vernacular
+	+field-prototypeDeclaredExplicity("V").abcTopic
+		label.bubble Topic in {lang}
+		+editable(kLanguageForPrototypeOnly)(data-book='abcTopic')
 
 mixin readerDescription
 	//- e.g. "Foobar Leveled Reader", will be in English only
 	+field-prototypeDeclaredExplicity("N1").readerDescription
-			label.bubble Reader description in {lang}
-			+editable(kLanguageForPrototypeOnly)(data-book='readerDescription')
+		label.bubble Reader description in {lang}
+		+editable(kLanguageForPrototypeOnly)(data-book='readerDescription')
+
+mixin readerDescriptionAndNonStandardTopic
+	.descriptionAndTopicRow
+		+readerDescription
+		+nonStandardTopic
 
 mixin levelOrStageAndNumber
 	.levelOrStageAndNumberRow
@@ -26,7 +36,7 @@ block cover-title
 		.numberCircle
 			span.numberLabel
 			div(data-book="levelOrStageNumber" lang="*")
-	+readerDescription
+	+readerDescriptionAndNonStandardTopic
 
 	//- override is to change the data-hint for this project
 block cover-bottom-credits
@@ -76,7 +86,7 @@ block titlePageContents
 		div(data-book="decodableStageLetters" lang="V")
 
 	//- e.g. "Foobar Leveled Reader", will be in English only
-	+readerDescription
+	+readerDescriptionAndNonStandardTopic
 	.levelOrStageAndNumberRow
 		+levelOrStageAndNumber
 
@@ -84,7 +94,7 @@ block titlePageContents
 block creditsContent
 	+field-mono-meta("V", 'bookTitle')
 			label.bubble Book title in {lang}
-	+readerDescription
+	+readerDescriptionAndNonStandardTopic
 	+levelOrStageAndNumber
 	//- this is intentionally in English while the one on the Cover & Title Pages are intentionally in Vernacular
 	+field-acknowledgments-originalVersion("N1", "The author and the illustrator in {lang}")


### PR DESCRIPTION
* Refactor .less into more logical structure
* Add non-standardized vernacular Topic field (right-
   justified, on the same line as Reader Description)
* Make Front Cover Title smaller and left-justified
* Make Reader Description left-justified
* Really fix license logo problem

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3723)
<!-- Reviewable:end -->
