### PR TITLE
BL-9346 Don't mess with Bloom Player versions of templates

### DIFF
--- a/src/BloomBrowserUI/bookPreview/previewMode.less
+++ b/src/BloomBrowserUI/bookPreview/previewMode.less
@@ -85,3 +85,25 @@ and as a result, the labels are shifted to this many pixels to the width. This s
 .hidePlaceHolders img[src*="placeHolder.png"] {
     display: none;
 }
+
+@stripeGrey: #f0f0f0;
+
+// To show where text goes, this has stripes.
+.preview.template,
+.bloomPlayer-page.template {
+    .numberedPage .bloom-translationGroup {
+        background: linear-gradient(
+            45deg,
+            @stripeGrey 12.5%,
+            #fff 12.5%,
+            #fff 37.5%,
+            @stripeGrey 37.5%,
+            @stripeGrey 62.5%,
+            #fff 62.5%,
+            #fff 87.5%,
+            @stripeGrey 87.5%
+        );
+        background-size: 50px 50px;
+        background-position: 50px 50px;
+    }
+}

--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -34,6 +34,7 @@
         "watchTemplatesLess": "less-watch-compiler templates  ../../output/browser/templates",
         "watchBookEditLess": "less-watch-compiler bookEdit ../../output/browser/bookEdit",
         "watchBookLayoutLess": "less-watch-compiler bookLayout ../../output/browser/bookLayout",
+        "watchBookPreviewLess": "less-watch-compiler bookPreview ../../output/browser/bookPreview",
         "watchPageChooserLess": "less-watch-compiler pageChooser ../../output/browser/pageChooser",
         "watchProblemDialogLess": "less-watch-compiler problemDialog ../../output/browser/problemDialog",
         "watch": "npm-run-all --parallel watchBrandingLess watchTemplatesLess watchBookEditLess watchBookLayoutLess watchBrandingFiles watchPageChooserLess watchProblemDialogLess watchCode",

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -959,6 +959,12 @@ namespace Bloom.Book
 			FixErrorsEncounteredByUsers(bookDOM);
 			AddReaderBodyClass(bookDOM);
 			AddLanguageAttributesToBody(bookDOM);
+
+			if (IsTemplateBook)
+			{
+				// this will turn on rules in previewMode.css that show the structure of the template and names of pages
+				HtmlDom.AddClassToBody(RawDom, "template");
+			}
 		}
 
 		private void AddLanguageAttributesToBody(HtmlDom bookDom)
@@ -1775,6 +1781,13 @@ namespace Bloom.Book
 			set { BookInfo.IsSuitableForMakingShells = value; }
 
 		}
+
+		/// <summary>
+		/// The name "IsSuitableForMakingShells" must have been the best at one point, but now that Template books are a built-in part of Bloom,
+		/// it makes code hard to read, when we just think in terms of "is this a template book"? If it turns out the semantics do not actually line up
+		/// well, then we will have to modify this and that's good.
+		/// </summary>
+		public bool IsTemplateBook => IsSuitableForMakingShells;
 
 		/// <summary>
 		/// A "Folio" document is one that acts as a wrapper for a number of other books

--- a/src/BloomExe/BookThumbNailer.cs
+++ b/src/BloomExe/BookThumbNailer.cs
@@ -345,7 +345,7 @@ namespace Bloom
 
 		private static HtmlThumbNailer.ThumbnailOptions.BorderStyles GetThumbnailBorderStyle(Book.Book book)
 		{
-			return book.IsSuitableForMakingShells
+			return book.IsTemplateBook
 				? HtmlThumbNailer.ThumbnailOptions.BorderStyles.Dashed
 				: HtmlThumbNailer.ThumbnailOptions.BorderStyles.None;
 		}

--- a/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
+++ b/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
@@ -129,7 +129,7 @@ namespace Bloom.Publish.Android
 			// See https://issues.bloomlibrary.org/youtrack/issue/BL-6835.
 			RemoveInvisibleImageElements(modifiedBook);
 			modifiedBook.Storage.CleanupUnusedImageFiles(keepFilesForEditing: false);
-			if (RobustFile.Exists(Path.Combine(modifiedBookFolderPath, "placeHolder.png")))
+			if (!modifiedBook.IsTemplateBook && RobustFile.Exists(Path.Combine(modifiedBookFolderPath, "placeHolder.png")))
 				RobustFile.Delete(Path.Combine(modifiedBookFolderPath, "placeHolder.png"));
 
 			modifiedBook.Storage.CleanupUnusedAudioFiles(isForPublish: true);


### PR DESCRIPTION
Currently templates lose placeholder flowers and  can lose their pages. This makes it hard to view them on blorg2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4182)
<!-- Reviewable:end -->
