### PR TITLE
Add graphicsmagick to Linux dependencies (20210331)

### DIFF
--- a/build/dependencies.config
+++ b/build/dependencies.config
@@ -28,10 +28,10 @@
 # npm is part of nodejs in newer versions of nodejs.
 
 [common]
-any=optipng libtidy5 mono5-sil libgdiplus5-sil libicu-dev wget unzip \
+any=optipng libtidy-sil mono5-sil libgdiplus5-sil libicu-dev wget unzip \
 fonts-sil-andikanewbasic nodejs sox ffmpeg lame libgtk3.0-cil \
 desktop-file-utils git libsndfile1 libenchant-dev libxklavier-dev \
-libdconf-dev libasound2-dev
+libdconf-dev libasound2-dev graphicsmagick
 
 [trusty]
 any=icu-devtools

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Vcs-Browser: https://github.com/BloomBooks/BloomDesktop
 Standards-Version: 4.1.4
 Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
  wget, unzip, desktop-file-utils, curl, git,
- optipng, libsndfile1,
+ optipng, libsndfile1, graphicsmagick,
  mono5-sil, mono5-sil-msbuild, libgdiplus5-sil,
  libgtk-3-0,
  libenchant-dev, libxklavier-dev, libdconf-dev,


### PR DESCRIPTION
It is used by some unit tests related to image processing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4324)
<!-- Reviewable:end -->
