### PR TITLE
New way to check for range selection prevents memory leak (BL-9757)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1046,6 +1046,12 @@ interface String {
     startsWith(string): boolean;
 }
 
+function isTextSelected(): boolean {
+    const selection = document.getSelection();
+    return !!selection && !selection.isCollapsed;
+}
+
+let reportedTextSelected = isTextSelected();
 // ---------------------------------------------------------------------------------
 // called inside document ready function
 // ---------------------------------------------------------------------------------
@@ -1055,6 +1061,18 @@ export function bootstrap() {
     $.fn.reverse = function() {
         return this.pushStack(this.get().reverse(), arguments);
     };
+
+    document.addEventListener("selectionchange", () => {
+        const textSelected = isTextSelected();
+        if (textSelected != reportedTextSelected) {
+            BloomApi.postBoolean("editView/isTextSelected", textSelected);
+            reportedTextSelected = textSelected;
+        }
+    });
+    // We could force this in C#, but it's easier to just send a message to convey the state
+    // that the page is in to begin with. I think this is always false at bootstrap.
+    reportedTextSelected = isTextSelected();
+    BloomApi.postBoolean("editView/isTextSelected", reportedTextSelected);
 
     /* reviewSlog typescript just couldn't cope with this. Our browser has this built in , so it's ok
             //if this browser doesn't have endsWith built in, add it

--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -13,6 +13,8 @@ using System.Windows.Forms;
 using System.Xml;
 using Bloom.Book;
 using Bloom.Api;
+using Bloom.Edit;
+using Bloom.web.controllers;
 using Gecko;
 using Gecko.DOM;
 using Gecko.Events;
@@ -274,8 +276,6 @@ namespace Bloom
 
 			try
 			{
-				// BL-3658 GeckoFx-45 has a bug in the CanXSelection Properties, they always return 'true'
-				// Tom Hindle suggested a workaround that seems to work.
 				var isTextSelection = IsThereACurrentTextSelection();
 				_cutCommand.Enabled = _browser != null && isTextSelection;
 				_copyCommand.Enabled = _browser != null && isTextSelection;
@@ -299,18 +299,13 @@ namespace Bloom
 		}
 
 		/// <summary>
-		/// Workaround suggested by Tom Hindle, since GeckoFx-45's CanXSelection properties aren't working.
+		/// We configure something in Javascript to keep track of this, since GeckoFx-45's CanXSelection properties aren't working,
+		/// and a workaround involving making a GeckoWindow object and querying its selection led to memory leaks (BL-9757).
 		/// </summary>
 		/// <returns></returns>
 		private bool IsThereACurrentTextSelection()
 		{
-			using (var win = new GeckoWindow(_browser.WebBrowserFocus.GetFocusedWindowAttribute()))
-			{
-				var sel = win.Selection;
-				if (sel.IsCollapsed || sel.FocusNode is GeckoImageElement)
-					return false;
-			}
-			return true;
+			return EditingModel.IsTextSelected;
 		}
 
 		enum JavaScriptUndoState

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1575,5 +1575,11 @@ namespace Bloom.Edit
 			}
 			return widgetPath;
 		}
+
+		/// <summary>
+		/// Currently this is only valid in EditingView, since it depends on the Javascript code being
+		/// configured to send appropriate messages to the editView/setIsSelectionRange API.
+		/// </summary>
+		public static bool IsTextSelected;
 	}
 }

--- a/src/BloomExe/web/controllers/EditingViewApi.cs
+++ b/src/BloomExe/web/controllers/EditingViewApi.cs
@@ -23,6 +23,13 @@ namespace Bloom.web.controllers
 			apiHandler.RegisterEndpointHandler("editView/editPagePainted", HandleEditPagePainted, true);
 			apiHandler.RegisterEndpointHandler("editView/saveToolboxSetting", HandleSaveToolboxSetting, true);
 			apiHandler.RegisterEndpointHandler("editView/setTopic", HandleSetTopic, true);
+			apiHandler.RegisterEndpointHandler("editView/isTextSelected", HandleIsTextSelected, false);
+		}
+
+		private void HandleIsTextSelected(ApiRequest request)
+		{
+			EditingModel.IsTextSelected = request.RequiredPostBooleanAsJson();
+			request.PostSucceeded();
 		}
 
 		public void HandleSetModalState(ApiRequest request)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4389)
<!-- Reviewable:end -->
