### PR TITLE
BL-10381 Hide Spreadsheet menu commands

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryListView.Designer.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.Designer.cs
@@ -152,6 +152,7 @@ namespace Bloom.CollectionTab
 			this.exportToSpreadsheetToolStripMenuItem.Size = new System.Drawing.Size(242, 26);
 			this.exportToSpreadsheetToolStripMenuItem.Text = "Export to Spreadsheet...";
 			this.exportToSpreadsheetToolStripMenuItem.Click += new System.EventHandler(this.exportToSpreadsheetToolStripMenuItem_Click);
+	        this.exportToSpreadsheetToolStripMenuItem.Visible = false;
 			// 
 			// SaveAsBloomToolStripMenuItem
 			// 
@@ -689,15 +690,16 @@ namespace Bloom.CollectionTab
 			this.renameToolStripMenuItem.Text = "Rename";
 			this.renameToolStripMenuItem.Click += new System.EventHandler(this.renameToolStripMenuItem_Click);
 			// 
-            // importContentFromSpreadsheetToolStripMenuItem
-            // 
-            this._L10NSharpExtender.SetLocalizationComment(this.importContentFromSpreadsheetToolStripMenuItem, null);
-            this._L10NSharpExtender.SetLocalizableToolTip(this.importContentFromSpreadsheetToolStripMenuItem, null);
-            this._L10NSharpExtender.SetLocalizingId(this.importContentFromSpreadsheetToolStripMenuItem, "CollectionTab.BookMenu.ImportContentFromSpreadsheet");
-            this.importContentFromSpreadsheetToolStripMenuItem.Name = "importContentFromSpreadsheetToolStripMenuItem";
-            this.importContentFromSpreadsheetToolStripMenuItem.Text = "Import Content from Spreadsheet...";
-            this.importContentFromSpreadsheetToolStripMenuItem.Size = new System.Drawing.Size(287, 26);
-            this.importContentFromSpreadsheetToolStripMenuItem.Click += new System.EventHandler(this.importContentFromSpreadsheetToolStripMenuItem_Click);
+			// importContentFromSpreadsheetToolStripMenuItem
+			// 
+			this._L10NSharpExtender.SetLocalizationComment(this.importContentFromSpreadsheetToolStripMenuItem, null);
+			this._L10NSharpExtender.SetLocalizableToolTip(this.importContentFromSpreadsheetToolStripMenuItem, null);
+			this._L10NSharpExtender.SetLocalizingId(this.importContentFromSpreadsheetToolStripMenuItem, "CollectionTab.BookMenu.ImportContentFromSpreadsheet");
+			this.importContentFromSpreadsheetToolStripMenuItem.Name = "importContentFromSpreadsheetToolStripMenuItem";
+			this.importContentFromSpreadsheetToolStripMenuItem.Text = "Import Content from Spreadsheet...";
+			this.importContentFromSpreadsheetToolStripMenuItem.Size = new System.Drawing.Size(287, 26);
+			this.importContentFromSpreadsheetToolStripMenuItem.Click += new System.EventHandler(this.importContentFromSpreadsheetToolStripMenuItem_Click);
+	        this.importContentFromSpreadsheetToolStripMenuItem.Visible = false;
 			// 
 			// LibraryListView
 			// 


### PR DESCRIPTION
* Initially tried commenting out the whole section,
   but it left a gap in the menu!
   Making the menu items not visible allowed it to adjust
   things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4712)
<!-- Reviewable:end -->
