### PR TITLE
BL-7883 Fix state of Next/Previous

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -1684,6 +1684,7 @@ export default class AudioRecording {
         if (!leaveChecked) {
             this.togglePlaybackOrderCheckedClass(false);
             this.showPlaybackInput.checked = false;
+            this.updateButtonStateAsync("check");
         }
         this.setCurrentAudioElementToFirstAudioElement();
     }


### PR DESCRIPTION
* after unchecking playback order box, sometimes
   next and previous were left in a bad state

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3736)
<!-- Reviewable:end -->
