### PR TITLE
Remove problematic max-width on imgs (BL-9350)

### DIFF
--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -492,19 +492,6 @@ Changes here generally require similar changes in EpubMaker.FixPictureSizes() an
 .SetMarginBox(@PageWidth, @PageHeight) {
     height: @PageHeight - (@MarginTop + @MarginBottom);
     width: @PageWidth - (@MarginOuter + @MarginInner);
-    img {
-        /* BL-1022, BL-2353 Keeps regular thumb images from going too wide */
-        max-width: @PageWidth - (@MarginOuter + @MarginInner);
-
-        // I don't understand why we are setting a max-width on imgs both in this file
-        // for all images and in bloom-xmatter-common for xmatter.
-        // But when we have full-bleed, the size is wrong. It is much easier to just unset
-        // the max-width like this than to try to figure out how to set the correct size everywhere.
-        // With the unset, the img is simply 100% width of the container which should always be correct.
-        .bloom-fullBleed & {
-            max-width: unset;
-        }
-    }
 }
 
 .marginBox {

--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-common.less
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-common.less
@@ -26,19 +26,6 @@
         //Just center the margin box, (for now, we're ignoring the binding)
         left: @MarginOuter;
         width: @PageWidth - (2 * @MarginOuter);
-        img {
-            /* BL-2353 Keeps XMatter thumb images from going too wide (or too small) */
-            max-width: @PageWidth - (2 * @MarginOuter);
-
-            // I don't understand why we are setting a max-width on imgs both in this file
-            // for xmatter and in basePage.less for all images.
-            // But when we have full-bleed, the size is wrong. It is much easier to just unset
-            // the max-width like this than to try to figure out how to set the correct size everywhere.
-            // With the unset, the img is simply 100% width of the container which should always be correct.
-            .bloom-fullBleed & {
-                max-width: unset;
-            }
-        }
     }
     .A3Landscape& {
         .SetMarginBoxCover(@A3Landscape-Height, @A3Landscape-Width);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4132)
<!-- Reviewable:end -->
