### PR TITLE
[5.0] BL-9960 Move line-break rule so ePubs get it

### DIFF
--- a/src/BloomBrowserUI/bookLayout/basePage-sharedRules.less
+++ b/src/BloomBrowserUI/bookLayout/basePage-sharedRules.less
@@ -104,3 +104,10 @@ body {
 .bloom-background-gray {
     background-color: @preferredBackgroundGray;
 }
+
+// The user can get this in by pressing shift-enter. See bloomField.ts
+// BL-9960 Moving this rule here from basePage.less, so that it will work for ePubs too.
+span.bloom-linebreak {
+    display: block;
+    text-indent: 0;
+}

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -173,12 +173,6 @@ td {
     width: 100%;
 }
 
-//user can get this in by pressing shift-enter. See bloomField.ts
-span.bloom-linebreak {
-    display: block;
-    text-indent: 0;
-}
-
 div.bloom-page {
     display: block;
 


### PR DESCRIPTION
* Works great on EKitabu and Lithium, whether or not the
   user chooses to honor the publisher's defaults.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4496)
<!-- Reviewable:end -->
