### PR TITLE
Fix hard crash from clicking a page before loading complete (BL-8619)

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1311,7 +1311,7 @@ namespace Bloom.Edit
 			RefreshDisplayOfCurrentPage(); //the cleanup() that is part of Save removes qtips, so let's redraw everything
 		}
 
-#if __MonoCS__
+//#if __MonoCS__	// See https://issues.bloomlibrary.org/youtrack/issue/BL-8619 for why we need these for Version4.8 on Windows.
 		/// <summary>
 		/// Flag that a page selection is currently under way.
 		/// </summary>
@@ -1327,7 +1327,7 @@ namespace Bloom.Edit
 		{
 			_pageSelection.ChangingPageFinished();
 		}
-#endif
+//#endif
 
 		public bool GetClipboardHasPage()
 		{

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -535,7 +535,7 @@ namespace Bloom.Edit
 				// never happens.
 				_browser1.WebBrowser.DocumentCompleted += WebBrowser_ReadyStateChanged;
 				_browser1.WebBrowser.ReadyStateChange += WebBrowser_ReadyStateChanged;
-#if __MonoCS__
+//#if __MonoCS__	// See https://issues.bloomlibrary.org/youtrack/issue/BL-8619 for why we need this for Version4.8 on Windows.
 				// On Linux/Mono, the user can click between pages too fast in Edit mode, resulting
 				// in a warning dialog popping up.  I've never seen this happen on Windows, but it's
 				// happening fairly often on Linux when I just try to move around a book.  The fix
@@ -543,12 +543,12 @@ namespace Bloom.Edit
 				// further page selecting until the current page has finished loading.
 				_model.PageSelectionStarted();
 				_browser1.WebBrowser.DocumentCompleted += WebBrowser_DocumentCompleted;
-#endif
+//#endif
 			}
 			UpdateDisplay();
 		}
 
-#if __MonoCS__
+//#if __MonoCS__	// See https://issues.bloomlibrary.org/youtrack/issue/BL-8619 for why we need this for Version4.8 on Windows.
 		/// <summary>
 		/// Flag the PageSelection object that the current (former?) page selection has completed,
 		/// so it's safe to select another page now.
@@ -558,7 +558,7 @@ namespace Bloom.Edit
 			_model.PageSelectionFinished();
 			_browser1.WebBrowser.DocumentCompleted -= WebBrowser_DocumentCompleted;
 		}
-#endif
+//#endif
 
 		void WebBrowser_ReadyStateChanged(object sender, EventArgs e)
 		{

--- a/src/BloomExe/Edit/PageSelection.cs
+++ b/src/BloomExe/Edit/PageSelection.cs
@@ -5,9 +5,9 @@ namespace Bloom.Edit
 {
 	public class PageSelection
 	{
-#if __MonoCS__
+//#if __MonoCS__	// See https://issues.bloomlibrary.org/youtrack/issue/BL-8619 for why we need this for Version4.8 on Windows.
 		private bool _stillChanging = false;	// whether in the process of changing the displayed page
-#endif
+//#endif
 		private IPage _currentSelection;
 		public event EventHandler SelectionChanging; // before it changes
 		public event EventHandler SelectionChanged; // after it changed
@@ -20,12 +20,12 @@ namespace Bloom.Edit
 		/// <returns></returns>
 		public bool SelectPage(IPage page, bool prepareAlreadyDone = false)
 		{
-#if __MonoCS__
+//#if __MonoCS__	// See https://issues.bloomlibrary.org/youtrack/issue/BL-8619 for why we need this for Version4.8 on Windows.
 			// If we haven't finished displaying the previously selected page, we can't select another page yet.
 			// See https://silbloom.myjetbrains.com/youtrack/issue/BL-3586.
 			if (_stillChanging)
 				return false;
-#endif
+//#endif
 			//enhance... make pre-change event cancellable
 			if (!prepareAlreadyDone)
 				PrepareToSelectPage();
@@ -61,7 +61,7 @@ namespace Bloom.Edit
 			}
 		}
 
-#if __MonoCS__
+//#if __MonoCS__	// See https://issues.bloomlibrary.org/youtrack/issue/BL-8619 for why we need these for Version4.8 on Windows.
 		/// <summary>
 		/// Flag that a page selection is currently under way.
 		/// </summary>
@@ -77,6 +77,6 @@ namespace Bloom.Edit
 		{
 			_stillChanging = false;
 		}
-#endif
+//#endif
 	}
 }


### PR DESCRIPTION
Also improve chances of getting a stack trace and error report when an
access violation hard crash occurs.

This fix is needed only for Version 4.8 using Geckofx45.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3804)
<!-- Reviewable:end -->
