### PR TITLE
Make cover images transparent in book preview (BL-10625)

### DIFF
--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -563,6 +563,12 @@ namespace Bloom.Api
 
 				if (String.IsNullOrEmpty(imageFile)) return false;
 			}
+			else if (info.RawUrl.StartsWith("/book-preview/", StringComparison.Ordinal))
+			{
+				// BL-10625: Cover images still need to be processed to be transparent for book previewing.
+				if (true == CurrentBook?.ImageFileShouldBeRenderedWithTransparency(imageFile))
+					imageFile = _cache.GetPathToResizedImage(imageFile, getThumbnail: false, makeTransparent: true);
+			}
 
 			info.ReplyWithImage(imageFile, originalImageFile);
 			return true;


### PR DESCRIPTION
This fix is for Version5.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4817)
<!-- Reviewable:end -->
