### PR TITLE
Add image file to error report when image import fails (BL-10310)

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1176,6 +1176,7 @@ namespace Bloom.Edit
 			catch (Exception e)
 			{
 				var msg = LocalizationManager.GetString("Errors.ProblemImportingPicture","Bloom had a problem importing this picture.");
+				e.Data["ProblemImagePath"] = imageInfo.OriginalFilePath;
 				ErrorReport.NotifyUserOfProblem(e, msg+Environment.NewLine+e.Message);
 			}
 		}

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1166,6 +1166,8 @@ namespace Bloom.Edit
 				{
 					using (PerformanceMeasurement.Global?.Measure("Processing Image"))
 					{
+						try
+						{
 						var sameAsOriginalImage = (imageInfo == dlg.ImageInfo &&
 							oldImage == dlg.ImageInfo.Image &&
 							oldSize == dlg.ImageInfo.Image.Size &&
@@ -1204,8 +1206,6 @@ namespace Bloom.Edit
 						}
 
 						var exceptionMsg = "Bloom had a problem including that image";
-						try
-						{
 							if (copyOriginalImage || sameAsOriginalImage)
 							{
 								// Try to copy the file only if we actually need to copy it.  (BL-9737)

--- a/src/BloomExe/ErrorReporter/HtmlErrorReporter.cs
+++ b/src/BloomExe/ErrorReporter/HtmlErrorReporter.cs
@@ -7,6 +7,7 @@ using Bloom.Api;
 using Bloom.MiscUI;
 using Bloom.ToPalaso;
 using Bloom.web.controllers;
+using SIL.IO;
 using SIL.Reporting;
 using SIL.Windows.Forms.Reporting;
 
@@ -318,7 +319,13 @@ namespace Bloom.ErrorReporter
 		public void ReportNonFatalExceptionWithMessage(Exception error, string messageFormat, params object[] args)
 		{
 			var message = String.Format(messageFormat, args);
-			ProblemReportApi.ShowProblemDialog(GetControlToUse(), error, message , ProblemLevel.kNonFatal);
+			var imageFilepath = error.Data["ProblemImagePath"] as string;
+			string[] extraFiles = null;
+			if (!String.IsNullOrEmpty(imageFilepath) && RobustFile.Exists(imageFilepath))
+			{
+				extraFiles = new string[] { imageFilepath };
+			}
+			ProblemReportApi.ShowProblemDialog(GetControlToUse(), error, message , ProblemLevel.kNonFatal, additionalFilesToInclude: extraFiles);
 		}
 
 		public void ReportNonFatalMessageWithStackTrace(string messageFormat, params object[] args)


### PR DESCRIPTION
I also shifted a try earlier in a method to catch more exceptions without re-indenting the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4684)
<!-- Reviewable:end -->
