### PR TITLE
[4.9] BL-9198 Copy from text source bubbles

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1729,6 +1729,11 @@
         <source xml:lang="en">Saving...</source>
         <note>ID: EditTab.SavingNotification</note>
       </trans-unit>
+      <trans-unit id="EditTab.SourceBubbleCopied" sil:dynamic="true">
+        <source xml:lang="en">Copied</source>
+        <note>ID: EditTab.SourceBubbleCopied</note>
+        <note>Displays briefly when the user clicks the copy icon in a source bubble.</note>
+      </trans-unit>
       <trans-unit id="EditTab.TextBoxProperties.Alignment" sil:dynamic="true">
         <source xml:lang="en">Alignment</source>
         <note>ID: EditTab.TextBoxProperties.Alignment</note>

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -160,7 +160,7 @@ export class BubbleManager {
 
         Comical.setActiveBubbleListener(activeElement => {
             if (activeElement) {
-                var focusElements = activeElement.getElementsByClassName(
+                const focusElements = activeElement.getElementsByClassName(
                     "bloom-visibility-code-on"
                 );
                 if (focusElements.length > 0) {
@@ -339,9 +339,9 @@ export class BubbleManager {
                 // it would be nice to do this only once, but there MIGHT
                 // be TOP elements in more than one image container...too complicated,
                 // and this only happens once per TOP.
-                Comical.update(top.closest(
-                    ".bloom-imageContainer"
-                ) as HTMLElement);
+                Comical.update(
+                    top.closest(".bloom-imageContainer") as HTMLElement
+                );
             }
         });
     }
@@ -374,9 +374,14 @@ export class BubbleManager {
 
     private static onDocClickClearActiveElement(event: Event) {
         const clickedElement = event.target as Element; // most local thing clicked on
-        if (clickedElement.closest(".bloom-imageContainer")) {
+        if (
+            clickedElement.closest(".bloom-imageContainer") ||
+            clickedElement.closest(".source-copy-button")
+        ) {
             // We have other code to handle setting and clearing Comical handles
             // if the click is inside a Comical area.
+            // BL-9198 We also have code (in BloomSourceBubbles) to handle clicks on source bubble
+            // copy buttons.
             return;
         }
         // If we clicked in the document outside a Comical picture

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/SourceBubblesSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/SourceBubblesSpec.ts
@@ -1,4 +1,4 @@
-/// <reference path="./BloomSourceBubbles.ts" />
+/// <reference path="./BloomSourceBubbles.tsx" />
 ///<reference path="../../typings/bundledFromTSC.d.ts"/>
 
 import BloomSourceBubbles from "./BloomSourceBubbles";
@@ -21,7 +21,7 @@ describe("SourceBubbles", () => {
         // currentCollectionLanguage2 ('tpi' in tests)
         // currentCollectionLanguage3 ('fr' in tests)
 
-        var testHtml = $(
+        const testHtml = $(
             [
                 "<div id='testTarget' class='bloom-translationGroup'>",
                 "   <div class='bloom-editable' lang='es'>Spanish text</div>",
@@ -32,7 +32,7 @@ describe("SourceBubbles", () => {
             ].join("\n")
         );
         $("body").append(testHtml);
-        var result = BloomSourceBubbles.MakeSourceTextDivForGroup(
+        const result = BloomSourceBubbles.MakeSourceTextDivForGroup(
             $("body").find("#testTarget")[0]
         );
 
@@ -50,7 +50,7 @@ describe("SourceBubbles", () => {
         // <div class='bloom-editable' lang='es'>Spanish text</div> (order not important here)
         // <div class='bloom-editable' lang='fr'>French text</div>
         // <div class='bloom-editable' lang='tpi'>Tok Pisin text</div>
-        var listItems = result.find("nav ul li");
+        const listItems = result.find("nav ul li");
         expect(listItems.length).toBe(3);
         expect(listItems.first().html()).toBe(
             '<a class="sourceTextTab" href="#tpi">Tok Pisin</a>'
@@ -61,7 +61,7 @@ describe("SourceBubbles", () => {
         expect(listItems.last().html()).toBe(
             '<a class="sourceTextTab" href="#es">español</a>'
         );
-        expect(result.find("div").length).toBe(3);
+        expect(result.find("div.source-text").length).toBe(3);
     });
 
     it("Run CreateDropdownIfNecessary with pre-defined settings", () => {

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/sourceBubbles.less
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/sourceBubbles.less
@@ -31,6 +31,9 @@
         .qtip-content {
             padding-bottom: 0 !important;
         }
+        .source-copy-button {
+            display: none;
+        }
     }
 
     // The "!important"s in here are needed to override qtip's defaults
@@ -135,9 +138,6 @@
         line-height: 1.5;
         color: black;
         padding-top: 4px;
-        &.active {
-            overflow-y: hidden !important;
-        }
 
         //thai script languages. If using Arial, they need to be 30% bigger or so. With the
         // popular Angsana New, it would need to be like 100% bigger
@@ -174,6 +174,7 @@
         }
     }
 }
+
 .dropdown-menu {
     width: 32px;
     border: none !important;
@@ -196,7 +197,27 @@
         display: none;
     }
 }
+
 .panel-container {
     border: 1px solid black;
     padding: 0 10px;
+}
+
+.source-copy-button {
+    display: flex;
+    flex-direction: row;
+    justify-content: end;
+    margin-right: -5px; // These negative margins get the icon to line up better with the content.
+    margin-bottom: -5px;
+    .copy-transition {
+        margin-right: 7px;
+        padding: 0 7px;
+        background-color: #dcc6da;
+    }
+    button {
+        padding: 0;
+    }
+    svg {
+        transform: scale(0.6);
+    }
 }

--- a/src/BloomBrowserUI/problemDialog/ProblemDialog.tsx
+++ b/src/BloomBrowserUI/problemDialog/ProblemDialog.tsx
@@ -22,7 +22,6 @@ import { useDrawAttention } from "../react_components/UseDrawAttention";
 import ReactDOM = require("react-dom");
 import { PrivacyScreen } from "./PrivacyScreen";
 import { useL10n } from "../react_components/l10nHooks";
-import Close from "@material-ui/icons/Close";
 
 export enum ProblemKind {
     User = "User",

--- a/src/BloomBrowserUI/react_components/CopyContentButton.tsx
+++ b/src/BloomBrowserUI/react_components/CopyContentButton.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { useState } from "react";
+import IconButton from "@material-ui/core/IconButton";
+import Fade from "@material-ui/core/Fade";
+import Typography from "@material-ui/core/Typography";
+import ContentCopyIcon from "./icons/ContentCopyIcon";
+import { useL10n } from "./l10nHooks";
+
+export interface ICopyContentButtonProps {
+    onClick: () => void;
+}
+
+const CopyContentButton: React.FC<ICopyContentButtonProps> = props => {
+    const copiedText = useL10n("Copied", "EditTab.SourceBubbleCopied");
+    const [showTransition, setShowTransition] = useState(false);
+
+    const transitionDuration = 300; // Length of time to transition "copied" message in or out
+    const feedbackDuration = 1000; // Length of time "copied" message stays "up"
+
+    const handleClick = () => {
+        setShowTransition(true);
+        props.onClick();
+    };
+
+    const handleOnEntered = () => {
+        setTimeout(() => {
+            setShowTransition(false);
+        }, feedbackDuration);
+    };
+
+    return (
+        <div className="bloom-ui source-copy-button">
+            <Fade
+                in={showTransition}
+                enter={true}
+                exit={true}
+                timeout={transitionDuration}
+                onEntered={handleOnEntered}
+            >
+                <div className="copy-transition">
+                    <Typography>{copiedText}</Typography>
+                </div>
+            </Fade>
+            <IconButton aria-label="copy" size="small" onClick={handleClick}>
+                <ContentCopyIcon />
+            </IconButton>
+        </div>
+    );
+};
+
+export default CopyContentButton;

--- a/src/BloomBrowserUI/react_components/icons/ContentCopyIcon.tsx
+++ b/src/BloomBrowserUI/react_components/icons/ContentCopyIcon.tsx
@@ -1,0 +1,15 @@
+import React = require("react");
+import SvgIcon from "@material-ui/core/SvgIcon";
+
+// I pulled this icon from www.materialui.co
+// (not the official material-ui site, which doesn't have what we want).
+export const ContentCopyIcon = props => (
+    <SvgIcon {...props}>
+        <path
+            d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+            fill="#96668f"
+        />
+    </SvgIcon>
+);
+
+export default ContentCopyIcon;


### PR DESCRIPTION
Cherry-picked from 5.0
* allows copy to clipboard from any source bubble
* convert BloomSourceBubbles to .tsx
* works with onclick
* got "Copied" transition working
* fix js test failure
* UI review chgs
* switched transition from zoom to fade
* fixed overflow problems
* hide copy button when text box not focused

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4092)
<!-- Reviewable:end -->
