### PR TITLE
Allow read-only image files (20210805)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -3737,7 +3737,7 @@ namespace Bloom.Book
 						if (path == filePath)
 							continue; // we already included a simplified version of the main HTML file
 						//AppendDebugInfo(debugBldr, path);
-						using (var input = new FileStream(path, FileMode.Open))
+						using (var input = new FileStream(path, FileMode.Open, FileAccess.Read))
 						{
 							byte[] buffer = new byte[4096];
 							int count;


### PR DESCRIPTION
Without this fix, computing the book's hash throws an exception when it
encounters a read-only file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4638)
<!-- Reviewable:end -->
