### PR TITLE
Fix URL encoding of books with punctuation in title (BL-9041)

### DIFF
--- a/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
@@ -56,6 +56,9 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
     const [closePending, setClosePending] = useState(false);
     const [highlightRefresh, setHighlightRefresh] = useState(false);
     const [progressState, setProgressState] = useState(ProgressState.Working);
+
+    // bookUrl is expected to be a normal, well-formed URL.
+    // (that is, one that you can directly copy/paste into your browser and it would work fine)
     const [bookUrl, setBookUrl] = useState(
         inStorybookMode
             ? window.location.protocol +
@@ -123,7 +126,7 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
                         url={
                             pathToOutputBrowser +
                             "bloom-player/dist/bloomplayer.htm?centerVertically=true&url=" +
-                            bookUrl +
+                            encodeURIComponent(bookUrl) + // Need to apply encoding to the bookUrl again as data to use it as a parameter of another URL
                             "&independent=false&host=bloomdesktop"
                         }
                         showRefresh={true}

--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -357,6 +357,12 @@ namespace Bloom.Publish.Android
 			}
 		}
 
+		/// <summary>
+		/// Updates the BloomReader preview. The URL of the BloomReader preview will be sent over the web socket.
+		/// The format of the URL is a valid ("single" encoded) URL.
+		/// If the caller wants to insert this URL as a query parameter to another URL (e.g. like what is often done with Bloom Player),
+		/// it's the caller's responsibility to apply another layer of URL encoding to make the URL suitable to be passed as data inside another URL.
+		/// </summary>
 		private void UpdatePreview(ApiRequest request)
 		{
 			InitializeLanguagesInBook(request);
@@ -457,6 +463,15 @@ namespace Bloom.Publish.Android
 
 		private static TemporaryFolder _stagingFolder;
 
+		/// <summary>
+		/// Generates a .bloomd file (bloompub) from the book
+		/// </summary>
+		/// <param name="book"></param>
+		/// <param name="bookServer"></param>
+		/// <param name="progress"></param>
+		/// <param name="backColor"></param>
+		/// <param name="settings"></param>
+		/// <returns>A valid, well-formed URL on localhost that points to the bloomd</returns>
 		public static string StageBloomD(Book.Book book, BookServer bookServer, WebSocketProgress progress, Color backColor, AndroidPublishSettings settings = null)
 		{
 			progress.Message("PublishTab.Epub.PreparingPreview", "Preparing Preview");	// message shared with Epub publishing
@@ -483,7 +498,7 @@ namespace Bloom.Publish.Android
 			_stagingFolder = new TemporaryFolder(StagingFolder);
 			var modifiedBook = BloomReaderFileMaker.PrepareBookForBloomReader(book.FolderPath, bookServer, _stagingFolder, progress, settings: settings);
 			progress.Message("Common.Done", "Shown in a list of messages when Bloom has completed a task.", "Done");
-			return modifiedBook.FolderPath.ToLocalhostFullyEscaped();
+			return modifiedBook.FolderPath.ToLocalhostProperlyEncoded();
 		}
 
 		/// <summary>

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Book\LicenseCheckerTests.cs" />
     <Compile Include="CLI\CreateArtifactsCommandTests.cs" />
     <Compile Include="Edit\MakeActivityTests.cs" />
+    <Compile Include="ExtensionsTests.cs" />
     <Compile Include="TestDoubles\Book\FakeBookServer.cs" />
     <Compile Include="CollectionTab\LibraryListViewTests.cs" />
     <Compile Include="Publish\BloomReaderPublishTests.cs" />

--- a/src/BloomTests/ExtensionsTests.cs
+++ b/src/BloomTests/ExtensionsTests.cs
@@ -1,0 +1,49 @@
+﻿using Bloom;
+using Bloom.Api;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BloomTests
+{
+	[TestFixture]
+	class ExtensionsTests
+	{
+		[TestCase("Guitar #14", "Guitar%20%2314")]	// Test for BL-8652.
+		[TestCase("a %+", "a%20%25%2B")]	// A test with multiple punctuation chars that gets past some earlier implementations
+		// Test every punctuation on a standard US QWERTY keyboard that is allowed in filenames.
+		[TestCase("a`", "a%60")]
+		[TestCase("a~", "a~")]
+		[TestCase("C#", "C%23")]
+		[TestCase("Yahoo!", "Yahoo%21")]
+		[TestCase("@user", "%40user")]
+		[TestCase("$100", "%24100")]
+		[TestCase("100%", "100%25")]
+		[TestCase("a^", "a%5E")]
+		[TestCase("AT&T", "AT%26T")]
+		[TestCase("(parens)", "%28parens%29")]
+		[TestCase("A-Z", "A-Z")]
+		[TestCase("_underscore", "_underscore")]
+		[TestCase("1+1=2", "1%2B1%3D2")]
+		[TestCase("[brackets]", "%5Bbrackets%5D")]
+		[TestCase("{braces}", "%7Bbraces%7D")]
+		[TestCase("A;", "A%3B")]
+		[TestCase("A'", "A%27")]
+		[TestCase("A,", "A%2C")]
+		[TestCase("A.", "A.")]
+		public static void ToLocalhostProperlyEncoded_AndroidPreviewBookTitleWithPunc_GeneratesWellFormedUrl(string bookTitle, string expectedEscapedTitle)
+		{
+			// Setup
+			string filename = $@"C:\PathToTemp\PlaceForStagingBook\{bookTitle}\meta.json";
+
+			// System under test
+			string result = filename.ToLocalhostProperlyEncoded();
+
+			// Verification
+			string expectedResult = $@"http://localhost:{BloomServer.portForHttp}/bloom/C%3A/PathToTemp/PlaceForStagingBook/{expectedEscapedTitle}/meta.json";
+			Assert.That(result, Is.EqualTo(expectedResult));
+		}
+	}
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3969)
<!-- Reviewable:end -->
