### PR TITLE
Clean up spreadsheet (BL-10368)

### DIFF
--- a/src/BloomExe/Spreadsheet/InternalSpreadsheet.cs
+++ b/src/BloomExe/Spreadsheet/InternalSpreadsheet.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
 
 namespace Bloom.Spreadsheet
 {
@@ -12,14 +14,19 @@ namespace Bloom.Spreadsheet
 	/// </summary>
 	public class InternalSpreadsheet
 	{
-		public const string ImageIndexOnPageLabel = "(image index on page)";
-		public const string ImageThumbnailLabel = "[image thumbnail]";
-		public const string ImageSourceLabel = "[image source]";
-		public const string ImageKeyLabel = "[image]";
-		public const string TextIndexOnPageLabel = "(text index on page)";
-		public const string MetadataKeyLabel = "[metadata key]";
-		public const string PageNumberLabel = "[page]";
-		public const string TextGroupLabel = "[textgroup]";
+		public static Color AlternatingRowsColor1 = Color.FromArgb(215, 239, 242); // lighter version of Color.PowderBlue
+		public static Color AlternatingRowsColor2 = Color.FromArgb(237, 249, 250); // even lighter version of Color.PowderBlue
+		public static Color HiddenColor = Color.FromArgb(210, 210, 210); // light gray
+
+		public const string MetadataKeyColumnLabel = "[metadata key]";
+		public const string PageNumberColumnLabel = "[page]";
+		public const string ImageThumbnailColumnLabel = "[image thumbnail]";
+		public const string ImageSourceColumnLabel = "[image source]";
+
+		public const string ImageRowLabel = "[image]";
+		public const string TextGroupRowLabel = "[textgroup]";
+		public const string BookTitleRowLabel = "[bookTitle]";
+
 		private List<SpreadsheetRow> _rows = new List<SpreadsheetRow>();
 		private HeaderRow _header;
 
@@ -27,13 +34,11 @@ namespace Bloom.Spreadsheet
 
 		public string[] StandardLeadingColumns = new[]
 		{
-			MetadataKeyLabel, // what kind of data is in the row; might be book-data key or [textgroup] or [image]
-			PageNumberLabel, // value from data-page-number of bloom-page
+			MetadataKeyColumnLabel, // what kind of data is in the row; might be book-data key or [textgroup] or [image]
+			PageNumberColumnLabel, // value from data-page-number of bloom-page
 			// Todo: [page layout], // something that indicates the template for the page
-			ImageIndexOnPageLabel, // for images, its index in document order
-			ImageSourceLabel, // the full path of where the image comes from
-			ImageThumbnailLabel, // a small version of the image embedded and displayed in the excel sheet
-			TextIndexOnPageLabel, // for textgroups, its index in reading order
+			ImageSourceColumnLabel, // the full path of where the image comes from
+			ImageThumbnailColumnLabel, // a small version of the image embedded and displayed in the excel sheet
 			// Todo: (lang slot) // L1, L2, L3, auto etc...which languages should be visible here?
 		};
 
@@ -119,7 +124,15 @@ namespace Bloom.Spreadsheet
 			return _header.Count - 1;
 		}
 
-		public int ColumnForPageNumber => ColumnForTag(PageNumberLabel); // or just answer 2? or cache?
+		public int ColumnForPageNumber => ColumnForTag(PageNumberColumnLabel); // or just answer 2? or cache?
+
+		public List<int> HiddenColumns => new List<int>{ColumnForTag(PageNumberColumnLabel), ColumnForTag(ImageSourceColumnLabel)};
+
+		public void SortHiddenRowsToTheBottom()
+		{
+			// Needs to be a stable sort, so can't use .Sort().
+			_rows = _rows.OrderBy(r => r.Hidden).ToList();
+		}
 
 		public void WriteToFile(string path)
 		{

--- a/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
@@ -81,13 +81,13 @@ namespace Bloom.Spreadsheet
 				}
 				var currentRow = _inputRows[_currentRowIndex];
 				string rowTypeLabel = currentRow.MetadataKey;
-				if (rowTypeLabel == InternalSpreadsheet.ImageKeyLabel)
+				if (rowTypeLabel == InternalSpreadsheet.ImageRowLabel)
 				{
 					//TODO import the pictures
 					_currentRowIndex++;
 					continue;
 				}
-				else if (rowTypeLabel == InternalSpreadsheet.TextGroupLabel)
+				else if (rowTypeLabel == InternalSpreadsheet.TextGroupRowLabel)
 				{
 					var rowPageNumberLabel = currentRow.PageNumber;
 					if (rowPageNumberLabel != pageNumber)
@@ -171,7 +171,7 @@ namespace Bloom.Spreadsheet
 				templateNode.SetAttribute("data-book", dataBookLabel);
 			}
 
-			var imageSrcCol = _sheet.ColumnForTag(InternalSpreadsheet.ImageSourceLabel);
+			var imageSrcCol = _sheet.ColumnForTag(InternalSpreadsheet.ImageSourceColumnLabel);
 			//TODO copy in images from their source paths. Will be done with the importing images step
 			var imageSrc = Path.GetFileName(currentRow.GetCell(imageSrcCol).Content);
 

--- a/src/BloomExe/Spreadsheet/SpreadsheetRow.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetRow.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Drawing;
 
 namespace Bloom.Spreadsheet
 {
@@ -13,6 +10,8 @@ namespace Bloom.Spreadsheet
 	{
 		private List<string> _cells = new List<string>();
 		public InternalSpreadsheet Spreadsheet;
+		public Color BackgroundColor;
+		public bool Hidden;
 
 		public SpreadsheetRow(InternalSpreadsheet spreadsheet)
 		{
@@ -50,7 +49,7 @@ namespace Bloom.Spreadsheet
 		{
 			get
 			{
-				return _cells[Spreadsheet.ColumnForTag(InternalSpreadsheet.MetadataKeyLabel)];
+				return _cells[Spreadsheet.ColumnForTag(InternalSpreadsheet.MetadataKeyColumnLabel)];
 			}
 		}
 

--- a/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
@@ -174,24 +174,10 @@ namespace BloomTests.Spreadsheet
 
 		[TestCase("fromExport")]
 		[TestCase("fromFile")]
-		public void AddsImageIndices(string source)
-		{
-			SetupFor(source);
-			var imageIndex = _sheet.ColumnForTag(InternalSpreadsheet.ImageIndexOnPageLabel);
-			Assert.That(_imageRows[0].GetCell(imageIndex).Content, Is.EqualTo("1"));
-			Assert.That(_imageRows[1].GetCell(imageIndex).Content, Is.EqualTo("2"));
-			Assert.That(_imageRows[2].GetCell(imageIndex).Content, Is.EqualTo("1"));
-
-			Assert.That(_textRows[0].GetCell(imageIndex).Content, Is.EqualTo(""));
-
-		}
-
-		[TestCase("fromExport")]
-		[TestCase("fromFile")]
 		public void AddsImagePageNumbers(string source)
 		{
 			SetupFor(source);
-			var pageNumberIndex = _sheet.ColumnForTag(InternalSpreadsheet.PageNumberLabel);
+			var pageNumberIndex = _sheet.ColumnForTag(InternalSpreadsheet.PageNumberColumnLabel);
 			Assert.That(_imageRows[0].GetCell(pageNumberIndex).Content, Is.EqualTo("1"));
 			Assert.That(_imageRows[1].GetCell(pageNumberIndex).Content, Is.EqualTo("1"));
 			Assert.That(_imageRows[2].GetCell(pageNumberIndex).Content, Is.EqualTo("2"));
@@ -202,11 +188,11 @@ namespace BloomTests.Spreadsheet
 		public void AddsImageRowLabels(string source)
 		{
 			SetupFor(source);
-			Assert.That(_imageRows[0].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.ImageKeyLabel));
-			Assert.That(_imageRows[1].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.ImageKeyLabel));
-			Assert.That(_imageRows[2].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.ImageKeyLabel));
+			Assert.That(_imageRows[0].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.ImageRowLabel));
+			Assert.That(_imageRows[1].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.ImageRowLabel));
+			Assert.That(_imageRows[2].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.ImageRowLabel));
 
-			Assert.That(_textRows[0].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.TextGroupLabel));
+			Assert.That(_textRows[0].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.TextGroupRowLabel));
 		}
 
 		[TestCase("fromExport")]
@@ -214,7 +200,7 @@ namespace BloomTests.Spreadsheet
 		public void SavesImageSources(string source)
 		{
 			SetupFor(source);
-			var imageSourceColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageSourceLabel);
+			var imageSourceColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageSourceColumnLabel);
 			var path = SIL.IO.FileLocationUtilities.GetDirectoryDistributedWithApplication(_pathToTestImages);
 			var manImagePath = Path.Combine(path, "man.jpg");
 			Assert.That(_imageRows[0].GetCell(imageSourceColumn).Text, Is.EqualTo(manImagePath));
@@ -230,7 +216,7 @@ namespace BloomTests.Spreadsheet
 		public void displayThumbnail_imageFilePresent_noErrorMessage(string source)
 		{
 			SetupFor(source);
-			var thumbnailColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageThumbnailLabel);
+			var thumbnailColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageThumbnailColumnLabel);
 			Assert.That(_imageRows[0].GetCell(thumbnailColumn).Text, Is.EqualTo(""));
 		}
 
@@ -238,7 +224,7 @@ namespace BloomTests.Spreadsheet
 		public void displayThumbnail_imageMissing_ErrorMessageForMissingFile(string source)
 		{
 			SetupFor(source);
-			var thumbnailColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageThumbnailLabel);
+			var thumbnailColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageThumbnailColumnLabel);
 			Assert.That(_imageRows[1].GetCell(thumbnailColumn).Text, Is.EqualTo("Missing"));
 		}
 
@@ -246,7 +232,7 @@ namespace BloomTests.Spreadsheet
 		public void displayThumbnail_imageEmpty_ErrorMessage(string source)
 		{
 			SetupFor(source);
-			var thumbnailColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageThumbnailLabel);
+			var thumbnailColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageThumbnailColumnLabel);
 			Assert.That(_imageRows[2].GetCell(thumbnailColumn).Text, Is.EqualTo("Bad image file"));
 		}
 
@@ -254,8 +240,8 @@ namespace BloomTests.Spreadsheet
 		public void displayThumbnail_svg_svgErrorMessage(string source)
 		{
 			SetupFor(source);
-			var thumbnailColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageThumbnailLabel);
-			var svgRow = _rows.First(x => x.GetCell(InternalSpreadsheet.MetadataKeyLabel).Text.Equals("[outside-back-cover-branding-bottom-html]"));
+			var thumbnailColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageThumbnailColumnLabel);
+			var svgRow = _rows.First(x => x.GetCell(InternalSpreadsheet.MetadataKeyColumnLabel).Text.Equals("[outside-back-cover-branding-bottom-html]"));
 			Assert.That(svgRow.GetCell(thumbnailColumn).Text, Is.EqualTo("Can't display SVG"));
 		}
 	}

--- a/src/BloomTests/Spreadsheet/SpreadsheetImporterTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetImporterTests.cs
@@ -42,7 +42,7 @@ namespace BloomTests.Spreadsheet
 			secondRowToModify.SetCell(frColumn, "<p>Riding on French elephants can be very risky.</p>");
 
 			var asteriskColumn = _sheet.ColumnForLang("*");
-			var imageSrcColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageSourceLabel);
+			var imageSrcColumn = _sheet.ColumnForTag(InternalSpreadsheet.ImageSourceColumnLabel);
 
 			var firstXmatterRowToModify = _sheet.ContentRows.FirstOrDefault(row => row.MetadataKey.Contains("styleNumberSequence"));
 			Assert.IsNotNull(firstXmatterRowToModify, "Did not find the first xmatter row that OneTimeSetup was expecting to modify");
@@ -59,7 +59,7 @@ namespace BloomTests.Spreadsheet
 			thirdXmatterRowToModify.SetCell(_sheet.ColumnForLang("en"), "<p>This is Not the End of the English World</p>");
 
 			var fourthXmatterRowToModify = _sheet.ContentRows.FirstOrDefault(row => row.MetadataKey.Contains("contentLanguage1"));
-			fourthXmatterRowToModify.SetCell(_sheet.ColumnForTag(InternalSpreadsheet.MetadataKeyLabel), "[newDataBookLabel]");
+			fourthXmatterRowToModify.SetCell(_sheet.ColumnForTag(InternalSpreadsheet.MetadataKeyColumnLabel), "[newDataBookLabel]");
 			fourthXmatterRowToModify.SetCell(asteriskColumn, "newContent");
 
 			var fifthXmatterRowToModify = _sheet.ContentRows.FirstOrDefault(row => row.MetadataKey.Contains("licenseImage"));
@@ -328,9 +328,8 @@ namespace BloomTests.Spreadsheet
 		public static void MakeRow(string pageNum, string langData1, string langData2, InternalSpreadsheet spreadsheet)
 		{
 			var newRow = new ContentRow(spreadsheet);
-			newRow.SetCell(InternalSpreadsheet.MetadataKeyLabel, InternalSpreadsheet.TextGroupLabel);
-			newRow.SetCell(InternalSpreadsheet.PageNumberLabel, pageNum);
-			newRow.SetCell(InternalSpreadsheet.TextIndexOnPageLabel, "1");// group index placeholder, not exactly right but near enough for this test
+			newRow.SetCell(InternalSpreadsheet.MetadataKeyColumnLabel, InternalSpreadsheet.TextGroupRowLabel);
+			newRow.SetCell(InternalSpreadsheet.PageNumberColumnLabel, pageNum);
 			newRow.SetCell("[en]", "<p>" + langData1 + "</p>");
 			newRow.SetCell("[fr]", "<p>" + langData2 + "</p>");
 		}
@@ -338,12 +337,12 @@ namespace BloomTests.Spreadsheet
 		public static void MakeXmatterRows(InternalSpreadsheet spreadsheet)
 		{
 			var topicRow = new ContentRow(spreadsheet);
-			topicRow.SetCell(InternalSpreadsheet.MetadataKeyLabel, "[topic]");
+			topicRow.SetCell(InternalSpreadsheet.MetadataKeyColumnLabel, "[topic]");
 			topicRow.SetCell("[en]", "Agriculture");
 			topicRow.SetCell("[*]", "Agricultura");
 
 			var coverImageRow = new ContentRow(spreadsheet);
-			coverImageRow.SetCell(InternalSpreadsheet.MetadataKeyLabel, "[coverImage]");
+			coverImageRow.SetCell(InternalSpreadsheet.MetadataKeyColumnLabel, "[coverImage]");
 			//No content, to check that we get a warning
 		}
 

--- a/src/BloomTests/Spreadsheet/SpreadsheetTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetTests.cs
@@ -271,11 +271,11 @@ namespace BloomTests.Spreadsheet
 			foreach (ContentRow row in allRows)
 			{
 				// Does not copy any header present
-				if (row.MetadataKey.Equals(InternalSpreadsheet.ImageKeyLabel))
+				if (row.MetadataKey.Equals(InternalSpreadsheet.ImageRowLabel))
 				{
 					imageRows.Add(row);
 				}
-				else if (row.MetadataKey.Equals(InternalSpreadsheet.TextGroupLabel))
+				else if (row.MetadataKey.Equals(InternalSpreadsheet.TextGroupRowLabel))
 				{
 					textRows.Add(row);
 				}
@@ -307,18 +307,6 @@ namespace BloomTests.Spreadsheet
 
 		[TestCase("fromExport")]
 		[TestCase("fromFile")]
-		public void InsertsGroupNumbers(string source)
-		{
-			SetupFor(source);
-			var groupIndex = _sheet.ColumnForTag(InternalSpreadsheet.TextIndexOnPageLabel);
-			Assert.That(_textRows[0].GetCell(groupIndex).Content, Is.EqualTo("1"));
-			Assert.That(_textRows[1].GetCell(groupIndex).Content, Is.EqualTo("2"));
-			Assert.That(_textRows[2].GetCell(groupIndex).Content, Is.EqualTo("1"));
-
-		}
-
-		[TestCase("fromExport")]
-		[TestCase("fromFile")]
 		public void SavesLangData(string source)
 		{
 			SetupFor(source);
@@ -330,14 +318,14 @@ namespace BloomTests.Spreadsheet
 		public void AddsRowLabels(string source)
 		{
 			SetupFor(source);
-			var pageNumIndex = _sheet.ColumnForTag(InternalSpreadsheet.PageNumberLabel);
+			var pageNumIndex = _sheet.ColumnForTag(InternalSpreadsheet.PageNumberColumnLabel);
 
 			Assert.That(_textRows[0].GetCell(pageNumIndex).Content, Is.EqualTo("1"));
 			Assert.That(_textRows[1].GetCell(pageNumIndex).Content, Is.EqualTo("1"));
 			Assert.That(_textRows[2].GetCell(pageNumIndex).Content, Is.EqualTo("2"));
-			Assert.That(_textRows[0].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.TextGroupLabel));
-			Assert.That(_textRows[1].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.TextGroupLabel));
-			Assert.That(_textRows[2].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.TextGroupLabel));
+			Assert.That(_textRows[0].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.TextGroupRowLabel));
+			Assert.That(_textRows[1].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.TextGroupRowLabel));
+			Assert.That(_textRows[2].GetCell(0).Content, Is.EqualTo(InternalSpreadsheet.TextGroupRowLabel));
 		}
 
 		[Test]
@@ -389,7 +377,7 @@ namespace BloomTests.Spreadsheet
 					{
 						Assert.That(r, Is.LessThan(rowCount), "did not find expected TextGroup row");
 						ExcelRange rowTypeCell = worksheet.Cells[r + 1, 1];
-						if (rowTypeCell.Value.ToString().Equals(InternalSpreadsheet.TextGroupLabel))
+						if (rowTypeCell.Value.ToString().Equals(InternalSpreadsheet.TextGroupRowLabel))
 						{
 							string markedUp = @"<p><span id=""e4bc05e5-4d65-4016-9bf3-ab44a0df3ea2"" class=""bloom-highlightSegment"" recordingmd5=""undefined"">This elephant is running amok.</span> <span id=""i2ba966b6-4212-4821-9268-04e820e95f50"" class=""bloom-highlightSegment"" recordingmd5=""undefined"">Causing much damage.</span></p>";
 							ExcelRange textCell = worksheet.Cells[r + 1, c + 1];

--- a/src/BloomTests/Spreadsheet/SpreadsheetXmatterTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetXmatterTests.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 using SIL.IO;
 using System.Collections.Generic;
 using System.Linq;
-using OfficeOpenXml;
 using System.IO;
 
 namespace BloomTests.Spreadsheet
@@ -186,7 +185,7 @@ namespace BloomTests.Spreadsheet
 		public void ImageSourceXmatterTest(string source)
 		{
 			SetupFor(source);
-			var imageSourceCol = _sheet.ColumnForTag(InternalSpreadsheet.ImageSourceLabel);
+			var imageSourceCol = _sheet.ColumnForTag(InternalSpreadsheet.ImageSourceColumnLabel);
 
 			var coverImageRow = _rows.Find(x => x.MetadataKey.Equals("[coverImage]"));
 			Assert.That(coverImageRow, Is.Not.Null);
@@ -208,6 +207,20 @@ namespace BloomTests.Spreadsheet
 			SetupFor(source);
 			Assert.That(_sheet.Languages.Contains("z"), Is.False);
 			Assert.That(_rows.FirstOrDefault(x => x.MetadataKey.Equals("[ztest]")), Is.Null);
+		}
+
+		[Test]
+		public void MetadataRowsAreHiddenExceptTitle()
+		{
+			SetupFor("fromExport");
+			foreach(var row in _rows)
+			{
+				if (row.MetadataKey == InternalSpreadsheet.BookTitleRowLabel)
+					Assert.That(row.Hidden, Is.False);
+				else
+					Assert.That(row.Hidden, Is.True);
+			}
+				
 		}
 	}
 }


### PR DESCRIPTION
- Remove image and text index columns
- Color-band every other page
- Hide metadata columns & make gray background
- Push most metadata rows to the end & hide & make gray background. This doesn't include the 1st row (labels) or title
- Bold the first row

TODO: combining text and image rows

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4806)
<!-- Reviewable:end -->
