### PR TITLE
Prevent nonstandard DPI warning on auto-restart (BL-8687)

### DIFF
--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -810,7 +810,7 @@ namespace Bloom.Workspace
 				var dy = g.DpiY;
 				if(dx!=96 || dy!=96)
 				{
-					SIL.Reporting.ErrorReport.NotifyUserOfProblem(
+					ErrorReport.NotifyUserOfProblem(new ShowOncePerSessionBasedOnExactMessagePolicy(),
 						"The \"text size (DPI)\" or \"Screen Magnification\" of the display on this computer is set to a special value, {0}. With that setting, some thing won't look right in Bloom. Possibly books won't lay out correctly. If this is a problem, change the DPI back to 96 (the default on most computers), using the 'Display' Control Panel.", dx);
 				}
 			}


### PR DESCRIPTION
This seems to be the source of observed GUI strangeness when the dialog
pops up but is hidden behind another window (usually Bloom itself).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3843)
<!-- Reviewable:end -->
