### PR TITLE
[4.9] BL-8515 Comic bubbles interfere with Image Desc.

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -225,6 +225,9 @@ div.hoverUp {
 }
 // override button positions when the image is shrunk to make room for an image description
 .bloom-showImageDescriptions {
+    canvas {
+        display: none;
+    }
     .imageButton {
         &.changeImageButton,
         &.pasteImageButton {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -1776,7 +1776,7 @@ describe("audio recording tests", () => {
             recording.audioRecordingMode = AudioRecordingMode.TextBox;
 
             // System under test
-            await recording.newPageReady();
+            await recording.newPageReady(true);
 
             // Verification
             const firstDiv = getFrameElementById("page", "div1")!;

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
@@ -1,4 +1,4 @@
-﻿import { ITool } from "../toolbox";
+﻿import { getTheOneToolbox, ITool } from "../toolbox";
 import { ToolBox } from "../toolbox";
 import * as AudioRecorder from "./audioRecording";
 
@@ -45,8 +45,9 @@ export default class TalkingBookTool implements ITool {
 
     // Called when a new page is loaded.
     public async newPageReady(): Promise<void> {
-        // if this class eventually extends our React Adaptor, this can be removed.
-        return AudioRecorder.theOneAudioRecorder.newPageReady();
+        return AudioRecorder.theOneAudioRecorder.newPageReady(
+            this.isImageDescriptionToolActive()
+        );
     }
 
     public hideTool() {
@@ -77,11 +78,18 @@ export default class TalkingBookTool implements ITool {
         return true;
     }
 
+    private isImageDescriptionToolActive(): boolean {
+        return getTheOneToolbox().isToolActive("imageDescriptionTool");
+    }
+
     private showImageDescriptionsIfAny() {
         // If we have any image descriptions we need to show them so we can record them.
-        // (Also because we WILL select them, which is confusing if they are not visible.)
+        // (BL-8515) Unless the image description tool is not currently active.
         const page = ToolBox.getPage();
         if (!page) {
+            return;
+        }
+        if (!this.isImageDescriptionToolActive()) {
             return;
         }
         const imageContainers = page.getElementsByClassName(

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -401,6 +401,15 @@ export class ToolBox {
         return getITool(toolId);
     }
 
+    // Returns 'true' if the checkbox in the More... tab for the requested tool (w/"Tool" suffix!) is checked.
+    public isToolActive(toolId: string): boolean {
+        const tools = $("*[data-toolId]");
+        const filteredTools = tools.filter(function() {
+            return $(this).attr("data-toolId") === toolId;
+        });
+        return filteredTools.length > 0;
+    }
+
     public activateToolFromId(toolId: string) {
         if (!getITool(toolId)) {
             // Normally we won't even give a way to see this tool if it's


### PR DESCRIPTION
* hide canvas and bubble text while Image Desc tool is active
* fix talking book tool so it doesn't show image descriptions if that
   tool is not active
* fix getRecordableDivs() to include/not include image descriptions
   based on whether the tool is active

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4008)
<!-- Reviewable:end -->
