### PR TITLE
Ensure using cross platform settings provides for all settings (BL-9842)

### DIFF
--- a/src/BloomExe/Properties/Settings.Designer.cs
+++ b/src/BloomExe/Properties/Settings.Designer.cs
@@ -334,7 +334,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool AdobeColorProfileEula2003Accepted {
             get {
@@ -346,7 +347,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string BloomDeviceFileExportFolder {
             get {
@@ -358,7 +360,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string PublishAndroidMethod {
             get {
@@ -370,7 +373,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
         public int CurrentStage {
             get {
@@ -382,7 +386,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
         public int CurrentLevel {
             get {
@@ -394,7 +399,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string CurrentBookPath {
             get {
@@ -406,7 +412,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0")]
         public int AutoUpdateDialogShown {
             get {

--- a/src/BloomExe/Properties/Settings.settings
+++ b/src/BloomExe/Properties/Settings.settings
@@ -74,25 +74,25 @@
     <Setting Name="PageZoom" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.String" Scope="User">
       <Value Profile="(Default)">1.0</Value>
     </Setting>
-    <Setting Name="AdobeColorProfileEula2003Accepted" Type="System.Boolean" Scope="User">
+    <Setting Name="AdobeColorProfileEula2003Accepted" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="BloomDeviceFileExportFolder" Type="System.String" Scope="User">
+    <Setting Name="BloomDeviceFileExportFolder" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="PublishAndroidMethod" Type="System.String" Scope="User">
+    <Setting Name="PublishAndroidMethod" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="CurrentStage" Type="System.Int32" Scope="User">
+    <Setting Name="CurrentStage" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">1</Value>
     </Setting>
-    <Setting Name="CurrentLevel" Type="System.Int32" Scope="User">
+    <Setting Name="CurrentLevel" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">1</Value>
     </Setting>
-    <Setting Name="CurrentBookPath" Type="System.String" Scope="User">
+    <Setting Name="CurrentBookPath" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="AutoUpdateDialogShown" Type="System.Int32" Scope="User">
+    <Setting Name="AutoUpdateDialogShown" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
     <Setting Name="AlwaysMeasurePerformance" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Boolean" Scope="User">


### PR DESCRIPTION
The standard Settings implementation in Mono has known issues which result
in very weird (and crashing) behavior.  I'm not sure why this hasn't hurt
us before the most recent change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4395)
<!-- Reviewable:end -->
