### PR TITLE
Fix Color Chooser getting reset on enter. (BL-10190)

### DIFF
--- a/src/BloomBrowserUI/publish/ReaderPublish/BulkBloomPub/BulkBloomPubDialog.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/BulkBloomPub/BulkBloomPubDialog.tsx
@@ -126,8 +126,7 @@ export const InnerBulkBloomPubDialog: React.FunctionComponent<{
                                     This file will cause these book to be
                                     grouped under a single bookshelf in Bloom
                                     Reader. This collection’s bookshelf is set
-                                    to "{params.bookshelfLabel}". Bug: after
-                                    entering a custom color, you must press TAB.
+                                    to "{params.bookshelfLabel}".
                                 </div>
                                 <div
                                     css={css`
@@ -148,8 +147,6 @@ export const InnerBulkBloomPubDialog: React.FunctionComponent<{
                                         {params.bookshelfLabel}
                                     </div>
 
-                                    {/* TODO: for some reason, you can't enter custom colors with enter (but tab works).
-                            After hitting Enter in the color chooser, we get "#" as the color, which appears as white. */}
                                     <ColorChooser
                                         menuLeft={true}
                                         disabled={false}

--- a/src/BloomBrowserUI/react_components/ContentEditable.tsx
+++ b/src/BloomBrowserUI/react_components/ContentEditable.tsx
@@ -75,6 +75,15 @@ export default class ContentEditable extends React.Component<
 
     private emitChange(event: React.FormEvent<HTMLDivElement>) {
         const content: string = event.currentTarget.innerText;
+
+        if (!content && event.type !== "keypress") {
+            // If the content is empty, be wary of whether or not we actually want to set it.
+            // Have it ignore event types that don't look relevent. (e.g. "blur", when it loses focus)
+            // (Note: I wonder if we could just ignore ANY event that's not keypress, regardless of the value of content.
+            // But it's more conservative to check content too.)
+            return;
+        }
+
         if (this.props.onChange && content !== this.lastContent) {
             // onChange will re-render, messing up the cursor position. So save it.
             const sel = window.getSelection();

--- a/src/BloomExe/Publish/Android/BulkBloomPubCreator.cs
+++ b/src/BloomExe/Publish/Android/BulkBloomPubCreator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.IO;
 using System.Text;
@@ -44,7 +44,9 @@ namespace Bloom.Publish.Android
 						// see https://docs.google.com/document/d/1UUvwxJ32W2X5CRgq-TS-1HmPj7gCKH9Y9bxZKbmpdAI
 
 						progress.MessageWithoutLocalizing($"Creating bloomshelf file...");
+						System.Diagnostics.Debug.Assert(!bulkSaveSettings.bookshelfColor.Contains("\n") && !bulkSaveSettings.bookshelfColor.Contains("\r"), "(BL-10190 Repro) Invalid bookshelfColor setting (contains newline). Please investigate!");
 						var colorString = getBloomReaderColorString(bulkSaveSettings.bookshelfColor);
+						System.Diagnostics.Debug.Assert(!colorString.Contains("\n") && !colorString.Contains("\r"), "(BL-10190 Repro) Invalid computed colorString value (contains newline). Please investigate!");
 
 						// OK I know this looks lame but trust me, using jsconvert to make that trivial label array is way too verbose.
 						var template =


### PR DESCRIPTION
Also add asserts to check for the invalid color string issue that Koen claims

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4673)
<!-- Reviewable:end -->
