### PR TITLE
BL-8648 new comical detection algorithm

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
@@ -322,6 +322,7 @@ const ComicToolControls: React.FunctionComponent = () => {
     };
 
     const styleSupportsShowTail = (style: string) => {
+        // Enhance: When tails only show outside of content rectangle, we can just return 'true' here always.
         switch (style) {
             case "none":
             case "":

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -765,7 +765,7 @@ namespace Bloom.Book
 				// This is only needed for updating from old Bloom versions. No need if we're copying the current
 				// edit book, on which it's already been done, to make an epub or similar.
 				if (!forCopyOfUpToDateBook)
-					ImageUtils.FixSizeAndTransparencyOfImagesInFolder(FolderPath, progress);
+					Storage.PerformNecessaryMaintenanceOnBook();
 				Save();
 			}
 

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -563,13 +563,12 @@ namespace Bloom.Edit
 				GetMultilingualContentLanguages(out lang2iso, out lang3iso);
 				CurrentBook.SetMultilingualContentLanguages(lang2iso, lang3iso);
 				CurrentBook.PrepareForEditing();
-				// If the book contains overlarge images, we want to fix those before editing because this can lead
-				// to thumbnails not being created properly and other bad behavior.  This is a one-time fix that can
-				// permanently change the images in the original book folder.  If any images must be shrunk, then a
-				// progress dialog pops up because that can be a very slow process.  If nothing needs to be done,
-				// nothing will appear on the screen, and it usually takes a small fraction of a second to determine
-				// this.  (almost no time if the maintenanceLevel has been set for this book)
-				CurrentBook.Storage.ShrinkImagesIfNecessary();
+				// As of 4.9, we are adding a hook here to do one-time maintenance to books, based on a
+				// metadata 'maintenanceLevel'.
+				// 0 -> 1 Deal with overlarge images.
+				// 1 -> 2 Remove comical SVGs associated with 'none' style textboxes.
+				// Takes almost no time if the maintenanceLevel has been set for this book.
+				CurrentBook.Storage.PerformNecessaryMaintenanceOnBook();
 			}
 
 			_currentlyDisplayedBook = CurrentBook;

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -1966,9 +1966,11 @@ namespace BloomTests.Book
 					<link rel='stylesheet' href='../../previewMode.css' type='text/css' />;
 				</head>
 				<body>
-					<div id='comicalItem' class='bloom-textOverPicture' data-bubble='`style`:`speech`'>my bubble</div>
 					<div class='bloom-page' id='guid3'>
-					   <div class='bloom-translationGroup bloom-trailingElement'>
+						<div class='bloom-imageContainer'>
+							<svg id='comicalItem' class='comical-generated' />
+						</div>
+						<div class='bloom-translationGroup bloom-trailingElement'>
 							<div class='bloom-editable bloom-content1' contenteditable='true' lang='de'>
 								Some German.
 							</div>
@@ -1996,7 +1998,7 @@ namespace BloomTests.Book
 			Assert.That(allLanguages["xyz"], Is.True);
 			Assert.That(allLanguages, Has.Count.EqualTo(1));
 
-			var comicalItem = book.OurHtmlDom.RawDom.SelectSingleNode("//div[@id='comicalItem']"); // GetElementById("comicalItem");
+			var comicalItem = book.OurHtmlDom.RawDom.SelectSingleNode("//svg[@id='comicalItem']"); // GetElementById("comicalItem");
 			comicalItem.ParentNode.RemoveChild(comicalItem);
 
 			allLanguages = book.AllPublishableLanguages(true);
@@ -2727,9 +2729,9 @@ namespace BloomTests.Book
 	<body>
 		<div class='bloom-page'>
 			<div class='bloom-imageContainer'>
-				<div class='bloom-textOverPicture' data-bubble='{`style`:`caption`'>
+				<svg class='comical-generated'>
 					<!-- Stuff goes here -->
-				</div>
+				</svg>
 			</div>
 		</div>
 	</body>

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -1550,7 +1550,7 @@ p {
 		}
 
 		[Test]
-		[TestCase(" color : rgb(98, 19, 45);", ",`backgroundColors `: [`white`,`#7b8eb8`] ", "",
+		[TestCase(" color : rgb(98, 19, 45);", ",`backgroundColors`: [`white`,`#7b8eb8`] ", "",
 				"", "",
 				"", "", 0)]
 		[TestCase("", "", "",
@@ -1618,6 +1618,20 @@ p {
 
 			// Verification
 			Assert.That(jsonString, Is.EqualTo(jsonResponses[responseIndex]));
+		}
+
+		[Test]
+		[TestCase("{`version`:`1.0`,`backgroundColors`:[`white`,`#7b8eb8`],`style`:`none`}", "none")]
+		[TestCase("{`style`:`caption`,`version`:`1.0`,`backgroundColors`:[`white`,`#7b8eb8`],`opacity`:`0.66`}", "caption")]
+		[TestCase("{`version`:`1.0`,`backgroundColors`:[`white`,`#7b8eb8`]}", "none")]
+		[TestCase("{`version`:`1.0`,`backgroundColors`:[`white`,`#7b8eb8`],`style`:`exclamation`}", "exclamation")]
+		public void GetStyleFromDataBubble_Works(string dataBubbleAttrVal, string result)
+		{
+			// SUT
+			var obj = HtmlDom.GetJsonObjectFromDataBubble(dataBubbleAttrVal);
+			var jsonString = HtmlDom.GetStyleFromDataBubbleJsonObj(obj);
+
+			Assert.That(jsonString, Is.EqualTo(result));
 		}
 
 		[Test]


### PR DESCRIPTION
* depends on updated comicaljs
* assumes Comical only inserts svgs that aren't transparent
* migrates old comical books by deleting transparent svgs
   inserted for 'none' style bubbles
* add migration tests
* handle case where old book goes directly to Publish
* refactor some stuff around BookStorage's
   PerformNecessaryMaintenanceOnBook()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3870)
<!-- Reviewable:end -->
