### PR TITLE
Handle more cases of joining an existing TC (BL-9864)

### DIFF
--- a/src/BloomBrowserUI/problemDialog/theme.ts
+++ b/src/BloomBrowserUI/problemDialog/theme.ts
@@ -3,6 +3,7 @@ import { ProblemKind } from "./ProblemDialog";
 
 const kBloomBlue = "#1d94a4";
 const kNonFatalColor = "#F3AA18";
+export const kBloomRed = "#d65649";
 export const kindParams = {
     User: {
         dialogHeaderColor: kBloomBlue,

--- a/src/BloomBrowserUI/react_components/BloomDialog/BloomDialog.tsx
+++ b/src/BloomBrowserUI/react_components/BloomDialog/BloomDialog.tsx
@@ -165,6 +165,7 @@ export const DialogBottomLeftButtons: React.FunctionComponent<{}> = props => (
                 margin-right: ${kDialogPadding};
             }
              //padding-left: 0;//  would be good, if we could only apply it to un-outlined material buttons to make them left-align
+             // or margin-left:-8px, which left-aligns such buttons but keeps the padding, which is used in hover effects.
 
              button{
                  margin-left:0 !important;
@@ -242,6 +243,33 @@ export const DialogCancelButton: React.FunctionComponent<{
     </BloomButton>
 );
 
+export const DialogReportButton: React.FunctionComponent<{
+    className?: string; // also supports Emotion CSS
+    shortMessage: string;
+    messageGenerator: () => string;
+}> = props => (
+    <BloomButton
+        className={props.className}
+        l10nKey="ErrorReport.Report"
+        hasText={true}
+        enabled={true}
+        variant="text"
+        onClick={() =>
+            BloomApi.postJson("problemReport/showDialog", {
+                shortMessage: props.shortMessage,
+                message: props.messageGenerator()
+            })
+        }
+        css={css`
+            span {
+                color: ${kErrorBoxColor};
+            }
+        `}
+    >
+        Report
+    </BloomButton>
+);
+
 export const NoteBox: React.FunctionComponent<{}> = props => (
     <div
         css={css`
@@ -279,11 +307,13 @@ export const CautionBox: React.FunctionComponent<{}> = props => (
     </div>
 );
 
+export const kErrorBoxColor = "#eb3941";
+
 export const ErrorBox: React.FunctionComponent<{}> = props => (
     <div
         css={css`
             display: flex;
-            background-color: #eb3941;
+            background-color: ${kErrorBoxColor};
             padding: ${kDialogBottomPadding};
             margin-top: ${kDialogBottomPadding};
             &,

--- a/src/BloomBrowserUI/teamCollection/JoinTeamCollectionDialog.tsx
+++ b/src/BloomBrowserUI/teamCollection/JoinTeamCollectionDialog.tsx
@@ -3,27 +3,52 @@ import { jsx, css } from "@emotion/core";
 
 import * as React from "react";
 import { BloomApi } from "../utils/bloomApi";
-import { Div, P } from "../react_components/l10nComponents";
+import { Div, P, Span } from "../react_components/l10nComponents";
 import BloomButton from "../react_components/bloomButton";
 
 import {
     BloomDialog,
     DialogBottomButtons,
+    DialogBottomLeftButtons,
     DialogCancelButton,
     DialogMiddle,
+    DialogReportButton,
     DialogTitle,
+    ErrorBox,
     IBloomDialogEnvironmentParams,
     NoteBox,
     useSetupBloomDialog
 } from "../react_components/BloomDialog/BloomDialog";
 import { useL10n } from "../react_components/l10nHooks";
 
-// The contents of the dialog that comes up when double-clicking a .JoinBloomTC file.
-// Two versions (create new local collection, and merge with existing local) are both handled here.
+// Five variations are all handled here.
+enum JoinCollectionState {
+    // there is no local collection with the same name. Offer to create one.
+    "CreateNewCollection",
+    // there is a local collection with the same name that is not a TC. Offer to merge.
+    "MatchesExistingNonTeamCollection",
+    // we are already joined to a matching TC (same collection ID and already points here). Offer to open.
+    "MatchesExistingTeamCollection",
+    // there is an existing local collection of the same name joined to this TC (same ID) but at another location. Offer to report.
+    "MatchesExistingTeamCollectionElsewhere",
+    // there is an existing local collection of the same name joined to another TC (different ID). Offer to report.
+    "MatchesDifferentTeamCollection"
+}
+
+// In normal use (not storybook), this is a top-level component in a ReactDialog.
+// The props are set in C# and passed to the ReactDialog constructor in FolderTeamCollection.ShowJoinCollectionTeamDialog()
 
 export const JoinTeamCollectionDialog: React.FunctionComponent<{
     collectionName: string;
     existingCollection: boolean;
+    isAlreadyTcCollection: boolean;
+    isSameCollection: boolean;
+    isCurrentCollection: boolean; // that is, it already points at the one we are joining
+    existingCollectionFolder: string; // if there's an existing local collection, a path to it
+    conflictingCollection: string; // if there's a conflicting repo that the existing collection is connected to, a path to it.
+    joiningRepo?: string; // the repo we're trying to join
+    joiningGuid?: string;
+    localGuid?: string;
     dialogEnvironment?: IBloomDialogEnvironmentParams;
 }> = props => {
     const {
@@ -38,87 +63,238 @@ export const JoinTeamCollectionDialog: React.FunctionComponent<{
         undefined,
         props.collectionName
     );
+    const dialogState = getDialogStateFromProps();
+    const l10nJoinButtonKey = getL10nKeyForJoinButton();
+    const joinButtonEnglish = getJoinButtonEnglish();
+
+    function getDialogStateFromProps(): JoinCollectionState {
+        if (!props.existingCollection) {
+            return JoinCollectionState.CreateNewCollection;
+        }
+        if (!props.isAlreadyTcCollection) {
+            return JoinCollectionState.MatchesExistingNonTeamCollection;
+        }
+        if (!props.isSameCollection) {
+            return JoinCollectionState.MatchesDifferentTeamCollection;
+        }
+        if (props.isCurrentCollection) {
+            return JoinCollectionState.MatchesExistingTeamCollection;
+        } else {
+            return JoinCollectionState.MatchesExistingTeamCollectionElsewhere;
+        }
+    }
+
+    function getL10nKeyForJoinButton(): string {
+        return dialogState ===
+            JoinCollectionState.MatchesExistingNonTeamCollection
+            ? "TeamCollection.JoinAndMerge"
+            : dialogState === JoinCollectionState.MatchesExistingTeamCollection
+            ? "TeamCollection.Open"
+            : "TeamCollection.Join";
+    }
+
+    function getJoinButtonEnglish(): string {
+        return dialogState ===
+            JoinCollectionState.MatchesExistingNonTeamCollection
+            ? "Join and Merge"
+            : dialogState === JoinCollectionState.MatchesExistingTeamCollection
+            ? "Open"
+            : "Join";
+        // Leaving it as "join" for the pathological cases, though it will be disabled.
+    }
+
+    function getBloomWillSetYouUp() {
+        return (
+            <P
+                l10nKey="TeamCollection.Joining"
+                l10nParam0={props.collectionName}
+                temporarilyDisableI18nWarning={true}
+            >
+                Bloom will set you up to work together with your team on this
+                collection of books.
+            </P>
+        );
+    }
+
+    function getDialogBodyExistingNonTC(): JSX.Element {
+        return (
+            <React.Fragment>
+                {getBloomWillSetYouUp()}
+                <NoteBox>
+                    <P
+                        l10nKey="TeamCollection.Merging"
+                        l10nParam0={props.collectionName}
+                        temporarilyDisableI18nWarning={true}
+                    >
+                        You already have a collection with this same name. If
+                        you continue, Bloom will merge your existing "%0"
+                        collection with the Team Collection that you are
+                        joining.
+                    </P>
+                </NoteBox>
+                {getMatchingCollection()}
+            </React.Fragment>
+        );
+    }
+
+    function getMatchingCollection() {
+        return (
+            <p
+                // Something with pretty high priority sets the top margin to zero.
+                // But this one is always right below a NoteBox or ErrorBox and needs
+                // some space above. In this context padding is fine.
+                css={css`
+                    padding-top: 10px;
+                `}
+            >
+                <Span
+                    l10nKey="TeamCollection.MatchingLocal"
+                    temporarilyDisableI18nWarning={true}
+                >
+                    Matching local collection:
+                </Span>
+                <span> </span>
+                <span>{props.existingCollectionFolder}</span>
+            </p>
+        );
+    }
+
+    // This one is for an existing TC which we determine we have already joined.
+    function getDialogBodyExistingTC(): JSX.Element {
+        return (
+            <React.Fragment>
+                <NoteBox>
+                    <Div
+                        l10nKey="TeamCollection.AlreadyJoined"
+                        temporarilyDisableI18nWarning={true}
+                    >
+                        This computer is already connected to this collection.
+                        Bloom will open it for you.
+                    </Div>
+                </NoteBox>
+                {getMatchingCollection()}
+            </React.Fragment>
+        );
+    }
+
+    // When there is no local TC already existing. Just the simple message saying Bloom will set one up.
+    function getDialogBodyCreateNew(): JSX.Element {
+        return <React.Fragment>{getBloomWillSetYouUp()}</React.Fragment>;
+    }
+
+    // Most of the content is common for the two pathological cases where the existing local
+    // collection is a TC but NOT already linked to the one we're trying to join.
+    function getConflictingCollectionCommon() {
+        return (
+            <React.Fragment>
+                <ErrorBox>
+                    <Div
+                        l10nKey="TeamCollection.ConflictingCollection"
+                        temporarilyDisableI18nWarning={true}
+                    >
+                        Bloom found another collection with this same name that
+                        is already connected to a Team Collection. Click REPORT
+                        to get help from the Bloom team.
+                    </Div>
+                </ErrorBox>
+                {getMatchingCollection()}
+                <p>
+                    <Span
+                        l10nKey="TeamCollection.ConflictingCollection"
+                        temporarilyDisableI18nWarning={true}
+                    >
+                        Conflicting Team collection:
+                    </Span>
+                    <span> </span>
+                    <span>{props.conflictingCollection}</span>
+                </p>
+            </React.Fragment>
+        );
+    }
+
+    // Existing local local collection is a TC linked to another location.
+    function getDialogBodyExistingTcElsewhere() {
+        return (
+            <React.Fragment>
+                {getConflictingCollectionCommon()}
+                <P
+                    l10nKey="TeamCollection.SameIds"
+                    temporarilyDisableI18nWarning={true}
+                >
+                    (Same TC IDs)
+                </P>
+            </React.Fragment>
+        );
+    }
+
+    // Existing local local collection is a TC for a different collection.
+    function getDialogBodyDifferentTc() {
+        return (
+            <React.Fragment>
+                {getConflictingCollectionCommon()}
+                <P
+                    l10nKey="TeamCollection.SameIds"
+                    temporarilyDisableI18nWarning={true}
+                >
+                    (Different TC IDs)
+                </P>
+            </React.Fragment>
+        );
+    }
+
+    function getBodyOfDialogByState(): JSX.Element {
+        switch (dialogState) {
+            case JoinCollectionState.MatchesExistingNonTeamCollection:
+                return getDialogBodyExistingNonTC();
+            case JoinCollectionState.MatchesExistingTeamCollection:
+                return getDialogBodyExistingTC();
+            case JoinCollectionState.CreateNewCollection:
+                return getDialogBodyCreateNew();
+            case JoinCollectionState.MatchesExistingTeamCollectionElsewhere:
+                return getDialogBodyExistingTcElsewhere();
+            case JoinCollectionState.MatchesDifferentTeamCollection:
+                return getDialogBodyDifferentTc();
+            default:
+                return <div />;
+        }
+    }
+
+    const wantReportButton =
+        dialogState === JoinCollectionState.MatchesDifferentTeamCollection ||
+        dialogState ===
+            JoinCollectionState.MatchesExistingTeamCollectionElsewhere;
 
     return (
         <BloomDialog {...propsForBloomDialog}>
             <DialogTitle title={`${dialogTitle} (experimental)`} />
-            <DialogMiddle>
-                {props.existingCollection ? (
-                    <React.Fragment>
-                        <P
-                            l10nKey="TeamCollection.Merging"
-                            l10nParam0={props.collectionName}
-                            temporarilyDisableI18nWarning={true}
-                        >
-                            You already have a collection with this same name,
-                            "%0". If you continue, Bloom will merge your
-                            existing "%0" collection with the Team Collection
-                            are joining.
-                        </P>
-                        <P
-                            l10nKey="TeamCollection.MergingExplanation"
-                            temporarilyDisableI18nWarning={true}
-                        >
-                            The rest of the team will receive any unique books
-                            found in that collection. Any books you have that
-                            are already in this Team Collection will be moved to
-                            the "Lost and Found" folder, unless Bloom can
-                            determine that they are the same.
-                        </P>
-                        <NoteBox>
-                            <Div
-                                l10nKey="TeamCollection.StartFresh"
-                                l10nParam0={props.collectionName}
-                                temporarilyDisableI18nWarning={true}
-                            >
-                                If you do not want to merge in your existing
-                                "%0" collection, click Cancel and rename your
-                                existing "%0" collection to something different,
-                                or delete it. Then come back and join again.
-                            </Div>
-                        </NoteBox>
-                    </React.Fragment>
-                ) : (
-                    <React.Fragment>
-                        <P
-                            l10nKey="TeamCollection.Joining"
-                            l10nParam0={props.collectionName}
-                            temporarilyDisableI18nWarning={true}
-                        >
-                            Bloom will set you up to work together with your
-                            team on this collection of books.
-                        </P>
-                        <NoteBox>
-                            <Div
-                                l10nKey="TeamCollection.MergeInstead"
-                                l10nParam0={props.collectionName}
-                                temporarilyDisableI18nWarning={true}
-                            >
-                                If, instead, you want to <strong>merge</strong>{" "}
-                                a collection you already have into this Team
-                                Collection, click Cancel and rename the
-                                collection you want to merge to "%0". Then try
-                                to join again.
-                            </Div>
-                        </NoteBox>
-                    </React.Fragment>
-                )}
-            </DialogMiddle>
+            <DialogMiddle>{getBodyOfDialogByState()}</DialogMiddle>
             <DialogBottomButtons>
+                {wantReportButton && (
+                    <DialogBottomLeftButtons>
+                        <DialogReportButton
+                            shortMessage="Problem joining Team Collection due to conflicting local collection"
+                            messageGenerator={() =>
+                                `trying to join ${props.joiningRepo} (${props.joiningGuid}), but local collection ${props.existingCollectionFolder} (${props.localGuid}) is linked to ${props.conflictingCollection}`
+                            }
+                            // It's tempting to look for a way to closeDialog() when Report is clicked;
+                            // but if we do it after opening the problem dialog, it closes that instead.
+                            // If we do it before opening the problem dialog, then the code to open it may get unloaded before it runs.
+                            // It's also just possible that the user might want to see some information in the dialog while writing
+                            // something helpful to us in the problem report dialog. So I decided not to. If we do want to do it,
+                            // we probably need a new API, as well as a click handler on DialogReportButton.
+                        />
+                    </DialogBottomLeftButtons>
+                )}
                 <BloomButton
-                    l10nKey={
-                        props.existingCollection
-                            ? "TeamCollection.JoinAndMerge"
-                            : "TeamCollection.Join"
-                    }
+                    l10nKey={l10nJoinButtonKey}
                     temporarilyDisableI18nWarning={true}
                     hasText={true}
-                    enabled={true}
+                    enabled={!wantReportButton}
                     onClick={() => {
                         BloomApi.post("teamCollection/joinTeamCollection");
                     }}
                 >
-                    {props.existingCollection ? "Join and Merge" : "Join"}
+                    {joinButtonEnglish}
                 </BloomButton>
                 <DialogCancelButton onClick={closeDialog} />
             </DialogBottomButtons>

--- a/src/BloomBrowserUI/teamCollection/stories.tsx
+++ b/src/BloomBrowserUI/teamCollection/stories.tsx
@@ -128,15 +128,17 @@ storiesOf("Team Collection components/StatusPanelCommon", module)
     );
 
 storiesOf("Team Collection components/JoinTeamCollection", module)
-    .add(" new collection", () => (
+    .add("new collection", () => (
         <div id="reactRoot" className="JoinTeamCollection">
             <JoinTeamCollectionDialog
                 collectionName="foobar"
                 existingCollection={false}
-                dialogEnvironment={{
-                    omitOuterFrame: false,
-                    initiallyOpen: true
-                }}
+                isAlreadyTcCollection={false}
+                isCurrentCollection={false}
+                isSameCollection={false}
+                existingCollectionFolder=""
+                conflictingCollection=""
+                dialogEnvironment={normalDialogEnvironmentForStorybook}
             />
         </div>
     ))
@@ -145,6 +147,53 @@ storiesOf("Team Collection components/JoinTeamCollection", module)
             <JoinTeamCollectionDialog
                 collectionName="foobar"
                 existingCollection={true}
+                isAlreadyTcCollection={false}
+                isCurrentCollection={false}
+                isSameCollection={false}
+                existingCollectionFolder="somewhere"
+                conflictingCollection=""
+                dialogEnvironment={normalDialogEnvironmentForStorybook}
+            />
+        </div>
+    ))
+    .add("existing TC collection, same location and guid", () => (
+        <div id="reactRoot" className="JoinTeamCollection">
+            <JoinTeamCollectionDialog
+                collectionName="foobar"
+                existingCollection={true}
+                isAlreadyTcCollection={true}
+                isCurrentCollection={true}
+                isSameCollection={true}
+                existingCollectionFolder="some good place"
+                conflictingCollection=""
+                dialogEnvironment={normalDialogEnvironmentForStorybook}
+            />
+        </div>
+    ))
+    .add("existing TC collection, different location same guid", () => (
+        <div id="reactRoot" className="JoinTeamCollection">
+            <JoinTeamCollectionDialog
+                collectionName="foobar"
+                existingCollection={true}
+                isAlreadyTcCollection={true}
+                isCurrentCollection={false}
+                isSameCollection={true}
+                existingCollectionFolder="some good place"
+                conflictingCollection="some bad place"
+                dialogEnvironment={normalDialogEnvironmentForStorybook}
+            />
+        </div>
+    ))
+    .add("existing TC collection, different location and guid", () => (
+        <div id="reactRoot" className="JoinTeamCollection">
+            <JoinTeamCollectionDialog
+                collectionName="foobar"
+                existingCollection={true}
+                isAlreadyTcCollection={true}
+                isCurrentCollection={false}
+                isSameCollection={false}
+                existingCollectionFolder="some good place"
+                conflictingCollection="some bad place"
                 dialogEnvironment={normalDialogEnvironmentForStorybook}
             />
         </div>
@@ -154,6 +203,11 @@ storiesOf("Team Collection components/JoinTeamCollection", module)
             <JoinTeamCollectionDialog
                 collectionName="foobar"
                 existingCollection={true}
+                isAlreadyTcCollection={false}
+                isCurrentCollection={false}
+                isSameCollection={false}
+                existingCollectionFolder="somewhere"
+                conflictingCollection=""
                 dialogEnvironment={{
                     omitOuterFrame: true,
                     initiallyOpen: true

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -340,6 +340,39 @@ namespace Bloom.Collection
 			return sb.ToString();
 		}
 
+		public static string CollectionIdFromCollectionFolder(string collectionFolder)
+		{
+			try
+			{
+				var settingsFilePath = Path.Combine(collectionFolder,
+					Path.ChangeExtension(Path.GetFileName(collectionFolder), "bloomCollection"));
+				if (!RobustFile.Exists(settingsFilePath))
+				{
+					// When we're joining a TC, we extract settings in to a temp folder whose name does not
+					// match the settings file.
+					var collections = Directory.EnumerateFiles(collectionFolder,
+						"*.bloomCollection").ToList();
+					if (collections.Count >= 1)
+					{
+						// Hopefully this repairs things.
+						settingsFilePath = collections[0];
+					}
+					else
+					{
+						return "";
+					}
+				}
+					
+				var settingsContent = RobustFile.ReadAllText(settingsFilePath, Encoding.UTF8);
+				var xml = XElement.Parse(settingsContent);
+				return ReadString(xml, "CollectionId", "");
+			}
+			catch (Exception ex)
+			{
+				return "";
+			}
+		}
+
 		
 		/// ------------------------------------------------------------------------------------
 		public void Load()
@@ -486,7 +519,7 @@ namespace Bloom.Collection
 		}
 
 
-		private string ReadString(XElement document, string id, string defaultValue)
+		private static string ReadString(XElement document, string id, string defaultValue)
 		{
 			var nodes = document.Descendants(id);
 			if (nodes != null && nodes.Count() > 0)

--- a/src/BloomExe/MiscUI/ReactDialogFactory.cs
+++ b/src/BloomExe/MiscUI/ReactDialogFactory.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Bloom.MiscUI
+﻿namespace Bloom.MiscUI
 {
 	public interface IReactDialogFactory
 	{

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -24,7 +24,6 @@ using SIL.Windows.Forms.Reporting;
 using SIL.Windows.Forms.UniqueToken;
 using System.Linq;
 using System.Xml;
-using Bloom.Book;
 using Bloom.CLI;
 using Bloom.CollectionChoosing;
 using Bloom.TeamCollection;
@@ -318,7 +317,7 @@ namespace Bloom
 										}
 										return 1; // something went wrong processing it, hopefully already reported.
 									}
-									newCollection = FolderTeamCollection.ShowJoinCollectionTeamDialog(args[0]);
+									newCollection = FolderTeamCollection.ShowJoinCollectionTeamDialog(args[0], projectContext.TeamCollectionManager);
 								}
 							}
 						}

--- a/src/BloomExe/TeamCollection/FolderTeamCollection.cs
+++ b/src/BloomExe/TeamCollection/FolderTeamCollection.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using System.Xml;
 using System.Xml.Linq;
 using Bloom.Api;
+using Bloom.Collection;
 using Bloom.CollectionCreating;
 using Bloom.MiscUI;
 using Bloom.Utils;
@@ -222,7 +223,7 @@ namespace Bloom.TeamCollection
 			foreach (var name in names)
 			{
 				var path = Path.Combine(_localCollectionFolder, name);
-				if (!File.Exists(path))
+				if (!RobustFile.Exists(path))
 					continue;
 				zipFile.AddTopLevelFile(path, true);
 			}
@@ -235,7 +236,7 @@ namespace Bloom.TeamCollection
 			get
 			{
 				var repoProjectFilesZipPath = GetRepoProjectFilesZipPath(_repoFolderPath);
-				if (!File.Exists(repoProjectFilesZipPath))
+				if (!RobustFile.Exists(repoProjectFilesZipPath))
 					return DateTime.MinValue; // brand new repo, want to copy TO it.
 				var collectionFilesModTime = new FileInfo(repoProjectFilesZipPath).LastWriteTime;
 				GetMaxModifyTime("Allowed Words", ref collectionFilesModTime);
@@ -247,7 +248,7 @@ namespace Bloom.TeamCollection
 		private void GetMaxModifyTime(string folderName, ref DateTime max)
 		{
 			var zipPath =Path.Combine(_repoFolderPath, "Other", Path.ChangeExtension(folderName,"zip"));
-			if (File.Exists(zipPath))
+			if (RobustFile.Exists(zipPath))
 			{
 				var thisModTime = new FileInfo(zipPath).LastWriteTime;
 				if (thisModTime > max)
@@ -384,7 +385,7 @@ namespace Bloom.TeamCollection
 		static void ExtractFolder(string collectionFolder, string repoFolder, string folderName)
 		{
 			var sourceZip = GetZipFileForFolder(folderName, repoFolder);
-			if (!File.Exists(sourceZip))
+			if (!RobustFile.Exists(sourceZip))
 				return;
 			var destFolder = Path.Combine(collectionFolder, folderName);
 			ExtractFolderFromZip(destFolder, sourceZip,
@@ -710,8 +711,9 @@ namespace Bloom.TeamCollection
 		// Create a new local collection from the team collection at the specified path.
 		// Return the path to its settings (not team settings) file...the path we need to
 		// open the new collection. This is the method that gets called when we open a
-		// JoinTeamCollection file.
-		public static string ShowJoinCollectionTeamDialog(string path)
+		// JoinTeamCollection file. The tcManager passed is a temporary one created by
+		// syncing the repo and its settings to a temporary folder.
+		public static string ShowJoinCollectionTeamDialog(string path, TeamCollectionManager tcManager)
 		{
 			if (!PromptForSufficientRegistrationIfNeeded())
 				return null;
@@ -722,11 +724,30 @@ namespace Bloom.TeamCollection
 			var collectionName = GetLocalCollectionNameFromTcName(Path.GetFileName(repoFolder));
 			var localCollectionFolder =
 				Path.Combine(NewCollectionWizard.DefaultParentDirectoryForCollections, collectionName);
+			var isExistingCollection = Directory.Exists(localCollectionFolder);
+			var tcLinkPath = TeamCollectionManager.GetTcLinkPathFromLcPath(localCollectionFolder);
+			var isAlreadyTcCollection = isExistingCollection &&
+			                            RobustFile.Exists(tcLinkPath);
+			var repoFolderPathFromLinkPath = isAlreadyTcCollection ? TeamCollectionManager.RepoFolderPathFromLinkPath(tcLinkPath) : "";
+			var isCurrentCollection = isAlreadyTcCollection &&
+			                          repoFolderPathFromLinkPath == repoFolder;
+			var joiningGuid = CollectionSettings.CollectionIdFromCollectionFolder(tcManager.CurrentCollection
+				.LocalCollectionFolder);
+			var localGuid = CollectionSettings.CollectionIdFromCollectionFolder(localCollectionFolder);
+			var isSameCollection = joiningGuid == localGuid;
 
 			using (var dlg = new ReactDialog("JoinTeamCollectionDialog", new
 			{
 				collectionName,
-				existingCollection = Directory.Exists(localCollectionFolder)
+				existingCollection = isExistingCollection,
+				isAlreadyTcCollection,
+				isCurrentCollection,
+				isSameCollection,
+				existingCollectionFolder = localCollectionFolder,
+				conflictingCollection = repoFolderPathFromLinkPath,
+				joiningRepo = repoFolder,
+				joiningGuid,
+				localGuid
 			}))
 			{
 				dlg.Width = 560;
@@ -752,6 +773,7 @@ namespace Bloom.TeamCollection
 			var collectionName = GetLocalCollectionNameFromTcName(Path.GetFileName(repoFolder));
 			var localCollectionFolder =
 				Path.Combine(NewCollectionWizard.DefaultParentDirectoryForCollections, collectionName);
+			var firstTimeJoin = !Directory.Exists(localCollectionFolder) || !RobustFile.Exists(TeamCollectionManager.GetTcLinkPathFromLcPath(localCollectionFolder));
 			// Most of the collection settings files will be copied later when we create the repo
 			// in TeamRepo.MakeInstance() and call CopyRepoCollectionFilesToLocal.
 			// However, when we start up with a command line argument that causes JoinCollectionTeam,
@@ -760,8 +782,9 @@ namespace Bloom.TeamCollection
 			// exist; so we have to make it exist.
 			_newCollectionToJoin = SetupMinimumLocalCollectionFilesForRepo(repoFolder, localCollectionFolder);
 			// Soon we will open the new collection, and do a SyncAtStartup. We want that to have some
-			// special behavior.
-			TeamCollectionManager.NextMergeIsJoinCollection = true;
+			// special behavior, but only if joining for the first time.
+			if (firstTimeJoin)
+				TeamCollectionManager.NextMergeIsFirstTimeJoinCollection = true;
 		}
 
 		/// <summary>

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -7,19 +7,16 @@ using SIL.IO;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 using System.Windows.Forms;
 using Bloom.Book;
 using Bloom.Registration;
 using Bloom.ToPalaso;
 using Bloom.Utils;
-using Bloom.web.controllers;
 using SIL.Reporting;
 
 namespace Bloom.TeamCollection
@@ -1571,8 +1568,8 @@ namespace Bloom.TeamCollection
 					progress.Message("StartingSync", "",
 						"Starting sync with Team Collection", ProgressKind.Progress);
 
-					bool doingJoinCollectionMerge = TeamCollectionManager.NextMergeIsJoinCollection;
-					TeamCollectionManager.NextMergeIsJoinCollection = false;
+					bool doingFirstTimeJoinCollectionMerge = TeamCollectionManager.NextMergeIsFirstTimeJoinCollection;
+					TeamCollectionManager.NextMergeIsFirstTimeJoinCollection = false;
 					// don't want messages about the collection being changed while we're synchronizing,
 					// and in some cases we might be the source of several changes (for example, multiple
 					// check ins while joining a collection). Normally we suppress notifications for
@@ -1580,7 +1577,7 @@ namespace Bloom.TeamCollection
 					// enough when we do several close together.
 					StopMonitoring();
 
-					var waitForUserToCloseDialogOrReportProblems = SyncAtStartup(progress, doingJoinCollectionMerge);
+					var waitForUserToCloseDialogOrReportProblems = SyncAtStartup(progress, doingFirstTimeJoinCollectionMerge);
 
 					// Now that we've finished synchronizing, update these icons based on the post-sync result
 					// REVIEW: What do we want to happen if exception throw here? Should we add to {problems} list?
@@ -1662,7 +1659,7 @@ namespace Bloom.TeamCollection
 		/// However, most of the logic involved in joining a collection is common, so I hate
 		/// to do that. Inclined to wait until we DO have an alternative implementation,
 		/// when it may be clearer how to refactor.
-		/// If we ever get another implementation that dose use .JoinBloomTC, thought will be needed as to
+		/// If we ever get another implementation that does use .JoinBloomTC, thought will be needed as to
 		/// how to get a local collection name from the .JoinBloomTC file path.
 		/// </summary>
 		/// <param name="tcName"></param>

--- a/src/BloomExe/TeamCollection/TeamCollectionManager.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionManager.cs
@@ -1,17 +1,12 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Windows.Forms;
 using System.Xml;
 using Bloom.Api;
 using Bloom.Book;
 using Bloom.Collection;
-using Bloom.Registration;
-using Bloom.Utils;
-using L10NSharp;
 using Sentry;
 using SIL.IO;
-using SIL.Reporting;
 
 namespace Bloom.TeamCollection
 {
@@ -211,12 +206,12 @@ namespace Bloom.TeamCollection
 					_overrideCurrentUserSurname = lines[3];
 			}
 
-			var localCollectionLinkPath = Path.Combine(_localCollectionFolder, TeamCollectionLinkFileName);
+			var localCollectionLinkPath = GetTcLinkPathFromLcPath(_localCollectionFolder);
 			if (RobustFile.Exists(localCollectionLinkPath))
 			{
 				try
 				{
-					var repoFolderPath = RobustFile.ReadAllText(localCollectionLinkPath).Trim();
+					var repoFolderPath = RepoFolderPathFromLinkPath(localCollectionLinkPath);
 					CurrentCollection = new FolderTeamCollection(this, _localCollectionFolder, repoFolderPath); // will be replaced if CheckConnection fails
 					if (CheckConnection())
 					{
@@ -244,6 +239,11 @@ namespace Bloom.TeamCollection
 					CurrentCollectionEvenIfDisconnected = null;
 				}
 			}
+		}
+
+		public static string RepoFolderPathFromLinkPath(string localCollectionLinkPath)
+		{
+			return RobustFile.ReadAllText(localCollectionLinkPath).Trim();
 		}
 
 		/// <summary>
@@ -300,11 +300,16 @@ namespace Bloom.TeamCollection
 			return Path.Combine(localCollectionFolder, "log.txt");
 		}
 
+		public static string GetTcLinkPathFromLcPath(string localCollectionFolder)
+		{
+			return Path.Combine(localCollectionFolder, TeamCollectionLinkFileName);
+		}
+
 		/// <summary>
 		/// This gets set when we join a new TeamCollection so that the merge we do
 		/// later as we open it gets the special behavior for this case.
 		/// </summary>
-		public static bool NextMergeIsJoinCollection { get; set; }
+		public static bool NextMergeIsFirstTimeJoinCollection { get; set; }
 
 		public BloomWebSocketServer SocketServer => _webSocketServer;
 


### PR DESCRIPTION
- Many changes to dialog messages
- If we've already joined, just open (without normal merge behavior of committing new local books)
- If the existing local collection is already a TC but NOT the one we're joining, prevent the join
(Some of this work was done by Gordon)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4454)
<!-- Reviewable:end -->
