### PR TITLE
Eliminate unnecessary missing file reports when previewing templates (BL-10409)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -766,7 +766,7 @@ namespace Bloom.Book
 
 			// Not needed for preview mode, so just remove them to reduce memory usage.
 			PreventVideoAutoLoad(previewDom);
-			RemoveImageResolutionMessage(previewDom);
+			RemoveImageResolutionMessageAndAddMissingImageMessage(previewDom);
 
 			_previewDom = previewDom;
 			return previewDom;
@@ -2554,12 +2554,23 @@ namespace Bloom.Book
 		/// This is only used in the preview.
 		/// Review: This works, but I'm not really "up" on the preview process. Should this go in bookPreview.ts?
 		/// </summary>
-		private static void RemoveImageResolutionMessage(HtmlDom dom)
+		private static void RemoveImageResolutionMessageAndAddMissingImageMessage(HtmlDom dom)
 		{
 			var imageContainerList = dom.Body.SafeSelectNodes("//div[contains(@class,'bloom-imageContainer')]");
 			foreach (XmlElement imageContainer in imageContainerList)
 			{
 				imageContainer.RemoveAttribute("title");
+				foreach (XmlElement img in imageContainer.SafeSelectNodes("img"))
+				{
+					var src = img.GetAttribute("src");
+					var alt = img.GetAttribute("alt");
+					if (!String.IsNullOrEmpty(src) && String.IsNullOrEmpty(alt))
+					{
+						var localizedFormatString = LocalizationManager.GetString("EditTab.Image.AltMsg", "This picture, {0}, is missing or was loading too slowly.");
+						var altValue = String.Format(localizedFormatString, src);
+						img.SetAttribute("alt", altValue);
+					}
+				}
 			}
 		}
 

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -1623,7 +1623,7 @@ namespace Bloom.Book
 		/// </review>
 		private void ExpensiveInitialization(bool fullyUpdateBookFiles = false)
 		{
-			Debug.WriteLine($"ExpensiveInitialization({FolderPath})");
+			Debug.WriteLine($"ExpensiveInitialization({fullyUpdateBookFiles}) for {FolderPath}");
 			Dom = new HtmlDom();
 			//the fileLocator we get doesn't know anything about this particular book.
 			_fileLocator.AddPath(FolderPath);

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -290,7 +290,9 @@ namespace Bloom.Workspace
 			if (inCurrentCollection || inSourceFolder)
 			{
 				var info = new BookInfo(selBookPath, inCurrentCollection);
-				var book = _bookServer.GetBookFromBookInfo(info);
+				// Fully updating book files ensures that the proper branding files are found for
+				// previewing when the collection settings change but the book selection does not.
+				var book = _bookServer.GetBookFromBookInfo(info, fullyUpdateBookFiles: true);
 				_bookSelection.SelectBook(book);
 			}
 		}

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -1358,7 +1358,7 @@ namespace Bloom.Api
 				return false;
 
 			var localPath = GetLocalPathWithoutQuery(info);
-			// We don't need even a toast for missing images in the book folder. That's the user's problem and should be adequately
+			// We don't need even a toast for missing files in the book folder. That's the user's problem and should be adequately
 			// documented by the browser message saying the file is missing.
 			if (currentBookFolderPath != null && localPath.StartsWith(currentBookFolderPath.Replace("\\", "/")))
 				return false;
@@ -1393,6 +1393,9 @@ namespace Bloom.Api
 				"missingpagetemplate",
 				// Branding image files are expected to be missing in the normal case.  Only organizations that care about branding would have these images.
 				"/branding/image",
+				// Files missing in the book-preview folder are really missing from the book folder.  See the comment above for checking localPath
+				// against the currentBookFolderPath.
+				"book-preview/",
 				// This is readium stuff that we don't ship with, because they are needed by the original reader to support display and implementation
 				// of controls we hide for things like adding books to collection, displaying the collection, playing audio (that last we might want back one day).
 				EpubMaker.kEPUBExportFolder.ToLowerInvariant(),


### PR DESCRIPTION
Also ensure branding images are found when changing collection settings
without changing the book selection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4735)
<!-- Reviewable:end -->
