### PR TITLE
Fix DEBUG settings for Linux (20200813)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -38,6 +38,9 @@
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)'!='Windows_NT' AND '$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DefineConstants>__MonoCS__;DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>..\..\output\Release\</OutputPath>
     <DebugType>pdbonly</DebugType>
@@ -58,8 +61,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
-    <DefineConstants>__MonoCS__</DefineConstants>
+  <PropertyGroup Condition="'$(OS)'!='Windows_NT' AND '$(Configuration)|$(Platform)' == 'Release|x86'">
+    <DefineConstants>__MonoCS__;TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>WinExe</OutputType>


### PR DESCRIPTION
A previous fix for Mono 5 worked for enabling #if \_\_MonoCS__, but lost the
DEBUG setting so that Debug.WriteLine, Debug.Assert, etc. didn't work on
Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3880)
<!-- Reviewable:end -->
