### PR TITLE
L10N cleanup. All components handle both {} and % (BL-9490)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -507,7 +507,7 @@ function SetAlternateTextOnImages(element) {
             .fail(() => {
                 $(element).attr(
                     "alt",
-                    theOneLocalizationManager.simpleDotNetFormat(englishText, [
+                    theOneLocalizationManager.simpleFormat(englishText, [
                         decodedName
                     ])
                 );

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -1714,7 +1714,7 @@ export class ReaderToolsModel {
             msgDiv.html("");
         } else {
             msgDiv.html(
-                theOneLocalizationManager.simpleDotNetFormat(
+                theOneLocalizationManager.simpleFormat(
                     $(toolbox)
                         .find("#allowed_word_list_truncated_text")
                         .html(),

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -458,11 +458,11 @@ export default class AudioRecording {
                     url = blAeneasUrl + "/linux";
                 }
                 const anchor = '<a href="' + url + '">' + aeneasName + "</a>";
-                const missingDependencyHoverTip = theOneLocalizationManager.simpleDotNetFormat(
+                const missingDependencyHoverTip = theOneLocalizationManager.simpleFormat(
                     localizedMessage,
                     [aeneasName]
                 );
-                const missingDependencyMsgWithLink = theOneLocalizationManager.simpleDotNetFormat(
+                const missingDependencyMsgWithLink = theOneLocalizationManager.simpleFormat(
                     localizedMessage,
                     [anchor]
                 );

--- a/src/BloomBrowserUI/lib/localizationManager/localizationManagerSpec.ts
+++ b/src/BloomBrowserUI/lib/localizationManager/localizationManagerSpec.ts
@@ -55,4 +55,34 @@ describe("localizationManager", () => {
         );
         expect(result6).toBe("This is a [**] test (*).");
     });
+
+    it("simpleFormat replaces %0 and %1 with l10nParams", () => {
+        const result = theOneLocalizationManager.simpleFormat(
+            "%1 likes %0, but %0 does not like %1",
+            ["Jack", "Jill"]
+        );
+        expect(result).toBe("Jill likes Jack, but Jack does not like Jill");
+    });
+    it("simpleFormat replaces {0} and {1} with l10nParams", () => {
+        const result = theOneLocalizationManager.simpleFormat(
+            "{1} likes {0}, but {0} does not like {1}",
+            ["Jack", "Jill"]
+        );
+        expect(result).toBe("Jill likes Jack, but Jack does not like Jill");
+    });
+    it("simpleFormat does not replace missing params", () => {
+        const result = theOneLocalizationManager.simpleFormat(
+            "{1} likes {0}, but {7} does not like %8",
+            ["Jack", undefined]
+        );
+        expect(result).toBe("{1} likes Jack, but {7} does not like %8");
+    });
+
+    it("simpleFormat can insert empty string", () => {
+        const result = theOneLocalizationManager.simpleFormat(
+            "the translation of '{0}' is '{1}'",
+            ["Jack", ""]
+        );
+        expect(result).toBe("the translation of 'Jack' is ''");
+    });
 });

--- a/src/BloomBrowserUI/react_components/l10n.ts
+++ b/src/BloomBrowserUI/react_components/l10n.ts
@@ -27,15 +27,11 @@ export function getLocalization({
             temporarilyDisableI18nWarning
         )
         .done(result => {
-            let text = result.text;
-            if (l10nParam0) {
-                text = text.replace("%0", l10nParam0);
-                text = text.replace("{0}", l10nParam0); // c# style
-                if (l10nParam1) {
-                    text = text.replace("%1", l10nParam1);
-                    text = text.replace("{1}", l10nParam1); // c# style
-                }
-            }
+            let text = theOneLocalizationManager.simpleFormat(result.text, [
+                l10nParam0,
+                l10nParam1
+            ]);
+
             // some legacy strings will have an ampersand which winforms interpreted as an accelerator key
             // enhance: we could conceivably implement this, using the html "accesskey" attribute
             if (text.indexOf("&") == 0) {


### PR DESCRIPTION
Major refactoring that hopefully makes it easier to understand what's going on in this code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4382)
<!-- Reviewable:end -->
