### PR TITLE
TalkingBook: Refactor showTool and newPageReady. (BL-8649)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
@@ -1,4 +1,4 @@
-import { ITool } from "../toolbox";
+﻿import { ITool } from "../toolbox";
 import { ToolBox } from "../toolbox";
 import * as AudioRecorder from "./audioRecording";
 
@@ -44,9 +44,9 @@ export default class TalkingBookTool implements ITool {
     }
 
     // Called when a new page is loaded.
-    public newPageReady() {
+    public async newPageReady(): Promise<void> {
         // if this class eventually extends our React Adaptor, this can be removed.
-        AudioRecorder.theOneAudioRecorder.newPageReady();
+        return AudioRecorder.theOneAudioRecorder.newPageReady();
     }
 
     public hideTool() {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookSpec.ts
@@ -319,6 +319,7 @@ describe("talking book tests", () => {
         async function runShowToolAsync(): Promise<void> {
             const tbTool = new TalkingBookTool();
             await tbTool.showTool();
+            await tbTool.newPageReady();
         }
 
         function verifyCommonAspects(scenario: AudioMode) {

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -33,7 +33,7 @@ export interface ITool {
     hideTool(); // called when changing tools or hiding the toolbox.
     updateMarkup(); // called on most keypresses (but notably, not on arrow navigation, also not Ctrl+C). It is called on typing letters (obviously), Ctrl+X, Ctrl+V, Ctrl+Z, Ctrl+Y etc... or even just pressing and releasing Ctrl or Shift.
     isUpdateMarkupAsync(): boolean; // should return true if updateMarkup does any async work that we should wait for.
-    newPageReady(); // called when a new page is displayed or tool is activated (called after showTool)
+    newPageReady(); // called when a new page is displayed or tool is activated (called after showTool completes)
     detachFromPage(); // called when a page is going away AND before hideTool
     id(): string; // without trailing "Tool"!
     hasRestoredSettings: boolean;
@@ -636,21 +636,11 @@ function activateTool(newTool: ITool) {
         if (!newTool.hasRestoredSettings) {
             newTool.hasRestoredSettings = true;
             newTool.beginRestoreSettings(savedSettings).then(() => {
-                if (toolElt) {
-                    newTool.finishToolLocalization(toolElt);
-                }
-                newTool.showTool();
-                newTool.newPageReady();
+                activateToolInternalAsync(newTool, toolElt);
             });
         } else {
-            if (toolElt) {
-                newTool.finishToolLocalization(toolElt);
-            }
-            newTool.showTool();
-            newTool.newPageReady();
+            activateToolInternalAsync(newTool, toolElt);
         }
-
-        ToolBox.insertLangAttributesIntoToolboxElements(); // allows language-specific CSS formatting to be applied.
     }
 }
 
@@ -670,6 +660,26 @@ function getToolElement(tool: ITool): HTMLElement | null {
     }
     return toolElement;
 }
+
+async function activateToolInternalAsync(
+    newTool: ITool,
+    toolElt: HTMLElement | null
+): Promise<void> {
+    if (toolElt) {
+        newTool.finishToolLocalization(toolElt);
+    }
+
+    // Await it so that we can guarantee that newPageReady() and insertLangAttributesIntoToolboxElements()
+    // happen after showTool.
+    await newTool.showTool();
+
+    // Note: Allowed to begin some async work too, but currently no need to await its result.
+    newTool.newPageReady();
+
+    // Note: Begins some async work too, but currently no need to await its result.
+    ToolBox.insertLangAttributesIntoToolboxElements();
+}
+
 /**
  * This function attempts to activate the tool whose "data-toolId" attribute is equal to the value
  * of "currentTool" (the last tool displayed).


### PR DESCRIPTION
Move logic which is about dealing with the newly ready page from showTool to newPageReady.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3871)
<!-- Reviewable:end -->
