### PR TITLE
Fix a bug in error reporting

### DIFF
--- a/src/BloomExe/MiscUI/StartupScreenManager.cs
+++ b/src/BloomExe/MiscUI/StartupScreenManager.cs
@@ -266,7 +266,9 @@ namespace Bloom.MiscUI
 				_splashForm.FadeAndClose(); //it's going to hang around while it fades,
 			}
 			_doWhenSplashScreenShouldClose?.Invoke();
+			_doWhenSplashScreenShouldClose = null;
 			DoLastOfAllAfterClosingSplashScreen?.Invoke();
+			DoLastOfAllAfterClosingSplashScreen = null;
 		}
 
 		public static void EnableProcessing()


### PR DESCRIPTION
CloseSplashScreen was dying trying to redo something only meant to happen once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4338)
<!-- Reviewable:end -->
