### PR TITLE
Fix to improve handling of hard crashes (BL_8619)

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -522,6 +522,7 @@ namespace Bloom
 			_projectContext = projectContext;
 		}
 
+		[HandleProcessCorruptedStateExceptions]
 		private static void Run()
 		{
 			_earliestWeShouldCloseTheSplashScreen = DateTime.Now.AddSeconds(3);
@@ -534,6 +535,14 @@ namespace Bloom
 			try
 			{
 				Application.Run();
+			}
+			catch (System.Reflection.TargetInvocationException bad)
+			{
+				if (bad.InnerException is System.AccessViolationException)
+					Logger.ShowUserATextFileRelatedToCatastrophicError(bad.InnerException);
+				else
+					Logger.ShowUserATextFileRelatedToCatastrophicError(bad);
+				System.Environment.FailFast("TargetInvocationException");
 			}
 			catch (System.AccessViolationException nasty)
 			{


### PR DESCRIPTION
This fix increases the chance of getting a stack trace and error report
for access violation crashes which otherwise cause the program to simply
disappear.  It's still not foolproof since the action of bringing up the
text editor with the stack trace can still cause another access violation
which is unhandled.  But it improves the odds considerably.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3810)
<!-- Reviewable:end -->
