### PR TITLE
Make Credits page bottom branding text use credits-page-style

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.pug
+++ b/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.pug
@@ -23,7 +23,7 @@ block outsideBackCover
 
 //- The standard template uses "*", but we need to put different disclaimers in for each of the 5 languages
 block credits-page-branding-bottom
-	div(data-book='credits-page-branding-bottom-html' lang="N1")
+	div.Credits-Page-style(data-book='credits-page-branding-bottom-html' lang="N1")
 
 block XMatterTitle
 	title Kyrgyzstan 2020 Front & Back Matter

--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
@@ -63,9 +63,13 @@ mixin credits-page-branding-top
 	block credits-page-branding-top
 		div(data-book='credits-page-branding-top-html' lang="*")
 
+//- Note that inclusion of Credits-Page-style makes it responsive to user changing other text on the page.
+//- This is a late (Dec 2020) change, which might cause older xmatters/branding problems if they don't
+//- already override this block. If so, we'll fix those to lock down the size if that's actually
+//- appropriate for them... copying the rest of the text should normally be the right thing to do.
 mixin credits-page-branding-bottom
 	block credits-page-branding-bottom
-		div(data-book='credits-page-branding-bottom-html' lang="*")
+		div.Credits-Page-style(data-book='credits-page-branding-bottom-html' lang="*")
 
 mixin title-page-branding-bottom
 	block title-page-branding-bottom


### PR DESCRIPTION
Needed by Kyrgyz project, but I also make this the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4109)
<!-- Reviewable:end -->
