### PR TITLE
BL-9914 don't show the close/quit button if in "Learn More" mode

### DIFF
--- a/src/BloomBrowserUI/problemDialog/ReportDialog.tsx
+++ b/src/BloomBrowserUI/problemDialog/ReportDialog.tsx
@@ -208,7 +208,7 @@ export const ReportDialog: React.FunctionComponent<{
                         Submit
                     </BloomButton>
                 )}
-                {getEndingButton()}
+                {mode !== Mode.showPrivacyDetails && getEndingButton()}
             </>
         );
     };


### PR DESCRIPTION
... it's too easy to accidentally close the whole thing when you just wanted to "go back".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4470)
<!-- Reviewable:end -->
