### PR TITLE
BL-9976 Video and image comics

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -86,10 +86,10 @@ div.bloom-imageContainer {
     border: 1px solid @MediumGray;
 }
 
-// The editing buttons are hidden when this class is added (currently by motion tool)
+// The editing buttons are hidden when this class is added (currently by motion and comic tools)
 .bloom-imageContainer.bloom-hideImageButtons {
-    .imageButton,
-    .miniButton {
+    > .imageButton,
+    > .miniButton {
         display: none;
     }
 }
@@ -182,15 +182,17 @@ div.hoverUp {
         background-color: @ChangeImageButtonColor;
         background-image: url("../img/changeButton.svg");
     }
-    &.imageDescriptionButton {
-        left: 0;
-        bottom: 0;
-        background-color: @bloom-blue;
-        background-image: url("../img/ImageDescriptionImageOverlayButton.svg");
-        // sorry, this background-size is kinda arbitrary, and "49px 40px" works at full size, but if we ever make these
-        //buttons shrink as the image container shrinks, this will still work.
-        background-size: 63%;
-    }
+    // BL-9976 JH - "We've gotten complaints that users click it and then are too confused and
+    // start typing text in the wrong place."
+    // &.imageDescriptionButton {
+    //     left: 0;
+    //     bottom: 0;
+    //     background-color: @bloom-blue;
+    //     background-image: url("../img/ImageDescriptionImageOverlayButton.svg");
+    //     // sorry, this background-size is kinda arbitrary, and "49px 40px" works at full size, but if we ever make these
+    //     //buttons shrink as the image container shrinks, this will still work.
+    //     background-size: 63%;
+    // }
     &.chooseWidgetButton {
         right: 0;
         top: 0;

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -178,28 +178,29 @@ function SetupImageContainer(containerDiv: HTMLElement) {
                     '"></button>'
             );
 
-            if (
-                // Only show this button if the toolbox is also offering it. It might not offer it
-                // if it's experimental and that settings isn't on, or for Bloom Enterprise reasons, or whatever.
-                getToolboxBundleExports()
-                    ?.getTheOneToolbox()
-                    .getToolIfOffered(ImageDescriptionAdapter.kToolID)
-            ) {
-                $this.prepend(
-                    '<button class="imageDescriptionButton imageButton imageOverlayButton ' +
-                        buttonModifier +
-                        '" title="' +
-                        theOneLocalizationManager.getText(
-                            "EditTab.Toolbox.ImageDescriptionTool" // not quite the "Show Image Description Tool", but... feeling parsimonious
-                        ) +
-                        '"></button>'
-                );
-                $this.find(".imageDescriptionButton").click(() => {
-                    getToolboxBundleExports()
-                        ?.getTheOneToolbox()
-                        .activateToolFromId(ImageDescriptionAdapter.kToolID);
-                });
-            }
+            // As part of BL-9976 JH decided to remove this button as users were getting confused.
+            // if (
+            //     // Only show this button if the toolbox is also offering it. It might not offer it
+            //     // if it's experimental and that settings isn't on, or for Bloom Enterprise reasons, or whatever.
+            //     getToolboxFrameExports()
+            //         ?.getTheOneToolbox()
+            //         .getToolIfOffered(ImageDescriptionAdapter.kToolID)
+            // ) {
+            //     $this.prepend(
+            //         '<button class="imageDescriptionButton imageButton imageOverlayButton ' +
+            //             buttonModifier +
+            //             '" title="' +
+            //             theOneLocalizationManager.getText(
+            //                 "EditTab.Toolbox.ImageDescriptionTool" // not quite the "Show Image Description Tool", but... feeling parsimonious
+            //             ) +
+            //             '"></button>'
+            //     );
+            //     $this.find(".imageDescriptionButton").click(() => {
+            //         getToolboxFrameExports()
+            //             ?.getTheOneToolbox()
+            //             .activateToolFromId(ImageDescriptionAdapter.kToolID);
+            //     });
+            // }
 
             SetImageTooltip(containerDiv);
 

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -162,8 +162,8 @@ export class BubbleManager {
         const imageContainers: HTMLElement[] = Array.from(
             document.getElementsByClassName(kImageContainerClass) as any
         );
-        imageContainers.forEach(e => {
-            BubbleManager.hideImageButtonsIfNotPlaceHolder(e);
+        imageContainers.forEach(container => {
+            BubbleManager.hideImageButtonsIfNotPlaceHolder(container);
         });
     }
 
@@ -1756,6 +1756,7 @@ export class BubbleManager {
             internalHtml +
             "</div>";
         const wrapperJQuery = $(wrapperHtml).insertAfter(lastContainerChild);
+        this.setDefaultWrapperBoxHeight(wrapperJQuery);
         const contentElement = wrapperJQuery.get(0);
         this.placeElementAtPosition(
             wrapperJQuery,
@@ -1774,6 +1775,22 @@ export class BubbleManager {
         return contentElement;
     }
 
+    // This 'wrapperBox' param has just been added to the DOM by JQuery before arriving here.
+    // All of the text-based bubbles' default heights are based on the min-height of 30px set
+    // in bubble.less for a .bloom-textOverPicture element. For video or picture over pictures,
+    // we want something a bit taller.
+    private setDefaultWrapperBoxHeight(wrapperBox: JQuery) {
+        const width = parseInt(wrapperBox.css("width"), 10);
+        if (wrapperBox.find(".bloom-videoContainer").length > 0) {
+            // Set the default video aspect to 4:3, the same as the sign language tool generates.
+            wrapperBox.css("height", (width * 3) / 4);
+        }
+        if (wrapperBox.find(".bloom-imageContainer").length > 0) {
+            // Set the default image aspect to square.
+            wrapperBox.css("height", width);
+        }
+    }
+
     // mouseX and mouseY are the location in the viewport of the mouse
     private getImageContainerFromMouse(mouseX: number, mouseY: number): JQuery {
         const clickElement = document.elementFromPoint(mouseX, mouseY);
@@ -1784,7 +1801,8 @@ export class BubbleManager {
         return $(BubbleManager.getTopLevelImageContainerElement(clickElement)!);
     }
 
-    // positionInViewport is the position to place the top-left corner of the wrapperBox
+    // This method is used both for creating new elements and in dragging/resizing.
+    // positionInViewport: is the position to place the top-left corner of the wrapperBox
     private placeElementAtPosition(
         wrapperBox: JQuery,
         container: Element,
@@ -2515,7 +2533,8 @@ export class BubbleManager {
 
     // Sets a text box's position in percentages (using CSS styling)
     // wrapperBox: The text box in question
-    // unscaledRelativeLeft/unscaledRelativeTop: The position to set the top-left corner/at. It should be in unscaled pixels, relative to the parent.
+    // unscaledRelativeLeft/unscaledRelativeTop: The position to set the top-left corner/at.
+    // It should be in unscaled pixels, relative to the parent.
     private static setTextboxPositionAsPercentage(
         wrapperBox: JQuery,
         unscaledRelativeLeft: number,

--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
@@ -47,6 +47,10 @@ const ComicToolControls: React.FunctionComponent = () => {
     );
 
     const [isXmatter, setIsXmatter] = useState(true);
+    // If the book is locked, we don't want users dragging things onto the page.
+    const [isBookLocked, setIsBookLocked] = useState(false);
+    // This 'counter' increments on new page ready so we can re-check if the book is locked.
+    const [pageRefreshIndicator, setPageRefreshIndicator] = useState(0);
 
     // Setup for color picker, in case we need it.
     const textColorTitle = useL10n(
@@ -108,6 +112,8 @@ const ComicToolControls: React.FunctionComponent = () => {
     ComicTool.theOneComicTool!.callOnNewPageReady = () => {
         bubbleSpecInitialization();
         setIsXmatter(ToolboxToolReactAdaptor.isXmatter());
+        const count = pageRefreshIndicator;
+        setPageRefreshIndicator(count + 1);
     };
 
     // Reset UI when current bubble spec changes (e.g. user clicked on a bubble).
@@ -140,6 +146,15 @@ const ComicToolControls: React.FunctionComponent = () => {
             setBubbleActive(false);
         }
     }, [currentFamilySpec]);
+
+    useEffect(() => {
+        // Get the lock/unlock state from C#-land. We have to do this every time the page is refreshed
+        // (see 'callOnNewPageReady') in case the user temporarily unlocks the book.
+        BloomApi.get("edit/pageControls/requestState", result => {
+            const jsonObj = result.data;
+            setIsBookLocked(jsonObj.BookLockedState === "BookLocked");
+        });
+    }, [pageRefreshIndicator]);
 
     // Callback for style changed
     const handleStyleChanged = event => {
@@ -321,7 +336,7 @@ const ComicToolControls: React.FunctionComponent = () => {
         // for the source element with screen coordinates of where the mouse was released.
         // This can be used to simulate the drop event with coordinate transformation.
         // See https://issues.bloomlibrary.org/youtrack/issue/BL-7958.
-        if (isLinux() && bubbleManager) {
+        if (isLinux() && bubbleManager && !isBookLocked) {
             bubbleManager.addOverPictureElementWithScreenCoords(
                 ev.screenX,
                 ev.screenY,
@@ -468,25 +483,49 @@ const ComicToolControls: React.FunctionComponent = () => {
                         id="shapeChooserSpeechBubble"
                         className="comicToolControlDraggableBubble"
                         src="comic-icon.svg"
-                        draggable={true}
-                        onDragStart={ev => ondragstart(ev, "speech")}
-                        onDragEnd={ev => ondragend(ev, "speech")}
+                        draggable={!isBookLocked} // insufficient to prevent dragging!
+                        onDragStart={
+                            !isBookLocked
+                                ? ev => ondragstart(ev, "speech")
+                                : undefined
+                        }
+                        onDragEnd={
+                            !isBookLocked
+                                ? ev => ondragend(ev, "speech")
+                                : undefined
+                        }
                     />
                     <img
                         id="shapeChooserImagePlaceholder"
                         className="comicToolControlDraggableBubble"
                         src="placeHolder.png"
-                        draggable={true}
-                        onDragStart={ev => ondragstart(ev, "image")}
-                        onDragEnd={ev => ondragend(ev, "image")}
+                        draggable={!isBookLocked}
+                        onDragStart={
+                            !isBookLocked
+                                ? ev => ondragstart(ev, "image")
+                                : undefined
+                        }
+                        onDragEnd={
+                            !isBookLocked
+                                ? ev => ondragend(ev, "image")
+                                : undefined
+                        }
                     />
                     <img
                         id="shapeChooserVideoPlaceholder"
                         className="comicToolControlDraggableBubble"
                         src="signLanguageTool.svg"
-                        draggable={true}
-                        onDragStart={ev => ondragstart(ev, "video")}
-                        onDragEnd={ev => ondragend(ev, "video")}
+                        draggable={!isBookLocked}
+                        onDragStart={
+                            !isBookLocked
+                                ? ev => ondragstart(ev, "video")
+                                : undefined
+                        }
+                        onDragEnd={
+                            !isBookLocked
+                                ? ev => ondragend(ev, "video")
+                                : undefined
+                        }
                     />
                 </div>
                 <div className={"shapeChooserRow"} id={"shapeChooserRow2"}>
@@ -494,9 +533,17 @@ const ComicToolControls: React.FunctionComponent = () => {
                         id="shapeChooserTextBlock"
                         l10nKey="EditTab.Toolbox.ComicTool.TextBlock"
                         className="comicToolControlDraggableBubble"
-                        draggable={true}
-                        onDragStart={ev => ondragstart(ev, "none")}
-                        onDragEnd={ev => ondragend(ev, "none")}
+                        draggable={!isBookLocked}
+                        onDragStart={
+                            !isBookLocked
+                                ? ev => ondragstart(ev, "none")
+                                : undefined
+                        }
+                        onDragEnd={
+                            !isBookLocked
+                                ? ev => ondragend(ev, "none")
+                                : undefined
+                        }
                     >
                         Text Block
                     </Span>
@@ -504,9 +551,17 @@ const ComicToolControls: React.FunctionComponent = () => {
                         id="shapeChooserCaption"
                         l10nKey="EditTab.Toolbox.ComicTool.Options.Style.Caption"
                         className="comicToolControlDraggableBubble"
-                        draggable={true}
-                        onDragStart={ev => ondragstart(ev, "caption")}
-                        onDragEnd={ev => ondragend(ev, "caption")}
+                        draggable={!isBookLocked}
+                        onDragStart={
+                            !isBookLocked
+                                ? ev => ondragstart(ev, "caption")
+                                : undefined
+                        }
+                        onDragEnd={
+                            !isBookLocked
+                                ? ev => ondragend(ev, "caption")
+                                : undefined
+                        }
                     >
                         Caption
                     </Span>

--- a/src/BloomBrowserUI/bookLayout/bubble.less
+++ b/src/BloomBrowserUI/bookLayout/bubble.less
@@ -105,7 +105,6 @@
     .bloom-textOverPicture {
         position: absolute;
         width: @DefaultTextBoxWidth;
-        height: @DefaultTextBoxHeight;
         min-width: @MinTextBoxWidth;
         min-height: @MinTextBoxHeight;
         border-radius: 3px;


### PR DESCRIPTION
* handle pic over pic editing
* make comic bubbles not draggable when the book is
   locked
* remove Image Description overlay button
* make pic/vid placeholders square

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4607)
<!-- Reviewable:end -->
