### PR TITLE
Fix scrolling issue in Upload ID Collision dialog

### DIFF
--- a/src/BloomBrowserUI/publish/stories.tsx
+++ b/src/BloomBrowserUI/publish/stories.tsx
@@ -132,7 +132,17 @@ const propsObject: IUploadCollisionDlgProps = {
     dialogEnvironment: normalDialogEnvironmentForStorybook
 };
 
-storiesOf("Publish/Share on the web", module).add(
-    "Upload Collision Dialog",
-    () => React.createElement(() => <UploadCollisionDlg {...propsObject} />)
-);
+const lotsOfLanguages = ["Sokoro", "English", "Swahili", "Hausa"];
+
+storiesOf("Publish/Share on the web", module)
+    .add("Upload Collision Dialog", () =>
+        React.createElement(() => <UploadCollisionDlg {...propsObject} />)
+    )
+    .add("Upload Collision Dialog -- lots of languages", () =>
+        React.createElement(() => (
+            <UploadCollisionDlg
+                {...propsObject}
+                newLanguages={lotsOfLanguages}
+            />
+        ))
+    );

--- a/src/BloomBrowserUI/react_components/bookInfoCard.tsx
+++ b/src/BloomBrowserUI/react_components/bookInfoCard.tsx
@@ -34,6 +34,8 @@ export const BookInfoCard: React.FunctionComponent<IBookInfoCardProps> = props =
         <div
             css={css`
                 width: 300px;
+                max-height: 150px;
+                overflow-y: auto;
             `}
         >
             <DialogControlGroup>


### PR DESCRIPTION
* Limits scrolling due to too many languages to the
   BookInfoCard component

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4855)
<!-- Reviewable:end -->
