### PR TITLE
Fix a Linux crash when restarting Bloom (20210414)

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -59,6 +59,8 @@ namespace Bloom
 
 		private static GeckoWebBrowser _debugServerStarter;
 
+		static string _originalPreload; // saves LD_PRELOAD environment variable for restarting Bloom
+
 #if PerProjectMutex
 		private static Mutex _oneInstancePerProjectMutex;
 #else
@@ -421,6 +423,7 @@ namespace Bloom
 							return 1;
 
 						// This has served its purpose on Linux, and with Geckofx60 it interferes with CommandLineRunner.
+						_originalPreload = Environment.GetEnvironmentVariable("LD_PRELOAD");
 						Environment.SetEnvironmentVariable("LD_PRELOAD", null);
 
 						Run();
@@ -580,6 +583,8 @@ namespace Bloom
 						args = "\"" + Application.ExecutablePath + "\"";
 					else
 						args = "\"" + Application.ExecutablePath + "\" " + args;
+					if (_originalPreload != null)
+						Environment.SetEnvironmentVariable("LD_PRELOAD", _originalPreload);
 				}
 				if (args == null)
 					Process.Start(program);


### PR DESCRIPTION
The user can manually restart Bloom fine after the scary green crash
dialog, but this keeps things going smoother.  This could be applied
to 4.9 if we think it worthwhile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4362)
<!-- Reviewable:end -->
