### PR TITLE
Use special epub-thumbnail.png file for publishing ePUBs (BL-8682)

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -821,6 +821,7 @@ namespace Bloom.Book
 			//Remove from that list each image actually in use
 			var element = Dom.RawDom.DocumentElement;
 			var pathsToNotDelete = GetImagePathsRelativeToBook(element);
+			pathsToNotDelete.Add("epub-thumbnail.png");	// this may have been carefully crafted...
 
 			if (keepFilesForEditing)
 			{

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -352,45 +352,50 @@ namespace Bloom.Publish.Epub
 				}
 			}
 
-			string coverPageImageFile = "thumbnail-256.png";
-			// This thumbnail is otherwise only made when uploading, so it may be out of date.
-			// Just remake it every time.
-			ApplicationException thumbNailException = null;
-			try
+			var epubThumbnailImagePath = Path.Combine(Book.FolderPath, "epub-thumbnail.png");
+			// If we don't have an epub thumbnail, or we have one that's not readonly, create a nice large thumbnail of
+			// the cover image.
+			if (!RobustFile.Exists(epubThumbnailImagePath) || !(new FileInfo(epubThumbnailImagePath)).IsReadOnly)
 			{
-				_thumbnailRequestId = Guid.NewGuid();
-				_thumbNailer.MakeThumbnailOfCover(Book, 256,_thumbnailRequestId);
-				_thumbnailRequestId = Guid.Empty;
-			}
-			catch (ApplicationException e)
-			{
-				thumbNailException = e;
-			}
-
-			if (AbortRequested)
-				return; // especially to avoid reporting problems making thumbnail, e.g., because aborted.
-
-			var coverPageImagePath = Path.Combine(Book.FolderPath, coverPageImageFile);
-			if (thumbNailException != null || !RobustFile.Exists(coverPageImagePath))
-			{
-				NonFatalProblem.Report(ModalIf.All, PassiveIf.All,
-					"Bloom failed to make a high-quality cover page for your book (BL-3209)",
-					"We will try to make the book anyway, but you may want to try again.",
-					thumbNailException);
-
-				coverPageImageFile = "thumbnail.png"; // Try a low-res image, which should always exist
-				coverPageImagePath = Path.Combine(Book.FolderPath, coverPageImageFile);
-				if (!RobustFile.Exists(coverPageImagePath))
+				string coverPageImageFile = "thumbnail-256.png";	// name created by _thumbNailer
+				ApplicationException thumbNailException = null;
+				try
 				{
-					// I don't think we can make an epub without a cover page so at this point we've had it.
-					// I suppose we could recover without actually crashing but it doesn't seem worth it unless this
-					// actually happens to real users.
-					throw new FileNotFoundException("Could not find or create thumbnail for cover page (BL-3209)",
-						coverPageImageFile);
+					_thumbnailRequestId = Guid.NewGuid();
+					_thumbNailer.MakeThumbnailOfCover(Book, 256, _thumbnailRequestId);
+					_thumbnailRequestId = Guid.Empty;
 				}
+				catch (ApplicationException e)
+				{
+					thumbNailException = e;
+				}
+
+				if (AbortRequested)
+					return; // especially to avoid reporting problems making thumbnail, e.g., because aborted.
+
+				var coverPageImagePath = Path.Combine(Book.FolderPath, coverPageImageFile);
+				if (thumbNailException != null || !RobustFile.Exists(coverPageImagePath))
+				{
+					NonFatalProblem.Report(ModalIf.All, PassiveIf.All,
+						"Bloom failed to make a high-quality cover page for your book (BL-3209)",
+						"We will try to make the book anyway, but you may want to try again.",
+						thumbNailException);
+
+					coverPageImageFile = "thumbnail.png"; // Try a low-res image, which should always exist
+					coverPageImagePath = Path.Combine(Book.FolderPath, coverPageImageFile);
+					if (!RobustFile.Exists(coverPageImagePath))
+					{
+						// I don't think we can make an epub without a cover page so at this point we've had it.
+						// I suppose we could recover without actually crashing but it doesn't seem worth it unless this
+						// actually happens to real users.
+						throw new FileNotFoundException("Could not find or create thumbnail for cover page (BL-3209)",
+							coverPageImageFile);
+					}
+				}
+				RobustFile.Move(coverPageImagePath, epubThumbnailImagePath);
 			}
 
-			CopyFileToEpub(coverPageImagePath, true, true, kImagesFolder);
+			CopyFileToEpub(epubThumbnailImagePath, true, true, kImagesFolder);
 
 			EmbedFonts(); // must call after copying stylesheets
 			MakeNavPage();
@@ -410,7 +415,7 @@ namespace Bloom.Publish.Epub
 					</rootfiles>
 					</container>");
 
-			MakeManifest(kImagesFolder + "/" + coverPageImageFile);
+			MakeManifest(kImagesFolder + "/" + Path.GetFileName(epubThumbnailImagePath));
 
 			foreach (var filename in Directory.EnumerateFiles(Path.Combine(_contentFolder, kImagesFolder), "*.*"))
 			{


### PR DESCRIPTION
This can either be a carefully crafted file placed in the original
book folder for permanent use, or it can be generated on the fly from
the cover image for one-time use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3835)
<!-- Reviewable:end -->
