### PR TITLE
Correctly handle forget and undo checkout when renamed (BL-10013)

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -87,7 +87,7 @@ namespace Bloom.Book
 
 		CollectionSettings CollectionSettings { get; }
 
-		void ReloadFromDisk();
+		void ReloadFromDisk(string renamedTo, Action betweenReloadAndEvents);
 	}
 
 	public class BookStorage : IBookStorage
@@ -1814,9 +1814,21 @@ namespace Bloom.Book
 			}
 		}
 
-		public void ReloadFromDisk()
+		public void ReloadFromDisk(string renamedTo, Action betweenReloadAndEvents)
 		{
+			var fromToPair = new KeyValuePair<string, string>(FolderPath, renamedTo);
+			if (renamedTo!= null)
+				FolderPath = renamedTo;
 			ExpensiveInitialization(true);
+
+			betweenReloadAndEvents();
+
+			if (renamedTo != null)
+			{
+				// The reload has renamed the book. We need to do the usual side effects.
+				_bookRenamedEvent.Raise(fromToPair);
+				OnFolderPathChanged();
+			}
 		}
 
 		public void CleanupUnusedSupportFiles(bool isForPublish, HashSet<string> langsToExcludeAudioFor = null)

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -1084,7 +1084,7 @@ namespace Bloom.CollectionTab
 		{
 			get
 			{
-				return AllBookButtons().FirstOrDefault(b => GetBookInfoFromButton(b) == SelectedBook.BookInfo);
+				return AllBookButtons().FirstOrDefault(b => GetBookInfoFromButton(b).FolderPath == SelectedBook?.BookInfo.FolderPath);
 			}
 		}
 
@@ -1104,6 +1104,7 @@ namespace Bloom.CollectionTab
 				// Just make a note to re-show it next time we're visible
 				_thumbnailRefreshPending = true;
 			}
+			BringButtonTitleUpToDate(_bookSelection.CurrentSelection);
 		}
 
 		private void OnBackColorChanged(object sender, EventArgs e)
@@ -1119,14 +1120,16 @@ namespace Bloom.CollectionTab
 				Book.Book book = SelectedBook;
 				if (book != null && SelectedButton != null)
 				{
-					var bestTitle = book.TitleBestForUserDisplay;
-					SelectedButton.SetTextSafely(ShortenTitleIfNeeded(bestTitle, SelectedButton));
-					SetBookButtonTooltip(SelectedButton);
+					BringButtonTitleUpToDate(book);
 					if (_thumbnailRefreshPending)
 					{
 						_thumbnailRefreshPending = false;
 						ScheduleRefreshOfOneThumbnail(book);
 					}
+				}
+				else
+				{
+
 				}
 				if (_primaryCollectionReloadPending)
 				{
@@ -1145,6 +1148,15 @@ namespace Bloom.CollectionTab
 				// We don't need to finish these now if we've already switched tabs.
 				PauseStartupActions();
 			}
+		}
+
+		private void BringButtonTitleUpToDate(Book.Book book)
+		{
+			if (SelectedButton == null || _bookSelection.CurrentSelection == null)
+				return;
+			var bestTitle = book.TitleBestForUserDisplay;
+			SelectedButton.SetTextSafely(ShortenTitleIfNeeded(bestTitle, SelectedButton));
+			SetBookButtonTooltip(SelectedButton);
 		}
 
 		private void RefreshOneThumbnail(Book.BookInfo bookInfo, Image image)

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -196,7 +196,6 @@ namespace Bloom.TeamCollection
 
 			status = status.WithLockedBy(null);
 			WriteBookStatus(finalBookName, status);
-			UpdateBookStatus(finalBookName, true);
 			return foldersNeedingUpdate;
 		}
 


### PR DESCRIPTION
Also fixes an intermittent problem in simple renames

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4615)
<!-- Reviewable:end -->
