### PR TITLE
Include L1 by default in Bloom Reader even if incomplete (BL-9587)

### DIFF
--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -350,7 +350,12 @@ namespace Bloom.Publish.Android
 					_languagesToPublish.Clear();
 					foreach (var kvp in _allLanguages)
 					{
-						if (kvp.Value)
+						if (kvp.Value ||
+							// We always select L1 by default because we assume the user wants to publish the language he is currently working on.
+							// It may be incomplete if he just wants to preview his work so far.
+							// If he really doesn't want to publish L1, he can deselect it.
+							// See BL-9587.
+							kvp.Key == request.CurrentCollectionSettings?.Language1Iso639Code)
 							_languagesToPublish.Add(kvp.Key);
 					}
 				}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4255)
<!-- Reviewable:end -->
