### PR TITLE
Change "Make a book using this source" button to black (BL-10358)

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
@@ -118,9 +118,7 @@ export const CollectionsTabBookPane: React.FunctionComponent<{
             color="secondary"
             css={css`
                 background-color: white !important;
-                color: ${editable
-                    ? "black !important"
-                    : "rgba(0, 0, 0, 0.26);"};
+                color: black !important;
 
                 img {
                     height: 2em;


### PR DESCRIPTION
Code says gray, but was actually showing up as purple (CSS selectivity favored the Material UI rule...)
Now made it the same color as the Edit text color.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4710)
<!-- Reviewable:end -->
