### PR TITLE
Fix vertical alignment of toolbox item when enterprise-only (BL-10622)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.less
@@ -104,12 +104,6 @@ div.checkbox-and-label {
     display: flex;
 }
 
-// This makes labels that are marked with enterprise-only-flag appear about the same
-// vertically in relation to the checkbox as those that aren't marked.
-.checkbox-label.enterprise-only-flag {
-    margin-top: -1px;
-}
-
 .ui-accordion h3 {
     padding-left: 28px;
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4813)
<!-- Reviewable:end -->
