### PR TITLE
Remove references to node_modules from generated html file (BL-9921)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.pug
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.pug
@@ -7,8 +7,6 @@ html
 		meta(charset='utf-8')
 		+stylesheet('/bloom/bookEdit/pageThumbnailList/pageThumbnailList.css')
 		+stylesheet('/bloom/bookEdit/pageThumbnailList/pageControls/pageControls.css')
-		+stylesheet('/node_modules/react-grid-layout/css/styles.css')
-		+stylesheet('/node_modules/react-resizable/css/styles.css')
 	body(data-pageSize='A5Portrait')
 		#panelFlexContainer
 			#pageGridWrapper


### PR DESCRIPTION
Removing these stylesheet references had no apparent effect on the
program.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4508)
<!-- Reviewable:end -->
