### PR TITLE
Fix Windows builds for SIL.Media having both 32- and 64-bit dlls

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -1486,6 +1486,29 @@ cp -p "$(SolutionDir)lib/dotnet/GeckofxHtmlToPdf.exe.config" "$(OutDir)BloomPdfM
     <Error Condition="!Exists('..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets'))" />
     <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.8.0.0-beta0239\build\SIL.Windows.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.8.0.0-beta0239\build\SIL.Windows.Forms.targets'))" />
     <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.0-beta0239\build\SIL.Windows.Forms.Keyboarding.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.0-beta0239\build\SIL.Windows.Forms.Keyboarding.targets'))" />
+  </Target>
+  <!-- msbuild mistakenly copies the 64-bit version of irrKlang.NET4.dll to $(Output) as it resolves
+       SIL.Media.dll in our 32-bit build.  It also always copies both the 32-bit and 64-bit versions
+       of the library files to $(Output)\lib\win-xXX.  We correct those errors here.  (We can't do
+       this in AfterBuild because that runs before _CopyFilesMarkedCopyLocal which does the incorrect
+       copying.) -->
+  <ItemGroup Condition="'$(OS)'=='Windows_NT' AND '$(Platform)'=='x86'">
+    <CopyForSILMedia Include="$(SolutionDir)packages\SIL.Media.8.0.0-beta0225\build\lib\win-x86\*.dll" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(OS)'=='Windows_NT' AND '$(Platform)'=='x64'">
+    <CopyForSILMedia Include="$(SolutionDir)packages\SIL.Media.8.0.0-beta0225\build\lib\win-x64\*.dll" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(OS)'=='Windows_NT'">
+    <DeleteForSILMedia Include="$(OutDir)lib\win-x64\*.*" />
+    <DeleteForSILMedia Include="$(OutDir)lib\win-x86\*.*" />
+    <RemoveForSILMedia Include="$(OutDir)lib\win-x86" />
+    <RemoveForSILMedia Include="$(OutDir)lib\win-x64" />
+    <RemoveForSILMedia Include="$(OutDir)lib" />
+  </ItemGroup>
+  <Target Name="ReallyAfterBuild" AfterTargets="AfterBuild;CopyFilesToOutputDirectory" Condition="'$(OS)'=='Windows_NT'">
+    <Copy SourceFiles="@(CopyForSILMedia)" DestinationFolder="$(OutDir)" />
+    <Delete Files="@(DeleteForSILMedia)" TreatErrorsAsWarnings="true" />
+    <RemoveDir Directories="@(RemoveForSILMedia)" />
   </Target>
   <!-- Note: Visual Studio automatically inserts any imports from installing packages into the end here,
   but the AfterBuild target may not run if .targets files are imported after it.

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -396,4 +396,27 @@
   <Import Project="..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets" Condition="Exists('..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets')" />
   <Import Project="..\..\packages\SIL.Windows.Forms.8.0.0-beta0225\build\SIL.Windows.Forms.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.8.0.0-beta0225\build\SIL.Windows.Forms.targets')" />
   <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.0-beta0225\build\SIL.Windows.Forms.Keyboarding.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.0-beta0225\build\SIL.Windows.Forms.Keyboarding.targets')" />
+  <!-- msbuild mistakenly copies the 64-bit version of irrKlang.NET4.dll to $(Output) as it resolves
+       SIL.Media.dll in our 32-bit build.  It also always copies both the 32-bit and 64-bit versions
+       of the library files to $(Output)\lib\win-xXX.  We correct those errors here.  (We can't do
+       this in AfterBuild because that runs before _CopyFilesMarkedCopyLocal which does the incorrect
+       copying.) -->
+  <ItemGroup Condition="'$(OS)'=='Windows_NT' AND '$(Platform)'=='x86'">
+    <CopyForSILMedia Include="$(SolutionDir)packages\SIL.Media.8.0.0-beta0225\build\lib\win-x86\*.dll" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(OS)'=='Windows_NT' AND '$(Platform)'=='x64'">
+    <CopyForSILMedia Include="$(SolutionDir)packages\SIL.Media.8.0.0-beta0225\build\lib\win-x64\*.dll" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(OS)'=='Windows_NT'">
+    <DeleteForSILMedia Include="$(OutDir)lib\win-x64\*.*" />
+    <DeleteForSILMedia Include="$(OutDir)lib\win-x86\*.*" />
+    <RemoveForSILMedia Include="$(OutDir)lib\win-x86" />
+    <RemoveForSILMedia Include="$(OutDir)lib\win-x64" />
+    <RemoveForSILMedia Include="$(OutDir)lib" />
+  </ItemGroup>
+  <Target Name="ReallyAfterBuild" AfterTargets="AfterBuild;CopyFilesToOutputDirectory" Condition="'$(OS)'=='Windows_NT'">
+    <Copy SourceFiles="@(CopyForSILMedia)" DestinationFolder="$(OutDir)" />
+    <Delete Files="@(DeleteForSILMedia)" TreatErrorsAsWarnings="true" />
+    <RemoveDir Directories="@(RemoveForSILMedia)" />
+  </Target>
 </Project>


### PR DESCRIPTION
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4121)
<!-- Reviewable:end -->
