### PR TITLE
BL-9091 Auto Order Xmatter

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1411,7 +1411,8 @@ namespace Bloom.Book
 			// this says, if you can't figure out the page size, use the one we got before we removed the xmatter...
 			// still requiring it to be a valid layout.
 			layout = Layout.FromDomAndChoices(bookDOM, layout, fileLocator);
-			helper.InjectXMatter(_bookData.GetWritingSystemCodes(), layout, CollectionSettings.BrandingProjectKey, Storage.FolderPath);
+			helper.InjectXMatter(_bookData.GetWritingSystemCodes(), layout, CollectionSettings.BrandingProjectKey, Storage.FolderPath, BookInfo.UseDeviceXMatter);
+			//if (BookInfo.UseDeviceXMatter)
 
 			var dataBookLangs = bookDOM.GatherDataBookLanguages();
 			TranslationGroupManager.PrepareDataBookTranslationGroups(bookDOM.RawDom, dataBookLangs);

--- a/src/BloomExe/Book/XMatterHelper.cs
+++ b/src/BloomExe/Book/XMatterHelper.cs
@@ -183,7 +183,7 @@ namespace Bloom.Book
 			InjectXMatter(writingSystemCodes, layout, null, null);
 		}
 
-		public void InjectXMatter(Dictionary<string, string> writingSystemCodes, Layout layout, string branding, string bookFolderPath)
+		public void InjectXMatter(Dictionary<string, string> writingSystemCodes, Layout layout, string branding, string bookFolderPath, bool orderXmatterForDeviceUse = false)
 		{
 			//don't want to pollute shells with this content
 			if (!string.IsNullOrEmpty(FolderPathForCopyingXMatterFiles))
@@ -204,7 +204,7 @@ namespace Bloom.Book
 			// See https://issues.bloomlibrary.org/youtrack/issue/BL-8845.
 			_bookDom.SortStyleSheetLinks();
 
-			//it's important that we append *after* this, so that these values take precendance (the template will just have empty values for this stuff)
+			//it's important that we append *after* this, so that these values take precedence (the template will just have empty values for this stuff)
 			//REVIEW: I think all stylesheets now get sorted once they are all added: see HtmlDoc.SortStyleSheetLinks()
 			XmlNode divBeforeNextFrontMattterPage = _bookDom.RawDom.SelectSingleNode("//body/div[@id='bloomDataDiv']");
 
@@ -214,7 +214,7 @@ namespace Bloom.Book
 				//give a new id, else thumbnail caches get messed up becuase every book has, for example, the same id for the cover.
 				newPageDiv.SetAttribute("id", Guid.NewGuid().ToString());
 
-				if (IsBackMatterPage(xmatterPage))
+				if (IsBackMatterPage(xmatterPage) || (orderXmatterForDeviceUse && ShouldBeInBackForDeviceUse(xmatterPage)))
 				{
 					//note: this is redundant unless this is the 1st backmatterpage in the list
 					divBeforeNextFrontMattterPage = _bookDom.RawDom.SelectSingleNode("//body/div[last()]");
@@ -311,6 +311,11 @@ namespace Bloom.Book
 		public static bool IsBackMatterPage(XmlElement pageDiv)
 		{
 			return pageDiv.SelectSingleNode("self::div[contains(@class, 'bloom-backMatter')]") != null;
+		}
+
+		public static bool ShouldBeInBackForDeviceUse(XmlElement pageDiv)
+		{
+			return pageDiv.SelectSingleNode("self::div[contains(@class, 'frontCover')]") == null;
 		}
 
 

--- a/src/BloomExe/Book/XMatterHelper.cs
+++ b/src/BloomExe/Book/XMatterHelper.cs
@@ -214,7 +214,16 @@ namespace Bloom.Book
 				//give a new id, else thumbnail caches get messed up becuase every book has, for example, the same id for the cover.
 				newPageDiv.SetAttribute("id", Guid.NewGuid().ToString());
 
-				if (IsBackMatterPage(xmatterPage) || (orderXmatterForDeviceUse && ShouldBeInBackForDeviceUse(xmatterPage)))
+				// We have some xmatters that don't know about devices, and these we replace with the
+				// standard Device Xmatter as needed.
+				// There is a second type where we have explicitly made a special xmatter just for devices:
+				// ABC, Dari, and Pasti are examples of these. 
+				// Finally, we have other xmatters that deal with device formatting via a stylesheet, without having
+				// a second folder and html for devices (e.g. Kyrgyzstan 2020). For this last one, we want to
+				// just automatically reorder the pages, when we are preparing the document for publishing
+				// to device contexts.
+				var moveNonCoverToBack = orderXmatterForDeviceUse && !PathToXMatterStylesheet.Contains("Device-XMatter");
+				if (IsBackMatterPage(xmatterPage) || (moveNonCoverToBack && ShouldBeInBackForDeviceUse(xmatterPage)))
 				{
 					//note: this is redundant unless this is the 1st backmatterpage in the list
 					divBeforeNextFrontMattterPage = _bookDom.RawDom.SelectSingleNode("//body/div[last()]");


### PR DESCRIPTION
If we know we're going to a device, automatically put all pages that aren't the cover to the back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3971)
<!-- Reviewable:end -->
