### PR TITLE
BL-9976 Add pics and video as options for comic "bubbles" over pictures

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -886,9 +886,9 @@ export function SetupElements(container: HTMLElement) {
         element.addEventListener("keydown", fixUpDownArrowEventHandler);
     });
 
-    // make any added text-over-picture bubbles draggable and clickable
+    // make any added over-picture elements draggable and clickable
     if (theOneBubbleManager) {
-        theOneBubbleManager.initializeTextOverPictureEditing();
+        theOneBubbleManager.initializeOverPictureEditing();
     }
 
     // focus on the first editable field

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -1,6 +1,7 @@
-// This class makes it possible to add and delete textboxes that float over images. These floating
-// textboxes are intended for use in making comic books, but could also be useful in the case of
-// any book that uses a picture where there is space for text within the bounds of the picture.
+// This class makes it possible to add and delete elements that float over images. These floating
+// elements were originally intended for use in making comic books, but could also be useful for many
+// other cases of where there is space for text or another image or a video within the bounds of
+// the picture.
 ///<reference path="../../typings/jquery/jquery.d.ts"/>
 // This collectionSettings reference defines the function GetSettings(): ICollectionSettings
 // The actual function is injected by C#.
@@ -25,7 +26,11 @@ const kTextOverPictureClass = "bloom-textOverPicture";
 const kTextOverPictureSelector = `.${kTextOverPictureClass}`;
 const kImageContainerSelector = ".bloom-imageContainer";
 
-// references to "TOP" in the code refer to the actual TextOverPicture box (what "Bubble"s were originally called) installed in the Bloom page.
+// References to "TOP" in the code refer to the actual TextOverPicture box (what "Bubble"s were
+// originally called) installed in the Bloom page. We are gradually removing these, since now there
+// are multiple types of elements that can be placed over pictures, not just Text.
+// "Bubble" now becomes a generic name for any element placed over a picture that communicates with
+// comicaljs.
 export class BubbleManager {
     // The min width/height needs to be kept in sync with the corresponding values in bubble.less
     public minTextBoxWidthPx = 30;
@@ -1589,6 +1594,7 @@ export class BubbleManager {
         imageContainerJQuery: JQuery,
         style?: string
     ): HTMLElement {
+        // todo: handle additional styles; image/video
         const defaultNewTextLanguage = GetSettings().languageForNewTextBoxes;
         // add a draggable text bubble to the html dom of the current page
         const editableDivClasses =

--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comic.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comic.less
@@ -35,58 +35,67 @@
     }
 
     .shapeChooserRow {
-        // Each row fills the entire width of the parent horizontally
-        width: 100%;
-
-        // Each row gets a little vertical cushion
-        margin-top: 10px;
-        margin-bottom: 10px;
-    }
-
-    #shapeChooserRow1 {
         // Using display: flex helps us grow some of the children
         // while also allowing us to adapt to the presence or absence of the vertical scrollbar
         display: flex;
+
+        // Each row fills the entire width of the parent horizontally
+        width: 100%;
         height: 50px;
-        align-items: center;
+        align-items: center; // vertical
+        justify-content: space-between; // horizontal
+        margin-right: 4px; // matches the space on the left
 
-        #shapeChooserSpeechBubble {
-            width: 50px;
-            height: 50px;
-        }
-
-        #shapeChooserTextBlock {
-            margin-left: 15px; // Create enough spacing between this and the icon to its left
-            flex-grow: 1; // Let it fill as much space as possible to the right
-            text-align: center; // Center the text horizontally
-
-            padding-top: 1em;
-            vertical-align: middle;
-            padding-bottom: 1em;
-
-            color: white;
-            border: 1px dotted white;
+        // Each row gets a little vertical cushion
+        margin-top: 10px;
+        > .shapeChooserRow {
+            // second row
+            margin-top: 0;
+            margin-bottom: 10px;
         }
     }
 
-    #shapeChooserRow2 {
-        display: flex; // Lets us have the button expand to fill the appropriate area
+    #shapeChooserSpeechBubble {
+        width: 50px;
+        height: 50px;
+    }
 
-        #shapeChooserCaption {
-            // Horizontal positioning / sizing of the element
-            margin-left: 14px;
-            flex-grow: 1; // Allow it to fill the entire space (but with margin-left and margin-right outside of it)
-            margin-right: 14px;
-            text-align: center;
+    #shapeChooserImagePlaceholder {
+        width: 50px;
+        height: 50px;
+    }
 
-            // Vertical sizing
-            padding-top: 5px;
-            padding-bottom: 5px;
+    #shapeChooserVideoPlaceholder {
+        width: 50px;
+        height: 50px;
+    }
 
-            border: 1px solid black;
-            color: black;
-            background-color: white;
-        }
+    #shapeChooserTextBlock {
+        margin-left: 5px; // Match the spacing on the bubble icon above
+        flex-grow: 1; // Let it fill as much space as possible to the right
+        text-align: center; // Center the text horizontally
+
+        padding-top: 1em;
+        vertical-align: middle;
+        padding-bottom: 1em;
+
+        color: white;
+        border: 1px dotted white;
+    }
+
+    #shapeChooserCaption {
+        // Horizontal positioning / sizing of the element
+        margin-left: 10px;
+        flex-grow: 1; // Allow it to fill the entire space (but with margin-left and margin-right outside of it)
+        text-align: center;
+
+        // Vertical sizing
+        padding-top: 5px;
+        padding-bottom: 5px;
+
+        border: 1px solid black;
+        color: black;
+        background-color: white;
     }
 }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
@@ -472,6 +472,24 @@ const ComicToolControls: React.FunctionComponent = () => {
                         onDragStart={ev => ondragstart(ev, "speech")}
                         onDragEnd={ev => ondragend(ev, "speech")}
                     />
+                    <img
+                        id="shapeChooserImagePlaceholder"
+                        className="comicToolControlDraggableBubble"
+                        src="placeHolder.png"
+                        draggable={true}
+                        onDragStart={ev => ondragstart(ev, "image")}
+                        onDragEnd={ev => ondragend(ev, "image")}
+                    />
+                    <img
+                        id="shapeChooserVideoPlaceholder"
+                        className="comicToolControlDraggableBubble"
+                        src="signLanguageTool.svg"
+                        draggable={true}
+                        onDragStart={ev => ondragstart(ev, "video")}
+                        onDragEnd={ev => ondragend(ev, "video")}
+                    />
+                </div>
+                <div className={"shapeChooserRow"} id={"shapeChooserRow2"}>
                     <Span
                         id="shapeChooserTextBlock"
                         l10nKey="EditTab.Toolbox.ComicTool.TextBlock"
@@ -482,8 +500,6 @@ const ComicToolControls: React.FunctionComponent = () => {
                     >
                         Text Block
                     </Span>
-                </div>
-                <div className={"shapeChooserRow"} id={"shapeChooserRow2"}>
                     <Span
                         id="shapeChooserCaption"
                         l10nKey="EditTab.Toolbox.ComicTool.Options.Style.Caption"

--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
@@ -297,7 +297,7 @@ const ComicToolControls: React.FunctionComponent = () => {
                 parentElement,
                 bubbleSpec
             );
-            bubbleManager.addChildTOPBoxAndRefreshPage(
+            bubbleManager.addChildOverPictureElementAndRefreshPage(
                 parentElement,
                 offsetX,
                 offsetY
@@ -322,7 +322,7 @@ const ComicToolControls: React.FunctionComponent = () => {
         // This can be used to simulate the drop event with coordinate transformation.
         // See https://issues.bloomlibrary.org/youtrack/issue/BL-7958.
         if (isLinux() && bubbleManager) {
-            bubbleManager.addFloatingTOPBoxWithScreenCoords(
+            bubbleManager.addOverPictureElementWithScreenCoords(
                 ev.screenX,
                 ev.screenY,
                 style


### PR DESCRIPTION
This is 3 commits:
* 1st adds the comicTool shapes to drag (still need updated icons)
* 2nd just refactors/renames mostly from 'text over picture' to 'over picture 
   element' wording
* 3rd a lot of refactoring and the guts of getting video and pics over pics to work

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4586)
<!-- Reviewable:end -->
