### PR TITLE
BL-9636 Hide two unsupported page orientations

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1492,16 +1492,19 @@ namespace Bloom.Edit
 				var layoutChoices = _model.GetLayoutChoices();
 				foreach(var l in layoutChoices)
 				{
+					if (l.ElementDistribution == Book.Layout.ElementDistributionChoices.SplitAcrossPages ||
+					l.Style== "SideBySide")
+					{
+						// Ref https://issues.bloomlibrary.org/youtrack/issue/BL-9636
+						// In 5.2, we remove all references to these, but for 5.0/5.1,
+						// we're just hiding them.
+						continue;
+					}
+
 					var text = l.DisplayName;
 					var item = AddDropdownItemSafely(_layoutChoices, text);
 					item.Tag = l;
 					//we don't allow the split options here
-					if(l.ElementDistribution == Book.Layout.ElementDistributionChoices.SplitAcrossPages)
-					{
-						item.Enabled = false;
-						item.ToolTipText = LocalizationManager.GetString("EditTab.LayoutInPublishTabOnlyNotice",
-							"This option is only available in the Publish tab.");
-					}
 					item.Text = text;
 					item.Click += new EventHandler(OnPaperSizeAndOrientationMenuClick);
 				}


### PR DESCRIPTION
This effects A4 Landscape (Side By Side) and A4 Landscape (Split Across Pages) page orientation. They are from the early days and were an attempt to provide layout-like capability through the page orientation system. At some point when we switched to actual layouts, we broke these and no one noticed.

For 5.0 & 5.1, we're hiding them.

For 5.2, we remove them from the code entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4814)
<!-- Reviewable:end -->
