### PR TITLE
BL-9976 Fix Over Picture sizing

### DIFF
--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -850,12 +850,6 @@ div[data-book*="branding"] {
     z-index: @bubbleCanvasZIndex;
     position: absolute;
 }
-//BL-7929 Sometimes text in bubbles gets cut off. In lieu of understanding exactly
-// what causes the discrepancy and how to compensate for it, we are just turning
-// off the cutoff when it's displayed by BloomPlayer. (Problem does not occur in PDF)
-.bloomPlayer-page .bloom-textOverPicture[data-bubble] {
-    height: auto !important;
-}
 
 // Custom Widget template page and Digital Comic Book both use this to make the page have no margins.
 // The .comic keeps pre-existing Digital Comic Books working.

--- a/src/BloomBrowserUI/bookLayout/bubble.less
+++ b/src/BloomBrowserUI/bookLayout/bubble.less
@@ -209,7 +209,8 @@
 .bloom-imageContainer {
     // Over picture elements with speech bubbles
     //
-    // a TOP element that contains a data-bubble attribute and does NOT contain the substring "`style`:`none`" in the value of the data-bubble attribute
+    // a TOP element that contains a data-bubble attribute and does NOT contain the substring
+    // "`style`:`none`" in the value of the data-bubble attribute
     .bloom-textOverPicture[data-bubble]:not([data-bubble*="`style`:`none`"]) {
         .bloom-translationGroup {
             .bloom-editable {


### PR DESCRIPTION
* removed a rule that fixed BL-7929 2 years ago
* more recent rules in bubble.less seem to have fixed the
   older problem

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4689)
<!-- Reviewable:end -->
