### PR TITLE
BL-9044 Fix strange AutoUpdate behavior

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -115,7 +115,9 @@ namespace Bloom
 			// Bloom has several command line scenarios, without a coherent system for them.
 			// The following is how we will do things from now on, and things can be moved
 			// into this as time allows. See CommandLineOptions.cs.
-			if (args1.Length > 0 && new[] {"--help", "hydrate", "upload", "download", "getfonts", "changeLayout", "createArtifacts"}.Contains(args1[0])) //restrict using the commandline parser to cases were it should work
+			if (args1.Length > 0 &&
+			    new[] {"--help", "hydrate", "upload", "download", "getfonts", "changeLayout", "createArtifacts"}
+				    .Contains(args1[0])) //restrict using the commandline parser to cases were it should work
 			{
 #if !__MonoCS__
 				AttachConsole(-1);
@@ -124,7 +126,11 @@ namespace Bloom
 				RunningInConsoleMode = true;
 
 				var exitCode = CommandLine.Parser.Default.ParseArguments(args1,
-					new[] {typeof (HydrateParameters), typeof(UploadParameters), typeof(DownloadBookOptions), typeof (GetUsedFontsParameters), typeof(ChangeLayoutParameters), typeof(CreateArtifactsParameters)})
+						new[]
+						{
+							typeof(HydrateParameters), typeof(UploadParameters), typeof(DownloadBookOptions), typeof(GetUsedFontsParameters),
+							typeof(ChangeLayoutParameters), typeof(CreateArtifactsParameters)
+						})
 					.MapResult(
 						(HydrateParameters opts) => HydrateBookCommand.Handle(opts),
 						(UploadParameters opts) =>
@@ -141,15 +147,16 @@ namespace Bloom
 						errors =>
 						{
 							var code = 0;
-							foreach(var error in errors)
+							foreach (var error in errors)
 							{
-								if(!(error is HelpVerbRequestedError))
+								if (!(error is HelpVerbRequestedError))
 								{
 									Debug.WriteLine(error.ToString());
 									Console.WriteLine(error.ToString());
 									code = 1;
 								}
 							}
+
 							return code;
 						});
 				return exitCode; // we're done

--- a/src/BloomExe/Properties/Settings.Designer.cs
+++ b/src/BloomExe/Properties/Settings.Designer.cs
@@ -334,8 +334,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
-		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool AdobeColorProfileEula2003Accepted {
             get {
@@ -347,8 +347,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
-		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string BloomDeviceFileExportFolder {
             get {
@@ -360,8 +360,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
-		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string PublishAndroidMethod {
             get {
@@ -373,8 +373,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
-		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
         public int CurrentStage {
             get {
@@ -386,8 +386,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
-		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1")]
         public int CurrentLevel {
             get {
@@ -399,8 +399,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
-		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string CurrentBookPath {
             get {
@@ -412,8 +412,8 @@ namespace Bloom.Properties {
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
-		[global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
-		[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0")]
         public int AutoUpdateDialogShown {
             get {
@@ -440,7 +440,7 @@ namespace Bloom.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool AutoUpdate {
             get {
                 return ((bool)(this["AutoUpdate"]));

--- a/src/BloomExe/Properties/Settings.settings
+++ b/src/BloomExe/Properties/Settings.settings
@@ -99,7 +99,7 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="AutoUpdate" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/src/BloomExe/app.config
+++ b/src/BloomExe/app.config
@@ -98,7 +98,7 @@
                 <value>False</value>
             </setting>
             <setting name="AutoUpdate" serializeAs="String">
-                <value>False</value>
+                <value>True</value>
             </setting>
         </Bloom.Properties.Settings>
     </userSettings>
@@ -106,7 +106,7 @@
         <assert assertuienabled="true" />
     </system.diagnostics>
     <runtime>
-        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">			
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />


### PR DESCRIPTION
* an inadvertent change of setting default led to discovery
   of a most bizarre behavior.
* most of the designer changes are just whitespace
* Somehow 'AutoUpdate' behaves differently than any
   other Setting in Bloom. To get things working correctly
   we've had to migrate to 'BloomAutoUpdate' which works
   fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4450)
<!-- Reviewable:end -->
