### PR TITLE
Fix check for quiz pages disabling overflow marking (BL-9952)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -338,7 +338,7 @@ export default class OverflowChecker {
                 // BL-1261: don't want the typed-in box to be marked overflow just because it made another box
                 // go past the margins
                 // $box.addClass('overflow'); // probably typing in the focused element caused this
-                if (quizPage) {
+                if (quizPage.length) {
                     // We want to ignore overflow on quiz pages.  See https://issues.bloomlibrary.org/youtrack/issue/BL-9952.
                     return;
                 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4507)
<!-- Reviewable:end -->
