### PR TITLE
Minimal fix to not duplicate audio ids after text copy/paste (BL-9221)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -2820,7 +2820,8 @@ export default class AudioRecording {
     // just using the original order, since it is possible we have a match and only spelling or punctuation changed.
     // We also attempt to use any sentence IDs specified by this.sentenceToIdListMap.
     // N.B. If Bloom comes in here with spans that have no audio-sentence class, we may end up wrapping spans in spans.
-    private makeAudioSentenceElementsLeaf(elt: JQuery): void {
+    // public to allow unit testing.
+    public makeAudioSentenceElementsLeaf(elt: JQuery): void {
         // When all text is deleted, we get in a temporary state with no paragraph elements, so the root editable div
         // may be processed...and if this happens during editing the format button may be present. The body of this function
         // will do weird things with it (wrap it in a sentence span, for example) so the easiest thing is to remove
@@ -2868,6 +2869,7 @@ export default class AudioRecording {
         // If any new sentence has an md5 that matches a saved one, attach that id/md5 pair to that fragment.
         for (let i = 0; i < htmlFragments.length; i++) {
             const fragment = htmlFragments[i];
+            (<any>fragment).matchingAudioSpan = null; // remove obsolete audio info from possibly cached value (BL-9221)
             if (this.isRecordable(fragment)) {
                 const currentMd5 = this.md5(fragment.text);
                 for (let j = 0; j < reuse.length; j++) {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -2,6 +2,7 @@ import AudioRecording, {
     AudioRecordingMode,
     AudioTextFragment
 } from "./audioRecording";
+import * as $ from "jquery";
 
 describe("audio recording tests", () => {
     describe(", Next()", () => {
@@ -1596,6 +1597,36 @@ describe("audio recording tests", () => {
         const result = recording.isInSoftSplitMode();
 
         expect(result).toBe(false);
+    });
+
+    it("makeAudioSentenceElementsLeaf creates new ids for duplicate text", () => {
+        const recording = new AudioRecording();
+
+        const sent1 =
+            '<span id="i00c41f76-0d90-41be-988d-084517eea47d" class="audio-sentence" recordingmd5="702edca0b2181c15d457eacac39de39b">This is a test!</span>';
+        // The outer <p>...</p> is needed to get the right jquery object passed to the method.
+        const elt1 = $($.parseHTML(`<p>${sent1}</p>`));
+        expect(elt1.html()).toBe(sent1); // verify original state
+        recording.makeAudioSentenceElementsLeaf(elt1);
+        expect(elt1.html()).toBe(sent1);
+        const oldId = elt1.find(".audio-sentence").attr("id");
+        expect(oldId).toBe("i00c41f76-0d90-41be-988d-084517eea47d");
+
+        const sent2 = "This is a test!";
+        const elt2 = $($.parseHTML(`<p>${sent2}</p>`));
+        expect(elt2.html()).toBe(sent2); // verify original state
+        recording.makeAudioSentenceElementsLeaf(elt2);
+        expect(elt2.html()).not.toBe(sent2);
+        const newId = elt2.find(".audio-sentence").attr("id");
+        expect(newId).not.toBe(oldId);
+        expect(newId.length).toBeGreaterThan(35);
+        expect(newId.length).toBeLessThan(38);
+        expect(elt2.html().startsWith('<span id="')).toBe(true);
+        expect(
+            elt2
+                .html()
+                .endsWith('" class="audio-sentence">This is a test!</span>')
+        ).toBe(true);
     });
 });
 


### PR DESCRIPTION
Duplication could also happen after typing the same sentence a second
time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4080)
<!-- Reviewable:end -->
