### PR TITLE
Fix credits page layout by removing license/copyright min-height (BL-8951)

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-sharedRules.less
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-sharedRules.less
@@ -39,7 +39,6 @@
 }
 .credits {
     .licenseAndCopyrightBlock {
-        min-height: 60px;
         .copyright {
             margin-bottom: @MarginBetweenBlocks;
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3931)
<!-- Reviewable:end -->
