### PR TITLE
Remove SideBySide and SplitAcrossPages

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2924,14 +2924,6 @@
         <source xml:lang="en">A4 Landscape</source>
         <note>ID: LayoutChoices.A4Landscape</note>
       </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SideBySide" sil:dynamic="true">
-        <source xml:lang="en">A4 Landscape (Side By Side)</source>
-        <note>ID: LayoutChoices.A4Landscape SideBySide</note>
-      </trans-unit>
-      <trans-unit id="LayoutChoices.A4Landscape SplitAcrossPages" sil:dynamic="true">
-        <source xml:lang="en">A4 Landscape (Split Across Pages)</source>
-        <note>ID: LayoutChoices.A4Landscape SplitAcrossPages</note>
-      </trans-unit>
       <trans-unit id="LayoutChoices.A4Portrait" sil:dynamic="true">
         <source xml:lang="en">A4 Portrait</source>
         <note>ID: LayoutChoices.A4Portrait</note>

--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -367,12 +367,6 @@ Changes here generally require similar changes in EpubMaker.FixPictureSizes() an
         max-height: @B5Portrait-Height;
     }
     &.A4Landscape,
-    &.A4LandscapeSideBySide {
-        min-width: @A4Landscape-Width;
-        max-width: @A4Landscape-Width;
-        min-height: @A4Landscape-Height;
-        max-height: @A4Landscape-Height;
-    }
     &.A4Portrait {
         min-width: @A4Portrait-Width;
         max-width: @A4Portrait-Width;

--- a/src/BloomBrowserUI/lib/json.js
+++ b/src/BloomBrowserUI/lib/json.js
@@ -1,8 +1,0 @@
-/**
- * Created by JetBrains WebStorm.
- * User: John
- * Date: 5/23/12
- * Time: 3:36 PM
- * To change this template use File | Settings | File Templates.
- */
-var x = {'bloom-configurations': [   'A5Portrait',  {'A4Landscape': {'Layout': ['Default', 'SideBySide']}}] }

--- a/src/BloomBrowserUI/templates/template books/Basic Book/Basic Book.less
+++ b/src/BloomBrowserUI/templates/template books/Basic Book/Basic Book.less
@@ -161,6 +161,25 @@ generic*/
             margin-top: @SpaceBetweenMultilingualAlternatives;
         }
     }
+    // ----- Text Boxes ------
+    .bloom-editable {
+        width: 100%;
+    }
+    &.bloom-monolingual .bloom-editable {
+        height: calc(
+            ~"100% - @{SpaceBetweenMultilingualAlternatives}"
+        ) !important;
+    }
+    &.bloom-bilingual .bloom-editable {
+        height: calc(
+            ~"50% - @{SpaceBetweenMultilingualAlternatives} - 1px"
+        ) !important;
+    }
+    &.bloom-trilingual .bloom-editable {
+        height: calc(
+            ~"33% - @{SpaceBetweenMultilingualAlternatives} - 1px"
+        ) !important;
+    }
 }
 
 .imageOnBottom {

--- a/src/BloomBrowserUI/templates/template books/Basic Book/Basic Book.less
+++ b/src/BloomBrowserUI/templates/template books/Basic Book/Basic Book.less
@@ -26,64 +26,63 @@ generic*/
     .bloom-editable {
         left: 0;
     }
-    &:not(.layout-style-SideBySide):not(.layout-style-SplitAcrossPages) {
-        .bloom-imageContainer {
-            .SetHeightWithPercentMinusConstant(
-                45%,
-                @StandardMultilingualEditBoxSeparation
-            );
-            width: 100%;
-            position: absolute;
-            left: 0;
-            top: 0;
-        }
-        .bloom-monolingual& {
-            .bloom-translationGroup {
-                top: 50%;
-                height: 50%;
-            }
-            .bloom-editable {
-                position: absolute;
-                bottom: 0;
-            }
-        }
-        .bloom-bilingual& {
-            @ImageHeight: 32%;
-            .bloom-imageContainer {
-                top: 33%;
-                height: @ImageHeight;
-                margin-top: 5px;
-            }
-            .bloom-editable {
-                height: @ImageHeight;
-            }
-            .bloom-content2 {
-                position: absolute;
-                bottom: 0;
-            }
-            .bloom-content3 {
-                position: absolute;
-                bottom: 0;
-            }
-        }
 
-        .bloom-trilingual& {
-            @ImageHeight: 24%;
-            .bloom-imageContainer {
-                top: calc(~"13px + @{ImageHeight}");
-                height: @ImageHeight;
-            }
-            .bloom-editable {
-                height: @ImageHeight;
-            }
-            .bloom-content2 {
-                position: absolute;
-                top: calc(~"1.3% + @{ImageHeight} +  @{ImageHeight}");
-            }
-            .bloom-content3 {
-                position: absolute;
-                bottom: 0;
-            }
+    .bloom-imageContainer {
+        .SetHeightWithPercentMinusConstant(
+            45%,
+            @StandardMultilingualEditBoxSeparation
+        );
+        width: 100%;
+        position: absolute;
+        left: 0;
+        top: 0;
+    }
+    .bloom-monolingual& {
+        .bloom-translationGroup {
+            top: 50%;
+            height: 50%;
+        }
+        .bloom-editable {
+            position: absolute;
+            bottom: 0;
+        }
+    }
+    .bloom-bilingual& {
+        @ImageHeight: 32%;
+        .bloom-imageContainer {
+            top: 33%;
+            height: @ImageHeight;
+            margin-top: 5px;
+        }
+        .bloom-editable {
+            height: @ImageHeight;
+        }
+        .bloom-content2 {
+            position: absolute;
+            bottom: 0;
+        }
+        .bloom-content3 {
+            position: absolute;
+            bottom: 0;
+        }
+    }
+
+    .bloom-trilingual& {
+        @ImageHeight: 24%;
+        .bloom-imageContainer {
+            top: calc(~"13px + @{ImageHeight}");
+            height: @ImageHeight;
+        }
+        .bloom-editable {
+            height: @ImageHeight;
+        }
+        .bloom-content2 {
+            position: absolute;
+            top: calc(~"1.3% + @{ImageHeight} +  @{ImageHeight}");
+        }
+        .bloom-content3 {
+            position: absolute;
+            bottom: 0;
         }
     }
 
@@ -118,35 +117,6 @@ generic*/
             top: 0;
             .bloom-editable {
                 font-size: 300%;
-            }
-        }
-    }
-    &.layout-style-SideBySide {
-        .bloom-imageContainer {
-            width: 48%;
-            height: 100%;
-            position: absolute;
-            left: auto; //need to override the "left" of the other layouts
-            right: 0;
-        }
-        .bloom-translationGroup {
-            width: 44%;
-        }
-        .bloom-editable {
-            &.bloom-monolingual {
-                height: 100%;
-            }
-            .bloom-bilingual& {
-                .SetHeightWithPercentMinusConstant(
-                    50%,
-                    @StandardMultilingualEditBoxSeparation
-                );
-            }
-            .bloom-trilingual& {
-                .SetHeightWithPercentMinusConstant(
-                    33%,
-                    @StandardMultilingualEditBoxSeparation
-                );
             }
         }
     }
@@ -185,23 +155,6 @@ generic*/
                 33%,
                 @StandardMultilingualEditBoxSeparation
             );
-        }
-    }
-
-    &.A4Landscape.layout-style-SideBySide {
-        .bloom-imageContainer {
-            width: 48%;
-            height: 100%;
-            position: absolute;
-            left: auto; //need to override the "left" of the other layouts
-            right: 0;
-        }
-        .bloom-translationGroup {
-            height: 100%;
-            width: 45%;
-            position: absolute;
-            left: 0;
-            top: 0;
         }
     }
 }
@@ -340,42 +293,6 @@ generic*/
             33%,
             @StandardMultilingualEditBoxSeparation
         );
-    }
-    &.A4Landscape.layout-style-SideBySide .bloom-imageContainer {
-        width: 48%;
-        height: 100%;
-        position: absolute;
-        left: auto; //need to override the "left" of the other layouts
-        right: 0;
-    }
-    &.A4Landscape.layout-style-SideBySide .bloom-translationGroup {
-        height: 100%;
-        width: 45%;
-        position: absolute;
-        left: 0;
-        top: 0;
-    }
-    &.layout-style-SplitAcrossPages {
-        .bloom-imageContainer {
-            width: 100%;
-            height: 100%;
-            top: 0;
-        }
-        .bloom-translationGroup {
-            width: 100%;
-            height: 100%;
-            /*Note, this is supposed to respond to bloom-centerVertically, but it doesn't. The jscript for CenterVerticallyInParent() always things the block is as big as the marginbox, so it doesn't center it*/
-            /*[disabled]position:relative;*/
-            /*So instead, we're settling for starting the text part of the way down*/
-            //position: relative !important;
-            display: block !important;
-            position: relative;
-            left: 0;
-            top: 0;
-            .bloom-editable {
-                font-size: 300%;
-            }
-        }
     }
 }
 .imageWholePage {

--- a/src/BloomBrowserUI/templates/template books/Basic Book/Basic Book.less
+++ b/src/BloomBrowserUI/templates/template books/Basic Book/Basic Book.less
@@ -85,41 +85,6 @@ generic*/
             bottom: 0;
         }
     }
-
-    &.layout-style-SplitAcrossPages {
-        .bloom-imageContainer {
-            width: 100%;
-            height: 100%;
-            top: 0;
-        }
-        &.bloom-bilingual .bloom-editable {
-            .SetHeightWithPercentMinusConstant(
-                50%,
-                @StandardMultilingualEditBoxSeparation
-            );
-        }
-        &.bloom-trilingual .bloom-editable {
-            .SetHeightWithPercentMinusConstant(
-                33%,
-                @StandardMultilingualEditBoxSeparation
-            );
-        }
-        .bloom-translationGroup {
-            height: 100%;
-            width: 100%;
-            /*Note, this is supposed to respond to bloom-centerVertically, but it doesn't. The jscript for CenterVerticallyInParent() always things the block is as big as the marginbox, so it doesn't center it*/
-            /*[disabled]position:relative;*/
-            /*So instead, we're settling for starting the text part of the way down*/
-            //position: relative !important;
-            display: block !important;
-            position: relative;
-            left: 0;
-            top: 0;
-            .bloom-editable {
-                font-size: 300%;
-            }
-        }
-    }
 }
 
 .nospecidalmovement_imageOnTop {
@@ -195,65 +160,6 @@ generic*/
         .bloom-editable {
             margin-top: @SpaceBetweenMultilingualAlternatives;
         }
-    }
-
-    &.layout-style-SplitAcrossPages {
-        .bloom-imageContainer {
-            width: 100%;
-            height: 100%;
-            top: 0;
-        }
-        .bloom-translationGroup {
-            .SetHeightWithPercentMinusConstant(
-                50%,
-                @StandardMultilingualEditBoxSeparation
-            );
-        }
-        &.bloom-bilingual .bloom-translationGroup .bloom-editable {
-            .SetHeightWithPercentMinusConstant(
-                50%,
-                @StandardMultilingualEditBoxSeparation
-            );
-        }
-        &.bloom-trilingual .bloom-translationGroup .bloom-editable {
-            .SetHeightWithPercentMinusConstant(
-                33%,
-                @StandardMultilingualEditBoxSeparation
-            );
-        }
-        .bloom-translationGroup {
-            width: 100%;
-            /*Note, this is supposed to respond to bloom-centerVertically, but it doesn't. The jscript for CenterVerticallyInParent() always things the block is as big as the marginbox, so it doesn't center it*/
-            /*[disabled]position:relative;*/
-            /*So instead, we're settling for starting the text part of the way down*/
-            //position: relative !important;
-            display: block !important;
-            position: relative;
-            left: 0;
-            top: 0;
-            .bloom-editable {
-                font-size: 300%;
-            }
-        }
-    }
-    // ----- Text Boxes ------
-    .bloom-editable {
-        width: 100%;
-    }
-    &.bloom-monolingual .bloom-editable {
-        height: calc(
-            ~"100% - @{SpaceBetweenMultilingualAlternatives}"
-        ) !important;
-    }
-    &.bloom-bilingual .bloom-editable {
-        height: calc(
-            ~"50% - @{SpaceBetweenMultilingualAlternatives} - 1px"
-        ) !important;
-    }
-    &.bloom-trilingual .bloom-editable {
-        height: calc(
-            ~"33% - @{SpaceBetweenMultilingualAlternatives} - 1px"
-        ) !important;
     }
 }
 

--- a/src/BloomExe/Book/SizeAndOrientation.cs
+++ b/src/BloomExe/Book/SizeAndOrientation.cs
@@ -139,8 +139,6 @@ namespace Bloom.Book
 			yield return new Layout { SizeAndOrientation = FromString("A6Landscape") };
 			yield return new Layout { SizeAndOrientation = FromString("A4Portrait") };
 			yield return new Layout { SizeAndOrientation = FromString("A4Landscape") };
-			yield return new Layout { SizeAndOrientation = FromString("A4Landscape"), Style = "SideBySide" };
-			yield return new Layout { SizeAndOrientation = FromString("A4Landscape"), Style = "SplitAcrossPages" }; // does this work anywhere?
 			yield return new Layout { SizeAndOrientation = FromString("A3Portrait") };
 			yield return new Layout { SizeAndOrientation = FromString("A3Landscape") };
 			yield return new Layout { SizeAndOrientation = FromString("B5Portrait") };

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1489,16 +1489,20 @@ namespace Bloom.Edit
 				var layoutChoices = _model.GetLayoutChoices();
 				foreach(var l in layoutChoices)
 				{
+					if (l.ElementDistribution == Book.Layout.ElementDistributionChoices.SplitAcrossPages)
+					{
+						// This option is only available in the Publish tab.
+						// Actually, it's not even there anymore, but we don't
+						// no why. In any case, it proved confusing to show it here
+						// in Edit tab, so we're removing it. Ref https://community.software.sil.org/t/a4-landscape-side-by-side-and-split-across-pages/5108
+
+						continue;
+					}
+
 					var text = l.DisplayName;
 					var item = AddDropdownItemSafely(_layoutChoices, text);
 					item.Tag = l;
 					//we don't allow the split options here
-					if(l.ElementDistribution == Book.Layout.ElementDistributionChoices.SplitAcrossPages)
-					{
-						item.Enabled = false;
-						item.ToolTipText = LocalizationManager.GetString("EditTab.LayoutInPublishTabOnlyNotice",
-							"This option is only available in the Publish tab.");
-					}
 					item.Text = text;
 					item.Click += new EventHandler(OnPaperSizeAndOrientationMenuClick);
 				}

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1489,20 +1489,9 @@ namespace Bloom.Edit
 				var layoutChoices = _model.GetLayoutChoices();
 				foreach(var l in layoutChoices)
 				{
-					if (l.ElementDistribution == Book.Layout.ElementDistributionChoices.SplitAcrossPages)
-					{
-						// This option is only available in the Publish tab.
-						// Actually, it's not even there anymore, but we don't
-						// no why. In any case, it proved confusing to show it here
-						// in Edit tab, so we're removing it. Ref https://community.software.sil.org/t/a4-landscape-side-by-side-and-split-across-pages/5108
-
-						continue;
-					}
-
 					var text = l.DisplayName;
 					var item = AddDropdownItemSafely(_layoutChoices, text);
 					item.Tag = l;
-					//we don't allow the split options here
 					item.Text = text;
 					item.Click += new EventHandler(OnPaperSizeAndOrientationMenuClick);
 				}

--- a/src/BloomTests/Book/SizeAndOrientationTests.cs
+++ b/src/BloomTests/Book/SizeAndOrientationTests.cs
@@ -26,7 +26,7 @@ namespace BloomTests.Book
 		{
 			string json = @"{'layouts': [
 		'A5Portrait',
-		{'A4Landscape' : { 'Styles': ['Default', 'SideBySide']}}
+		{'A4Landscape' : { 'Styles': ['Default', 'Foobar']}}
 	]}";
 			var x = Layout.GetConfigurationsFromConfigurationOptionsString(json);
 			Assert.AreEqual(3, x.Count());
@@ -39,10 +39,10 @@ namespace BloomTests.Book
 			Assert.IsTrue(a4landscapeDefault.SizeAndOrientation.IsLandScape);
 			Assert.AreEqual("Default", a4landscapeDefault.Style);
 
-			Layout a4landscapeSideBySide = x.ToArray()[2];
-			Assert.AreEqual("A4", a4landscapeSideBySide.SizeAndOrientation.PageSizeName);
-			Assert.IsTrue(a4landscapeSideBySide.SizeAndOrientation.IsLandScape);
-			Assert.AreEqual("SideBySide", a4landscapeSideBySide.Style);
+			Layout a4landscapeFoobar = x.ToArray()[2];
+			Assert.AreEqual("A4", a4landscapeFoobar.SizeAndOrientation.PageSizeName);
+			Assert.IsTrue(a4landscapeFoobar.SizeAndOrientation.IsLandScape);
+			Assert.AreEqual("Foobar", a4landscapeFoobar.Style);
 		}
 
 		[Test]


### PR DESCRIPTION
These were used before we had page layouts. Nowadays, we keep "layouts" separate from "page size/orientation".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4815)
<!-- Reviewable:end -->
