### PR TITLE
BL-10418 Fix persistent error mode

### DIFF
--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -43,7 +43,8 @@ namespace Bloom.Publish
 			Printing,
 			ResumeAfterPrint,
 			Android,
-			EPUB
+			EPUB,
+			NotPublishable
 		}
 
 		public enum BookletPortions


### PR DESCRIPTION
* Extend the existing DisplayMode to include
   NotPublishable
* Save a couple of initial strings in ctor, so a second book
   will update the error message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4737)
<!-- Reviewable:end -->
