### PR TITLE
Tweak fix for cropping only second time bug (BL-8638)

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1088,8 +1088,8 @@ namespace Bloom.Edit
 					// Save the possibly modified (by cropping) image to the file.
 					// The code for ensuring non-transparency uses GraphicsMagick on the file content if possible, so the
 					// file must be in sync with the imageInfo.  See https://issues.bloomlibrary.org/youtrack/issue/BL-8638.
-					if (newImagePath != null && imageInfo.OriginalFilePath == newImagePath)
-						imageInfo.Save(newImagePath);
+					if (newImagePath != null && dlg.ImageInfo.OriginalFilePath == newImagePath)
+						dlg.ImageInfo.Save(newImagePath);
 					SaveChangedImage(imageElement, dlg.ImageInfo, "Bloom had a problem including that image");
 #if MEMORYCHECK
 					// Warn the user if we're starting to use too much memory.


### PR DESCRIPTION
Looking at the code again, this seems like an obvious fix.  The current
implementation of the the dialog makes the current code work okay, but
what if the implementation changes to always instantiate a new ImageInfo
when the image changes in any way, not just a new Image in the ImageInfo?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3824)
<!-- Reviewable:end -->
