### PR TITLE
Stop removing transparency from all incoming images (BL-9349)

### DIFF
--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Reflection;
 using Bloom.ImageProcessing;
 using NUnit.Framework;
 using SIL.IO;
@@ -71,42 +72,17 @@ namespace BloomTests.ImageProcessing
 		}
 
 		// See BL-3646 which showed we were blacking out the image when converting from png to jpg
-		[Test]
-		[Platform(Exclude = "Linux",
-			Reason = "This test throws a low-level warning which TC is currently treating as an error")]
-		public static void
-			ProcessAndSaveImageIntoFolder_SimpleImageHasTransparentBackground_ImageNotConvertedAndFileSizeNotIncreased()
-		{
-			var inputPath =
-				SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "shirtWithTransparentBg.png");
-			var originalFileSize = new FileInfo(inputPath).Length;
-			using (var image = PalasoImage.FromFileRobustly(inputPath))
-			{
-				using (var folder = new TemporaryFolder("TransparentPngTest"))
-				{
-					var fileName = ImageUtils.ProcessAndSaveImageIntoFolder(image, folder.Path, false);
-					Assert.AreEqual(".png", Path.GetExtension(fileName));
-					var outputPath = folder.Combine(fileName);
-					using (var result = Image.FromFile(outputPath))
-					{
-						Assert.AreEqual(ImageFormat.Png, result.RawFormat);
-						Assert.That(originalFileSize <= new FileInfo(outputPath).Length);
-					}
-				}
-			}
-		}
-
+		[TestCase("shirt.png")]
 		// I think shirt.png still has a transparent background after being fixed by optipng, but I'm not absolutely sure,
 		// so I'm leaving both tests in place.
-		[Test]
-		public static void
-			ProcessAndSaveImageIntoFolder_SimpleImageHasTransparentBackground_ImageNotConvertedAndFileSizeNotIncreased2()
+		[TestCase("shirtWithTransparentBg.png"), Platform(Exclude = "Linux", Reason = "This test throws a low-level warning which TC is currently treating as an error")]
+		public static void ProcessAndSaveImageIntoFolder_SimpleImageHasTransparentBackground_ImageNotConvertedAndFileSizeNotIncreased(string sourceFileName)
 		{
-			var inputPath = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "shirt.png");
+			var inputPath = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, sourceFileName);
 			var originalFileSize = new FileInfo(inputPath).Length;
 			using (var image = PalasoImage.FromFileRobustly(inputPath))
 			{
-				using (var folder = new TemporaryFolder("TransparentPngTest"))
+				using (var folder = new TemporaryFolder(MethodBase.GetCurrentMethod().Name + sourceFileName))
 				{
 					var fileName = ImageUtils.ProcessAndSaveImageIntoFolder(image, folder.Path, false);
 					Assert.AreEqual(".png", Path.GetExtension(fileName));


### PR DESCRIPTION
This warrants some discussion before merging. For one thing, it targets 4.9. So I've made it a draft even though the code change is complete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4125)
<!-- Reviewable:end -->
