### PR TITLE
Get bulk upload link working on Linux (BL-9997)

### DIFF
--- a/src/BloomExe/CLI/UploadCommand.cs
+++ b/src/BloomExe/CLI/UploadCommand.cs
@@ -54,8 +54,6 @@ namespace Bloom.CLI
 				using (var applicationContainer = new ApplicationContainer())
 				{
 					Program.SetUpLocalization(applicationContainer);
-					Browser.SetUpXulRunner();
-					Browser.XulRunnerShutdown += Program.OnXulRunnerShutdown;
 					LocalizationManager.SetUILanguage(Settings.Default.UserInterfaceLanguage, false);
 					var singleBookUploader = new BookUpload(new BloomParseClient(), ProjectContext.CreateBloomS3Client(),
 						applicationContainer.BookThumbNailer);


### PR DESCRIPTION
Also fix a minor typo in a progress message that I missed earlier.
The CLI invocation uses no GUI, so it doesn't need to initialize
XulRunner (Geckofx), which was crashing on Linux anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4574)
<!-- Reviewable:end -->
