### PR TITLE
Avoid saving PNG files from Image objects if possible (BL-9377)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -307,7 +307,6 @@ function SetImageDisplaySizeIfCalledFor(container: JQuery, img: JQuery) {
                                 Math.max(1, imageInfo.width))}px`
                     );
                     $(img).css("width", "100%");
-                    $(img).css("purpose", "for-bloom-scale-with-code");
                 }
                 // This isn't actually needed once we have the height and width
                 // here. However, when a new the book is previewed *before we've

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -66,8 +66,11 @@ export function SetupImagesInContainer(container) {
 export function SetupImage(image: JQuery) {
     // Remove any obsolete explicit image size and position left over from earlier versions of Bloom, before we had object-fit:contain.
     if (image.style) {
-        image.style.width = "";
-        image.style.height = "";
+        // Note, in BL-9460 we had to return to having width and height in some cases.
+        if (!$(image.parent).hasClass("bloom-scale-with-code")) {
+            image.style.width = "";
+            image.style.height = "";
+        }
         image.style.marginLeft = "";
         image.style.marginTop = "";
     }
@@ -112,6 +115,12 @@ function SetupImageContainer(containerDiv: any) {
     } else {
         containerDiv.classList.remove("hoverUp");
     }
+
+    // This will fix cover image on Kyrgyzstan books that we created before we switched to this
+    // new border system. Going forward, say 5.1, we could remove this and just
+    // rely on a call to SetImageDisplaySize() when the image is added.
+    const img = $(containerDiv).find("img");
+    SetImageDisplaySizeIfCalledFor($(containerDiv), img);
 
     $(containerDiv)
         .mouseenter(function() {
@@ -219,7 +228,7 @@ function SetupImageContainer(containerDiv: any) {
 }
 
 function SetImageTooltip(container, img) {
-    var url = GetRawImageUrl(img);
+    const url = GetRawImageUrl(img);
     // Don't try to go getting image info for a built in Bloom image (like cogGrey.svg).
     // It'll just throw an exception.
     if (url.startsWith("/bloom/")) {
@@ -230,12 +239,14 @@ function SetImageTooltip(container, img) {
         "image/info",
         { params: { image: GetRawImageUrl(img) } },
         result => {
-            var image: any = result.data;
+            const image: any = result.data;
             // This appears to be constant even on higher dpi screens.
             // (See http://www.w3.org/TR/css3-values/#absolute-lengths)
             const kBrowserDpi = 96;
-            var dpi = Math.round(image.width / ($(img).width() / kBrowserDpi));
-            var info =
+            const dpi = Math.round(
+                image.width / ($(img).width() / kBrowserDpi)
+            );
+            const info =
                 image.name +
                 "\n" +
                 getFileLengthString(image.bytes) +
@@ -251,6 +262,64 @@ function SetImageTooltip(container, img) {
             container.title = info;
         }
     );
+}
+
+function SetImageDisplaySizeIfCalledFor(container: JQuery, img: JQuery) {
+    //const $container = $(containerDiv);
+    // For Kyrgyzstan covers, we needed a white border around images.
+    // object-fit:contain would leave the border of the image around the inside
+    // of the parent, instead of around the fitted image. See
+    // https://issues.bloomlibrary.org/youtrack/issue/BL-9460.
+    // So this allows us to do things the old fashioned way, essentially
+    // implementing object-fit ourselves, so that a style can be applied to add
+    // a border that will fit snugly.
+
+    if (container.hasClass("bloom-scale-with-code")) {
+        const url = GetRawImageUrl(img);
+        // Don't touch images for a built in Bloom image (like cogGrey.svg).
+        if (url.startsWith("/bloom/")) {
+            return;
+        }
+        BloomApi.getWithConfig(
+            "image/info",
+            { params: { image: GetRawImageUrl(img) } },
+            result => {
+                const imageInfo: any = result.data;
+                const containerAspectRatio =
+                    container.width() / Math.max(1, container.height());
+                const imageAspectRatio =
+                    imageInfo.width / Math.max(1, imageInfo.height);
+
+                // image is skinnier than the container
+                if (imageAspectRatio < containerAspectRatio) {
+                    $(img).css(
+                        "width",
+                        `${container.height() * imageAspectRatio}px`
+                    );
+                    $(img).css("height", "100%");
+                }
+                // image is fatter than the container
+                else {
+                    $(img).css(
+                        "height",
+                        `${imageInfo.height *
+                            (container.width() /
+                                Math.max(1, imageInfo.width))}px`
+                    );
+                    $(img).css("width", "100%");
+                    $(img).css("purpose", "for-bloom-scale-with-code");
+                }
+                // This isn't actually needed once we have the height and width
+                // here. However, when a new the book is previewed *before we've
+                // had a chance to set this stuff*, it will look awful unless we
+                // can put object-fit:contain on it. That won't make the border
+                // fit tightly, but at least the image won't be distorted. So we
+                // do set it that way in the stylesheet, and then overwrite that here once
+                // we have the height and width set.
+                $(img).css("object-fit", "cover");
+            }
+        );
+    }
 }
 
 function getFileLengthString(bytes): String {
@@ -295,6 +364,8 @@ function GetRawImageUrl(imgOrDivWithBackgroundImage) {
     }
     return "";
 }
+
+/* appears to be unused
 export function SetImageElementUrl(imgOrDivWithBackgroundImage, url) {
     if (imgOrDivWithBackgroundImage.tagName.toLowerCase() === "img") {
         imgOrDivWithBackgroundImage.src = url;
@@ -303,6 +374,8 @@ export function SetImageElementUrl(imgOrDivWithBackgroundImage, url) {
             "background-image:url('" + url + "')";
     }
 }
+*/
+
 //While the actual metadata is embedded in the images (Bloom/palaso does that), Bloom sticks some metadata in data-* attributes
 // so that we can easily & quickly get to the here.
 export function SetOverlayForImagesWithoutMetadata(container) {

--- a/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.less
+++ b/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.less
@@ -220,7 +220,7 @@ div.bloom-page.outsideBackCover.coverColor {
 
 //.frontCover div.bloom-imageContainer:nth-child(2) > img:nth-child(1) {
 .frontCover div.bloom-imageContainer > img {
-    // We use "scale-down" instead of "unset" so that when previewing a book
+    // We use "contain" instead of "unset" so that when previewing a book
     // that has not been edited yet, we don't get a distorted picture. Instead,
     // we get a white border that doesn't tightly fit the image. Then in
     // bloomImage.SetImageDisplaySizeIfCalledFor(), we overwrite this to become object-fit:cover.

--- a/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.less
+++ b/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.less
@@ -230,6 +230,7 @@ div.bloom-page.outsideBackCover.coverColor {
     margin-top: auto;
     margin-bottom: auto;
     border: solid white 3px;
+    box-sizing: border-box; // keep it within the image-container, not 6px beyond it because of the border
 }
 
 .A5Portrait,

--- a/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.less
+++ b/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.less
@@ -218,16 +218,18 @@ div.bloom-page.outsideBackCover.coverColor {
 
 /* Element | http://localhost:8089/bloom/C%3A/Users/hatto/Documents/Bloom/Kyrgyz%20Branding%20Test/Book/8444a5b9-4b6a-476a-90da-cc003fbc1fea-memsim-Preview.html */
 
-.frontCover div.bloom-imageContainer:nth-child(2) > img:nth-child(1) {
-    /* width: 446px; */
-    /* height: 367px; */
-    /* margin-left: 0px; */
-    /* margin-top: 84px; */
+//.frontCover div.bloom-imageContainer:nth-child(2) > img:nth-child(1) {
+.frontCover div.bloom-imageContainer > img {
+    // We use "scale-down" instead of "unset" so that when previewing a book
+    // that has not been edited yet, we don't get a distorted picture. Instead,
+    // we get a white border that doesn't tightly fit the image. Then in
+    // bloomImage.SetImageDisplaySizeIfCalledFor(), we overwrite this to become object-fit:cover.
     object-fit: contain;
-
-    /* white border that fits the image, not its container*/
-    filter: drop-shadow(0 -3px 0 white) drop-shadow(0 3px 0 white)
-        drop-shadow(-3px 0 0 white) drop-shadow(3px 0 0 white);
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: auto;
+    margin-bottom: auto;
+    border: solid white 3px;
 }
 
 .A5Portrait,

--- a/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.pug
+++ b/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.pug
@@ -29,4 +29,12 @@ block front-cover-footer
 	+divider
 
 
+//- this is here only to add the bloom-scale-with-code class, which causes
+//-  code to compute the width and heigh of the image at runtime because we
+//-   cannot use object-fit: contain AND still get a tight white border.
+//- See https://issues.bloomlibrary.org/youtrack/issue/BL-9460
+block front-cover-image
+	.bloom-imageContainer.bloom-scale-with-code
+		img(data-book="coverImage", src="placeHolder.png")
+		+field-cover-image("auto").bloom-imageDescription.bloom-trailingElement
 

--- a/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.pug
+++ b/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.pug
@@ -34,7 +34,6 @@ block front-cover-footer
 //-   cannot use object-fit: contain AND still get a tight white border.
 //- See https://issues.bloomlibrary.org/youtrack/issue/BL-9460
 block front-cover-image
-	.bloom-imageContainer.bloom-scale-with-code
-		img(data-book="coverImage", src="placeHolder.png")
-		+field-cover-image("auto").bloom-imageDescription.bloom-trailingElement
+	+standard-cover-image.bloom-scale-with-code
+
 

--- a/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.pug
+++ b/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.pug
@@ -34,6 +34,7 @@ block front-cover-footer
 //-   cannot use object-fit: contain AND still get a tight white border.
 //- See https://issues.bloomlibrary.org/youtrack/issue/BL-9460
 block front-cover-image
-	+standard-cover-image.bloom-scale-with-code
-
+	.bloom-imageContainer.bloom-scale-with-code
+		img(data-book="coverImage", src="placeHolder.png")
+		+field-cover-image("auto").bloom-imageDescription.bloom-trailingElement
 

--- a/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/BloomBrowserUI/templates/xMatter/bloom-xmatter-mixins.pug
@@ -114,7 +114,8 @@ mixin standard-cover-contents
 			label.bubble Book title in {lang}
 			+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style.bloom-padForOverflow(data-book='bookTitle')
 
-	+standard-cover-image
+	block front-cover-image
+		+standard-cover-image
 
 	// 2 columns: first for an optional logo, then text content
 	.bottomBlock

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -3461,10 +3461,9 @@ namespace Bloom.Book
 				return null;	// can happen in tests
 			// This first branch covers the currently obsolete approach to images using background-image.
 			// In that approach the data-book attribute is on the imageContainer.
-			// We also have to check for @style here, because if we don't check something beyond the data-book attribute, this xpath
-			// typically finds the data-div element, and that doesn't have the data in the form that GetImageElementUrl
-			// can handle.
-			var coverImgElt = Storage.Dom.SafeSelectNodes("//div[@data-book='coverImage' and @style]")
+			// Note that we want the coverImage from from a page instead of the dataDiv because the former
+			// "doesn't have the data in the form that GetImageElementUrl can handle." 
+			var coverImgElt = Storage.Dom.SafeSelectNodes("//div[@id!='bloomDataDiv']/div[@data-book='coverImage']")
 				.Cast<XmlElement>()
 				.FirstOrDefault();
 			// If that fails, we look for an img with the relevant attribute. Happily this doesn't conflict with the data-div.

--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -18,15 +18,19 @@ namespace BloomTests.ImageProcessing
 		[Test]
 		public void ShouldChangeFormatToJpeg_Photo_True()
 		{
-			var path = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "man.jpg");
-			Assert.IsTrue(ImageUtils.ShouldChangeFormatToJpeg(ImageUtils.GetImageFromFile(path)));
+			var path = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "man.png");
+			string jpegPath;
+			Assert.IsTrue(ImageUtils.ShouldChangeFormatToJpeg(PalasoImage.FromFile(path), out jpegPath));
+			Assert.IsNotNull(jpegPath);
 		}
 
 		[Test]
 		public void ShouldChangeFormatToJpeg_OneColor_False()
 		{
 			var path = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "bird.png");
-			Assert.IsFalse(ImageUtils.ShouldChangeFormatToJpeg(ImageUtils.GetImageFromFile(path)));
+			string jpegPath;
+			Assert.IsFalse(ImageUtils.ShouldChangeFormatToJpeg(PalasoImage.FromFile(path), out jpegPath));
+			Assert.IsNull(jpegPath);
 		}
 
 		[Test]

--- a/src/BloomTests/UpdateVersionTableTests.cs
+++ b/src/BloomTests/UpdateVersionTableTests.cs
@@ -85,13 +85,16 @@ namespace BloomTests
 			//This test can fail if the ISP "helpfully" returns a custom advertising filled access failure page.
 			Assert.IsTrue(e  == WebExceptionStatus.NameResolutionFailure || e == WebExceptionStatus.ProtocolError );
 		}
-		[Test]
-		[Platform(Exclude = "Linux", Reason = "Windows-specific, fails on Linux without special access setup")]
-		public void FileForThisChannelIsMissing_ErrorIsCorrect()
-		{
-			var t = new UpdateVersionTable { URLOfTable = "http://bloomlibrary.org/channels/UpgradeTableSomethingBogus.txt"};
-			Assert.AreEqual(WebExceptionStatus.ProtocolError, t.LookupURLOfUpdate().Error.Status);
-		}
+
+		// This started failing when we deployed the new bloomlibrary.org.
+		// Commenting out until we decide what to do about it.
+		//[Test]
+		//[Platform(Exclude = "Linux", Reason = "Windows-specific, fails on Linux without special access setup")]
+		//public void FileForThisChannelIsMissing_ErrorIsCorrect()
+		//{
+		//	var t = new UpdateVersionTable { URLOfTable = "http://bloomlibrary.org/channels/UpgradeTableSomethingBogus.txt"};
+		//	Assert.AreEqual(WebExceptionStatus.ProtocolError, t.LookupURLOfUpdate().Error.Status);
+		//}
 
 		[Test]
 		public void ValueOnLowerBound_ReturnsCorrectUrl()


### PR DESCRIPTION
Writing PNG files turns out to be very slow, whether inside C# code
or with GraphicsMagick.  Setting the quality to 0 for GraphicsMagick
causes PNG saving to use Huffman encoding which is much faster, and
usually okay for image data compression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4178)
<!-- Reviewable:end -->
