### PR TITLE
Discourage use of TC in 5.0 (BL-10546)

### DIFF
--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -10,6 +10,7 @@ using SIL.Windows.Forms.WritingSystems;
 using SIL.Extensions;
 using SIL.WritingSystems;
 using System.Collections.Generic;
+using System.Reflection;
 using Bloom.Api;
 using Bloom.TeamCollection;
 using Bloom.MiscUI;
@@ -59,6 +60,12 @@ namespace Bloom.Collection
 			_queueRenameOfCollection = queueRenameOfCollection;
 			_pageRefreshEvent = pageRefreshEvent;
 			InitializeComponent();
+
+			// Don't merge this block beyond 5.0!
+			var version = Assembly.GetExecutingAssembly().GetName().Version;
+			if (version < new Version(5, 1))
+				_allowTeamCollection.Visible = false;
+
 			// moved from the Designer where it was deleted if the Designer was touched
 			_xmatterList.Columns.AddRange(new[] { new ColumnHeader() { Width = 250 } });
 

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Windows.Forms;
@@ -1432,6 +1433,16 @@ namespace Bloom.TeamCollection
 			_tcLog.WriteMilestone(MessageAndMilestoneType.Reloaded);
 
 			var hasProblems = false; //set true if we get any problems
+
+			// Don't merge this block beyond 5.0!
+			// Since we don't need this message permanently, not giving it a real l10nId.
+			var version = Assembly.GetExecutingAssembly().GetName().Version;
+			if (!Program.RunningUnitTests && version < new Version(5,1))
+			{
+				ReportProgressAndLog(progress, ProgressKind.Error, "",
+					"Because this is a Team Collection, you need to upgrade to Bloom 5.1");
+				hasProblems = true;
+			}
 
 			var newBooks = GetNewRepoBookMap();
 


### PR DESCRIPTION
This should get a null-merge into 5.1; we don't want these changes after 5.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4790)
<!-- Reviewable:end -->
