### PR TITLE
Have Android depend on user settings for blind and sign language (BL-8995)

### DIFF
--- a/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
+++ b/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
@@ -138,10 +138,14 @@ namespace Bloom.Publish.Android
 
 			// We want these to run after RemoveUnwantedContent() so that the metadata will more accurately reflect
 			// the subset of contents that are included in the .bloomd
+			// Note that we generally want to disable features here, but not enable them, especially while
+			// running harvester!  See https://issues.bloomlibrary.org/youtrack/issue/BL-8995.
+			var enableBlind = modifiedBook.BookInfo.MetaData.Feature_Blind || !Program.RunningHarvesterMode;
+			var enableSignLanguage = modifiedBook.BookInfo.MetaData.Feature_SignLanguage || !Program.RunningHarvesterMode;
 			modifiedBook.UpdateMetadataFeatures(
-				isBlindEnabled: true,
-				isSignLanguageEnabled: true,
-				isTalkingBookEnabled: true);
+				isBlindEnabled: enableBlind,
+				isSignLanguageEnabled: enableSignLanguage,
+				isTalkingBookEnabled: true);	// talkingBook is only ever set automatically as far as I can tell.
 
 			modifiedBook.SetAnimationDurationsFromAudioDurations();
 


### PR DESCRIPTION
Creating bloomd books through harvester were setting signLanguage as a
feature whenever a video exists in the book.  This was then getting set
in the parse table, and showing in next.blorg.  Blind and sign language
should be set only by the user when uploading.  (Talking book is still
being set automatically as a feature: it will be controlled by the user
allowing narration audio to be uploaded.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3978)
<!-- Reviewable:end -->
