### PR TITLE
BL-8249 Make Problem dialog draggable

### DIFF
--- a/src/BloomBrowserUI/problemDialog/ProblemDialog.tsx
+++ b/src/BloomBrowserUI/problemDialog/ProblemDialog.tsx
@@ -237,10 +237,11 @@ export const ProblemDialog: React.FunctionComponent<{
                     Close icon inside of the title's Typography element, where we don't have control over its CSS. */}
                 <DialogTitle className="dialog-title" disableTypography={true}>
                     <Typography variant="h6">{localizedDlgTitle}</Typography>
-                    <Close
+                    {/* We moved the X up to the winforms dialog so that it is draggable
+                         <Close
                         className="close-in-title"
                         onClick={() => BloomApi.post("dialog/close")}
-                    />
+                    /> */}
                 </DialogTitle>
                 <DialogContent className="content">
                     {(() => {

--- a/src/BloomExe/MiscUI/BrowserDialog.cs
+++ b/src/BloomExe/MiscUI/BrowserDialog.cs
@@ -23,7 +23,8 @@ namespace Bloom.MiscUI
 		public BrowserDialog(string url)
 		{
 			InitializeComponent();
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow; // draggable
+			this.Text = ""; // don't show the title, we do that in the html
 
 			// The Size setting is needed on Linux to keep the browser from coming up as a small
 			// rectangle in the upper left corner...


### PR DESCRIPTION
Make the winforms host have a draggable title bar, then remove the "X" from the html part of the dialog because it is already there in the title bar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3794)
<!-- Reviewable:end -->
