### PR TITLE
Generalize error handling when creating/copying PNG files (BL-9533)

### DIFF
--- a/src/BloomExe/Book/BookCopyrightAndLicense.cs
+++ b/src/BloomExe/Book/BookCopyrightAndLicense.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Text;
 using System.Web;
 using System.Xml;
+using Bloom.ImageProcessing;
 using Bloom.Utils;
 using L10NSharp;
 using SIL.Extensions;
@@ -280,69 +281,8 @@ namespace Bloom.Book
 			// Don't try to overwrite the license image for a template book.  (See BL-3284.)
 			if (RobustFile.Exists(imagePath) && BloomFileLocator.IsInstalledFileOrDirectory(imagePath))
 				return;
-			var originalReadOnly = FileAttributes.Normal;
-			try
-			{
-				// Almost all of the reports for BL-3227 that have been generated are for an UnauthorizedAccessException
-				// in the FileStream constructor (which is different than the original error reported in BL-3227).  This
-				// can happen if the file has become read-only for some reason.  Changing the FileAttribute is easy.  The
-				// more complicated permission settings are probably too difficult to fix, and fixing them even likelier
-				// to not be allowed.
-				if (RobustFile.Exists(imagePath))
-				{
-					var originalFileAttributes= RobustFile.GetAttributes(imagePath);
-					originalReadOnly = originalFileAttributes & FileAttributes.ReadOnly;
-					if (originalReadOnly == FileAttributes.ReadOnly)
-						RobustFile.SetAttributes(imagePath, FileAttributes.Normal);
-				}
-				if(licenseImage != null)
-				{
-					using(Stream fs = new FileStream(imagePath, FileMode.Create))
-					{
-						RobustImageIO.SaveImage(licenseImage, fs, ImageFormat.Png);
-					}
-					if (originalReadOnly == FileAttributes.ReadOnly)
-					{
-						// This may be useful to know even if only reported with other issues happening elsewhere.
-						Logger.WriteEvent($"Updating {imagePath} required turning off the ReadOnly attribute (BL-3227).");
-					}
-				}
-				else
-				{
-					if(RobustFile.Exists(imagePath))
-						RobustFile.Delete(imagePath);
-				}
-			}
-			catch(Exception error)
-			{
-				// BL-3227 Occasionally get The process cannot access the file '...\license.png' because it is being used by another process.
-				// That's worth a toast, since the user might like a hint why the license image isn't up to date.
-				// However, if the problem is a MISSING icon in the installed templates, which on Linux or if an allUsers install
-				// the system will never let us write, is not worth bothering the user at all. We can't fix it. Too bad.
-				if (BloomFileLocator.IsInstalledFileOrDirectory(imagePath))
-					return;
-				// BL-9533: these errors keep happening, but we can't help users who respond to a toast and send in an error report.
-				// Logging it will allow us to possibly correlate an error here with another problem that does get reported.
-				var message = $"Could not update license image (BL-3227) at {imagePath}";
-				string details;
-				if (RobustFile.Exists(imagePath))
-				{
-					var bldr = new StringBuilder();
-					bldr.AppendLine($"You may find help for this problem at https://community.software.sil.org/t/when-bloom-is-prevented-from-changing-png-image-files/4445.");
-					bldr.AppendLine($"The following specific information may also be helpful.");
-					bldr.Append(MiscUtils.CollectFilePermissionInformation(imagePath));
-					bldr.Append(MiscUtils.InstalledAntivirusPrograms());
-					details = bldr.ToString();
-				}
-				else
-				{
-					details = $"The file ({imagePath}) does not exist!?";
-				}
-				NonFatalProblem.Report(ModalIf.None, PassiveIf.All, message, details, exception: error, showSendReport:false, showRequestDetails:true);
-			}
+			ImageUtils.SaveOrDeletePngImageToPath(licenseImage, imagePath);
 		}
-
-
 
 		public static void RemoveLicense(BookStorage storage)
 		{

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -2107,8 +2107,10 @@ namespace Bloom.Book
 				if(_alreadyNotifiedAboutOneFailedCopy)
 					return;//don't keep bugging them
 				_alreadyNotifiedAboutOneFailedCopy = true;
-				var msg = $"Could not update one of the support files in this document ({documentPath} to {factoryPath}).";
-				NonFatalProblem.Report(ModalIf.None, PassiveIf.All, "Can't Update Support File", msg, exception: e);
+				// We probably can't help the user if they create an issue, but we can display a bit more information to help local tech support.
+				var msg = MiscUtils.GetExtendedFileCopyErrorInformation(documentPath,
+					$"Could not update one of the support files in this document ({documentPath} from {factoryPath}).");
+				NonFatalProblem.Report(ModalIf.None, PassiveIf.All, "Can't Update Support File", msg, exception: e, false, showRequestDetails:true);
 			}
 		}
 

--- a/src/BloomExe/Book/ImageUpdater.cs
+++ b/src/BloomExe/Book/ImageUpdater.cs
@@ -63,7 +63,7 @@ namespace Bloom.Book
 		{
 			foreach (var path in Directory.EnumerateFiles(folderPath).Where(s => s.EndsWith(".png", StringComparison.OrdinalIgnoreCase) || s.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase)))
 			{
-				if (ExcludedFiles.Contains(path.ToLowerInvariant()))
+				if (ExcludedFiles.Contains(Path.GetFileName(path).ToLowerInvariant()))
 					continue;
 				var metaData = Metadata.FromFile(path);
 				if (metaData != null && ImageIsFromOfficialCollection(metaData))

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -791,7 +791,7 @@ namespace Bloom.Edit
 						//update so any overlays on the image are brought up to data
 						PageEditingModel.UpdateMetadataAttributesOnImage(new ElementProxy(imageElement), imageInfo);
 						imageElement.Click(); //wake up javascript to update overlays
-						SaveChangedImage(imageElement, imageInfo, "Bloom had a problem updating the image metadata");
+						imageInfo.SaveUpdatedMetadataIfItMakesSense();
 
 						var answer =
 							MessageBox.Show(

--- a/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
+++ b/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
@@ -269,7 +269,10 @@ namespace Bloom.ImageProcessing
 							GraphicsUnit.Pixel,
 							imageAttributes); // changing white to transparent if a png
 					}
-					RobustImageIO.SaveImage(thumbnail, pathToProcessedImage);
+					if (!appearsToBeJpeg || Path.GetExtension(pathToProcessedImage) == ".png")
+						ImageUtils.SaveOrDeletePngImageToPath(thumbnail, pathToProcessedImage);
+					else
+						RobustImageIO.SaveImage(thumbnail, pathToProcessedImage);
 					// PNG thumbnails created from jpeg files seem to often be way too big, so try to save them as jpeg
 					// files instead if it saves space.  See https://silbloom.myjetbrains.com/youtrack/issue/BL-5605.
 					if (appearsToBeJpeg && Path.GetFileName(pathToProcessedImage) == "thumbnail.png")

--- a/src/BloomExe/Utils/MiscUtils.cs
+++ b/src/BloomExe/Utils/MiscUtils.cs
@@ -5,6 +5,9 @@ using SIL.IO;
 
 namespace Bloom.Utils
 {
+	/// <summary>
+	/// Collection of static utility methods that don't fit comfortably anywhere else.
+	/// </summary>
 	public static class MiscUtils
 	{
 		public static string CollectFilePermissionInformation(string filePath)
@@ -109,6 +112,36 @@ namespace Bloom.Utils
 				}
 			}
 			return result;
+		}
+
+		/// <summary>
+		/// Get what information we can about why a given file could not be written to the filesystem.
+		/// This includes the identity of the current user, the identity of the file owner, the file
+		/// permission information, and (grasping at straws) the system's anti-virus programs, if any.
+		/// This information may be helpful for local technical support people even if we can't help
+		/// users at a distance.
+		/// </summary>
+		/// <remarks>
+		/// See https://issues.bloomlibrary.org/youtrack/issue/BL-9533.
+		/// </remarks>
+		public static string GetExtendedFileCopyErrorInformation(string path, string firstLine=null)
+		{
+			var bldr = new StringBuilder();
+			if (!String.IsNullOrEmpty(firstLine))
+				bldr.AppendLine(firstLine);
+			if (RobustFile.Exists(path))
+			{
+				bldr.AppendLine($"You may find help for this problem at https://community.software.sil.org/t/when-bloom-is-prevented-from-changing-png-image-files/4445.");
+				bldr.AppendLine($"The following specific information may also be helpful.");
+				bldr.Append(CollectFilePermissionInformation(path));
+			}
+			else
+			{
+				bldr.AppendLine($"The file ({path}) does not exist!?");
+				bldr.AppendLine($"The following specific information may be helpful.");
+			}
+			bldr.Append(InstalledAntivirusPrograms());
+			return bldr.ToString();
 		}
 	}
 }


### PR DESCRIPTION
Also fix a couple of image related bugs along the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4240)
<!-- Reviewable:end -->
