### PR TITLE
BL-9815 and 9819 Better 'transparent' handling

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/colorBar.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/colorBar.tsx
@@ -8,20 +8,21 @@ import {
 import * as tinycolor from "tinycolor2";
 import { CSSProperties } from "react";
 
-export interface IColorBarProps extends ISwatchDefn {
+export interface IColorBarProps {
     id: string;
     // if defined, 'text' will display over the color bar in either white or black,
     // depending on the color bar's "perceived brightness".
     text?: string;
     onClick: () => void;
+    swatch: ISwatchDefn;
 }
 // Displays a color bar menu item with optional localizable text.
 export const ColorBar: React.FunctionComponent<IColorBarProps> = (
     props: IColorBarProps
 ) => {
-    const baseColor = props.colors; // An array of strings representing colors
+    const baseColor = props.swatch.colors; // An array of strings representing colors
 
-    const backgroundColorString = getBackgroundFromSwatch(props);
+    const backgroundColorString = getBackgroundFromSwatch(props.swatch);
 
     const isDark = (colorString: string): boolean => {
         const color = tinycolor(colorString); // handles named colors, rgba() and hex strings!!!

--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
@@ -396,7 +396,7 @@ const ComicToolControls: React.FunctionComponent = () => {
 
     const needToCalculateTransparency = (): boolean => {
         const opacityDecimal = backgroundColorSwatch.opacity;
-        return !!opacityDecimal && opacityDecimal < 1.0;
+        return opacityDecimal < 1.0;
     };
 
     const percentTransparentFromOpacity = (): string => {
@@ -571,8 +571,7 @@ const ComicToolControls: React.FunctionComponent = () => {
                         <ColorBar
                             id="text-color-bar"
                             onClick={launchTextColorChooser}
-                            name={textColorSwatch.name}
-                            colors={textColorSwatch.colors}
+                            swatch={textColorSwatch}
                         />
                     </FormControl>
                     <FormControl>
@@ -589,9 +588,8 @@ const ComicToolControls: React.FunctionComponent = () => {
                             onClick={() =>
                                 launchBackgroundColorChooser(isCaption)
                             }
-                            name={backgroundColorSwatch.name}
+                            swatch={backgroundColorSwatch}
                             text={percentTransparencyString()}
-                            colors={backgroundColorSwatch.colors}
                         />
                     </FormControl>
                     <FormControl>

--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comicToolColorHelper.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comicToolColorHelper.ts
@@ -7,42 +7,49 @@ export const specialColors: ISwatchDefn[] = [
     // so I decided it was the best choice for keeping that option.
     {
         name: "whiteToCalico",
-        colors: ["white", "#DFB28B"]
+        colors: ["white", "#DFB28B"],
+        opacity: 1
     },
     // https://www.htmlcsscolor.com/hex/ACCCDD
     {
         name: "whiteToFrenchPass",
-        colors: ["white", "#ACCCDD"]
+        colors: ["white", "#ACCCDD"],
+        opacity: 1
     },
     // https://encycolorpedia.com/7b8eb8
     {
         name: "whiteToPortafino",
-        colors: ["white", "#7b8eb8"]
+        colors: ["white", "#7b8eb8"],
+        opacity: 1
     }
 ];
 
 export const defaultTextColors: ISwatchDefn[] = [
     {
         name: "black",
-        colors: ["black"]
+        colors: ["black"],
+        opacity: 1
     },
     {
         name: "gray",
-        colors: ["gray"] // #808080
+        colors: ["gray"], // #808080
+        opacity: 1
     },
     {
         name: "lightgray",
-        colors: ["lightgray"] // #D3D3D3
+        colors: ["lightgray"], // #D3D3D3
+        opacity: 1
     },
-    { name: "white", colors: ["white"] }
+    { name: "white", colors: ["white"], opacity: 1 }
 ];
 
 const temp: ISwatchDefn[] = [
     {
         name: "black",
-        colors: ["black"]
+        colors: ["black"],
+        opacity: 1
     },
-    { name: "white", colors: ["white"] },
+    { name: "white", colors: ["white"], opacity: 1 },
     {
         name: "partialTransparent",
         colors: ["#575757"], // bloom-gray
@@ -69,6 +76,14 @@ export const getSwatchFromBubbleSpecColor = (
     // We need to pull out the "opacity" and add it to the swatch here.
     const colorStruct = tinycolor(bubbleSpecColor);
     const opacity = colorStruct.getAlpha();
+    // Complete transparency, though, is a special case.
+    // We want to continue using 'transparent' as the background color in that case.
+    if (opacity === 0.0) {
+        return {
+            colors: ["transparent"],
+            opacity: opacity
+        };
+    }
     return {
         colors: [`#${colorStruct.toHex()}`],
         opacity: opacity

--- a/src/BloomBrowserUI/react_components/colorPickerDialog.tsx
+++ b/src/BloomBrowserUI/react_components/colorPickerDialog.tsx
@@ -153,7 +153,7 @@ const ColorPickerDialog: React.FC<IColorPickerDialogProps> = props => {
         isSwatchInThisArray(swatch, swatchArray);
 
     const willSwatchBeFilteredOut = (swatch: ISwatchDefn): boolean => {
-        if (props.noAlphaSlider && swatch.opacity && swatch.opacity !== 1) {
+        if (props.noAlphaSlider && swatch.opacity !== 1) {
             return true;
         }
         if (props.noGradientSwatches && swatch.colors.length > 1) {
@@ -184,13 +184,11 @@ const ColorPickerDialog: React.FC<IColorPickerDialogProps> = props => {
                 return false;
             }
         }
-        const swatchOpacity = swatch.opacity ? swatch.opacity : 1;
-        const itemOpacity = item.opacity ? item.opacity : 1;
         const swatchColor1 = tinycolor(swatch.colors[0]);
         const itemColor1 = tinycolor(item.colors[0]);
         return (
             swatchColor1.toHex() === itemColor1.toHex() &&
-            swatchOpacity === itemOpacity
+            swatch.opacity === item.opacity
         );
     };
 

--- a/src/BloomBrowserUI/react_components/colorSwatch.tsx
+++ b/src/BloomBrowserUI/react_components/colorSwatch.tsx
@@ -9,7 +9,7 @@ export interface ISwatchDefn {
     // We use an array here, so we can support gradients (top to bottom).
     colors: string[];
     name?: string;
-    opacity?: number;
+    opacity: number;
 }
 
 // More complete definition we need to pass in for handling swatch display.
@@ -57,13 +57,15 @@ export const getBackgroundFromSwatch = (swatch: ISwatchDefn): string => {
     // Otherwise, it could be a name of a color (OldLace) or a hex value starting with '#'
     const initialColorString =
         baseColor.length === 1 ? baseColor[0] : "gradient";
-    const opacity = swatch.opacity ? swatch.opacity : 1.0;
+    if (swatch.opacity === 0.0) {
+        return "transparent";
+    }
     // 'backgroundString' will end up being a named color, a linear-gradient string,
     // or an rgba string (with possible opacity values).
     let backgroundString: string = initialColorString;
     if (initialColorString.startsWith("#")) {
         const rgb = tinycolor(initialColorString).toRgb();
-        backgroundString = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${opacity})`;
+        backgroundString = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${swatch.opacity})`;
     }
     if (initialColorString === "gradient") {
         backgroundString =

--- a/src/BloomBrowserUI/react_components/customColorPicker.tsx
+++ b/src/BloomBrowserUI/react_components/customColorPicker.tsx
@@ -46,10 +46,20 @@ export const CustomColorPicker: React.FunctionComponent<ICustomPicker> = props =
         customName: string
     ): ISwatchDefn => {
         // A Swatch that comes from the ChromePicker (not from clicking on a swatch), cannot be a gradient.
+        let opacity = color.rgb.a;
+        // ColorResult (from react-color) CAN have undefined alpha in its RGBColor, so we just
+        // check here and assume the color is opaque if the alpha channel is undefined.
+        if (opacity === undefined) {
+            opacity = 1.0;
+        }
+        let colorString = color.hex;
+        if (opacity === 0.0) {
+            colorString = "transparent";
+        }
         return {
             name: customName,
-            colors: [color.hex],
-            opacity: color.rgb.a
+            colors: [colorString],
+            opacity: opacity
         };
     };
 
@@ -64,8 +74,7 @@ export const CustomColorPicker: React.FunctionComponent<ICustomPicker> = props =
                     }
                 })
                 .filter(swatch => {
-                    const opacity = swatch.opacity ? swatch.opacity : 1;
-                    return props.noAlphaSlider ? opacity === 1 : true;
+                    return props.noAlphaSlider ? swatch.opacity === 1 : true;
                 })
                 .map((swatchDefn: ISwatchDefn, i: number) => (
                     <ColorSwatch
@@ -82,7 +91,7 @@ export const CustomColorPicker: React.FunctionComponent<ICustomPicker> = props =
     const getRgbOfCurrentSwatch = (): RGBColor => {
         const currentSwatch = colorChoice;
         const rgbColor = tinycolor(currentSwatch.colors[0]).toRgb();
-        rgbColor.a = currentSwatch.opacity ? currentSwatch.opacity : 1;
+        rgbColor.a = currentSwatch.opacity;
         return rgbColor;
     };
 

--- a/src/BloomBrowserUI/react_components/stories.tsx
+++ b/src/BloomBrowserUI/react_components/stories.tsx
@@ -387,10 +387,10 @@ const initialOverDivStyles: React.CSSProperties = {
 };
 
 const defaultSwatches: ISwatchDefn[] = [
-    { name: "white", colors: ["#ffffff"] },
-    { name: "grey", colors: ["#777777"] },
-    { name: "black", colors: ["#000000"] },
-    { name: "whiteToCalico", colors: ["white", "#DFB28B"] },
+    { name: "white", colors: ["#ffffff"], opacity: 1 },
+    { name: "grey", colors: ["#777777"], opacity: 1 },
+    { name: "black", colors: ["#000000"], opacity: 1 },
+    { name: "whiteToCalico", colors: ["white", "#DFB28B"], opacity: 1 },
     { name: "60%Portafino", colors: ["#7b8eb8"], opacity: 0.6 }
 ];
 


### PR DESCRIPTION
* for background color in Text Blocks and elsewhere

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4391)
<!-- Reviewable:end -->
