### PR TITLE
More fixes for ampersands in language names (BL-9919)

### DIFF
--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -47,6 +47,9 @@ namespace Bloom.Collection
 			_language1Name.UseMnemonic = false;	// Allow & to be part of the language display names.
 			_language2Name.UseMnemonic = false;	// This may be unlikely, but can't be ruled out.
 			_language3Name.UseMnemonic = false;	// See https://issues.bloomlibrary.org/youtrack/issue/BL-9919.
+			_language1FontLabel.UseMnemonic = false;
+			_language2FontLabel.UseMnemonic = false;
+			_language3FontLabel.UseMnemonic = false;
 
 			if (_collectionSettings.IsSourceCollection)
 			{

--- a/src/BloomExe/Collection/ScriptSettingsDialog.cs
+++ b/src/BloomExe/Collection/ScriptSettingsDialog.cs
@@ -11,6 +11,7 @@ namespace Bloom.Collection
 			InitializeComponent();
 			SetLineHeightList();
 			LoadFontSizeCombo();
+			_languageNameLabel.UseMnemonic = false;
 		}
 
 		private void SetLineHeightList()

--- a/src/BloomExe/Publish/BloomLibrary/BloomLibraryUploadControl.cs
+++ b/src/BloomExe/Publish/BloomLibrary/BloomLibraryUploadControl.cs
@@ -119,6 +119,7 @@ namespace Bloom.Publish.BloomLibrary
 			foreach (var lang in allLanguages.Keys)
 			{
 				var checkBox = new CheckBox();
+				checkBox.UseMnemonic = false;
 				checkBox.Text = _model.PrettyLanguageName(lang);
 				if (allLanguages[lang])
 					checkBox.Checked = true;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4515)
<!-- Reviewable:end -->
