### PR TITLE
Use GraphicsMagick to process incoming image files (BL-8512)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ WebSite/
 lib/dotnet/Palaso*.*
 lib/dotnet/Chorus*.*
 lib/lame/*
+lib/gm/*
 DistFiles/exiftool.exe
 Copy*.bat
 !CopyLocalSquirrelToLocalBloom.bat

--- a/build/getDependencies-windows.sh
+++ b/build/getDependencies-windows.sh
@@ -77,7 +77,7 @@ cd -
 #     URL: https://build.palaso.org/viewType.html?buildTypeId=bt396
 #     clean: false
 #     revision: latest.lastSuccessful
-#     paths: {"ghostscript-win32.zip!**"=>"DistFiles/ghostscript", "optipng-0.7.4-win32/optipng.exe"=>"DistFiles", "connections.dll"=>"DistFiles", "MSBuild.Community.Tasks.dll"=>"build", "MSBuild.Community.Tasks.Targets"=>"build", "Lame.zip!**"=>"lib/lame"}
+#     paths: {"ghostscript-win32.zip!**"=>"DistFiles/ghostscript", "optipng-0.7.4-win32/optipng.exe"=>"DistFiles", "connections.dll"=>"DistFiles", "MSBuild.Community.Tasks.dll"=>"build", "MSBuild.Community.Tasks.Targets"=>"build", "Lame.zip!**"=>"lib/lame", "gm.zip!**"=>"lib"}
 # [1] build: PortableDevices (from PodcastUtilities) (Bloom_PortableDevicesFromPodcastUtitlies)
 #     project: Bloom
 #     URL: https://build.palaso.org/viewType.html?buildTypeId=Bloom_PortableDevicesFromPodcastUtitlies
@@ -161,6 +161,7 @@ mkdir -p ../DistFiles/ghostscript
 mkdir -p ../DistFiles/pdf
 mkdir -p ../Downloads
 mkdir -p ../build
+mkdir -p ../lib
 mkdir -p ../lib/dotnet
 mkdir -p ../lib/dotnet/
 mkdir -p ../lib/lame
@@ -172,6 +173,7 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/bt396/latest.las
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt396/latest.lastSuccessful/MSBuild.Community.Tasks.dll ../build/MSBuild.Community.Tasks.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt396/latest.lastSuccessful/MSBuild.Community.Tasks.Targets ../build/MSBuild.Community.Tasks.Targets
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt396/latest.lastSuccessful/Lame.zip ../Downloads/Lame.zip
+copy_auto http://build.palaso.org/guestAuth/repository/download/bt396/latest.lastSuccessful/gm.zip ../Downloads/gm.zip
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_PortableDevicesFromPodcastUtitlies/latest.lastSuccessful/PodcastUtilities.PortableDevices.dll ../lib/dotnet/PodcastUtilities.PortableDevices.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_PortableDevicesFromPodcastUtitlies/latest.lastSuccessful/PodcastUtilities.PortableDevices.pdb ../lib/dotnet/PodcastUtilities.PortableDevices.pdb
 copy_auto http://build.palaso.org/guestAuth/repository/download/Bloom_PortableDevicesFromPodcastUtitlies/latest.lastSuccessful/Interop.PortableDeviceApiLib.dll ../lib/dotnet/Interop.PortableDeviceApiLib.dll
@@ -236,5 +238,6 @@ copy_auto http://build.palaso.org/guestAuth/repository/download/Libpalaso_Palaso
 # extract downloaded zip files
 unzip -uqo ../Downloads/ghostscript-win32.zip -d "../DistFiles/ghostscript"
 unzip -uqo ../Downloads/Lame.zip -d "../lib/lame"
+unzip -uqo ../Downloads/gm.zip -d "../lib"
 unzip -uqo ../Downloads/pdfjs-viewer.zip -d "../DistFiles/pdf"
 # End of script

--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
  fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,
  optipng, libsndfile1,
  wmctrl, lame, ghostscript,
- ffmpeg,
+ ffmpeg, graphicsmagick,
  python3-aeneas | python-aeneas
 Suggests: art-of-reading3
 Replaces: bloom-desktop, bloom-desktop-beta, bloom-desktop-betainternal

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1327,6 +1327,7 @@
 "$(DevEnvDir)..\..\VC\bin\editbin.exe" /largeaddressaware "$(TargetPath)"
 copy /Y "$(SolutionDir)\lib\msvcr120.dll" $(OutDir)
 copy /Y "$(SolutionDir)\lib\ffmpeg.exe" $(OutDir)
+xcopy "$(SolutionDir)lib\gm" "$(OutDir)gm\" /S /R /Y
 copy /Y "$(SolutionDir)\lib\dotnet\libtidy.dll" $(OutDir)
 copy /Y "$(SolutionDir)\lib\dotnet\Interop.AcroPDFLib.dll" $(OutDir)
 copy /Y "$(SolutionDir)\lib\dotnet\Interop.Acrobat.dll" $(OutDir)

--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -140,5 +140,28 @@ namespace BloomTests.ImageProcessing
 				Assert.That(Path.GetFileNameWithoutExtension(filename), Is.EqualTo(expectedResult));
 			}
 		}
+
+		[Test]
+		[TestCase(3500, 2550, 3500, 2550)]	// maximum size landscape
+		[TestCase(2550, 3500, 2550, 3500)]	// maximum size portrait
+		[TestCase(3400, 2500, 3400, 2500)]	// smaller than bounds landscape
+		[TestCase(2500, 3400, 2500, 3400)]	// smaller than bounds portrait
+		[TestCase(3000, 3000, 2550, 2550)]	// square too large
+		[TestCase(4000, 3000, 3400, 2550)]	// landscape, both too large squashed
+		[TestCase(5250, 3825, 3500, 2550)]	// landscape, both too large same aspect ratio
+		[TestCase(5000, 3000, 3500, 2100)]	// landscape, both too large elongated
+		[TestCase(3000, 4000, 2550, 3400)]	// portrait, both too large squashed
+		[TestCase(3825, 5250, 2550, 3500)]	// portrait, both too large same aspect ratio
+		[TestCase(3000, 5000, 2100, 3500)]	// portrait, both too large elongated
+		[TestCase(2500, 5000, 1750, 3500)]	// portrait, height too large
+		[TestCase(5000, 2500, 3500, 1750)]	// landscape, width too large
+		[TestCase(3400, 2700, 3211, 2550)]	// landscape, height too large
+		[TestCase(2700, 3400, 2550, 3211)]	// portrait, width too large
+		public static void TestGetImageSizes(int width, int height, int newWidth, int newHeight)
+		{
+			var size = ImageUtils.GetDesiredImageSize(width, height);
+			Assert.AreEqual(size.Width, newWidth, $"Computed width for {width},{height} is correct.");
+			Assert.AreEqual(size.Height, newHeight, $"Computed height for {width},{height} is correct.");
+		}
 	}
 }


### PR DESCRIPTION
This allows much larger PNG files to be handled by shrinking them in an
external program to a more manageable size.  This shrinkage takes place
either when the picture is first imported into Bloom using the Image Chooser
dialog or when the user clicks on the "Bring Book Up to Date" menu item.
In the latter case, no effort is made to convert the PNG to JPEG to achieve
even more disk space savings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3767)
<!-- Reviewable:end -->
