### PR TITLE
Allow choosing background color when initially transparent (BL-9922)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
@@ -391,6 +391,12 @@ const ComicToolControls: React.FunctionComponent = () => {
             defaultSwatchColors: defaultBackgroundColors,
             onChange: color => updateBackgroundColor(color)
         };
+        // If the background color is fully transparent, change it to fully opaque
+        // so that the user can choose a color immediately (and adjust opacity to
+        // a lower value as well if wanted).
+        // See https://issues.bloomlibrary.org/youtrack/issue/BL-9922.
+        if (colorPickerDialogProps.initialColor.opacity === 0)
+            colorPickerDialogProps.initialColor.opacity = 100;
         getEditViewFrameExports().showColorPickerDialog(colorPickerDialogProps);
     };
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4497)
<!-- Reviewable:end -->
