### PR TITLE
Convert <b> to <strong> and <i> to <em> when pasting (BL-8711)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -117,6 +117,18 @@ export default class BloomField {
                 event.data.dataValue
             );
 
+            // Deal with sources that still use <b> and <i> instead of <strong> and <em>.
+            // Check if any of these markers are present, and if so, fix all of them.
+            // See https://issues.bloomlibrary.org/youtrack/issue/BL-8711.
+            if (/<\/?[bi]>/i.test(event.data.dataValue)) {
+                const fixBold = event.data.dataValue.replace(
+                    /<(\/?)b>/gi,
+                    "<$1strong>"
+                );
+                const fixItalic = fixBold.replace(/<(\/?)i>/gi, "<$1em>");
+                event.data.dataValue = fixItalic;
+            }
+
             const paras = event.data.dataValue.match(/<p>/g);
             if (!paras) {
                 // Enhance: should we remove the probable <span> and just leave the text?

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1059,6 +1059,8 @@ namespace Bloom.Book
 
 			UpdateTextsNewlyChangedToRequiresParagraph(bookDOM);
 
+			UpdateCharacterStyleMarkup(bookDOM);
+
 			bookDOM.SetImageAltAttrsFromDescriptions(CollectionSettings.Language1Iso639Code);
 
 			//we've removed and possible added pages, so our page cache is invalid
@@ -1421,6 +1423,36 @@ namespace Bloom.Book
 						s += "<p>" + chunk + "</p>";
 				}
 				text.InnerXml = s;
+			}
+		}
+
+		/// <summary>
+		/// Convert old &lt;b&gt; and &lt;i&gt; to &lt;strong&gt; and &lt;em&gt; respectively.
+		/// Also remove instances like &lt;/b&gt;&lt;b&gt; altogether since such markup is redundant.
+		/// </summary>
+		public void UpdateCharacterStyleMarkup(HtmlDom bookDOM)
+		{
+			var preserve = bookDOM.RawDom.PreserveWhitespace;
+			bookDOM.RawDom.PreserveWhitespace = true;
+			var paragraphs = bookDOM.SafeSelectNodes("//div[contains(@class,'bloom-editable')]/p");
+			foreach (XmlElement para in paragraphs)
+			{
+				string inner = para.InnerXml;
+				if (String.IsNullOrEmpty(inner) || !inner.Contains("<"))
+					continue;
+				inner = Regex.Replace(inner, @"</b>(\p{Z}*)<b>", "$1",
+					RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+				inner = Regex.Replace(inner, @"</i>(\p{Z}*)<i>", "$1",	// we've handled "</i></b> <b><i>"
+					RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+				inner = Regex.Replace(inner, @"</b>(\p{Z}*)<b>", "$1",	// repeat in case "</b></i> <i><b>" happens
+					RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+				// Note that .*? is the non-greedy match for any number of any characters.
+				inner = Regex.Replace(inner, @"<b>(.*?)</b>", "<strong>$1</strong>",
+					RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+				inner = Regex.Replace(inner, @"<i>(.*?)</i>", "<em>$1</em>",
+					RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+				if (inner != para.InnerXml)
+					para.InnerXml = inner;
 			}
 		}
 


### PR DESCRIPTION
Microsoft Word still uses the old markup.  Other sources probably do as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3850)
<!-- Reviewable:end -->
