### PR TITLE
Fix bubble jump upon paste (BL-8559)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -851,9 +851,20 @@ export class BubbleManager {
         const padding = BubbleManager.getLeftAndTopPaddings(element);
         const borderAndPadding = border.add(padding);
 
+        // If the text overflows, then scrollTop is probably some positive value.
+        // We want to add it in because the number we return represents the distance of the text box
+        // from the start of the element, not from where the visible edge of the element is.
+        const scroll = new Point(
+            element.scrollLeft,
+            element.scrollTop,
+            PointScaling.Unscaled,
+            "Element ScrollLeft/Top (Unscaled)"
+        );
+
         const transposedPoint = pointRelativeToViewport
             .subtract(origin)
-            .subtract(borderAndPadding);
+            .subtract(borderAndPadding)
+            .add(scroll);
         return transposedPoint;
     }
 


### PR DESCRIPTION
If you paste in enough text that it overflows out the bottom, the scroll amount will be set and will mess up calculations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3791)
<!-- Reviewable:end -->
