### PR TITLE
Fix BulkUploader to call ExpensiveInitialization(true) (BL-10347)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -744,7 +744,7 @@ namespace Bloom.Book
 				return GetErrorDom();
 			}
 			//Console.WriteLine("DEBUG GetPreviewHtmlFileForWholeBook(): calling BringBookUpToDate() for new previewDOM");
-			BringBookUpToDate(previewDom, new NullProgress());
+			BringBookUpToDateInternal(previewDom, new NullProgress());
 
 			// this is normally the vernacular, but when we're previewing a shell, well it won't have anything for the vernacular
 			var primaryLanguage = Language1IsoCode;
@@ -785,7 +785,7 @@ namespace Bloom.Book
 			{
 				oldMetaData = RobustFile.ReadAllText(BookInfo.MetaDataPath); // Have to read this before other migration overwrites it.
 			}
-			BringBookUpToDate(OurHtmlDom, progress, oldMetaData);
+			BringBookUpToDateInternal(OurHtmlDom, progress, oldMetaData);
 			progress.WriteStatus("Updating pages...");
 			foreach (XmlElement pageDiv in OurHtmlDom.SafeSelectNodes("//body/div[contains(@class, 'bloom-page')]"))
 			{
@@ -1105,7 +1105,7 @@ namespace Bloom.Book
 		/// and making older Blooms unable to read new books. But because this is run, the xmatter will be
 		/// migrated to the new template.
 		/// </summary>
-		private void BringBookUpToDate(HtmlDom bookDOM /* may be a 'preview' version*/, IProgress progress, string oldMetaData = "")
+		private void BringBookUpToDateInternal(HtmlDom bookDOM /* may be a 'preview' version*/, IProgress progress, string oldMetaData = "")
 		{
 			RemoveImgTagInDataDiv(bookDOM);
 			RemoveCkeEditorResidue(bookDOM);
@@ -1605,7 +1605,7 @@ namespace Bloom.Book
 
 		public void UpdateBrandingForCurrentOrientation(HtmlDom bookDOM)
 		{
-			BringBookUpToDate(bookDOM, new NullProgress());
+			BringBookUpToDateInternal(bookDOM, new NullProgress());
 			// We need this to reinstate the classes that control visibility, otherwise no bloom-editable
 			// text is shown
 			UpdateMultilingualSettings(bookDOM);
@@ -3402,7 +3402,7 @@ namespace Bloom.Book
 		{
 			if (!_haveDoneUpdate)
 			{
-				BringBookUpToDate(OurHtmlDom, new NullProgress());
+				BringBookUpToDateInternal(OurHtmlDom, new NullProgress());
 				_haveDoneUpdate = true;
 			}
 			//We could re-enable RebuildXMatter() here later, so that we get this nice refresh each time.

--- a/src/BloomExe/Book/BookServer.cs
+++ b/src/BloomExe/Book/BookServer.cs
@@ -22,14 +22,14 @@ namespace Bloom.Book
 			_configuratorFactory = configuratorFactory;
 		}
 
-		public virtual Book GetBookFromBookInfo(BookInfo bookInfo, bool forSelectedBook = false)
+		public virtual Book GetBookFromBookInfo(BookInfo bookInfo, bool fullyUpdateBookFiles = false)
 		{
 			//Review: Note that this isn't doing any caching yet... worried that caching will just eat up memory, but if anybody is holding onto these, then the memory won't be freed anyhow
 			if(bookInfo is ErrorBookInfo)
 			{
 				return new ErrorBook(((ErrorBookInfo)bookInfo).Exception, bookInfo.FolderPath, true );
 			}
-			var book = _bookFactory(bookInfo, _storageFactory(bookInfo.FolderPath, forSelectedBook));
+			var book = _bookFactory(bookInfo, _storageFactory(bookInfo.FolderPath, fullyUpdateBookFiles));
 			return book;
 		}
 

--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -588,9 +588,9 @@ namespace Bloom.CollectionTab
 
 		}
 
-		public Book.Book GetBookFromBookInfo(BookInfo bookInfo, bool forSelectedBook = false)
+		public Book.Book GetBookFromBookInfo(BookInfo bookInfo, bool fullyUpdateBookFiles = false)
 		{
-			return _bookServer.GetBookFromBookInfo(bookInfo, forSelectedBook);
+			return _bookServer.GetBookFromBookInfo(bookInfo, fullyUpdateBookFiles);
 		}
 
 		/// <summary>

--- a/src/BloomExe/WebLibraryIntegration/BulkUploader.cs
+++ b/src/BloomExe/WebLibraryIntegration/BulkUploader.cs
@@ -278,7 +278,7 @@ namespace Bloom.WebLibraryIntegration
 				}
 				var server = context.BookServer;
 				var bookInfo = new BookInfo(uploadParams.Folder, true);
-				var book = server.GetBookFromBookInfo(bookInfo);
+				var book = server.GetBookFromBookInfo(bookInfo, fullyUpdateBookFiles: true);
 				book.BringBookUpToDate(new NullProgress());
 				book.Storage.CleanupUnusedSupportFiles(isForPublish: false); // we are publishing, but this is the real folder not a copy, so play safe.
 

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -49,7 +49,7 @@ namespace BloomTests.Book
 			_fileLocator = new BloomFileLocator(collectionSettings, xmatterFinder, ProjectContext.GetFactoryFileLocations(), ProjectContext.GetFoundFileLocations(), ProjectContext.GetAfterXMatterFileLocations());
 
 
-			_starter = new BookStarter(_fileLocator, (dir, forSelectedBook) => new BookStorage(dir, _fileLocator, new BookRenamedEvent(), collectionSettings), _defaultCollectionSettings);
+			_starter = new BookStarter(_fileLocator, (dir, fullyUpdateBookFiles) => new BookStorage(dir, _fileLocator, new BookRenamedEvent(), collectionSettings), _defaultCollectionSettings);
 			_shellCollectionFolder = new TemporaryFolder("BookStarterTests_ShellCollection");
 
 			// These settings are used in some tests, especially of static BookStarter methods.
@@ -152,7 +152,7 @@ namespace BloomTests.Book
 				return new Bloom.Book.Book(bookInfo, storage, null, collectionSettings,
 					new PageSelection(),
 					new PageListChangedEvent(), new BookRefreshEvent());
-			}, (path, forSelectedBook) => new BookStorage(path, _fileLocator, null, collectionSettings), () => _starter, null);
+			}, (path, fullyUpdateBookFiles) => new BookStorage(path, _fileLocator, null, collectionSettings), () => _starter, null);
 			return server;
 		}
 

--- a/src/BloomTests/Book/BookTestsBase.cs
+++ b/src/BloomTests/Book/BookTestsBase.cs
@@ -269,7 +269,7 @@ namespace BloomTests.Book
 			_collectionSettings = CreateDefaultCollectionsSettings();
 			var xmatterFinder = new XMatterPackFinder(new[] { BloomFileLocator.GetInstalledXMatterDirectory() });
 			var fileLocator = new BloomFileLocator(_collectionSettings, xmatterFinder, ProjectContext.GetFactoryFileLocations(), ProjectContext.GetFoundFileLocations(), ProjectContext.GetAfterXMatterFileLocations());
-			var starter = new BookStarter(fileLocator, (dir, forSelectedBook) => new BookStorage(dir, fileLocator, new BookRenamedEvent(), _collectionSettings), _collectionSettings);
+			var starter = new BookStarter(fileLocator, (dir, fullyUpdateBookFiles) => new BookStorage(dir, fileLocator, new BookRenamedEvent(), _collectionSettings), _collectionSettings);
 
 			return new BookServer(
 				//book factory
@@ -281,7 +281,7 @@ namespace BloomTests.Book
 				},
 
 				// storage factory
-				(path, forSelectedBook) =>
+				(path, fullyUpdateBookFiles) =>
 				{
 					var storage = new BookStorage(path, fileLocator, new BookRenamedEvent(), _collectionSettings);
 					storage.BookInfo = new BookInfo(path, true);

--- a/src/BloomTests/Edit/ConfiguratorTest.cs
+++ b/src/BloomTests/Edit/ConfiguratorTest.cs
@@ -53,7 +53,7 @@ namespace BloomTests.Edit
 			var projectFolder = new TemporaryFolder("BookStarterTests_ProjectCollection");
 			var collectionSettings = new CollectionSettings(Path.Combine(projectFolder.Path, "test.bloomCollection"));
 
-			_starter = new BookStarter(_fileLocator, (dir, forSelectedBook) => new BookStorage(dir, _fileLocator, new BookRenamedEvent(), collectionSettings), library);
+			_starter = new BookStarter(_fileLocator, (dir, fullyUpdateBookFiles) => new BookStorage(dir, _fileLocator, new BookRenamedEvent(), collectionSettings), library);
 			_shellCollectionFolder = new TemporaryFolder("BookStarterTests_ShellCollection");
 			_libraryFolder = new TemporaryFolder("BookStarterTests_LibraryCollection");
 		}

--- a/src/BloomTests/TestDoubles/Book/FakeBookServer.cs
+++ b/src/BloomTests/TestDoubles/Book/FakeBookServer.cs
@@ -18,7 +18,7 @@ namespace BloomTests.TestDoubles.Book
 		/// A dumbed down implementation that is able to return a book with the BookInfo and set the book's FolderPath.
 		/// </summary>
 		/// <returns></returns>
-		public override Bloom.Book.Book GetBookFromBookInfo(BookInfo bookInfo, bool forSelectedBook = false)
+		public override Bloom.Book.Book GetBookFromBookInfo(BookInfo bookInfo, bool fullyUpdateBookFiles = false)
 		{
 			var collectionSettings = new Bloom.Collection.CollectionSettings();
 			var fileLocator = new Bloom.BloomFileLocator(collectionSettings, new XMatterPackFinder(Enumerable.Empty<string>()), Enumerable.Empty<string>(), Enumerable.Empty<string>(),


### PR DESCRIPTION
This ensures that the proper support files are included in the uploaded
books.

I also renamed a method to reduce confusion moving forward.
The forSelectedBook parameter to ExpensiveInitialization has also been
renamed to fullyUpdateBookFiles to express usage instead of one caller's
intention.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4727)
<!-- Reviewable:end -->
