### PR TITLE
BL-9320 Follow up

### DIFF
--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -863,6 +863,24 @@ div[data-book*="branding"] {
 .bloomPlayer-page .bloom-textOverPicture[data-bubble] {
     height: auto !important;
 }
+
+// Custom Widget template page and Digital Comic Book both use this to make the page have no margins.
+.no-margin-page {
+    &::after {
+        /* Hide page number */
+        display: none;
+    }
+    & .marginBox img {
+        max-width: unset; // device.less sets this, presumably expecting a margin
+    }
+    .marginBox {
+        left: 0 !important;
+        top: 0 !important;
+        height: 100% !important;
+        width: 100% !important;
+    }
+}
+
 //... to be continued. We sandwich most other sheets between this one and the langVisibility.css, which comes last-ish
 
 // now apply any book features

--- a/src/BloomBrowserUI/templates/template books/Activity/customWidgetPage.pug
+++ b/src/BloomBrowserUI/templates/template books/Activity/customWidgetPage.pug
@@ -1,4 +1,4 @@
 mixin customWidgetPage
-	+page("Widget Page", "A page where you can import an HTML5 widget which readers can interact with").custom-widget-page.customPage.bloom-interactive-page.enterprise-only.numberedPage#3a705ac1-c1f2-45cd-8a7d-011c009cf406(data-page='extra' data-analyticsCategories="widget")
+	+page("Widget Page", "A page where you can import an HTML5 widget which readers can interact with").custom-widget-page.customPage.bloom-interactive-page.enterprise-only.no-margin-page.numberedPage#3a705ac1-c1f2-45cd-8a7d-011c009cf406(data-page='extra' data-analyticsCategories="widget")
 		.split-pane-component-inner
 			.bloom-widgetContainer.bloom-noWidgetSelected.bloom-leadingElement

--- a/src/BloomBrowserUI/templates/template books/Digital Comic Book/Digital Comic Book.htm
+++ b/src/BloomBrowserUI/templates/template books/Digital Comic Book/Digital Comic Book.htm
@@ -217,11 +217,7 @@
             <div class="pageDescription" lang="en"></div>
 
             <div class="marginBox">
-                <div
-                    class="bloom-imageContainer"
-                    data-book="coverImage"
-                    style="placeHolder.png"
-                ></div>
+                <div class="bloom-imageContainer" data-book="coverImage"></div>
             </div>
         </div>
 
@@ -379,7 +375,7 @@
         </div>
 
         <div
-            class="bloom-page comic numberedPage customPage Device16x9Landscape side-right bloom-monolingual"
+            class="bloom-page comic no-margin-page numberedPage customPage Device16x9Landscape side-right bloom-monolingual"
             id="cc25eed1-74af-4d31-9120-aefd8d17205c"
             data-pagelineage="adcd48df-e9ab-4a07-afd4-6a24d0398385"
             data-page-number="1"

--- a/src/BloomBrowserUI/templates/template books/Digital Comic Book/Digital Comic Book.less
+++ b/src/BloomBrowserUI/templates/template books/Digital Comic Book/Digital Comic Book.less
@@ -14,19 +14,6 @@
 
 .comic {
     background-color: @dark !important;
-    &::after {
-        /* Hide page number */
-        display: none;
-    }
-    & .marginBox img {
-        max-width: unset; // device.less sets this, presumably expecting a margin
-    }
-    .marginBox {
-        left: 0 !important;
-        top: 0 !important;
-        height: 100% !important;
-        width: 100% !important;
-    }
 
     /* make highlighted white text easier to read if it is normally a light color (like white)*/
     span.ui-audioCurrent:not(.disableHighlight),


### PR DESCRIPTION
* pulled out a no-margin-page class to basePage.less
   so both Digital Comic Book and Activity templates
   can use it.