### PR TITLE
Fixes more problems with corrupt zip .bloom files (BL-10097)

### DIFF
--- a/src/BloomExe/MiscUI/BrowserProgressDialog.cs
+++ b/src/BloomExe/MiscUI/BrowserProgressDialog.cs
@@ -51,7 +51,21 @@ namespace Bloom.MiscUI
 					// A way of waiting until the dialog is ready to receive progress messages
 					while (!socketServer.IsSocketOpen(socketContext))
 						Thread.Sleep(50);
-					var waitForUserToCloseDialogOrReportProblems = doWhat(progress);
+					bool waitForUserToCloseDialogOrReportProblems;
+					try
+					{
+						waitForUserToCloseDialogOrReportProblems = doWhat(progress);
+					}
+					catch (Exception ex)
+					{
+						// depending on the nature of the problem, we might want to do more or less than this.
+						// But at least this lets the dialog reach one of the states where it can be closed,
+						// and gives the user some idea things are not right.
+						socketServer.SendEvent(socketContext, "finished");
+						waitForUserToCloseDialogOrReportProblems = true;
+						progress.MessageWithoutLocalizing("Something went wrong: " + ex.Message, ProgressKind.Error);
+					}
+
 					// stop the spinner
 					socketServer.SendEvent(socketContext, "finished");
 					if (waitForUserToCloseDialogOrReportProblems)

--- a/src/BloomExe/SplashScreen.cs
+++ b/src/BloomExe/SplashScreen.cs
@@ -29,7 +29,8 @@ namespace Bloom
 
 		public void FadeAndClose()
 		{
-			_fadeOutTimer.Enabled = true;
+			Invoke((Action) (() =>
+				_fadeOutTimer.Enabled = true));
 		}
 
 		private SplashScreen()

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -1789,7 +1789,21 @@ namespace Bloom.TeamCollection
 				RaiseBookStatusChanged(bookName, CheckedOutBy.Deleted);
 				return;
 			}
-			var status = GetStatus(bookName);
+
+			BookStatus status;
+			try
+			{
+				status = GetStatus(bookName);
+			}
+			catch (Exception ex)
+			{
+				// We may want to do more, such as put a red circle on the book. But at least don't crash.
+				// The case where we observed this, a corrupt zip file that can't be read, caused
+				// plenty of other errors, so I'm thinking just giving up is enough. This is just
+				// trying to give the user a quick idea of status.
+				return;
+			}
+
 			if (IsCheckedOutHereBy(status))
 				RaiseBookStatusChanged(bookName, CheckedOutBy.Self);
 			else if (status.IsCheckedOut())


### PR DESCRIPTION
- uncaught exception in progress dialog task was leaving the dialog frozen
- Failure to get status from a corrupt .bloom file when updating book status was throwing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4560)
<!-- Reviewable:end -->
