### PR TITLE
Give the browser the UI language for toLocaleString() calls (BL-8275)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -835,7 +835,11 @@ export default class StyleEditor {
         });
     }
 
+    private uiLang: string;
+
     public AttachToBox(targetBox: HTMLElement) {
+        this.uiLang = theOneLocalizationManager.getCurrentUILocale();
+
         // This method is called when the window gets focus. This may be before CkEditor has finished loading.
         // Somewhere in the course of loading, it detects editable divs that are empty except for our gear icon.
         // It decides to insert some content...typically <p><br></p>, and in doing so, replaces the gear icon div.
@@ -1521,7 +1525,7 @@ export default class StyleEditor {
             let text = sortedItems[i];
             if (useNumericSort) {
                 // get localized version (e.g. with different decimal separator)
-                text = parseFloat(text).toLocaleString();
+                text = parseFloat(text).toLocaleString(this.uiLang);
             }
             if (maxlength && text.length > maxlength) {
                 text = text.substring(0, maxlength) + "...";

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -1625,6 +1625,8 @@ export class ReaderToolsModel {
         const words: string[] = this.selectWordsFromAllowedLists(stageNumber);
         const returnVal: DataWord[] = [];
 
+        const uiLang = theOneLocalizationManager.getCurrentUILocale();
+
         for (let i = 0; i < words.length; i++) {
             returnVal.push(new DataWord(words[i]));
         }
@@ -1642,7 +1644,7 @@ export class ReaderToolsModel {
                     $(toolbox)
                         .find("#allowed_word_list_truncated_text")
                         .html(),
-                    [this.maxAllowedWords.toLocaleString()]
+                    [this.maxAllowedWords.toLocaleString(uiLang)]
                 )
             );
         }

--- a/src/BloomBrowserUI/lib/localizationManager/localizationManager.ts
+++ b/src/BloomBrowserUI/lib/localizationManager/localizationManager.ts
@@ -77,6 +77,11 @@ export class LocalizationManager {
         });
     }
 
+    public getCurrentUILocale(): string {
+        // This is set in C# code by setting the "intl.accept_languages" preference.
+        return navigator.language;
+    }
+
     /**
      * Set dictionary values from an object.
      * Used in Bloom 2.0
@@ -174,7 +179,7 @@ export class LocalizationManager {
      *      .done(translation => {
      *          $(this).text(translation);
      *      });
-    */
+     */
     public asyncGetTextInLang(
         id: string,
         englishText: string,
@@ -206,7 +211,7 @@ export class LocalizationManager {
      *      .done(translation => {
      *          $(this).text(translation);
      *      });
-    */
+     */
     public asyncGetText(
         id: string,
         englishText: string,

--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -48,6 +48,8 @@ namespace Bloom
 		// generated.
 		internal Point ContextMenuLocation;
 
+		public static string DefaultBrowserLangs;
+
 		// TODO: refactor to use same initialization code as Palaso
 		public static void SetUpXulRunner()
 		{
@@ -163,6 +165,29 @@ namespace Bloom
 			// This setting is needed only on Linux as far as we can tell.
 			if (SIL.PlatformUtilities.Platform.IsLinux)
 				GeckoPreferences.User["layers.acceleration.force-enabled"] = true;
+
+			// Save the default system language tags for later use.
+			DefaultBrowserLangs = GeckoPreferences.User["intl.accept_languages"].ToString();
+		}
+
+		public static void SetBrowserLanguage(string langId)
+		{
+			var defaultLangs = DefaultBrowserLangs.Split(',');
+			if (defaultLangs.Contains(langId))
+			{
+				var newLangs = new StringBuilder();
+				newLangs.Append(langId);
+				foreach (var lang in defaultLangs)
+				{
+					if (lang != langId)
+						newLangs = newLangs.AppendFormat(",{0}",lang);
+				}
+				GeckoPreferences.User["intl.accept_languages"] = newLangs.ToString();
+			}
+			else
+			{
+				GeckoPreferences.User["intl.accept_languages"] = langId + "," + DefaultBrowserLangs;
+			}
 		}
 
 		public Browser()

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -314,6 +314,7 @@ namespace Bloom
 						}
 
 						LocalizationManager.SetUILanguage(Settings.Default.UserInterfaceLanguage, false);
+						Browser.SetBrowserLanguage(Settings.Default.UserInterfaceLanguage);
 
 						DialogAdapters.CommonDialogAdapter.ForceKeepAbove = true;
 						DialogAdapters.CommonDialogAdapter.UseMicrosoftPositioning = true;

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -439,6 +439,7 @@ namespace Bloom.Workspace
 			var tag = (LanguageItem)item.Tag;
 
 			LocalizationManager.SetUILanguage(tag.IsoCode, true);
+			Browser.SetBrowserLanguage(tag.IsoCode);
 			Settings.Default.UserInterfaceLanguage = tag.IsoCode;
 			Settings.Default.UserInterfaceLanguageSetExplicitly = true;
 			Settings.Default.Save();


### PR DESCRIPTION
This is needed for Geckofx60 to use anything except English.  Firefox 60
no longer picks up the OS locale (which was a poor substitute anyway for
the current UI language).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3982)
<!-- Reviewable:end -->
