### PR TITLE
Preserve original images when desired for BloomPub books (BL-10162)

### DIFF
--- a/src/BloomBrowserUI/branding/Kyrgyzstan2020/branding.json
+++ b/src/BloomBrowserUI/branding/Kyrgyzstan2020/branding.json
@@ -9,13 +9,13 @@
         {
             "data-book": "outside-back-cover-branding-top-left-html",
             "lang": "*",
-            "content": "<img class='branding' src='Kyrgyzstan2020-{flavor}-USAID.png'/>",
+            "content": "<img class='branding bloom-doNotShrinkImage' src='Kyrgyzstan2020-{flavor}-USAID.png'/>",
             "condition": "always"
         },
         {
             "data-book": "outside-back-cover-branding-top-right-html",
             "lang": "*",
-            "content": "<img class='branding' src='Kyrgyzstan2020-{flavor}-government-seal.png'/>",
+            "content": "<img class='branding bloom-doNotShrinkImage' src='Kyrgyzstan2020-{flavor}-government-seal.png'/>",
             "condition": "always"
         },
         {

--- a/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.pug
+++ b/src/BloomBrowserUI/templates/xMatter/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.pug
@@ -14,7 +14,7 @@ block outsideBackCover
 	div.bottomHalfGrid
 		+field-mono-meta("N1","outsideBackCover").Outside-Back-Cover-style
 			label.bubble If you need somewhere to put more information about the book, you can use this page, which is the outside of the back cover.
-		+image-xmatter('level-image')
+		+image-xmatter('level-image').bloom-doNotShrinkImage
 			label.bubble Paste the level diagram here.
 	+divider
 


### PR DESCRIPTION
The Kyrgyzstan branding files were modified to apply the new class to back-cover images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4600)
<!-- Reviewable:end -->
