### PR TITLE
BL-9346 Don't mess with Bloom Player versions of templates

### DIFF
--- a/src/BloomBrowserUI/bookPreview/previewMode.less
+++ b/src/BloomBrowserUI/bookPreview/previewMode.less
@@ -85,3 +85,25 @@ and as a result, the labels are shifted to this many pixels to the width. This s
 .hidePlaceHolders img[src*="placeHolder.png"] {
     display: none;
 }
+
+@stripeGrey: #f0f0f0;
+
+// To show where text goes, this has stripes.
+.preview.template,
+.bloomPlayer-page.template {
+    .numberedPage .bloom-translationGroup {
+        background: linear-gradient(
+            45deg,
+            @stripeGrey 12.5%,
+            #fff 12.5%,
+            #fff 37.5%,
+            @stripeGrey 37.5%,
+            @stripeGrey 62.5%,
+            #fff 62.5%,
+            #fff 87.5%,
+            @stripeGrey 87.5%
+        );
+        background-size: 50px 50px;
+        background-position: 50px 50px;
+    }
+}

--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -34,6 +34,7 @@
         "watchTemplatesLess": "less-watch-compiler templates  ../../output/browser/templates",
         "watchBookEditLess": "less-watch-compiler bookEdit ../../output/browser/bookEdit",
         "watchBookLayoutLess": "less-watch-compiler bookLayout ../../output/browser/bookLayout",
+        "watchBookPreviewLess": "less-watch-compiler bookPreview ../../output/browser/bookPreview",
         "watchPageChooserLess": "less-watch-compiler pageChooser ../../output/browser/pageChooser",
         "watchProblemDialogLess": "less-watch-compiler problemDialog ../../output/browser/problemDialog",
         "watch": "npm-run-all --parallel watchBrandingLess watchTemplatesLess watchBookEditLess watchBookLayoutLess watchBrandingFiles watchPageChooserLess watchProblemDialogLess watchCode",

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -959,6 +959,12 @@ namespace Bloom.Book
 			FixErrorsEncounteredByUsers(bookDOM);
 			AddReaderBodyClass(bookDOM);
 			AddLanguageAttributesToBody(bookDOM);
+
+			if (IsTemplateBook)
+			{
+				// this will turn on rules in previewMode.css that show the structure of the template and names of pages
+				HtmlDom.AddClassToBody(RawDom, "template");
+			}
 		}
 
 		private void AddLanguageAttributesToBody(HtmlDom bookDom)
@@ -1775,6 +1781,13 @@ namespace Bloom.Book
 			set { BookInfo.IsSuitableForMakingShells = value; }
 
 		}
+
+		/// <summary>
+		/// The name "IsSuitableForMakingShells" must have been the best at one point, but now that Template books are a built-in part of Bloom,
+		/// it makes code hard to read, when we just think in terms of "is this a template book"? If it turns out the semantics do not actually line up
+		/// well, then we will have to modify this and that's good.
+		/// </summary>
+		public bool IsTemplateBook => IsSuitableForMakingShells;
 
 		/// <summary>
 		/// A "Folio" document is one that acts as a wrapper for a number of other books

--- a/src/BloomExe/BookThumbNailer.cs
+++ b/src/BloomExe/BookThumbNailer.cs
@@ -345,7 +345,7 @@ namespace Bloom
 
 		private static HtmlThumbNailer.ThumbnailOptions.BorderStyles GetThumbnailBorderStyle(Book.Book book)
 		{
-			return book.IsSuitableForMakingShells
+			return book.IsTemplateBook
 				? HtmlThumbNailer.ThumbnailOptions.BorderStyles.Dashed
 				: HtmlThumbNailer.ThumbnailOptions.BorderStyles.None;
 		}

--- a/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
+++ b/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
@@ -129,7 +129,7 @@ namespace Bloom.Publish.Android
 			// See https://issues.bloomlibrary.org/youtrack/issue/BL-6835.
 			RemoveInvisibleImageElements(modifiedBook);
 			modifiedBook.Storage.CleanupUnusedImageFiles(keepFilesForEditing: false);
-			if (RobustFile.Exists(Path.Combine(modifiedBookFolderPath, "placeHolder.png")))
+			if (!modifiedBook.IsTemplateBook && RobustFile.Exists(Path.Combine(modifiedBookFolderPath, "placeHolder.png")))
 				RobustFile.Delete(Path.Combine(modifiedBookFolderPath, "placeHolder.png"));
 
 			modifiedBook.Storage.CleanupUnusedAudioFiles(isForPublish: true);

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -105,15 +105,20 @@ namespace Bloom.Publish
 			// or PDF published books.)
 			foreach (XmlElement elt in dom.RawDom.SafeSelectNodes("//div"))
 			{
-				if (HasClass (elt, "pageLabel"))
-					elt.ParentNode.RemoveChild (elt);
-				if (HasClass (elt, "pageDescription"))
-					elt.ParentNode.RemoveChild (elt);
+				if (!book.IsTemplateBook)
+				{
+					if (HasClass(elt, "pageLabel"))
+						elt.ParentNode.RemoveChild(elt);
+
+					if (HasClass(elt, "pageDescription"))
+						elt.ParentNode.RemoveChild(elt);
+				}
+
 				// REVIEW: is this needed now with the new strategy?
 				if (HasClass (elt, "bloom-editable") && HasClass (elt, "bloom-visibility-user-off"))
 					elt.ParentNode.RemoveChild (elt);
 			}
-			// Our recordingmd5 attribute is not allowed
+			// Our recordingmd5 attribute is not allowed by epub
 			foreach (XmlElement elt in HtmlDom.SelectAudioSentenceElementsWithRecordingMd5(dom.RawDom.DocumentElement))
 			{
 				elt.RemoveAttribute ("recordingmd5");
@@ -138,19 +143,26 @@ namespace Bloom.Publish
 				var src = img.GetOptionalStringAttribute("src", null);
 				if (String.IsNullOrEmpty(src) || src == "placeHolder.png")
 				{
-					// If the image file doesn't exist, we want to find out about it.  But if there is no
-					// image file, epubcheck complains and it doesn't do any good anyway.
-					img.ParentNode.RemoveChild(img);
+
+					// If this is a template book, then the whole point of the book is to not have content. So then we want to preserve the placeholders so
+					// that people looking at the book on Bloom Library can see how the template pages are constructed.
+					if (!book.IsTemplateBook)
+					{
+						// If the image file doesn't exist, we want to find out about it.  But if there is no
+						// image file, epubcheck complains and it doesn't do any good anyway.
+						img.ParentNode.RemoveChild(img);
+					}
 				}
 				else
 				{
 					var parent = img.ParentNode as XmlElement;
-					parent.RemoveAttribute("title");	// We don't want this in published books.
-					img.RemoveAttribute("title");	// We don't want this in published books.  (probably doesn't exist)
-					img.RemoveAttribute("type");	// This is invalid, but has appeared for svg branding images.
+					parent.RemoveAttribute("title"); // We don't want this in published books.
+					img.RemoveAttribute(
+						"title"); // We don't want this in published books.  (probably doesn't exist)
+					img.RemoveAttribute("type"); // This is invalid, but has appeared for svg branding images.
 				}
 			}
-
+				
 			if (epubMaker != null)
 			{
 				// epub-check doesn't like these attributes (BL-6036).  I suppose BloomReader might find them useful.
@@ -213,35 +225,42 @@ namespace Bloom.Publish
 			if (this != _latestInstance)
 				return;
 
-			var toBeDeleted = new List<XmlElement>();
-			// Deleting the elements in place during the foreach messes up the list and some things that should be deleted aren't
-			// (See BL-5234). So we gather up the elements to be deleted and delete them afterwards.
-			foreach (XmlElement page in pageElts)
-			{
-				// As the constant's name here suggests, in theory, we could include divs
-				// that don't have .bloom-editable, and all their children.
-				// But I'm not smart enough to write that selector and for bloomds, all we're doing here is saving space,
-				// so those other divs we are missing doesn't seem to matter as far as I can think.
-				var kSelectThingsThatCanBeHiddenButAreNotText = ".//img";
-				var selector = removeInactiveLanguages ? kSelectThingsThatCanBeHidden : kSelectThingsThatCanBeHiddenButAreNotText;
-				foreach (XmlElement elt in page.SafeSelectNodes(selector))
+				var toBeDeleted = new List<XmlElement>();
+				// Deleting the elements in place during the foreach messes up the list and some things that should be deleted aren't
+				// (See BL-5234). So we gather up the elements to be deleted and delete them afterwards.
+				foreach (XmlElement page in pageElts)
 				{
-					// Even when they are not displayed we want to keep image descriptions if they aren't empty.
-					// This is necessary for retaining any associated audio files to play.
-					// (If they are empty, they won't have any audio and may trigger embedding an unneeded font.)
-					// See https://issues.bloomlibrary.org/youtrack/issue/BL-7237.
-					// As noted above, if the displayDom is not sufficiently loaded for a definitive
-					// answer to IsDisplayed, we will throw when making epubs but not for bloom reader.
-					if (!IsDisplayed(elt, epubMaker != null) && !IsNonEmptyImageDescription(elt))
+					// BL-9501 Don't remove pages from template books, which are often empty but we still want to show their components
+					if (!book.IsTemplateBook)
 					{
-						toBeDeleted.Add(elt);
+						// As the constant's name here suggests, in theory, we could include divs
+						// that don't have .bloom-editable, and all their children.
+						// But I'm not smart enough to write that selector and for bloomds, all we're doing here is saving space,
+						// so those other divs we are missing doesn't seem to matter as far as I can think.
+						var kSelectThingsThatCanBeHiddenButAreNotText = ".//img";
+						var selector = removeInactiveLanguages
+							? kSelectThingsThatCanBeHidden
+							: kSelectThingsThatCanBeHiddenButAreNotText;
+						foreach (XmlElement elt in page.SafeSelectNodes(selector))
+						{
+							// Even when they are not displayed we want to keep image descriptions if they aren't empty.
+							// This is necessary for retaining any associated audio files to play.
+							// (If they are empty, they won't have any audio and may trigger embedding an unneeded font.)
+							// See https://issues.bloomlibrary.org/youtrack/issue/BL-7237.
+							// As noted above, if the displayDom is not sufficiently loaded for a definitive
+							// answer to IsDisplayed, we will throw when making epubs but not for bloom reader.
+							if (!IsDisplayed(elt, epubMaker != null) && !IsNonEmptyImageDescription(elt))
+							{
+								toBeDeleted.Add(elt);
+							}
+						}
+
+						foreach (var elt in toBeDeleted)
+						{
+							elt.ParentNode.RemoveChild(elt);
+						}
 					}
-				}
-				foreach (var elt in toBeDeleted)
-				{
-					elt.ParentNode.RemoveChild(elt);
-				}
-				// We need the font information for visible text elements as well.  This is a side-effect but related to
+					// We need the font information for visible text elements as well.  This is a side-effect but related to
 				// unwanted elements in that we don't need fonts that are used only by unwanted elements.
 				foreach (XmlElement elt in page.SafeSelectNodes(".//div"))
 				{


### PR DESCRIPTION
Currently templates lose placeholder flowers and  can lose their pages. This makes it hard to view them on blorg2.
Fix up some indentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4189)
<!-- Reviewable:end -->
