### PR TITLE
Fix Bloom packaging to have the full version number in the assembly

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -34,10 +34,11 @@ override_dh_auto_build:
 	npm install --no-save yarn && \
 	export PATH="`pwd`/node_modules/.bin:$$PATH" && \
 	. ./environ && \
-	xbuild /t:RestoreBuildTasks build/Bloom.proj && \
-	xbuild /t:SetAssemblyVersion /p:RootDir=$(shell pwd) /p:BUILD_NUMBER=$(FULL_BUILD_NUMBER) build/Bloom.proj && \
-	xbuild /p:Configuration=$(BUILD) "Bloom.sln" && \
-	xbuild /p:Configuration=$(BUILD) src/LinuxBloomLauncher/LinuxBloomLauncher.cproj
+	if [ -f ./build_number.env ]; then . ./build_number.env; else FULL_BUILD_NUMBER=0.0.0.0; fi && \
+	xbuild /t:RestoreBuildTasks /p:BUILD_NUMBER=$$FULL_BUILD_NUMBER build/Bloom.proj && \
+	xbuild /t:SetAssemblyVersion /p:RootDir=$(shell pwd) /p:BUILD_NUMBER=$$FULL_BUILD_NUMBER build/Bloom.proj && \
+	xbuild /p:Configuration=$(BUILD) /p:BUILD_NUMBER=$$FULL_BUILD_NUMBER "Bloom.sln" && \
+	xbuild /p:Configuration=$(BUILD) /p:BUILD_NUMBER=$$FULL_BUILD_NUMBER src/LinuxBloomLauncher/LinuxBloomLauncher.cproj
 
 override_dh_auto_test:
 


### PR DESCRIPTION
For local builds, the version stays at 4.7.0.0.
For jenkins builds, the build number and git sha are used for the last two numbers instead of 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3771)
<!-- Reviewable:end -->
