### PR TITLE
Fix BookMetadataTable to tab between textboxes (BL-9022)

### DIFF
--- a/src/BloomBrowserUI/publish/metadata/BookMetadataTable.tsx
+++ b/src/BloomBrowserUI/publish/metadata/BookMetadataTable.tsx
@@ -20,10 +20,11 @@ interface IProps {
 
 // The BookMetadataTable shows some elements of https://docs.google.com/document/d/e/2PACX-1vREQ7fUXgSE7lGMl9OJkneddkWffO4sDnMG5Vn-IleK35fJSFqnC-6ulK1Ss3eoETCHeLn0wPvcxJOf/pub
 
-// @observer means mobx will automatically track which observables this component uses
-// in its render() function, and then re-render when they change. The "observable" here is the
-// metadata prop, and it's observable because it is marked as such back where it is created in our parent component.
-@mobxReact.observer
+// BookMetadataTable should not be marked with @mobxReact.observer because this causes problems tabbing
+// between TextField elements: re-rendering the entire table resets the tab position to the beginning, so
+// editing a text field and trying to tab to the next field would send the user to the initial (picture?)
+// field instead of the next field.  See https://issues.bloomlibrary.org/youtrack/issue/BL-9022.
+
 export default class BookMetadataTable extends React.Component<IProps> {
     constructor(props) {
         super(props);
@@ -155,64 +156,89 @@ export default class BookMetadataTable extends React.Component<IProps> {
         );
     }
 
+    // <mobxReact.Observer> means mobx will automatically track which observables this component uses
+    // in its render attribute function, and then re-render when they change. The "observable" here is
+    // the metadata.hazards prop, and it's observable because metadata is marked as such back where it
+    // is created in our parent component.
     private makeHazardControls() {
         return (
-            <div className="checkbox-list">
-                {/* from https://www.w3.org/wiki/WebSchemas/Accessibility*/}
-                {/* "Sound Hazard" is too hard to explain (BL-6947) */}
-                {["flashingHazard", "motionSimulationHazard"].map(
-                    hazardName => {
-                        return (
-                            <StringListCheckbox
-                                key={hazardName}
-                                l10nKey={"BookMetadata." + hazardName}
-                                alreadyLocalized={true}
-                                list={this.props.metadata.hazards.value}
-                                itemName={hazardName}
-                                tristateItemOffName={
-                                    "no" + this.capitalizeFirstChar(hazardName)
-                                }
-                                onChange={list =>
-                                    (this.props.metadata.hazards.value = list)
-                                }
-                                label={
-                                    this.props.translatedControlStrings[
-                                        hazardName
-                                    ]
-                                }
-                            />
-                        );
-                    }
+            <mobxReact.Observer
+                render={() => (
+                    <div className="checkbox-list">
+                        {/* from https://www.w3.org/wiki/WebSchemas/Accessibility*/}
+                        {/* "Sound Hazard" is too hard to explain (BL-6947) */}
+                        {["flashingHazard", "motionSimulationHazard"].map(
+                            hazardName => {
+                                return (
+                                    <StringListCheckbox
+                                        key={hazardName}
+                                        l10nKey={"BookMetadata." + hazardName}
+                                        alreadyLocalized={true}
+                                        list={this.props.metadata.hazards.value}
+                                        itemName={hazardName}
+                                        tristateItemOffName={
+                                            "no" +
+                                            this.capitalizeFirstChar(hazardName)
+                                        }
+                                        onChange={list =>
+                                            (this.props.metadata.hazards.value = list)
+                                        }
+                                        label={
+                                            this.props.translatedControlStrings[
+                                                hazardName
+                                            ]
+                                        }
+                                    />
+                                );
+                            }
+                        )}
+                    </div>
                 )}
-            </div>
+            />
         );
     }
     private capitalizeFirstChar(hazardName: string): string {
         let uc = hazardName[0].toUpperCase();
         return uc + hazardName.substr(1, hazardName.length - 1);
     }
+
+    // <mobxReact.Observer> means mobx will automatically track which observables this component uses
+    // in its render attribute function, and then re-render when they change. The "observable" here is
+    // the metadata.a11yFeatures prop, and it's observable because metadata is marked as such back where
+    // it is created in our parent component.
     private makeA11yFeaturesControls() {
         return (
-            <div className="checkbox-list">
-                {/* from https://www.w3.org/wiki/WebSchemas/Accessibility*/}
-                {["alternativeText", "signLanguage"].map(featureName => {
-                    return (
-                        <StringListCheckbox
-                            key={featureName}
-                            l10nKey={"BookMetadata." + featureName}
-                            alreadyLocalized={true}
-                            list={this.props.metadata.a11yFeatures.value}
-                            itemName={featureName}
-                            onChange={list =>
-                                (this.props.metadata.a11yFeatures.value = list)
+            <mobxReact.Observer
+                render={() => (
+                    <div className="checkbox-list">
+                        {/* from https://www.w3.org/wiki/WebSchemas/Accessibility*/}
+                        {["alternativeText", "signLanguage"].map(
+                            featureName => {
+                                return (
+                                    <StringListCheckbox
+                                        key={featureName}
+                                        l10nKey={"BookMetadata." + featureName}
+                                        alreadyLocalized={true}
+                                        list={
+                                            this.props.metadata.a11yFeatures
+                                                .value
+                                        }
+                                        itemName={featureName}
+                                        onChange={list =>
+                                            (this.props.metadata.a11yFeatures.value = list)
+                                        }
+                                        label={
+                                            this.props.translatedControlStrings[
+                                                featureName
+                                            ]
+                                        }
+                                    />
+                                );
                             }
-                            label={
-                                this.props.translatedControlStrings[featureName]
-                            }
-                        />
-                    );
-                })}
-            </div>
+                        )}
+                    </div>
+                )}
+            />
         );
     }
 }

--- a/src/BloomBrowserUI/react_components/bloomSelect.tsx
+++ b/src/BloomBrowserUI/react_components/bloomSelect.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import Select from "react-select";
 import theOneLocalizationManager from "../lib/localizationManager/localizationManager";
+import * as mobxReact from "mobx-react";
 
 export interface IProps {
     // I don't know how to express exact types in Typescript here and it doesn't seem worth a lot of effort.
@@ -10,6 +11,12 @@ export interface IProps {
     className: string;
 }
 
+// @mobxReact.observer means mobx will automatically track which observables this component uses
+// in its render attribute function, and then re-render when they change. The "observable" here
+// would be currentOption as set somewhere in a parent control.  That is why currentOption is
+// defined as "any" instead of "string", so that the object reference can tie back to the parent
+// control's data.  If nothing is set as an observable, then there won't be automatic re-rendering.
+@mobxReact.observer
 export class BloomSelect extends React.Component<IProps> {
     constructor(props) {
         super(props);
@@ -49,9 +56,11 @@ export class BloomSelect extends React.Component<IProps> {
     }
 
     public handleChange(selectedOption) {
-        this.props.currentOption.value = selectedOption.value;
-        if (selectedOption.value == this.props.nullOption)
+        if (selectedOption.value == this.props.nullOption) {
             this.props.currentOption.value = "";
+        } else {
+            this.props.currentOption.value = selectedOption.value;
+        }
     }
 }
 

--- a/src/BloomBrowserUI/react_components/stringListCheckbox.tsx
+++ b/src/BloomBrowserUI/react_components/stringListCheckbox.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as mobxReact from "mobx-react";
 import { ILocalizationProps, LocalizableElement } from "./l10nComponents";
 import { MuiCheckbox } from "./muiCheckBox";
 
@@ -18,7 +17,6 @@ interface IProps extends ILocalizationProps {
 // something is not true, and just be silent on the matter. In the case of the "something is not true",
 // a "tristateItemOffName" is used, e.g. "noMotionHazard".
 
-@mobxReact.observer
 export class StringListCheckbox extends LocalizableElement<IProps, {}> {
     public constructor(props: IProps) {
         super(props);


### PR DESCRIPTION
Also remove an unneeded @mobxReact.observer flag from a component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3970)
<!-- Reviewable:end -->
