### PR TITLE
BL-9912 saving tool state too late

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -893,6 +893,14 @@ namespace Bloom.Edit
 
 		internal void SaveToolboxSettings(string data)
 		{
+			// ref BL-9859, BL-9912, BL-9978
+			// If _currentlyDisplayedBook is null, it's because we go the API call to save
+			// tool state too late. The Book has already been saved and we're back on
+			// the Collection Tab. In testing with the leveled and decodable readers,
+			// I found that the important state, like what
+			// level we are on, sort order, etc. has already been saved.
+			if (_currentlyDisplayedBook == null)
+				return;
 			ToolboxView.SaveToolboxSettings(_currentlyDisplayedBook,data);
 		}
 

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1267,6 +1267,11 @@ namespace Bloom.Edit
 		/// </summary>
 		public void CleanHtmlAndCopyToPageDom()
 		{
+			// NOTE: these calls to may lead to API calls from the JS. These are async, so the actions
+			// that JS might perform may not actually happen until well after this method. We ran into a problem in
+			// BL-9912 where the Leveled Reader Tool was prompted by some of this to call us back with a save to the
+			// tool state, but by then the editingModel had cleared out its knowledge of what book it had previously
+			// been editing, so there was an null.
 			RunJavaScript("if (typeof(FrameExports) !=='undefined' && typeof(FrameExports.getPageFrameExports()) !=='undefined') {FrameExports.getToolboxFrameExports().removeToolboxMarkup();}");
 			var bodyHtml = RunJavaScript("if (typeof(FrameExports && typeof(FrameExports.getPageFrameExports()) !=='undefined') !=='undefined') {return FrameExports.getPageFrameExports().getBodyContentForSavePage();}");
 			var userCssContent = RunJavaScript("if (typeof(FrameExports) !=='undefined' && typeof(FrameExports.getPageFrameExports()) !=='undefined') {return FrameExports.getPageFrameExports().userStylesheetContent();}");


### PR DESCRIPTION
If a save to tool state comes in after we're already back on the collection tab, it's not going to get saved anyways. And it seem to not matter, since important tool state gets saved as it happens (e.g. reader level). A better fix JohnT and I decided is way too expensive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4474)
<!-- Reviewable:end -->
