### PR TITLE
Fix an event handler to fire only the one time it is needed (BL-8619)

### DIFF
--- a/src/BloomExe/Edit/WebThumbNailList.cs
+++ b/src/BloomExe/Edit/WebThumbNailList.cs
@@ -294,6 +294,7 @@ namespace Bloom.Edit
 		void WebBrowser_DocumentCompleted(object sender, Gecko.Events.GeckoDocumentCompletedEventArgs e)
 		{
 			SelectPage(PageListApi?.SelectedPage);
+			_browser.WebBrowser.DocumentCompleted -= WebBrowser_DocumentCompleted;	// need to do this only once
 		}
 
 		internal void PageClicked(IPage page)


### PR DESCRIPTION
I found this in the course of fixing BL-8619.  I don't know if it helps
that issue directly, but it seems an obvious fix that is needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3809)
<!-- Reviewable:end -->
