### PR TITLE
Remove rule which caused landscape back cover to not allow full text box to be used (BL-9356)

### DIFF
--- a/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.less
+++ b/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.less
@@ -111,10 +111,6 @@ div.bloom-page.outsideBackCover.coverColor {
     padding-top: @bleed + @USComicPortrait-Height-Excess / 2;
 }
 
-.outsideBackCover [data-book="outsideBackCover"] p:last-of-type {
-    margin-bottom: 4em;
-}
-
 .outsideBackCover {
     .Outside-Back-Cover-style {
         margin-top: 8mm; // 15mm wasn't enough room for text 15mm;  In Landscape mode, we remove this


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4142)
<!-- Reviewable:end -->
