### PR TITLE
Comic book templates should make books with overlay tool open (BL-10413)

### DIFF
--- a/src/BloomBrowserUI/templates/template books/Digital Comic Book/meta.json
+++ b/src/BloomBrowserUI/templates/template books/Digital Comic Book/meta.json
@@ -5,11 +5,11 @@
     "suitableForMakingShells": "true",
     "tools": [
         {
-            "name": "comic",
+            "name": "overlay",
             "enabled": true,
             "state": null
         }
     ],
-    "currentTool": "comicTool",
+    "currentTool": "overlayTool",
     "toolboxIsOpen": true
 }

--- a/src/BloomBrowserUI/templates/template books/Paper Comic Book/meta.json
+++ b/src/BloomBrowserUI/templates/template books/Paper Comic Book/meta.json
@@ -5,11 +5,11 @@
     "suitableForMakingShells": "true",
     "tools": [
         {
-            "name": "comic",
+            "name": "overlay",
             "enabled": true,
             "state": null
         }
     ],
-    "currentTool": "comicTool",
+    "currentTool": "overlayTool",
     "toolboxIsOpen": true
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4749)
<!-- Reviewable:end -->
