### PR TITLE
Fix no  matching words in Decodable Reader setup dialog (BL-10439)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
@@ -77,7 +77,7 @@ function process_UI_Message(event: MessageEvent): void {
             )).innerHTML = fileList.replace(/\r/g, "<br>");
             return;
 
-        case "Words":
+        case "UpdateWordsDisplay":
             const useSampleWords =
                 $('input[name="words-or-letters"]:checked').val() === "1";
             if (useSampleWords) displayAllowedWordsForSelectedStage(params[1]);
@@ -289,6 +289,7 @@ function requestWordsForSelectedStage(): void {
     const win = toolboxWindow();
     if (!win) return;
 
+    // FYI: This is supposed to invoke the Words handler in readerTools.ts
     if (useSampleWords)
         win.postMessage(
             "Words\n" + (<HTMLTableCellElement>tr.cells[0]).innerHTML,

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools.ts
@@ -82,8 +82,14 @@ function processDLRMessage(event: MessageEvent): void {
             }
 
             if (setupDialogWindow) {
+                // Post a message to the handler in readerSetup.ui.ts.
+                // Best for this to post a message to a handler with a different name than this (Words) though.
+                // Although at one point, only one set of handlers is attached to the window,
+                // at a later point both handlers are attached due to jquery.text-markup.ts importing a file which imports this file (readerTools)
+                // That causes an infinite recursion where this handler calls itself (with the wrong parameters) over and over.
+                // It's more future proof to resolve this by making sure the handlers have unique names.
                 setupDialogWindow.postMessage(
-                    "Words\n" + JSON.stringify(words),
+                    "UpdateWordsDisplay\n" + JSON.stringify(words),
                     "*"
                 );
             }


### PR DESCRIPTION
The problem is that the "Words" message handler in readerTools.ts tries to call the "Words" message handler in readerSetup.ui.ts. However, because now the readerTools handler is somehow attached too (an import which indirectly imports ReaderTools causes this somehow, see commit 6edf699819f39df3073e1b8a3710337a3afb34fc's jquery.text-markup.ts), now both handlers respond to the "Words" message. Note that Words is now invoking itself (along with its desired target) which means this is an infinite recursion. It invokes itself repeatedly (with the wrong parameters after the 1st time) and the matching words are overwritten after the 1st iteration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4751)
<!-- Reviewable:end -->
