### PR TITLE
Finish using toolboxBundle inside the toolbox (BL-10235)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettingsToolboxTool.pug
+++ b/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettingsToolboxTool.pug
@@ -4,7 +4,7 @@
 		=englishLabel
 	br
 mixin checkbox(key, i18nKey, englishLabel)
-	input(type='checkbox', name=key, value=theValue, onClick='editTabBundle.handleBookSettingCheckboxClick(this);')
+	input(type='checkbox', name=key, value=theValue, onClick='toolboxBundle.handleBookSettingCheckboxClick(this);')
 	label(data-i18n=i18nKey)
 		=englishLabel
 mixin text(i18nKey, englishText)

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/decodableReader/decodableReaderToolboxTool.pug
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/decodableReader/decodableReaderToolboxTool.pug
@@ -36,7 +36,7 @@ html
 			.tableHolder.clear
 				.wordList#wordList
 			#make-letter-word-list-div.clear
-				a#make-letter-word-list(href='javascript:editTabBundle.makeLetterWordList();', data-i18n='EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport') Generate a letter and word list report
+				a#make-letter-word-list(href='javascript:toolboxBundle.makeLetterWordList();', data-i18n='EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport') Generate a letter and word list report
 			#allowed-word-list-truncated.clear(style="color: red")
 			#hiddenWordListForDecodableReader(style="display: none")
 				label#allowed_word_list_truncated_text(data-i18n='EditTab.Toolbox.DecodableReaderTool.AllowedWordListTruncated') Bloom can handle only the first {0} words.

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.io.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.io.ts
@@ -91,7 +91,7 @@ let previousMoreWords: string;
 window.addEventListener("message", process_IO_Message, false);
 
 export interface ToolboxWindow extends Window {
-    editTabBundle: any;
+    toolboxBundle: any;
 }
 export function toolboxWindow(): ToolboxWindow | undefined {
     if (window.parent) {
@@ -270,7 +270,7 @@ function saveClicked(): void {
     beginSaveChangedSettings(); // don't wait for full refresh
     const win = toolboxWindow();
     if (win) {
-        win.editTabBundle.closeSetupDialog();
+        win.toolboxBundle.closeSetupDialog();
     }
 }
 
@@ -286,7 +286,7 @@ export function beginSaveChangedSettings(): JQueryPromise<void> {
     // and the 'then' clause never got invoked.
     const win = toolboxWindow();
     if (win) {
-        return win.editTabBundle.beginSaveChangedSettings(
+        return win.toolboxBundle.beginSaveChangedSettings(
             settings,
             previousMoreWords
         );

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
@@ -1213,7 +1213,7 @@ $(document).ready(() => {
     // http://stackoverflow.com/questions/3032770/execute-javascript-function-in-a-another-iframe-when-parent-is-from-different-do
     const container = $("body");
     //   const pageIframe = parent.frames['page'];
-    //   pageIframe.editTabBundle.loadLongpressInstructions(container.find('textarea'));
+    //   pageIframe.toolboxBundle.loadLongpressInstructions(container.find('textarea'));
     getToolboxBundleExports()!.loadLongpressInstructions(
         container.find("textarea")
     );

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolboxBootstrap.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolboxBootstrap.ts
@@ -37,7 +37,7 @@ export interface IToolboxFrameExports {
     applyToolboxStateToPage(): void;
 }
 
-// each of these exports shows up under this window's editTabBundle object (see bloomFrames.ts)
+// each of these exports shows up under this window's toolboxBundle object (see bloomFrames.ts)
 export { removeToolboxMarkup, showOrHideTool_click };
 export {
     showSetupDialog,


### PR DESCRIPTION
This should finish the renaming task after splitting into bundle
specific exports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4635)
<!-- Reviewable:end -->
