### PR TITLE
Don't allow the default of a gray Bloom logo on the back cover (BL-8372, BL-8549)

### DIFF
--- a/src/BloomBrowserUI/branding/Afghan-Children-Read/branding.json
+++ b/src/BloomBrowserUI/branding/Afghan-Children-Read/branding.json
@@ -41,6 +41,12 @@
             "lang": "*",
             "content": "<img class='branding' src='logo.png'/>",
             "condition": "always"
+        },
+        {
+            "data-book": "outside-back-cover-branding-bottom-html",
+            "lang": "*",
+            "content": "<!--override default-->",
+            "condition": "always"
         }
     ]
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3766)
<!-- Reviewable:end -->
