### PR TITLE
Disable turning off image descriptions in xmatter pages (BL-10472)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
@@ -79,7 +79,12 @@ export class ImageDescriptionToolControls extends React.Component<
                         </ul>
                     </div>
                     <div className="imgDescLabelBlock">
-                        <Label l10nKey="EditTab.Toolbox.ImageDescriptionTool.CheckThisBox">
+                        <Label
+                            l10nKey="EditTab.Toolbox.ImageDescriptionTool.CheckThisBox"
+                            className={
+                                ToolBox.isXmatterPage() ? "disabled " : ""
+                            }
+                        >
                             Otherwise, check this box:
                         </Label>
                         <Checkbox
@@ -89,6 +94,7 @@ export class ImageDescriptionToolControls extends React.Component<
                             }
                             className="imageDescriptionCheck"
                             name=""
+                            disabled={ToolBox.isXmatterPage()}
                             checked={this.state.descriptionNotNeeded}
                             onCheckChanged={checked =>
                                 this.onCheckChanged(checked)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4758)
<!-- Reviewable:end -->
