### PR TITLE
Better BL-9948 fix

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -249,6 +249,7 @@ namespace Bloom.Book
 			return display;
 		}
 
+		// might be better named RemoveMarkup; what can be in here is *HTML*, e.g. bold, italics, etc.
 		public static string RemoveXmlMarkup(string input)
 		{
 			try

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -574,9 +574,7 @@ namespace Bloom.CollectionTab
 				{
 					Debug.WriteLine(buttonText + " --> " + titleBestForUserDisplay);
 					button.SetTextSafely(titleBestForUserDisplay);
-					// We changed the tooltip to show the folder name to help when you have duplicates of the book, e.g. when
-					// something goes amiss when using Dropbox and it creates copies.
-					toolTip1.SetToolTip(button, Path.GetFileName(bookInfo.FolderPath));
+					
 				}
 			}
 			if (buttonRefreshInfo.ThumbnailRefreshNeeded)
@@ -587,8 +585,23 @@ namespace Bloom.CollectionTab
 				if (book != null)
 					ScheduleRefreshOfOneThumbnail(book);
 			}
+			SetBookButtonTooltip(button);
 		}
 
+		private void SetBookButtonTooltip(Button button)
+		{
+			// We changed the tooltip to show the folder name to help when you have duplicates of the book, e.g. when
+			// something goes amiss when using Dropbox and it creates copies.
+			var info = GetBookInfoFromButton(button);
+			if (info == null)
+			{
+				toolTip1.SetToolTip(button,"error");
+			}
+			else
+			{
+				toolTip1.SetToolTip(button, Path.GetFileName(info.FolderPath));
+			}
+		}
 		private Book.Book LoadBookAndBringItUpToDate(BookInfo bookInfo, out bool badBook)
 		{
 			try
@@ -829,7 +842,7 @@ namespace Bloom.CollectionTab
 			button.FlatAppearance.BorderSize = 1;
 			button.FlatAppearance.BorderColor = BackColor;
 
-			toolTip1.SetToolTip(button, title);
+			SetBookButtonTooltip(button);
 
 			Image thumbnail = Resources.PagePlaceHolder;
 			_bookThumbnails.Images.Add(bookInfo.Id, thumbnail);
@@ -1100,7 +1113,7 @@ namespace Bloom.CollectionTab
 				{
 					var bestTitle = book.TitleBestForUserDisplay;
 					SelectedButton.SetTextSafely(ShortenTitleIfNeeded(bestTitle, SelectedButton));
-					toolTip1.SetToolTip(SelectedButton, bestTitle);
+					SetBookButtonTooltip(SelectedButton);
 					if (_thumbnailRefreshPending)
 					{
 						_thumbnailRefreshPending = false;


### PR DESCRIPTION
Turns out there were three places where this was set, and I only had covered one of them. This PR factors out the setting of the tooltip so that all 3 places share the same code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4471)
<!-- Reviewable:end -->
