### PR TITLE
Remove PNG-RISE contact information boilerplate as requested (BL-9546)

### DIFF
--- a/src/BloomBrowserUI/branding/PNG-RISE/branding.json
+++ b/src/BloomBrowserUI/branding/PNG-RISE/branding.json
@@ -1,13 +1,6 @@
 {
     "presets": [
         {
-            "//note": "Normally we would set this to outside-back-cover-branding-top-html, but when this branding was introduced, we didn't have that option; we could only insert text into the edit box (data-book=outsideBackCover). If we were to change to the new system, all old books, which already had that inserted, would end up with two copies of this text.",
-            "data-book": "outsideBackCover",
-            "lang": "en",
-            "content": "<p></p><p>If you have feedback (spelling corrections, sentence order, or other changes)</p><p>that should be made to this book, please contact SIL PNG.<p></p></p><p>Email: mytalkingbooks@gmail.com</p><p>Or stop by an SIL office</p><p></p><p></p><p><b> Go to <u>www.mytalkingbooks.org</u> for more books. </b></p>",
-            "condition": "always"
-        },
-        {
             "data-book": "title-page-branding-bottom-html",
             "lang": "*",
             "content": "<img class='branding' src='title-page.png'/>",


### PR DESCRIPTION
This does nothing to remove it from existing books, but at least it will
stop introducing it automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4397)
<!-- Reviewable:end -->
