### PR TITLE
Escape hash character in synphony regex (BL-5031)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.js
@@ -655,9 +655,10 @@ LibSynphony.prototype.array_sort_length = function(arr) {
 };
 
 // function to escape special characters before performing a regular expression check
+// # is required when using XRegEx with the 'x' option, which makes # a line comment delimiter
 if (!RegExp.quote) {
     RegExp.quote = function(str) {
-        return (str + "").replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
+        return (str + "").replace(/([#.?*+^$[\]\\(){}|-])/g, "\\$1");
     };
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3980)
<!-- Reviewable:end -->
