### PR TITLE
Fix bug where context prevents "|" from delimiting phrases (BL-8649)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/bloomSynphonyExtensions.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/bloomSynphonyExtensions.js
@@ -3,12 +3,7 @@
  */
 import XRegExp from "xregexp";
 require("./bloom_xregexp_categories.js"); // reviewslog should add PEP to XRegExp, but it's not working
-import {
-    theOneLibSynphony,
-    theOneLanguageDataInstance,
-    LanguageData,
-    LibSynphony
-} from "./synphony_lib";
+import { theOneLibSynphony, LanguageData, LibSynphony } from "./synphony_lib";
 import * as _ from "underscore";
 
 export function clearWordCache() {
@@ -116,7 +111,7 @@ LibSynphony.prototype.setExtraSentencePunctuation = function(extra) {
             alias: "Sentence_Ending_Punctuation",
             bmp:
                 extraRe +
-                "\u0021\u002e\u003f\u007c\u055c\u055e\u0589\u061f\u06d4\u0700\u0701\u0702\u0964\u0965\u104b\u1362\u1367\u1368\u166e\u1803\u1809\u1944\u1945\u203c\u203d\u2047\u2048\u2049\u3002\ufe52\ufe56\ufe57\uff01\uff0e\uff1f\uff61\u00a7"
+                "\u0021\u002e\u003f\u055c\u055e\u0589\u061f\u06d4\u0700\u0701\u0702\u0964\u0965\u104b\u1362\u1367\u1368\u166e\u1803\u1809\u1944\u1945\u203c\u203d\u2047\u2048\u2049\u3002\ufe52\ufe56\ufe57\uff01\uff0e\uff1f\uff61\u00a7"
         }
     ]);
 };
@@ -195,7 +190,7 @@ LibSynphony.prototype.stringToSentences = function(textHTML) {
         intersentenceSpace +
         "([\\u0005]*)" + // closing tag between sentences
         "(?![^\\p{L}]*" + // may be followed by non-letter chars
-            "[\\p{Ll}\\p{SCP}]+)", // first letter following is not lower case
+            "[\\p{Ll}\\p{SCP}]+)", // first letter following is not lower case. (This works by consuming all the lowercase letters/etc. up until the first uppercase letter/etc)
         "g"
     );
 
@@ -207,6 +202,16 @@ LibSynphony.prototype.stringToSentences = function(textHTML) {
             regex,
             "$1" + delimiter + nonSentence + "$2" + "$3" + "$4" + delimiter
         );
+
+        // Phrase Delimiting
+        // It's possible to use a fancy regex-based approach too (akin to sentence splitting regex)
+        // But that's not so intuitive nor easy to obtain/verify correctness
+        // due to many corner cases... need to consider sentence continuing punctuation, etc
+        // Instead, let's start with a simple, easy to understand approach:
+        //    "|" character is a phrase delimiter. Context doesn't matter.
+        //    (But collapse empty entries created from having multiple "|" character in a row)
+        // It should be easier for us to implement, test, and communicate, and easier for the user to understand.
+        paragraph = XRegExp.replace(paragraph, /(\|+)/g, "$1" + delimiter);
 
         // restore line breaks
         paragraph = paragraph.replace(/\u0001/g, "<br />");

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/bloom_xregexp_categories.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/bloom_xregexp_categories.js
@@ -18,7 +18,6 @@ export function setSentenceEndingPunctuationForBloom() {
      * \u0021 = Exclamation Mark
      * \u002E = Full Stop
      * \u003F = Question Mark
-     * \u007C = Vertical Line - Serves as a pseudo-sentence delimiter in order to support phrase-level splitting for Talking Book tool
      * \u055C = Armenian Exclamation Mark
      * \u055E = Armenian Question Mark
      * \u0589 = Armenian Full Stop
@@ -62,7 +61,7 @@ export function setSentenceEndingPunctuationForBloom() {
             name: "SEP",
             alias: "Sentence_Ending_Punctuation",
             bmp:
-                "\u0021\u002e\u003f\u007c\u055c\u055e\u0589\u061f\u06d4\u0700\u0701\u0702\u0964\u0965\u104b\u1362\u1367\u1368\u166e\u1803\u1809\u1944\u1945\u203c\u203d\u2047\u2048\u2049\u3002\ufe52\ufe56\ufe57\uff01\uff0e\uff1f\uff61\u00a7"
+                "\u0021\u002e\u003f\u055c\u055e\u0589\u061f\u06d4\u0700\u0701\u0702\u0964\u0965\u104b\u1362\u1367\u1368\u166e\u1803\u1809\u1944\u1945\u203c\u203d\u2047\u2048\u2049\u3002\ufe52\ufe56\ufe57\uff01\uff0e\uff1f\uff61\u00a7"
         }
     ]);
 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -349,17 +349,33 @@ describe("audio recording tests", () => {
             expect(spans[0].innerHTML).toBe("This <b>is</b> a sentence.");
             expect(spans[1].innerHTML).toBe("This <i>is</i> another");
         });
-        it("treats vertical bar as a delimiter", () => {
-            const div = $("<div><p>Phrase 1| Phrase 2.</p></div>");
-            const recording = new AudioRecording();
-            recording.makeAudioSentenceElements(
-                div,
-                AudioRecordingMode.Sentence
-            );
-            const spans = div.find("span");
-            expect(spans.length).toBe(2);
-            expect(spans[0].innerText).toBe("Phrase 1|");
-            expect(spans[1].innerText).toBe("Phrase 2.");
+        [
+            "Phrase 1| Phrase 2.",
+            "phrase 1| phrase 2.",
+            "1 | 2",
+            "1 ||| 2" // collapse multiple
+        ].forEach(testInput => {
+            it(`treats vertical bar as a phrase delimiter (Input=${testInput})`, () => {
+                const div = $(`<div><p>${testInput}</p></div>`);
+                const recording = new AudioRecording();
+                recording.makeAudioSentenceElements(
+                    div,
+                    AudioRecordingMode.Sentence
+                );
+                const spans = div.find("span");
+                expect(spans.length).toBe(
+                    2,
+                    `Input "${testInput}" should be split into 2 phrase.`
+                );
+                expect(spans[0].innerText.endsWith("|")).toBe(
+                    true,
+                    `${spans[0].innerText} should end with "|"`
+                );
+                expect(div[0].innerText).toBe(
+                    testInput,
+                    "InnerText no longer matches"
+                );
+            });
         });
         it("keeps id with unchanged recorded sentence when new inserted before", () => {
             const div = $(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3874)
<!-- Reviewable:end -->
