### PR TITLE
Trace memory leaks changing pages (BL-9261)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -511,7 +511,7 @@ export function applyToolboxStateToUpdatedPage() {
 
 function doWhenPageReady(action: () => void) {
     const page = ToolBox.getPage();
-    if (!page) {
+    if (!page || !ToolBox.getPageFrame()) {
         // Somehow, despite firing this function when the document is supposedly ready,
         // it may not really be ready when this is first called. If it doesn't even have a body yet,
         // we need to try again later.
@@ -931,7 +931,9 @@ function handleKeyboardInput(): void {
             // if we don't have one.
             if (ckeditorOfThisBox) {
                 let ckeditorSelection = ckeditorOfThisBox.getSelection();
-
+                if (!ckeditorSelection) {
+                    return; // may be changing pages?
+                }
                 // there is also createBookmarks2(), which avoids actually inserting anything. That has the
                 // advantage that changing a character in the middle of a word will allow the entire word to
                 // be evaluated by the markup routine. However, testing shows that the cursor then doesn't

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -487,6 +487,8 @@ namespace Bloom.Edit
 			}
 		}
 
+		DateTime _beginPageLoad;
+
 		public void UpdateSingleDisplayedPage(IPage page)
 		{
 			if(!_model.Visible)
@@ -500,6 +502,7 @@ namespace Bloom.Edit
 #endif
 			if(_model.HaveCurrentEditableBook)
 			{
+				_beginPageLoad = DateTime.Now;
 				_pageListView.SelectThumbnailWithoutSendingEvent(page);
 				_pageListView.UpdateThumbnailAsync(page);
 				_model.SetupServerWithCurrentPageIframeContents();
@@ -518,9 +521,18 @@ namespace Bloom.Edit
 				_model.NavigatingSoSuspendSaving = true;
 				if (_model.AreToolboxAndOuterFrameCurrent())
 				{
-					var pageUrl = _model.GetUrlForCurrentPage();
 					_browser1.SetEditDom(domForCurrentPage);
-					RunJavaScript("FrameExports.switchContentPage('" + pageUrl + "');");
+					if (ReloadCurrentPage())
+					{
+						Logger.WriteEvent("changing page via Navigate(\"CURRENTPAGE.htm\")");
+						_browser1.WebBrowser.Navigate(BloomServer.ServerUrlWithBloomPrefixEndingInSlash + "CURRENTPAGE.htm");
+					}
+					else
+					{
+						Logger.WriteEvent("changing page via FrameExports.switchContentPage()");
+						var pageUrl = _model.GetUrlForCurrentPage();
+						RunJavaScript("FrameExports.switchContentPage('" + pageUrl + "');");
+					}
 				}
 				else
 				{
@@ -562,6 +574,18 @@ namespace Bloom.Edit
 #endif
 		}
 
+		private bool ReloadCurrentPage()
+		{
+			// Note that ModifierKeys does not seem to work on Linux.
+			return ((ModifierKeys & Keys.Shift) == Keys.Shift) || RobustFile.Exists("/tmp/UseCURRENTPAGE");
+		}
+
+		private bool UseBackgroundGC()
+		{
+			// Note that ModifierKeys does not seem to work on Linux.
+			return ((ModifierKeys & Keys.Alt) == Keys.Alt) || RobustFile.Exists("/tmp/UseBackgroundGC");
+		}
+
 #if __MonoCS__
 		/// <summary>
 		/// Flag the PageSelection object that the current (former?) page selection has completed,
@@ -583,13 +607,27 @@ namespace Bloom.Edit
 			ChangingPages = false;
 			_model.DocumentCompleted();
 			_browser1.Focus(); //fix BL-3078 No Initial Insertion Point when any page shown
-			GC.Collect();
-			GC.WaitForPendingFinalizers();
-			MemoryService.MinimizeHeap(true);
-#if MEMORYCHECK
+			var beginGarbageCollect = DateTime.Now;
+			if (UseBackgroundGC())
+			{
+				Logger.WriteEvent("performing backgound garbage collection without finalizers");
+				GC.Collect(2, GCCollectionMode.Optimized, false, true);
+				//GC.WaitForPendingFinalizers();
+				MemoryService.MinimizeHeap(false);
+			}
+			else
+			{
+				Logger.WriteEvent("performing blocking garbage collection with finalizers");
+				GC.Collect(/*2, GCCollectionMode.Optimized, false, true*/);
+				GC.WaitForPendingFinalizers();
+				MemoryService.MinimizeHeap(true);
+			}
+			var endPageLoad = DateTime.Now;
+			Logger.WriteEvent($"update page elapsed time = {endPageLoad - _beginPageLoad} (garbage collect took {endPageLoad - beginGarbageCollect}");
+//#if MEMORYCHECK
 			// Check memory for the benefit of developers.
 			SIL.Windows.Forms.Reporting.MemoryManagement.CheckMemory(false, "EditingView - display page updated", false);
-#endif
+//#endif
 		}
 
 		public void AddMessageEventListener(string eventName, Action<string> action)

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1488,6 +1488,13 @@ namespace Bloom.Edit
 
 		public void UpdateEditButtons()
 		{
+			// Checking whether to enable these buttons is done by javascript code.  This check
+			// will fail with a javascript error while pages are being changed.  The code for
+			// changing pages makes the browser invisible while the change is happening, so
+			// that's what we have to check to prevent spurious javascript errors.
+			// Note that this method is called by a timer (probably about 110msec cycle).
+			if (!_browser1.Visible)
+				return;	
 			_browser1.UpdateEditButtons();
 			UpdateButtonEnabled(_cutButton, _cutCommand);
 			UpdateButtonEnabled(_copyButton, _copyCommand);


### PR DESCRIPTION
Holding SHIFT down while changing pages causes a different navigation that doesn't leak as much but is slower.
Holding ALT down while changing pages causes garbage collection to occur in the background without waiting for finalizers.
(This should make page changing appear faster, but may not minimize memory use quite as much.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4112)
<!-- Reviewable:end -->
