### PR TITLE
Disable videos in preview mode (BL-9845)

### DIFF
--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -35,7 +35,7 @@
         "watchBookPreviewLess": "less-watch-compiler bookPreview ../../output/browser/bookPreview",
         "watchPageChooserLess": "less-watch-compiler pageChooser ../../output/browser/pageChooser",
         "watchProblemDialogLess": "less-watch-compiler problemDialog ../../output/browser/problemDialog",
-        "watch": "npm-run-all --parallel watchBrandingLess watchTemplatesLess watchBookEditLess watchBookLayoutLess watchBrandingFiles watchPageChooserLess watchProblemDialogLess watchCode",
+        "watch": "npm-run-all --parallel watchBrandingLess watchTemplatesLess watchBookEditLess watchBookLayoutLess watchBookPreviewLess watchBrandingFiles watchPageChooserLess watchProblemDialogLess watchCode",
         "gitSemiClean": "git clean -X --dry-run --exclude='!node_modules'",
         "gitSemiCleanForReal": "git clean -fX --exclude='!node_modules'",
         "tslint": "tslint --project tsconfig.json",

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -745,6 +745,10 @@ namespace Bloom.Book
 
 			AddPreviewJavascript(previewDom);
 			previewDom.AddPublishClassToBody("preview");
+
+			// Not needed for preview mode, so just remove them to reduce memory usage.
+			RemoveVideos(previewDom);
+			
 			return previewDom;
 		}
 
@@ -2312,7 +2316,7 @@ namespace Bloom.Book
 		/// <returns></returns>
 		public bool HasVideos()
 		{
-			return OurHtmlDom.SelectVideoElements()
+			return OurHtmlDom.SelectVideoSources()
 				.Cast<XmlElement>().Any(NonTrivialVideoFileExists);
 		}
 
@@ -2459,6 +2463,25 @@ namespace Bloom.Book
 		{
 			dom.AddJavascriptFile("commonBundle.js".ToLocalhost());
 			dom.AddJavascriptFile("bookPreviewBundle.js".ToLocalhost());
+		}
+
+		/// <summary>
+		/// Removes each video element contained in DOM. Useful for preview mode, where the videos will never actually play.
+		/// </summary>
+		/// <param name="dom">The dom containing the video elements.</param>
+		private void RemoveVideos(HtmlDom dom)
+		{
+			var videos = dom.SelectVideoSources();
+
+			for (int i = 0; i < (videos?.Count ?? 0); ++i)
+			{
+				var videoSrc = videos[i];
+				var videoTag = videoSrc.ParentNode;
+
+				// Actually removing the video element (unsurprisingly) saves even more memory than doing "display:none" on it.
+				// FYI, either of these methods should cause the placeholder image to appear instead.
+				videoTag?.ParentNode.RemoveChild(videoTag);
+			}
 		}
 
 		public IEnumerable<IPage> GetPages()

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -2204,7 +2204,7 @@ namespace Bloom.Book
 			return element.SelectSingleNode(BookStorage.ComicalXpath) != null;
 		}
 
-		public XmlNodeList SelectVideoElements()
+		public XmlNodeList SelectVideoSources()
 		{
 			return RawDom.SafeSelectNodes("//div[contains(@class, 'bloom-videoContainer')]//source");
 		}

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -43,6 +43,31 @@ namespace BloomTests.Book
 		}
 
 		[Test]
+		public void GetPreviewHtmlFileForWholeBook_BookHasVideo_PreviewRemovesVideo()
+		{
+			var htmlSourceBook = $@"<html><head></head><body>
+					<div class='bloom-page numberedPage' id='page1' data-page-number='1'>
+						<div class='bloom-videoContainer'>
+							<video>
+								<source src='video/fakeVideo.mp4'>
+								</source>
+							</video>
+						</div>
+					</div>
+				</body></html>";
+			var doc = new XmlDocument();
+			doc.LoadXml(htmlSourceBook);
+			var dom = new HtmlDom(doc);
+			_storage.SetupGet(x => x.Dom).Returns(() => dom);
+
+			// System Under Test
+			var result = CreateBook().GetPreviewHtmlFileForWholeBook();
+
+			// Verification
+			AssertThatXmlIn.Dom(result.RawDom.StripXHtmlNameSpace()).HasSpecifiedNumberOfMatchesForXpath("//video", 0);
+		}
+
+		[Test]
 		public void SetCoverColor_WorksWithCaps()
 		{
 			var newValue = "#777777";

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -1447,7 +1447,7 @@ p {
 	</div>
 </html>");
 
-			XmlNodeList result = htmlDom.SelectVideoElements();
+			XmlNodeList result = htmlDom.SelectVideoSources();
 
 			Assert.AreEqual(1, result.Count, "Count does not match");
 			Assert.AreEqual("vidSource", ((XmlElement)result[0]).GetAttribute("id"), "ID does not match.");


### PR DESCRIPTION
The thought is to reduce unnecessary memory allocation/garbage collection required by the book preview.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4409)
<!-- Reviewable:end -->
