### PR TITLE
Handle branding bookshelf settings better (BL-10451)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1234,6 +1234,7 @@ namespace Bloom.Book
 			else //used for making a preview dom
 			{
 				var bd = new BookData(bookDOM, CollectionSettings, UpdateImageMetadataAttributes);
+				bd.MergeBrandingSettings(CollectionSettings.BrandingProjectKey);
 				bd.SynchronizeDataItemsThroughoutDOM();
 			}
 			// get any license info into the json and restored in the replaced front matter.

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -1713,7 +1713,14 @@ namespace Bloom.Book
 					}
 
 					var content = item.Content.Replace("{flavor}", CollectionSettings.GetBrandingFlavor());
-					content = content.Replace("{bookshelfUrlKey}", CollectionSettings.DefaultBookshelf);
+					if (content.Contains("{bookshelfUrlKey}"))
+					{
+						// If the bookshelf isn't set, then don't incorporate the branding image display for it.  See BL-10451.
+						if (String.IsNullOrEmpty(CollectionSettings.DefaultBookshelf) && content.Contains("src='{bookshelfUrlKey}.svg'"))
+							content = "";
+						else
+							content = content.Replace("{bookshelfUrlKey}", CollectionSettings.DefaultBookshelf);
+					}
 					Set(item.DataBook, XmlString.FromXml(content), item.Lang);
 				}
 			}


### PR DESCRIPTION
This includes setting bookshelf to "None" not displaying a bogus missing
image message and updating the book preview more promptly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4744)
<!-- Reviewable:end -->
