### PR TITLE
Rework change "Make a book using this source" button to black (BL-10358)

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
@@ -97,9 +97,12 @@ export const CollectionsTabBookPane: React.FunctionComponent<{
         collectionKind
     ]);
 
+    // Note: If canMakeBook is true, then editable is probably false (the source book is likely not in the editable collection),
+    // but you still want the button to be enabled
+    const isButtonEnabled = canMakeBook || editable;
     const editOrMakeButton: JSX.Element = (
         <BloomButton
-            enabled={canMakeBook || editable}
+            enabled={isButtonEnabled}
             variant={"outlined"}
             l10nKey={
                 canMakeBook
@@ -118,8 +121,9 @@ export const CollectionsTabBookPane: React.FunctionComponent<{
             color="secondary"
             css={css`
                 background-color: white !important;
-                color: black !important;
-
+                color: ${isButtonEnabled
+                    ? "black"
+                    : "rgba(0, 0, 0, 0.26)"} !important;
                 img {
                     height: 2em;
                     margin-right: 10px;


### PR DESCRIPTION
Old: The Make a book using this source button was purple
1st change: Always made the button black. However, if the book button was disabled, it was black instead of gray.
This change: If the button is enabled, it is black. If disabled, it is gray.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4713)
<!-- Reviewable:end -->
