### PR TITLE
BL-9198 Copy text from source bubbles

### DIFF
--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/sourceBubbles.less
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/sourceBubbles.less
@@ -31,6 +31,9 @@
         .qtip-content {
             padding-bottom: 0 !important;
         }
+        .source-copy-button {
+            display: none;
+        }
     }
 
     // The "!important"s in here are needed to override qtip's defaults
@@ -135,9 +138,6 @@
         line-height: 1.5;
         color: black;
         padding-top: 4px;
-        &.active {
-            overflow: hidden !important;
-        }
 
         //thai script languages. If using Arial, they need to be 30% bigger or so. With the
         // popular Angsana New, it would need to be like 100% bigger
@@ -174,6 +174,7 @@
         }
     }
 }
+
 .dropdown-menu {
     width: 32px;
     border: none !important;
@@ -196,6 +197,7 @@
         display: none;
     }
 }
+
 .panel-container {
     border: 1px solid black;
     padding: 0 10px;
@@ -205,8 +207,8 @@
     display: flex;
     flex-direction: row;
     justify-content: end;
-    margin-right: -5px; // These negative margins along with an overflow hidden above get the icon
-    margin-bottom: -5px; // to line up with the content better.
+    margin-right: -5px; // These negative margins get the icon to line up better with the content.
+    margin-bottom: -5px;
     .copy-transition {
         margin-right: 7px;
         padding: 0 7px;

--- a/src/BloomBrowserUI/react_components/CopyContentButton.tsx
+++ b/src/BloomBrowserUI/react_components/CopyContentButton.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import IconButton from "@material-ui/core/IconButton";
-import Zoom from "@material-ui/core/Zoom";
+import Fade from "@material-ui/core/Fade";
 import Typography from "@material-ui/core/Typography";
 import ContentCopyIcon from "./icons/ContentCopyIcon";
 import { useL10n } from "./l10nHooks";
@@ -30,7 +30,7 @@ const CopyContentButton: React.FC<ICopyContentButtonProps> = props => {
 
     return (
         <div className="bloom-ui source-copy-button">
-            <Zoom
+            <Fade
                 in={showTransition}
                 enter={true}
                 exit={true}
@@ -40,7 +40,7 @@ const CopyContentButton: React.FC<ICopyContentButtonProps> = props => {
                 <div className="copy-transition">
                     <Typography>{copiedText}</Typography>
                 </div>
-            </Zoom>
+            </Fade>
             <IconButton aria-label="copy" size="small" onClick={handleClick}>
                 <ContentCopyIcon />
             </IconButton>


### PR DESCRIPTION
* switched transition from zoom to fade
* fixed overflow problems
* hide copy button when text box not focused

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4079)
<!-- Reviewable:end -->
