### PR TITLE
[4.9] BL-9319 Make custom widgets Enterprise-only

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomWidgets.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomWidgets.ts
@@ -9,12 +9,19 @@ import { BloomApi } from "../../utils/bloomApi";
 // (https://support.apple.com/en-us/HT204433)
 // such as using information in Info.plist to locate the root file.
 
+// BL-9319 Custom widgets should only be Enterprise-enabled.
+
 // Initialization function, sets up all the editing functions we support for these elements.
 export function SetupWidgetEditing(container: HTMLElement): void {
-    const widgets = Array.from(
-        container.getElementsByClassName("bloom-widgetContainer")
-    );
-    widgets.forEach(w => SetupWidget(w));
+    BloomApi.get("featurecontrol/enterpriseEnabled", result => {
+        const isEnterpriseEnabled: boolean = result.data;
+        if (isEnterpriseEnabled) {
+            const widgets = Array.from(
+                container.getElementsByClassName("bloom-widgetContainer")
+            );
+            widgets.forEach(w => SetupWidget(w));
+        }
+    });
 }
 
 function SetupWidget(w: Element): void {

--- a/src/BloomBrowserUI/bookEdit/js/origami.ts
+++ b/src/BloomBrowserUI/bookEdit/js/origami.ts
@@ -17,38 +17,48 @@ $(() => {
 
 export function setupOrigami(isBookLocked: boolean) {
     BloomApi.get("featurecontrol/showAdvancedFeatures", result => {
-        const customPages = document.getElementsByClassName("customPage");
-        if (customPages.length > 0) {
-            const width = customPages[0].clientWidth;
-            const origamiControl = getOrigamiControl()
-                .append(createTypeSelectors(result.data))
-                .append(createTextBoxIdentifier());
-            $("#page-scaling-container").append(origamiControl);
-            // We want to say "right: 19px" in css, but that should be relative to the
-            // page; and it's now a child of the page-scaling-container which is
-            // a parent of the page and can't use the page width.
-            // So set the left based on the two widths and an extra 19px.
-            const origamiWidth = origamiControl.get(0).clientWidth;
-            origamiControl.get(0).style.left = `${width - origamiWidth - 19}px`;
-        }
-        // I'm not clear why the rest of this needs to wait until we have
-        // result, but none of the controls shows up if we leave it all
-        // outside the result function.
-        if (isBookLocked) {
-            //$(".origami-toggle").attr("title", "localized tooltip");
-            $("#myonoffswitch").attr("disabled", "true");
-        } else {
-            $(".origami-toggle .onoffswitch").change(layoutToggleClickHandler);
-        }
+        const showAdvanced: boolean = result.data;
+        BloomApi.get("featurecontrol/enterpriseEnabled", result2 => {
+            const isEnterpriseEnabled: boolean = result2.data;
+            const customPages = document.getElementsByClassName("customPage");
+            if (customPages.length > 0) {
+                const width = customPages[0].clientWidth;
+                const origamiControl = getOrigamiControl()
+                    .append(
+                        createTypeSelectors(showAdvanced && isEnterpriseEnabled)
+                    )
+                    .append(createTextBoxIdentifier());
+                $("#page-scaling-container").append(origamiControl);
+                // We want to say "right: 19px" in css, but that should be relative to the
+                // page; and it's now a child of the page-scaling-container which is
+                // a parent of the page and can't use the page width.
+                // So set the left based on the two widths and an extra 19px.
+                const origamiWidth = origamiControl.get(0).clientWidth;
+                origamiControl.get(0).style.left = `${width -
+                    origamiWidth -
+                    19}px`;
+            }
+            // I'm not clear why the rest of this needs to wait until we have
+            // the two results, but none of the controls shows up if we leave it all
+            // outside the BloomApi functions.
+            if (isBookLocked) {
+                //$(".origami-toggle").attr("title", "localized tooltip");
+                $("#myonoffswitch").attr("disabled", "true");
+            } else {
+                $(".origami-toggle .onoffswitch").change(
+                    layoutToggleClickHandler
+                );
+            }
 
-        if ($(".customPage .marginBox.origami-layout-mode").length) {
-            setupLayoutMode();
-            $("#myonoffswitch").prop("checked", true);
-        }
+            if ($(".customPage .marginBox.origami-layout-mode").length) {
+                setupLayoutMode();
+                $("#myonoffswitch").prop("checked", true);
+            }
 
-        $(".customPage")
-            .find("*[data-i18n]")
-            .localize();
+            $(".customPage")
+                .find("*[data-i18n]")
+                .localize();
+        });
     });
 }
 

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -3746,10 +3746,12 @@ namespace Bloom.Book
 
 		public static bool IsPageBloomEnterpriseOnly(XmlElement page)
 		{
-			return page.GetAttribute("class").Contains("enterprise-only") ||
-				   // legacy quiz pages don't have 'enterprise-only'
-			       page.GetAttribute("class").Contains("questions") ||
-				   page.SafeSelectNodes(".//video").Count > 0;
+			var classAttrib = page.GetAttribute("class");
+			return classAttrib.Contains("enterprise-only") ||
+				// legacy quiz pages don't have 'enterprise-only'
+			    classAttrib.Contains("questions") ||
+				page.SafeSelectNodes(".//video").Count > 0 ||
+				page.SafeSelectNodes(".//div[contains(@class,'bloom-widgetContainer')]").Count > 0;
 		}
 	}
 }


### PR DESCRIPTION
* existing widget works when not in Enterprise mode
* if NOT in Enterprise or not in Advanced Features,
   - cannot import .wdgt file where there is a placeholder
   - cannot change layout of page to add/delete widget

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4119)
<!-- Reviewable:end -->
