### PR TITLE
Prevent bookshelf getting cleared when other settings saved (BL-10093)

### DIFF
--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -79,6 +79,10 @@ namespace Bloom.Collection
 			else
 				_automaticallyUpdate.Hide();
 
+			// Without this, PendingDefaultBookshelf stays null unless the user changes it.
+			// The result is the bookshelf selection gets cleared when other collection settings are saved. See BL-10093.
+			PendingDefaultBookshelf = _collectionSettings.DefaultBookshelf;
+
 //		    _showSendReceive.CheckStateChanged += (sender, args) =>
 //		                                              {
 //		                                                  Settings.Default.ShowSendReceive = _showSendReceive.CheckState ==


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4553)
<!-- Reviewable:end -->
