### PR TITLE
Handle failure to load image from clipboard (BL-9009)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1661,6 +1661,10 @@
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
         <note>ID: EditTab.NoImageFoundOnClipboard</note>
       </trans-unit>
+      <trans-unit id="EditTab.NoValidImageFoundOnClipboard">
+        <source xml:lang="en">Bloom failed to interpret the clipboard contents as an image. Possibly it was a damaged file, or too large. Try copying something else.</source>
+        <note>ID: EditTab.NoValidImageFoundOnClipboard</note>
+      </trans-unit>
       <trans-unit id="EditTab.NoOtherLayouts">
         <source xml:lang="en">There are no other options for this template.</source>
         <note>ID: EditTab.NoOtherLayouts</note>

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -827,7 +827,18 @@ namespace Bloom.Edit
 			PalasoImage clipboardImage = null;
 			try
 			{
-				clipboardImage = GetImageFromClipboard();
+				try
+				{
+					clipboardImage = PortableClipboard.GetImageFromClipboardWithExceptions();
+				}
+				catch (Exception ex)
+				{
+					MessageBox.Show(
+						LocalizationManager.GetString("EditTab.NoValidImageFoundOnClipboard",
+							"Bloom failed to interpret the clipboard contents as an image. Possibly it was a damaged file, or too large. Try copying something else."));
+					return;
+				}
+
 				if(clipboardImage == null)
 				{
 					MessageBox.Show(


### PR DESCRIPTION
Make sure https://github.com/sillsdev/libpalaso/pull/980 is merged first!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4023)
<!-- Reviewable:end -->
