### PR TITLE
Show the description in the Problem Dialog in 4.9 (BL-9520)

### DIFF
--- a/src/BloomBrowserUI/problemDialog/ProblemDialog.less
+++ b/src/BloomBrowserUI/problemDialog/ProblemDialog.less
@@ -9,6 +9,9 @@
             padding-top: 4px;
         }
     }
+    .report-heading {
+        font-style: italic;
+    }
     .content {
         #please_help_us {
             flex: 0 0 100%;

--- a/src/BloomBrowserUI/problemDialog/ProblemDialog.tsx
+++ b/src/BloomBrowserUI/problemDialog/ProblemDialog.tsx
@@ -43,6 +43,13 @@ export const ProblemDialog: React.FunctionComponent<{
     const [mode, setMode] = useState(Mode.gather);
     const [includeBook, setIncludeBook] = useState(true);
     const [includeScreenshot, setIncludeScreenshot] = useState(true);
+
+    // Precondition: The returned string from BloomServer must already encode any special characters
+    // which are not meant to be treated as HTML code.
+    const [reportHeadingHtml] = BloomApi.useApiString(
+        "problemReport/reportHeadingHtml",
+        ""
+    );
     const [email, setEmail] = BloomApi.useApiString(
         "problemReport/emailAddress",
         ""
@@ -291,6 +298,12 @@ export const ProblemDialog: React.FunctionComponent<{
                             case Mode.gather:
                                 return (
                                     <>
+                                        <div
+                                            className="report-heading allowSelect"
+                                            dangerouslySetInnerHTML={{
+                                                __html: reportHeadingHtml
+                                            }}
+                                        />
                                         <Typography id="please_help_us">
                                             {localizedPleaseHelpUs}
                                         </Typography>

--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -29,6 +29,7 @@ namespace Bloom.web.controllers
 		protected string YouTrackProjectKey = "BL";
 		private static Exception _currentException;
 		private static string _detailedMessage; // usually from Bloom itself
+		private static string _headingHtml;
 
 		/// <summary>
 		/// We want this name "different" enough that it's not likely to be supplied by a user in a book,
@@ -45,6 +46,12 @@ namespace Bloom.web.controllers
 
 		public void RegisterWithApiHandler(BloomApiHandler apiHandler)
 		{
+			// ProblemDialog.tsx uses this endpoint to get the string to show at the top of the main dialog
+			apiHandler.RegisterEndpointHandler("problemReport/reportHeadingHtml",
+				(ApiRequest request) =>
+				{
+					request.ReplyWithText(_headingHtml ?? "");
+				}, false);
 			// ProblemDialog.tsx uses this endpoint to get the screenshot image.
 			apiHandler.RegisterEndpointHandler("problemReport/screenshot",
 				(ApiRequest request) =>
@@ -307,6 +314,11 @@ namespace Bloom.web.controllers
 			_showingProblemReport = true;
 			_currentException = exception;
 			_detailedMessage = detailedMessage;
+			var heading = detailedMessage;
+			if (string.IsNullOrEmpty(heading) && exception != null)
+				heading = exception.Message;
+			if (!string.IsNullOrEmpty(heading))
+				_headingHtml = UrlPathString.CreateFromUnencodedString(heading).HtmlXmlEncoded;
 			if (controlForScreenshotting == null)
 				controlForScreenshotting = Form.ActiveForm;
 			if (controlForScreenshotting == null) // still possible if we come from a "Details" button


### PR DESCRIPTION
This fix is based on the 5.0 code, but is much simpler in the C# part.
It should *not* be merged into 5.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4185)
<!-- Reviewable:end -->
