### PR TITLE
Remove extra scroll bar in CollectionsTabBookPane (BL-10220)

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
@@ -75,6 +75,7 @@ export const CollectionsTabBookPane: React.FunctionComponent<{
         <div
             css={css`
                 height: 100%;
+                box-sizing: border-box;
                 display: flex;
                 flex: 1;
                 flex-direction: column;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4613)
<!-- Reviewable:end -->
