### PR TITLE
Replace Clipboard with PortableClipboard in Version5.0 (BL-10469)

### DIFF
--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 using SIL.Extensions;
 using SIL.IO;
 using SIL.PlatformUtilities;
+using SIL.Windows.Forms.Miscellaneous;
 using ApplicationException = System.ApplicationException;
 using Timer = System.Windows.Forms.Timer;
 
@@ -78,7 +79,7 @@ namespace Bloom.web.controllers
 						{
 							try
 							{
-								result = Clipboard.GetText();
+								result = PortableClipboard.GetText();
 							}
 							catch (Exception e)
 							{
@@ -101,7 +102,7 @@ namespace Bloom.web.controllers
 							{
 								try
 								{
-									Clipboard.SetText(content);
+									PortableClipboard.SetText(content);
 								}
 								catch (Exception e)
 								{


### PR DESCRIPTION
These two occurrences were fixed earlier in Version5.1, but somehow were
missed in Version5.0 until our intrepid tester stumbled over them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4798)
<!-- Reviewable:end -->
