### PR TITLE
Bring dependencies.config up to date with debian/control (20200514)

### DIFF
--- a/build/dependencies.config
+++ b/build/dependencies.config
@@ -28,13 +28,21 @@
 # npm is part of nodejs in newer versions of nodejs.
 
 [common]
-any=optipng libtidy5 mono4-sil libgdiplus4-sil libicu-dev wget unzip \
-fonts-sil-andika-new-basic nodejs sox ffmpeg lame
+any=optipng libtidy5 mono5-sil libgdiplus5-sil libicu-dev wget unzip \
+fonts-sil-andikanewbasic nodejs sox ffmpeg lame \
+desktop-file-utils git libsndfile1 libenchant-dev libxklavier-dev \
+libdconf-dev libgtk2.0-cil libgtk2.0-dev libasound2-dev
 
 [trusty]
 any=icu-devtools
 
 [xenial]
+any=@trusty.any
+
+[bionic]
+any=@trusty.any
+
+[focal]
 any=@trusty.any
 
 [jessie]


### PR DESCRIPTION
Perhaps most important is mono5-sil instead of mono4-sil since Version4.8 (and Version4.7)
does not build with the older mono's compiler.

This file is used in TeamCity builds.  Theoretically new developers on
Linux might use it at well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3742)
<!-- Reviewable:end -->
