### PR TITLE
Turn on image descriptions in newPageReady, not updateMarkup (BL-9115)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
@@ -1,4 +1,4 @@
-﻿import { getTheOneToolbox, ITool } from "../toolbox";
+import { getTheOneToolbox, ITool } from "../toolbox";
 import { ToolBox } from "../toolbox";
 import * as AudioRecorder from "./audioRecording";
 
@@ -27,7 +27,7 @@ export default class TalkingBookTool implements ITool {
     // Some scenarios:
     // * Open the toolbox and Talking Book shows up  - showTool, newPageReady
     // * Open a book and Talking Book tool automatically opens - showTool, newPageReady
-    // * Creating a new page while tool is open - newPageReady, updateMarkup, newPageReady (again), updateMarkup (again)
+    // * Creating a new page while tool is open - newPageReady, newPageReady (again)
     // * Changing to an existing page while tool is open - same as above.
     // * Typing in a text box while tool is open - updateMarkup
     // * Close the toolbox: hideTool()
@@ -39,12 +39,12 @@ export default class TalkingBookTool implements ITool {
         // the initialize function had completed, now that it isn't there we need to treat the initialize
         // as the asynchronous method it is.
         await AudioRecorder.initializeTalkingBookToolAsync();
-        this.showImageDescriptionsIfAny();
         await AudioRecorder.theOneAudioRecorder.setupForRecordingAsync();
     }
 
     // Called when a new page is loaded.
     public async newPageReady(): Promise<void> {
+        this.showImageDescriptionsIfAny();
         return AudioRecorder.theOneAudioRecorder.newPageReady(
             this.isImageDescriptionToolActive()
         );


### PR DESCRIPTION
updateMarkup is no longer called when switching pages. It's called for editing text, which does not require this; but we do need it when loading a new page, including changing zoom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4021)
<!-- Reviewable:end -->
