### PR TITLE
Stop creating box-header-off translation groups

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/origami.ts
+++ b/src/BloomBrowserUI/bookEdit/js/origami.ts
@@ -285,10 +285,7 @@ function getSplitPaneComponentWithNewContent(position) {
     return spc;
 }
 function getSplitPaneComponentInner() {
-    /* the stylesheet will hide this initially; we will have UI later than switches it to box-header-on */
-    var spci = $(
-        "<div class='split-pane-component-inner adding'><div class='box-header-off bloom-translationGroup'></div></div>"
-    );
+    var spci = $("<div class='split-pane-component-inner'></div>");
     spci.append(getTypeSelectors());
     spci.append(getButtons());
     return spci;

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -473,8 +473,8 @@ h1 {
 h2 {
     font-size: 1.2em;
 }
-/* we will have UI that switches this .box-header-on if th user wants it*/
-/* If this is not important, it can be overridden by display:flex in langVisibility.css (BL-3555, BL-3711) */
+/* box-header is an idea we never implemented. We don't use it any more, but older
+books may contain divs with box-header-off, so we need a rule to hide them.*/
 .box-header-off {
     display: none !important;
 }

--- a/src/BloomBrowserUI/templates/bloom-foundation-mixins.pug
+++ b/src/BloomBrowserUI/templates/bloom-foundation-mixins.pug
@@ -110,9 +110,6 @@ mixin image
 
 mixin video
 	- requireZeroArguments('video', arguments);
-	.box-header-off.bloom-translationGroup
-		.bloom-editable.bloom-content1.bloom-contentNational1.bloom-visibility-code-on(aria-label='false' role='textbox' spellcheck='true' tabindex='0' contenteditable='true' lang='en')
-			p
 	.bloom-videoContainer.bloom-noVideoSelected&attributes(attributes)
 
 //- Will show a table. Bloom's basePage.css should style it with a border around each cell

--- a/src/BloomBrowserUI/templates/template books/experiments/Full Screen/Full Screen Template Pages.htm
+++ b/src/BloomBrowserUI/templates/template books/experiments/Full Screen/Full Screen Template Pages.htm
@@ -372,21 +372,6 @@
                             style="position: relative;"
                             class="split-pane-component-inner adding"
                         >
-                            <div class="box-header-off bloom-translationGroup">
-                                <div
-                                    data-languagetipcontent="English"
-                                    aria-label="false"
-                                    role="textbox"
-                                    spellcheck="true"
-                                    tabindex="0"
-                                    class="bloom-editable bloom-content1 bloom-contentNational1 bloom-visibility-code-on"
-                                    contenteditable="true"
-                                    lang="en"
-                                >
-                                    <p></p>
-                                </div>
-                            </div>
-
                             <div
                                 title="placeHolder.png 6.58 KB 341 x 335 49 DPI (should be 300-600) Bit Depth: 32"
                                 class="bloom-imageContainer bloom-leadingElement"
@@ -420,23 +405,6 @@
                                     style="position: relative;"
                                     class="split-pane-component-inner adding"
                                 >
-                                    <div
-                                        class="box-header-off bloom-translationGroup"
-                                    >
-                                        <div
-                                            data-languagetipcontent="English"
-                                            aria-label="false"
-                                            role="textbox"
-                                            spellcheck="true"
-                                            tabindex="0"
-                                            class="bloom-editable bloom-content1 bloom-contentNational1 bloom-visibility-code-on"
-                                            contenteditable="true"
-                                            lang="en"
-                                        >
-                                            <p></p>
-                                        </div>
-                                    </div>
-
                                     <div
                                         data-hasqtip="true"
                                         class="bloom-translationGroup bloom-trailingElement"
@@ -502,24 +470,7 @@
                                     min-height="60px 150px 250px"
                                     style="position: relative;"
                                     class="split-pane-component-inner adding"
-                                >
-                                    <div
-                                        class="box-header-off bloom-translationGroup"
-                                    >
-                                        <div
-                                            data-languagetipcontent="English"
-                                            aria-label="false"
-                                            role="textbox"
-                                            spellcheck="true"
-                                            tabindex="0"
-                                            class="bloom-editable bloom-content1 bloom-contentNational1 bloom-visibility-code-on"
-                                            contenteditable="true"
-                                            lang="en"
-                                        >
-                                            <p></p>
-                                        </div>
-                                    </div>
-                                </div>
+                                ></div>
                             </div>
                         </div>
                     </div>
@@ -559,21 +510,6 @@
                             style="position: relative;"
                             class="split-pane-component-inner adding"
                         >
-                            <div class="box-header-off bloom-translationGroup">
-                                <div
-                                    data-languagetipcontent="English"
-                                    aria-label="false"
-                                    role="textbox"
-                                    spellcheck="true"
-                                    tabindex="0"
-                                    class="bloom-editable bloom-content1 bloom-contentNational1 bloom-visibility-code-on"
-                                    contenteditable="true"
-                                    lang="en"
-                                >
-                                    <p></p>
-                                </div>
-                            </div>
-
                             <div
                                 title="placeHolder.png 6.58 KB 341 x 335 49 DPI (should be 300-600) Bit Depth: 32"
                                 class="bloom-imageContainer bloom-leadingElement"
@@ -605,24 +541,7 @@
                                     min-width="60px 150px 250px"
                                     style="position: relative;"
                                     class="split-pane-component-inner"
-                                >
-                                    <div
-                                        class="box-header-off bloom-translationGroup"
-                                    >
-                                        <div
-                                            data-languagetipcontent="English"
-                                            aria-label="false"
-                                            role="textbox"
-                                            spellcheck="true"
-                                            tabindex="0"
-                                            class="bloom-editable bloom-content1 bloom-contentNational1 bloom-visibility-code-on"
-                                            contenteditable="true"
-                                            lang="en"
-                                        >
-                                            <p></p>
-                                        </div>
-                                    </div>
-                                </div>
+                                ></div>
                             </div>
                             <div
                                 style="bottom: 80.7808%;"
@@ -655,23 +574,6 @@
                                                     style="position: relative;"
                                                     class="split-pane-component-inner adding"
                                                 >
-                                                    <div
-                                                        class="box-header-off bloom-translationGroup"
-                                                    >
-                                                        <div
-                                                            data-languagetipcontent="English"
-                                                            aria-label="false"
-                                                            role="textbox"
-                                                            spellcheck="true"
-                                                            tabindex="0"
-                                                            class="bloom-editable bloom-content1 bloom-contentNational1 bloom-visibility-code-on"
-                                                            contenteditable="true"
-                                                            lang="en"
-                                                        >
-                                                            <p></p>
-                                                        </div>
-                                                    </div>
-
                                                     <div
                                                         class="bloom-translationGroup bloom-trailingElement"
                                                     >
@@ -706,24 +608,7 @@
                                                     min-width="60px 150px"
                                                     style="position: relative;"
                                                     class="split-pane-component-inner adding"
-                                                >
-                                                    <div
-                                                        class="box-header-off bloom-translationGroup"
-                                                    >
-                                                        <div
-                                                            data-languagetipcontent="English"
-                                                            aria-label="false"
-                                                            role="textbox"
-                                                            spellcheck="true"
-                                                            tabindex="0"
-                                                            class="bloom-editable bloom-content1 bloom-contentNational1 bloom-visibility-code-on"
-                                                            contenteditable="true"
-                                                            lang="en"
-                                                        >
-                                                            <p></p>
-                                                        </div>
-                                                    </div>
-                                                </div>
+                                                ></div>
                                             </div>
                                         </div>
                                     </div>
@@ -749,24 +634,7 @@
                                                     min-width="60px 150px 250px"
                                                     style="position: relative;"
                                                     class="split-pane-component-inner adding"
-                                                >
-                                                    <div
-                                                        class="box-header-off bloom-translationGroup"
-                                                    >
-                                                        <div
-                                                            data-languagetipcontent="English"
-                                                            aria-label="false"
-                                                            role="textbox"
-                                                            spellcheck="true"
-                                                            tabindex="0"
-                                                            class="bloom-editable bloom-content1 bloom-contentNational1 bloom-visibility-code-on"
-                                                            contenteditable="true"
-                                                            lang="en"
-                                                        >
-                                                            <p></p>
-                                                        </div>
-                                                    </div>
-                                                </div>
+                                                ></div>
                                             </div>
                                             <div
                                                 style="bottom: 81.7259%;"
@@ -790,24 +658,7 @@
                                                             min-width="60px 150px"
                                                             style="position: relative;"
                                                             class="split-pane-component-inner adding"
-                                                        >
-                                                            <div
-                                                                class="box-header-off bloom-translationGroup"
-                                                            >
-                                                                <div
-                                                                    data-languagetipcontent="English"
-                                                                    aria-label="false"
-                                                                    role="textbox"
-                                                                    spellcheck="true"
-                                                                    tabindex="0"
-                                                                    class="bloom-editable bloom-content1 bloom-contentNational1 bloom-visibility-code-on"
-                                                                    contenteditable="true"
-                                                                    lang="en"
-                                                                >
-                                                                    <p></p>
-                                                                </div>
-                                                            </div>
-                                                        </div>
+                                                        ></div>
                                                     </div>
                                                     <div
                                                         class="split-pane-divider vertical-divider"
@@ -822,22 +673,6 @@
                                                             style="position: relative;"
                                                             class="split-pane-component-inner adding"
                                                         >
-                                                            <div
-                                                                class="box-header-off bloom-translationGroup"
-                                                            >
-                                                                <div
-                                                                    data-languagetipcontent="English"
-                                                                    aria-label="false"
-                                                                    role="textbox"
-                                                                    spellcheck="true"
-                                                                    tabindex="0"
-                                                                    class="bloom-editable bloom-content1 bloom-contentNational1 bloom-visibility-code-on"
-                                                                    contenteditable="true"
-                                                                    lang="en"
-                                                                >
-                                                                    <p></p>
-                                                                </div>
-                                                            </div>
                                                             <div
                                                                 class="bloom-videoContainer bloom-leadingElement bloom-noVideoSelected bloom-selected"
                                                             ></div>
@@ -879,21 +714,6 @@
                     style="position: relative;"
                     class="split-pane-component-inner adding"
                 >
-                    <div class="box-header-off bloom-translationGroup">
-                        <div
-                            data-languagetipcontent="English"
-                            aria-label="false"
-                            role="textbox"
-                            spellcheck="true"
-                            tabindex="0"
-                            class="bloom-editable bloom-content1 bloom-contentNational1 bloom-visibility-code-on"
-                            contenteditable="true"
-                            lang="en"
-                        >
-                            <p></p>
-                        </div>
-                    </div>
-
                     <div
                         title=""
                         class="bloom-imageContainer bloom-leadingElement"

--- a/src/BloomBrowserUI/templates/template books/standard-page-mixins.pug
+++ b/src/BloomBrowserUI/templates/template books/standard-page-mixins.pug
@@ -70,7 +70,6 @@ mixin standardPage-JustVideo
 mixin standardPage-Custom
    +page-choice-layout('Custom','A blank page that allows you to add items.').customPage#5dcd48df-e9ab-4a07-afd4-6a24d0398386
       .split-pane-component-inner
-         .box-header-off.bloom-translationGroup
 
 
 //- The following list all the pages in Basic Book, Decodable Reader, & Leveled Reader


### PR DESCRIPTION
Something obsolete we were still inserting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3750)
<!-- Reviewable:end -->
