### PR TITLE
Expand list for font-family in DialogTitle (BL-10208)

### DIFF
--- a/src/BloomBrowserUI/react_components/BloomDialog/BloomDialog.tsx
+++ b/src/BloomBrowserUI/react_components/BloomDialog/BloomDialog.tsx
@@ -111,7 +111,9 @@ export const DialogTitle: React.FunctionComponent<{
                 css={css`
                     margin-top: auto;
                     margin-bottom: auto;
-                    font-family: "Roboto";
+                    // This value is the same as that given in bloomMaterialUITheme.
+                    // For some reason, it is not being applied here.  See BL-10208.
+                    font-family: NotoSans, Roboto, sans-serif;
                 `}
             >
                 {props.title}


### PR DESCRIPTION
ThemeProvider is already applied to BloomDialog.  Applying it in more
places had no effect.  The expanded list is the same as that given in
bloomMaterialUITheme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4619)
<!-- Reviewable:end -->
