### PR TITLE
Ensure Linux package builds use C# 7.3 (20210817)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -60,6 +60,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>TRACE</DefineConstants>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)'!='Windows_NT' AND '$(Configuration)|$(Platform)' == 'Release|x86'">
     <DefineConstants>__MonoCS__;TRACE</DefineConstants>


### PR DESCRIPTION
This will fix a recurring source of package build failures that I've
previously changed code to fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4662)
<!-- Reviewable:end -->
