### PR TITLE
BL-8537 Handle partly transparent bubbles

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -15,6 +15,7 @@ import {
 import { Point, PointScaling } from "./point";
 import { isLinux } from "../../utils/isLinux";
 import { reportError } from "../../lib/errorHandler";
+import { getRgbaColorStringFromColorAndOpacity } from "../toolbox/comic/comicToolColorHelper";
 
 const kComicalGeneratedClass: string = "comical-generated";
 const kTextOverPictureClass = "bloom-textOverPicture";
@@ -353,9 +354,9 @@ export class BubbleManager {
                 // it would be nice to do this only once, but there MIGHT
                 // be TOP elements in more than one image container...too complicated,
                 // and this only happens once per TOP.
-                Comical.update(top.closest(
-                    ".bloom-imageContainer"
-                ) as HTMLElement);
+                Comical.update(
+                    top.closest(".bloom-imageContainer") as HTMLElement
+                );
             }
         });
     }
@@ -474,8 +475,7 @@ export class BubbleManager {
     }
 
     // Set the color of the background in all of the active bubble family's TextOverPicture boxes.
-    // Enhance: BL-8537 Change opacity the same way (and probably update the method name).
-    public setBackgroundColor(colors: string[]) {
+    public setBackgroundColor(colors: string[], opacity: number | undefined) {
         if (!this.activeElement) {
             return;
         }
@@ -484,9 +484,15 @@ export class BubbleManager {
         if (parentBubble) {
             this.setActiveElement(parentBubble.content);
         }
+        let newBackgroundColors = colors;
+        if (opacity && opacity < 1) {
+            newBackgroundColors[0] = getRgbaColorStringFromColorAndOpacity(
+                colors[0],
+                opacity
+            );
+        }
         this.updateSelectedItemBubbleSpec({
-            backgroundColors: colors
-            // opacity: newColorSwatch.opacity?!
+            backgroundColors: newBackgroundColors
         });
         // reset active element
         this.setActiveElement(originalActiveElement);

--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comicToolColorHelper.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comicToolColorHelper.ts
@@ -1,3 +1,4 @@
+import tinycolor = require("tinycolor2");
 import { ISwatchDefn } from "../../../react_components/colorSwatch";
 
 export const specialColors: ISwatchDefn[] = [
@@ -52,13 +53,25 @@ const temp: ISwatchDefn[] = [
 // We insert the Super Bible gradients after our partial transparency menu item
 export const defaultBackgroundColors = temp.concat(specialColors);
 
-export const getSwatchFromHex = (
-    hexColor: string,
-    opacity?: number
+// Handles all types of color strings: special-named, hex, rgb(), or rgba().
+// If BubbleSpec entails opacity, this string should be of the form "rgba(r, g, b, a)".
+export const getSwatchFromBubbleSpecColor = (
+    bubbleSpecColor: string
 ): ISwatchDefn => {
+    if (isSpecialColorName(bubbleSpecColor)) {
+        // A "special" color gradient, get our swatch from the definitions.
+        // It "has" to be there, because we just checked to see if the name was a special color!
+        return specialColors.find(
+            color => color.name === bubbleSpecColor
+        ) as ISwatchDefn;
+    }
+    // If currentBubbleSpec has transparency, the background color will be an rgba() string.
+    // We need to pull out the "opacity" and add it to the swatch here.
+    const colorStruct = tinycolor(bubbleSpecColor);
+    const opacity = colorStruct.getAlpha();
     return {
-        colors: [hexColor],
-        opacity: opacity ? opacity : 1
+        colors: [`#${colorStruct.toHex()}`],
+        opacity: opacity
     };
 };
 
@@ -72,4 +85,13 @@ export const getSpecialColorName = (
         elem => elem.colors[1] === colorArray[1]
     );
     return special ? special.name : undefined;
+};
+
+export const getRgbaColorStringFromColorAndOpacity = (
+    color: string,
+    opacity: number
+): string => {
+    let rgbColor = tinycolor(color).toRgb();
+    rgbColor.a = opacity;
+    return tinycolor(rgbColor).toRgbString(); // actually format is "rgba(r, g, b, a)"
 };

--- a/src/BloomBrowserUI/react_components/colorSwatch.tsx
+++ b/src/BloomBrowserUI/react_components/colorSwatch.tsx
@@ -5,7 +5,8 @@ import * as tinycolor from "tinycolor2";
 
 // External definition of a color swatch
 export interface ISwatchDefn {
-    // Hex colors; We use an array here, so we can support gradients (top to bottom).
+    // Usually Hex colors
+    // We use an array here, so we can support gradients (top to bottom).
     colors: string[];
     name?: string;
     opacity?: number;

--- a/src/BloomBrowserUI/react_components/customColorPicker.tsx
+++ b/src/BloomBrowserUI/react_components/customColorPicker.tsx
@@ -28,12 +28,15 @@ export const CustomColorPicker: React.FunctionComponent<ICustomPicker> = props =
     // This handler may be 'hit' many times as sliders are manipulated, etc.
     const handleColorChange: ColorChangeHandler = (color, event) => {
         const newColor = getSwatchDefnFromColorResult(color, "");
-        setColorChoice(newColor);
-        props.onChange(newColor);
+        changeColor(newColor);
     };
 
     // Handler for when the user clicks on a swatch at the bottom of the picker.
     const handleSwatchClick = (swatch: ISwatchDefn) => (e: any) => {
+        changeColor(swatch);
+    };
+
+    const changeColor = (swatch: ISwatchDefn) => {
         setColorChoice(swatch);
         props.onChange(swatch);
     };

--- a/src/BloomBrowserUI/react_components/stories.tsx
+++ b/src/BloomBrowserUI/react_components/stories.tsx
@@ -358,7 +358,7 @@ const defaultSwatches: ISwatchDefn[] = [
     { name: "grey", colors: ["#777777"] },
     { name: "black", colors: ["#000000"] },
     { name: "whiteToCalico", colors: ["white", "#DFB28B"] },
-    { name: "50%Portafino", colors: ["#7b8eb8"], opacity: 0.5 }
+    { name: "60%Portafino", colors: ["#7b8eb8"], opacity: 0.6 }
 ];
 
 storiesOf("Custom Color Chooser", module)

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -840,18 +840,16 @@ namespace Bloom.Book
 				var jsonObject = GetJsonObjectFromDataBubble(dataBubbleAttr);
 				if (jsonObject == null)
 					continue; // only happens if it fails to parse the "json"
+
+				// Note: background color strings with opacity will be in the form "rgba(r, g, b, a)",
+				// while text color strings and background strings w/o opacity could be hex strings or even named colors.
 				string[] backgroundColorArray = GetBackgroundColorsFromDataBubbleJsonObj(jsonObject);
 				if (backgroundColorArray == null || backgroundColorArray.Length == 0)
 					continue;
 
-				// Review: opacity doesn't yet exist in data-bubble, but it will when we do BL-8537.
-				// float.Parse() here keeps the opacity from being in quotes (and therefore a string)
-				// This is important for matching swatch opacity on the js end.
-				var opacityValue = GetOpacityFromDataBubbleJsonObj(jsonObject);
 				var backgroundColorString = DynamicJson.Serialize(new
 				{
-					colors = backgroundColorArray,
-					opacity = opacityValue
+					colors = backgroundColorArray
 				});
 
 				colorElementList.Add(backgroundColorString);
@@ -895,20 +893,6 @@ namespace Bloom.Book
 			catch (RuntimeBinderException)
 			{
 				return null; // This is the 'normal' branch if backgroundColors aren't defined.
-			}
-		}
-
-		private static float GetOpacityFromDataBubbleJsonObj(dynamic jsonObject)
-		{
-			if (jsonObject == null)
-				return 1F;
-			try
-			{
-				return float.Parse(jsonObject.opacity);
-			}
-			catch (RuntimeBinderException)
-			{
-				return 1F;
 			}
 		}
 


### PR DESCRIPTION
* set bubble background including opacity and update
   spec
* rework getSwatchFromHex and rename to
   getSwatchFromBubbleSpecColor
* simplify setBackgroundColor
* adjust api getColors to not do opacity, since it is now
   part of the color string
* move more logic to getSwatchFromBubbleSpecColor
   so it handles all expressions of color that can be found
   in a bubbleSpec
* fix generation of rgba() string for bubblespec

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4152)
<!-- Reviewable:end -->
