### PR TITLE
Nag user about concurrent updates only when problematic (BL-10227)

### DIFF
--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -143,7 +143,7 @@ namespace Bloom.Book
 					// Change the id since every element must have a different id value.
 					HtmlDom.SetNewHtmlIdValue(node);
 				}
-				Console.WriteLine("DEBUG ReplaceAllIdValues(\"{0}\") => \"{1}\"", xmlContent, doc.FirstChild.InnerXml);
+				//Console.WriteLine("DEBUG ReplaceAllIdValues(\"{0}\") => \"{1}\"", xmlContent, doc.FirstChild.InnerXml);
 				xmlContent = doc.FirstChild.InnerXml;   // exclude the outer div we introduced
 			}
 			catch (Exception e)
@@ -1829,7 +1829,7 @@ namespace Bloom.Book
 				if (idxEnd > idxStart)
 				{
 					var cssContent = htmlContent.Substring(idxStart, idxEnd - idxStart);
-					Console.WriteLine("DEBUG cssContent from HTML <style> = \"{0}\"", cssContent);
+					//Console.WriteLine("DEBUG cssContent from HTML <style> = \"{0}\"", cssContent);
 					FindFontsUsedInCss(cssContent, result, includeFallbackFonts);
 				}
 			}


### PR DESCRIPTION
With React asynchronously asking for HTML which can trigger a preview
update, creating a new book from an existing one often updates the
preview DOM and the real DOM simultaneously.  This seems harmless to
me as the code is operating on different input data.  The master branch
has also added more calls to BringBookUpToDate, such as from SelectBook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4628)
<!-- Reviewable:end -->
