### PR TITLE
Update libpalaso to fix crash in ImageToolboxDialog (BL-10314)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -221,29 +221,29 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>../../packages/SharpFont.3.1.0/lib/net20/SharpFont.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Core.8.0.1-beta0026\lib\net461\SIL.Core.dll</HintPath>
+    <Reference Include="SIL.Core, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Core.9.0.0-beta0043\lib\net461\SIL.Core.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Core.Desktop, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Core.Desktop.8.0.1-beta0026\lib\net461\SIL.Core.Desktop.dll</HintPath>
+    <Reference Include="SIL.Core.Desktop, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Core.Desktop.9.0.0-beta0043\lib\net461\SIL.Core.Desktop.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Media, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Media.8.0.1-beta0026\lib\net461\SIL.Media.dll</HintPath>
+    <Reference Include="SIL.Media, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Media.9.0.0-beta0043\lib\net461\SIL.Media.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.8.0.1-beta0026\lib\net461\SIL.Windows.Forms.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.9.0.0-beta0043\lib\net461\SIL.Windows.Forms.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms.GeckoBrowserAdapter, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.GeckoBrowserAdapter.8.0.1-beta0026\lib\net461\SIL.Windows.Forms.GeckoBrowserAdapter.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms.GeckoBrowserAdapter, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.GeckoBrowserAdapter.9.0.0-beta0043\lib\net461\SIL.Windows.Forms.GeckoBrowserAdapter.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms.Keyboarding, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.1-beta0026\lib\net461\SIL.Windows.Forms.Keyboarding.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms.Keyboarding, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.Keyboarding.9.0.0-beta0043\lib\net461\SIL.Windows.Forms.Keyboarding.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms.WritingSystems, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.WritingSystems.8.0.1-beta0026\lib\net461\SIL.Windows.Forms.WritingSystems.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms.WritingSystems, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.WritingSystems.9.0.0-beta0043\lib\net461\SIL.Windows.Forms.WritingSystems.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.WritingSystems, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.WritingSystems.8.0.1-beta0026\lib\net461\SIL.WritingSystems.dll</HintPath>
+    <Reference Include="SIL.WritingSystems, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.WritingSystems.9.0.0-beta0043\lib\net461\SIL.WritingSystems.dll</HintPath>
     </Reference>
     <Reference Include="SourceMapDotNet, Version=1.0.5478.26629, Culture=neutral, PublicKeyToken=d357635542166cea, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SourceMapDotNet.1.0.5478.26629\lib\SourceMapDotNet.dll</HintPath>
@@ -1525,9 +1525,9 @@ cp -p "$(SolutionDir)lib/dotnet/GeckofxHtmlToPdf.exe.config" "$(OutDir)BloomPdfM
   <Import Project="..\..\packages\LargeAddressAware.1.0.5\build\LargeAddressAware.targets" Condition="'$(OS)'=='Windows_NT' AND Exists('..\..\packages\LargeAddressAware.1.0.5\build\LargeAddressAware.targets')" />
   <Import Project="..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets" Condition="Exists('..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets')" />
   <Import Project="..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets" Condition="'$(OS)'=='Windows_NT' AND Exists('..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets')" />
-  <Import Project="..\..\packages\SIL.Media.8.0.1-beta0026\build\SIL.Media.targets" Condition="Exists('..\..\packages\SIL.Media.8.0.1-beta0026\build\SIL.Media.targets')" />
-  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.1-beta0026\build\SIL.Windows.Forms.Keyboarding.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.1-beta0026\build\SIL.Windows.Forms.Keyboarding.targets')" />
-  <Import Project="..\..\packages\SIL.Windows.Forms.8.0.1-beta0026\build\SIL.Windows.Forms.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.8.0.1-beta0026\build\SIL.Windows.Forms.targets')" />
+  <Import Project="..\..\packages\SIL.Media.9.0.0-beta0043\build\SIL.Media.targets" Condition="Exists('..\..\packages\SIL.Media.9.0.0-beta0043\build\SIL.Media.targets')" />
+  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.9.0.0-beta0043\build\SIL.Windows.Forms.Keyboarding.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.9.0.0-beta0043\build\SIL.Windows.Forms.Keyboarding.targets')" />
+  <Import Project="..\..\packages\SIL.Windows.Forms.9.0.0-beta0043\build\SIL.Windows.Forms.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.9.0.0-beta0043\build\SIL.Windows.Forms.targets')" />
   <Target Name="AfterBuild">
     <Copy SourceFiles="@(SourceFiles)" DestinationFolder="$(OutDir)" />
     <Copy SourceFiles="@(LameFiles)" DestinationFolder="../../DistFiles" Condition="'$(OS)'=='Windows_NT'" />
@@ -1547,9 +1547,9 @@ cp -p "$(SolutionDir)lib/dotnet/GeckofxHtmlToPdf.exe.config" "$(OutDir)BloomPdfM
     <Error Condition="'$(OS)'=='Windows_NT' AND !Exists('..\..\packages\LargeAddressAware.1.0.5\build\LargeAddressAware.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\LargeAddressAware.1.0.5\build\LargeAddressAware.targets'))" />
     <Error Condition="!Exists('..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets'))" />
     <Error Condition="'$(OS)'=='Windows_NT' AND !Exists('..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Media.8.0.1-beta0026\build\SIL.Media.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Media.8.0.1-beta0026\build\SIL.Media.targets'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.1-beta0026\build\SIL.Windows.Forms.Keyboarding.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.1-beta0026\build\SIL.Windows.Forms.Keyboarding.targets'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.8.0.1-beta0026\build\SIL.Windows.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.8.0.1-beta0026\build\SIL.Windows.Forms.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Media.9.0.0-beta0043\build\SIL.Media.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Media.9.0.0-beta0043\build\SIL.Media.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.9.0.0-beta0043\build\SIL.Windows.Forms.Keyboarding.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.9.0.0-beta0043\build\SIL.Windows.Forms.Keyboarding.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.9.0.0-beta0043\build\SIL.Windows.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.9.0.0-beta0043\build\SIL.Windows.Forms.targets'))" />
   </Target>
   <!-- msbuild mistakenly copies the 64-bit version of irrKlang.NET4.dll to $(Output) as it resolves
        SIL.Media.dll in our 32-bit build.  It also always copies both the 32-bit and 64-bit versions

--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -37,14 +37,14 @@
   <package id="Sentry.PlatformAbstractions" version="1.1.1" targetFramework="net461" />
   <package id="Sentry.Protocol" version="2.1.6" targetFramework="net461" />
   <package id="SharpZipLib" version="1.3.0" targetFramework="net461" />
-  <package id="SIL.Core" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Core.Desktop" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Media" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Windows.Forms" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Windows.Forms.GeckoBrowserAdapter" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Windows.Forms.Keyboarding" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Windows.Forms.WritingSystems" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.WritingSystems" version="8.0.1-beta0026" targetFramework="net461" />
+  <package id="SIL.Core" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Core.Desktop" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Media" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Windows.Forms" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Windows.Forms.GeckoBrowserAdapter" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Windows.Forms.Keyboarding" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Windows.Forms.WritingSystems" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.WritingSystems" version="9.0.0-beta0043" targetFramework="net461" />
   <package id="SourceMapDotNet" version="1.0.5478.26629" targetFramework="net461" />
   <package id="Spart" version="1.0.0" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.7.1" targetFramework="net461" />

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -37,14 +37,14 @@
   <package id="Sentry.PlatformAbstractions" version="1.1.1" targetFramework="net461" />
   <package id="Sentry.Protocol" version="2.1.6" targetFramework="net461" />
   <package id="SharpZipLib" version="1.3.0" targetFramework="net461" />
-  <package id="SIL.Core" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Core.Desktop" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Media" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Windows.Forms" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Windows.Forms.GeckoBrowserAdapter" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Windows.Forms.Keyboarding" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Windows.Forms.WritingSystems" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.WritingSystems" version="8.0.1-beta0026" targetFramework="net461" />
+  <package id="SIL.Core" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Core.Desktop" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Media" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Windows.Forms" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Windows.Forms.GeckoBrowserAdapter" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Windows.Forms.Keyboarding" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Windows.Forms.WritingSystems" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.WritingSystems" version="9.0.0-beta0043" targetFramework="net461" />
   <package id="SourceMapDotNet" version="1.0.5478.26629" targetFramework="net461" />
   <package id="Spart" version="1.0.0" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.7.1" targetFramework="net461" />

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -174,29 +174,29 @@
     <Reference Include="RestSharp, Version=106.11.7.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\..\packages\RestSharp.106.11.7\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Core.8.0.1-beta0026\lib\net461\SIL.Core.dll</HintPath>
+    <Reference Include="SIL.Core, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Core.9.0.0-beta0043\lib\net461\SIL.Core.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Core.Desktop, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Core.Desktop.8.0.1-beta0026\lib\net461\SIL.Core.Desktop.dll</HintPath>
+    <Reference Include="SIL.Core.Desktop, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Core.Desktop.9.0.0-beta0043\lib\net461\SIL.Core.Desktop.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Media, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Media.8.0.1-beta0026\lib\net461\SIL.Media.dll</HintPath>
+    <Reference Include="SIL.Media, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Media.9.0.0-beta0043\lib\net461\SIL.Media.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.TestUtilities, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.TestUtilities.8.0.1-beta0026\lib\net461\SIL.TestUtilities.dll</HintPath>
+    <Reference Include="SIL.TestUtilities, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.TestUtilities.9.0.0-beta0043\lib\net461\SIL.TestUtilities.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.8.0.1-beta0026\lib\net461\SIL.Windows.Forms.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.9.0.0-beta0043\lib\net461\SIL.Windows.Forms.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms.Keyboarding, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.1-beta0026\lib\net461\SIL.Windows.Forms.Keyboarding.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms.Keyboarding, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.Keyboarding.9.0.0-beta0043\lib\net461\SIL.Windows.Forms.Keyboarding.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.Windows.Forms.WritingSystems, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.Windows.Forms.WritingSystems.8.0.1-beta0026\lib\net461\SIL.Windows.Forms.WritingSystems.dll</HintPath>
+    <Reference Include="SIL.Windows.Forms.WritingSystems, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.Windows.Forms.WritingSystems.9.0.0-beta0043\lib\net461\SIL.Windows.Forms.WritingSystems.dll</HintPath>
     </Reference>
-    <Reference Include="SIL.WritingSystems, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SIL.WritingSystems.8.0.1-beta0026\lib\net461\SIL.WritingSystems.dll</HintPath>
+    <Reference Include="SIL.WritingSystems, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cab3c8c5232dfcf2, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SIL.WritingSystems.9.0.0-beta0043\lib\net461\SIL.WritingSystems.dll</HintPath>
     </Reference>
     <Reference Include="Spart, Version=1.0.0.0, Culture=neutral, PublicKeyToken=14d24e064e474331, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Spart.1.0.0\lib\net461\Spart.dll</HintPath>
@@ -413,15 +413,15 @@
     <Error Condition="!Exists('..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets'))" />
     <Error Condition="'$(OS)'=='Windows_NT' AND !Exists('..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets'))" />
     <Error Condition="!Exists('..\..\packages\NUnit.3.13.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.13.0\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Media.8.0.1-beta0026\build\SIL.Media.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Media.8.0.1-beta0026\build\SIL.Media.targets'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.1-beta0026\build\SIL.Windows.Forms.Keyboarding.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.1-beta0026\build\SIL.Windows.Forms.Keyboarding.targets'))" />
-    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.8.0.1-beta0026\build\SIL.Windows.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.8.0.1-beta0026\build\SIL.Windows.Forms.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Media.9.0.0-beta0043\build\SIL.Media.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Media.9.0.0-beta0043\build\SIL.Media.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.9.0.0-beta0043\build\SIL.Windows.Forms.Keyboarding.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.Keyboarding.9.0.0-beta0043\build\SIL.Windows.Forms.Keyboarding.targets'))" />
+    <Error Condition="!Exists('..\..\packages\SIL.Windows.Forms.9.0.0-beta0043\build\SIL.Windows.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\SIL.Windows.Forms.9.0.0-beta0043\build\SIL.Windows.Forms.targets'))" />
   </Target>
   <Import Project="..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets" Condition="Exists('..\..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets')" />
   <Import Project="..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets" Condition="'$(OS)'=='Windows_NT' AND Exists('..\..\packages\Mono.Posix.5.4.0.201\build\net45\Mono.Posix.targets')" />
-  <Import Project="..\..\packages\SIL.Media.8.0.1-beta0026\build\SIL.Media.targets" Condition="Exists('..\..\packages\SIL.Media.8.0.1-beta0026\build\SIL.Media.targets')" />
-  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.1-beta0026\build\SIL.Windows.Forms.Keyboarding.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.8.0.1-beta0026\build\SIL.Windows.Forms.Keyboarding.targets')" />
-  <Import Project="..\..\packages\SIL.Windows.Forms.8.0.1-beta0026\build\SIL.Windows.Forms.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.8.0.1-beta0026\build\SIL.Windows.Forms.targets')" />
+  <Import Project="..\..\packages\SIL.Media.9.0.0-beta0043\build\SIL.Media.targets" Condition="Exists('..\..\packages\SIL.Media.9.0.0-beta0043\build\SIL.Media.targets')" />
+  <Import Project="..\..\packages\SIL.Windows.Forms.Keyboarding.9.0.0-beta0043\build\SIL.Windows.Forms.Keyboarding.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.Keyboarding.9.0.0-beta0043\build\SIL.Windows.Forms.Keyboarding.targets')" />
+  <Import Project="..\..\packages\SIL.Windows.Forms.9.0.0-beta0043\build\SIL.Windows.Forms.targets" Condition="Exists('..\..\packages\SIL.Windows.Forms.9.0.0-beta0043\build\SIL.Windows.Forms.targets')" />
   <!-- msbuild mistakenly copies the 64-bit version of irrKlang.NET4.dll to $(Output) as it resolves
        SIL.Media.dll in our 32-bit build.  It also always copies both the 32-bit and 64-bit versions
        of the library files to $(Output)\lib\win-xXX.  We correct those errors here.  (We can't do

--- a/src/BloomTests/packages.config
+++ b/src/BloomTests/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AtkSharp-signed" version="3.22.24.37" targetFramework="net461" />
   <package id="CairoSharp-signed" version="3.22.24.37" targetFramework="net461" />
@@ -31,14 +31,14 @@
   <package id="PangoSharp-signed" version="3.22.24.37" targetFramework="net461" />
   <package id="RestSharp" version="106.11.7" targetFramework="net461" />
   <package id="SharpZipLib" version="1.3.0" targetFramework="net461" />
-  <package id="SIL.Core" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Core.Desktop" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Media" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.TestUtilities" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Windows.Forms" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Windows.Forms.Keyboarding" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.Windows.Forms.WritingSystems" version="8.0.1-beta0026" targetFramework="net461" />
-  <package id="SIL.WritingSystems" version="8.0.1-beta0026" targetFramework="net461" />
+  <package id="SIL.Core" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Core.Desktop" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Media" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.TestUtilities" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Windows.Forms" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Windows.Forms.Keyboarding" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.Windows.Forms.WritingSystems" version="9.0.0-beta0043" targetFramework="net461" />
+  <package id="SIL.WritingSystems" version="9.0.0-beta0043" targetFramework="net461" />
   <package id="Spart" version="1.0.0" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
This also required moving the 5.0 tag on PdfDroplet to match.

If these changes do not merge cleanly to master, there will be a separate PR for master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4688)
<!-- Reviewable:end -->
