### PR TITLE
[4.7] BL-8527 XMatter should not be part of measure

### DIFF
--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -336,7 +336,7 @@ namespace Bloom.Publish.Android
 		{
 			lock (_lockForLanguages)
 			{
-				_allLanguages = request.CurrentBook.AllPublishableLanguages(countXmatter: true);
+				_allLanguages = request.CurrentBook.AllPublishableLanguages(includeLangsOccurringOnlyInXmatter: true);
 				if (_bookForLanguagesToPublish != request.CurrentBook)
 				{
 					// reinitialize our list of which languages to publish, defaulting to the ones

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -1762,7 +1762,7 @@ namespace BloomTests.Book
 		[Test]
 		[TestCase(false)]
 		[TestCase(true)]
-		public void AllLanguages_FindsBloomEditableElements(bool countXmatter)
+		public void AllLanguages_FindsBloomEditableElements(bool includeLangsOccurringOnlyInXmatter)
 		{
 			_bookDom = new HtmlDom(
 				@"<html>
@@ -1837,10 +1837,10 @@ namespace BloomTests.Book
 				</body></html>");
 
 			var book = CreateBook();
-			var allLanguages = book.AllLanguages(countXmatter);
+			var allLanguages = book.AllLanguages(includeLangsOccurringOnlyInXmatter);
 			// In the case where 'countXmatter' is true, the stored bool will be true for thai, which occurs
 			// on all pages. For all the others, it will be false, since there is no text in the xmatter pages.
-			if (countXmatter)
+			if (includeLangsOccurringOnlyInXmatter)
 			{
 				Assert.That(allLanguages["en"], Is.False);
 				Assert.That(allLanguages["de"], Is.False);


### PR DESCRIPTION
* to decide whether or not something is fully translated or not

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3793)
<!-- Reviewable:end -->
