### PR TITLE
Always reload the top page in the edit view when switching

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -380,6 +380,7 @@
     <Compile Include="Publish\Epub\EpubPublishUiSettings.cs" />
     <Compile Include="Publish\Epub\PublishEpubApi.cs" />
     <Compile Include="ToPalaso\BackgroundWorkerProgressAdapter.cs" />
+    <Compile Include="Utils\MemoryUtils.cs" />
     <Compile Include="WebLibraryIntegration\FirebaseLoginDialog.cs" />
     <Compile Include="web\WebProgressAdapter.cs" />
     <Compile Include="Publish\HtmlPublishPanel.cs">

--- a/src/BloomExe/Utils/MemoryUtils.cs
+++ b/src/BloomExe/Utils/MemoryUtils.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bloom.Utils
+{
+	class MemoryUtils
+	{
+		/// <summary>
+		/// A crude way of measuring when we might be short enough of memory to need a full reload.
+		/// </summary>
+		/// <returns></returns>
+		public static bool SystemIsShortOfMemory()
+		{
+			// A rather arbitrary limit of 750M...a bit more than Bloom typically uses for a large book
+			// before memory leaks start to mount up.
+			return GetPrivateBytes() > 750000000;
+		}
+
+		/// <summary>
+		/// Significance: This counter indicates the current number of bytes allocated to this process that cannot be shared with
+		/// other processes. This counter has been useful for identifying memory leaks.
+		/// </summary>
+		/// <remarks>We've had other versions of this method which, confusingly, returned results in KB. This one actually answers bytes.</remarks>
+		/// <returns></returns>
+		public static long GetPrivateBytes()
+		{
+			using (var perfCounter = new PerformanceCounter("Process", "Private Bytes",
+				Process.GetCurrentProcess().ProcessName))
+			{
+				return perfCounter.RawValue;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is a partial cure for memory leaks.
Code is present, but disabled, to only do it when short of memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4287)
<!-- Reviewable:end -->
