### PR TITLE
BL-10296 Hide placeholder flower if overlayed

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -4,10 +4,8 @@ import { BloomApi } from "../../utils/bloomApi";
 // Enhance: this could be turned into a Typescript Module with only two public methods
 
 import theOneLocalizationManager from "../../lib/localizationManager/localizationManager";
-import { ImageDescriptionAdapter } from "../toolbox/imageDescription/imageDescription";
-import { getToolboxBundleExports } from "../editViewFrame";
 
-declare function ResetRememberedSize(element: HTMLElement);
+import { updateOverlayClass } from "./bubbleManager";
 
 const kPlaybackOrderContainerSelector: string =
     ".bloom-playbackOrderControlsContainer";
@@ -104,9 +102,9 @@ export function GetButtonModifier(container) {
     return buttonModifier;
 }
 
-//Bloom "imageContainer"s are <div>'s with wrap an <img>, and automatically proportionally resize
-//the img to fit the available space
-//Precondition: containerDiv must be just a single HTMLElement
+// Bloom "imageContainer"s are <div>'s which wrap an <img>, and automatically proportionally resize
+// the img to fit the available space.
+// Precondition: containerDiv must be just a single HTMLElement
 function SetupImageContainer(containerDiv: HTMLElement) {
     // Initialize the value of the hoverUp class.
     // the hoverup class should be present whenever the mouse is over the containerDiv.
@@ -119,6 +117,10 @@ function SetupImageContainer(containerDiv: HTMLElement) {
     } else {
         containerDiv.classList.remove("hoverUp");
     }
+
+    // Now that we can overlay things on top of images, we don't want to show the flower placeholder
+    // if the image container contains an overlay.
+    updateOverlayClass(containerDiv);
 
     // This will fix cover image on Kyrgyzstan books that we created before we switched to this
     // new border system. Going forward, say 5.1, we could remove this and just

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -31,6 +31,8 @@ const kImageContainerClass = "bloom-imageContainer";
 const kImageContainerSelector = `.${kImageContainerClass}`;
 const kVideoContainerClass = "bloom-videoContainer";
 
+const kOverlayClass = "hasOverlay";
+
 // References to "TOP" in the code refer to the actual TextOverPicture box (what "Bubble"s were
 // originally called) installed in the Bloom page. We are gradually removing these, since now there
 // are multiple types of elements that can be placed over pictures, not just Text.
@@ -493,6 +495,11 @@ export class BubbleManager {
             Comical.activateBubble(bubble);
             this.updateComicalForSelectedElement(newTextOverPictureElement);
             SetupElements(imageContainer);
+
+            // Since we may have just added an element, check if the container has at least one
+            // overlay element and add the 'hasOverlay' class.
+            updateOverlayClass(imageContainer);
+
             // SetupElements (above) will do most of what we need, but when it gets to
             // 'turnOnBubbleEditing()', it's already on, so the method will get skipped.
             // The only piece left from that method that still needs doing is to set the
@@ -522,6 +529,10 @@ export class BubbleManager {
             this.focusLastVisibleFocusable(focusableContainer);
             // When the last visible editable gets focus, onFocusSetActiveElement()
             // will call setActiveElement() to update the toolbox UI.
+
+            // Also, since we just deleted an element, check if the original container no longer
+            // has any overlay elements and remove the 'hasOverlay' class.
+            updateOverlayClass(imageContainer);
         }
     }
 
@@ -2747,6 +2758,17 @@ export class BubbleManager {
             return Bubble.makeDefaultTail(activeElement);
         }
         return undefined;
+    }
+}
+
+// For use by bloomImages.ts, so that newly opened books get this class updated for their images.
+export function updateOverlayClass(imageContainer: HTMLElement) {
+    if (
+        imageContainer.getElementsByClassName(kTextOverPictureClass).length > 0
+    ) {
+        imageContainer.classList.add(kOverlayClass);
+    } else {
+        imageContainer.classList.remove(kOverlayClass);
     }
 }
 

--- a/src/BloomBrowserUI/bookLayout/basePage-sharedRules.less
+++ b/src/BloomBrowserUI/bookLayout/basePage-sharedRules.less
@@ -38,6 +38,11 @@ textarea,
     }
 }
 
+// Now that we have overlay elements, we don't want to show the placeholder flower underneath them.
+.bloom-imageContainer.hasOverlay > img[src="placeHolder.png"] {
+    display: none;
+}
+
 // overridden if it is also nested in bloom-showImageDescriptions, but this can't be shared,
 // because we can't use display:flex in epubs.
 .bloom-imageContainer .bloom-imageDescription {


### PR DESCRIPTION
* if an imageContainer has an overlay element on top and
   is just a placeholder, hide the placeholder

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4681)
<!-- Reviewable:end -->
