### PR TITLE
Allow error reporting if opening collection fails (BL-9916)

### DIFF
--- a/src/BloomExe/ApplicationContainer.cs
+++ b/src/BloomExe/ApplicationContainer.cs
@@ -6,6 +6,7 @@ using Bloom.Properties;
 using System.Linq;
 using L10NSharp;
 using System.Windows.Forms;
+using Bloom.web.controllers;
 
 namespace Bloom
 {
@@ -70,6 +71,8 @@ namespace Bloom
 			public HtmlThumbNailer HtmlThumbnailer => _container.Resolve<HtmlThumbNailer>();
 
 			public BookThumbNailer BookThumbNailer => _container.Resolve<BookThumbNailer>();
+
+			internal ProblemReportApi ProblemReportApi => _container.Resolve<ProblemReportApi>();
 
 			public void Dispose()
 			{

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -453,9 +453,9 @@ namespace Bloom.Collection
 				Administrators=ReadString(xml, "Administrators", "")
 					.Split(new[] {","}, StringSplitOptions.RemoveEmptyEntries);
 			}
-			catch (Exception e)
+			catch (Exception)
 			{
-				string settingsContents = "";
+				string settingsContents;
 				try
 				{
 					settingsContents = RobustFile.ReadAllText(SettingsFilePath);
@@ -464,8 +464,11 @@ namespace Bloom.Collection
 				{
 					settingsContents = error.Message;
 				}
-				Logger.WriteEvent("Contents of "+SettingsFilePath+": /r/n"+ settingsContents);
-				SIL.Reporting.ErrorReport.NotifyUserOfProblem(e, "There was an error reading the file {0}.  Please report this error to the developers. To get access to your books, you should make a new collection, then copy your book folders from this broken collection into the new one, then run Bloom again.",SettingsFilePath);
+				Logger.WriteEvent("Contents of " + SettingsFilePath + ": /r/n" + settingsContents);
+
+				// We used to notify the user of a problem here.
+				// But now we decided it is better to catch at a higher level, at OpenProjectWindow(), else we have two different
+				// error UI dialogs for the same problem. See BL-9916.
 				throw;
 			}
 


### PR DESCRIPTION
* Add the "Report" button to the Ui dialog opened
* Re-factoring of fallback reporting
* Add mechanism to submit reports including the problematic .bloomCollection file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4509)
<!-- Reviewable:end -->
