### PR TITLE
[4.8] Tweak ABC XMatter rules to work in BP

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/ABC-Reader-XMatter/ABC-Reader-XMatter.less
+++ b/src/BloomBrowserUI/templates/xMatter/ABC-Reader-XMatter/ABC-Reader-XMatter.less
@@ -5,7 +5,8 @@
 @circleDiameter: 80px;
 @creditsLineSpacing: 14px;
 
-body {
+body,
+div.bloomPlayer-page {
     &.leveled-reader {
         .numberLabel::before {
             content: "Level";


### PR DESCRIPTION
* because of scoped CSS in Swiper, we can't just put the
   body classes on the body in BP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3730)
<!-- Reviewable:end -->
