### PR TITLE
Properly set version number during package build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,10 +12,6 @@ DESTDIR = debian/$(PACKAGE)
 LIB     = usr/lib/$(PACKAGE)
 SHARE   = usr/share/$(PACKAGE)
 
-# NOTE: make the third (and fourth?) number match changelog if you are
-# building the package manually.
-FULL_BUILD_NUMBER ?= 0.0.0.0
-
 %:
 	dh $@ --with=cli --parallel
 
@@ -34,10 +30,11 @@ override_dh_auto_build:
 	npm install --no-save yarn && \
 	export PATH="`pwd`/node_modules/.bin:$$PATH" && \
 	. ./environ && \
-	xbuild /t:RestoreBuildTasks build/Bloom.proj && \
-	xbuild /t:SetAssemblyVersion /p:RootDir=$(shell pwd) /p:BUILD_NUMBER=$(FULL_BUILD_NUMBER) build/Bloom.proj && \
-	xbuild /p:Configuration=$(BUILD) "Bloom.sln" && \
-	xbuild /p:Configuration=$(BUILD) src/LinuxBloomLauncher/LinuxBloomLauncher.cproj
+	. ./build_number.env && \
+	xbuild /t:RestoreBuildTasks /p:BUILD_NUMBER=$$FULL_BUILD_NUMBER build/Bloom.proj && \
+	xbuild /t:SetAssemblyVersion /p:RootDir=$(shell pwd) /p:BUILD_NUMBER=$$FULL_BUILD_NUMBER build/Bloom.proj && \
+	xbuild /p:Configuration=$(BUILD) /p:BUILD_NUMBER=$$FULL_BUILD_NUMBER "Bloom.sln" && \
+	xbuild /p:Configuration=$(BUILD) /p:BUILD_NUMBER=$$FULL_BUILD_NUMBER src/LinuxBloomLauncher/LinuxBloomLauncher.cproj
 
 override_dh_auto_test:
 


### PR DESCRIPTION
The package build, which runs inside of a chroot environment, didn't have access to the environment variable that we tried to set before we started the package build. The result was that the patch version was always 0.

This change depends on a change in [ci-builder-scripts](https://gerrit.lsdev.sil.org/c/ci-builder-scripts/+/7516) that stores the build number in `build_number.env`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3768)
<!-- Reviewable:end -->
