### PR TITLE
Use fallback dialog for errors occurring before Server starts (BL-9749)

### DIFF
--- a/src/BloomExe/ErrorReporter/HtmlErrorReporter.cs
+++ b/src/BloomExe/ErrorReporter/HtmlErrorReporter.cs
@@ -400,6 +400,24 @@ namespace Bloom.ErrorReporter
 
 					var message = GetMessage(messageText, exception);
 
+					if (!Api.BloomServer.ServerIsListening)
+					{
+						// There's no hope of using the HtmlErrorReporter dialog if our server is not yet running.
+						// We'll likely get errors, maybe Javascript alerts, that won't lead to a clean fallback to
+						// the exception handler below. Besides, failure of HtmlErrorReporter in these circumstances
+						// is expected; we just want to cleanly report the original problem, not to report a
+						// failure of error handling.
+						var fallbackReporter = new WinFormsErrorReporter();
+						if (exception != null)
+							fallbackReporter.ReportNonFatalException(exception, new ShowAlwaysPolicy());
+						else
+						{
+							fallbackReporter.NotifyUserOfProblem(new ShowAlwaysPolicy(), null, ErrorResult.OK,
+								message.NotEncoded);
+						}
+						return;
+					}
+
 					string urlQueryString = CreateNotifyUrlQueryString(message, reportButtonLabel, secondaryButtonLabel);
 
 					

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -988,6 +988,8 @@ namespace Bloom.Api
 			return false;
 		}
 
+		public static bool ServerIsListening { get; private set; }
+
 		private static void VerifyWeAreNowListening()
 		{
 			try
@@ -1004,6 +1006,8 @@ namespace Bloom.Api
 				ErrorReport.NotifyUserOfProblem(error,GetServerStartFailureMessage());
 				Application.Exit();
 			}
+
+			ServerIsListening = true;
 		}
 
 		private static string GetServerStartFailureMessage()
@@ -1447,6 +1451,7 @@ namespace Bloom.Api
 				// dispose managed and unmanaged objects
 				try
 				{
+					ServerIsListening = false;
 					if (_listener != null)
 					{
 						//prompted by the mysterious BL 273, Crash while closing down the imageserver


### PR DESCRIPTION
It doesn't sound as if this would fix that issue, but it does...that issue just happened to be where this problem cropped up

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4330)
<!-- Reviewable:end -->
