### PR TITLE
Several problems when a zip file is corrupt (BL-10097)

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryView.cs
+++ b/src/BloomExe/CollectionTab/LibraryView.cs
@@ -91,7 +91,7 @@ namespace Bloom.CollectionTab
 				// Instead, in the short term we may add a button to show the file.
 				// Later we may implement some efficient way to scroll through them.
 				// tcManager.CurrentCollection?.MessageLog?.LoadSavedMessages();
-				using (var dlg = new ReactDialog("TeamCollectionDialog", new {showReloadButton}))
+				using (var dlg = new ReactDialog("TeamCollectionDialog", new {showReloadButton}, "Team Collection"))
 				{
 					dlg.ShowDialog(this);
 					tcManager.CurrentCollectionEvenIfDisconnected?.MessageLog.WriteMilestone(MessageAndMilestoneType.LogDisplayed);

--- a/src/BloomExe/MiscUI/ReactDialog.cs
+++ b/src/BloomExe/MiscUI/ReactDialog.cs
@@ -24,13 +24,15 @@ namespace Bloom.MiscUI
 
 		private static readonly List<ReactDialog> _activeDialogs = new List<ReactDialog>();
 
-		public ReactDialog(string reactComponentName, object props = null)
+		public ReactDialog(string reactComponentName, object props = null, string taskBarTitle="Bloom")
 		{
 			InitializeComponent();
 			FormClosing += ReactDialog_FormClosing;
 			reactControl.ReactComponentName = reactComponentName;
             reactControl.Props = props;
 			_activeDialogs.Add(this);
+			Text = taskBarTitle;
+			ShowInTaskbar = false;
 
 			Icon = global::Bloom.Properties.Resources.BloomIcon;
 		}
@@ -78,11 +80,13 @@ namespace Bloom.MiscUI
 		/// <param name="height">used to set the WinForms dialog Height property</param>
 		/// <param name="initialize">an optional action done after width and height are set but before ShowDialog is called</param>
 		/// <param name="handleResult">an optional action done after the dialog is closed; takes a DialogResult</param>
-		public static void ShowOnIdle(string reactComponentName, object props, int width, int height, Action initialize = null, Action<DialogResult> handleResult = null)
+		/// <param name="taskBarTitle">Label to show in the task bar for this form</param>
+		public static void ShowOnIdle(string reactComponentName, object props, int width, int height,
+			Action initialize = null, Action<DialogResult> handleResult = null, string taskBarTitle="Bloom")
 		{
 			DoOnceOnIdle(() =>
 			{
-				using (var dlg = new ReactDialog(reactComponentName, props))
+				using (var dlg = new ReactDialog(reactComponentName, props, taskBarTitle))
 				{
 					dlg.Width = width;
 					dlg.Height = height;

--- a/src/BloomExe/NonFatalProblem.cs
+++ b/src/BloomExe/NonFatalProblem.cs
@@ -145,7 +145,7 @@ namespace Bloom
 							}
 						}
 					}
-					catch(Exception)
+					catch(Exception ex)
 					{
 						//if we're running when the UI is already shut down, the above is going to throw.
 						//At least if we're running in a debugger, we'll stop here:

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -681,7 +681,7 @@ namespace Bloom
 						var shell = _projectContext.ProjectWindow as Shell;
 						if (shell != null)
 						{
-							shell.ReallyComeToFront();
+							shell.Invoke((Action) (()=> shell.ReallyComeToFront()));
 						}
 					}
 				};

--- a/src/BloomExe/TeamCollection/FolderTeamCollection.cs
+++ b/src/BloomExe/TeamCollection/FolderTeamCollection.cs
@@ -774,7 +774,7 @@ namespace Bloom.TeamCollection
 				joiningRepo = repoFolder,
 				joiningGuid,
 				localGuid
-			}))
+			}, "Join Team Collection"))
 			{
 				dlg.Width = 560;
 				dlg.Height = 400;

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -1132,7 +1132,7 @@ namespace Bloom.TeamCollection
 
 		private static string GetStatusFilePathFromBookFolderPath(string bookFolderPath)
 		{
-			var statusFile = Path.Combine(bookFolderPath, "book.status");
+			var statusFile = Path.Combine(bookFolderPath, "TeamCollection.status");
 			return statusFile;
 		}
 
@@ -1260,6 +1260,40 @@ namespace Bloom.TeamCollection
 			"衝突複本" // zh-tx, taiwan
 			// Probably many others
 		};
+
+		/// <summary>
+		/// In our early TC alphas and very early 5.0 betas, the TeamCollection.status files we keep in each book's folder
+		/// were called book.status. This code converts them. It can be discarded once all early adopters
+		/// have used a version that has this once.
+		/// </summary>
+		public void MigrateStatusFiles()
+		{
+			foreach (var path in Directory.EnumerateDirectories(_localCollectionFolder))
+			{
+
+				try
+				{
+					if (!IsBloomBookFolder(path))
+						continue;
+					var bookFolderName = Path.GetFileName(path);
+					var statusFilePath = GetStatusFilePath(bookFolderName, _localCollectionFolder);
+					// data migration
+					var obsoleteTcStatusPath = Path.Combine(path, "book.status");
+					if (RobustFile.Exists(obsoleteTcStatusPath))
+					{
+						if (RobustFile.Exists(statusFilePath))
+							RobustFile.Delete(obsoleteTcStatusPath); // somehow left behind
+						else
+							RobustFile.Move(obsoleteTcStatusPath, statusFilePath); // migrate
+					}
+				}
+				catch (Exception ex)
+				{
+					SentrySdk.AddBreadcrumb(string.Format("failed to migrate status file for {0}", path));
+					SentrySdk.CaptureException(ex);
+				}
+			}
+		}
 
 		/// <summary>
 		/// Run this when Bloom starts up to get the repo and local directories as sync'd as possible.
@@ -1583,7 +1617,7 @@ namespace Bloom.TeamCollection
 						titleBackgroundColor = Palette.kBloomBlueHex,
 						webSocketContext = TeamCollection.kWebSocketContext,
 						showReportButton = "if-error"
-		})
+		}, "Sync Team Collection")
 					// winforms dialog properties
 					{Width = 620, Height = 550},
 				doWhat, doWhenMainActionFalse);
@@ -1623,6 +1657,7 @@ namespace Bloom.TeamCollection
 					// enough when we do several close together.
 					StopMonitoring();
 
+					MigrateStatusFiles();
 					var waitForUserToCloseDialogOrReportProblems = SyncAtStartup(progress, doingFirstTimeJoinCollectionMerge);
 
 					// Now that we've finished synchronizing, update these icons based on the post-sync result

--- a/src/BloomExe/TeamCollection/TeamCollectionApi.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionApi.cs
@@ -60,7 +60,7 @@ namespace Bloom.TeamCollection
 
 		private void HandleShowCreateTeamCollectionDialog(ApiRequest request)
 		{
-			ReactDialog.ShowOnIdle("CreateTeamCollectionDialog", new { defaultRepoFolder = DropboxUtils.GetDropboxFolderPath() }, 600, 580);
+			ReactDialog.ShowOnIdle("CreateTeamCollectionDialog", new { defaultRepoFolder = DropboxUtils.GetDropboxFolderPath() }, 600, 580, null, null, "Create Team Collection");
 			request.PostSucceeded();
 		}
 

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -900,15 +900,15 @@ namespace Bloom.Workspace
 				// hide the progress dialog. This is as much as we can postpone.
 				StartupScreenManager.AddStartupAction( () =>
 					{
-						using (var dlg = new ReactDialog("AutoUpdateSoftwareDialog"))
+						using (var dlg = new ReactDialog("AutoUpdateSoftwareDialog", "Auto Update"))
 						{
 							dlg.Height = 350;
 							dlg.FormBorderStyle = FormBorderStyle.FixedDialog;
 							dlg.ControlBox = false;
 							dlg.Text = ""; // Don't show a title on the dialog
-							// FWIW: We don't want this dialog draggable, but if I didn't set Text to empty string,
-							// the dialog is draggable, but says "ReactDialog" in the upper left corner.
-							// If we need a draggable one sometime, we can just set the Text to what we want.
+										   // FWIW: We don't want this dialog draggable, but if I didn't set Text to empty string,
+										   // the dialog is draggable, but says "ReactDialog" in the upper left corner.
+										   // If we need a draggable one sometime, we can just set the Text to what we want.
 							dlg.ShowDialog(this);
 						}
 					}, shouldHideSplashScreen:true, lowPriority:false);

--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -456,7 +456,7 @@ namespace Bloom.web.controllers
 					}
 
 					// Precondition: we must be on the UI thread for Gecko to work.
-					using (var dlg = new ReactDialog("ProblemDialog", new { level = levelOfProblem}))
+					using (var dlg = new ReactDialog("ProblemDialog", new { level = levelOfProblem}, "Problem Report"))
 					{
 						dlg.FormBorderStyle = FormBorderStyle.FixedToolWindow; // Allows the window to be dragged around
 						dlg.ControlBox = true; // Add controls like the X button back to the top bar


### PR DESCRIPTION
- Error reporting was failing due to being on the wrong thread when trying to close the splash screen
- ReactDialog was not setting suitable titles to show in the task bar, so it just showed up as ReactDialog
We also decided to rename book.status to TeamCollection.status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4556)
<!-- Reviewable:end -->
