### PR TITLE
Run GraphicsMagick with ASCII-only filenames (BL-8512)

### DIFF
--- a/src/BloomExe/TempFiles.cs
+++ b/src/BloomExe/TempFiles.cs
@@ -68,6 +68,21 @@ namespace BloomTemp
 			//now insert the non-xml-ish <!doctype html>
 			return string.Format("<!DOCTYPE html>{0}{1}", Environment.NewLine, xhtml);
 		}
+
+		/// <summary>
+		/// Return a temporary path (that does not yet exist) using standard methods that should yield safe
+		/// filenames regardless of the current codepage.  The caller is responsible to delete the temporary
+		/// file after creating it and using it.
+		/// </summary>
+		public static string GetTempFilepathWithExtension(string extension)
+		{
+			// The Dispose call caused by the using block ensures that the returned file path
+			// is not for an existing file.
+			using (var temp = TempFile.WithExtension(extension))
+			{
+				return temp.Path;
+			}
+		}
 	}
 
 	// ENHANCE: Replace with TemporaryFolder implemented in Palaso. However, that means


### PR DESCRIPTION
Filenames with characters outside the user's default codepage cannot be
handled when running a GraphicsMagick process from inside Bloom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3818)
<!-- Reviewable:end -->
