### PR TITLE
Fix problems with collection settings sync (BL-9783)

### DIFF
--- a/src/BloomExe/NonFatalProblem.cs
+++ b/src/BloomExe/NonFatalProblem.cs
@@ -62,7 +62,10 @@ namespace Bloom
 					//but there are others in which say, not finding a file is expected. Either way,
 					//the rest of the test should fail if the problem is real, so doing anything here
 					//would just be a help, not really necessary for getting the test to fail.
-					//So, for now I'm going to just go with doing nothing.
+					//So, for now I'm going to just go with doing nothing in general.
+					// We'll save a little information so we can write specific "this does not report a problem"
+					// tests.
+					LastNotFatalProblemReported = fullDetailedMessage;
 					return;
 				}
 
@@ -228,6 +231,7 @@ namespace Bloom
 		}
 
 		private static ExpectedByUnitTest s_expectedByUnitTest = null;
+		public static string LastNotFatalProblemReported = null;
 
 		/// <summary>
 		/// use this in unit tests to cleanly check that a message would have been shown.

--- a/src/BloomExe/NonFatalProblem.cs
+++ b/src/BloomExe/NonFatalProblem.cs
@@ -65,7 +65,7 @@ namespace Bloom
 					//So, for now I'm going to just go with doing nothing in general.
 					// We'll save a little information so we can write specific "this does not report a problem"
 					// tests.
-					LastNotFatalProblemReported = fullDetailedMessage;
+					LastNonFatalProblemReported = fullDetailedMessage;
 					return;
 				}
 
@@ -231,7 +231,7 @@ namespace Bloom
 		}
 
 		private static ExpectedByUnitTest s_expectedByUnitTest = null;
-		public static string LastNotFatalProblemReported = null;
+		public static string LastNonFatalProblemReported = null; // just for unit tests
 
 		/// <summary>
 		/// use this in unit tests to cleanly check that a message would have been shown.

--- a/src/BloomExe/TeamCollection/FolderTeamCollection.cs
+++ b/src/BloomExe/TeamCollection/FolderTeamCollection.cs
@@ -379,7 +379,9 @@ namespace Bloom.TeamCollection
 				return;
 			var destFolder = Path.Combine(collectionFolder, folderName);
 			ExtractFolderFromZip(destFolder, sourceZip,
-				() => new HashSet<string>(Directory.EnumerateFiles(destFolder).Select(p => Path.GetFileName(p))));
+				() => Directory.Exists(destFolder)
+					? new HashSet<string>(Directory.EnumerateFiles(destFolder).Select(p => Path.GetFileName(p)))
+					: new HashSet<string>());
 		}
 
 		// All the people who have something checked out in the repo.

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -526,7 +526,8 @@ namespace Bloom.TeamCollection
 			return GetStatus(bookName).checksum;
 		}
 
-		private bool _haveShownRemoteSettingsChangeWarning;
+		// internal for testing
+		internal bool _haveShownRemoteSettingsChangeWarning;
 
 		/// <summary>
 		/// Bring the collection-level files in the repo and the local collection into sync.
@@ -553,15 +554,19 @@ namespace Bloom.TeamCollection
 					// except when the warning below has already been seen.
 					CopyRepoCollectionFilesToLocal(_localCollectionFolder);
 				}
-				else if (!_haveShownRemoteSettingsChangeWarning)
+				else if (LocalCollectionFilesUpdated())
 				{
-					_haveShownRemoteSettingsChangeWarning = true;
-					// if it's not a startup sync, it's happening because of a local change. It will get lost.
-					// Not sure this is worth localizing. Eventually only one or two users per collection will be
-					// allowed to make such changes. Collection settings should rarely be changed at all
-					// in Team Collections. This message will hopefully be seen rarely if at all.
-					ErrorReport.NotifyUserOfProblem(
-						"Collection settings have been changed remotely. Your recent changes will be lost when Bloom syncs the next time it starts up");
+					// We have a conflict we should warn the user about...if we haven't already.
+					if (!_haveShownRemoteSettingsChangeWarning)
+					{
+						_haveShownRemoteSettingsChangeWarning = true;
+						// if it's not a startup sync, it's happening because of a local change. It will get lost.
+						// Not sure this is worth localizing. Eventually only one or two users per collection will be
+						// allowed to make such changes. Collection settings should rarely be changed at all
+						// in Team Collections. This message will hopefully be seen rarely if at all.
+						ErrorReport.NotifyUserOfProblem(
+							"Collection settings have been changed remotely. Your recent changes will be lost when Bloom syncs the next time it starts up");
+					}
 				}
 			}
 			else if (LocalCollectionFilesUpdated())

--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -437,6 +437,20 @@ namespace Bloom.web.controllers
 				{
 					var query = $"?level={levelOfProblem}";
 
+					if (!BloomServer.ServerIsListening)
+					{
+						// We can't use the react dialog!
+						var fallbackReporter = new WinFormsErrorReporter();
+						if (exception != null)
+							fallbackReporter.ReportNonFatalException(exception, new ShowAlwaysPolicy());
+						else
+						{
+							fallbackReporter.NotifyUserOfProblem(new ShowAlwaysPolicy(), null, ErrorResult.OK,
+								detailedMessage);
+						}
+						return;
+					}
+
 					// Precondition: we must be on the UI thread for Gecko to work.
 					using (var dlg = new ReactDialog("problemReportBundle.js", "ProblemDialog", query))
 					{

--- a/src/BloomTests/TeamCollection/FolderTeamCollectionTests.cs
+++ b/src/BloomTests/TeamCollection/FolderTeamCollectionTests.cs
@@ -471,6 +471,11 @@ namespace BloomTests.TeamCollection
 			// First SUT: copy from local to repo
 			_collection.CopyRepoCollectionFilesFromLocal(_collectionFolder.FolderPath);
 
+			// (We verify that we sucessfully copied to the various zip files by copying back
+			// from there to a new folder. Thus we don't need the test code to have white-box
+			// knowledge of the format in which the data is stored in the repo. CopyFromLocal
+			// must have succeeded if we get the expected data back from CopyToLocal.)
+
 			using (var tempDest = new TemporaryFolder("CopySharedCollectionFilesToLocal_RetrievesFilePut"))
 			{
 				var destCollectionFilePath =
@@ -538,12 +543,12 @@ namespace BloomTests.TeamCollection
 				var destCollectionFilePath =
 					Path.Combine(tempDest.FolderPath, Path.GetFileName(collectionFilePath));
 				File.WriteAllText(destCollectionFilePath, "This should get overwritten");
-				NonFatalProblem.LastNotFatalProblemReported = null;
+				NonFatalProblem.LastNonFatalProblemReported = null;
 
 				// Second SUT: copy back
 				_collection.CopyRepoCollectionFilesToLocal(tempDest.FolderPath);
 
-				Assert.That(NonFatalProblem.LastNotFatalProblemReported, Is.Null);
+				Assert.That(NonFatalProblem.LastNonFatalProblemReported, Is.Null);
 
 				Assert.That(File.ReadAllText(destCollectionFilePath), Is.EqualTo("This is a fake collection"));
 				var destStylesPath = Path.Combine(tempDest.FolderPath, "customCollectionStyles.css");


### PR DESCRIPTION
- Spurious problem report if local folder has no Sample Texts folder, remote user added folder but no contents
- Problem reporting failed if BloomServer not yet running

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4346)
<!-- Reviewable:end -->
