### PR TITLE
Show adder buttons as much as possible (BL-9176)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/origami.less
+++ b/src/BloomBrowserUI/bookEdit/css/origami.less
@@ -173,6 +173,8 @@
 /*the commented line below would also add it to an empty bloom-content1 for re-entry to layout mode*/
 /*but that would be problematic/confusing in a multilingual context*/
 /*.origami-layout-mode .split-pane-component-inner .bloom-editable.bloom-content1:empty:before,*/
+/* not setting z-index in the upper layer allows the adder buttons to be visible and active when the */
+/* cursor is over the "Text Box" text, but not when it is over the .formatButton gearbox icon. (BL-9176) */
 .origami-layout-mode .split-pane-component-inner .textBox-identifier {
     /*content: "Text Box";*/
     color: @flowerPetalGrey;
@@ -183,7 +185,6 @@
     width: 100%;
     position: absolute;
     top: 45%;
-    z-index: 50000;
     .formatButton {
         z-index: 60000;
         padding-left: 10px;
@@ -196,10 +197,16 @@
 .container-textBox-id {
     display: none;
 }
-.selector-links {
+
+/* splitting into two layers allows the adder buttons to remain visible and active except */
+/* when the cursor is over the selector links themselves. (BL-9176) */
+.selector-links-parent {
     top: 45%;
     text-align: center;
+}
+.selector-links {
     z-index: 50000;
+    display: inline-block;
 }
 
 .selector-links div {

--- a/src/BloomBrowserUI/bookEdit/js/origami.ts
+++ b/src/BloomBrowserUI/bookEdit/js/origami.ts
@@ -442,7 +442,17 @@ function createTextBoxIdentifier() {
     ).append(textBoxId);
 }
 function getTypeSelectors() {
-    return $(".container-selector-links > .selector-links").clone(true);
+    // Putting two levels of div here for selector-links allows us to keep the adder
+    // buttons visible and active except when the cursor is actually over the links.
+    // See https://issues.bloomlibrary.org/youtrack/issue/BL-9176.
+    const linksDiv = $(".container-selector-links > .selector-links").clone(
+        true
+    );
+    const parentDiv = $(
+        "<div class='selector-links-parent bloom-ui origami-ui'></div>"
+    );
+    parentDiv.append(linksDiv);
+    return parentDiv;
 }
 function getTextBoxIdentifier() {
     return $(".container-textBox-id > .textBox-identifier").clone();
@@ -459,7 +469,7 @@ function makeTextFieldClickHandler(e) {
     $(translationGroup).addClass("normal-style"); // replaces above to make new text boxes normal
     container.append(translationGroup).append(getTextBoxIdentifier());
     $(this)
-        .closest(".selector-links")
+        .closest(".selector-links-parent")
         .remove();
     // hook up TextBoxProperties dialog to this new Text Box (via its origami overlay)
     var dialog = GetTextBoxPropertiesDialog();
@@ -482,7 +492,7 @@ function makePictureFieldClickHandler(e) {
     SetupImage(image); // Must attach it first so event handler gets added to parent
     container.append(imageContainer);
     $(this)
-        .closest(".selector-links")
+        .closest(".selector-links-parent")
         .remove();
 }
 
@@ -500,7 +510,7 @@ function makeVideoFieldClickHandler(e) {
     // sure it is present in the book folder.
     BloomApi.post("edit/pageControls/requestVideoPlaceHolder");
     $(this)
-        .closest(".selector-links")
+        .closest(".selector-links-parent")
         .remove();
 }
 
@@ -518,6 +528,6 @@ function makeHtmlWidgetFieldClickHandler(e) {
     // sure it is present in the book folder.
     BloomApi.post("edit/pageControls/requestWidgetPlaceHolder");
     $(this)
-        .closest(".selector-links")
+        .closest(".selector-links-parent")
         .remove();
 }


### PR DESCRIPTION
I've thought of a possible simpler CSS-only solution, so hold off on reviewing/approving this change.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4124)
<!-- Reviewable:end -->
