### PR TITLE
BL-8195 fixes

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
@@ -305,8 +305,12 @@ const ComicToolControls: React.FunctionComponent = () => {
         getEditViewFrameExports().showColorPickerDialog(colorPickerDialogProps);
     };
 
+    // We have temporarily disabled the alpha slider for the background color chooser.
+    // Unfortunately, with an alpha slider, the hex input will automatically switch to rgb
+    // the moment the user sets alpha to anything but max opacity.
     const launchBackgroundColorChooser = () => {
         const colorPickerDialogProps: IColorPickerDialogProps = {
+            noAlphaSlider: true, // Temporary, when BL-8537 is in testing, remove this line.
             localizedTitle: backgroundColorTitle,
             initialColor: backgroundColorSwatch,
             defaultSwatchColors: defaultBackgroundColors,


### PR DESCRIPTION
* turn alpha slider off in comic tool, not in dialog
   (makes other things easier)
* fix deletion mechanism
* skip swatches in calculating "full" swatch panel that will
   not be shown anyway

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3806)
<!-- Reviewable:end -->
