### PR TITLE
Reduce time taken by ExportEpubTests

### DIFF
--- a/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
+++ b/src/BloomExe/Publish/Android/BloomReaderFileMaker.cs
@@ -165,7 +165,7 @@ namespace Bloom.Publish.Android
 
 			modifiedBook.OurHtmlDom.SetMedia("bloomReader");
 			modifiedBook.OurHtmlDom.AddOrReplaceMetaElement("bloom-digital-creator", creator);
-			EmbedFonts(modifiedBook, progress, fontsUsed, new FontFileFinder());
+			EmbedFonts(modifiedBook, progress, fontsUsed, FontFileFinder.GetInstance(Program.RunningUnitTests));
 
 			var bookFile = BookStorage.FindBookHtmlInFolder(modifiedBook.FolderPath);
 			StripImgIfWeCannotFindFile(modifiedBook.RawDom, bookFile);

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -1927,7 +1927,7 @@ namespace Bloom.Publish.Epub
 		/// </summary>
 		private void EmbedFonts()
 		{
-			var fontFileFinder = new FontFileFinder ();
+			var fontFileFinder = FontFileFinder.GetInstance(Program.RunningUnitTests);
 			var filesToEmbed = _fontsUsedInBook.SelectMany(fontFileFinder.GetFilesForFont).ToArray();
 			foreach (var file in filesToEmbed) {
 				CopyFileToEpub(file, subfolder:kFontsFolder);

--- a/src/BloomExe/Publish/Epub/FontFileFinder.cs
+++ b/src/BloomExe/Publish/Epub/FontFileFinder.cs
@@ -22,6 +22,27 @@ namespace Bloom.Publish.Epub
 	{
 		private Dictionary<string, FontGroup> FontNameToFiles { get; set; }
 
+		private static FontFileFinder _instance = null;
+		/// <summary>
+		/// Creates or gets an instance of the class
+		/// </summary>
+		/// <param name="isReuseAllowed">If false, always constructs a new instance. If true, then it operates like a singleton.
+		/// If you're paranoid about the available fonts changing under you, you can pass false.
+		/// Otherwise, you can pass true if you're happy with re-using whatever fonts were available the first time this ran.
+		/// </param>
+		public static FontFileFinder GetInstance(bool isReuseAllowed)
+		{
+			if (isReuseAllowed)
+			{
+				if (_instance == null)
+					_instance = new FontFileFinder();
+
+				return _instance;
+			}
+			else
+				return new FontFileFinder();
+		}
+
 		/// <summary>
 		/// This is really hard. We somehow need to figure out what font file(s) are used for a particular font.
 		/// http://stackoverflow.com/questions/16769758/get-a-font-filename-based-on-the-font-handle-hfont
@@ -58,6 +79,9 @@ namespace Bloom.Publish.Epub
 			return result;
 		}
 
+		/// <summary>
+		/// Note: There is some performance overhead to initializing this. 
+		/// </summary>
 		private void InitializeFontData()
 		{
 			FontNameToFiles = new Dictionary<string, FontGroup>();


### PR DESCRIPTION
Discovered that IntializeFontData() is a bottleneck in ExportEpubTests.  Making that function only happen once instead of every time reduced the time for me to run the entire test suite from 11 minutes to 8.2 minutes, a reduction of 2.8 minutes or 25% speedup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4363)
<!-- Reviewable:end -->
