### PR TITLE
Get file dialogs to work properly on Linux (BL-8518)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -291,8 +291,11 @@
     <Reference Include="TidyManaged">
       <HintPath>..\..\lib\dotnet\TidyManaged.dll</HintPath>
     </Reference>
-    <Reference Include="DialogAdapters">
+    <Reference Include="DialogAdapters" Condition="'$(OS)'=='Windows_NT'">
       <HintPath>..\..\packages\DialogAdapters.0.1.4.30000\lib\net45\DialogAdapters.dll</HintPath>
+    </Reference>
+    <Reference Include="DialogAdapters" Condition="'$(OS)'!='Windows_NT'">
+      <HintPath>..\..\packages\DialogAdapters.Gtk2.0.1.10\lib\net461\DialogAdapters.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -24,7 +24,7 @@
     <package id="SourceMapDotNet" version="1.0.5478.26629" targetFramework="net461" />
     <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
     <package id="TechTalk.JiraRestClient.RestSharp105" version="2.3.0.1" targetFramework="net461" />
-    <package id="DialogAdapters" version="0.1.4.30000" targetFramework="net461" />
+    <package id="DialogAdapters.Gtk2" version="0.1.10" targetFramework="net461" />
     <!-- Linux specific packages.  Changes above this line must be copied to ../packages.config -->
     <package id="Geckofx45.32.Linux" version="45.0.23.0" targetFramework="net461" />
     <package id="Geckofx45.64.Linux" version="45.0.23.0" targetFramework="net461" />


### PR DESCRIPTION
A new version of DialogAdapters.Gtk2 is needed to fix observed problems
on Linux.  The old version of DialogAdapters works fine on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3774)
<!-- Reviewable:end -->
