### PR TITLE
BL-8195 Color picker UI mods

### DIFF
--- a/src/BloomBrowserUI/react_components/colorPickerDialog.less
+++ b/src/BloomBrowserUI/react_components/colorPickerDialog.less
@@ -2,6 +2,9 @@
     .MuiDialog-paperScrollPaper {
         max-height: unset;
     }
+    .MuiDialogActions-spacing {
+        padding: 10px 14px 10px 10px; // maintain same spacing all around dialog content and between header/footer
+    }
 }
 
 .MuiBackdrop-root {
@@ -11,4 +14,5 @@
 
 #draggable-color-picker-title {
     text-align: center;
+    padding: 14px 24px; // maintain same spacing all around dialog content
 }

--- a/src/BloomBrowserUI/react_components/colorPickerDialog.tsx
+++ b/src/BloomBrowserUI/react_components/colorPickerDialog.tsx
@@ -3,14 +3,17 @@ import * as ReactDOM from "react-dom";
 import { useState } from "react";
 import Dialog from "@material-ui/core/Dialog";
 import {
+    Button,
     DialogTitle,
     DialogActions,
     DialogContent,
     Paper
 } from "@material-ui/core";
 import CloseOnEscape from "react-close-on-escape";
-import BloomButton from "./bloomButton";
 import { getEditViewFrameExports } from "../bookEdit/js/bloomFrames";
+import { useL10n } from "./l10nHooks";
+import { ThemeProvider } from "@material-ui/styles";
+import theme from "../bloomMaterialUITheme";
 import { BloomApi } from "../utils/bloomApi";
 import CustomColorPicker from "./customColorPicker";
 import * as tinycolor from "tinycolor2";
@@ -149,49 +152,52 @@ const ColorPickerDialog: React.FC<IColorPickerDialogProps> = props => {
         props.onChange(color);
     };
 
+    const OkText = useL10n("OK", "Common.OK");
+    const CancelText = useL10n("Cancel", "Common.Cancel");
+
     return (
-        <CloseOnEscape onEscape={() => onClose(DialogResult.Cancel)}>
-            <Dialog
-                className="bloomModalDialog color-picker-dialog"
-                open={open}
-                PaperComponent={PaperComponent}
-            >
-                <DialogTitle
-                    id="draggable-color-picker-title"
-                    style={{ cursor: "move" }}
+        <ThemeProvider theme={theme}>
+            <CloseOnEscape onEscape={() => onClose(DialogResult.Cancel)}>
+                <Dialog
+                    className="bloomModalDialog color-picker-dialog"
+                    open={open}
+                    PaperComponent={PaperComponent}
                 >
-                    {props.localizedTitle}
-                </DialogTitle>
-                <DialogContent>
-                    <CustomColorPicker
-                        onChange={handleOnChange}
-                        currentColor={currentColor}
-                        swatchColors={swatchArray}
-                        noAlphaSlider={props.noAlphaSlider}
-                        noGradientSwatches={props.noGradientSwatches}
-                    />
-                </DialogContent>
-                <DialogActions>
-                    <BloomButton
-                        l10nKey="Common.OK"
-                        enabled={true}
-                        onClick={() => onClose(DialogResult.OK)}
-                        hasText={true}
+                    <DialogTitle
+                        id="draggable-color-picker-title"
+                        style={{ cursor: "move" }}
                     >
-                        OK
-                    </BloomButton>
-                    <BloomButton
-                        l10nKey="Common.Cancel"
-                        enabled={true}
-                        onClick={() => onClose(DialogResult.Cancel)}
-                        hasText={true}
-                        variant="outlined"
-                    >
-                        Cancel
-                    </BloomButton>
-                </DialogActions>
-            </Dialog>
-        </CloseOnEscape>
+                        {props.localizedTitle}
+                    </DialogTitle>
+                    <DialogContent>
+                        <CustomColorPicker
+                            onChange={handleOnChange}
+                            currentColor={currentColor}
+                            swatchColors={swatchArray}
+                            // Temporary: When comical does alpha, chg to 'props.noAlphaSlider'.
+                            // Unfortunately, with an alpha slider, the hex input will automatically switch to rgb
+                            // the moment the user sets alpha to anything but max opacity.
+                            noAlphaSlider={true}
+                            noGradientSwatches={props.noGradientSwatches}
+                        />
+                    </DialogContent>
+                    <DialogActions>
+                        <Button
+                            onClick={() => onClose(DialogResult.OK)}
+                            color="primary"
+                        >
+                            {OkText}
+                        </Button>
+                        <Button
+                            onClick={() => onClose(DialogResult.Cancel)}
+                            color="primary"
+                        >
+                            {CancelText}
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+            </CloseOnEscape>
+        </ThemeProvider>
     );
 };
 

--- a/src/BloomBrowserUI/react_components/customColorPicker.less
+++ b/src/BloomBrowserUI/react_components/customColorPicker.less
@@ -3,13 +3,20 @@
 @swatch-row-left-pad: @swatch-margin;
 
 .custom-color-picker {
-    height: 300px;
     display: flex;
     width: max-content;
     flex-direction: column;
-    box-shadow: rgba(0, 0, 0, 0.3) 0px 0px 2px, rgba(0, 0, 0, 0.3) 0px 4px 8px;
     .chrome-picker {
         box-shadow: none !important;
+        // here follows some customization of the react-color chrome-picker to remove bits we don't want
+        > div:nth-child(2) > div:nth-child(2) {
+            > div div div span {
+                display: none !important; // Hide "HEX" label
+            }
+            > div:nth-child(2) {
+                display: none; // Hide control that switches to RGBA or HSLA input
+            }
+        }
     }
     .swatch-row {
         display: flex;


### PR DESCRIPTION
* remove inner shadow
* change to material-ui buttons
* use Bloom theme
* temporarily remove alpha slider
* hide "HEX" label
* hide control to switch to RGB or HSL input
* regularize padding around dialog contents

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3799)
<!-- Reviewable:end -->
