### PR TITLE
Fix the fix to hide content overflowing page in preview (BL-9352)

### DIFF
--- a/src/BloomBrowserUI/bookPreview/previewMode.less
+++ b/src/BloomBrowserUI/bookPreview/previewMode.less
@@ -86,12 +86,12 @@ and as a result, the labels are shifted to this many pixels to the width. This s
     display: none;
 }
 
-// Absolutely positioned elements can show outside the margin box
+// Absolutely positioned elements can show outside the page
 // because margin box is also absolutely positioned.
-// So hide anything overflowing the margin box in the collection preview.
+// So hide anything overflowing the page in the collection preview.
 // @media screen ensures we don't mess up full-bleed printing.
 @media screen {
-    .bloom-page .marginBox {
+    .bloom-page {
         overflow: hidden;
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4131)
<!-- Reviewable:end -->
