### PR TITLE
Add "Comic Portrait" page size (BL-8832)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2843,6 +2843,10 @@
         <source xml:lang="en">13cm Square</source>
         <note>ID: LayoutChoices.Cm13Landscape</note>
       </trans-unit>
+      <trans-unit id="LayoutChoices.ComicPortrait" sil:dynamic="true">
+        <source xml:lang="en">Comic Portrait</source>
+        <note>ID: LayoutChoices.ComicPortrait</note>
+      </trans-unit>
       <trans-unit id="LicenseDialog.WindowTitle">
         <source xml:lang="en">Bloom {0}</source>
         <note>ID: LicenseDialog.WindowTitle</note>

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
@@ -185,6 +185,14 @@ body {
         }
     }
 
+    &.ComicPortrait {
+        height: 63px;
+        width: 41 px;
+        .bloom-page {
+            transform: scale(0.07);
+        }
+    }
+
     //http://stackoverflow.com/questions/17824060/ios-safari-runs-out-of-memory-with-webkit-transform
     transform-style: preserve-3d;
     .bloom-page {

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -330,6 +330,12 @@ Changes here generally require similar changes in EpubMaker.FixPictureSizes() an
         min-height: @Cm13Square-Side;
         max-height: @Cm13Square-Side;
     }
+    &.ComicPortrait {
+        min-width: @ComicPortrait-Width;
+        max-width: @ComicPortrait-Width;
+        min-height: @ComicPortrait-Height;
+        max-height: @ComicPortrait-Height;
+    }
 }
 /*Margins*/
 .textWholePage .marginBox {
@@ -417,6 +423,9 @@ Changes here generally require similar changes in EpubMaker.FixPictureSizes() an
     }
     .Cm13Landscape & {
         .SetMarginBox(@Cm13Square-Side, @Cm13Square-Side);
+    }
+    .ComicPortrait & {
+        .SetMarginBox(@ComicPortrait-Width, @ComicPortrait-Height);
     }
 }
 

--- a/src/BloomBrowserUI/branding/Juarez-USDA-PCI-Guatemala/branding.css
+++ b/src/BloomBrowserUI/branding/Juarez-USDA-PCI-Guatemala/branding.css
@@ -22,6 +22,7 @@ Rules that format the branding go in branding-base.less, or in the branding.less
 .landscapeOnly {
     display: none;
 }
+.ComicPortrait .portraitOnly,
 .Device16x9Portrait .portraitOnly,
 .QuarterLetterPortrait .portraitOnly,
 .HalfLetterPortrait .portraitOnly,

--- a/src/BloomBrowserUI/branding/branding-base.less
+++ b/src/BloomBrowserUI/branding/branding-base.less
@@ -32,6 +32,7 @@ Rules that format the branding go in branding-base.less, or in the branding.less
 .landscapeOnly {
     display: none;
 }
+.ComicPortrait,
 .Device16x9Portrait,
 .QuarterLetterPortrait,
 .HalfLetterPortrait,

--- a/src/BloomBrowserUI/templates/common-mixins.less
+++ b/src/BloomBrowserUI/templates/common-mixins.less
@@ -91,6 +91,9 @@
 
 @Cm13Square-Side: 130mm;
 
+@ComicPortrait-Height: 10.5in;
+@ComicPortrait-Width: 6.75in;
+
 @MarginTop: 15mm;
 @MarginOuter: 15mm;
 @MarginBottom: 15mm;

--- a/src/BloomBrowserUI/templates/template books/Basic Book/Basic Book.less
+++ b/src/BloomBrowserUI/templates/template books/Basic Book/Basic Book.less
@@ -464,6 +464,9 @@ in javascript. Search for 'bloom-centerContentVertically'.
     &.Cm13Landscape {
         .Setup(60%, 400%);
     }
+    &.ComicPortrait {
+        .Setup(65%, 400%);
+    }
     .bloom-translationGroup {
         width: 100%;
         text-align: center;

--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-common.less
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-common.less
@@ -97,6 +97,9 @@
     .Cm13Landscape& {
         .SetMarginBoxCover(@Cm13Square-Side, @Cm13Square-Side);
     }
+    .ComicPortrait& {
+        .SetMarginBoxCover(@ComicPortrait-Height, @ComicPortrait-Width);
+    }
 }
 
 .insideFrontCover {

--- a/src/BloomExe/Book/SizeAndOrientation.cs
+++ b/src/BloomExe/Book/SizeAndOrientation.cs
@@ -152,6 +152,7 @@ namespace Bloom.Book
 			yield return new Layout { SizeAndOrientation = FromString("Device16x9Portrait") };
 			yield return new Layout { SizeAndOrientation = FromString("Device16x9Landscape") };
 			yield return new Layout { SizeAndOrientation = FromString("Cm13Landscape") };	// actually square, but acts more like landscape than portrait
+			yield return new Layout { SizeAndOrientation = FromString("ComicPortrait") };
 		}
 
 

--- a/src/BloomExe/Publish/PDF/MakePdfUsingGeckofxHtmlToPdfProgram.cs
+++ b/src/BloomExe/Publish/PDF/MakePdfUsingGeckofxHtmlToPdfProgram.cs
@@ -190,6 +190,10 @@ namespace Bloom.Publish.PDF
 					size = size * 10;	// convert from cm to mm
 				bldr.AppendFormat(" -h {0} -w {0}", size);
 			}
+			else if (paperSizeName == "Comic")
+			{
+				bldr.Append(" -h 266.7 -w 171.45");	// 10.5" x 6.75"
+			}
 			else
 			{
 				bldr.AppendFormat(" -s {0}", paperSizeName);

--- a/src/BloomExe/Publish/PDF/PdfMaker.cs
+++ b/src/BloomExe/Publish/PDF/PdfMaker.cs
@@ -36,7 +36,7 @@ namespace Bloom.Publish.PDF
 		///  </summary>
 		/// <param name="inputHtmlPath"></param>
 		/// <param name="outputPdfPath"></param>
-		/// <param name="paperSizeName">A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,B0,B1,B10,B2,B3,B4,B5,B6,B7,B8,B9,C5E,Comm10E,DLE,Executive,Folio,Ledger,Legal,Letter,Tabloid,Cm13</param>
+		/// <param name="paperSizeName">A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,B0,B1,B10,B2,B3,B4,B5,B6,B7,B8,B9,C5E,Comm10E,DLE,Executive,Folio,Ledger,Legal,Letter,Tabloid,Cm13,Comic</param>
 		/// <param name="landscape">true if landscape orientation, false if portrait orientation</param>
 		/// <param name="saveMemoryMode">true if PDF file is to be produced using less memory (but more time)</param>
 		/// <param name="layoutPagesForRightToLeft">true if RTL, false if LTR layout</param>
@@ -230,6 +230,9 @@ namespace Bloom.Publish.PDF
 					break;
 				case "Cm13":
 					pageSize = PageSize.A3;
+					break;
+				case "Comic":
+					pageSize = PageSize.A3;	// Ledger would work as well.
 					break;
 				default:
 					throw new ApplicationException("PdfMaker.MakeBooklet() does not contain a map from " + incomingPaperSize + " to a PdfSharp paper size.");


### PR DESCRIPTION
This creates a new page size/layout called "Comic Portrait" that is 10.5" high by 6.75" wide.
This PR does nothing to implement the bleed margin of .125" at the top, bottom and outside edges.
The booklet PDF printing assumes A3 paper in the printer.  (Ledger would work as well, fwiw.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3884)
<!-- Reviewable:end -->
