### PR TITLE
Make Bloom more robust for harvesting comics (20200721)

### DIFF
--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -1826,7 +1826,8 @@ namespace Bloom.Publish.Epub
 			if(string.IsNullOrEmpty (BookInStagingFolder)) {
 				StageEpub(progress);
 			}
-			ZipAndSaveEpub (destinationEpubPath, progress);
+			if (!AbortRequested)
+				ZipAndSaveEpub (destinationEpubPath, progress);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Bloom won't create an ePUB for comics, but there's no need to crash!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3848)
<!-- Reviewable:end -->
