### PR TITLE
Save page before re-ordering (BL-8509)

### DIFF
--- a/src/BloomExe/Edit/WebThumbNailList.cs
+++ b/src/BloomExe/Edit/WebThumbNailList.cs
@@ -581,6 +581,7 @@ namespace Bloom.Edit
 
 		private void GridReordered(string s)
 		{
+			Model.SaveNow();
 			var newSeq = new List<IPage>();
 			var keys = s.Split(new [] {','}, StringSplitOptions.RemoveEmptyEntries);
 			foreach (var key in keys)


### PR DESCRIPTION
Try not to merge this into 4.8 and later...they already have a fix, and the file this modifies has been drastically changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3759)
<!-- Reviewable:end -->
