### PR TITLE
Show debug menu items for alpha test builds (BL-9261)

### DIFF
--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -599,7 +599,8 @@ namespace Bloom
 			var debugBloom = Environment.GetEnvironmentVariable("DEBUGBLOOM");
 			var _addDebuggingMenuItems = !String.IsNullOrEmpty(debugBloom) && debugBloom.ToLowerInvariant() != "false" && debugBloom.ToLowerInvariant() != "no";
 #endif
-			if (_addDebuggingMenuItems)
+			// Allow debugging entries on any alpha builds as well as any debug builds.
+			if (_addDebuggingMenuItems || ApplicationUpdateSupport.IsDevOrAlpha)
 				AddOtherMenuItemsForDebugging(e);
 
 			e.ContextMenu.MenuItems.Add(LocalizationManager.GetString("Browser.CopyTroubleshootingInfo", "Copy Troubleshooting Information"), OnGetTroubleShootingInformation);


### PR DESCRIPTION
This includes things like opening the "about:memory" window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4114)
<!-- Reviewable:end -->
