### PR TITLE
Don't allow multiple spaces in image names (BL-9145)

### DIFF
--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -239,6 +239,12 @@ namespace Bloom.ImageProcessing
 				// See https://silbloom.myjetbrains.com/youtrack/issue/BL-2627 ("Weird Image Problem").
 				basename = Path.GetFileNameWithoutExtension(imageInfo.FileName);
 			}
+
+			// Multiple spaces are prone to being collapsed in HTML, particularly if the name ends up in
+			// the content of some element like a data-div one, such as the coverImage src. See BL-9145.
+			// So we will just collapse them before we save the file.
+			while (basename.Contains("  "))
+				basename = basename.Replace("  ", " ");
 			return GetUnusedFilename(bookFolderPath, basename, extension);
 		}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4052)
<!-- Reviewable:end -->
