### PR TITLE
Fix audio current getting set to wrong element sometimes (BL-8849)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -635,23 +635,6 @@ export default class AudioRecording {
             elemToCheck = parentEditable || elem;
         }
 
-        // Make sure to process user overrides first, before checking the code-generated ones
-        if (elemToCheck.classList.contains("bloom-visibility-user-on")) {
-            return true;
-        } else if (
-            elemToCheck.classList.contains("bloom-visibility-user-off")
-        ) {
-            return false;
-        } else if (elemToCheck.classList.contains("bloom-visibility-code-on")) {
-            return true;
-        } else if (
-            elemToCheck.classList.contains("bloom-visibility-code-off")
-        ) {
-            return false;
-        }
-
-        // Still not sure about the visibility. Check its display setting.
-        // (Note that getComputedStyle can sometimes be expensive, so we waited till last for this)
         const style = window.getComputedStyle(elemToCheck);
         return style.display !== "none";
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -619,7 +619,40 @@ export default class AudioRecording {
     }
 
     private isVisible(elem: Element) {
-        const style = window.getComputedStyle(elem);
+        // Spans (and probably other inline elements?) can have display=inline even if they're inside a div that's display=none
+        let elemToCheck = elem;
+
+        if (elem.tagName === "SPAN") {
+            const parentEditable = elem.closest(".bloom-editable");
+
+            // Really not wanting this scenario to happen, because we may get inaccurate results, but...
+            // We ought to be able to continue on without anything terrible happening
+            console.assert(
+                parentEditable,
+                "isVisible(): Unexpected span that is not inside a bloom-editable. span = " +
+                    elem
+            );
+            elemToCheck = parentEditable || elem;
+        }
+
+        // Make sure to process user overrides first, before checking the code-generated ones
+        if (elemToCheck.classList.contains("bloom-visibility-user-on")) {
+            return true;
+        } else if (
+            elemToCheck.classList.contains("bloom-visibility-user-off")
+        ) {
+            return false;
+        } else if (elemToCheck.classList.contains("bloom-visibility-code-on")) {
+            return true;
+        } else if (
+            elemToCheck.classList.contains("bloom-visibility-code-off")
+        ) {
+            return false;
+        }
+
+        // Still not sure about the visibility. Check its display setting.
+        // (Note that getComputedStyle can sometimes be expensive, so we waited till last for this)
+        const style = window.getComputedStyle(elemToCheck);
         return style.display !== "none";
     }
 
@@ -1261,6 +1294,7 @@ export default class AudioRecording {
 
     // Moves the highlight to the next sub-element
     // startTimeInSecs is an optional fallback that will be used in case the currentTime cannot be determined from the audio player element.
+    // Note: May kick off some async work, but it's fairly inconsequential and no need to await it currently.
     private highlightNextSubElement(startTimeInSecs: number = 0) {
         // the item should not be popped off the stack until it's completely done with.
         const subElementCount = this.subElementsWithTimings.length;
@@ -1273,6 +1307,7 @@ export default class AudioRecording {
         const element = topTuple[0];
         const endTimeInSecs: number = topTuple[1];
 
+        // Kicks off some async work of minimal consequence, no need to await it currently.
         this.setHighlightToAsync(
             element,
             false // disableHighlightIfNoAudio: Should be false when playing sub-elements, because the highlighted sub-element doesn't have audio. The audio belongs to parent.
@@ -2537,10 +2572,17 @@ export default class AudioRecording {
         if (!pageDocBody) {
             return null;
         }
+
+        // Find the relevant audioSentences
+        // Note that we check they're descendants of bloom-translationGroup
+        // so that we exclude the qTip versions of these
         const audioSentenceElems = Array.from(
-            pageDocBody.getElementsByClassName(kAudioSentence),
+            pageDocBody.querySelectorAll(
+                `.bloom-translationGroup .${kAudioSentence}`
+            ),
             elem => <HTMLElement>elem
         );
+
         const visibleAudioSentenceElems = audioSentenceElems.filter(elem => {
             return this.isVisible(elem);
         });

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -1752,6 +1752,32 @@ describe("audio recording tests", () => {
         }
     });
 
+    describe("- newPageReady()", () => {
+        it("sets current to correct 1st element upon newPageReady", async () => {
+            // Regression test to make sure we don't set it to the qTip element or a different language's text box.
+            const editable1 =
+                '<div id="div1" class="bloom-editable audio-sentence bloom-visibility-code-on" lang="es" data-audiorecordingmode="TextBox"><p>Uno. Dos.</p></div>';
+            const editable2 =
+                '<div id="div2" class="bloom-editable audio-sentence" lang="en" data-audiorecordingmode="TextBox"><p>One. Two.</p></div>';
+            const translationGroup = `<div class="bloom-translationGroup">${editable1}${editable2}</div>`;
+
+            // Note: Theoretically this should have ${editable2}${editable1} inside, but...
+            // For the test case, let's just use editable2 only so less chance of false negatives.
+            const qtip = `<div id="qtip-0" class="qtip qtip-default">${editable2}</div>`;
+            SetupIFrameFromHtml(translationGroup + qtip);
+
+            const recording = new AudioRecording();
+            recording.audioRecordingMode = AudioRecordingMode.TextBox;
+
+            // System under test
+            await recording.newPageReady();
+
+            // Verification
+            const firstDiv = getFrameElementById("page", "div1")!;
+            expect(firstDiv).toHaveClass("ui-audioCurrent");
+        });
+    });
+
     describe("- initializeAudioRecordingMode()", () => {
         it("initializeAudioRecordingMode gets mode from current div if available (synchronous) (Text Box)", () => {
             SetupIFrameFromHtml(

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookSpec.ts
@@ -175,7 +175,7 @@ describe("talking book tests", () => {
             }
         }
 
-        function setupPureSentenceModeHtml(checksums: string[]): string {
+        function getPureSentenceModeHtml(checksums: string[]): string {
             const div1Html = `<div class="bloom-editable" id="div1" data-audioRecordingMode="Sentence"><p><span id="1.1" class="audio-sentence ui-audioCurrent" recordingmd5="${
                 checksums[0]
             }">Sentence 1.1၊</span> <span id="1.2" class="audio-sentence" recordingmd5="${
@@ -189,7 +189,7 @@ describe("talking book tests", () => {
             return `${div1Html}${div2Html}`;
         }
 
-        function setupPreTextBoxModeHtml(checksums: string[]): string {
+        function getPreTextBoxModeHtml(checksums: string[]): string {
             const div1Html = `<div class="bloom-editable ui-audioCurrent" id="div1" data-audiorecordingmode="TextBox"><p><span id="1.1" class="audio-sentence" recordingmd5="${
                 checksums[0]
             }">Sentence 1.1၊</span> <span id="1.2" class="audio-sentence" recordingmd5="${
@@ -213,7 +213,7 @@ describe("talking book tests", () => {
             return `${div1Html}${div2Html}`;
         }
 
-        function setupTextBoxHardSplitHtml(checksums: string[]): string {
+        function getTextBoxHardSplitHtml(checksums: string[]): string {
             let html = "";
             let checksumIndex = 0;
             for (let i = 1; i <= 2; ++i) {
@@ -232,7 +232,7 @@ describe("talking book tests", () => {
             return html;
         }
 
-        function setupTextBoxSoftSplitHtml(checksums: string[]): string {
+        function getTextBoxSoftSplitHtml(checksums: string[]): string {
             let html = "";
             for (let i = 1; i <= 2; ++i) {
                 const divStartHtml = `<div class="bloom-editable audio-sentence${
@@ -258,26 +258,26 @@ describe("talking book tests", () => {
         ): void {
             const checksums = getTestMd5s(checksumSetting, scenario);
 
-            let pageInnerHtml: string = "";
+            let innerHtml: string = "";
             switch (scenario) {
                 case AudioMode.PureSentence: {
-                    pageInnerHtml = setupPureSentenceModeHtml(checksums);
+                    innerHtml = getPureSentenceModeHtml(checksums);
                     break;
                 }
                 case AudioMode.PreTextBox: {
-                    pageInnerHtml = setupPreTextBoxModeHtml(checksums);
+                    innerHtml = getPreTextBoxModeHtml(checksums);
                     break;
                 }
                 case AudioMode.PureTextBox: {
-                    pageInnerHtml = setupPureTextBoxModeHtml(checksums);
+                    innerHtml = setupPureTextBoxModeHtml(checksums);
                     break;
                 }
                 case AudioMode.HardSplitTextBox: {
-                    pageInnerHtml = setupTextBoxHardSplitHtml(checksums);
+                    innerHtml = getTextBoxHardSplitHtml(checksums);
                     break;
                 }
                 case AudioMode.SoftSplitTextBox: {
-                    pageInnerHtml = setupTextBoxSoftSplitHtml(checksums);
+                    innerHtml = getTextBoxSoftSplitHtml(checksums);
                     break;
                 }
                 default: {
@@ -289,7 +289,9 @@ describe("talking book tests", () => {
                 }
             }
 
-            SetupIFrameFromHtml(`<div id="page1">${pageInnerHtml}</div>`);
+            SetupIFrameFromHtml(
+                `<div id="page1"><div class="bloom-translationGroup">${innerHtml}</div></div>`
+            );
 
             if (scenario === AudioMode.PureSentence) {
                 theOneAudioRecorder.audioRecordingMode =


### PR DESCRIPTION
It is possible for the audio current to get set to the qtip version of it instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3894)
<!-- Reviewable:end -->
