### PR TITLE
Fix some problems with renaming things in team Collection

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -358,6 +358,7 @@
     <Compile Include="AboutMemory.Designer.cs">
       <DependentUpon>AboutMemory.cs</DependentUpon>
     </Compile>
+    <Compile Include="Book\SaveContext.cs" />
     <Compile Include="Utils\BloomArchiveFile.cs" />
     <Compile Include="Utils\BloomTarArchive.cs" />
     <Compile Include="BloomWebClient.cs">

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -78,7 +78,7 @@ namespace Bloom.Book
 			PageSelection pageSelection,
 			PageListChangedEvent pageListChangedEvent,
 			BookRefreshEvent bookRefreshEvent,
-			BookSavedEvent bookSavedEvent=null)
+			BookSavedEvent bookSavedEvent=null, ISaveContext context = null)
 		{
 			BookInfo = info;
 			if (bookSavedEvent == null) // unit testing
@@ -648,6 +648,12 @@ namespace Bloom.Book
 				return !HasFatalError;
 			}
 		}
+
+		/// <summary>
+		/// True if changes to the book may currently be saved. This includes the book being checked out
+		/// if it is in a team collection, and by intent should include any future requirements.
+		/// </summary>
+		public bool IsSaveable => IsEditable && BookInfo.IsSaveable;
 
 
 		/// <summary>
@@ -3530,13 +3536,7 @@ namespace Bloom.Book
 			{
 				if (LockDownTheFileAndFolderName || BookInfo.NameLocked)
 					return false;
-				// I really wish Book didn't need to know about TeamCollection. But Save is used
-				// in BringBookUpToDate, and it is disastrous to change the folder name of a book
-				// that is not checked out.
-				var tcm = TeamCollectionManager.TheOneInstance;
-				if (tcm != null && tcm.NeedCheckoutToEdit(FolderPath))
-					return false;
-				return true;
+				return IsSaveable;
 			}
 		}
 

--- a/src/BloomExe/Book/BookInfo.cs
+++ b/src/BloomExe/Book/BookInfo.cs
@@ -20,6 +20,7 @@ using SIL.Reporting;
 using SIL.Windows.Forms.ClearShare;
 using SIL.Text;
 using Bloom.Utils;
+using SIL.Code;
 
 namespace Bloom.Book
 {
@@ -32,6 +33,7 @@ namespace Bloom.Book
 		private const string kTopicPrefix = "topic:";
 		private const string kBookshelfPrefix = "bookshelf:";
 		public const string BookOrderExtension = ".BloomBookOrder";
+		private ISaveContext _saveContext;
 
 		private BookMetaData _metadata;
 
@@ -46,10 +48,23 @@ namespace Bloom.Book
 
 		}
 
-		public BookInfo(string folderPath, bool isEditable)
+		internal BookInfo(string folderPath, bool isEditable)
+			// By default (especially for many test cases), BookInfo's should assume savability
+			// unless not editable
+			: this(folderPath, isEditable, isEditable ? new AlwaysEditSaveContext() : new NoEditSaveContext() as ISaveContext)
 		{
-			FolderPath = folderPath;
+			// For real code, please explicitly provide a correct saveContext unless isEditable is false
+			if (isEditable)
+				Guard.Against(!Program.RunningUnitTests, "Only use this ctor for tests and non-editable collections");
+		}
 
+		public BookInfo(string folderPath, bool isEditable, ISaveContext saveContext)
+		{
+			Guard.AgainstNull(saveContext, "Please supply an actual saveContext");
+			
+			_saveContext = saveContext ?? (isEditable ? new AlwaysEditSaveContext() : new NoEditSaveContext() as ISaveContext);
+
+			FolderPath = folderPath;
 			//NB: This was coded in an unfortunate way such that touching almost any property causes a new metadata to be quietly created.
 			//So It's vital that we not touch properties that could create a blank metadata, before attempting to load the existing one.
 
@@ -263,7 +278,18 @@ namespace Bloom.Book
 			set { MetaData.Copyright = value; }
 		}
 
+		/// <summary>
+		/// Determined at construction time, and really means whether it is part of the editable collection.
+		/// May not really be OK to edit, for example, if it isn't checked out.
+		/// Wants a better name; consider whether IsSaveable should be used instead.
+		/// </summary>
 		public bool IsEditable { get; private set; }
+
+		/// <summary>
+		/// Determined by the SaveContext, which if relevant will consider team collection status.
+		/// This determines whether changes to this book can currently be saved.
+		/// </summary>
+		public bool IsSaveable => IsEditable && _saveContext.CanSaveChanges(this);
 
 		/// <summary>
 		/// If true, use a device-specific xmatter pack.
@@ -594,7 +620,10 @@ namespace Bloom.Book
 		/// <remarks>internal for testing</remarks>
 		internal static void InstallFreshInstanceGuid(string bookFolder)
 		{
-			var bookInfo = new BookInfo(bookFolder, true);
+			// This is a temporary BookInfo that shouldn't get asked about saveability of the book.
+			// But, this method should not have been called unless we already verified that we can save
+			// changes legitimately.
+			var bookInfo = new BookInfo(bookFolder, true, new AlwaysEditSaveContext());
 			bookInfo.InstallFreshGuidInternal();
 		}
 

--- a/src/BloomExe/Book/SaveContext.cs
+++ b/src/BloomExe/Book/SaveContext.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bloom.Book
+{
+	/// <summary>
+	/// This interface provides contextual information for a book to enable it to determine
+	/// what it can't decide from internal knowledge about whether changes to it can currently
+	/// be saved.
+	/// </summary>
+	/// <remarks>We may extend it with functions for requesting to be put into a saveable state.</remarks>
+	public interface ISaveContext
+	{
+		bool CanSaveChanges(BookInfo info);
+	}
+
+	/// <summary>
+	/// Implementation of ISaveContext appropriate for collections that are not TheOneEditableCollection.
+	/// Saving changes is never allowed.
+	/// </summary>
+	class NoEditSaveContext : ISaveContext
+	{
+		public bool CanSaveChanges(BookInfo info)
+		{
+			return false;
+		}
+	}
+
+	/// <summary>
+	/// Implementation of ISaveContext appropriate for TheOneEditableCollection when it is not
+	/// a team collection. As far as the collection is concerned, saving is always allowed.
+	/// </summary>
+	class AlwaysEditSaveContext : ISaveContext
+	{
+		public bool CanSaveChanges(BookInfo info)
+		{
+			return true;
+		}
+	}
+
+	// (The other implementations are kinds of TeamCollections, where changes can be saved
+	// only if the book is checked out.)
+}

--- a/src/BloomExe/CLI/CreateArtifactsCommand.cs
+++ b/src/BloomExe/CLI/CreateArtifactsCommand.cs
@@ -159,7 +159,7 @@ namespace Bloom.CLI
 
 		private static void LoadBook(string bookPath)
 		{
-			_book = _projectContext.BookServer.GetBookFromBookInfo(new BookInfo(bookPath, true));
+			_book = _projectContext.BookServer.GetBookFromBookInfo(new BookInfo(bookPath, true, _projectContext.TeamCollectionManager.CurrentCollectionEvenIfDisconnected));
 		}
 
 		/// <summary>

--- a/src/BloomExe/CLI/HydrateBookCommand.cs
+++ b/src/BloomExe/CLI/HydrateBookCommand.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Xml;
 using Bloom.Book;
 using Bloom.Collection;
+using Bloom.TeamCollection;
 using CommandLine;
 using SIL.IO;
 using SIL.Progress;
@@ -44,6 +45,13 @@ namespace Bloom.CLI
 				SizeAndOrientation = SizeAndOrientation.FromString(options.SizeAndOrientation)
 			};
 
+			if (File.Exists(TeamCollectionManager.GetTcLinkPathFromLcPath(Path.GetDirectoryName(options.Path))))
+			{
+				throw new ApplicationException("Hydrate command cannot currently be used in Team Collections");
+				// To make this possible, we'd need to spin up a TeamCollectionManager and TeamCollection and pass the latter
+				// to the Book as its SaveContext and still changes would be forbidden unless the book was checked out.
+			}
+
 			var collectionSettings = new CollectionSettings
 			{
 				XMatterPackName = options.XMatter,
@@ -56,7 +64,8 @@ namespace Bloom.CLI
 			var locator = new BloomFileLocator(collectionSettings, xmatterFinder, ProjectContext.GetFactoryFileLocations(),
 				ProjectContext.GetFoundFileLocations(), ProjectContext.GetAfterXMatterFileLocations());
 
-			var bookInfo = new BookInfo(options.Path, true);
+			// alwaysSaveable is fine here, as we already checked it's not a TC.
+			var bookInfo = new BookInfo(options.Path, true, new AlwaysEditSaveContext());
 			var book = new Book.Book(bookInfo, new BookStorage(options.Path, locator, new BookRenamedEvent(), collectionSettings),
 				null, collectionSettings, null, null, new BookRefreshEvent(), new BookSavedEvent());
 			// This was added as part of the phase 1 changes towards the new language system, where book languages

--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using Bloom.Book;
+using Bloom.TeamCollection;
 using SIL.IO;
 using SIL.Reporting;
 using SIL.Windows.Forms.FileSystem;
@@ -24,6 +25,7 @@ namespace Bloom.Collection
 		private readonly string _path;
 		private List<BookInfo> _bookInfos;
 		private string _factoryDir;
+		private TeamCollectionManager _tcManager;
 
 		private readonly BookSelection _bookSelection;
 
@@ -39,10 +41,11 @@ namespace Bloom.Collection
 		}
 
 		public BookCollection(string path, CollectionType collectionType,
-			BookSelection bookSelection)
+			BookSelection bookSelection, TeamCollectionManager tcm = null)
 		{
 			_path = path;
 			_bookSelection = bookSelection;
+			_tcManager = tcm;
 
 			Type = collectionType;
 
@@ -188,7 +191,9 @@ namespace Bloom.Collection
 					// BL-6099: don't hide the book if we at least have a valid backup file
 					!BackupFileExists(folderPath))
 						return;
-				var bookInfo = new BookInfo(folderPath, Type == CollectionType.TheOneEditableCollection);
+				var editable = Type == CollectionType.TheOneEditableCollection;
+				ISaveContext sc = editable ? _tcManager?.CurrentCollectionEvenIfDisconnected : null;
+				var bookInfo = new BookInfo(folderPath, editable, sc);
 
 				_bookInfos.Add(bookInfo);
 			}

--- a/src/BloomExe/CollectionTab/LibraryListView.cs
+++ b/src/BloomExe/CollectionTab/LibraryListView.cs
@@ -152,7 +152,7 @@ namespace Bloom.CollectionTab
 				// It's in a location where editing makes sense, so all the menu options are
 				// relevant. I don't think we want to hide any of them. But, we need to disable
 				// the ones that require checkout if we don't have it.
-				bool needsCheckout = _tcManager.NeedCheckoutToEdit(btnInfo.BookInfo.FolderPath);
+				bool needsCheckout = btnInfo.BookInfo.IsSaveable;
 				foreach (ToolStripItem menuItem in (sender as ContextMenuStrip).Items)
 				{
 					if (needsCheckout)
@@ -1796,7 +1796,7 @@ namespace Bloom.CollectionTab
 			if (!bookInfoFromButton.IsEditable)
 				return;
 			// ...or not checked out
-			if (_tcManager.NeedCheckoutToEdit(bookInfoFromButton.FolderPath))
+			if (!bookInfoFromButton.IsSaveable)
 				return;
 			if (_renameOverlay != null)
 			{

--- a/src/BloomExe/CollectionTab/LibraryModel.cs
+++ b/src/BloomExe/CollectionTab/LibraryModel.cs
@@ -177,7 +177,7 @@ namespace Bloom.CollectionTab
 			{
 				if (IsCurrentBookInCollection())
 				{
-					if (!_tcManager.CanEditBook())
+					if (!_bookSelection.CurrentSelection.IsSaveable)
 					{
 						var msg = LocalizationManager.GetString("TeamCollection.CheckOutForDelete",
 							"Please check out the book before deleting it.");
@@ -227,7 +227,7 @@ namespace Bloom.CollectionTab
 		{
 			// If we need the book to be checked out for editing, make sure it is. Do not allow double click
 			// to check it out. 
-			if (_tcManager.CanEditBook())
+			if (_bookSelection.CurrentSelection?.IsSaveable ?? false)
 			{
 				_editBookCommand.Raise(_bookSelection.CurrentSelection);
 			}

--- a/src/BloomExe/Publish/BloomLibrary/BloomLibraryUploadControl.cs
+++ b/src/BloomExe/Publish/BloomLibrary/BloomLibraryUploadControl.cs
@@ -109,7 +109,7 @@ namespace Bloom.Publish.BloomLibrary
 			_copyrightLabel.Text = _model.Copyright;
 			_creditsLabel.Text = _model.Credits;
 			_summaryBox.Text = _model.Summary;
-			if (!TeamCollectionApi.TheOneInstance.CanEditBook())
+			if (!_model.Book.IsSaveable)
 			{
 				_summaryBox.Enabled = false;
 				_summaryOptionalLabel.Text = LocalizationManager.GetString("TeamCollection.OptionalCheckOutEdit",

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -412,7 +412,8 @@ namespace Bloom.Publish
 			HashSet<string> omittedPageLabels = null)
 		{
 			BookStorage.CopyDirectory(bookFolderPath, tempFolderPath);
-			var bookInfo = new BookInfo(tempFolderPath, true) {UseDeviceXMatter = !isTemplateBook};
+			// We can always save in a temp book
+			var bookInfo = new BookInfo(tempFolderPath, true, new AlwaysEditSaveContext()) {UseDeviceXMatter = !isTemplateBook};
 			var modifiedBook = bookServer.GetBookFromBookInfo(bookInfo);
 			modifiedBook.BringBookUpToDate(new NullProgress(), true);
 			modifiedBook.RemoveNonPublishablePages(omittedPageLabels);

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -31,7 +31,7 @@ namespace Bloom.TeamCollection
 	/// The idea is to leave open the possibility of other implementations, for example, based on
 	/// a DVCS.
 	/// </summary>
-	public abstract class TeamCollection: IDisposable
+	public abstract class TeamCollection: IDisposable, ISaveContext
 	{
 		// special value for BookStatus.lockedBy when the book is newly created and not in the repo at all.
 		public const string FakeUserIndicatingNewBook = "this user";
@@ -2075,6 +2075,11 @@ namespace Bloom.TeamCollection
 		~TeamCollection()
 		{
 			Dispose(false);
+		}
+
+		public bool CanSaveChanges(BookInfo info)
+		{
+			return !NeedCheckoutToEdit(info.FolderPath);
 		}
 
 		/// <summary>

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -52,6 +52,11 @@ namespace Bloom.TeamCollection
 
 		protected bool _updatingCollectionFiles;
 
+		/// <summary>
+		/// Books that have been remotely renamed but not yet reloaded and renamed locally.
+		/// </summary>
+		private HashSet<string> _remotelyRenamedBooks = new HashSet<string>();
+
 		public TeamCollection(ITeamCollectionManager manager, string localCollectionFolder,
 			TeamCollectionMessageLog tcLog = null)
 		{
@@ -1138,6 +1143,8 @@ namespace Bloom.TeamCollection
 
 		public virtual bool HasBeenChangedRemotely(string bookName)
 		{
+			if (_remotelyRenamedBooks.Contains(bookName))
+				return true;
 			return GetLocalStatus(bookName).checksum != GetStatus(bookName).checksum;
 		}
 
@@ -1289,6 +1296,7 @@ namespace Bloom.TeamCollection
 				}
 				else
 				{
+					_remotelyRenamedBooks.Add(oldName);
 					_tcLog.WriteMessage(MessageAndMilestoneType.NewStuff, "TeamCollection.RenameFromRemote",
 						"The book \"{0}\" has been renamed to \"{1}\" by a teammate.",
 						oldName, bookBaseName);
@@ -1522,6 +1530,10 @@ namespace Bloom.TeamCollection
 
 			var newBooks = GetNewRepoBookMap();
 
+			// The list of these that we maintain to track changes while we are running
+			// is distinct from the list that is a local variable here and tracks ones
+			// we actually are in the process of fixing.
+			_remotelyRenamedBooks.Clear();
 			var remotelyRenamedBooks = new HashSet<string>(); // Books actually found to be renamed (by new name)
 
 			// Delete books that we think have been deleted remotely from the repo.

--- a/src/BloomExe/TeamCollection/TeamCollectionApi.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionApi.cs
@@ -698,12 +698,5 @@ namespace Bloom.TeamCollection
 				_bookSelection.InvokeSelectionChanged(false);
 			}));
 		}
-
-		// Some pre-existing logic for whether the user can edit the book, combined with checking
-		// that it is checked-out to this user 
-		public bool CanEditBook()
-		{
-			return _tcManager.CanEditBook();
-		}
 	}
 }

--- a/src/BloomExe/TeamCollection/TeamCollectionManager.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionManager.cs
@@ -210,10 +210,18 @@ namespace Bloom.TeamCollection
 			}
 		}
 
+		/// <summary>
+		/// Use this as a last resort. Objects created by AutoFac should just add a TCM to their argument
+		/// list if they need it. But there are objects like Book where this is not a logical member variable,
+		/// but for a very few special cases they need to be able to get it.
+		/// </summary>
+		public static TeamCollectionManager TheOneInstance { get; private set; }
+
 		public TeamCollectionManager(string localCollectionPath, BloomWebSocketServer webSocketServer,
 			BookRenamedEvent bookRenamedEvent, BookStatusChangeEvent bookStatusChangeEvent,
 			BookSelection bookSelection, LibraryClosing libraryClosingEvent)
 		{
+			TheOneInstance = this;
 			_webSocketServer = webSocketServer;
 			_bookStatusChangeEvent = bookStatusChangeEvent;
 			_localCollectionFolder = Path.GetDirectoryName(localCollectionPath);

--- a/src/BloomExe/TeamCollection/TeamCollectionManager.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionManager.cs
@@ -19,12 +19,9 @@ namespace Bloom.TeamCollection
 
 		bool CheckConnection();
 		void ConnectToTeamCollection(string repoFolderParentPath, string collectionId);
-		bool NeedCheckoutToEdit(string bookFolderPath);
 		string PlannedRepoFolderPath(string repoFolderParentPath);
 
 		bool OkToEditCollectionSettings { get; }
-
-		bool CanEditBook();
 
 		bool UserMayChangeEmail { get; }
 
@@ -128,29 +125,6 @@ namespace Bloom.TeamCollection
 			TeamCollectionStatusChanged?.Invoke(null, new EventArgs());
 		}
 
-		/// <summary>
-		/// Return true if the user must check this book out before editing it,
-		/// deleting it, etc. This is automatically false if the collection is not
-		/// a TC; if it is a TC (even a disconnected one), it's true if the book is
-		/// NOT checked out.
-		/// </summary>
-		/// <remarks>if bookFolderPath is null or empty, it currently returns false.
-		/// This is a bit arbitrary. If there's no book currently selected, then we can't
-		/// do editing operations...in that sense this situation is similar to a selected
-		/// book that needs to be checked out. But strictly it's not true that we need
-		/// to check out the selected book to edit...we need a book to be selected!
-		/// I wanted to settle on some answer so that callers don't each have to be careful
-		/// not to pass null, so I settled on false.</remarks>
-		public bool NeedCheckoutToEdit(string bookFolderPath)
-		{
-			// We use the EvenIfDisconnected version here because we want
-			// editing attempts to FAIL if we are in a disconnected TC and don't already have it
-			// checked out; we don't just want to edit it as if the collection was not a TC at all.
-			if (CurrentCollectionEvenIfDisconnected == null || string.IsNullOrEmpty(bookFolderPath))
-				return false;
-			return CurrentCollectionEvenIfDisconnected.NeedCheckoutToEdit(bookFolderPath);
-		}
-
 		public bool UserMayChangeEmail
 		{
 			get
@@ -159,17 +133,6 @@ namespace Bloom.TeamCollection
 					return true;
 				return !CurrentCollection.AnyBooksCheckedOutHereByCurrentUser;
 			}
-		}
-
-		public bool CanEditBook()
-		{
-			if (BookSelection.CurrentSelection == null || !BookSelection.CurrentSelection.IsEditable)
-			{
-				return false; // no book, or the book's own logic says it's not editable
-			}
-
-			// We can edit it unless TC says we need a checkout to do it.
-			return !NeedCheckoutToEdit(BookSelection.CurrentSelection.FolderPath);
 		}
 
 		/// <summary>
@@ -210,18 +173,10 @@ namespace Bloom.TeamCollection
 			}
 		}
 
-		/// <summary>
-		/// Use this as a last resort. Objects created by AutoFac should just add a TCM to their argument
-		/// list if they need it. But there are objects like Book where this is not a logical member variable,
-		/// but for a very few special cases they need to be able to get it.
-		/// </summary>
-		public static TeamCollectionManager TheOneInstance { get; private set; }
-
 		public TeamCollectionManager(string localCollectionPath, BloomWebSocketServer webSocketServer,
 			BookRenamedEvent bookRenamedEvent, BookStatusChangeEvent bookStatusChangeEvent,
 			BookSelection bookSelection, LibraryClosing libraryClosingEvent)
 		{
-			TheOneInstance = this;
 			_webSocketServer = webSocketServer;
 			_bookStatusChangeEvent = bookStatusChangeEvent;
 			_localCollectionFolder = Path.GetDirectoryName(localCollectionPath);

--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -424,7 +424,8 @@ namespace Bloom.WebLibraryIntegration
 			{
 				if (!IsBookOnServer(bookFolder))
 					return false;
-				var bkInfo = new BookInfo(bookFolder, true);
+				// This instance of BookInfo is temporary, always Saveable is fine.
+				var bkInfo = new BookInfo(bookFolder, true, new AlwaysEditSaveContext());
 				var s3id = S3BookId(bkInfo.MetaData);
 				var key = s3id + BloomS3Client.kDirectoryDelimeterForS3 + Path.GetFileName(bookFolder) + BloomS3Client.kDirectoryDelimeterForS3 + UploadHashesFilename;
 				hashInfoOnS3 = _s3Client.DownloadFile(UseSandbox ? BloomS3Client.SandboxBucketName : BloomS3Client.ProductionBucketName, key);
@@ -471,7 +472,8 @@ namespace Bloom.WebLibraryIntegration
 
 			Directory.CreateDirectory(tempFolderPath);
 			BookStorage.CopyDirectory(book.FolderPath, tempFolderPath);
-			var bookInfo = new BookInfo(tempFolderPath, true);
+			// In the temp folder it's safe to assume we can save changes.
+			var bookInfo = new BookInfo(tempFolderPath, true, new AlwaysEditSaveContext());
 			var copiedBook = bookServer.GetBookFromBookInfo(bookInfo);
 			copiedBook.BringBookUpToDate(new NullProgress(), true);
 			var pages = new List<XmlElement>();

--- a/src/BloomExe/WebLibraryIntegration/BulkUploader.cs
+++ b/src/BloomExe/WebLibraryIntegration/BulkUploader.cs
@@ -277,7 +277,7 @@ namespace Bloom.WebLibraryIntegration
 					Program.SetProjectContext(context);
 				}
 				var server = context.BookServer;
-				var bookInfo = new BookInfo(uploadParams.Folder, true);
+				var bookInfo = new BookInfo(uploadParams.Folder, true, context.TeamCollectionManager.CurrentCollectionEvenIfDisconnected);
 				var book = server.GetBookFromBookInfo(bookInfo, fullyUpdateBookFiles: true);
 				book.BringBookUpToDate(new NullProgress());
 				book.Storage.CleanupUnusedSupportFiles(isForPublish: false); // we are publishing, but this is the real folder not a copy, so play safe.
@@ -319,7 +319,7 @@ namespace Bloom.WebLibraryIntegration
 				bookSelection.SelectBook(book);
 				var currentEditableCollectionSelection = new CurrentEditableCollectionSelection();
 
-				var collection = new BookCollection(collectionPath, BookCollection.CollectionType.SourceCollection, bookSelection);
+				var collection = new BookCollection(collectionPath, BookCollection.CollectionType.SourceCollection, bookSelection, context.TeamCollectionManager);
 				currentEditableCollectionSelection.SelectCollection(collection);
 
 				var publishModel = new PublishModel(bookSelection, new PdfMaker(), currentEditableCollectionSelection, context.Settings, server, _thumbnailer);

--- a/src/BloomExe/Workspace/WorkspaceModel.cs
+++ b/src/BloomExe/Workspace/WorkspaceModel.cs
@@ -35,7 +35,7 @@ namespace Bloom.Workspace
 			get { return _bookSelection.CurrentSelection != null && _bookSelection.CurrentSelection.IsEditable && !_bookSelection.CurrentSelection.HasFatalError; }
 		}
 
-		public bool EditTabLocked => !TeamCollectionApi.TheOneInstance.CanEditBook();
+		public bool EditTabLocked => !_bookSelection.CurrentSelection.IsSaveable;
 
 		public bool ShowPublishTab
 		{

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -231,7 +231,6 @@ namespace Bloom.Workspace
 
 			bookSelection.SelectionChanged += HandleBookSelectionChanged;
 			bookStatusChangeEvent.Subscribe(args => { HandleBookStatusChange(args); });
-			SelectPreviouslySelectedBook();
 		}
 
 		public void HandleRenameCommand()
@@ -269,6 +268,12 @@ namespace Bloom.Workspace
 					);
 				}, shouldHideSplashScreen: true);
 			}
+
+			// Must not do this until we've done TC sync. Among various potential confusions,
+			// if the book has been renamed remotely but not yet here, we may not be able to tell that it
+			// needs to be checked out before BringBookUpToDate renames it here.
+			StartupScreenManager.AddStartupAction(() =>
+				SelectPreviouslySelectedBook());
 		}
 
 		/// <summary>

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -294,7 +294,7 @@ namespace Bloom.Workspace
 			var inSourceFolder = !inCurrentCollection && _model.GetSourceCollectionFolders().ToList().Exists(folder => selBookCollectionFolder == folder);
 			if (inCurrentCollection || inSourceFolder)
 			{
-				var info = new BookInfo(selBookPath, inCurrentCollection);
+				var info = new BookInfo(selBookPath, inCurrentCollection, _tcManager.CurrentCollectionEvenIfDisconnected);
 				// Fully updating book files ensures that the proper branding files are found for
 				// previewing when the collection settings change but the book selection does not.
 				var book = _bookServer.GetBookFromBookInfo(info, fullyUpdateBookFiles: true);
@@ -329,7 +329,7 @@ namespace Bloom.Workspace
 			var result = JsonConvert.SerializeObject(new
 			{
 				id = book?.ID,
-				editable = _tcManager.CanEditBook(),
+				editable = _bookSelection.CurrentSelection?.IsSaveable ?? false,
 				collectionKind
 			});
 			return result;

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -181,7 +181,7 @@ namespace Bloom.web.controllers
 		/// <param name="request"></param>
 		private void HandleCanModifyCurrentBook(ApiRequest request)
 		{
-			request.ReplyWithBoolean(TeamCollectionApi.TheOneInstance.CanEditBook());
+			request.ReplyWithBoolean(request.CurrentBook?.IsSaveable ?? false);
 		}
 
 

--- a/src/BloomExe/web/controllers/PageTemplatesApi.cs
+++ b/src/BloomExe/web/controllers/PageTemplatesApi.cs
@@ -302,7 +302,9 @@ namespace Bloom.web.controllers
 		private static bool IsTemplateInvisible(string templatePath)
 		{
 			var folderPath = Path.GetDirectoryName(templatePath);
-			var info = new BookInfo(folderPath, true);
+			// This book info should never be asked about savability, so it doesn't matter much,
+			// but it feels safer to say it can't be saved.
+			var info = new BookInfo(folderPath, true, new NoEditSaveContext());
 			return !info.ShowThisBookAsSource();
 		}
 


### PR DESCRIPTION
Remotely renamed book not yet reloaded allowed user to try to check out (BL-10528)
BringBookUpToDate could rename a not-checked-out book, with various nasty consequence (BL-10529)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4784)
<!-- Reviewable:end -->
