### PR TITLE
Fix Linux package build error (20210309)

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -2110,7 +2110,7 @@ namespace Bloom.Book
 				// We probably can't help the user if they create an issue, but we can display a bit more information to help local tech support.
 				var msg = MiscUtils.GetExtendedFileCopyErrorInformation(documentPath,
 					$"Could not update one of the support files in this document ({documentPath} from {factoryPath}).");
-				NonFatalProblem.Report(ModalIf.None, PassiveIf.All, "Can't Update Support File", msg, exception: e, false, showRequestDetails:true);
+				NonFatalProblem.Report(ModalIf.None, PassiveIf.All, "Can't Update Support File", msg, e, showSendReport:false, showRequestDetails:true);
 			}
 		}
 


### PR DESCRIPTION
Compiler complained about needing version 7.2 of C#: not sure if Mono 5
offers that level, and the fix seems clearer anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4264)
<!-- Reviewable:end -->
