### PR TITLE
Fix problems with disconnected collection (BL-9748)

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -253,7 +253,7 @@ namespace Bloom.CollectionTab
 			// before anything else, and we'll need to close the splash screen to make room for
 			// that dialog.
 			// Note, this not put into _startupActions...it should never be disabled.
-			if (_tcManager?.CurrentCollection != null)
+			if (_tcManager?.CurrentCollectionEvenIfDisconnected != null)
 			{
 				StartupScreenManager.AddStartupAction( () =>
 					{

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -284,8 +284,29 @@ namespace Bloom
 										ErrorReport.NotifyUserOfProblem(msg);
 										return 1;
 									}
+
 									if (projectContext.TeamCollectionManager.CurrentCollection == null)
+									{
+										if (projectContext.TeamCollectionManager.CurrentCollectionEvenIfDisconnected !=
+										    null)
+										{
+
+											var msg = LocalizationManager.GetString("TeamCollection.ConnectToJoin",
+												"Bloom cannot currently join this collection.");
+											// This is a bit of a kludge, but when we make a disconnected collection it's pretty
+											// consistently true that the last message just says "you'll be disconnected till you fix this",
+											// but the previous one actually says what's wrong. So we'll reuse this in this (hopefully)
+											// rare case.
+											var messages = projectContext.TeamCollectionManager
+												.CurrentCollectionEvenIfDisconnected.MessageLog.PrettyPrintMessages;
+											if (messages.Length > 1 && messages[messages.Length - 2].Item1 == MessageAndMilestoneType.Error)
+											{
+												msg += Environment.NewLine + messages[messages.Length - 2].Item2;
+											}
+											ErrorReport.NotifyUserOfProblem(msg);
+										}
 										return 1; // something went wrong processing it, hopefully already reported.
+									}
 									newCollection = FolderTeamCollection.ShowJoinCollectionTeamDialog(args[0]);
 								}
 							}


### PR DESCRIPTION
- DisconnectedCollection was not receiving CollectionId, making it think every status file was irrelevant, and every book was a local creation
- No explanation when we can't join while disconnected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4353)
<!-- Reviewable:end -->
