### PR TITLE
BL-8648 Set 'none' bubbles to be transparent

### DIFF
--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -86,7 +86,7 @@
         "bloom-player": "^1.1.68",
         "calculate-aspect-ratio": "^0.1.3",
         "color-blind": "^0.1.1",
-        "comicaljs": "^0.1.51",
+        "comicaljs": "^0.1.61",
         "css-element-queries": "^0.3.2",
         "firebase": "^7.17.1",
         "firebaseui": "^4.6.1",

--- a/src/BloomBrowserUI/yarn.lock
+++ b/src/BloomBrowserUI/yarn.lock
@@ -4186,10 +4186,10 @@ combined-stream@^1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comicaljs@^0.1.51:
-  version "0.1.55"
-  resolved "https://registry.yarnpkg.com/comicaljs/-/comicaljs-0.1.55.tgz#cdbb931144e4f4df116b2c5f1540032b68b86c9f"
-  integrity sha512-C37VUBU8Fpz+CIzXx0mGY9E4e9d+tzq+plE2b1WyBJ4hDuK0S4yN1RMmo++S5beRpcm/acLZfV/1PeZVfrCaxw==
+comicaljs@^0.1.61:
+  version "0.1.61"
+  resolved "https://registry.yarnpkg.com/comicaljs/-/comicaljs-0.1.61.tgz#348eeee034f4ec70f3e93072180d0a3f3dfb68c8"
+  integrity sha512-jctRBq/nJiWUPZzxPDQwwXjizA4kue56Fa1+Cz+aqcAiR0W1dkyFjm3Q5uotI9NlLYhLQhGFK5tZZr129UTyug==
 
 comma-separated-tokens@^1.0.0:
   version "1.0.6"

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -878,6 +878,22 @@ namespace Bloom.Book
 			return result;
 		}
 
+		internal static void SetDataBubbleFromJsonObject(dynamic jsonObject, XmlElement textOverPictureElement)
+		{
+			if (jsonObject == null)
+				return;
+			try
+			{
+				var dataBubbleString = jsonObject.ToString().Replace("\"", "`");
+				if (!string.IsNullOrEmpty(dataBubbleString))
+					textOverPictureElement.SetAttribute("data-bubble", dataBubbleString);
+			}
+			catch (Exception)
+			{
+				Logger.WriteEvent("HtmlDom.SetDataBubbleFromJsonObject() failed to set data-bubble.");
+			}
+		}
+
 		private static string[] GetBackgroundColorsFromDataBubbleJsonObj(dynamic jsonObject)
 		{
 			if (jsonObject == null)

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -1246,6 +1246,7 @@ namespace BloomTests.Book
 		<div class='bloom-imageContainer'>
 			<svg class='comical-generated'/>
 			<div class='bloom-textOverPicture' data-bubble='{`version`:`1.0`,`tails`:[{`tipX`:5.5,`tipY`:99,`midpointX`:5.1,`midpointY`:1.95,`joiner`:true,`autoCurve`:true}],`level`:1,`style`:`speech`,`order`:2}'/>
+			<div class='bloom-textOverPicture' data-bubble='{`version`:`1.0`,`tails`:[{`tipX`:6.5,`tipY`:99,`midpointX`:4.1,`midpointY`:1.8,`joiner`:true,`autoCurve`:true}],`level`:1,`style`:`exclamation`,`order`:3}'/>
 			<div class='bloom-textOverPicture' data-bubble='" + MinimalDataBubbleValue + @"'/>
 		</div>
 	</div>
@@ -1258,6 +1259,7 @@ namespace BloomTests.Book
 			var maintLevel = storage.Dom.GetMetaValue("maintenanceLevel", "0");
 			Assert.That(maintLevel, Is.GreaterThanOrEqualTo("2"));
 			Assert.That(storage.Dom.SafeSelectNodes("//*[@class='comical-generated']").Count, Is.EqualTo(1));
+			Assert.That(storage.Dom.SafeSelectNodes("//*[@class='bloom-textOverPicture' and contains(@data-bubble, 'transparent')]").Count, Is.EqualTo(3));
 		}
 
 		[Test]


### PR DESCRIPTION
* migration to maintenance level 2 sets background color
   to transparent for bubbles with 'none' style

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3887)
<!-- Reviewable:end -->
