### PR TITLE
Remake PDF when changing CMYK setting (BL-8925)

### DIFF
--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -419,6 +419,7 @@ namespace Bloom.Publish
 			cmykItem.Click += (sender, args) =>
 				{
 					_model.BookSelection.CurrentSelection.UserPrefs.CmykPdf = cmykItem.Checked;
+					SetModelFromButtons(); // this calls for updating the preview so the user won't think it's done already
 				};
 
 			var fullBleedText = LocalizationManager.GetString("PublishTab.PdfMaker.FullBleed", "Full Bleed");


### PR DESCRIPTION
The "Full Bleed" setting was already working properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3915)
<!-- Reviewable:end -->
