### PR TITLE
Change test file to use UTF-8 instead of ISO-8859-1 encoding (20200602)

### DIFF
--- a/src/BloomTests/Publish/BloomReaderPublishTests.cs
+++ b/src/BloomTests/Publish/BloomReaderPublishTests.cs
@@ -265,7 +265,7 @@ namespace BloomTests.Publish
                                     <p></p>
                                 </div>
 
-                                <div data-languagetipcontent='español' style='' aria-label='false' role='textbox' spellcheck='true' tabindex='0' class='bloom-editable normal-style bloom-contentNational1' contenteditable='true' lang='es'>
+                                <div data-languagetipcontent='espaÃ±ol' style='' aria-label='false' role='textbox' spellcheck='true' tabindex='0' class='bloom-editable normal-style bloom-contentNational1' contenteditable='true' lang='es'>
                                     <p></p>
                                 </div>
                             </div>
@@ -286,7 +286,7 @@ namespace BloomTests.Publish
                                 <p></p>
                             </div>
 
-                            <div data-languagetipcontent='español' aria-label='false' role='textbox' spellcheck='true' tabindex='0' style='min-height: 24px;' class='bloom-editable normal-style bloom-contentNational1' contenteditable='true' lang='es'>
+                            <div data-languagetipcontent='espaÃ±ol' aria-label='false' role='textbox' spellcheck='true' tabindex='0' style='min-height: 24px;' class='bloom-editable normal-style bloom-contentNational1' contenteditable='true' lang='es'>
                                 <p></p>
                             </div>
 


### PR DESCRIPTION
It's the español that somehow got entered as ISO-8859-1 aka Latin-1, and
maybe also the same as Windows 1252 for this character.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3764)
<!-- Reviewable:end -->
