### PR TITLE
Fix problem with TeamCollection method disabling Edit tab (20210311)

### DIFF
--- a/src/BloomExe/TeamCollection/TeamCollectionApi.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionApi.cs
@@ -393,6 +393,9 @@ namespace Bloom.TeamCollection
 		// that it is checked-out to this user 
 		public bool CanEditBook()
 		{
+			if (_tcManager.CollectionStatus == TeamCollectionStatus.None)
+				return true;	// not a team collection
+
 			if (!TeamCollectionManager.IsRegistrationSufficient())
 				return false;
 


### PR DESCRIPTION
It should do so only when the user is in a team collection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4281)
<!-- Reviewable:end -->
