### PR TITLE
BL-9746 UI tweaks to Settings dialog

### DIFF
--- a/src/BloomBrowserUI/collection/enterpriseSettings.less
+++ b/src/BloomBrowserUI/collection/enterpriseSettings.less
@@ -1,9 +1,13 @@
 @import "../bloomUI.less";
 @greyBackground: #ebebeb;
 @subitemIndent: 27px;
-
-.enterpriseSettings {
-    padding: 0px 4px 0px 4px;
+@tab-panel-margin-top: 24px;
+@tab-panel-margin-sides: 26px;
+body {
+    margin: 0;
+}
+div.enterpriseSettings {
+    margin: @tab-panel-margin-top @tab-panel-margin-sides 0;
     font-family: @UIFontStack;
     font-size: @ui-font-size;
 

--- a/src/BloomBrowserUI/teamCollection/TeamCollectionSettingsPanel.less
+++ b/src/BloomBrowserUI/teamCollection/TeamCollectionSettingsPanel.less
@@ -1,10 +1,23 @@
 @import "../bloomUI.less";
+@tab-panel-margin-top: 24px;
+@tab-panel-margin-sides: 26px;
+
 .button-row {
     display: flex;
 }
 
+// Something higher up in our system that I haven't been able to discover sets the height of
+// html and body to 100% (possibly the Forms Dock.Fill?),
+// but it's unhelpful at best, we tend to get vertical scrollbars where not needed.
+html,
+body {
+    height: unset !important;
+}
+
 #teamCollection-settings {
-    padding: 10px;
+    margin: @tab-panel-margin-top @tab-panel-margin-sides 0;
+    font-family: @UIFontStack;
+    font-size: @ui-font-size;
     .requiresEnterpriseOverlay {
         justify-content: center;
         align-items: center;

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -11,12 +11,9 @@ using SIL.Extensions;
 using SIL.WritingSystems;
 using System.Collections.Generic;
 using Bloom.Api;
-using Bloom.CollectionTab;
 using Bloom.TeamCollection;
 using Bloom.MiscUI;
-using Bloom.web;
 using Bloom.web.controllers;
-using Gecko;
 
 namespace Bloom.Collection
 {


### PR DESCRIPTION
* enterprise tab top/left/right margins now match
   previous tabs
* TC collection tab margins are same as enterprise
* TC font type and size now match other tabs
* removed a few unused usings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4340)
<!-- Reviewable:end -->
