### PR TITLE
Fix package build failure on Jenkins (20210504)

### DIFF
--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -1028,7 +1028,7 @@ namespace BloomTests.Book
 					</div>
 				</div>
 				</body></html>");
-			var collectionSettings = CreateCollection(Language1Iso639Code: "etr", Language1Name:null, "en",null,"tpi",null);
+			var collectionSettings = CreateCollection("etr", null, "en", null, "tpi", null);
 			var data = new BookData(dom, collectionSettings, null);
 			data.SynchronizeDataItemsThroughoutDOM();
 			XmlElement nationalTitle =


### PR DESCRIPTION
The C# compiler on jenkins was reporting Book/BookDataTests.cs(1031,94):
 error CS1738: Named argument specifications must appear after all fixed
 arguments have been specified. Please use language version 7.2 or
 greater to allow non-trailing named arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4427)
<!-- Reviewable:end -->
