### PR TITLE
Fix wrong default spreadsheet export folder (BL-10259)

### DIFF
--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -1758,7 +1758,7 @@ namespace Bloom.CollectionTab
 					var filename = _bookSelection.CurrentSelection.Storage.FileName;
 					dlg.FileName = Path.ChangeExtension(filename, extension);
 					dlg.Filter = "xlsx|*.xlsx";
-					dlg.InitialDirectory = Settings.Default.ExportImportFileFolder ?? Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+					dlg.InitialDirectory = !String.IsNullOrWhiteSpace(Settings.Default.ExportImportFileFolder) ? Settings.Default.ExportImportFileFolder : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 					dlg.RestoreDirectory = true;
 					dlg.OverwritePrompt = true;
 					if (DialogResult.Cancel == dlg.ShowDialog())


### PR DESCRIPTION
The setting could be present in the userprefs file but listed as <value>\r\n        </value>, in which case the Null Coalescing Operator failed to detect that it was uninitialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4770)
<!-- Reviewable:end -->
