### PR TITLE
Compromise on video memory leak in preview (BL-9875)

### DIFF
--- a/src/BloomBrowserUI/bookPreview/bookPreview.ts
+++ b/src/BloomBrowserUI/bookPreview/bookPreview.ts
@@ -29,6 +29,24 @@ $(document).ready(() => {
         $(this).removeClass("disabledVisual");
     });
 
+    // In preview mode we set videos to be preload="none" to prevent a memory leak. This observer is set up
+    // so that videos that are scrolled into view will be loaded, so the user can see
+    // the first frame, not just a placholder. See book.PreventVideoAutoLoad()
+    var videos = [].slice.call(document.querySelectorAll("video"));
+    var videoObserver = new IntersectionObserver(function(entries, observer) {
+        entries.forEach(function(video) {
+            if (video.isIntersecting) {
+                // doesn't work
+                //video.target.setAttribute("preview", "metadata");
+                (video.target as HTMLVideoElement).load();
+                videoObserver.unobserve(video.target);
+            }
+        });
+    });
+    videos.forEach(function(video) {
+        videoObserver.observe(video);
+    });
+
     //Allow labels and separators to be marked such that if the user doesn't fill in a value, the label will be invisible when published.
     //NB: why in cleanup? it's not ideal, but if it gets called after each editing session, then things will be left in the proper state.
     //If we ever get into jscript at publishing time, well then this could go there.


### PR DESCRIPTION
With this change SL books don't cause leaks when simply selected, but it's still possible to see the first frame if you scroll to a page that has video. Unfortunately doing that will still cause some memory leakage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4466)
<!-- Reviewable:end -->
