### PR TITLE
Comply with more Epub 3.2 rules (BL-9067)

### DIFF
--- a/src/BloomExe/ToPalaso/XmlExtensions.cs
+++ b/src/BloomExe/ToPalaso/XmlExtensions.cs
@@ -23,5 +23,18 @@ namespace Bloom.ToPalaso
 				current = current.ParentNode as XmlElement;
 			return current;
 		}
+
+		/// <summary>
+		/// Find the closest ancestor (not 'start' itself) that has the specified value for the specified attribute.
+		/// If no parent does, answer null.
+		/// </summary>
+		/// <returns></returns>
+		public static XmlElement AncestorWithAttributeValue(this XmlElement start, string targetAttr, string targetVal)
+		{
+			var current = start.ParentNode as XmlElement;
+			while (current != null && current.Attributes[targetAttr]?.Value != targetVal)
+				current = current.ParentNode as XmlElement;
+			return current;
+		}
 	}
 }

--- a/src/BloomTests/Publish/ExportEpubTests.cs
+++ b/src/BloomTests/Publish/ExportEpubTests.cs
@@ -602,6 +602,18 @@ namespace BloomTests.Publish
 		}
 
 		[Test]
+		public void Tabindex_IsRemoved()
+		{
+			var book = SetupBookLong("This is some text", "en",
+				extraContentOutsideTranslationGroup: "<div class='bloom-translationGroup' tabindex='1'><div class='bloom-editable bloom-content1 bloom-visibility-code-on' lang='xyz' tabindex='2'>This could be focused</div></div>",
+				images: new[] { "myImage.png?1023456" });
+			MakeEpub("output", "Tabindex_IsRemoved", book);
+			CheckBasicsInManifest();
+
+			AssertThatXmlIn.String(_page1Data).HasNoMatchForXpath("//*[@tabindex]");
+		}
+
+		[Test]
 		public void StandardStyleSheets_AreRemoved()
 		{
 			var book = SetupBookLong("Some text", "en");
@@ -724,6 +736,49 @@ namespace BloomTests.Publish
 			assertThatPage1.HasNoMatchForXpath("//xhtml:div[@lang='de']", _ns);
 			assertThatPage1.HasNoMatchForXpath("//xhtml:label", _ns); // labels are hidden
 			assertThatPage1.HasNoMatchForXpath("//xhtml:div[@class='pageLabel']", _ns);
+		}
+
+		[Test]
+		public void ContentInfo_IsAddedToTitleAndCredits_ButNotToChildren()
+		{
+			var book = SetupBookLong("normal content.", "xyz",
+				extraPageClass: " bloom-frontMatter titlePage' data-page='required singleton",
+				extraContentOutsideTranslationGroup: "<div class='bloom-translationGroup' id='originalContributions'><div class='bloom-editable' lang='xyz'>this is a original contributions that would get contentinfo if not inside title page</div></div>",
+				extraPages:
+				@"<div class='bloom-page bloom-frontMatter credits' data-page='required singleton'>
+							<div class='bloom-translationGroup' data-derived='copyright'>
+							<div class='bloom-editable' lang='xyz'>this is a copyright message that would get contentinfo if not inside credits page</div></div></div>",
+				defaultLanguages: "V,N1");
+
+			MakeEpub("output", "ContentInfo_IsAddedToTitleAndCredits_ButNotToChildren", book);
+			var assertThatPage1 = AssertThatXmlIn.String(_page1Data);
+			assertThatPage1.HasAtLeastOneMatchForXpath("//div[@id='originalContributions']");
+			assertThatPage1.HasSpecifiedNumberOfMatchesForXpath("//div[contains(@class, 'bloom-page') and @role='contentinfo']", 1);
+			assertThatPage1.HasSpecifiedNumberOfMatchesForXpath("//div[@role='contentinfo']", 1);
+			var page2Data = GetPageNData(2);
+			var assertThatPage2 = AssertThatXmlIn.String(page2Data);
+			assertThatPage2.HasAtLeastOneMatchForXpath("//div[@data-derived='copyright']");
+			assertThatPage2.HasSpecifiedNumberOfMatchesForXpath("//div[contains(@class, 'bloom-page') and @role='contentinfo']",1);
+			assertThatPage2.HasSpecifiedNumberOfMatchesForXpath("//div[@role='contentinfo']", 1);
+		}
+
+		[Test]
+		public void ContentInfo_IsAddedToInfoElementsNotInInfoPages()
+		{
+			var book = SetupBookLong("normal content.", "xyz",
+				extraPageClass: " bloom-frontMatter insideFrontCover' data-page='required singleton",
+				extraContentOutsideTranslationGroup: @"<div class='bloom-translationGroup' id='originalContributions'><div class='bloom-editable' lang='xyz'>this is a original contributions that should get contentinfo</div></div>
+					<div class='bloom-translationGroup' data-derived='copyright'>
+							<div class='bloom-editable' lang='xyz'>this is a copyright message that should get contentinfo</div></div>",
+				extraPages:
+				@"<div class='bloom-page bloom-frontMatter credits' data-page='required singleton'>
+							</div>",
+				defaultLanguages: "V,N1");
+
+			MakeEpub("output", "ContentInfo_IsAddedToInfoElementsNotInInfoPages", book);
+			var assertThatPage1 = AssertThatXmlIn.String(_page1Data);
+			assertThatPage1.HasAtLeastOneMatchForXpath("//div[@id='originalContributions' and @role='contentinfo']");
+			assertThatPage1.HasAtLeastOneMatchForXpath("//div[@data-derived='copyright' and @role='contentinfo']");
 		}
 
 		[Test]

--- a/src/BloomTests/Publish/ExportEpubTestsBaseClass.cs
+++ b/src/BloomTests/Publish/ExportEpubTestsBaseClass.cs
@@ -484,7 +484,7 @@ namespace BloomTests.Publish
 			// Check accessibilityFeature section
 			foundOther = false;
 			var foundSynchronizedAudio = false;
-			var foundResizeText = false;
+			var foundDisplayTransformability = false;
 			var foundPageNumbers = false;
 			var foundUnlocked = false;
 			var foundReadingOrder = false;
@@ -496,7 +496,7 @@ namespace BloomTests.Publish
 				switch (node.InnerXml)
 				{
 				case "synchronizedAudioText": foundSynchronizedAudio = true; break;
-				case "displayTransformability/resizeText": foundResizeText = true; break;
+				case "displayTransformability": foundDisplayTransformability = true; break;
 				case "printPageNumbers": foundPageNumbers = true; break;
 				case "unlocked": foundUnlocked = true; break;
 				case "readingOrder": foundReadingOrder = true; break;
@@ -508,7 +508,7 @@ namespace BloomTests.Publish
 			}
 			Assert.IsFalse(foundOther, "Unrecognized accessibilityFeature value in manifest");
 			Assert.AreEqual(hasAudio, foundSynchronizedAudio, "Bloom Audio is synchronized iff it exists (which it does{0}) [manifest accessibilityFeature]", hasAudio ? "" : " not");
-			Assert.IsTrue(foundResizeText, "Bloom text should always be resizable [manifest accessibilityFeature]");
+			Assert.IsTrue(foundDisplayTransformability, "Bloom text should always be displayTransformability [manifest accessibilityFeature]");
 			Assert.IsTrue(foundPageNumbers, "Bloom books provide page number mapping to the print edition [manifest accessibilityFeature]");
 			Assert.IsTrue(foundUnlocked, "Bloom books are always unlocked [manifest accessibilityFeature]");
 			Assert.IsTrue(foundReadingOrder, "Bloom books have simple formats that are always in reading order [manifest accessibilityFeature]");


### PR DESCRIPTION
- contentinfo elements should not be nested
- tabindex should not be used (at least not with value > 0)
- displayTransformability should not use /resizeText

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3937)
<!-- Reviewable:end -->
