### PR TITLE
Reenable a number of tests on Linux (20201020)

### DIFF
--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -61,6 +61,9 @@
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)'!='Windows_NT' AND '$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DefineConstants>__MonoCS__;DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>..\..\output\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -81,8 +84,8 @@
     <DebugSymbols>true</DebugSymbols>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(OS)'!='Windows_NT'">
-    <DefineConstants>__MonoCS__</DefineConstants>
+  <PropertyGroup Condition="'$(OS)'!='Windows_NT' AND '$(Configuration)|$(Platform)' == 'Release|x86'">
+    <DefineConstants>__MonoCS__;TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">

--- a/src/BloomTests/Collection/CollectionSettingsTests.cs
+++ b/src/BloomTests/Collection/CollectionSettingsTests.cs
@@ -149,7 +149,7 @@ namespace BloomTests.Collection
 		[TestCase("", "2")] // default
 		[TestCase("Decimal", "2")]
 		[TestCase("Devanagari", "२")]
-		[TestCase("Khmer", "២", ExcludePlatform = "Linux", Reason = "Fails until BL-4796 provides a better implementation")]
+		[TestCase("Khmer", "២")]
 		[TestCase("Cjk-Decimal", "二")]
 		public void CharactersForDigitsForPageNumbers_Tests(string numberStyleName, string digitForNumber2)
 		{

--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -72,8 +72,9 @@ namespace BloomTests.ImageProcessing
 
 		// See BL-3646 which showed we were blacking out the image when converting from png to jpg
 		[Test]
-		[Platform(Exclude = "Linux",
-			Reason = "This test throws a low-level warning which TC is currently treating as an error")]
+#if __MonoCS__
+		[Category("SkipOnTeamCity")]	// only for Linux: TeamCity creates an error from a low-level warning message.
+#endif
 		public static void
 			ProcessAndSaveImageIntoFolder_SimpleImageHasTransparentBackground_ImageNotConvertedAndFileSizeNotIncreased()
 		{

--- a/src/BloomTests/PdfMakerTests.cs
+++ b/src/BloomTests/PdfMakerTests.cs
@@ -17,7 +17,6 @@ namespace BloomTestsThatAvoidTheSetupFixture
 	[TestFixture]
 #if __MonoCS__
 	[RequiresSTA]
-	[Platform(Exclude="Linux", Reason="Currently hanging on Linux when run with Jenkins (BL-831)")]
 #endif
 	[NUnit.Framework.Category("RequiresUI")]
 	public class PdfMakerTests

--- a/src/BloomTests/WebLibraryIntegration/BookTransferTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BookTransferTests.cs
@@ -120,7 +120,6 @@ namespace BloomTests.WebLibraryIntegration
 			// The only omitted one that messes up current unit tests is meta.bak
 			var filesToUpload = Directory.GetFiles(originalBookFolder).Where(p => !p.EndsWith(".bak") && !p.Contains(BookStorage.PrefixForCorruptHtmFiles));
 			int fileCount = filesToUpload.Count();
-
 			Login();
 			//HashSet<string> notifications = new HashSet<string>();
 
@@ -133,7 +132,7 @@ namespace BloomTests.WebLibraryIntegration
 #if DEBUG
 			++expectedFileCount;	// and if in debug mode, then plus one for S3 ID
 #endif
-			Assert.That(uploadMessages.Length, Is.EqualTo(expectedFileCount));
+			Assert.That(uploadMessages.Length, Is.EqualTo(expectedFileCount), "Uploaded file counts do not match");
 			Assert.That(progress.Text, Does.Contain(
 				LocalizationManager.GetString("PublishTab.Upload.UploadingBookMetadata", "Uploading book metadata",
 				"In this step, Bloom is uploading things like title, languages, & topic tags to the bloomlibrary.org database.")));
@@ -146,7 +145,7 @@ namespace BloomTests.WebLibraryIntegration
 			var url = BookTransfer.BloomS3UrlPrefix + BloomS3Client.UnitTestBucketName + "/" + s3Id;
 			var newBookFolder = _transfer.HandleDownloadWithoutProgress(url, dest);
 
-			Assert.That(Directory.GetFiles(newBookFolder).Length, Is.EqualTo(fileCount + 1)); // book order is added during upload
+			Assert.That(Directory.GetFiles(newBookFolder).Length, Is.EqualTo(fileCount + 1), "Book order was not added during upload"); // book order is added during upload
 
 			Assert.That(_downloadedBooks.Count, Is.EqualTo(1));
 			Assert.That(_downloadedBooks[0].FolderPath,Is.EqualTo(newBookFolder));
@@ -186,7 +185,6 @@ namespace BloomTests.WebLibraryIntegration
 		}
 
 		[Test]
-		[Platform(Exclude="Linux", Reason="Currently hangs on Linux on Jenkins (BL-831)")]
 		public void UploadBooks_SimilarIds_DoNotOverwrite()
 		{
 			var firstPair = UploadAndDownLoadNewBook("first", "book1", "Jack", "Jack's data");
@@ -237,7 +235,6 @@ namespace BloomTests.WebLibraryIntegration
 		}
 
 		[Test]
-		[Platform(Exclude="Linux", Reason="Currently hangs on Linux on Jenkins (BL-831)")]
 		public void UploadBook_SameId_Replaces()
 		{
 			var bookFolder = MakeBook("unittest", "myId", "me", "something");


### PR DESCRIPTION
The reasons for disabling them appear to no longer apply.  They all run
okay on the local machine.
I added a "SkipOnTeamCityLinux" category for the one test that runs okay
locally but would produce an error from a warning message on TeamCity.
It is possible that one or more of the reactivated tests may fall into
that category.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4030)
<!-- Reviewable:end -->
