### PR TITLE
BL-8956 switch BookCompressor from black to whitelist

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -4273,6 +4273,8 @@ export default class AudioRecording {
             return;
         }
 
+        // If we ever import audio file types other than .mp3, we will need to update
+        // BookCompressor.AudioFileExtensions.
         const targetPath =
             resultAudioDir.data + "/" + this.getCurrentAudioId() + ".mp3";
         await BloomApi.postData(

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -2363,7 +2363,7 @@ namespace Bloom.Publish.Epub
 		/// </summary>
 		internal virtual void CopyFile(string srcPath, string dstPath, bool limitImageDimensions=false, bool needTransparentBackground=false)
 		{
-			if (limitImageDimensions && BookCompressor.ImageFileExtensions.Contains(Path.GetExtension(srcPath.ToLowerInvariant())))
+			if (limitImageDimensions && BookCompressor.ImageFileExtensions.Contains(Path.GetExtension(srcPath).ToLowerInvariant()))
 			{
 				var imageBytes = BookCompressor.GetImageBytesForElectronicPub(srcPath, needTransparentBackground);
 				RobustFile.WriteAllBytes(dstPath, imageBytes);

--- a/src/BloomExe/web/controllers/SignLanguageApi.cs
+++ b/src/BloomExe/web/controllers/SignLanguageApi.cs
@@ -189,6 +189,7 @@ namespace Bloom.web.controllers
 				{
 					Multiselect = false,
 					CheckFileExists = true,
+					// If this filter ever changes, make sure we update BookCompressor.VideoFileExtensions.
 					Filter = $"{videoFiles} (*.mp4)|*.mp4"
 				};
 				var result = dlg.ShowDialog();

--- a/src/BloomTests/Book/BookCompressorTests.cs
+++ b/src/BloomTests/Book/BookCompressorTests.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using Bloom.Book;
 using NUnit.Framework;
 using SIL.IO;
@@ -119,6 +116,90 @@ namespace BloomTests.Book
 							"book/audio/musicfile1.mp3", "book/audio/musicfile2.ogg", "book/audio/musicfile3.wav", "book/audio/narration.mp3" });
 					}
 					Assert.AreEqual(5, count, "Should be five files stored in test .bloomd file");
+				}
+			}
+		}
+
+		[Test]
+		public void CompressDirectory_CompressBooksWithExtraFiles()
+		{
+			// Setup //
+			var bookHtml = @"<html><head><link rel='stylesheet' href='Basic Book.css' type='text/css'></link></head><body>
+					<div class='bloom-page' id='guid1'></div>
+					<div class='bloom-page' id='guid2' data-backgroundaudio='musicfile.ogg'></div>
+					<div class='bloom-page' id='guid3'></div>
+			</body></html>";
+			SetupDirectoryWithHtml(bookHtml,
+				actionsOnFolderBeforeCompressing: folderPath =>
+				{
+					// Extra top-level book files should get ignored (non-whitelisted extensions).
+					File.WriteAllText(Path.Combine(folderPath, "temp.tmp"), "dummy temporary file data");
+					File.WriteAllText(Path.Combine(folderPath, "temp.xyz"), "dummy temporary file data");
+					// Valid entries should get through.
+					File.WriteAllText(Path.Combine(folderPath, "meta.json"), "dummy meta.json file");
+					File.WriteAllText(Path.Combine(folderPath, "thumbnail.png"), "dummy thumbnail file");
+
+					string audioDir = Path.Combine(folderPath, "audio");
+					Directory.CreateDirectory(audioDir);
+					File.WriteAllText(Path.Combine(audioDir, "musicfile.ogg"), "dummy ogg content");
+					// These 2 should not be included (non-whitelisted extensions)
+					File.WriteAllText(Path.Combine(audioDir, "midiMusic.mid"), "dummy midi file data");
+					File.WriteAllText(Path.Combine(audioDir, "other.aif"), "dummy audio file data");
+					// This subsubfolder should be completely ignored (only 'activities' can have
+					// subsubfolders).
+					string subAudioDir = Path.Combine(audioDir, "audio2");
+					Directory.CreateDirectory(subAudioDir);
+					File.WriteAllText(Path.Combine(subAudioDir, "other.mp3"), "dummy audio file data");
+
+					string videoDir = Path.Combine(folderPath, "video");
+					Directory.CreateDirectory(videoDir);
+					File.WriteAllText(Path.Combine(videoDir, "signlanguageVid.mp4"), "dummy video content");
+					// These 2 should not be included (non-whitelisted extensions)
+					File.WriteAllText(Path.Combine(videoDir, "sign.mov"), "dummy movie file data");
+					File.WriteAllText(Path.Combine(videoDir, "sign.wmv"), "dummy movie file data");
+					// This subsubfolder should be completely ignored (only 'activities' can have
+					// subsubfolders).
+					string subVideoDir = Path.Combine(videoDir, "video2");
+					Directory.CreateDirectory(subVideoDir);
+					File.WriteAllText(Path.Combine(subVideoDir, "other.mp4"), "dummy video file data");
+
+					// We don't know all the file types that might be in a widget,
+					// so we expect to pass through every file and folder within the 'activities' folder.
+					string activityDir = Path.Combine(folderPath, "activities");
+					Directory.CreateDirectory(activityDir);
+					string widgetDir = Path.Combine(activityDir, "My Widget");
+					Directory.CreateDirectory(widgetDir);
+					File.WriteAllText(Path.Combine(widgetDir, "odd.html"), "dummy html content");
+					File.WriteAllText(Path.Combine(widgetDir, "strange.js"), "dummy js content");
+					var widgetResources = Path.Combine(widgetDir, "Resources");
+					Directory.CreateDirectory(widgetResources);
+					File.WriteAllText(Path.Combine(widgetResources, "includable.blob"),
+						"some unknown blob-type file contents");
+
+					// We expect this folder to be excluded completely (non-whitelisted book subfolder).
+					string bookWithinABookDir = Path.Combine(folderPath, "Book Within A Book");
+					Directory.CreateDirectory(bookWithinABookDir);
+					File.WriteAllText(Path.Combine(bookWithinABookDir, "extra book.html"), "dummy html content");
+				});
+
+			// System Under Test //
+			using (var bloomdTempFile = TempFile.WithFilenameInTempFolder("BookCompressorWithExtraFiles" + BookCompressor.BloomPubExtensionWithDot))
+			{
+				BookCompressor.CompressBookDirectory(bloomdTempFile.Path, _bookFolder.Path, "");
+				// Test by looking at the temp file content.
+				using (var zippedFile = new ZipFile(bloomdTempFile.Path))
+				{
+					var count = 0;
+					foreach (ZipEntry zipEntry in zippedFile)
+					{
+						++count;
+						//Console.Out.WriteLine($"DEBUG: name={zipEntry.Name}, IsFile={zipEntry.IsFile}");
+						Assert.Contains(zipEntry.Name, new[] { "book/book.htm", "book/meta.json",
+							"book/thumbnail.png", "book/audio/musicfile.ogg", "book/video/signlanguageVid.mp4",
+							"book/activities/My Widget/odd.html", "book/activities/My Widget/strange.js",
+							"book/activities/My Widget/Resources/includable.blob" });
+					}
+					Assert.AreEqual(8, count, "Should be eight files stored in test .bloomd file");
 				}
 			}
 		}

--- a/src/BloomTests/Utils/MiscUtilsTests.cs
+++ b/src/BloomTests/Utils/MiscUtilsTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Bloom.Utils;
+﻿using Bloom.Utils;
 using NUnit.Framework;
 
 namespace BloomTests.Utils


### PR DESCRIPTION
* whitelists file extensions for book level and audio and video folders
* whitelists an activities folder (Widgets) and any contents

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4843)
<!-- Reviewable:end -->
