### PR TITLE
ErrorReport closes splash screen inside SafeInvoke (BL-9736)

### DIFF
--- a/src/BloomExe/ErrorReporter/HtmlErrorReporter.cs
+++ b/src/BloomExe/ErrorReporter/HtmlErrorReporter.cs
@@ -385,7 +385,6 @@ namespace Bloom.ErrorReporter
         {
 			// Before we do anything that might be "risky", put the problem in the log.
 			ProblemReportApi.LogProblem(exception, messageText, severity);
-			StartupScreenManager.CloseSplashScreen(); // if it's still up, it'll be on top of the dialog
 
 			ErrorResult returnResult = ErrorResult.OK;
 
@@ -397,6 +396,8 @@ namespace Bloom.ErrorReporter
 				// Uses a browser dialog to show the problem report
 				try
 				{
+					StartupScreenManager.CloseSplashScreen(); // if it's still up, it'll be on top of the dialog
+
 					var message = GetMessage(messageText, exception);
 
 					string urlQueryString = CreateNotifyUrlQueryString(message, reportButtonLabel, secondaryButtonLabel);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4325)
<!-- Reviewable:end -->
