### PR TITLE
Don't allow Team Collections to be renamed (BL-9810)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
@@ -1,3 +1,6 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
+
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { BloomApi } from "../../../utils/bloomApi";
@@ -90,6 +93,15 @@ export class ImageDescriptionToolControls extends React.Component<
                             onCheckChanged={checked =>
                                 this.onCheckChanged(checked)
                             }
+                            // This is a rather ugly way of reaching inside our checkbox class,
+                            // but the usual box positioning just doesn't look right in this context.
+                            css={css`
+                                input {
+                                    margin-right: 3px;
+                                    align-self: center;
+                                    margin-top: -4px;
+                                }
+                            `}
                         >
                             This image should not be described.
                         </Checkbox>

--- a/src/BloomBrowserUI/bookEdit/toolbox/impairmentVisualizer/impairmentVisualizer.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/impairmentVisualizer/impairmentVisualizer.less
@@ -12,10 +12,6 @@
     flex-direction: column;
     justify-content: space-between;
 
-    .checkBox {
-        margin-top: 10px;
-    }
-
     .radioLabel {
         display: inline-block;
         max-width: 120px;
@@ -28,9 +24,6 @@
     .radioInput {
         vertical-align: top;
         margin-top: 3px; // spread the buttons apart a bit: can overlap on Linux (BL-6520)
-    }
-    .colorBlindCheckBox {
-        margin-bottom: 6px;
     }
 }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/impairmentVisualizer/impairmentVisualizer.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/impairmentVisualizer/impairmentVisualizer.tsx
@@ -1,3 +1,6 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
+
 import * as React from "react";
 import ToolboxToolReactAdaptor from "../toolboxToolReactAdaptor";
 import { Div } from "../../../react_components/l10nComponents";
@@ -39,22 +42,26 @@ export class ImpairmentVisualizerControls extends React.Component<{}, IState> {
                         your images would look with various visual impairments.
                     </Div>
                     <ApiBackedCheckbox
-                        className="checkBox"
                         apiEndpoint="accessibilityCheck/cataracts"
                         l10nKey="EditTab.Toolbox.ImpairmentVisualizer.Cataracts"
                         onCheckChanged={simulate =>
                             this.updateCataracts(simulate)
                         }
+                        css={css`
+                            margin-bottom: 6px;
+                        `}
                     >
                         Cataracts
                     </ApiBackedCheckbox>
                     <ApiBackedCheckbox
-                        className="checkBox colorBlindCheckBox"
                         apiEndpoint="accessibilityCheck/colorBlindness"
                         l10nKey="EditTab.Toolbox.ImpairmentVisualizer.ColorBlindness"
                         onCheckChanged={simulate =>
                             this.updateColorBlindnessCheck(simulate)
                         }
+                        css={css`
+                            margin-bottom: 2px;
+                        `}
                     >
                         Color Blindness
                     </ApiBackedCheckbox>

--- a/src/BloomBrowserUI/bookEdit/toolbox/motion/motionTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/motion/motionTool.tsx
@@ -1121,7 +1121,7 @@ export class MotionControl extends React.Component<IMotionProps, IMotionState> {
                 <Checkbox
                     id="motion"
                     name="motion"
-                    wrapClassName="enable-checkbox"
+                    className="enable-checkbox"
                     l10nKey="EditTab.Toolbox.Motion.ThisPage"
                     // tslint:disable-next-line:max-line-length
                     l10nComment="Motion here refers to panning and zooms image when it is viewed in Bloom Reader. Google 'Ken Burns effect' to see exactly what we mean."

--- a/src/BloomBrowserUI/pageChooser/page-chooser.less
+++ b/src/BloomBrowserUI/pageChooser/page-chooser.less
@@ -13,7 +13,6 @@
 // Intended to be similar to HighlightColor when over the default dialog background, but I haven't
 // tried to figure out exactly what would achieve that.
 @TransparentHiglightColor: hsla(186.9, 49.1%, 65%, 0.45);
-@CheckboxPadding: 20px; // used to get hanging indent to work on convert whole book checkbox
 @VerticalMarginBetweenPreviewItems: 10px;
 
 // The badge in Add Page/Change Layout on pages that are BE-only is larger than the ones
@@ -266,9 +265,6 @@ body {
     margin-left: @PreviewPaneLeftPadding;
     margin-right: @PreviewPaneLeftPadding;
     margin-top: @VerticalMarginBetweenPreviewItems;
-    display: block;
-    padding-left: @CheckboxPadding;
-    text-indent: -@CheckboxPadding;
     .disabled {
         color: @bloom-buff;
     }

--- a/src/BloomBrowserUI/pageChooser/selectedTemplatePageControls.tsx
+++ b/src/BloomBrowserUI/pageChooser/selectedTemplatePageControls.tsx
@@ -84,7 +84,7 @@ export const SelectedTemplatePageControls: React.FunctionComponent<ISelectedTemp
                     <div>
                         <Checkbox
                             id="convertWholeBookCheckbox"
-                            wrapClassName="convertWholeBook"
+                            className="convertWholeBook"
                             l10nKey="EditTab.AddPageDialog.ChooseLayoutConvertBookCheckbox"
                             name="WholeBook"
                             checked={convertWholeBookChecked}
@@ -111,7 +111,7 @@ export const SelectedTemplatePageControls: React.FunctionComponent<ISelectedTemp
                                     name="Continue"
                                     checked={continueChecked}
                                     tristate={false}
-                                    wrapClassName="convertAnyway"
+                                    className="convertAnyway"
                                     onCheckChanged={() =>
                                         setContinueChecked(!continueChecked)
                                     }

--- a/src/BloomBrowserUI/react_components/checkbox.tsx
+++ b/src/BloomBrowserUI/react_components/checkbox.tsx
@@ -1,3 +1,6 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
+
 import * as React from "react";
 import {
     ILocalizationProps,
@@ -8,9 +11,9 @@ import {
 interface ICheckboxProps extends ILocalizationProps {
     id?: string;
     name?: string;
-    className?: string;
+    inputClassName?: string;
     disabled?: boolean;
-    wrapClassName?: string;
+    className?: string;
     // toggle between on, off, and unknown
     tristate?: boolean;
     // Note: checked can be undefined, if tristate==true
@@ -51,11 +54,24 @@ export class Checkbox extends LocalizableElement<ICheckboxProps, {}> {
 
     public render() {
         return (
-            <div className={this.props.wrapClassName}>
+            <div
+                // To allow emotion css to apply to the Checkbox class, it's important that our main
+                // div is given the className of the Checkbox. (An earlier version of this code
+                // had a property wrapClassName for this, and passed className to the input
+                // element. This produced bizarre results with emotion. If you really need to apply
+                // a class to the input element from outside, it's probably best done with emotion
+                // using a child element rule. If you must pass in a className for that element,
+                // props.inputClassName is available.)
+                className={this.props.className}
+                css={css`
+                    display: flex;
+                    align-items: baseline;
+                `}
+            >
                 <input
                     id={this.props.id}
                     type="checkbox"
-                    className={this.props.className}
+                    className={this.props.inputClassName}
                     name={this.props.name}
                     disabled={this.props.disabled}
                     checked={this.props.checked}
@@ -63,10 +79,12 @@ export class Checkbox extends LocalizableElement<ICheckboxProps, {}> {
                         this.onChange(event.target);
                     }}
                     ref={input => (this.input = input)}
+                    css={css`
+                        margin-right: 10px;
+                    `}
                 />
                 <Label
-                    l10nKey={this.props.l10nKey}
-                    alreadyLocalized={this.props.alreadyLocalized}
+                    {...this.props}
                     onClick={() => this.onLabelClicked()}
                     className={this.props.disabled ? "disabled" : ""}
                 >

--- a/src/BloomBrowserUI/teamCollection/CreateTeamCollection.tsx
+++ b/src/BloomBrowserUI/teamCollection/CreateTeamCollection.tsx
@@ -21,10 +21,9 @@ import {
     useSetupBloomDialog
 } from "../react_components/BloomDialog/BloomDialog";
 import { useL10n } from "../react_components/l10nHooks";
+import { Checkbox } from "../react_components/checkbox";
 
 // Contents of a dialog launched from TeamCollectionSettingsPanel Create Team Collection button.
-
-export let showCreateTeamCollectionDialog: () => void;
 
 export const CreateTeamCollectionDialog: React.FunctionComponent<{
     errorForTesting?: string;
@@ -55,12 +54,21 @@ export const CreateTeamCollectionDialog: React.FunctionComponent<{
         "Create a Team Collection",
         "TeamCollection.CreateTeamCollection"
     );
+
+    const [collectionName] = BloomApi.useApiString(
+        "teamCollection/getCollectionName",
+        ""
+    );
+    const [boxesChecked, setBoxesChecked] = useState(0);
     const {
         showDialog,
         closeDialog,
         propsForBloomDialog
     } = useSetupBloomDialog(props.dialogEnvironment);
-    showCreateTeamCollectionDialog = showDialog;
+
+    const checkChanged = (newVal: boolean) => {
+        setBoxesChecked(oldCount => (newVal ? oldCount + 1 : oldCount - 1));
+    };
     return (
         <BloomDialog {...propsForBloomDialog}>
             <DialogTitle title={`${dialogTitle}`} />
@@ -119,30 +127,52 @@ export const CreateTeamCollectionDialog: React.FunctionComponent<{
                         Choose shared folder
                     </BloomButton>
                 </div>
-
-                {errorMessage ? (
-                    <ErrorBox>{errorMessage}</ErrorBox>
-                ) : (
-                    <CautionBox>
-                        <Div
-                            l10nKey="TeamCollection.MustBeDoneOnce"
-                            temporarilyDisableI18nWarning={true}
-                        >
-                            This can only be done once, by a single member of
-                            the team. Bloom will remember that you are the one
-                            who created it. When other people join this Team
-                            Collection, you will be the only one allowed to
-                            modify collection settings.
-                        </Div>
-                    </CautionBox>
-                )}
+                <Checkbox
+                    l10nKey="TeamCollection.NameWillWork"
+                    l10nParam0={collectionName}
+                    onCheckChanged={checkChanged}
+                    temporarilyDisableI18nWarning={true}
+                    css={css`
+                        margin-top: 5px;
+                    `}
+                >
+                    The name, "%0", will be a good one for the whole team, and
+                    will not be confused with other collections. I understand
+                    that I will not be able to change this name, later.
+                </Checkbox>
+                <Checkbox
+                    l10nKey="TeamCollection.OnlyOneCreator"
+                    onCheckChanged={checkChanged}
+                    temporarilyDisableI18nWarning={true}
+                    css={css`
+                        margin-top: 20px;
+                    `}
+                >
+                    I am the only person on the team creating this Team
+                    Collection. The rest of the team will join this collection.
+                </Checkbox>
+                <Checkbox
+                    l10nKey="TeamCollection.OnlyCreatorCanChangeSettings"
+                    onCheckChanged={checkChanged}
+                    temporarilyDisableI18nWarning={true}
+                    css={css`
+                        margin-top: 20px;
+                        margin-bottom: 15px;
+                    `}
+                >
+                    I understand that as the creator of the project, I will be
+                    the only person who can change Collection Settings.
+                </Checkbox>
+                {errorMessage && <ErrorBox>{errorMessage}</ErrorBox>}
             </DialogMiddle>
             <DialogBottomButtons>
                 <BloomButton
                     id="create-and-restart"
                     l10nKey="TeamCollection.CreateAndRestart"
                     hasText={true}
-                    enabled={!!repoFolderPath && !errorMessage}
+                    enabled={
+                        !!repoFolderPath && !errorMessage && boxesChecked == 3
+                    }
                     temporarilyDisableI18nWarning={true}
                     onClick={() => {
                         BloomApi.post("teamCollection/createTeamCollection");
@@ -150,7 +180,9 @@ export const CreateTeamCollectionDialog: React.FunctionComponent<{
                 >
                     Create &amp; Restart
                 </BloomButton>
-                <DialogCancelButton onClick={closeDialog} />
+                <DialogCancelButton
+                    onClick={() => BloomApi.post("common/closeReactDialog")}
+                />
             </DialogBottomButtons>
         </BloomDialog>
     );

--- a/src/BloomBrowserUI/teamCollection/TeamCollectionSettingsPanel.tsx
+++ b/src/BloomBrowserUI/teamCollection/TeamCollectionSettingsPanel.tsx
@@ -16,10 +16,7 @@ import { kBloomBlue } from "../bloomMaterialUITheme";
 import BloomButton from "../react_components/bloomButton";
 
 import StarIcon from "@material-ui/icons/Star";
-import {
-    CreateTeamCollectionDialog,
-    showCreateTeamCollectionDialog
-} from "./CreateTeamCollection";
+import { CreateTeamCollectionDialog } from "./CreateTeamCollection";
 //import joiningImage from "../images/joining-team-collection.png";
 
 // The contents of the Team Collection panel of the Settings dialog.
@@ -138,7 +135,11 @@ export const TeamCollectionSettingsPanel: React.FunctionComponent = props => {
                     enabled={true}
                     hasText={true}
                     variant="outlined"
-                    onClick={() => showCreateTeamCollectionDialog()}
+                    onClick={() =>
+                        BloomApi.post(
+                            "teamCollection/showCreateTeamCollectionDialog"
+                        )
+                    }
                     temporarilyDisableI18nWarning={true}
                 >
                     Create a Team Collection
@@ -182,7 +183,6 @@ export const TeamCollectionSettingsPanel: React.FunctionComponent = props => {
                                 {repoFolderPath
                                     ? isTeamCollection
                                     : isNotTeamCollection}
-                                <CreateTeamCollectionDialog />
                             </React.Fragment>
                         )}
                     </BloomEnterpriseAvailableContext.Consumer>

--- a/src/BloomBrowserUI/utils/WireUpReact.ts
+++ b/src/BloomBrowserUI/utils/WireUpReact.ts
@@ -8,6 +8,7 @@ import { AutoUpdateSoftwareDialog } from "../react_components/AutoUpdateSoftware
 import { ProblemDialog } from "../problemDialog/ProblemDialog";
 import { ProgressDialog } from "../react_components/Progress/ProgressDialog";
 import { IBloomDialogEnvironmentParams } from "../react_components/BloomDialog/BloomDialog";
+import { CreateTeamCollectionDialog } from "../teamCollection/CreateTeamCollection";
 
 // this is a bummer... haven't figured out how to do a lookup just from the string... have to have this map
 const knownComponents = {
@@ -17,7 +18,8 @@ const knownComponents = {
     JoinTeamCollectionDialog: JoinTeamCollectionDialog,
     AutoUpdateSoftwareDialog: AutoUpdateSoftwareDialog,
     ProblemDialog: ProblemDialog,
-    ProgressDialog: ProgressDialog
+    ProgressDialog: ProgressDialog,
+    CreateTeamCollectionDialog: CreateTeamCollectionDialog
 };
 
 // This is called from an html file created in the c# ReactControl class.

--- a/src/BloomExe/Collection/CollectionSettingsDialog.Designer.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.Designer.cs
@@ -64,6 +64,7 @@ namespace Bloom.Collection
 			this._language1FontLabel = new System.Windows.Forms.Label();
 			this._xmatterPackLabel = new System.Windows.Forms.Label();
 			this.tabPage3 = new System.Windows.Forms.TabPage();
+			this._noRenameTeamCollectionLabel = new System.Windows.Forms.Label();
 			this._bloomCollectionName = new System.Windows.Forms.TextBox();
 			this.label1 = new System.Windows.Forms.Label();
 			this._districtText = new System.Windows.Forms.TextBox();
@@ -549,6 +550,7 @@ namespace Bloom.Collection
 			// 
 			// tabPage3
 			// 
+			this.tabPage3.Controls.Add(this._noRenameTeamCollectionLabel);
 			this.tabPage3.Controls.Add(this._bloomCollectionName);
 			this.tabPage3.Controls.Add(this.label1);
 			this.tabPage3.Controls.Add(this._districtText);
@@ -566,6 +568,18 @@ namespace Bloom.Collection
 			this.tabPage3.TabIndex = 2;
 			this.tabPage3.Text = "Project Information";
 			this.tabPage3.UseVisualStyleBackColor = true;
+			// 
+			// _noRenameTeamCollectionLabel
+			// 
+			this._L10NSharpExtender.SetLocalizableToolTip(this._noRenameTeamCollectionLabel, null);
+			this._L10NSharpExtender.SetLocalizationComment(this._noRenameTeamCollectionLabel, null);
+			this._L10NSharpExtender.SetLocalizingId(this._noRenameTeamCollectionLabel, "NoRenameTeamCollection");
+			this._noRenameTeamCollectionLabel.Location = new System.Drawing.Point(32, 278);
+			this._noRenameTeamCollectionLabel.Name = "_noRenameTeamCollectionLabel";
+			this._noRenameTeamCollectionLabel.Size = new System.Drawing.Size(291, 95);
+			this._noRenameTeamCollectionLabel.TabIndex = 23;
+			this._noRenameTeamCollectionLabel.Text = "The collection name cannot be changed because this is a Team Collection. Contact " +
+    "the Bloom team for more information.";
 			// 
 			// _bloomCollectionName
 			// 
@@ -955,5 +969,6 @@ namespace Bloom.Collection
 		private web.ReactControl reactControl1;
 		private Label label2;
 		private CheckBox _allowTeamCollection;
+		private Label _noRenameTeamCollectionLabel;
 	}
 }

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -82,7 +82,8 @@ namespace Bloom.Collection
 			TeamCollectionApi.TheOneInstance.SetCallbackToReopenCollection(() =>
 			{
 				_restartRequired = true;
-				_okButton_Click(null, null);
+				ReactDialog.CloseCurrentModal(); // close the top Create dialog
+				_okButton_Click(null, null); // close this dialog
 			});
 
 			UpdateDisplay();
@@ -90,6 +91,15 @@ namespace Bloom.Collection
 			if (CollectionSettingsApi.FixEnterpriseSubscriptionCodeMode)
 			{
 				_tab.SelectedTab = _enterpriseTab;
+			}
+
+			if (tcManager.CurrentCollectionEvenIfDisconnected == null)
+			{
+				_noRenameTeamCollectionLabel.Visible = false;
+			}
+			else
+			{
+				_bloomCollectionName.Enabled = false;
 			}
 		}
 

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -187,10 +187,15 @@ namespace Bloom.TeamCollection
 				try
 				{
 					var bookFolderName = Path.GetFileName(path);
-					var status = GetStatus(bookFolderName);
+					var statusString = GetBookStatusJsonFromRepo(bookFolderName);
+					// don't just use GetStatus().checksum here, since if the book isn't in the repo but DOES have a local
+					// status, perhaps from being previously in another TC, it will retrieve the local status, which
+					// will have the same checksum as localStatus, and we will wrongly conclude we don't need to copy
+					// the book to the repo.
+					var repoChecksum = string.IsNullOrEmpty(statusString) ? null : BookStatus.FromJson(statusString).checksum;
 					var localStatus = GetLocalStatus(bookFolderName);
 					var localHtmlFilePath = Path.Combine(path, BookStorage.FindBookHtmlInFolder(path));
-					if ((status?.checksum == null || status.checksum != localStatus?.checksum) && RobustFile.Exists(localHtmlFilePath))
+					if ((repoChecksum == null || repoChecksum != localStatus?.checksum) && RobustFile.Exists(localHtmlFilePath))
 					{
 						progress.MessageWithParams("SendingFile", "", "Adding {0} to the collection", ProgressKind.Progress, bookFolderName);
 						PutBook(path);

--- a/src/BloomExe/TeamCollection/TeamCollectionApi.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionApi.cs
@@ -52,6 +52,35 @@ namespace Bloom.TeamCollection
 			apiHandler.RegisterEndpointHandler("teamCollection/createTeamCollection", HandleCreateTeamCollection, true);
 			apiHandler.RegisterEndpointHandler("teamCollection/joinTeamCollection", HandleJoinTeamCollection, true);
 			apiHandler.RegisterEndpointHandler("teamCollection/getLog", HandleGetLog, false);
+			apiHandler.RegisterEndpointHandler("teamCollection/getCollectionName", HandleGetCollectionName, false);
+			apiHandler.RegisterEndpointHandler("teamCollection/showCreateTeamCollectionDialog", HandleShowCreateTeamCollectionDialog, true);
+		}
+
+		private void HandleShowCreateTeamCollectionDialog(ApiRequest request)
+		{
+			// If we create the dialog here, the request that launched it will still be active.
+			// This means our server is still locked, and all kinds of things the dialog wants to
+			// do through the server won't work, or have to be made to work unlocked.
+			// Instead, we arrange for it to be launched when the system is idle
+			// (and the server is no longer locked).
+			Application.Idle += ShowCreateTeamCollectionDialog;
+			request.PostSucceeded();
+		}
+
+		private void ShowCreateTeamCollectionDialog(object sender, EventArgs e)
+		{
+			Application.Idle -= ShowCreateTeamCollectionDialog;
+			using (var dlg = new ReactDialog("CreateTeamCollectionDialog"))
+			{
+				dlg.Width = 600;
+				dlg.Height = 580;
+				dlg.ShowDialog();
+			}
+		}
+
+		private void HandleGetCollectionName(ApiRequest request)
+		{
+			request.ReplyWithText(_settings.CollectionName);
 		}
 
 		private void HandleGetLog(ApiRequest request)


### PR DESCRIPTION
Also:
- fix a bug where our Checkbox class could not handle localization params
- Improve the way the Checkbox aligns the checkbox and label
- Make Checkbox class handle emotion css properly.
- Fix various other uses of Checkbox that this broke.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4449)
<!-- Reviewable:end -->
