### PR TITLE
Speed up processing book buttons at idle time (BL-8376)

### DIFF
--- a/src/BloomExe/Book/BookInfo.cs
+++ b/src/BloomExe/Book/BookInfo.cs
@@ -9,6 +9,8 @@ using System.Threading;
 using Bloom.ImageProcessing;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using Bloom.Api;
+using Bloom.Collection;
 using Bloom.Edit;
 using L10NSharp;
 using Newtonsoft.Json;
@@ -17,6 +19,7 @@ using SIL.IO;
 using SIL.Reporting;
 using SIL.Windows.Forms.ClearShare;
 using Bloom.Properties;
+using SIL.Text;
 
 namespace Bloom.Book
 {
@@ -635,6 +638,26 @@ namespace Bloom.Book
 			var bi = new BookInfo(currentFolder, false);
 			var id = bi.Id;
 			SafelyAddToIdSet(id, metaFileLastWriteTime, currentFolder, idToSortedFilepathsMap);
+		}
+
+		internal string GetBestTitleForUserDisplay(CollectionSettings settings)
+		{
+			try
+			{
+				// JSON parsing requires newlines to be double quoted with backslashes inside string values.
+				var jsonString = AllTitles == null ? "{}" : AllTitles.Replace("\r", "\\r").Replace("\n", "\\n");
+				dynamic titles = DynamicJson.Parse(jsonString);
+				IEnumerable<string> langs = titles.GetDynamicMemberNames();
+				var multiText = new MultiTextBase();
+				foreach (var lang in langs)
+					multiText[lang] = titles[lang].Trim();
+				return Book.GetBestTitleForDisplay(multiText, settings, IsEditable);
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e);
+			}
+			return Title;
 		}
 
 		private static void SafelyAddToIdSet(string bookId, DateTime lastWriteTime, string bookFolder,

--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -78,6 +78,11 @@ namespace Bloom.CollectionTab
 
 		}
 
+		internal CollectionSettings CollectionSettings
+		{
+			get { return _collectionSettings; }
+		}
+
 		public string LanguageName
 		{
 			get { return _collectionSettings.Language1.Name; }


### PR DESCRIPTION
This can greatly speed up loading a collection with large, complex books
such as nontrivial picture dictionaries.  This is most noticeable when
starting Bloom with the Splash screen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3827)
<!-- Reviewable:end -->
