### PR TITLE
WebsocketManager refactor

### DIFF
--- a/src/BloomBrowserUI/bookPreview/BookPreviewPanel.tsx
+++ b/src/BloomBrowserUI/bookPreview/BookPreviewPanel.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { useState } from "react";
 import { BloomApi } from "../utils/bloomApi";
 import "./BookPreviewPanel.less";
-import { useWebSocketListenerForOneMessage } from "../utils/WebSocketManager";
+import { useSubscribeToWebSocketForStringMessage } from "../utils/WebSocketManager";
 import { TeamCollectionBookStatusPanel } from "../teamCollection/TeamCollectionBookStatusPanel";
 
 const urlParams = new URLSearchParams(window.location.search);
@@ -21,8 +21,10 @@ export const BookPreviewPanel: React.FunctionComponent = props => {
         );
     }, [previewUrl]);
 
-    useWebSocketListenerForOneMessage("bookStatus", "changeBook", message =>
-        setPreviewUrl(message)
+    useSubscribeToWebSocketForStringMessage(
+        "bookStatus",
+        "changeBook",
+        message => setPreviewUrl(message)
     );
 
     return (

--- a/src/BloomBrowserUI/performance/PerformanceLogPage.tsx
+++ b/src/BloomBrowserUI/performance/PerformanceLogPage.tsx
@@ -1,10 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import { BloomApi } from "../utils/bloomApi";
-import {
-    useWebSocketListenerForOneMessage,
-    useWebSocketListenerForOneObject
-} from "../utils/WebSocketManager";
+import { useSubscribeToWebSocketForObject } from "../utils/WebSocketManager";
 import "./PerformanceLogPage.less";
 import { ScatterPlot } from "@nivo/scatterplot";
 import ReactDOM = require("react-dom");
@@ -39,7 +36,7 @@ export const PerformanceLogPage: React.FunctionComponent<{
         setMeasurements(earlierMeasurements);
     }, earlierMeasurements);
 
-    useWebSocketListenerForOneObject<IMeasurement>(
+    useSubscribeToWebSocketForObject<IMeasurement>(
         // this prop is just used during testing when there is no server (i.e. storybook).
         props.webSocketContext ?? "performance",
         "event",
@@ -49,7 +46,6 @@ export const PerformanceLogPage: React.FunctionComponent<{
             });
         }
     );
-    //const websocket = new WebSocket("ws://127.0.0.1:8090");
 
     const allMeasurements = earlierMeasurements.concat(measurements);
     return (

--- a/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
@@ -18,8 +18,8 @@ import { ThemeProvider } from "@material-ui/styles";
 import theme from "../../bloomMaterialUITheme";
 import { StorybookContext } from "../../.storybook/StoryBookContext";
 import {
-    useWebSocketListenerForOneMessage,
-    useWebSocketListenerForOneEvent
+    useSubscribeToWebSocketForStringMessage,
+    useSubscribeToWebSocketForEvent
 } from "../../utils/WebSocketManager";
 import { BloomApi } from "../../utils/bloomApi";
 import HelpLink from "../../react_components/helpLink";
@@ -78,7 +78,7 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
         "publish/android/canRotate",
         false
     );
-    useWebSocketListenerForOneMessage(
+    useSubscribeToWebSocketForStringMessage(
         "publish-android",
         "androidPreview",
         url => {
@@ -89,7 +89,7 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
     const usbWorking = useL10n("Publishing", "PublishTab.Common.Publishing");
     const wifiWorking = useL10n("Publishing", "PublishTab.Common.Publishing");
 
-    useWebSocketListenerForOneEvent(
+    useSubscribeToWebSocketForEvent(
         "publish-android",
         "publish/android/state",
         e => {

--- a/src/BloomBrowserUI/publish/commonPublish/PublishProgressDialog.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/PublishProgressDialog.tsx
@@ -7,7 +7,7 @@ import {
 import { BloomApi } from "../../utils/bloomApi";
 import WebSocketManager, {
     IBloomWebSocketProgressEvent,
-    useWebSocketListenerForOneEvent
+    useSubscribeToWebSocketForEvent
 } from "../../utils/WebSocketManager";
 
 export const PublishProgressDialog: React.FunctionComponent<{
@@ -85,7 +85,7 @@ export const PublishProgressDialog: React.FunctionComponent<{
         });
     }, []);
 
-    useWebSocketListenerForOneEvent(
+    useSubscribeToWebSocketForEvent(
         props.webSocketClientContext,
         "message",
         e => {

--- a/src/BloomBrowserUI/publish/ePUBPublish/ePUBPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ePUBPublish/ePUBPublishScreen.tsx
@@ -13,8 +13,8 @@ import ThemeProvider from "@material-ui/styles/ThemeProvider";
 import theme from "../../bloomMaterialUITheme";
 import { StorybookContext } from "../../.storybook/StoryBookContext";
 import {
-    useWebSocketListenerForOneMessage,
-    useWebSocketListenerForOneEvent
+    useSubscribeToWebSocketForStringMessage,
+    useSubscribeToWebSocketForEvent
 } from "../../utils/WebSocketManager";
 import BloomButton from "../../react_components/bloomButton";
 import { EPUBHelpGroup } from "./ePUBHelpGroup";
@@ -57,7 +57,7 @@ const EPUBPublishScreenInternal: React.FunctionComponent<{
             : "" // otherwise, wait for the websocket to deliver a url when the c# has finished creating the bloomd
     );
 
-    useWebSocketListenerForOneEvent(
+    useSubscribeToWebSocketForEvent(
         "publish-epub",
         "startingEbookCreation",
         e => {
@@ -67,11 +67,15 @@ const EPUBPublishScreenInternal: React.FunctionComponent<{
 
     // The c# api responds to changes of settings by auto-starting a new epub build. When
     // it is done, it calls this (but actually the same url, alas).
-    useWebSocketListenerForOneMessage("publish-epub", "newEpubReady", url => {
-        // add a random component so that react will reload the iframe
-        setBookUrl(url + "&random=" + Math.random().toString());
-        setClosePending(true);
-    });
+    useSubscribeToWebSocketForStringMessage(
+        "publish-epub",
+        "newEpubReady",
+        url => {
+            // add a random component so that react will reload the iframe
+            setBookUrl(url + "&random=" + Math.random().toString());
+            setClosePending(true);
+        }
+    );
 
     return (
         <>

--- a/src/BloomBrowserUI/teamCollection/CreateTeamCollection.tsx
+++ b/src/BloomBrowserUI/teamCollection/CreateTeamCollection.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from "react";
 import ReactDOM = require("react-dom");
 import { BloomApi } from "../utils/bloomApi";
 import WebSocketManager, {
-    useWebSocketListenerForOneEvent
+    useSubscribeToWebSocketForEvent
 } from "../utils/WebSocketManager";
 import BloomButton from "../react_components/bloomButton";
 import "./CreateTeamCollection.less";
@@ -31,7 +31,7 @@ export const CreateTeamCollection: React.FunctionComponent<IProps> = props => {
         setRepoFolderPath(e.repoFolderPath);
         setProblemReport(e.problem);
     };
-    useWebSocketListenerForOneEvent(
+    useSubscribeToWebSocketForEvent(
         "teamCollectionCreate",
         "shared-folder-path",
         listener,

--- a/src/BloomBrowserUI/teamCollection/TeamCollectionBookStatusPanel.tsx
+++ b/src/BloomBrowserUI/teamCollection/TeamCollectionBookStatusPanel.tsx
@@ -8,7 +8,7 @@ import "./TeamCollectionBookStatusPanel.less";
 import { StatusPanelCommon, getLockedInfoChild } from "./statusPanelCommon";
 import BloomButton from "../react_components/bloomButton";
 import { BloomAvatar } from "../react_components/bloomAvatar";
-import { useWebSocketListenerForOneEvent } from "../utils/WebSocketManager";
+import { useSubscribeToWebSocketForEvent } from "../utils/WebSocketManager";
 
 // The panel that shows the book preview and settings in the collection tab in a Team Collection.
 
@@ -89,7 +89,7 @@ export const TeamCollectionBookStatusPanel: React.FunctionComponent = props => {
         );
     }, [reload]);
 
-    useWebSocketListenerForOneEvent("bookStatus", "reload", () =>
+    useSubscribeToWebSocketForEvent("bookStatus", "reload", () =>
         setReload(oldValue => oldValue + 1)
     );
 

--- a/src/BloomBrowserUI/utils/WebSocketManager.ts
+++ b/src/BloomBrowserUI/utils/WebSocketManager.ts
@@ -42,7 +42,7 @@ function useWebSocketListenerInner<T>(
     }, []);
 }
 
-export function useWebSocketListenerForOneEvent(
+export function useSubscribeToWebSocketForEvent(
     clientContext: string,
     eventId: string,
     listener: (e: IBloomWebSocketEvent) => void,
@@ -56,7 +56,7 @@ export function useWebSocketListenerForOneEvent(
         onlyCallListenerIfMessageIsTruthy ? e => !!e.message : e => true
     );
 }
-export function useWebSocketListenerForOneMessage(
+export function useSubscribeToWebSocketForStringMessage(
     clientContext: string,
     eventId: string,
     listener: (message: string) => void
@@ -66,10 +66,13 @@ export function useWebSocketListenerForOneMessage(
         eventId,
         listener,
         e => e.message!,
-        e => !!e.message
+        e => !!e.message // ignore if no message
     );
 }
-export function useWebSocketListenerForOneObject<T>(
+
+// Subscribe to an event where the message string is holding a JSON object
+// which this will parse.
+export function useSubscribeToWebSocketForObject<T>(
     clientContext: string,
     eventId: string,
     listener: (message: T) => void
@@ -78,9 +81,11 @@ export function useWebSocketListenerForOneObject<T>(
         clientContext,
         eventId,
         listener,
-        e => JSON.parse(e.message!) as T
+        e => JSON.parse(e.message!) as T,
+        e => !!e.message // ignore if no message
     );
 }
+
 // This class manages a websocket, currently at the WebSocketManager.socketMap level, currently with
 // a fixed name. (Possible enhancement: support top WebSocketManager.socketMap level).
 // You can add listeners (for "message") with addListener(),


### PR DESCRIPTION
The point of the refactoring was to introduce an automatic disconnect from listening when components are dismounted. That code is still there, and we do want it, but I commented it out because it breaks Bloom Reader Publish preview. Will make a 5.1 card to revisit this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4437)
<!-- Reviewable:end -->
