### PR TITLE
BL-9976 Third section of tweaks, one UI bit to go

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -5,7 +5,7 @@
 
 @EditBoxItemsColor: #0000001a;
 @MediumGray: #c0b9b9;
-@ImageHoverOverlay: #d5d5e4;
+@ImageAndVideoHoverOverlay: #d5d5e4;
 @ImageButtonBorder: #716666;
 @ChangeImageButtonColor: @ControlColor;
 @PasteImageButtonColor: @bloom-blue; /*#0C8597; */
@@ -143,21 +143,26 @@ div.page {
     border: medium outset black;
 }
 div.page.coverColor {
-    background-color: @ImageHoverOverlay;
+    background-color: @ImageAndVideoHoverOverlay;
     border: medium outset black;
 }
 /* We want divs which are used for editing to look just like textareas (e.g. border).
-   For now, this readOnlyInTranslationMode is an indicator that this is edtiable,
-   but there could be divs which are always edtiable... unfortunately we can't access
-   the contentEditable thing itself. Note that borders are made transpartent by the languagedisplay.css,
-   and there is javascript which notices that transparnet border and makes the field read-only.
+   For now, this readOnlyInTranslationMode is an indicator that this is editable,
+   but there could be divs which are always editable... unfortunately we can't access
+   the contentEditable thing itself. Note that borders are made transparent by the languagedisplay.css,
+   and there is javascript which notices that transparent border and makes the field read-only.
 */
 div.readOnlyInTranslationMode {
     border: thin solid @MediumGray;
 }
-div.hoverUp {
-    background-color: @ImageHoverOverlay;
+
+// Since 'basePage.less' has a rule that puts the video placeholder in as a background image,
+// '.customPage' is needed to add enough specificity here to override that rule.
+.customPage .bloom-videoContainer.hoverUp,
+.bloom-imageContainer.hoverUp {
+    background-color: @ImageAndVideoHoverOverlay;
 }
+
 .imageButton {
     width: 87px;
     height: 52px;

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -172,8 +172,13 @@ function SetupClickToShowSignLanguageTool(containerDiv: Element) {
     // if the user clicks on the video placeholder (or the video for that matter--see BL-6149),
     // bring up the sign language tool
     $(containerDiv).click(() => {
-        getToolboxBundleExports()
-            ?.getTheOneToolbox()
-            .activateToolFromId(SignLanguageToolControls.kToolID);
+        if (containerDiv.classList.contains("bloom-selected")) {
+            // In comic mode, we remove this class, so the click handler won't take us to the sign
+            // language tool, but when we are in the sign language tool and click on a video element
+            // the class gets re-added.
+            getToolboxBundleExports()
+                ?.getTheOneToolbox()
+                .activateToolFromId(SignLanguageToolControls.kToolID);
+        }
     });
 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comicTool.tsx
@@ -92,6 +92,7 @@ const ComicToolControls: React.FunctionComponent = () => {
 
         bubbleManager.turnOnBubbleEditing();
         bubbleManager.turnOnHidingImageButtons();
+        bubbleManager.deselectVideoContainers();
 
         const bubbleSpec = bubbleManager.getSelectedFamilySpec();
 

--- a/src/BloomBrowserUI/bookLayout/bubble.less
+++ b/src/BloomBrowserUI/bookLayout/bubble.less
@@ -31,6 +31,9 @@
     #formatButton {
         display: none;
     }
+    .bloom-imageContainer {
+        border: none; // overwrite rule from editMode.less
+    }
 }
 
 .bloom-imageContainer {
@@ -130,6 +133,14 @@
             }
         }
 
+        // Overrides the inherited values from editMode.less, which are a slightly different shade of blue.
+        // This rule now works for regular just text bubbles and picture or video over picture.
+        div:focus,
+        video:focus {
+            border: 1px solid @bloom-blue;
+            box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1), 0 0 8px @bloom-blue;
+        }
+
         .bloom-translationGroup {
             background: transparent; // don't want to worry about what background the image has
             border: none;
@@ -151,13 +162,6 @@
                     //right: 100% + 33px;
                     bottom: -18px;
                 }
-            }
-
-            .bloom-editable:focus {
-                // Overrides the inherited values from editMode.less, which are a slightly different shade of blue.
-                border: 1px solid @bloom-blue;
-                box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1),
-                    0 0 8px @bloom-blue;
             }
 
             // Language tip CSS
@@ -201,7 +205,7 @@
 
 // Code to handle borders
 .bloom-imageContainer {
-    // Text-over-picture elements with speech bubbles
+    // Over picture elements with speech bubbles
     //
     // a TOP element that contains a data-bubble attribute and does NOT contain the substring "`style`:`none`" in the value of the data-bubble attribute
     .bloom-textOverPicture[data-bubble]:not([data-bubble*="`style`:`none`"]) {


### PR DESCRIPTION
* fix hiding of image buttons for nested imageContainers
* use video container constant
* take off video .bloom-selected when entering comicTool
* add hover background color for video container
* give picture and video over picture elements the blue
   border when selected that Just Text bubbles have
* keep video placeholders from automatically jumping to
   the sign language tool when clicked
* match size on duplicate picture/video on picture

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4626)
<!-- Reviewable:end -->
