### PR TITLE
Strip anchor wrappers from internal hyperlinks in epubs (BL-10373)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -3645,6 +3645,10 @@
         <note>ID: PublishTab.Epub.ImageDescriptionLinkLabel</note>
         <note>Used in Epubs as the text of a link that leads to the description of an image</note>
       </trans-unit>
+      <trans-unit id="PublishTab.Epub.LocalLinksProblem">
+        <source xml:lang="en">Links to other pages do not work in epubs. They will be changed to plain text that does not look like a link.</source>
+        <note>ID: PublishTab.Epub.LocalLinksProblem</note>
+      </trans-unit>
       <trans-unit id="PublishTab.Epub.IncludeOnPage">
         <source xml:lang="en">Include image descriptions on page</source>
         <note>ID: PublishTab.Epub.IncludeOnPage</note>

--- a/src/BloomExe/ToPalaso/XmlExtensions.cs
+++ b/src/BloomExe/ToPalaso/XmlExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml;
+﻿using System.Linq;
+using System.Xml;
 
 namespace Bloom.ToPalaso
 {
@@ -35,6 +36,22 @@ namespace Bloom.ToPalaso
 			while (current != null && current.Attributes[targetAttr]?.Value != targetVal)
 				current = current.ParentNode as XmlElement;
 			return current;
+		}
+
+		/// <summary>
+		/// Replace the element with its children.
+		/// </summary>
+		/// <param name="unwrapMe"></param>
+		public static void UnwrapElement(this XmlElement unwrapMe)
+		{
+			var content = unwrapMe.ChildNodes.Cast<XmlNode>().Reverse().ToArray();
+			var parent = unwrapMe.ParentNode as XmlElement;
+			foreach (var child in content)
+			{
+				parent.InsertAfter(child, unwrapMe);
+			}
+
+			parent.RemoveChild(unwrapMe);
 		}
 	}
 }

--- a/src/BloomTests/ToPalaso/XmlExtensionsTests.cs
+++ b/src/BloomTests/ToPalaso/XmlExtensionsTests.cs
@@ -7,6 +7,7 @@ using System.Xml;
 using Bloom.ToPalaso;
 using Gecko.WebIDL;
 using NUnit.Framework;
+using SIL.Xml;
 
 namespace BloomTests.ToPalaso
 {
@@ -63,6 +64,24 @@ namespace BloomTests.ToPalaso
 			var child = doc.CreateElement("child");
 			intermediate.AppendChild(child);
 			Assert.That(child.ParentWithClass("target"), Is.EqualTo(parent));
+		}
+
+		[Test]
+		public void UnwrapElement_AnchorInDiv_Unwraps()
+		{
+			var doc = new XmlDocument();
+			doc.LoadXml(@"<html><body><div>This is <a href='somewhere'>a <i>nice</i> link</a> that goes nowhere</div></body></html>");
+
+			var anchor =doc.SafeSelectNodes("//a")[0] as XmlElement;
+			var div = anchor.ParentNode as XmlElement;
+
+			anchor.UnwrapElement();
+
+			Assert.That(div.InnerText, Is.EqualTo("This is a nice link that goes nowhere"));
+			Assert.That(doc.SafeSelectNodes("//a"), Has.Count.EqualTo(0));
+
+			var italics = doc.SafeSelectNodes("//i")[0] as XmlElement;
+			Assert.That(italics.InnerText, Is.EqualTo("nice"));
 		}
 	}
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4771)
<!-- Reviewable:end -->
