### PR TITLE
Cleanup ToLocalhost references to use updated implementation (BL-9093)

### DIFF
--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -498,7 +498,7 @@ namespace Bloom.Publish.Android
 			_stagingFolder = new TemporaryFolder(StagingFolder);
 			var modifiedBook = BloomReaderFileMaker.PrepareBookForBloomReader(book.FolderPath, bookServer, _stagingFolder, progress, settings: settings);
 			progress.Message("Common.Done", "Shown in a list of messages when Bloom has completed a task.", "Done");
-			return modifiedBook.FolderPath.ToLocalhostProperlyEncoded();
+			return modifiedBook.FolderPath.ToLocalhost();
 		}
 
 		/// <summary>

--- a/src/BloomExe/Publish/PDF/PdfViewer.cs
+++ b/src/BloomExe/Publish/PDF/PdfViewer.cs
@@ -112,12 +112,12 @@ namespace Bloom.Publish.PDF
 			// with having a # in the query (file path) there without any problem.  You may
 			// regard this double escaping as a hack to get around the Linux xulrunner which
 			// behaves differently than the Windows xulrunner.  It is an exception to the rule
-			// of matching EscapeCharsForHttp() with UnescapeCharsForHttp().  See a comment in
+			// of matching EscapeFileNameForHttp() with UnescapeFileNameForHttp().  See a comment in
 			// https://jira.sil.org/browse/BL-951 for a description of the buggy program
 			// behavior without this hack.
 			var file = pdfFile;
 			if (SIL.PlatformUtilities.Platform.IsUnix)
-				file = file.EscapeCharsForHttp().EscapeCharsForHttp();
+				file = file.EscapeFileNameForHttp().EscapeFileNameForHttp();
 			var url = string.Format("{0}{1}?file=/bloom/{2}",
 				Api.BloomServer.ServerUrlWithBloomPrefixEndingInSlash,
 				FileLocationUtilities.GetFileDistributedWithApplication("pdf/web/viewer.html"),

--- a/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
+++ b/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
@@ -242,7 +242,7 @@ namespace Bloom.web.controllers
 
 				// The html client is set to treat a text reply as a url of the report. Make sure it's valid for being a URL.
 				// See https://silbloom.myjetbrains.com/youtrack/issue/BL-6197.
-				request.ReplyWithText("/bloom/" + answerPath.EscapeCharsForHttp().Replace(Path.DirectorySeparatorChar, '/'));
+				request.ReplyWithText("/bloom/" + answerPath.EscapeFileNameForHttp());
 				return;
 			}
 

--- a/src/BloomTests/ExtensionsTests.cs
+++ b/src/BloomTests/ExtensionsTests.cs
@@ -11,6 +11,32 @@ namespace BloomTests
 	[TestFixture]
 	class ExtensionsTests
 	{
+		[Test]
+		public static void ToLocalhost_GivenALocalhostUrl_ReturnsUnchanged()
+		{
+			// Setup
+			string input = $"http://localhost:{BloomServer.portForHttp}/bloom/C%3A/Directory/filename.txt";
+
+			// System under test
+			string result = input.ToLocalhost();
+
+			// Verification
+			Assert.That(result, Is.EqualTo(input));
+		}
+
+		[Test]
+		public static void ToLocalhost_GivenSimpleFilename_ConvertsToUrl()
+		{
+			// Setup
+			string fileName = $@"C:\Directory\Book Title\Book Title.htm";
+
+			// System under test
+			string result = fileName.ToLocalhost();
+
+			// Verification
+			Assert.That(result, Is.EqualTo($@"http://localhost:{BloomServer.portForHttp}/bloom/C%3A/Directory/Book%20Title/Book%20Title.htm"));
+		}
+
 		[TestCase("Guitar #14", "Guitar%20%2314")]	// Test for BL-8652.
 		[TestCase("a %+", "a%20%25%2B")]	// A test with multiple punctuation chars that gets past some earlier implementations
 		// Test every punctuation on a standard US QWERTY keyboard that is allowed in filenames.
@@ -33,13 +59,13 @@ namespace BloomTests
 		[TestCase("A'", "A%27")]
 		[TestCase("A,", "A%2C")]
 		[TestCase("A.", "A.")]
-		public static void ToLocalhostProperlyEncoded_AndroidPreviewBookTitleWithPunc_GeneratesWellFormedUrl(string bookTitle, string expectedEscapedTitle)
+		public static void ToLocalhost_AndroidPreviewBookTitleWithPunc_GeneratesWellFormedUrl(string bookTitle, string expectedEscapedTitle)
 		{
 			// Setup
-			string filename = $@"C:\PathToTemp\PlaceForStagingBook\{bookTitle}\meta.json";
+			string fileName = $@"C:\PathToTemp\PlaceForStagingBook\{bookTitle}\meta.json";
 
 			// System under test
-			string result = filename.ToLocalhostProperlyEncoded();
+			string result = fileName.ToLocalhost();
 
 			// Verification
 			string expectedResult = $@"http://localhost:{BloomServer.portForHttp}/bloom/C%3A/PathToTemp/PlaceForStagingBook/{expectedEscapedTitle}/meta.json";

--- a/src/BloomTests/PretendRequestInfo.cs
+++ b/src/BloomTests/PretendRequestInfo.cs
@@ -30,7 +30,7 @@ namespace Bloom.Api
 			RawUrl = url.Replace(BloomServer.ServerUrl, "");
 
 			// Reducing the /// emulates a behavior of the real HttpListener
-			var urlToDecode = url.Replace(BloomServer.ServerUrl, "").Replace("/bloom/OriginalImages///", "/bloom/OriginalImages/").Replace("/bloom///", "/bloom/").UnescapeCharsForHttp();
+			var urlToDecode = url.Replace(BloomServer.ServerUrl, "").Replace("/bloom/OriginalImages///", "/bloom/OriginalImages/").Replace("/bloom///", "/bloom/").UnescapeFileNameForHttp();
 			// Use the same decoding logic as in the "real" RequestInfo.
 			var pathWithoutLiteralPlusSigns = urlToDecode.Replace("+","%2B");
 			LocalPathWithoutQuery = System.Web.HttpUtility.UrlDecode(pathWithoutLiteralPlusSigns);


### PR DESCRIPTION
Encodes more special characters now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/3986)
<!-- Reviewable:end -->
