### PR TITLE
TalkingBook also updates sentence splits after text modified (BL-8649)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/test/testUtil.ts
+++ b/src/BloomBrowserUI/bookEdit/test/testUtil.ts
@@ -1,0 +1,31 @@
+// A generic wrapper for Jasmine tests with a done() async callback
+// Runs an Arrange-Act-Assert pattern test where Setup or Act may be asynchronous
+// It is assumed that verify is synchronous.
+// Handles properly wrapping try/catches and calling done() at the right places.
+//
+// Note: This wrapper is only necessary if you must have a done() based callback.
+// However, if you're just using async/await or promises, this wrapper isn't necessary.
+// You can just mark the "it" call's function as async and then await all the appropriate things.
+// Jasmine will await your async it's completion before moving on to the next thing.
+// Using just async/await is more recommended, cleaner, and less error-prone than using done callbacks.
+// For more info: https://jasmine.github.io/tutorials/async
+export async function runAsyncTest(
+    done: () => void, // The done callback provided by Jasmine framework
+    setupAsync: () => void | Promise<void>,
+    runAsync: () => void | Promise<void>,
+    verify: () => void
+) {
+    // For async tests, the whole thing should be wrapped in a try/catch to ensure that done() always gets called by the end, no matter what.
+    try {
+        await setupAsync();
+        await runAsync();
+        verify();
+    } catch (error) {
+        // Note: When run asynchronously, exceptions thrown don't fail tests in the same way that synchronous exceptions do.
+        // Asynchronous ones usually just cause the test to time out).
+        // So, we explicitly catch and fail the test so that the cause is more obvious than recognizing that timeout -> probably exception thrown.
+        fail(error);
+    } finally {
+        done();
+    }
+}

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -45,6 +45,7 @@ import ImportIcon from "../../../react_components/icons/ImportIcon";
 import { getEditViewFrameExports } from "../../js/bloomFrames";
 import PlaybackOrderControls from "../../../react_components/playbackOrderControls";
 import Recordable from "./recordable";
+import { getMd5 } from "./md5Util";
 
 enum Status {
     Disabled, // Can't use button now (e.g., Play when there is no recording)
@@ -67,13 +68,23 @@ export enum AudioRecordingMode {
     TextBox = "TextBox"
 }
 
-// TODO: Replace AudioRecordingMode with this?
+// ENHANCE: Replace AudioRecordingMode with this?
 export enum AudioMode {
     PureSentence, // Record by Sentence, Play by Sentence
     PreTextBox, // Record by TextBox, Play by Sentence. An intermediate stage when transitioning from PureSentence -> PureTextBox
     PureTextBox, // Record by TextBox, Play by TextBox
     HardSplitTextBox, // Version 4.5 only. Record by TextBox, then split into sentences. (Each sentence has own audio file)
     SoftSplitTextBox // Version 4.6+. Record by TextBox, then split into sentences. (The entire text box only has 1 audio file. The timings for where each sentence starts is annotated).
+}
+
+export function getAllAudioModes(): AudioMode[] {
+    return [
+        AudioMode.PureSentence,
+        AudioMode.PreTextBox,
+        AudioMode.PureTextBox,
+        AudioMode.HardSplitTextBox,
+        AudioMode.SoftSplitTextBox
+    ];
 }
 
 const kWebsocketContext = "audio-recording";
@@ -213,7 +224,7 @@ export default class AudioRecording {
             .click(e => this.listenAsync());
         $("#audio-clear")
             .off()
-            .click(e => this.clearRecording());
+            .click(e => this.clearRecordingAsync());
 
         $("#" + kPlaybackOrderClickHandler)
             .off()
@@ -321,30 +332,30 @@ export default class AudioRecording {
             }
         }
 
-        if (
-            this.getPageDocBodyJQuery().find("[data-audiorecordingmode]")
-                .length > 0
-        ) {
-            // For a text box that doesn't already have mode specified, first fallback is to make it the same as another text box on the page that does have it
-            const audioRecordingModeStr: string = this.getPageDocBodyJQuery()
-                .find("[data-audiorecordingmode]")
-                .first()
-                .attr("data-audiorecordingmode");
-
-            const recordingMode = AudioRecording.getAudioRecordingModeFromString(
-                audioRecordingModeStr
+        const pageDocBody = this.getPageDocBody();
+        if (pageDocBody) {
+            const firstWithRecordingMode = pageDocBody.querySelector(
+                "[data-audiorecordingmode]"
             );
-            if (recordingMode != AudioRecordingMode.Unknown) {
-                return recordingMode;
-            }
-        }
+            if (firstWithRecordingMode) {
+                // For a text box that doesn't already have mode specified, first fallback is to make it the same as another text box on the page that does have it
+                const audioRecordingModeStr = firstWithRecordingMode.getAttribute(
+                    "data-audiorecordingmode"
+                );
 
-        if (
-            this.getPageDocBodyJQuery().find("span.audio-sentence").length > 0
-        ) {
-            // This may happen when loading books from 4.3 or earlier that already have text recorded,
-            // and is especially important if the collection default is set to anything other than Sentence.
-            return AudioRecordingMode.Sentence;
+                const recordingMode = AudioRecording.getAudioRecordingModeFromString(
+                    audioRecordingModeStr
+                );
+                if (recordingMode != AudioRecordingMode.Unknown) {
+                    return recordingMode;
+                }
+            }
+
+            if (pageDocBody.querySelector("span.audio-sentence")) {
+                // This may happen when loading books from 4.3 or earlier that already have text recorded,
+                // and is especially important if the collection default is set to anything other than Sentence.
+                return AudioRecordingMode.Sentence;
+            }
         }
 
         // We are not sure what it should be.
@@ -847,7 +858,7 @@ export default class AudioRecording {
         disableHighlightIfNoAudio?: boolean,
         currentElement: Element | null | undefined = undefined // Optional. Provides some minor optimization if set.
     ): Promise<void> {
-        // Note: setHighlightTo() should be run first so that ui-audioCurrent points to the correct element when setSoundFrom() is run.
+        // Note: setHighlightToAsync() should be run first so that ui-audioCurrent points to the correct element when setSoundFrom() is run.
         await this.setHighlightToAsync(
             elementToChangeTo,
             disableHighlightIfNoAudio,
@@ -1059,22 +1070,28 @@ export default class AudioRecording {
     }
 
     private async finishNewRecordingOrImportAsync(): Promise<void> {
-        if (this.audioRecordingMode == AudioRecordingMode.TextBox) {
-            // Reset the audioRecordingTimings.
-            const currentTextBox = this.getCurrentTextBox();
-            if (currentTextBox) {
+        const currentTextBox = this.getCurrentTextBoxSync();
+        if (currentTextBox) {
+            if (this.audioRecordingMode == AudioRecordingMode.TextBox) {
+                // Reset the audioRecordingTimings.
+                //
                 // When ending a recording for a whole text box, we enter the state for Recording=TextBox,Playback=TextBox.
-                // (Previously, it was in Record=TextBox,Play=Sentence.
-                // Being in this intermediate state allows the user to easily switch between Sentence and TextBox without losing their existing sentence recordings.
+                // (Previously, it may have been in Record=TextBox,Play=Sentence if switching from Record by Sentence to Record By Text Box
+                // Being in that intermediate state allows the user to easily switch between Sentence and TextBox without losing their existing sentence recordings.)
                 this.updateMarkupForTextBox(
                     currentTextBox,
+                    AudioRecordingMode.TextBox,
                     AudioRecordingMode.TextBox
                 );
                 await this.resetCurrentAudioElementAsync(currentTextBox);
 
                 currentTextBox.removeAttribute(kEndTimeAttributeName);
             }
+
+            const recordable = new Recordable(currentTextBox);
+            recordable.setChecksum();
         }
+
         this.updatePlayerStatus();
         return this.changeStateAndSetExpectedAsync("play");
     }
@@ -1533,7 +1550,7 @@ export default class AudioRecording {
     }
 
     // Clear the recording for this sentence
-    private clearRecording(): void {
+    public async clearRecordingAsync(): Promise<void> {
         toastr.clear();
 
         if (!this.isEnabledOrExpected("clear")) {
@@ -1556,10 +1573,11 @@ export default class AudioRecording {
         }
 
         // Now go about sending out the API calls to actually delete them.
+        const promisesToAwait: Promise<void>[] = [];
         for (let i = 0; i < elementIdsToDelete.length; ++i) {
             const idToDelete = elementIdsToDelete[i];
 
-            axios
+            const request = axios
                 .post("/bloom/api/audio/deleteSegment?id=" + idToDelete)
                 .then(result => {
                     // data-duration needs to be deleted when the file is deleted.
@@ -1567,7 +1585,7 @@ export default class AudioRecording {
                     // Note: this is not foolproof because the durationchange handler is
                     // being called asynchronously with stale data and sometimes restoring
                     // the deleted attribute.
-                    var current = this.getPageDocBodyJQuery().find(
+                    const current = this.getPageDocBodyJQuery().find(
                         "#" + idToDelete
                     );
                     if (current.length !== 0) {
@@ -1577,11 +1595,22 @@ export default class AudioRecording {
                 .catch(error => {
                     toastr.error(error.statusText);
                 });
+            promisesToAwait.push(request);
         }
 
-        this.clearAudioSplit();
+        // Remove the recording md5(s)
+        const current = this.getCurrentTextBoxSync();
+        if (current) {
+            const recordable = new Recordable(current);
+            recordable.unsetChecksum();
+
+            this.clearAudioSplit();
+        }
+
         this.updatePlayerStatus();
-        this.changeStateAndSetExpectedAsync("record");
+
+        await Promise.all(promisesToAwait);
+        return this.changeStateAndSetExpectedAsync("record");
     }
 
     private doesRecordingExistForCurrentSelection(): boolean {
@@ -1846,6 +1875,7 @@ export default class AudioRecording {
             if (currentTextBox) {
                 this.updateMarkupForTextBox(
                     currentTextBox,
+                    this.audioRecordingMode,
                     AudioRecordingMode.Sentence
                 );
             }
@@ -1866,7 +1896,10 @@ export default class AudioRecording {
 
             const currentTextBox = this.getCurrentTextBox();
             if (currentTextBox) {
-                this.persistRecordingMode(currentTextBox);
+                this.persistRecordingMode(
+                    currentTextBox,
+                    this.audioRecordingMode
+                );
                 await this.setCurrentAudioElementBasedOnRecordingModeAsync(
                     currentTextBox
                 );
@@ -1891,15 +1924,15 @@ export default class AudioRecording {
         }
     }
 
-    public persistRecordingMode(element: Element) {
+    public persistRecordingMode(
+        element: Element,
+        recordingMode: AudioRecordingMode = this.audioRecordingMode
+    ) {
         console.assert(
-            this.audioRecordingMode !== AudioRecordingMode.Unknown,
+            recordingMode !== AudioRecordingMode.Unknown,
             "AudioRecordingMode should not be set to Unknown"
         );
-        element.setAttribute(
-            "data-audiorecordingmode",
-            this.audioRecordingMode
-        );
+        element.setAttribute("data-audiorecordingmode", recordingMode);
 
         // This only set the RECORDING mode. Don't touch the audio-sentence markup, which represents the PLAYBACK mode.
     }
@@ -2083,8 +2116,9 @@ export default class AudioRecording {
             !pageBody ||
             // Tests may not have a value for 'showPlaybackInput'.
             (this.showPlaybackInput && this.showPlaybackInput.checked)
-        )
+        ) {
             return null;
+        }
 
         let audioCurrentElements = pageBody.getElementsByClassName(
             kAudioCurrent
@@ -2092,6 +2126,16 @@ export default class AudioRecording {
 
         if (audioCurrentElements.length === 0) {
             // Oops, ui-audioCurrent not set on anything. Just going to have to stick it onto the first element.
+
+            // ENHANCE: Theoretically, we should await this. (Or at least, the end of the function should await this promise
+            // That means all the callers should be async'ify'd, which is like... everything. :(
+            // But the only asynchronous work done is if you try to fallback by setting the current audio element
+            // Luckily for us, setCurrentAudioElementToFirstAudioElementAsync() does enough work synchronously to allow
+            // the rest of this function to complete without bothering to await the asynchronous work.
+            //
+            // So, I've made two versions of this function.
+            // 1) This original version (that includes the asynchronous fallback)
+            // 2) Also a synchronous (but no fallback) version of this function called getCurrentTextBoxSync()
             this.setCurrentAudioElementToFirstAudioElementAsync();
             audioCurrentElements = pageBody.getElementsByClassName(
                 kAudioCurrent
@@ -2107,6 +2151,34 @@ export default class AudioRecording {
         return <HTMLElement | null>(
             this.getTextBoxOfElement(audioCurrentElements.item(0))
         );
+    }
+
+    // Gets the current text box. If none exists, immediately returns null.
+    public getCurrentTextBoxSync(): HTMLElement | null {
+        // TODO: Refactor the old getCurrentTextBox to something like: getCurrentTextBoxWithFallbackAsync
+        // After that, you can rename this function to getCurrentTextBox
+
+        const pageBody = this.getPageDocBody();
+        if (
+            !pageBody ||
+            // Tests may not have a value for 'showPlaybackInput'.
+            (this.showPlaybackInput && this.showPlaybackInput.checked)
+        ) {
+            return null;
+        }
+
+        const audioCurrentElements = pageBody.getElementsByClassName(
+            kAudioCurrent
+        );
+
+        if (audioCurrentElements.length === 0) {
+            // Oops, ui-audioCurrent not set on anything. Just give up.
+            return null;
+        }
+
+        const currentTextBox = audioCurrentElements.item(0);
+        console.assert(currentTextBox, "CurrentTextBox should not be null");
+        return <HTMLElement>currentTextBox;
     }
 
     // Returns the text box corresponding to this element.
@@ -2198,23 +2270,16 @@ export default class AudioRecording {
     public async setupAndUpdateMarkupAsync(): Promise<void> {
         const recordables = this.getRecordableDivs();
 
-        const asyncTasks: Promise<void>[] = recordables.map(elem => {
-            const playbackMode = this.getPlaybackMode(elem);
-
-            // This method doesn't attempt to modify sentence splits if a recording is already present.
-            // Why? This method is called when you first open a page. Your Bloom version may've updated since then and the sentence splits may now be different.
-            // If the splitting happens differently and the number of sentences changes, it is easily possible to have your now "extra" audio recordings
-            // deleted when you close the book. :(
-            // So we try not to update the sentence splits in this case unless the user does some editing of the text.
-            const preserveSplitsIfRecorded = true;
-
-            return this.tryUpdateMarkupForTextBoxAsync(
-                elem,
-                playbackMode,
-                preserveSplitsIfRecorded
-            );
+        const asyncTasks: Promise<void>[] = recordables.map(async elem => {
+            await new Recordable(elem).setMd5IfMissingAsync();
+            return this.tryUpdateMarkupForTextBoxAsync(elem);
         });
         await Promise.all(asyncTasks);
+
+        // seting the current audio element right now is optional - we could also just wait around
+        // for the first thing that calls getCurrentTextbox.
+        // But let's just do it explicitly instead.
+        await this.resetCurrentAudioElementAsync();
 
         return this.changeStateAndSetExpectedAsync("record");
     }
@@ -2242,17 +2307,10 @@ export default class AudioRecording {
         }
 
         // Now we can carry on with changing the HTML markup with the audio-sentence classes, ids, etc.
-        const playbackMode = this.getCurrentPlaybackMode();
-
         // Because the user has edited the document, any existing recordings are suspect.
         // Although some might still be useful, and some may survive, we think at this point it is more important
         // that the markup is consistent with the current text in preparation for updating the recordings to match.
-        const preserveSplitsIfRecorded = false;
-        await this.tryUpdateMarkupForTextBoxAsync(
-            currentTextBox,
-            playbackMode,
-            preserveSplitsIfRecorded
-        );
+        await this.tryUpdateMarkupForTextBoxAsync(currentTextBox);
 
         // Adjust the current highlight appropriately
         // Regardless of whether it's present, we always need to set the current audio element
@@ -2293,18 +2351,16 @@ export default class AudioRecording {
 
     // Asychronously updates the markup on the specified text box, but only if the operation is currently allowed.
     private async tryUpdateMarkupForTextBoxAsync(
-        textBox: HTMLElement,
-        audioPlaybackMode,
-        preserveSplitsIfRecorded: boolean
+        textBox: HTMLElement
     ): Promise<void> {
         const recordable = new Recordable(textBox);
 
-        const shouldSkipUpdate =
-            preserveSplitsIfRecorded &&
-            (await recordable.areRecordingsPresentAsync());
+        const shouldUpdateMarkup = await recordable.shouldUpdateMarkupAsync();
 
-        if (!shouldSkipUpdate) {
-            this.updateMarkupForTextBox(textBox, audioPlaybackMode);
+        if (shouldUpdateMarkup) {
+            const recordingMode = this.getRecordingModeOfTextBox(textBox);
+            const playbackMode = this.getPlaybackMode(textBox);
+            this.updateMarkupForTextBox(textBox, recordingMode, playbackMode);
         } else {
             // Just keep the code from changing the splits.
             // No notification right now, which I think in many cases would be fine
@@ -2323,9 +2379,14 @@ export default class AudioRecording {
     // Review: possibly 'audioMarkupMode' would be a better name than 'audioPlaybackMode'?
     private updateMarkupForTextBox(
         textBox: HTMLElement,
-        audioPlaybackMode: AudioRecordingMode
+        audioRecordingMode: AudioRecordingMode,
+        audioPlaybackMode
     ): void {
-        this.makeAudioSentenceElements($(textBox), audioPlaybackMode);
+        this.makeAudioSentenceElements(
+            $(textBox),
+            audioRecordingMode,
+            audioPlaybackMode
+        );
     }
 
     private async resetCurrentAudioElementAsync(
@@ -2395,11 +2456,10 @@ export default class AudioRecording {
         }
 
         if (this.audioRecordingMode == AudioRecordingMode.Sentence) {
-            this.setCurrentAudioElementToFirstAudioSentenceWithinElement(
+            return this.setCurrentAudioElementToFirstAudioSentenceWithinElementAsync(
                 element,
                 isEarlyAbortEnabled
             );
-            return;
         }
         console.assert(this.audioRecordingMode == AudioRecordingMode.TextBox);
 
@@ -2431,7 +2491,7 @@ export default class AudioRecording {
         }
     }
 
-    public setCurrentAudioElementToFirstAudioSentenceWithinElement(
+    public async setCurrentAudioElementToFirstAudioSentenceWithinElementAsync(
         element: Element,
         isEarlyAbortEnabled: boolean = false
     ) {
@@ -2476,8 +2536,7 @@ export default class AudioRecording {
         }
 
         if (changeTo) {
-            // ENHANCE: Maybe async/await this
-            this.setSoundAndHighlightAsync(changeTo);
+            await this.setSoundAndHighlightAsync(changeTo);
         }
     }
 
@@ -2584,260 +2643,6 @@ export default class AudioRecording {
         return uuid;
     }
 
-    private md5(message): string {
-        var HEX_CHARS = "0123456789abcdef".split("");
-        var EXTRA = [128, 32768, 8388608, -2147483648];
-        var blocks: number[] = [];
-
-        var h0,
-            h1,
-            h2,
-            h3,
-            a,
-            b,
-            c,
-            d,
-            bc,
-            da,
-            code,
-            first = true,
-            end = false,
-            index = 0,
-            i,
-            start = 0,
-            bytes = 0,
-            length = message.length;
-        blocks[16] = 0;
-        var SHIFT = [0, 8, 16, 24];
-
-        do {
-            blocks[0] = blocks[16];
-            blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] = blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
-            for (i = start; index < length && i < 64; ++index) {
-                code = message.charCodeAt(index);
-                if (code < 0x80) {
-                    blocks[i >> 2] |= code << SHIFT[i++ & 3];
-                } else if (code < 0x800) {
-                    blocks[i >> 2] |= (0xc0 | (code >> 6)) << SHIFT[i++ & 3];
-                    blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
-                } else if (code < 0xd800 || code >= 0xe000) {
-                    blocks[i >> 2] |= (0xe0 | (code >> 12)) << SHIFT[i++ & 3];
-                    blocks[i >> 2] |=
-                        (0x80 | ((code >> 6) & 0x3f)) << SHIFT[i++ & 3];
-                    blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
-                } else {
-                    code =
-                        0x10000 +
-                        (((code & 0x3ff) << 10) |
-                            (message.charCodeAt(++index) & 0x3ff));
-                    blocks[i >> 2] |= (0xf0 | (code >> 18)) << SHIFT[i++ & 3];
-                    blocks[i >> 2] |=
-                        (0x80 | ((code >> 12) & 0x3f)) << SHIFT[i++ & 3];
-                    blocks[i >> 2] |=
-                        (0x80 | ((code >> 6) & 0x3f)) << SHIFT[i++ & 3];
-                    blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
-                }
-            }
-            bytes += i - start;
-            start = i - 64;
-            if (index == length) {
-                blocks[i >> 2] |= EXTRA[i & 3];
-                ++index;
-            }
-            if (index > length && i < 56) {
-                blocks[14] = bytes << 3;
-                end = true;
-            }
-
-            if (first) {
-                a = blocks[0] - 680876937;
-                a = (((a << 7) | (a >>> 25)) - 271733879) << 0;
-                d = (-1732584194 ^ (a & 2004318071)) + blocks[1] - 117830708;
-                d = (((d << 12) | (d >>> 20)) + a) << 0;
-                c =
-                    (-271733879 ^ (d & (a ^ -271733879))) +
-                    blocks[2] -
-                    1126478375;
-                c = (((c << 17) | (c >>> 15)) + d) << 0;
-                b = (a ^ (c & (d ^ a))) + blocks[3] - 1316259209;
-                b = (((b << 22) | (b >>> 10)) + c) << 0;
-            } else {
-                a = h0;
-                b = h1;
-                c = h2;
-                d = h3;
-                a += (d ^ (b & (c ^ d))) + blocks[0] - 680876936;
-                a = (((a << 7) | (a >>> 25)) + b) << 0;
-                d += (c ^ (a & (b ^ c))) + blocks[1] - 389564586;
-                d = (((d << 12) | (d >>> 20)) + a) << 0;
-                c += (b ^ (d & (a ^ b))) + blocks[2] + 606105819;
-                c = (((c << 17) | (c >>> 15)) + d) << 0;
-                b += (a ^ (c & (d ^ a))) + blocks[3] - 1044525330;
-                b = (((b << 22) | (b >>> 10)) + c) << 0;
-            }
-
-            a += (d ^ (b & (c ^ d))) + blocks[4] - 176418897;
-            a = (((a << 7) | (a >>> 25)) + b) << 0;
-            d += (c ^ (a & (b ^ c))) + blocks[5] + 1200080426;
-            d = (((d << 12) | (d >>> 20)) + a) << 0;
-            c += (b ^ (d & (a ^ b))) + blocks[6] - 1473231341;
-            c = (((c << 17) | (c >>> 15)) + d) << 0;
-            b += (a ^ (c & (d ^ a))) + blocks[7] - 45705983;
-            b = (((b << 22) | (b >>> 10)) + c) << 0;
-            a += (d ^ (b & (c ^ d))) + blocks[8] + 1770035416;
-            a = (((a << 7) | (a >>> 25)) + b) << 0;
-            d += (c ^ (a & (b ^ c))) + blocks[9] - 1958414417;
-            d = (((d << 12) | (d >>> 20)) + a) << 0;
-            c += (b ^ (d & (a ^ b))) + blocks[10] - 42063;
-            c = (((c << 17) | (c >>> 15)) + d) << 0;
-            b += (a ^ (c & (d ^ a))) + blocks[11] - 1990404162;
-            b = (((b << 22) | (b >>> 10)) + c) << 0;
-            a += (d ^ (b & (c ^ d))) + blocks[12] + 1804603682;
-            a = (((a << 7) | (a >>> 25)) + b) << 0;
-            d += (c ^ (a & (b ^ c))) + blocks[13] - 40341101;
-            d = (((d << 12) | (d >>> 20)) + a) << 0;
-            c += (b ^ (d & (a ^ b))) + blocks[14] - 1502002290;
-            c = (((c << 17) | (c >>> 15)) + d) << 0;
-            b += (a ^ (c & (d ^ a))) + blocks[15] + 1236535329;
-            b = (((b << 22) | (b >>> 10)) + c) << 0;
-            a += (c ^ (d & (b ^ c))) + blocks[1] - 165796510;
-            a = (((a << 5) | (a >>> 27)) + b) << 0;
-            d += (b ^ (c & (a ^ b))) + blocks[6] - 1069501632;
-            d = (((d << 9) | (d >>> 23)) + a) << 0;
-            c += (a ^ (b & (d ^ a))) + blocks[11] + 643717713;
-            c = (((c << 14) | (c >>> 18)) + d) << 0;
-            b += (d ^ (a & (c ^ d))) + blocks[0] - 373897302;
-            b = (((b << 20) | (b >>> 12)) + c) << 0;
-            a += (c ^ (d & (b ^ c))) + blocks[5] - 701558691;
-            a = (((a << 5) | (a >>> 27)) + b) << 0;
-            d += (b ^ (c & (a ^ b))) + blocks[10] + 38016083;
-            d = (((d << 9) | (d >>> 23)) + a) << 0;
-            c += (a ^ (b & (d ^ a))) + blocks[15] - 660478335;
-            c = (((c << 14) | (c >>> 18)) + d) << 0;
-            b += (d ^ (a & (c ^ d))) + blocks[4] - 405537848;
-            b = (((b << 20) | (b >>> 12)) + c) << 0;
-            a += (c ^ (d & (b ^ c))) + blocks[9] + 568446438;
-            a = (((a << 5) | (a >>> 27)) + b) << 0;
-            d += (b ^ (c & (a ^ b))) + blocks[14] - 1019803690;
-            d = (((d << 9) | (d >>> 23)) + a) << 0;
-            c += (a ^ (b & (d ^ a))) + blocks[3] - 187363961;
-            c = (((c << 14) | (c >>> 18)) + d) << 0;
-            b += (d ^ (a & (c ^ d))) + blocks[8] + 1163531501;
-            b = (((b << 20) | (b >>> 12)) + c) << 0;
-            a += (c ^ (d & (b ^ c))) + blocks[13] - 1444681467;
-            a = (((a << 5) | (a >>> 27)) + b) << 0;
-            d += (b ^ (c & (a ^ b))) + blocks[2] - 51403784;
-            d = (((d << 9) | (d >>> 23)) + a) << 0;
-            c += (a ^ (b & (d ^ a))) + blocks[7] + 1735328473;
-            c = (((c << 14) | (c >>> 18)) + d) << 0;
-            b += (d ^ (a & (c ^ d))) + blocks[12] - 1926607734;
-            b = (((b << 20) | (b >>> 12)) + c) << 0;
-            bc = b ^ c;
-            a += (bc ^ d) + blocks[5] - 378558;
-            a = (((a << 4) | (a >>> 28)) + b) << 0;
-            d += (bc ^ a) + blocks[8] - 2022574463;
-            d = (((d << 11) | (d >>> 21)) + a) << 0;
-            da = d ^ a;
-            c += (da ^ b) + blocks[11] + 1839030562;
-            c = (((c << 16) | (c >>> 16)) + d) << 0;
-            b += (da ^ c) + blocks[14] - 35309556;
-            b = (((b << 23) | (b >>> 9)) + c) << 0;
-            bc = b ^ c;
-            a += (bc ^ d) + blocks[1] - 1530992060;
-            a = (((a << 4) | (a >>> 28)) + b) << 0;
-            d += (bc ^ a) + blocks[4] + 1272893353;
-            d = (((d << 11) | (d >>> 21)) + a) << 0;
-            da = d ^ a;
-            c += (da ^ b) + blocks[7] - 155497632;
-            c = (((c << 16) | (c >>> 16)) + d) << 0;
-            b += (da ^ c) + blocks[10] - 1094730640;
-            b = (((b << 23) | (b >>> 9)) + c) << 0;
-            bc = b ^ c;
-            a += (bc ^ d) + blocks[13] + 681279174;
-            a = (((a << 4) | (a >>> 28)) + b) << 0;
-            d += (bc ^ a) + blocks[0] - 358537222;
-            d = (((d << 11) | (d >>> 21)) + a) << 0;
-            da = d ^ a;
-            c += (da ^ b) + blocks[3] - 722521979;
-            c = (((c << 16) | (c >>> 16)) + d) << 0;
-            b += (da ^ c) + blocks[6] + 76029189;
-            b = (((b << 23) | (b >>> 9)) + c) << 0;
-            bc = b ^ c;
-            a += (bc ^ d) + blocks[9] - 640364487;
-            a = (((a << 4) | (a >>> 28)) + b) << 0;
-            d += (bc ^ a) + blocks[12] - 421815835;
-            d = (((d << 11) | (d >>> 21)) + a) << 0;
-            da = d ^ a;
-            c += (da ^ b) + blocks[15] + 530742520;
-            c = (((c << 16) | (c >>> 16)) + d) << 0;
-            b += (da ^ c) + blocks[2] - 995338651;
-            b = (((b << 23) | (b >>> 9)) + c) << 0;
-            a += (c ^ (b | ~d)) + blocks[0] - 198630844;
-            a = (((a << 6) | (a >>> 26)) + b) << 0;
-            d += (b ^ (a | ~c)) + blocks[7] + 1126891415;
-            d = (((d << 10) | (d >>> 22)) + a) << 0;
-            c += (a ^ (d | ~b)) + blocks[14] - 1416354905;
-            c = (((c << 15) | (c >>> 17)) + d) << 0;
-            b += (d ^ (c | ~a)) + blocks[5] - 57434055;
-            b = (((b << 21) | (b >>> 11)) + c) << 0;
-            a += (c ^ (b | ~d)) + blocks[12] + 1700485571;
-            a = (((a << 6) | (a >>> 26)) + b) << 0;
-            d += (b ^ (a | ~c)) + blocks[3] - 1894986606;
-            d = (((d << 10) | (d >>> 22)) + a) << 0;
-            c += (a ^ (d | ~b)) + blocks[10] - 1051523;
-            c = (((c << 15) | (c >>> 17)) + d) << 0;
-            b += (d ^ (c | ~a)) + blocks[1] - 2054922799;
-            b = (((b << 21) | (b >>> 11)) + c) << 0;
-            a += (c ^ (b | ~d)) + blocks[8] + 1873313359;
-            a = (((a << 6) | (a >>> 26)) + b) << 0;
-            d += (b ^ (a | ~c)) + blocks[15] - 30611744;
-            d = (((d << 10) | (d >>> 22)) + a) << 0;
-            c += (a ^ (d | ~b)) + blocks[6] - 1560198380;
-            c = (((c << 15) | (c >>> 17)) + d) << 0;
-            b += (d ^ (c | ~a)) + blocks[13] + 1309151649;
-            b = (((b << 21) | (b >>> 11)) + c) << 0;
-            a += (c ^ (b | ~d)) + blocks[4] - 145523070;
-            a = (((a << 6) | (a >>> 26)) + b) << 0;
-            d += (b ^ (a | ~c)) + blocks[11] - 1120210379;
-            d = (((d << 10) | (d >>> 22)) + a) << 0;
-            c += (a ^ (d | ~b)) + blocks[2] + 718787259;
-            c = (((c << 15) | (c >>> 17)) + d) << 0;
-            b += (d ^ (c | ~a)) + blocks[9] - 343485551;
-            b = (((b << 21) | (b >>> 11)) + c) << 0;
-
-            if (first) {
-                h0 = (a + 1732584193) << 0;
-                h1 = (b - 271733879) << 0;
-                h2 = (c - 1732584194) << 0;
-                h3 = (d + 271733878) << 0;
-                first = false;
-            } else {
-                h0 = (h0 + a) << 0;
-                h1 = (h1 + b) << 0;
-                h2 = (h2 + c) << 0;
-                h3 = (h3 + d) << 0;
-            }
-        } while (!end);
-
-        var hex = HEX_CHARS[(h0 >> 4) & 0x0f] + HEX_CHARS[h0 & 0x0f];
-        hex += HEX_CHARS[(h0 >> 12) & 0x0f] + HEX_CHARS[(h0 >> 8) & 0x0f];
-        hex += HEX_CHARS[(h0 >> 20) & 0x0f] + HEX_CHARS[(h0 >> 16) & 0x0f];
-        hex += HEX_CHARS[(h0 >> 28) & 0x0f] + HEX_CHARS[(h0 >> 24) & 0x0f];
-        hex += HEX_CHARS[(h1 >> 4) & 0x0f] + HEX_CHARS[h1 & 0x0f];
-        hex += HEX_CHARS[(h1 >> 12) & 0x0f] + HEX_CHARS[(h1 >> 8) & 0x0f];
-        hex += HEX_CHARS[(h1 >> 20) & 0x0f] + HEX_CHARS[(h1 >> 16) & 0x0f];
-        hex += HEX_CHARS[(h1 >> 28) & 0x0f] + HEX_CHARS[(h1 >> 24) & 0x0f];
-        hex += HEX_CHARS[(h2 >> 4) & 0x0f] + HEX_CHARS[h2 & 0x0f];
-        hex += HEX_CHARS[(h2 >> 12) & 0x0f] + HEX_CHARS[(h2 >> 8) & 0x0f];
-        hex += HEX_CHARS[(h2 >> 20) & 0x0f] + HEX_CHARS[(h2 >> 16) & 0x0f];
-        hex += HEX_CHARS[(h2 >> 28) & 0x0f] + HEX_CHARS[(h2 >> 24) & 0x0f];
-        hex += HEX_CHARS[(h3 >> 4) & 0x0f] + HEX_CHARS[h3 & 0x0f];
-        hex += HEX_CHARS[(h3 >> 12) & 0x0f] + HEX_CHARS[(h3 >> 8) & 0x0f];
-        hex += HEX_CHARS[(h3 >> 20) & 0x0f] + HEX_CHARS[(h3 >> 16) & 0x0f];
-        hex += HEX_CHARS[(h3 >> 28) & 0x0f] + HEX_CHARS[(h3 >> 24) & 0x0f];
-        return hex;
-    }
-
     // AudioRecordingMode=Sentence: We want to make out of each sentence in root a span which has a unique ID.
     // AudioRecordingMode=TextBox: We want to turn the bloom-editable text box into the unit which will be
     // recorded. (It needs a unique ID too). No spans will be created though.
@@ -2849,6 +2654,7 @@ export default class AudioRecording {
     // in a root (possibly the root itself, if it has no children).
     public makeAudioSentenceElements(
         rootElementList: JQuery,
+        audioRecordingMode: AudioRecordingMode,
         audioPlaybackMode: AudioRecordingMode = this.audioRecordingMode
     ): void {
         // Preconditions:
@@ -2862,7 +2668,7 @@ export default class AudioRecording {
         rootElementList.each((index: number, root: Element) => {
             if (audioPlaybackMode == AudioRecordingMode.Sentence) {
                 if (this.isRootRecordableDiv(root)) {
-                    this.persistRecordingMode(root);
+                    this.persistRecordingMode(root, audioRecordingMode);
 
                     // Cleanup markup from AudioRecordingMode=TextBox
                     root.classList.remove(kAudioSentence);
@@ -2871,7 +2677,7 @@ export default class AudioRecording {
                 // Note: Includes cases where you are in Soft Split mode. (You will return without running makeAudioSentenceElementsLeaf()
                 if (this.isRootRecordableDiv(root)) {
                     // Save the RECORDING (not the playback) setting  used, so we can load it properly later
-                    this.persistRecordingMode(root);
+                    this.persistRecordingMode(root, audioRecordingMode);
 
                     // Cleanup markup from AudioRecordingMode=Sentence
                     $(root)
@@ -2919,6 +2725,7 @@ export default class AudioRecording {
                     $(child).replaceWith($(child).html()); // clean up.
                     this.makeAudioSentenceElements(
                         rootElementList,
+                        audioRecordingMode,
                         audioPlaybackMode
                     ); // start over.
                     return;
@@ -2940,7 +2747,11 @@ export default class AudioRecording {
                     $(child).attr("id") !== "formatButton"
                 ) {
                     processedChild = true;
-                    this.makeAudioSentenceElements($(child), audioPlaybackMode);
+                    this.makeAudioSentenceElements(
+                        $(child),
+                        audioRecordingMode,
+                        audioPlaybackMode
+                    );
                 }
             }
 
@@ -3007,7 +2818,7 @@ export default class AudioRecording {
         for (let i = 0; i < htmlFragments.length; i++) {
             const fragment = htmlFragments[i];
             if (this.isRecordable(fragment)) {
-                const currentMd5 = this.md5(fragment.text);
+                const currentMd5 = getMd5(fragment.text);
                 for (let j = 0; j < reuse.length; j++) {
                     if (currentMd5 === reuse[j].md5) {
                         // It's convenient here (very locally) to add a field to fragment which is not part
@@ -3473,7 +3284,7 @@ export default class AudioRecording {
         }
     }
 
-    private setEnabledOrExpecting(verb: string, expectedVerb: string) {
+    public setEnabledOrExpecting(verb: string, expectedVerb: string) {
         if (expectedVerb == verb) this.setStatus(verb, Status.Expected);
         else this.setStatus(verb, Status.Enabled);
     }
@@ -3801,7 +3612,7 @@ export default class AudioRecording {
         const isSuccess = result && result.data;
 
         if (isSuccess) {
-            // Now that we know the Auto Segmentation succeeded, finally convert into by-sentence mode.
+            // Now that we know the Auto Segmentation succeeded, finally update the markup
             const allEndTimesString: string = result.data;
             const currentTextBox = this.getCurrentTextBox();
             if (currentTextBox) {
@@ -3816,6 +3627,7 @@ export default class AudioRecording {
                 // Note that this will want to use the sentenceToIdListMap member variable to inform it to re-use the IDs used to create the split audio files
                 this.updateMarkupForTextBox(
                     currentTextBox,
+                    this.audioRecordingMode,
                     AudioRecordingMode.Sentence
                 );
             }
@@ -3874,6 +3686,7 @@ export default class AudioRecording {
         const currentTextBox = this.getCurrentTextBox();
         if (currentTextBox) {
             currentTextBox.classList.remove("bloom-postAudioSplit");
+            currentTextBox.removeAttribute("data-audioRecordingEndTimes");
         }
     }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -1850,7 +1850,7 @@ export function SetupTalkingBookUIElements() {
     document.body.firstElementChild!.insertAdjacentHTML("afterend", html);
 }
 
-function StripPlayerSrcNoCacheSuffix(url: string): string {
+export function StripPlayerSrcNoCacheSuffix(url: string): string {
     const index = url.lastIndexOf("&");
     if (index < 0) {
         return url;

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -1,8 +1,11 @@
 import AudioRecording, {
     AudioRecordingMode,
     AudioTextFragment,
-    initializeTalkingBookToolAsync
+    initializeTalkingBookToolAsync,
+    AudioMode,
+    getAllAudioModes
 } from "./audioRecording";
+import { runAsyncTest } from "../../test/testUtil";
 import axios from "axios";
 
 // Notes:
@@ -22,6 +25,24 @@ describe("audio recording tests", () => {
         await initializeTalkingBookToolAsync();
         done();
     });
+
+    // Returns the HTML for a single text box for a variety of recording modes
+    function getTextBoxHtmlSimple1(scenario: AudioMode) {
+        if (scenario === AudioMode.PureSentence) {
+            return `<div class="bloom-editable" id="div1" data-audioRecordingMode="Sentence"><p><span id="1.1" class="audio-sentence ui-audioCurrent">Sentence 1.1.</span> <span id="1.2" class="audio-sentence">Sentence 1.2</span></p></div>`;
+        } else if (scenario === AudioMode.PreTextBox) {
+            return `<div class="bloom-editable ui-audioCurrent" id="div1" data-audioRecordingMode="TextBox"><p><span id="1.1" class="audio-sentence">Sentence 1.1.</span> <span id="1.2" class="audio-sentence">Sentence 1.2</span></p></div>`;
+        } else if (scenario === AudioMode.PureTextBox) {
+            return `<div class="bloom-editable audio-sentence ui-audioCurrent" id="div1" data-audioRecordingMode="TextBox"><p>Sentence 1.1. Sentence 1.2</p></div>`;
+        } else if (scenario === AudioMode.HardSplitTextBox) {
+            // FYI: Yes, it is confirmed that in hardSplit, ui-audioCurrent goes on the div, not the span.
+            return `<div class="bloom-editable ui-audioCurrent bloom-postAudioSplit" id="div1" data-audioRecordingMode="TextBox"><p><span id="1.1" class="audio-sentence">Sentence 1.1.</span> <span id="1.2" class="audio-sentence">Sentence 1.2</span></p></div>`;
+        } else if (scenario === AudioMode.SoftSplitTextBox) {
+            return `<div class="bloom-editable audio-sentence ui-audioCurrent bloom-postAudioSplit" id="div1" data-audioRecordingMode="TextBox" data-audiorecordingendtimes="1.0 2.0"><p><span id="1.1" class="bloom-highlightSegment">Sentence 1.1.</span> <span id="1.2" class="bloom-highlightSegment">Sentence 1.2</span></p></div>`;
+        } else {
+            throw new Error("Unknown scenario: " + AudioMode[scenario]);
+        }
+    }
 
     describe("- Next()", () => {
         it("Record=Sentence, last sentence returns disabled for Next button", () => {
@@ -269,7 +290,10 @@ describe("audio recording tests", () => {
         it("inserts sentence spans with ids and class when none exist", () => {
             const div = $("<div>This is a sentence. This is another</div>");
             const recording = new AudioRecording();
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
             const spans = div.find("span");
             expect(spans.length).toBe(2);
             expect(spans[0].innerHTML).toBe("This is a sentence.");
@@ -289,7 +313,10 @@ describe("audio recording tests", () => {
                 '<div><p><span id="abc" recordingmd5="d15ba5f31fa7c797c093931328581664" class="audio-sentence">This is a sentence.</span> This is another</p></div>'
             );
             const recording = new AudioRecording();
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
             const spans = div.find("span");
             expect(spans.length).toBe(2);
             expect(spans[0].innerHTML).toBe("This is a sentence.");
@@ -313,7 +340,10 @@ describe("audio recording tests", () => {
                 '<div><p><span id="abc" class="audio-sentence">This <b>is</b> a sentence.</span> This <i>is</i> another</p></div>'
             );
             const recording = new AudioRecording();
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
             const spans = div.find("span");
             expect(spans.length).toBe(2);
             expect(spans[0].innerHTML).toBe("This <b>is</b> a sentence.");
@@ -324,7 +354,10 @@ describe("audio recording tests", () => {
                 '<div><p>This is a new sentence. <span id="abc" recordingmd5="d15ba5f31fa7c797c093931328581664" class="audio-sentence">This is a sentence.</span></p></div>'
             );
             const recording = new AudioRecording();
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
             const spans = div.find("span");
             expect(spans.length).toBe(2);
             expect(spans[0].innerHTML).toBe("This is a new sentence.");
@@ -358,7 +391,10 @@ describe("audio recording tests", () => {
                 '<div><p><span id="abcd" recordingmd5="qed" class="audio-sentence">This is the first sentence.</span> This is inserted. <span id="abc" recordingmd5="d15ba5f31fa7c797c093931328581664" class="audio-sentence">This is a sentence.</span> Inserted after.</p></div>'
             );
             const recording = new AudioRecording();
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
             const spans = div.find("span");
             expect(spans.length).toBe(4);
             expect(spans[0].innerHTML).toBe("This is the first sentence.");
@@ -433,7 +469,10 @@ describe("audio recording tests", () => {
                 '<div><p>This is the first sentence.<span data-cke-bookmark="1" style="display: none;" id="cke_bm_35C"> </span></p></div>'
             );
             const recording = new AudioRecording();
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
             const spans = div.find("span");
             expect(spans.length).toBe(2);
             expect(spans[0].innerHTML).toBe("This is the first sentence.");
@@ -448,7 +487,7 @@ describe("audio recording tests", () => {
                 '<p><span data-cke-bookmark="1" style="display: none;" id="cke_bm_35C">&nbsp;</span><br></p>'
             );
             const recording = new AudioRecording();
-            recording.makeAudioSentenceElements(p);
+            recording.makeAudioSentenceElements(p, AudioRecordingMode.Sentence);
             const spans = p.find("span");
             expect(spans.length).toBe(1);
             expect(spans[0].innerHTML).toBe("&nbsp;");
@@ -460,7 +499,7 @@ describe("audio recording tests", () => {
                 '<p><span id="efgh" recordingmd5="xyz" class="audio-sentence"><span id="abcd" recordingmd5="qed" class="audio-sentence">This is the first.</span> <span id="abde" recordingmd5="qef" class="audio-sentence">This is the second.</span> This is the third.</span></p>'
             );
             const recording = new AudioRecording();
-            recording.makeAudioSentenceElements(p);
+            recording.makeAudioSentenceElements(p, AudioRecordingMode.Sentence);
             const spans = p.find("span");
             // Should have removed the outer span and left the two inner ones and added a third one.
             expect(spans.length).toBe(3);
@@ -497,7 +536,7 @@ describe("audio recording tests", () => {
             );
             const recording = new AudioRecording();
             recording.audioRecordingMode = AudioRecordingMode.Sentence;
-            recording.makeAudioSentenceElements(p);
+            recording.makeAudioSentenceElements(p, AudioRecordingMode.Sentence);
             const spans = p.find("span");
             // Should have removed the outer span and left the two inner ones and added a third one.
             expect(spans.length).toBe(3); // If regresses, it would probably show twice as many (i.e. 6) instead of 3.
@@ -509,7 +548,7 @@ describe("audio recording tests", () => {
                 '<p>Random text <strong><span data-duration="9.400227" id="abcd" class="audio-sentence" recordingmd5="undefined"><u>underlined</u></span></strong> finish the sentence. Another sentence <u><strong>boldunderlined</strong></u> finish the second.</p>'
             );
             const recording = new AudioRecording();
-            recording.makeAudioSentenceElements(p);
+            recording.makeAudioSentenceElements(p, AudioRecordingMode.Sentence);
             const spans = p.find("span");
             // Should have expanded the first span and created one for the second sentence.
             expect(spans.length).toBe(2);
@@ -536,7 +575,10 @@ describe("audio recording tests", () => {
             const sentence3 = "Click them.";
             const div = $(`<div>${sentence1} ${sentence2} ${sentence3}</div>`);
             const recording = new AudioRecording();
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
             const spans = div.find("span");
             expect(spans.length).toBe(3);
             expect(spans[0].innerHTML).toBe(sentence1); // Make sure the anchor is not lost in the HTML
@@ -570,7 +612,10 @@ describe("audio recording tests", () => {
             const div = $(originalHtml);
             const recording = new AudioRecording();
             recording.audioRecordingMode = AudioRecordingMode.TextBox;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.TextBox
+            );
 
             expect(div.text()).toBe(
                 "Paragraph 1 Sentence 1. Paragraph 1, Sentence 2. Paragraph 2, Sentence 1. Paragraph 2, Sentence 2.",
@@ -643,7 +688,10 @@ describe("audio recording tests", () => {
             );
 
             recording.audioRecordingMode = AudioRecordingMode.Sentence;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
             expect(div.text).toBe($(originalHtml).text, "Swap back test");
             // Note: It is not expected that going to by-sentence to here will lead back the original HTML structure. (Because we started with unmarked text, not by-sentence)
         });
@@ -662,7 +710,10 @@ describe("audio recording tests", () => {
             const div = $(originalHtml);
             const recording = new AudioRecording();
             recording.audioRecordingMode = AudioRecordingMode.TextBox;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.TextBox
+            );
 
             expect(div.text()).toBe("Hello world", "div text");
 
@@ -718,7 +769,10 @@ describe("audio recording tests", () => {
             );
 
             recording.audioRecordingMode = AudioRecordingMode.Sentence;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
             expect(div.text).toBe($(originalHtml).text, "Swap back test");
             // Note: It is not expected that going to by-sentence to here will lead back the original HTML structure. (Because we started with unmarked text, not by-sentence)
         });
@@ -737,7 +791,10 @@ describe("audio recording tests", () => {
             const div = $(originalHtml);
             const recording = new AudioRecording();
             recording.audioRecordingMode = AudioRecordingMode.TextBox;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.TextBox
+            );
 
             expect(div.text()).toBe("Hello world", "div text");
 
@@ -785,7 +842,10 @@ describe("audio recording tests", () => {
             );
 
             recording.audioRecordingMode = AudioRecordingMode.Sentence;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
             expect(div.text).toBe($(originalHtml).text, "Swap back test");
             // Note: It is not expected that going to by-sentence to here will lead back the original HTML structure. (Because we started with unmarked text, not by-sentence)
         });
@@ -796,7 +856,10 @@ describe("audio recording tests", () => {
             const div = $(originalHtml);
             const recording = new AudioRecording();
             recording.audioRecordingMode = AudioRecordingMode.Sentence; // Should be the new mode
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
 
             const parent = $("<div>")
                 .append(div)
@@ -831,7 +894,10 @@ describe("audio recording tests", () => {
 
             const recording = new AudioRecording();
             recording.audioRecordingMode = AudioRecordingMode.TextBox;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.TextBox
+            );
 
             let parent = $("<div>")
                 .append(div)
@@ -887,7 +953,10 @@ describe("audio recording tests", () => {
             );
 
             recording.audioRecordingMode = AudioRecordingMode.Sentence;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
             parent = $("<div>")
                 .append(div)
                 .clone();
@@ -917,7 +986,10 @@ describe("audio recording tests", () => {
 
             let recording = new AudioRecording();
             recording.audioRecordingMode = AudioRecordingMode.Sentence;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.Sentence
+            );
 
             expect(div.text()).toBe(
                 "Sentence 1. Sentence 2. Sentence 3.Paragraph 2.",
@@ -980,7 +1052,10 @@ describe("audio recording tests", () => {
             // Test that you can switch back and recover more-or-less the original
             recording = new AudioRecording();
             recording.audioRecordingMode = AudioRecordingMode.TextBox;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.TextBox
+            );
             parentDiv = $("<div>")
                 .append(div)
                 .clone();
@@ -1008,7 +1083,10 @@ describe("audio recording tests", () => {
 
             const recording = new AudioRecording();
             recording.audioRecordingMode = AudioRecordingMode.TextBox;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.TextBox
+            );
 
             const parent = $("<div>")
                 .append(div)
@@ -1028,7 +1106,10 @@ describe("audio recording tests", () => {
             const div = $(originalHtml);
             const recording = new AudioRecording();
             recording.audioRecordingMode = AudioRecordingMode.TextBox;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.TextBox
+            );
 
             expect(div.text()).toBe(
                 "Paragraph 1A. Paragraph 1B.Paragraph 2A. Paragraph 2B.",
@@ -1066,7 +1147,10 @@ describe("audio recording tests", () => {
             const div = $(originalHtml);
             const recording = new AudioRecording();
             recording.audioRecordingMode = AudioRecordingMode.TextBox;
-            recording.makeAudioSentenceElements(div);
+            recording.makeAudioSentenceElements(
+                div,
+                AudioRecordingMode.TextBox
+            );
 
             const parent = $("<div>")
                 .append(div)
@@ -1135,7 +1219,7 @@ describe("audio recording tests", () => {
 
             const expectedDiv2Result =
                 '<div class="bloom-editable ui-audioCurrent audio-sentence" id="div2" data-audiorecordingmode="TextBox"><p>Sentence 2.1. Sentence 2.2.</p></div>';
-            expect(div2.outerHTML).toBe(
+            expect(StripRecordingMd5(div2.outerHTML)).toBe(
                 expectedDiv2Result,
                 "Div2 HTML should switch to textbox mode"
             );
@@ -1390,6 +1474,253 @@ describe("audio recording tests", () => {
 
             done();
         });
+    });
+
+    describe("endRecordCurrentAsync", () => {
+        function setupMockRecording() {
+            // Make all the startRecord and endRecord post calls "succeed".
+            spyOn(axios, "post").and.returnValue(Promise.resolve());
+        }
+
+        function setupTest(checksumSetting: string, scenario: AudioMode) {
+            const divHtml = getTextBoxHtmlSimple1(scenario);
+            SetupIFrameFromHtml(`<div id="page1">${divHtml}</div>`);
+
+            if (checksumSetting === "missing") {
+                // No need to do anything
+                //
+                // But let's double-check that the test is setup correctly.
+                const spans = [
+                    getFrameElementById("page", "1.1"),
+                    getFrameElementById("page", "1.2")
+                ];
+
+                spans.forEach(span => {
+                    // Span may be null in PureTextBox scenario
+                    if (span) {
+                        const md5 = span.getAttribute("recordingmd5");
+                        expect(!md5 || md5 === "undefined").toBe(
+                            true,
+                            "Test setup failure: recordingmd5 is not missing."
+                        );
+                    }
+                });
+            } else if (checksumSetting === "outOfDate") {
+                const div = getFrameElementById("page", "div1")!;
+                div.setAttribute("recordingmd5", "wrongMD5");
+            } else {
+                throw new Error(
+                    "Unrecognized checksumSetting: " + checksumSetting
+                );
+            }
+        }
+
+        async function runEndRecordSetsMd5TestsAsync(
+            md5Setting: string,
+            scenario: AudioMode
+        ) {
+            // Setup
+            setupTest(md5Setting, scenario);
+            setupMockRecording();
+
+            // StartRecording doesn't do anything unless Record button is enabled.
+            // So set it up into enabled state.
+            const recording = new AudioRecording();
+            if (scenario === AudioMode.PureSentence) {
+                recording.audioRecordingMode = AudioRecordingMode.Sentence;
+            } else {
+                recording.audioRecordingMode = AudioRecordingMode.TextBox;
+            }
+
+            recording.setEnabledOrExpecting("record", "record");
+
+            // Need to start recording because endRecord() doesn't do anything if a recording hasn't been started.
+            await recording.startRecordCurrentAsync();
+
+            // System under test
+            await recording.endRecordCurrentAsync();
+
+            // Verification
+            if (scenario === AudioMode.PureSentence) {
+                // Only PureSentence should set a sentence-level MD5.
+                // All the other ones shoudl set a text-box level MD5.
+                const span1 = getFrameElementById("page", "1.1") as HTMLElement;
+                // This md5 is for "Sentence 1.1."
+                expect(span1).toHaveAttr(
+                    "recordingmd5",
+                    "7b07751111f5c613158db809b20a1aad"
+                );
+
+                // Only the current one should've been updated. span2's should stay its original value
+                const span2 = getFrameElementById("page", "1.2") as HTMLElement;
+                expect(span2).not.toHaveAttr("recordingmd5");
+            } else {
+                const div = getFrameElementById("page", "div1") as HTMLElement;
+
+                // This md5 is for "Sentence 1.1. Sentence 1.2"
+                expect(div).toHaveAttr(
+                    "recordingmd5",
+                    "134edfa2be336e3ff596f013b0cbe16b"
+                );
+            }
+        }
+
+        const md5Settings = ["missing", "outOfDate"];
+        md5Settings.forEach(md5Setting => {
+            getAllAudioModes().forEach(scenario => {
+                const scenarioName = AudioMode[scenario];
+                it(`recording updates the md5 (md5=${md5Setting}, scenario=${scenarioName})`, async () => {
+                    await runEndRecordSetsMd5TestsAsync(md5Setting, scenario);
+                });
+            });
+        });
+    });
+
+    describe("clearRecording", () => {
+        function setupClearRecordingTest(
+            scenario: AudioMode = AudioMode.PureSentence
+        ) {
+            const divHtml = getTextBoxHtmlSimple1(scenario);
+            SetupIFrameFromHtml(`<div id="page1">${divHtml}</div>`);
+
+            addRecordingChecksums(scenario);
+
+            const clearButton = document.getElementById("audio-clear")!;
+            clearButton.classList.add("enabled");
+        }
+
+        function addRecordingChecksums(scenario: AudioMode) {
+            const audioSentenceIds =
+                scenario === AudioMode.PureTextBox ||
+                scenario === AudioMode.SoftSplitTextBox
+                    ? ["div1"]
+                    : ["1.1", "1.2"];
+
+            audioSentenceIds.forEach(id => {
+                const elem = getFrameElementById("page", id)!;
+                elem.setAttribute("recordingmd5", "fakeMd5");
+            });
+        }
+
+        const runClearRecordingAsync = async scenario => {
+            const recording = new AudioRecording();
+            if (scenario === AudioMode.PureSentence) {
+                recording.audioRecordingMode = AudioRecordingMode.Sentence;
+            } else {
+                recording.audioRecordingMode = AudioRecordingMode.TextBox;
+            }
+            await recording.clearRecordingAsync();
+        };
+
+        getAllAudioModes().forEach(scenario => {
+            const scenarioName = AudioMode[scenario];
+            it(`clearRecording() removes recordingmd5 (scenario=${scenarioName}`, async () => {
+                await runClearRecordingMd5TestAsync(scenario);
+            });
+        });
+
+        async function runClearRecordingMd5TestAsync(scenario: AudioMode) {
+            setupClearRecordingTest(scenario);
+            await runClearRecordingAsync(scenario);
+
+            // Verification
+            if (scenario === AudioMode.PureSentence) {
+                // Deleted
+                const span1 = getFrameElementById("page", "1.1");
+                expect(span1).not.toHaveAttr("recordingmd5");
+
+                // The other spans aren't deleted though.
+                const span2 = getFrameElementById("page", "1.2");
+                expect(span2).toHaveAttr("recordingmd5", "fakeMd5");
+            } else if (
+                scenario === AudioMode.PreTextBox ||
+                scenario === AudioMode.HardSplitTextBox
+            ) {
+                // All recordings within the text box should be cleared out
+                const spanIds = ["1.1", "1.2"];
+                spanIds.forEach(id => {
+                    const span = getFrameElementById("page", id);
+                    expect(span).not.toHaveAttr("recordingmd5");
+                });
+            } else {
+                const div = getFrameElementById("page", "div1");
+                expect(div).not.toHaveAttr("recordingmd5");
+            }
+        }
+
+        it("clearRecording() disables button", async done => {
+            const run = async () => {
+                return runClearRecordingAsync(AudioMode.PureSentence);
+            };
+            const verify = () => {
+                const clearButton = document.getElementById("audio-clear")!;
+                expect(clearButton).not.toHaveClass("enabled");
+                expect(clearButton).toHaveClass("disabled");
+            };
+
+            runAsyncTest(done, setupClearRecordingTest, run, verify);
+        });
+
+        getAllAudioModes().forEach(scenario => {
+            const scenarioName = AudioMode[scenario];
+            it(`clearRecording() deletes recordings (${scenarioName})`, async () => {
+                runClearRecordingDeleteTest(scenario);
+            });
+        });
+
+        async function runClearRecordingDeleteTest(scenario: AudioMode) {
+            spyOn(axios, "post").and.callFake((url: string) => {
+                if (url.includes("/bloom/api/audio/deleteSegment?id")) {
+                    // Helps it test a more realistic scenario, instead of always testing the 404s
+                    return Promise.resolve();
+                } else {
+                    return Promise.reject("Fake 404 error.");
+                }
+            });
+
+            const setup = () => {
+                setupClearRecordingTest(scenario);
+            };
+
+            const run = async () => {
+                return runClearRecordingAsync(scenario);
+            };
+
+            const verify = () => {
+                let ids: string[] = [];
+                switch (scenario) {
+                    case AudioMode.PureSentence: {
+                        ids = ["1.1"]; // , "1.2"];
+                        break;
+                    }
+                    case AudioMode.PreTextBox:
+                    case AudioMode.HardSplitTextBox: {
+                        ids = ["1.1", "1.2"];
+                        break;
+                    }
+                    case AudioMode.PureTextBox:
+                    case AudioMode.SoftSplitTextBox: {
+                        ids = ["div1"];
+                        break;
+                    }
+                    default:
+                        throw new Error(
+                            "Unrecognized scenario: " + AudioMode[scenario]
+                        );
+                }
+
+                ids.forEach(id => {
+                    const path = "/bloom/api/audio/deleteSegment?id=" + id;
+                    expect(axios.post).toHaveBeenCalledWith(path);
+                });
+
+                expect(axios.post).toHaveBeenCalledTimes(ids.length);
+            };
+
+            setup();
+            await run();
+            verify();
+        }
     });
 
     describe("- initializeAudioRecordingMode()", () => {
@@ -1782,6 +2113,10 @@ function StripAudioCurrent(html) {
     return html
         .replace(/ ui-audioCurrent/g, "")
         .replace(/ class="ui-audioCurrent"/g, "");
+}
+
+export function StripRecordingMd5(html: string): string {
+    return html.replace(/ recordingmd5="[0-9A-Za-z]*"/g, "");
 }
 
 // Adds the iframe into the parent window.

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/md5Util.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/md5Util.ts
@@ -1,0 +1,251 @@
+export function getMd5(message): string {
+    const HEX_CHARS = "0123456789abcdef".split("");
+    const EXTRA = [128, 32768, 8388608, -2147483648];
+    const blocks: number[] = [];
+
+    let h0,
+        h1,
+        h2,
+        h3,
+        a,
+        b,
+        c,
+        d,
+        bc,
+        da,
+        code,
+        first = true,
+        end = false,
+        index = 0,
+        i,
+        start = 0,
+        bytes = 0;
+
+    const length = message.length;
+    blocks[16] = 0;
+    const SHIFT = [0, 8, 16, 24];
+
+    do {
+        blocks[0] = blocks[16];
+        blocks[16] = blocks[1] = blocks[2] = blocks[3] = blocks[4] = blocks[5] = blocks[6] = blocks[7] = blocks[8] = blocks[9] = blocks[10] = blocks[11] = blocks[12] = blocks[13] = blocks[14] = blocks[15] = 0;
+        for (i = start; index < length && i < 64; ++index) {
+            code = message.charCodeAt(index);
+            if (code < 0x80) {
+                blocks[i >> 2] |= code << SHIFT[i++ & 3];
+            } else if (code < 0x800) {
+                blocks[i >> 2] |= (0xc0 | (code >> 6)) << SHIFT[i++ & 3];
+                blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+            } else if (code < 0xd800 || code >= 0xe000) {
+                blocks[i >> 2] |= (0xe0 | (code >> 12)) << SHIFT[i++ & 3];
+                blocks[i >> 2] |=
+                    (0x80 | ((code >> 6) & 0x3f)) << SHIFT[i++ & 3];
+                blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+            } else {
+                code =
+                    0x10000 +
+                    (((code & 0x3ff) << 10) |
+                        (message.charCodeAt(++index) & 0x3ff));
+                blocks[i >> 2] |= (0xf0 | (code >> 18)) << SHIFT[i++ & 3];
+                blocks[i >> 2] |=
+                    (0x80 | ((code >> 12) & 0x3f)) << SHIFT[i++ & 3];
+                blocks[i >> 2] |=
+                    (0x80 | ((code >> 6) & 0x3f)) << SHIFT[i++ & 3];
+                blocks[i >> 2] |= (0x80 | (code & 0x3f)) << SHIFT[i++ & 3];
+            }
+        }
+        bytes += i - start;
+        start = i - 64;
+        if (index == length) {
+            blocks[i >> 2] |= EXTRA[i & 3];
+            ++index;
+        }
+        if (index > length && i < 56) {
+            blocks[14] = bytes << 3;
+            end = true;
+        }
+
+        if (first) {
+            a = blocks[0] - 680876937;
+            a = (((a << 7) | (a >>> 25)) - 271733879) << 0;
+            d = (-1732584194 ^ (a & 2004318071)) + blocks[1] - 117830708;
+            d = (((d << 12) | (d >>> 20)) + a) << 0;
+            c = (-271733879 ^ (d & (a ^ -271733879))) + blocks[2] - 1126478375;
+            c = (((c << 17) | (c >>> 15)) + d) << 0;
+            b = (a ^ (c & (d ^ a))) + blocks[3] - 1316259209;
+            b = (((b << 22) | (b >>> 10)) + c) << 0;
+        } else {
+            a = h0;
+            b = h1;
+            c = h2;
+            d = h3;
+            a += (d ^ (b & (c ^ d))) + blocks[0] - 680876936;
+            a = (((a << 7) | (a >>> 25)) + b) << 0;
+            d += (c ^ (a & (b ^ c))) + blocks[1] - 389564586;
+            d = (((d << 12) | (d >>> 20)) + a) << 0;
+            c += (b ^ (d & (a ^ b))) + blocks[2] + 606105819;
+            c = (((c << 17) | (c >>> 15)) + d) << 0;
+            b += (a ^ (c & (d ^ a))) + blocks[3] - 1044525330;
+            b = (((b << 22) | (b >>> 10)) + c) << 0;
+        }
+
+        a += (d ^ (b & (c ^ d))) + blocks[4] - 176418897;
+        a = (((a << 7) | (a >>> 25)) + b) << 0;
+        d += (c ^ (a & (b ^ c))) + blocks[5] + 1200080426;
+        d = (((d << 12) | (d >>> 20)) + a) << 0;
+        c += (b ^ (d & (a ^ b))) + blocks[6] - 1473231341;
+        c = (((c << 17) | (c >>> 15)) + d) << 0;
+        b += (a ^ (c & (d ^ a))) + blocks[7] - 45705983;
+        b = (((b << 22) | (b >>> 10)) + c) << 0;
+        a += (d ^ (b & (c ^ d))) + blocks[8] + 1770035416;
+        a = (((a << 7) | (a >>> 25)) + b) << 0;
+        d += (c ^ (a & (b ^ c))) + blocks[9] - 1958414417;
+        d = (((d << 12) | (d >>> 20)) + a) << 0;
+        c += (b ^ (d & (a ^ b))) + blocks[10] - 42063;
+        c = (((c << 17) | (c >>> 15)) + d) << 0;
+        b += (a ^ (c & (d ^ a))) + blocks[11] - 1990404162;
+        b = (((b << 22) | (b >>> 10)) + c) << 0;
+        a += (d ^ (b & (c ^ d))) + blocks[12] + 1804603682;
+        a = (((a << 7) | (a >>> 25)) + b) << 0;
+        d += (c ^ (a & (b ^ c))) + blocks[13] - 40341101;
+        d = (((d << 12) | (d >>> 20)) + a) << 0;
+        c += (b ^ (d & (a ^ b))) + blocks[14] - 1502002290;
+        c = (((c << 17) | (c >>> 15)) + d) << 0;
+        b += (a ^ (c & (d ^ a))) + blocks[15] + 1236535329;
+        b = (((b << 22) | (b >>> 10)) + c) << 0;
+        a += (c ^ (d & (b ^ c))) + blocks[1] - 165796510;
+        a = (((a << 5) | (a >>> 27)) + b) << 0;
+        d += (b ^ (c & (a ^ b))) + blocks[6] - 1069501632;
+        d = (((d << 9) | (d >>> 23)) + a) << 0;
+        c += (a ^ (b & (d ^ a))) + blocks[11] + 643717713;
+        c = (((c << 14) | (c >>> 18)) + d) << 0;
+        b += (d ^ (a & (c ^ d))) + blocks[0] - 373897302;
+        b = (((b << 20) | (b >>> 12)) + c) << 0;
+        a += (c ^ (d & (b ^ c))) + blocks[5] - 701558691;
+        a = (((a << 5) | (a >>> 27)) + b) << 0;
+        d += (b ^ (c & (a ^ b))) + blocks[10] + 38016083;
+        d = (((d << 9) | (d >>> 23)) + a) << 0;
+        c += (a ^ (b & (d ^ a))) + blocks[15] - 660478335;
+        c = (((c << 14) | (c >>> 18)) + d) << 0;
+        b += (d ^ (a & (c ^ d))) + blocks[4] - 405537848;
+        b = (((b << 20) | (b >>> 12)) + c) << 0;
+        a += (c ^ (d & (b ^ c))) + blocks[9] + 568446438;
+        a = (((a << 5) | (a >>> 27)) + b) << 0;
+        d += (b ^ (c & (a ^ b))) + blocks[14] - 1019803690;
+        d = (((d << 9) | (d >>> 23)) + a) << 0;
+        c += (a ^ (b & (d ^ a))) + blocks[3] - 187363961;
+        c = (((c << 14) | (c >>> 18)) + d) << 0;
+        b += (d ^ (a & (c ^ d))) + blocks[8] + 1163531501;
+        b = (((b << 20) | (b >>> 12)) + c) << 0;
+        a += (c ^ (d & (b ^ c))) + blocks[13] - 1444681467;
+        a = (((a << 5) | (a >>> 27)) + b) << 0;
+        d += (b ^ (c & (a ^ b))) + blocks[2] - 51403784;
+        d = (((d << 9) | (d >>> 23)) + a) << 0;
+        c += (a ^ (b & (d ^ a))) + blocks[7] + 1735328473;
+        c = (((c << 14) | (c >>> 18)) + d) << 0;
+        b += (d ^ (a & (c ^ d))) + blocks[12] - 1926607734;
+        b = (((b << 20) | (b >>> 12)) + c) << 0;
+        bc = b ^ c;
+        a += (bc ^ d) + blocks[5] - 378558;
+        a = (((a << 4) | (a >>> 28)) + b) << 0;
+        d += (bc ^ a) + blocks[8] - 2022574463;
+        d = (((d << 11) | (d >>> 21)) + a) << 0;
+        da = d ^ a;
+        c += (da ^ b) + blocks[11] + 1839030562;
+        c = (((c << 16) | (c >>> 16)) + d) << 0;
+        b += (da ^ c) + blocks[14] - 35309556;
+        b = (((b << 23) | (b >>> 9)) + c) << 0;
+        bc = b ^ c;
+        a += (bc ^ d) + blocks[1] - 1530992060;
+        a = (((a << 4) | (a >>> 28)) + b) << 0;
+        d += (bc ^ a) + blocks[4] + 1272893353;
+        d = (((d << 11) | (d >>> 21)) + a) << 0;
+        da = d ^ a;
+        c += (da ^ b) + blocks[7] - 155497632;
+        c = (((c << 16) | (c >>> 16)) + d) << 0;
+        b += (da ^ c) + blocks[10] - 1094730640;
+        b = (((b << 23) | (b >>> 9)) + c) << 0;
+        bc = b ^ c;
+        a += (bc ^ d) + blocks[13] + 681279174;
+        a = (((a << 4) | (a >>> 28)) + b) << 0;
+        d += (bc ^ a) + blocks[0] - 358537222;
+        d = (((d << 11) | (d >>> 21)) + a) << 0;
+        da = d ^ a;
+        c += (da ^ b) + blocks[3] - 722521979;
+        c = (((c << 16) | (c >>> 16)) + d) << 0;
+        b += (da ^ c) + blocks[6] + 76029189;
+        b = (((b << 23) | (b >>> 9)) + c) << 0;
+        bc = b ^ c;
+        a += (bc ^ d) + blocks[9] - 640364487;
+        a = (((a << 4) | (a >>> 28)) + b) << 0;
+        d += (bc ^ a) + blocks[12] - 421815835;
+        d = (((d << 11) | (d >>> 21)) + a) << 0;
+        da = d ^ a;
+        c += (da ^ b) + blocks[15] + 530742520;
+        c = (((c << 16) | (c >>> 16)) + d) << 0;
+        b += (da ^ c) + blocks[2] - 995338651;
+        b = (((b << 23) | (b >>> 9)) + c) << 0;
+        a += (c ^ (b | ~d)) + blocks[0] - 198630844;
+        a = (((a << 6) | (a >>> 26)) + b) << 0;
+        d += (b ^ (a | ~c)) + blocks[7] + 1126891415;
+        d = (((d << 10) | (d >>> 22)) + a) << 0;
+        c += (a ^ (d | ~b)) + blocks[14] - 1416354905;
+        c = (((c << 15) | (c >>> 17)) + d) << 0;
+        b += (d ^ (c | ~a)) + blocks[5] - 57434055;
+        b = (((b << 21) | (b >>> 11)) + c) << 0;
+        a += (c ^ (b | ~d)) + blocks[12] + 1700485571;
+        a = (((a << 6) | (a >>> 26)) + b) << 0;
+        d += (b ^ (a | ~c)) + blocks[3] - 1894986606;
+        d = (((d << 10) | (d >>> 22)) + a) << 0;
+        c += (a ^ (d | ~b)) + blocks[10] - 1051523;
+        c = (((c << 15) | (c >>> 17)) + d) << 0;
+        b += (d ^ (c | ~a)) + blocks[1] - 2054922799;
+        b = (((b << 21) | (b >>> 11)) + c) << 0;
+        a += (c ^ (b | ~d)) + blocks[8] + 1873313359;
+        a = (((a << 6) | (a >>> 26)) + b) << 0;
+        d += (b ^ (a | ~c)) + blocks[15] - 30611744;
+        d = (((d << 10) | (d >>> 22)) + a) << 0;
+        c += (a ^ (d | ~b)) + blocks[6] - 1560198380;
+        c = (((c << 15) | (c >>> 17)) + d) << 0;
+        b += (d ^ (c | ~a)) + blocks[13] + 1309151649;
+        b = (((b << 21) | (b >>> 11)) + c) << 0;
+        a += (c ^ (b | ~d)) + blocks[4] - 145523070;
+        a = (((a << 6) | (a >>> 26)) + b) << 0;
+        d += (b ^ (a | ~c)) + blocks[11] - 1120210379;
+        d = (((d << 10) | (d >>> 22)) + a) << 0;
+        c += (a ^ (d | ~b)) + blocks[2] + 718787259;
+        c = (((c << 15) | (c >>> 17)) + d) << 0;
+        b += (d ^ (c | ~a)) + blocks[9] - 343485551;
+        b = (((b << 21) | (b >>> 11)) + c) << 0;
+
+        if (first) {
+            h0 = (a + 1732584193) << 0;
+            h1 = (b - 271733879) << 0;
+            h2 = (c - 1732584194) << 0;
+            h3 = (d + 271733878) << 0;
+            first = false;
+        } else {
+            h0 = (h0 + a) << 0;
+            h1 = (h1 + b) << 0;
+            h2 = (h2 + c) << 0;
+            h3 = (h3 + d) << 0;
+        }
+    } while (!end);
+
+    let hex = HEX_CHARS[(h0 >> 4) & 0x0f] + HEX_CHARS[h0 & 0x0f];
+    hex += HEX_CHARS[(h0 >> 12) & 0x0f] + HEX_CHARS[(h0 >> 8) & 0x0f];
+    hex += HEX_CHARS[(h0 >> 20) & 0x0f] + HEX_CHARS[(h0 >> 16) & 0x0f];
+    hex += HEX_CHARS[(h0 >> 28) & 0x0f] + HEX_CHARS[(h0 >> 24) & 0x0f];
+    hex += HEX_CHARS[(h1 >> 4) & 0x0f] + HEX_CHARS[h1 & 0x0f];
+    hex += HEX_CHARS[(h1 >> 12) & 0x0f] + HEX_CHARS[(h1 >> 8) & 0x0f];
+    hex += HEX_CHARS[(h1 >> 20) & 0x0f] + HEX_CHARS[(h1 >> 16) & 0x0f];
+    hex += HEX_CHARS[(h1 >> 28) & 0x0f] + HEX_CHARS[(h1 >> 24) & 0x0f];
+    hex += HEX_CHARS[(h2 >> 4) & 0x0f] + HEX_CHARS[h2 & 0x0f];
+    hex += HEX_CHARS[(h2 >> 12) & 0x0f] + HEX_CHARS[(h2 >> 8) & 0x0f];
+    hex += HEX_CHARS[(h2 >> 20) & 0x0f] + HEX_CHARS[(h2 >> 16) & 0x0f];
+    hex += HEX_CHARS[(h2 >> 28) & 0x0f] + HEX_CHARS[(h2 >> 24) & 0x0f];
+    hex += HEX_CHARS[(h3 >> 4) & 0x0f] + HEX_CHARS[h3 & 0x0f];
+    hex += HEX_CHARS[(h3 >> 12) & 0x0f] + HEX_CHARS[(h3 >> 8) & 0x0f];
+    hex += HEX_CHARS[(h3 >> 20) & 0x0f] + HEX_CHARS[(h3 >> 16) & 0x0f];
+    hex += HEX_CHARS[(h3 >> 28) & 0x0f] + HEX_CHARS[(h3 >> 24) & 0x0f];
+    return hex;
+}

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/md5UtilSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/md5UtilSpec.ts
@@ -1,0 +1,13 @@
+import { getMd5 } from "./md5Util";
+
+describe("getMd5 tests", () => {
+    it("calculates md5 on non-empty string", () => {
+        expect(getMd5("Sentence 2.1၊ Sentence 2.2")).toBe(
+            "ad15831c388fb93285cbb18306a4b734"
+        );
+    });
+
+    it("calculates md5 on an empty string", () => {
+        expect(getMd5("")).toBe("d41d8cd98f00b204e9800998ecf8427e");
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
@@ -1,4 +1,4 @@
-﻿import { ITool } from "../toolbox";
+import { ITool } from "../toolbox";
 import { ToolBox } from "../toolbox";
 import * as AudioRecorder from "./audioRecording";
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookSpec.ts
@@ -3,14 +3,16 @@ import {
     theOneAudioRecorder,
     initializeTalkingBookToolAsync,
     AudioRecordingMode,
-    AudioMode
+    AudioMode,
+    getAllAudioModes
 } from "./audioRecording";
 import {
     SetupTalkingBookUIElements,
     SetupIFrameAsync,
     SetupIFrameFromHtml,
     getFrameElementById,
-    StripPlayerSrcNoCacheSuffix
+    StripPlayerSrcNoCacheSuffix,
+    StripRecordingMd5
 } from "./audioRecordingSpec";
 import * as XRegExp from "xregexp"; // Not sure why, but import * as XRegExp works better. import XRegExp causes "xregexp_1.default is undefined" error
 import { setSentenceEndingPunctuationForBloom } from "../readers/libSynphony/bloom_xregexp_categories";
@@ -25,7 +27,7 @@ describe("talking book tests", () => {
     });
 
     describe("- updateMarkup()", () => {
-        it("moves highlight after focus changes", async done => {
+        it("moves highlight after focus changes", async () => {
             // Setup Initial HTML
             const textBox1 =
                 '<div class="bloom-editable" id="div1"><p><span id="1.1" class="audio-sentence ui-audioCurrent">1.1</span></p></div>';
@@ -51,7 +53,6 @@ describe("talking book tests", () => {
             const currentTextBox = theOneAudioRecorder.getCurrentTextBox()!;
             const currentId = currentTextBox.getAttribute("id");
             expect(currentId).toBe("div2");
-            done();
         });
     });
 
@@ -77,61 +78,184 @@ describe("talking book tests", () => {
         function setAudioFilesDontExist() {
             // Mark that the recording doesn't exist.
             // FYI - spies only last for the scope of the "describe" or "it" block in which it was defined.
-            spyOn(axios, "get").and.returnValue(
-                Promise.reject(new Error("Fake 404 Error"))
-            );
+            spyOn(axios, "get").and.callFake((url: string) => {
+                if (
+                    url.includes("/bloom/api/audio/checkForAllRecording?ids=")
+                ) {
+                    return Promise.resolve({ data: false });
+                } else {
+                    return Promise.reject(new Error("Fake 404 Error"));
+                }
+            });
         }
 
         function setAudioFilesPresent() {
             // Mark that the recording exists.
             // FYI - spies only last for the scope of the "describe" or "it" block in which it was defined.
-            spyOn(axios, "get").and.returnValue(Promise.resolve());
+            spyOn(axios, "get").and.callFake((url: string) => {
+                if (
+                    url.includes("/bloom/api/audio/checkForAllRecording?ids=")
+                ) {
+                    // ENHANCE: This test would be more realisitic if only specific ids for checkAllRecording returned true.
+                    return Promise.resolve({ data: true });
+                } else {
+                    return Promise.resolve();
+                }
+            });
         }
 
-        function setupPureSentenceModeHtml(): string {
-            const div1Html =
-                '<div class="bloom-editable" id="div1" data-audioRecordingMode="Sentence"><p><span id="1.1" class="audio-sentence ui-audioCurrent">Sentence 1.1၊</span> <span id="1.2" class="audio-sentence">Sentence 1.2</span></p></div>';
-            const div2Html =
-                '<div class="bloom-editable" id="div2" data-audioRecordingMode="Sentence"><p><span id="2.1" class="audio-sentence">Sentence 2.1၊</span> <span id="2.2" class="audio-sentence">Sentence 2.2</span></p></div>';
+        function setAudioFilesPartiallyPresent(scenario: AudioMode) {
+            // Mark that the recording exists.
+            // FYI - spies only last for the scope of the "describe" or "it" block in which it was defined.
+            let anyPresent: string[] = [];
+            let allPresent: string[] = [];
+            switch (scenario) {
+                case AudioMode.PureSentence:
+                case AudioMode.PreTextBox:
+                case AudioMode.HardSplitTextBox: {
+                    anyPresent = [
+                        "ids=1.2",
+                        "ids=2.2",
+                        "ids=1.1,1.2",
+                        "ids=2.1,2.2"
+                    ];
+                    allPresent = ["ids=1.2", "ids=2.2"];
+                    break;
+                }
+                case AudioMode.PureTextBox:
+                case AudioMode.SoftSplitTextBox: {
+                    throw new Error(`invalid scenario: ${AudioMode[scenario]}`);
+                }
+                default: {
+                    throw new Error(
+                        `Unhandled scenario: ${scenario} (${
+                            AudioMode[scenario]
+                        })`
+                    );
+                }
+            }
+
+            const urlToResponse = {};
+            anyPresent.forEach(params => {
+                const url = "/bloom/api/audio/checkForAnyRecording?" + params;
+                urlToResponse[url] = Promise.resolve();
+            });
+            allPresent.forEach(params => {
+                const url = "/bloom/api/audio/checkForAllRecording?" + params;
+                urlToResponse[url] = Promise.resolve({ data: true });
+            });
+            spyOn(axios, "get").and.callFake((url: string) => {
+                const response = urlToResponse[url];
+                if (response) {
+                    return response;
+                } else {
+                    return Promise.reject("Fake 404 error.");
+                }
+            });
+        }
+
+        function getTestMd5s(
+            md5ValueSetting: string,
+            scenario: AudioMode
+        ): string[] {
+            if (md5ValueSetting === "missing") {
+                return ["undefined", "undefined", "undefined", "undefined"];
+            } else if (md5ValueSetting === "differs") {
+                return ["001", "002", "003", "004"];
+            } else if (md5ValueSetting === "same") {
+                switch (scenario) {
+                    case AudioMode.PureSentence:
+                    case AudioMode.PreTextBox:
+                    case AudioMode.HardSplitTextBox: {
+                        return [
+                            "28e9f104eacb2cf2afe90c7074733103",
+                            "4aaf751627dd525fb2a5ebb7928ff353",
+                            "3de477f0b8b44a793a313b344d6687d6",
+                            "b82352b9566d3bf74be60fb2d1a81a7b"
+                        ];
+                    }
+                    case AudioMode.PureTextBox:
+                    case AudioMode.SoftSplitTextBox: {
+                        return [
+                            "b65fad901ce36fb8251f21f9aca8e2d0",
+                            "ad15831c388fb93285cbb18306a4b734"
+                        ];
+                    }
+                    default: {
+                        throw new Error("Unknown scenario: " + scenario);
+                    }
+                }
+            } else {
+                throw new Error("Unknown checksum setting: " + md5ValueSetting);
+            }
+        }
+
+        function setupPureSentenceModeHtml(checksums: string[]): string {
+            const div1Html = `<div class="bloom-editable" id="div1" data-audioRecordingMode="Sentence"><p><span id="1.1" class="audio-sentence ui-audioCurrent" recordingmd5="${
+                checksums[0]
+            }">Sentence 1.1၊</span> <span id="1.2" class="audio-sentence" recordingmd5="${
+                checksums[1]
+            }">Sentence 1.2</span></p></div>`;
+            const div2Html = `<div class="bloom-editable" id="div2" data-audioRecordingMode="Sentence" recordingmd5=""><p><span id="2.1" class="audio-sentence" recordingmd5="${
+                checksums[2]
+            }">Sentence 2.1၊</span> <span id="2.2" class="audio-sentence" recordingmd5="${
+                checksums[3]
+            }">Sentence 2.2</span></p></div>`;
             return `${div1Html}${div2Html}`;
         }
 
-        function setupPreTextBoxModeHtml(): string {
-            const div1Html =
-                '<div class="bloom-editable ui-audioCurrent" id="div1" data-audiorecordingmode="TextBox"><p><span id="1.1" class="audio-sentence">Sentence 1.1၊</span> <span id="1.1" class="audio-sentence">Sentence 1.2</span></p></div>';
-            const div2Html =
-                '<div class="bloom-editable audio-sentence" id="div2" data-audiorecordingmode="TextBox"><p><span id="2.1" class="audio-sentence">Sentence 2.1၊</span> <span id="2.1" class="audio-sentence">Sentence 2.2</span></p></div>';
+        function setupPreTextBoxModeHtml(checksums: string[]): string {
+            const div1Html = `<div class="bloom-editable ui-audioCurrent" id="div1" data-audiorecordingmode="TextBox"><p><span id="1.1" class="audio-sentence" recordingmd5="${
+                checksums[0]
+            }">Sentence 1.1၊</span> <span id="1.2" class="audio-sentence" recordingmd5="${
+                checksums[1]
+            }">Sentence 1.2</span></p></div>`;
+            const div2Html = `<div class="bloom-editable" id="div2" data-audiorecordingmode="TextBox"><p><span id="2.1" class="audio-sentence" recordingmd5="${
+                checksums[2]
+            }">Sentence 2.1၊</span> <span id="2.2" class="audio-sentence" recordingmd5="${
+                checksums[3]
+            }">Sentence 2.2</span></p></div>`;
             return `${div1Html}${div2Html}`;
         }
 
-        function setupPureTextBoxModeHtml(): string {
-            const div1Html =
-                '<div class="bloom-editable audio-sentence ui-audioCurrent" id="div1" data-audiorecordingmode="TextBox"><p>Sentence 1.1၊ Sentence 1.2</p></div>';
-            const div2Html =
-                '<div class="bloom-editable audio-sentence" id="div2" data-audiorecordingmode="TextBox"><p>Sentence 2.1၊ Sentence 2.2</p></div>';
+        function setupPureTextBoxModeHtml(checksums: string[]): string {
+            const div1Html = `<div class="bloom-editable audio-sentence ui-audioCurrent" id="div1" data-audiorecordingmode="TextBox" recordingmd5="${
+                checksums[0]
+            }"><p>Sentence 1.1၊ Sentence 1.2</p></div>`;
+            const div2Html = `<div class="bloom-editable audio-sentence" id="div2" data-audiorecordingmode="TextBox" recordingmd5="${
+                checksums[1]
+            }"><p>Sentence 2.1၊ Sentence 2.2</p></div>`;
             return `${div1Html}${div2Html}`;
         }
 
-        function setupTextBoxHardSplitHtml(): string {
+        function setupTextBoxHardSplitHtml(checksums: string[]): string {
             let html = "";
+            let checksumIndex = 0;
             for (let i = 1; i <= 2; ++i) {
+                // FYI: Yes, it is confirmed that in hardSplit, ui-audioCurrent goes on the div, not the span.
                 const divStartHtml = `<div class="bloom-editable${
                     i === 1 ? " ui-audioCurrent" : ""
                 }" id="div${i}" data-audiorecordingmode="TextBox">`;
-                const divInnerHtml = `<p><span id="${i}.1" class="audio-sentence">Sentence ${i}.1၊</span> <span id="${i}.2" class="audio-sentence">Sentence ${i}.2</span></p>`;
+                const divInnerHtml = `<p><span id="${i}.1" class="audio-sentence" recordingmd5="${
+                    checksums[checksumIndex++]
+                }">Sentence ${i}.1၊</span> <span id="${i}.2" class="audio-sentence" recordingmd5="${
+                    checksums[checksumIndex++]
+                }">Sentence ${i}.2</span></p>`;
                 const divHtml = `${divStartHtml}${divInnerHtml}</div>`;
                 html += divHtml;
             }
             return html;
         }
 
-        function setupTextBoxSoftSplitHtml(): string {
+        function setupTextBoxSoftSplitHtml(checksums: string[]): string {
             let html = "";
             for (let i = 1; i <= 2; ++i) {
                 const divStartHtml = `<div class="bloom-editable audio-sentence${
                     i === 1 ? " ui-audioCurrent" : ""
-                }" id="div${i}" data-audiorecordingmode="TextBox" data-audiorecordingendtimes="1.0 2.0">`;
-                const divInnerHtml = `<p><span id="${i}.1" class="bloom-highlightSegment">Sentence ${i}.1၊</span> <span id="Sentence ${i}.2" class="bloom-highlightSegment">${i}.2</span></p>`;
+                }" id="div${i}" data-audiorecordingmode="TextBox" recordingmd5="${
+                    checksums[i - 1]
+                }" data-audiorecordingendtimes="1.0 2.0">`;
+                const divInnerHtml = `<p><span id="${i}.1" class="bloom-highlightSegment">Sentence ${i}.1၊</span> <span id="${i}.2" class="bloom-highlightSegment">Sentence ${i}.2</span></p>`;
 
                 const divHtml = `${divStartHtml}${divInnerHtml}</div>`;
                 html += divHtml;
@@ -139,30 +263,44 @@ describe("talking book tests", () => {
             return html;
         }
 
-        async function runSentenceSplittingTestsAsync(
+        let originalDiv1Html = "";
+        let originalDiv2Html = "";
+
+        function setupSentenceSplitTest(
             scenario: AudioMode,
-            areRecordingsPresent: boolean
-        ) {
+            checksumSetting: string,
+            areRecordingsPresent: string
+        ): void {
+            const checksums = getTestMd5s(checksumSetting, scenario);
+
             let pageInnerHtml: string = "";
             switch (scenario) {
                 case AudioMode.PureSentence: {
-                    pageInnerHtml = setupPureSentenceModeHtml();
+                    pageInnerHtml = setupPureSentenceModeHtml(checksums);
+                    break;
+                }
+                case AudioMode.PreTextBox: {
+                    pageInnerHtml = setupPreTextBoxModeHtml(checksums);
                     break;
                 }
                 case AudioMode.PureTextBox: {
-                    pageInnerHtml = setupPureTextBoxModeHtml();
+                    pageInnerHtml = setupPureTextBoxModeHtml(checksums);
                     break;
                 }
                 case AudioMode.HardSplitTextBox: {
-                    pageInnerHtml = setupTextBoxHardSplitHtml();
+                    pageInnerHtml = setupTextBoxHardSplitHtml(checksums);
                     break;
                 }
                 case AudioMode.SoftSplitTextBox: {
-                    pageInnerHtml = setupTextBoxSoftSplitHtml();
+                    pageInnerHtml = setupTextBoxSoftSplitHtml(checksums);
                     break;
                 }
                 default: {
-                    throw new Error("Unknown scenario: " + scenario);
+                    throw new Error(
+                        `Unhandled scenario: ${scenario} (${
+                            AudioMode[scenario]
+                        })`
+                    );
                 }
             }
 
@@ -176,72 +314,107 @@ describe("talking book tests", () => {
                     AudioRecordingMode.TextBox;
             }
 
-            const originalHtml = getFrameElementById("page", "page1")!
-                .innerHTML;
+            originalDiv1Html = getFrameElementById("page", "div1")!.outerHTML;
+            originalDiv2Html = getFrameElementById("page", "div2")!.outerHTML;
 
-            if (areRecordingsPresent) {
+            if (areRecordingsPresent === "present") {
                 setAudioFilesPresent();
-            } else {
+            } else if (areRecordingsPresent === "partiallyPresent") {
+                setAudioFilesPartiallyPresent(scenario);
+            } else if (areRecordingsPresent === "missing") {
                 setAudioFilesDontExist();
+            } else {
+                throw new Error(
+                    "Unhandled value of areRecordingsPresent: " +
+                        areRecordingsPresent
+                );
             }
-
-            // System under test
-            const tbTool = new TalkingBookTool();
-            await tbTool.showTool();
-
-            // Verification
-            verifyHtmlStructure(scenario, areRecordingsPresent, originalHtml);
-            verifyCurrentHighlight(scenario);
-            verifyRecordButtonEnabled(); // Make sure we didn't accidentally disable all the toolbox buttons
         }
 
-        function verifyHtmlStructure(
-            scenario: AudioMode,
-            areRecordingsPresent: boolean,
-            originalDiv1Html: string
-        ) {
-            if (
-                areRecordingsPresent ||
-                scenario === AudioMode.SoftSplitTextBox
-            ) {
-                // NOTE: SoftSplit test doesn't have very intuitive results.
-                // Even if recordings aren't present, it actually preserves the original splits, even though normally, no recordings present means we should update them.
-                // Prior to this check-if-recordings-present feature, it was actually the case that upon Soft Split, it never updated the markup.
-                // (That's because the playback mode was identified as text box, and in that case, it never actually runs makeAudioSentenceElementsLeaf())
-                // I'm not sure if that was entirely intentional, but it does seem very problematic to risk increasing/decreasing the number of splits while an audio is aligned to it.
-                // Now that we do check if recordings present...
-                // If they're somehow missing, we COULD now update the markup, but it doesn't seem worth the time, complexity, or risk to add that functionality.
-                // I guess it's more like if there's no recordings present, then we do whatever the old behavior was... which in this case, is to not do anything.
+        async function runShowToolAsync(): Promise<void> {
+            const tbTool = new TalkingBookTool();
+            await tbTool.showTool();
+        }
 
-                // Verify unchanged.
-                const currentHtml = getFrameElementById("page", "page1")!
-                    .innerHTML;
-                expect(currentHtml).toBe(originalDiv1Html);
-            } else if (
+        function verifyCommonAspects(scenario: AudioMode) {
+            verifyCurrentHighlight(scenario);
+            verifySoundForShowToolTests(scenario);
+            verifyRecordButtonEnabled(); // Check that we didn't accidentally disable all the toolbox buttons.
+        }
+
+        function verifySplitsUpdated(scenario: AudioMode) {
+            verifyHtmlUpdated(scenario);
+            verifyCommonAspects(scenario);
+        }
+
+        function verifySplitsPreserved(scenario: AudioMode) {
+            verifyHtmlPreserved(scenario);
+            verifyCommonAspects(scenario);
+        }
+
+        function verifyHtmlUpdated(scenario: AudioMode) {
+            if (
                 scenario === AudioMode.PureSentence ||
+                scenario === AudioMode.PreTextBox ||
                 scenario === AudioMode.HardSplitTextBox
             ) {
                 for (let i = 1; i <= 2; ++i) {
                     const spans = getAudioSentenceSpans(`div${i}`);
-                    const texts = spans.map(elem => {
-                        return elem.innerText;
-                    });
-                    expect(texts).toEqual(
-                        [`Sentence ${i}.1၊ Sentence ${i}.2`],
-                        `Failure for div${i}`
+
+                    expect(spans).toHaveLength(1);
+                    expect(spans[0]).toHaveText(
+                        `Sentence ${i}.1၊ Sentence ${i}.2`
                     );
                 }
             } else if (scenario === AudioMode.PureTextBox) {
-                for (let i = 1; i <= 2; ++i) {
-                    const paragraphs = getParagraphsOfTextBox(`div${i}`);
-                    const innerHTMLs = paragraphs.map(p => p.innerHTML);
-                    expect(innerHTMLs).toEqual(
-                        [`Sentence ${i}.1၊ Sentence ${i}.2`],
-                        `Failure for div${i}`
-                    );
-                }
+                // There's actually nothing that needs to be updated if it's in TextBox mode.
+                // So you should actually get the same result as when you preserve it.
+                verifyHtmlPreserved(scenario);
+            } else if (scenario === AudioMode.SoftSplitTextBox) {
+                // TODO: Maybe now is the time to try changing it.
+                //
+                // SoftSplit test doesn't have very intuitive results.
+                // Historically, it was actually the case that upon Soft Split, it never updated the markup.
+                // (That's because the playback mode was identified as text box, and in that case, it never actually runs makeAudioSentenceElementsLeaf())
+                // I'm not sure if that was entirely intentional, but it does seem very problematic to risk increasing/decreasing the number of splits while an audio is aligned to it.
+                // Now that we do check if it's safe..
+                // I guesss now we COULD now update the markup, but it doesn't seem worth the time, complexity, or risk to add that functionality.
+                // I guess it's more like if it's not safe, then we do whatever the old behavior was... which in this case, is to not do anything.
+                verifyHtmlPreserved(scenario);
             } else {
-                throw new Error("Unrecognized scenario: " + scenario);
+                throw new Error(
+                    `Unhandled scenario: ${scenario} (${AudioMode[scenario]})`
+                );
+            }
+        }
+
+        function verifyHtmlPreserved(scenario: AudioMode) {
+            const currentHtml1 = getFrameElementById("page", "div1")!.outerHTML;
+            expect(StripRecordingMd5(currentHtml1)).toBe(
+                StripRecordingMd5(originalDiv1Html)
+            );
+            const currentHtml2 = getFrameElementById("page", "div2")!.outerHTML;
+            expect(StripRecordingMd5(currentHtml2)).toBe(
+                StripRecordingMd5(originalDiv2Html)
+            );
+        }
+
+        function expectMd5(id, expectedMd5) {
+            const elem = getFrameElementById("page", id);
+            expect(elem).not.toBeNull(`Could not find element "${id}"`);
+            if (elem) {
+                const md5 = elem.getAttribute("recordingmd5");
+
+                if (md5 === null && expectedMd5 === "undefined") {
+                    // Not having recordingmd5 is considered an acceptable result for this expectation.
+                    // Just return without performing any more expectations
+                    return;
+                }
+
+                expect(md5).toBe(
+                    expectedMd5,
+                    `recordingmd5 does not match for element: ${elem.outerHTML}`
+                );
             }
         }
 
@@ -267,295 +440,6 @@ describe("talking book tests", () => {
                     break;
                 }
 
-                case AudioMode.PureTextBox:
-                case AudioMode.HardSplitTextBox:
-                case AudioMode.SoftSplitTextBox: {
-                    expect(div).toHaveClass("ui-audioCurrent");
-                    break;
-                }
-
-                default: {
-                    throw new Error("Unrecognized scenario: " + scenario);
-                }
-            }
-        }
-
-        it("[Sentence/Sentence] showTool() should update sentence splits if no recordings exist", async done => {
-            try {
-                await runSentenceSplittingTestsAsync(
-                    AudioMode.PureSentence,
-                    false
-                );
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
-        });
-
-        it("[Sentence/Sentence] showTool() should not update sentence splits if recordings do exist", async done => {
-            try {
-                await runSentenceSplittingTestsAsync(
-                    AudioMode.PureSentence,
-                    true
-                );
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
-        });
-
-        it("[Text Box/Text Box] showTool() should update sentence splits if no recordings exist", async done => {
-            try {
-                await runSentenceSplittingTestsAsync(
-                    AudioMode.PureTextBox,
-                    false
-                );
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
-        });
-
-        // This returns the same result as above.
-        it("[Text Box/Text Box] showTool() should NOT update sentence splits if recordings do exist", async done => {
-            try {
-                await runSentenceSplittingTestsAsync(
-                    AudioMode.PureTextBox,
-                    true
-                );
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
-        });
-
-        it("[TextBox/Sentence Hard Split] showTool() should update sentence splits if no recordings exist", async done => {
-            try {
-                await runSentenceSplittingTestsAsync(
-                    AudioMode.HardSplitTextBox,
-                    false
-                );
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
-        });
-
-        it("[TextBox/Sentence Hard Split] showTool() should NOT update sentence splits if recordings do exist", async done => {
-            try {
-                await runSentenceSplittingTestsAsync(
-                    AudioMode.HardSplitTextBox,
-                    true
-                );
-
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
-        });
-
-        it("[TextBox/Sentence Soft Split] showTool() DOESN'T update sentence splits even if no recordings exist", async done => {
-            try {
-                await runSentenceSplittingTestsAsync(
-                    AudioMode.SoftSplitTextBox,
-                    false
-                );
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
-        });
-
-        it("[TextBox/Sentence Soft Split] showTool() should NOT update sentence splits if recordings do exist", async done => {
-            try {
-                await runSentenceSplittingTestsAsync(
-                    AudioMode.SoftSplitTextBox,
-                    true
-                );
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
-        });
-
-        async function runSentenceSplitTestsForUpdateMarkupAsync(
-            scenario: AudioMode,
-            areRecordingsPresent: boolean
-        ) {
-            let pageInnerHtml: string = "";
-            let currentElementId: string = "";
-            switch (scenario) {
-                case AudioMode.PureSentence: {
-                    pageInnerHtml = setupPureSentenceModeHtml();
-                    currentElementId = "2.1";
-                    break;
-                }
-                case AudioMode.PreTextBox: {
-                    pageInnerHtml = setupPreTextBoxModeHtml();
-                    currentElementId = "div2";
-                    break;
-                }
-                case AudioMode.PureTextBox: {
-                    pageInnerHtml = setupPureTextBoxModeHtml();
-                    currentElementId = "div2";
-                    break;
-                }
-                case AudioMode.HardSplitTextBox: {
-                    pageInnerHtml = setupTextBoxHardSplitHtml();
-                    currentElementId = "div2";
-                    break;
-                }
-                case AudioMode.SoftSplitTextBox: {
-                    pageInnerHtml = setupTextBoxSoftSplitHtml();
-                    currentElementId = "div2";
-                    break;
-                }
-                default: {
-                    throw new Error("Unknown scenario: " + scenario);
-                }
-            }
-
-            SetupIFrameFromHtml(`<div id="page1">${pageInnerHtml}</div>`);
-
-            if (scenario === AudioMode.PureSentence) {
-                theOneAudioRecorder.audioRecordingMode =
-                    AudioRecordingMode.Sentence;
-            } else {
-                theOneAudioRecorder.audioRecordingMode =
-                    AudioRecordingMode.TextBox;
-            }
-
-            const currentElement = getFrameElementById(
-                "page",
-                currentElementId
-            );
-            if (!currentElement) {
-                throw new Error(
-                    `Requested currentElement (id=${currentElementId}) not found.`
-                );
-            }
-
-            theOneAudioRecorder.setSoundAndHighlightAsync(
-                currentElement,
-                false
-            );
-
-            const originalHtml1 = getFrameElementById("page", "div1")!
-                .outerHTML;
-            const originalHtml2 = getFrameElementById("page", "div2")!
-                .outerHTML;
-
-            if (areRecordingsPresent) {
-                setAudioFilesPresent();
-            } else {
-                setAudioFilesDontExist();
-            }
-
-            // System under test
-            const tbTool = new TalkingBookTool();
-            await tbTool.updateMarkup();
-
-            // Verification
-            verifyHtmlStructureForUpdateMarkupTests(
-                scenario,
-                originalHtml1,
-                originalHtml2
-            );
-            verifyCurrentHighlightForUpdateMarkup(scenario);
-            verifySoundForUpdateMarkup(scenario);
-            verifyRecordButtonEnabled(); // Make sure we didn't accidentally disable all the toolbox buttons
-        }
-
-        function verifyHtmlStructureForUpdateMarkupTests(
-            scenario: AudioMode,
-            originalHtml1: string,
-            originalHtml2: string
-        ) {
-            // Div 1 should be untouched.
-            const currentHtml1 = getFrameElementById("page", "div1")!.outerHTML;
-            expect(currentHtml1).toBe(originalHtml1);
-
-            if (scenario === AudioMode.SoftSplitTextBox) {
-                // NOTE: SoftSplit test doesn't have very intuitive results.
-                // Even if recordings aren't present, it actually preserves the original splits, even though normally, no recordings present means we should update them.
-                // Prior to this check-if-recordings-present feature, it was actually the case that upon Soft Split, it never updated the markup.
-                // (That's because the playback mode was identified as text box, and in that case, it never actually runs makeAudioSentenceElementsLeaf())
-                // I'm not sure if that was entirely intentional, but it does seem very problematic to risk increasing/decreasing the number of splits while an audio is aligned to it.
-                // Now that we do check if recordings present...
-                // If they're somehow missing, we COULD now update the markup, but it doesn't seem worth the time, complexity, or risk to add that functionality.
-                // I guess it's more like if there's no recordings present, then we do whatever the old behavior was... which in this case, is to not do anything.
-
-                // Verify unchanged.
-                const currentHtml = getFrameElementById("page", "div2")!
-                    .outerHTML;
-                expect(currentHtml).toBe(originalHtml2);
-            } else if (
-                scenario === AudioMode.PureSentence ||
-                scenario === AudioMode.PreTextBox ||
-                scenario === AudioMode.HardSplitTextBox
-            ) {
-                // Desired behavior is that after keypress, it will re-do the spans
-                // Even if you already have it recorded.
-                const spans = getAudioSentenceSpans(`div2`);
-                const texts = spans.map(elem => {
-                    return elem.innerText;
-                });
-                expect(texts).toEqual(
-                    [`Sentence 2.1၊ Sentence 2.2`],
-                    `Failure for div2`
-                );
-            } else if (scenario === AudioMode.PureTextBox) {
-                const paragraphs = getParagraphsOfTextBox("div2");
-                const innerHTMLs = paragraphs.map(p => p.innerHTML);
-                expect(innerHTMLs).toEqual(
-                    ["Sentence 2.1၊ Sentence 2.2"],
-                    "Failure for div2"
-                );
-            } else {
-                throw new Error("Unrecognized scenario: " + scenario);
-            }
-        }
-
-        function verifyCurrentHighlightForUpdateMarkup(
-            scenario: AudioMode
-        ): void {
-            const div = getFrameElementById("page", "div2");
-            if (!div) {
-                expect(div).not.toBeNull("div2 is null");
-                return;
-            }
-
-            const page1 = getFrameElementById("page", "page1")!;
-            const numCurrents = page1.querySelectorAll(".ui-audioCurrent")
-                .length;
-            expect(numCurrents).toBe(
-                1,
-                "Only 1 item is allowed to be the current: " + page1.innerHTML
-            );
-
-            switch (scenario) {
-                case AudioMode.PureSentence: {
-                    const firstSpan = div.querySelector("span.audio-sentence");
-                    expect(firstSpan).toHaveClass("ui-audioCurrent");
-                    break;
-                }
-
                 case AudioMode.PreTextBox:
                 case AudioMode.PureTextBox:
                 case AudioMode.HardSplitTextBox:
@@ -565,12 +449,25 @@ describe("talking book tests", () => {
                 }
 
                 default: {
-                    throw new Error("Unrecognized scenario: " + scenario);
+                    throw new Error(
+                        `Unhandled scenario: ${scenario} (${
+                            AudioMode[scenario]
+                        })`
+                    );
                 }
             }
         }
 
-        function verifySoundForUpdateMarkup(scenario: AudioMode): void {
+        function verifySoundForShowToolTests(scenario: AudioMode): void {
+            verifySound(scenario, "div1", "1.1");
+        }
+
+        // Checks that the audio player's src corresponds to the ID of either the first div or the first span (depending on the scenario)
+        function verifySound(
+            scenario: AudioMode,
+            firstDivId: string,
+            firstSpanId: string
+        ): void {
             const player = document.getElementById(
                 "player"
             ) as HTMLMediaElement | null;
@@ -579,31 +476,23 @@ describe("talking book tests", () => {
                 return;
             }
 
-            const page1 = getFrameElementById("page", "page1")!;
-            const numCurrents = page1.querySelectorAll(".ui-audioCurrent")
-                .length;
-            expect(numCurrents).toBe(
-                1,
-                "Only 1 item is allowed to be the current: " + page1.innerHTML
-            );
-
             let expectedSrc: string = "";
             switch (scenario) {
                 case AudioMode.PureSentence:
                 case AudioMode.PreTextBox:
                 case AudioMode.HardSplitTextBox: {
-                    expectedSrc = "2.1";
+                    expectedSrc = firstSpanId;
                     break;
                 }
 
                 case AudioMode.PureTextBox:
                 case AudioMode.SoftSplitTextBox: {
-                    expectedSrc = "div2";
+                    expectedSrc = firstDivId;
                     break;
                 }
 
                 default: {
-                    throw new Error("Unrecognized scenario: " + scenario);
+                    throw new Error("Unhandled scenario: " + scenario);
                 }
             }
 
@@ -612,81 +501,231 @@ describe("talking book tests", () => {
             );
         }
 
-        // Although showTool() won't update sentence splits if recordings exist,
-        // but we do want that to happen when a keypress happens (i.e. updateMarkup)
-        it("[Sentence/Sentence] updateMarkup() will update sentence splits if recordings do exist", async done => {
-            try {
-                await runSentenceSplitTestsForUpdateMarkupAsync(
-                    AudioMode.PureSentence,
-                    true
-                );
+        function verifyChecksumsUpToDate(
+            scenario: AudioMode,
+            splitUpdateSetting: string
+        ) {
+            const expectedMd5s = getTestMd5s("same", scenario);
+            if (
+                scenario === AudioMode.PureSentence ||
+                scenario == AudioMode.PreTextBox ||
+                scenario === AudioMode.HardSplitTextBox
+            ) {
+                expectMd5("1.1", expectedMd5s[0]);
+                expectMd5("2.1", expectedMd5s[2]);
 
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
+                if (splitUpdateSetting !== "updated") {
+                    // If the splits are updated in this test scenario,
+                    // then it will be down to just one sentence each.
+                    // These two won't exist. And that's not worrisome.
+                    expectMd5("1.2", expectedMd5s[1]);
+                    expectMd5("2.2", expectedMd5s[3]);
+                }
+            } else {
+                expectMd5("div1", expectedMd5s[0]);
+                expectMd5("div2", expectedMd5s[1]);
             }
+        }
+
+        function verifyChecksumsNotUpdated(
+            scenario: AudioMode,
+            splitUpdateSetting: string
+        ) {
+            if (
+                scenario === AudioMode.PureSentence ||
+                scenario == AudioMode.PreTextBox ||
+                scenario === AudioMode.HardSplitTextBox
+            ) {
+                expectMd5("1.1", "undefined");
+                expectMd5("2.1", "undefined");
+
+                if (splitUpdateSetting === "preserved") {
+                    expectMd5("1.2", "undefined");
+                    expectMd5("2.2", "undefined");
+                } else if (splitUpdateSetting === "updated") {
+                    // Don't need to check 1.2 and 2.2 in this case,
+                    // because it's been updated down to just 1 span.
+                } else {
+                    throw new Error(
+                        "Unhandled splitUpdateSetting: " + splitUpdateSetting
+                    );
+                }
+            } else {
+                expectMd5("div1", "undefined");
+                expectMd5("div2", "undefined");
+            }
+        }
+
+        function verifyCheckumsStillDiffers(scenario: AudioMode) {
+            // Verify that it matches the original value and hasn't been updated
+            const expectedMd5s = getTestMd5s("differs", scenario);
+            if (
+                scenario === AudioMode.PureSentence ||
+                scenario == AudioMode.PreTextBox ||
+                scenario === AudioMode.HardSplitTextBox
+            ) {
+                // Expecting differs -> update, which means that there will only be one sentence left. Only need to check the 1st one.
+                expectMd5("1.1", expectedMd5s[0]);
+                expectMd5("2.1", expectedMd5s[2]);
+            } else {
+                expectMd5("div1", expectedMd5s[0]);
+                expectMd5("div2", expectedMd5s[1]);
+            }
+        }
+
+        describe("showTool(checksum=missing, audio=missing, scenario=*) => UPDATE", () => {
+            getAllAudioModes().forEach(scenario => {
+                const scenarioName = AudioMode[scenario];
+                it(`showTool(checksum=missing, audio=missing, scenario=${scenarioName}) => UPDATE`, async () => {
+                    return runNoChecksumNoAudioTestAsync(scenario);
+                });
+            });
+
+            const runNoChecksumNoAudioTestAsync = async (
+                scenario: AudioMode
+            ) => {
+                // Setup
+                const checksumSetting = "missing";
+                const audioPresent = "missing";
+                setupSentenceSplitTest(scenario, checksumSetting, audioPresent);
+
+                // System under test
+                await runShowToolAsync();
+
+                // Verify
+                verifySplitsUpdated(scenario);
+                verifyChecksumsNotUpdated(scenario, "updated");
+            };
         });
 
-        it("[TextBox/Sentence] updateMarkup() will update sentence splits if recordings do exist", async done => {
-            try {
-                await runSentenceSplitTestsForUpdateMarkupAsync(
-                    AudioMode.PreTextBox,
-                    true
-                );
+        describe("showTool(checksum=missing, audio=present, scenario=*) => SKIP UPDATE", () => {
+            getAllAudioModes().forEach(scenario => {
+                const scenarioName = AudioMode[scenario];
+                it(`showTool(checksum=missing, audio=present, scenario=${scenarioName}) => SKIP UPDATE`, async () => {
+                    return runNoChecksumYesAudioTestAsync(scenario);
+                });
+            });
 
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
+            const runNoChecksumYesAudioTestAsync = async (
+                scenario: AudioMode
+            ) => {
+                // Setup
+                const checksumSetting = "missing";
+                const audioPresent = "present";
+                setupSentenceSplitTest(scenario, checksumSetting, audioPresent);
+
+                // System Under Test
+                await runShowToolAsync();
+
+                // Verify
+                verifySplitsPreserved(scenario);
+                verifyChecksumsUpToDate(scenario, "preserved");
+            };
         });
 
-        it("[TextBox/TextBox] updateMarkup() will update sentence splits if recordings do exist", async done => {
-            try {
-                await runSentenceSplitTestsForUpdateMarkupAsync(
-                    AudioMode.PureTextBox,
-                    true
-                );
+        describe("showTool(checksum=same, audio=missing, scenario=*) => UPDATE", () => {
+            getAllAudioModes().forEach(scenario => {
+                const scenarioName = AudioMode[scenario];
+                it(`showTool(checksum=same, audio=missing, scenario=${scenarioName}) => UPDATE`, async () => {
+                    return runSameChecksumNoAudioTestAsync(scenario);
+                });
+            });
 
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
+            const runSameChecksumNoAudioTestAsync = async (
+                scenario: AudioMode
+            ) => {
+                // Setup
+                const checksumSetting = "same";
+                const audioPresent = "missing";
+                setupSentenceSplitTest(scenario, checksumSetting, audioPresent);
+
+                // System under test
+                await runShowToolAsync();
+
+                // Verify
+                verifySplitsUpdated(scenario);
+                verifyChecksumsUpToDate(scenario, "updated"); // Not really necessary, but make sure it's not messed up
+            };
         });
 
-        it("[TextBox/Sentence Hard Split] updateMarkup() will update sentence splits if recordings do exist", async done => {
-            try {
-                await runSentenceSplitTestsForUpdateMarkupAsync(
-                    AudioMode.HardSplitTextBox,
-                    true
-                );
+        describe("showTool(checksum=same, audio=partial, scenario=*) => UPDATE", () => {
+            // PureTextBox and SoftSplit not applicable, because there's only 1 recording per text box.
+            // Can't be partially recorded.
+            const scenarios = [
+                AudioMode.PureSentence,
+                AudioMode.PreTextBox,
+                AudioMode.HardSplitTextBox
+            ];
+            scenarios.forEach(scenario => {
+                const scenarioName = AudioMode[scenario];
+                it(`showTool(checksum=same, audio=partial, scenario=${scenarioName}) => UPDATE`, async () => {
+                    return runSameChecksumPartialAudioTestAsync(scenario);
+                });
+            });
 
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
+            const runSameChecksumPartialAudioTestAsync = async (
+                scenario: AudioMode
+            ) => {
+                // Setup
+                const checksumSetting = "same";
+                const audioPresent = "partiallyPresent";
+                setupSentenceSplitTest(scenario, checksumSetting, audioPresent);
+
+                // System under test
+                await runShowToolAsync();
+
+                // Verify
+                verifySplitsUpdated(scenario);
+            };
         });
 
-        it("[TextBox/Sentence Soft Split] updateMarkup() will update sentence splits if recordings do exist", async done => {
-            try {
-                await runSentenceSplitTestsForUpdateMarkupAsync(
-                    AudioMode.SoftSplitTextBox,
-                    true
-                );
+        describe("showTool(checksum=same, audio=present, scenario=*) => SKIP UPDATE", () => {
+            getAllAudioModes().forEach(scenario => {
+                const scenarioName = AudioMode[scenario];
+                it(`showTool(checksum=same, audio=present, scenario=${scenarioName}) => SKIP UPDATE`, async () => {
+                    return runSameChecksumYesAudioTestAsync(scenario);
+                });
+            });
 
-                done();
-            } catch (error) {
-                fail(error);
-                done();
-                throw error;
-            }
+            const runSameChecksumYesAudioTestAsync = async (
+                scenario: AudioMode
+            ) => {
+                const checksumSetting = "same";
+                const audioPresent = "present";
+                setupSentenceSplitTest(scenario, checksumSetting, audioPresent);
+
+                // System under test
+                await runShowToolAsync();
+
+                // Verify
+                verifySplitsPreserved(scenario);
+                verifyChecksumsUpToDate(scenario, "updated");
+            };
+        });
+
+        describe("showTool(checksum=differs, recording=*, scenario=*) => UPDATE", () => {
+            getAllAudioModes().forEach(scenario => {
+                const scenarioName = AudioMode[scenario];
+                it(`showTool(checksum=differs, recording=*, scenario=${scenarioName}) => UPDATE`, async () => {
+                    return runDifferentChecksumTestAsync(scenario);
+                });
+            });
+
+            const runDifferentChecksumTestAsync = async (
+                scenario: AudioMode
+            ) => {
+                // Setup
+                const checksumSetting = "differs";
+                const audioPresent = "present"; // Value doesn't really matter, but pick the "harder" input.
+                setupSentenceSplitTest(scenario, checksumSetting, audioPresent);
+
+                // System under test
+                await runShowToolAsync();
+
+                // Verify
+                verifySplitsUpdated(scenario);
+                verifyCheckumsStillDiffers(scenario);
+            };
         });
     });
 });

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookSpec.ts
@@ -9,7 +9,8 @@ import {
     SetupTalkingBookUIElements,
     SetupIFrameAsync,
     SetupIFrameFromHtml,
-    getFrameElementById
+    getFrameElementById,
+    StripPlayerSrcNoCacheSuffix
 } from "./audioRecordingSpec";
 import * as XRegExp from "xregexp"; // Not sure why, but import * as XRegExp works better. import XRegExp causes "xregexp_1.default is undefined" error
 import { setSentenceEndingPunctuationForBloom } from "../readers/libSynphony/bloom_xregexp_categories";
@@ -89,17 +90,25 @@ describe("talking book tests", () => {
 
         function setupPureSentenceModeHtml(): string {
             const div1Html =
-                '<div class="bloom-editable" id="div1" data-audioRecordingMode="Sentence"><p><span id="1.1" class="audio-sentence ui-audioCurrent">1.1၊</span> <span id="1.2" class="audio-sentence">1.2</span></p></div>';
+                '<div class="bloom-editable" id="div1" data-audioRecordingMode="Sentence"><p><span id="1.1" class="audio-sentence ui-audioCurrent">Sentence 1.1၊</span> <span id="1.2" class="audio-sentence">Sentence 1.2</span></p></div>';
             const div2Html =
-                '<div class="bloom-editable" id="div2" data-audioRecordingMode="Sentence"><p><span id="2.1" class="audio-sentence">2.1၊</span> <span id="2.2" class="audio-sentence">2.2</span></p></div>';
+                '<div class="bloom-editable" id="div2" data-audioRecordingMode="Sentence"><p><span id="2.1" class="audio-sentence">Sentence 2.1၊</span> <span id="2.2" class="audio-sentence">Sentence 2.2</span></p></div>';
+            return `${div1Html}${div2Html}`;
+        }
+
+        function setupPreTextBoxModeHtml(): string {
+            const div1Html =
+                '<div class="bloom-editable ui-audioCurrent" id="div1" data-audiorecordingmode="TextBox"><p><span id="1.1" class="audio-sentence">Sentence 1.1၊</span> <span id="1.1" class="audio-sentence">Sentence 1.2</span></p></div>';
+            const div2Html =
+                '<div class="bloom-editable audio-sentence" id="div2" data-audiorecordingmode="TextBox"><p><span id="2.1" class="audio-sentence">Sentence 2.1၊</span> <span id="2.1" class="audio-sentence">Sentence 2.2</span></p></div>';
             return `${div1Html}${div2Html}`;
         }
 
         function setupPureTextBoxModeHtml(): string {
             const div1Html =
-                '<div class="bloom-editable audio-sentence ui-audioCurrent" id="div1" data-audiorecordingmode="TextBox"><p>1.1၊ 1.2</p></div>';
+                '<div class="bloom-editable audio-sentence ui-audioCurrent" id="div1" data-audiorecordingmode="TextBox"><p>Sentence 1.1၊ Sentence 1.2</p></div>';
             const div2Html =
-                '<div class="bloom-editable audio-sentence" id="div2" data-audiorecordingmode="TextBox"><p>2.1၊ 2.2</p></div>';
+                '<div class="bloom-editable audio-sentence" id="div2" data-audiorecordingmode="TextBox"><p>Sentence 2.1၊ Sentence 2.2</p></div>';
             return `${div1Html}${div2Html}`;
         }
 
@@ -109,19 +118,20 @@ describe("talking book tests", () => {
                 const divStartHtml = `<div class="bloom-editable${
                     i === 1 ? " ui-audioCurrent" : ""
                 }" id="div${i}" data-audiorecordingmode="TextBox">`;
-                const divInnerHtml = `<p><span class="audio-sentence">${i}.1၊</span> <span class="audio-sentence">${i}.2</span></p>`;
+                const divInnerHtml = `<p><span id="${i}.1" class="audio-sentence">Sentence ${i}.1၊</span> <span id="${i}.2" class="audio-sentence">Sentence ${i}.2</span></p>`;
                 const divHtml = `${divStartHtml}${divInnerHtml}</div>`;
                 html += divHtml;
             }
             return html;
         }
+
         function setupTextBoxSoftSplitHtml(): string {
             let html = "";
             for (let i = 1; i <= 2; ++i) {
                 const divStartHtml = `<div class="bloom-editable audio-sentence${
                     i === 1 ? " ui-audioCurrent" : ""
                 }" id="div${i}" data-audiorecordingmode="TextBox" data-audiorecordingendtimes="1.0 2.0">`;
-                const divInnerHtml = `<p><span id="${i}.1" class="bloom-highlightSegment">${i}.1၊</span> <span id="${i}.2" class="bloom-highlightSegment">${i}.2</span></p>`;
+                const divInnerHtml = `<p><span id="${i}.1" class="bloom-highlightSegment">Sentence ${i}.1၊</span> <span id="Sentence ${i}.2" class="bloom-highlightSegment">${i}.2</span></p>`;
 
                 const divHtml = `${divStartHtml}${divInnerHtml}</div>`;
                 html += divHtml;
@@ -188,7 +198,7 @@ describe("talking book tests", () => {
         function verifyHtmlStructure(
             scenario: AudioMode,
             areRecordingsPresent: boolean,
-            originalHtml: string
+            originalDiv1Html: string
         ) {
             if (
                 areRecordingsPresent ||
@@ -206,7 +216,7 @@ describe("talking book tests", () => {
                 // Verify unchanged.
                 const currentHtml = getFrameElementById("page", "page1")!
                     .innerHTML;
-                expect(currentHtml).toBe(originalHtml);
+                expect(currentHtml).toBe(originalDiv1Html);
             } else if (
                 scenario === AudioMode.PureSentence ||
                 scenario === AudioMode.HardSplitTextBox
@@ -217,7 +227,7 @@ describe("talking book tests", () => {
                         return elem.innerText;
                     });
                     expect(texts).toEqual(
-                        [`${i}.1၊ ${i}.2`],
+                        [`Sentence ${i}.1၊ Sentence ${i}.2`],
                         `Failure for div${i}`
                     );
                 }
@@ -226,7 +236,7 @@ describe("talking book tests", () => {
                     const paragraphs = getParagraphsOfTextBox(`div${i}`);
                     const innerHTMLs = paragraphs.map(p => p.innerHTML);
                     expect(innerHTMLs).toEqual(
-                        [`${i}.1၊ ${i}.2`],
+                        [`Sentence ${i}.1၊ Sentence ${i}.2`],
                         `Failure for div${i}`
                     );
                 }
@@ -376,6 +386,301 @@ describe("talking book tests", () => {
                     AudioMode.SoftSplitTextBox,
                     true
                 );
+                done();
+            } catch (error) {
+                fail(error);
+                done();
+                throw error;
+            }
+        });
+
+        async function runSentenceSplitTestsForUpdateMarkupAsync(
+            scenario: AudioMode,
+            areRecordingsPresent: boolean
+        ) {
+            let pageInnerHtml: string = "";
+            let currentElementId: string = "";
+            switch (scenario) {
+                case AudioMode.PureSentence: {
+                    pageInnerHtml = setupPureSentenceModeHtml();
+                    currentElementId = "2.1";
+                    break;
+                }
+                case AudioMode.PreTextBox: {
+                    pageInnerHtml = setupPreTextBoxModeHtml();
+                    currentElementId = "div2";
+                    break;
+                }
+                case AudioMode.PureTextBox: {
+                    pageInnerHtml = setupPureTextBoxModeHtml();
+                    currentElementId = "div2";
+                    break;
+                }
+                case AudioMode.HardSplitTextBox: {
+                    pageInnerHtml = setupTextBoxHardSplitHtml();
+                    currentElementId = "div2";
+                    break;
+                }
+                case AudioMode.SoftSplitTextBox: {
+                    pageInnerHtml = setupTextBoxSoftSplitHtml();
+                    currentElementId = "div2";
+                    break;
+                }
+                default: {
+                    throw new Error("Unknown scenario: " + scenario);
+                }
+            }
+
+            SetupIFrameFromHtml(`<div id="page1">${pageInnerHtml}</div>`);
+
+            if (scenario === AudioMode.PureSentence) {
+                theOneAudioRecorder.audioRecordingMode =
+                    AudioRecordingMode.Sentence;
+            } else {
+                theOneAudioRecorder.audioRecordingMode =
+                    AudioRecordingMode.TextBox;
+            }
+
+            const currentElement = getFrameElementById(
+                "page",
+                currentElementId
+            );
+            if (!currentElement) {
+                throw new Error(
+                    `Requested currentElement (id=${currentElementId}) not found.`
+                );
+            }
+
+            theOneAudioRecorder.setSoundAndHighlightAsync(
+                currentElement,
+                false
+            );
+
+            const originalHtml1 = getFrameElementById("page", "div1")!
+                .outerHTML;
+            const originalHtml2 = getFrameElementById("page", "div2")!
+                .outerHTML;
+
+            if (areRecordingsPresent) {
+                setAudioFilesPresent();
+            } else {
+                setAudioFilesDontExist();
+            }
+
+            // System under test
+            const tbTool = new TalkingBookTool();
+            await tbTool.updateMarkup();
+
+            // Verification
+            verifyHtmlStructureForUpdateMarkupTests(
+                scenario,
+                originalHtml1,
+                originalHtml2
+            );
+            verifyCurrentHighlightForUpdateMarkup(scenario);
+            verifySoundForUpdateMarkup(scenario);
+            verifyRecordButtonEnabled(); // Make sure we didn't accidentally disable all the toolbox buttons
+        }
+
+        function verifyHtmlStructureForUpdateMarkupTests(
+            scenario: AudioMode,
+            originalHtml1: string,
+            originalHtml2: string
+        ) {
+            // Div 1 should be untouched.
+            const currentHtml1 = getFrameElementById("page", "div1")!.outerHTML;
+            expect(currentHtml1).toBe(originalHtml1);
+
+            if (scenario === AudioMode.SoftSplitTextBox) {
+                // NOTE: SoftSplit test doesn't have very intuitive results.
+                // Even if recordings aren't present, it actually preserves the original splits, even though normally, no recordings present means we should update them.
+                // Prior to this check-if-recordings-present feature, it was actually the case that upon Soft Split, it never updated the markup.
+                // (That's because the playback mode was identified as text box, and in that case, it never actually runs makeAudioSentenceElementsLeaf())
+                // I'm not sure if that was entirely intentional, but it does seem very problematic to risk increasing/decreasing the number of splits while an audio is aligned to it.
+                // Now that we do check if recordings present...
+                // If they're somehow missing, we COULD now update the markup, but it doesn't seem worth the time, complexity, or risk to add that functionality.
+                // I guess it's more like if there's no recordings present, then we do whatever the old behavior was... which in this case, is to not do anything.
+
+                // Verify unchanged.
+                const currentHtml = getFrameElementById("page", "div2")!
+                    .outerHTML;
+                expect(currentHtml).toBe(originalHtml2);
+            } else if (
+                scenario === AudioMode.PureSentence ||
+                scenario === AudioMode.PreTextBox ||
+                scenario === AudioMode.HardSplitTextBox
+            ) {
+                // Desired behavior is that after keypress, it will re-do the spans
+                // Even if you already have it recorded.
+                const spans = getAudioSentenceSpans(`div2`);
+                const texts = spans.map(elem => {
+                    return elem.innerText;
+                });
+                expect(texts).toEqual(
+                    [`Sentence 2.1၊ Sentence 2.2`],
+                    `Failure for div2`
+                );
+            } else if (scenario === AudioMode.PureTextBox) {
+                const paragraphs = getParagraphsOfTextBox("div2");
+                const innerHTMLs = paragraphs.map(p => p.innerHTML);
+                expect(innerHTMLs).toEqual(
+                    ["Sentence 2.1၊ Sentence 2.2"],
+                    "Failure for div2"
+                );
+            } else {
+                throw new Error("Unrecognized scenario: " + scenario);
+            }
+        }
+
+        function verifyCurrentHighlightForUpdateMarkup(
+            scenario: AudioMode
+        ): void {
+            const div = getFrameElementById("page", "div2");
+            if (!div) {
+                expect(div).not.toBeNull("div2 is null");
+                return;
+            }
+
+            const page1 = getFrameElementById("page", "page1")!;
+            const numCurrents = page1.querySelectorAll(".ui-audioCurrent")
+                .length;
+            expect(numCurrents).toBe(
+                1,
+                "Only 1 item is allowed to be the current: " + page1.innerHTML
+            );
+
+            switch (scenario) {
+                case AudioMode.PureSentence: {
+                    const firstSpan = div.querySelector("span.audio-sentence");
+                    expect(firstSpan).toHaveClass("ui-audioCurrent");
+                    break;
+                }
+
+                case AudioMode.PreTextBox:
+                case AudioMode.PureTextBox:
+                case AudioMode.HardSplitTextBox:
+                case AudioMode.SoftSplitTextBox: {
+                    expect(div).toHaveClass("ui-audioCurrent");
+                    break;
+                }
+
+                default: {
+                    throw new Error("Unrecognized scenario: " + scenario);
+                }
+            }
+        }
+
+        function verifySoundForUpdateMarkup(scenario: AudioMode): void {
+            const player = document.getElementById(
+                "player"
+            ) as HTMLMediaElement | null;
+            if (!player) {
+                expect(player).not.toBeNull("player is null");
+                return;
+            }
+
+            const page1 = getFrameElementById("page", "page1")!;
+            const numCurrents = page1.querySelectorAll(".ui-audioCurrent")
+                .length;
+            expect(numCurrents).toBe(
+                1,
+                "Only 1 item is allowed to be the current: " + page1.innerHTML
+            );
+
+            let expectedSrc: string = "";
+            switch (scenario) {
+                case AudioMode.PureSentence:
+                case AudioMode.PreTextBox:
+                case AudioMode.HardSplitTextBox: {
+                    expectedSrc = "2.1";
+                    break;
+                }
+
+                case AudioMode.PureTextBox:
+                case AudioMode.SoftSplitTextBox: {
+                    expectedSrc = "div2";
+                    break;
+                }
+
+                default: {
+                    throw new Error("Unrecognized scenario: " + scenario);
+                }
+            }
+
+            expect(StripPlayerSrcNoCacheSuffix(player.src)).toBe(
+                `http://localhost:9876/bloom/api/audio/wavFile?id=audio/${expectedSrc}.wav`
+            );
+        }
+
+        // Although showTool() won't update sentence splits if recordings exist,
+        // but we do want that to happen when a keypress happens (i.e. updateMarkup)
+        it("[Sentence/Sentence] updateMarkup() will update sentence splits if recordings do exist", async done => {
+            try {
+                await runSentenceSplitTestsForUpdateMarkupAsync(
+                    AudioMode.PureSentence,
+                    true
+                );
+
+                done();
+            } catch (error) {
+                fail(error);
+                done();
+                throw error;
+            }
+        });
+
+        it("[TextBox/Sentence] updateMarkup() will update sentence splits if recordings do exist", async done => {
+            try {
+                await runSentenceSplitTestsForUpdateMarkupAsync(
+                    AudioMode.PreTextBox,
+                    true
+                );
+
+                done();
+            } catch (error) {
+                fail(error);
+                done();
+                throw error;
+            }
+        });
+
+        it("[TextBox/TextBox] updateMarkup() will update sentence splits if recordings do exist", async done => {
+            try {
+                await runSentenceSplitTestsForUpdateMarkupAsync(
+                    AudioMode.PureTextBox,
+                    true
+                );
+
+                done();
+            } catch (error) {
+                fail(error);
+                done();
+                throw error;
+            }
+        });
+
+        it("[TextBox/Sentence Hard Split] updateMarkup() will update sentence splits if recordings do exist", async done => {
+            try {
+                await runSentenceSplitTestsForUpdateMarkupAsync(
+                    AudioMode.HardSplitTextBox,
+                    true
+                );
+
+                done();
+            } catch (error) {
+                fail(error);
+                done();
+                throw error;
+            }
+        });
+
+        it("[TextBox/Sentence Soft Split] updateMarkup() will update sentence splits if recordings do exist", async done => {
+            try {
+                await runSentenceSplitTestsForUpdateMarkupAsync(
+                    AudioMode.SoftSplitTextBox,
+                    true
+                );
+
                 done();
             } catch (error) {
                 fail(error);

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -31,9 +31,9 @@ export interface ITool {
     configureElements(container: HTMLElement);
     showTool(); // called when a new tool is chosen, but not necessarily when a new page is displayed.
     hideTool(); // called when changing tools or hiding the toolbox.
-    updateMarkup(); // called on every keypress AND after newPageReady
+    updateMarkup(); // called on most keypresses (but notably, not on arrow navigation, also not Ctrl+C). It is called on typing letters (obviously), Ctrl+X, Ctrl+V, Ctrl+Z, Ctrl+Y etc... or even just pressing and releasing Ctrl or Shift.
     isUpdateMarkupAsync(): boolean; // should return true if updateMarkup does any async work that we should wait for.
-    newPageReady(); // called when a new page is displayed AND after showTool
+    newPageReady(); // called when a new page is displayed or tool is activated (called after showTool)
     detachFromPage(); // called when a page is going away AND before hideTool
     id(): string; // without trailing "Tool"!
     hasRestoredSettings: boolean;
@@ -492,7 +492,9 @@ export function applyToolboxStateToUpdatedPage() {
         doWhenPageReady(() => {
             if (currentTool) {
                 currentTool.newPageReady();
-                currentTool.updateMarkup();
+                // We used to call updateMarkup() here
+                // Now we don't because it would mess up the Talking Book Tool
+                // if you really need it, add call to updateMarkup to currentTool's implementation of newPageReady.
             }
         });
     }

--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -104,6 +104,7 @@ namespace Bloom.Edit
 			// a consistent state of the audio folder, and therefore should NOT run on the UI thread.
 			// Also, explicitly setting requiresSync to true (even tho that's default anyway) to make concurrency less complicated to think about
 			apiHandler.RegisterEndpointHandler("audio/checkForAnyRecording", HandleCheckForAnyRecording, false, true);
+			apiHandler.RegisterEndpointHandler("audio/checkForAllRecording", HandleCheckForAllRecording, false, true);
 			apiHandler.RegisterEndpointHandler("audio/deleteSegment", HandleDeleteSegment, false, true);
 			apiHandler.RegisterEndpointHandler("audio/checkForSegment", HandleCheckForSegment, false, true);
 			apiHandler.RegisterEndpointHandler("audio/wavFile", HandleAudioFileRequest, false, true);
@@ -141,6 +142,27 @@ namespace Bloom.Edit
 				}
 			}
 			request.Failed("no audio");
+		}
+
+		private void HandleCheckForAllRecording(ApiRequest request)
+		{
+			var ids = request.RequiredParam("ids");
+			var idList = ids.Split(',');
+
+			if (idList.Any())
+			{
+				WaitForRecordingToComplete();	// More straightforward to test for the existence of the files by waiting until all the files have been written.
+			}
+
+			foreach (var id in idList)
+			{
+				if (!RobustFile.Exists(GetPathToRecordableAudioForSegment(id)) && !RobustFile.Exists(GetPathToPublishableAudioForSegment(id)))
+				{
+					request.ReplyWithBoolean(false);
+					return;
+				}
+			}
+			request.ReplyWithBoolean(true);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Recently, it was added that if recordings already existed, the sentence splits would be locked. Now, typing will cause the splits to be re-calculated, even if recordings exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3846)
<!-- Reviewable:end -->
