### PR TITLE
BL-9976 tool UI changes

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1911,6 +1911,11 @@
         <note>ID: EditTab.Toolbox.ComicTool.Options.Duplicate</note>
         <note>Tooltip for the bubble Duplicate icon</note>
       </trans-unit>
+      <trans-unit id="EditTab.Toolbox.ComicTool.Options.ImageSelected" sil:dynamic="true">
+        <source xml:lang="en">Image selected</source>
+        <note>ID: EditTab.Toolbox.ComicTool.Options.ImageSelected</note>
+        <note>This notification shows if a picture over picture is selected.</note>
+      </trans-unit>
       <trans-unit id="EditTab.Toolbox.ComicTool.Options.OuterOutlineColor" sil:dynamic="true">
         <source xml:lang="en">Outer Outline Color</source>
         <note>ID: EditTab.Toolbox.ComicTool.Options.OuterOutlineColor</note>
@@ -1924,6 +1929,11 @@
         <source xml:lang="en">Rounded Corners</source>
         <note>ID: EditTab.Toolbox.ComicTool.Options.RoundedCorners</note>
         <note>This checkbox indicates whether a text box has rounded corners instead of square corners.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.ComicTool.Options.ShowSignLanguageTool" sil:dynamic="true">
+        <source xml:lang="en">Show Sign Language Tool</source>
+        <note>ID: EditTab.Toolbox.ComicTool.Options.ShowSignLanguageTool</note>
+        <note>This button shows if a video bubble is selected.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.ComicTool.Options.ShowTail" sil:dynamic="true">
         <source xml:lang="en">Show Tail</source>

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -439,7 +439,8 @@ export function SetOverlayForImagesWithoutMetadata(container) {
     $(container)
         .find(".bloom-imageContainer")
         .each(function() {
-            var img = $(this).find("img");
+            // BL-9976: now that we can have images on images, only look one level down from the container.
+            var img = $(this).find("> img");
             SetOverlayForImagesWithoutMetadataInner($(img).parent(), img);
         });
 }

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -176,9 +176,13 @@ function SetupClickToShowSignLanguageTool(containerDiv: Element) {
             // In comic mode, we remove this class, so the click handler won't take us to the sign
             // language tool, but when we are in the sign language tool and click on a video element
             // the class gets re-added.
-            getToolboxBundleExports()
-                ?.getTheOneToolbox()
-                .activateToolFromId(SignLanguageToolControls.kToolID);
+            showSignLanguageTool();
         }
     });
+}
+
+export function showSignLanguageTool() {
+    getToolboxBundleExports()
+        ?.getTheOneToolbox()
+        .activateToolFromId(SignLanguageToolControls.kToolID);
 }

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -1698,6 +1698,13 @@ export class BubbleManager {
         return false;
     }
 
+    public isActiveElementPictureOverPicture(): boolean {
+        if (!this.activeElement) {
+            return false;
+        }
+        return this.isPictureOverPictureElement(this.activeElement);
+    }
+
     private isPictureOverPictureElement(
         overPictureElement: HTMLElement
     ): boolean {
@@ -1714,6 +1721,13 @@ export class BubbleManager {
             overPictureElement,
             kVideoContainerClass
         );
+    }
+
+    public isActiveElementVideoOverPicture(): boolean {
+        if (!this.activeElement) {
+            return false;
+        }
+        return this.isVideoOverPictureElement(this.activeElement);
     }
 
     // This method is called when the user "drops" an element from the comicTool onto an image.

--- a/src/BloomBrowserUI/bookEdit/toolbox/comic/comic.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/comic/comic.less
@@ -221,6 +221,15 @@
     }
 }
 
+// This section replaces the main controls of style, colors, tails, etc. which we don't need
+// for picture over picture or video over picture.
+#videoOrImageSubstituteSection {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
 // Empty region that does all the growing and shrinking.
 // makes the comicToolControlFooterRegion go to the bottom,
 // but unlike making it position: absolute and bottom:3,


### PR DESCRIPTION
* figured out "hooks" problem
* replaced 'bubbleActive' state with 'bubbleType', which
   allows the UI to distinguish text/video/image bubbles
* added a "Show Sign Language Tool" button to go to that
   tool when a video is selected in comic tool
* added a message "Image selected" when a picture over
   picture element is selected in comic tool
* fix image metadata problem question mark that was
   showing twice on picture over picture

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4630)
<!-- Reviewable:end -->
