### PR TITLE
Fix another glitch caused by unsplit TextBox-mode audio (BL-9370)

### DIFF
--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -839,7 +839,8 @@ namespace Bloom.Publish.Epub
 					// We have some subelements to worry about.
 
 					string timingsStr = audioSentenceElement.GetAttribute("data-audiorecordingendtimes");    // These should be in seconds
-
+					if (String.IsNullOrEmpty(timingsStr))
+						timingsStr = audioSentenceElement.GetAttribute("data-duration");    // audio hasn't been split (https://issues.bloomlibrary.org/youtrack/issue/BL-9370)
 					string[] timingFields = timingsStr.Split(' ');
 					var segmentEndTimesSecs = new List<float>(timingFields.Length);
 					foreach (var timing in timingFields)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4139)
<!-- Reviewable:end -->
