### PR TITLE
Fix some problems with renaming team collections

### DIFF
--- a/src/BloomExe/MiscUI/ReactDialog.cs
+++ b/src/BloomExe/MiscUI/ReactDialog.cs
@@ -60,6 +60,7 @@ namespace Bloom.MiscUI
 				CurrentOpenModal.CloseSource = labelOfUiElementUsedToCloseTheDialog;
 
 				CurrentOpenModal.Close();
+				_currentOpenModal = null;
 			}
 		}
 	}

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -211,6 +211,17 @@ namespace Bloom
 						builder.Register<CollectionSettings>(c =>
 						{
 							c.Resolve<TeamCollectionManager>();
+							if (!RobustFile.Exists(projectSettingsPath))
+							{
+								// TCManager constructor may have deleted it in the process of syncing TC settings
+								var collections = Directory.EnumerateFiles(Path.GetDirectoryName(projectSettingsPath),
+									"*.bloomCollection").ToList();
+								if (collections.Count >= 1)
+								{
+									// Hopefully this repairs things.
+									projectSettingsPath = collections[0];
+								}
+							}
 							return new CollectionSettings(projectSettingsPath);
 						}).InstancePerLifetimeScope();
 					}

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -1565,7 +1565,8 @@ namespace Bloom.TeamCollection
 					// When we would normally close the splash screen, close the progress dialog.
 					StartupScreenManager.DoWhenSplashScreenShouldClose(() =>
 					{
-						dlg.Close();
+						// Not dlg.Close(); that may not clear ReactDialog.CurrentOpenModal fast enough.
+						ReactDialog.CloseCurrentModal();
 					});
 				});
 


### PR DESCRIPTION
--one more round of making it possible to have a problem report before the TC progress dialog closes
-- problem caused by not finding the .bloomCollection we expect after getting one with a different name from Repo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4361)
<!-- Reviewable:end -->
