### PR TITLE
Avoid saving PNG files from Image objects if possible (BL-9377)

### DIFF
--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -18,15 +18,27 @@ namespace BloomTests.ImageProcessing
 		[Test]
 		public void ShouldChangeFormatToJpeg_Photo_True()
 		{
-			var path = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "man.jpg");
-			Assert.IsTrue(ImageUtils.ShouldChangeFormatToJpeg(ImageUtils.GetImageFromFile(path)));
+			var path = FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "man.png");
+			string jpegPath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName() + ".jpg");
+			try
+			{
+				Assert.IsTrue(ImageUtils.TryChangeFormatToJpegIfHelpful(PalasoImage.FromFile(path), jpegPath));
+				Assert.IsTrue(File.Exists(jpegPath));
+			}
+			finally
+			{
+				if (File.Exists(jpegPath))
+					File.Delete(jpegPath);
+			}
 		}
 
 		[Test]
 		public void ShouldChangeFormatToJpeg_OneColor_False()
 		{
-			var path = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "bird.png");
-			Assert.IsFalse(ImageUtils.ShouldChangeFormatToJpeg(ImageUtils.GetImageFromFile(path)));
+			var path = FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "bird.png");
+			string jpegPath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName() + ".jpg");
+			Assert.IsFalse(ImageUtils.TryChangeFormatToJpegIfHelpful(PalasoImage.FromFile(path), jpegPath));
+			Assert.IsFalse(File.Exists(jpegPath));
 		}
 
 		[Test]


### PR DESCRIPTION
Writing PNG files turns out to be very slow, whether inside C# code
or with GraphicsMagick.  Setting the quality to 0 for GraphicsMagick
causes PNG saving to use Huffman encoding which is much faster, and
usually okay for image data compression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4179)
<!-- Reviewable:end -->
