### PR TITLE
Improvements to manual book rename (BL-10056)

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -2380,12 +2380,12 @@ namespace Bloom.Book
 		/// </summary>
 		internal static string GetUniqueFolderName(string parentPath, string name)
 		{
-			int i = 0;
+			int i = 1; // First non-blank suffix should be " (2)"
 			string suffix = "";
 			while (Directory.Exists(Path.Combine(parentPath, name + suffix)))
 			{
 				++i;
-				suffix = i.ToString(CultureInfo.InvariantCulture);
+				suffix = " (" + i.ToString(CultureInfo.InvariantCulture) + ")";
 			}
 			return name + suffix;
 		}

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -1823,7 +1823,7 @@ namespace Bloom.CollectionTab
 			_renameOverlay.Focus();
 			_renameOverlay.AcceptsReturn = true;
 			_renameOverlay.KeyPress += _renameOverlay_KeyPress;
-			_renameOverlay.LostFocus += (sender, args) => RemoveRenameOverlay();
+			_renameOverlay.LostFocus += (sender, args) => FinishRename();
 			_renameOverlay.BringToFront();
 		}
 
@@ -1842,14 +1842,19 @@ namespace Bloom.CollectionTab
 		{
 			if (e.KeyChar == '\x0d') // enter
 			{
-				var newName = _renameOverlay.Text;
-				RemoveRenameOverlay();
-				var book = SelectedBook;
-				if (book == null) //don't think this can happen, but play safe
-					return;
-				book.SetAndLockBookName(newName);
-				BringButtonTitleUpToDate(book);
+				FinishRename();
 			}
+		}
+
+		private void FinishRename()
+		{
+			var newName = _renameOverlay.Text;
+			RemoveRenameOverlay();
+			var book = SelectedBook;
+			if (book == null) //don't think this can happen, but play safe
+				return;
+			book.SetAndLockBookName(newName);
+			BringButtonTitleUpToDate(book);
 		}
 	}
 

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -665,7 +665,7 @@ namespace BloomTests.Book
 			string secondPath = _starter.CreateBookOnDiskFromTemplate(GetShellBookFolder(), _projectFolder.Path);
 
 			Assert.IsTrue(File.Exists(firstPath.CombineForPath("Book.htm")));
-			Assert.IsTrue(File.Exists(secondPath.CombineForPath("Book1.htm")));
+			Assert.IsTrue(File.Exists(secondPath.CombineForPath("Book (2).htm")));
 			Assert.IsTrue(Directory.Exists(secondPath),"it clobbered the first one!");
 		}
 
@@ -843,17 +843,17 @@ namespace BloomTests.Book
 		public void CreateBookOnDiskFromTemplate_FromFactoryTemplate_SameNameAlreadyUsed_FindsUsableNumberSuffix()
 		{
 			Directory.CreateDirectory(_projectFolder.Combine("Book"));
-			Directory.CreateDirectory(_projectFolder.Combine("Book1"));
-			Directory.CreateDirectory(_projectFolder.Combine("Book3"));
+			Directory.CreateDirectory(_projectFolder.Combine("Book (2)"));
+			Directory.CreateDirectory(_projectFolder.Combine("Book (4)"));
 
 			var source = BloomFileLocator.GetFactoryBookTemplateDirectory(
 																			"Basic Book");
 
 			var path = _starter.CreateBookOnDiskFromTemplate(source, _projectFolder.Path);
 
-			Assert.AreEqual("Book2", Path.GetFileName(path));
+			Assert.AreEqual("Book (3)", Path.GetFileName(path));
 			Assert.IsTrue(Directory.Exists(path));
-			Assert.IsTrue(File.Exists(Path.Combine(path, "Book2.htm")));
+			Assert.IsTrue(File.Exists(Path.Combine(path, "Book (3).htm")));
 		}
 
 		[Test]

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -99,7 +99,7 @@ namespace BloomTests.Book
 
 			var desiredFolder = bookFolder.Replace("e\x0301", "\x00e9");
 			Directory.CreateDirectory(desiredFolder);
-			var expectedFolder = desiredFolder + "1";
+			var expectedFolder = desiredFolder + " (2)";
 
 
 			Assert.That(BookStorage.MoveBookToSafeName(bookFolder), Is.EqualTo(expectedFolder));
@@ -761,8 +761,8 @@ namespace BloomTests.Book
 		{
 			using (var original = new TemporaryFolder(_folder, "original"))
 			using (var x = new TemporaryFolder(_folder, "foo"))
-			using (new TemporaryFolder(_folder, "foo1"))
-			using (var z = new TemporaryFolder(_folder, "foo2"))
+			using (new TemporaryFolder(_folder, "foo (2)"))
+			using (var z = new TemporaryFolder(_folder, "foo (3)"))
 			using (var projectFolder = new TemporaryFolder("BookStorage_ProjectCollection"))
 			{
 				File.WriteAllText(Path.Combine(original.Path, "original.htm"), "<html><head> href='file://blahblah\\editMode.css' type='text/css' /></head><body><div class='bloom-page'></div></body></html>");
@@ -772,10 +772,10 @@ namespace BloomTests.Book
 				storage.Save();
 
 				Directory.Delete(z.Path);
-				//so, we ask for "foo", but should get "foo2", because there is already a foo and foo1
+				//so, we ask for "foo", but should get "foo (3)", because there is already a foo and foo (2)
 				var newBookName = Path.GetFileName(x.Path);
 				storage.SetBookName(newBookName);
-				var newPath = z.Combine("foo2.htm");
+				var newPath = z.Combine("foo (3).htm");
 				Assert.IsTrue(Directory.Exists(z.Path), "Expected folder:" + z.Path);
 				Assert.IsTrue(File.Exists(newPath), "Expected file:" + newPath);
 			}
@@ -786,8 +786,8 @@ namespace BloomTests.Book
 		{
 			using (var original = new TemporaryFolder(_folder, "original"))
 			using (new TemporaryFolder(_folder, "foo"))
-			using (new TemporaryFolder(_folder, "foo1"))
-			using (var z = new TemporaryFolder(_folder, "foo2"))
+			using (new TemporaryFolder(_folder, "foo (2)"))
+			using (var z = new TemporaryFolder(_folder, "foo (3)"))
 			using (var projectFolder = new TemporaryFolder("BookStorage_ProjectCollection"))
 			{
 				File.WriteAllText(Path.Combine(original.Path, "original.htm"), "<html><head> href='file://blahblah\\editMode.css' type='text/css' /></head><body><div class='bloom-page'></div></body></html>");
@@ -797,11 +797,11 @@ namespace BloomTests.Book
 				storage.Save();
 
 				Directory.Delete(z.Path);
-				//so, we ask for "foo", but should get "foo2", because there is already a foo and foo1
+				//so, we ask for "foo", but should get "foo (3)", because there is already a foo and foo (2)
 				// BL-7816 We added some new characters to the sanitization routine
 				const string newBookName = "foo?:&<>\'\"{}";
 				storage.SetBookName(newBookName);
-				var newPath = z.Combine("foo2.htm");
+				var newPath = z.Combine("foo (3).htm");
 				Assert.IsTrue(Directory.Exists(z.Path), "Expected folder:" + z.Path);
 				Assert.IsTrue(File.Exists(newPath), "Expected file:" + newPath);
 			}


### PR DESCRIPTION
- loss of focus proceeds with rename
- conflicting names now use (n) starting at 2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4640)
<!-- Reviewable:end -->
