### PR TITLE
BL-8249 Close splash screen before problem dialog

### DIFF
--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -268,6 +268,7 @@ namespace Bloom.web.controllers
 		{
 			// Before we do anything that might be "risky", put the problem in the log.
 			LogProblem(exception, detailedMessage, levelOfProblem);
+			Program.CloseSplashScreen(); // if it's still up, it'll be on top of the dialog
 			if (_showingProblemReport)
 			{
 				// If a problem is reported when already reporting a problem, that could


### PR DESCRIPTION
* so far unsuccessful getting problem dialog to be
   draggable, but this should keep the splash screen from
   being a problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3792)
<!-- Reviewable:end -->
