### PR TITLE
Fix a broken build on Linux (20210223)

### DIFF
--- a/src/BloomExe/TeamCollection/FolderTeamCollection.cs
+++ b/src/BloomExe/TeamCollection/FolderTeamCollection.cs
@@ -8,7 +8,6 @@ using System.Xml.Linq;
 using Bloom.CollectionCreating;
 using Bloom.MiscUI;
 using ICSharpCode.SharpZipLib.Zip;
-using NuGet;
 using SIL.IO;
 
 namespace Bloom.TeamCollection


### PR DESCRIPTION
I don't know how this stray "using NuGet" got added: it's not used even
on Windows.  And it's totally invalid on Linux/Mono.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4233)
<!-- Reviewable:end -->
