### PR TITLE
BL-10679 Don't publish multiple .htm files

### DIFF
--- a/src/BloomExe/Book/BookStarter.cs
+++ b/src/BloomExe/Book/BookStarter.cs
@@ -61,7 +61,8 @@ namespace Bloom.Book
 			//if something bad happens from here on out, we need to delete that folder we just made
 			try
 			{
-				var oldNamedFile = Path.Combine(newBookFolder, Path.GetFileName(GetPathToHtmlFile(sourceBookFolder)));
+				var oldNamedFile = Path.Combine(newBookFolder,
+					Path.GetFileName(GetPathToSingleHtmlFileOrReport(sourceBookFolder)));
 				var newNamedFile = Path.Combine(newBookFolder, initialBookName + ".htm");
 				RobustFile.Move(oldNamedFile, newNamedFile);
 
@@ -80,19 +81,9 @@ namespace Bloom.Book
 			return newBookFolder;
 		}
 
-		private string GetPathToHtmlFile(string folder)
+		private string GetPathToSingleHtmlFileOrReport(string folder)
 		{
-			// BL-4160 don't put an asterisk after the .htm. It is unnecessary as this search pattern
-			// already returns both *.htm and *.html, but NOT *.htm.xyz [returns *.html only for Windows]
-			// For both, "*.htm?" should work, but it doesn't return *.htm on Linux [Mono4 bug?].
-			var candidates = from x in Directory.GetFiles(folder, "*.htm")
-							 where !(Path.GetFileName(x).ToLowerInvariant().StartsWith("configuration.htm") ||
-									 IsPathToReadMeHtm(x))
-							 select x;
-			if (!candidates.Any())
-				candidates = from x in Directory.GetFiles(folder, "*.html")
-							 where !(Path.GetFileName(x).ToLowerInvariant().StartsWith("configuration.html"))
-							 select x;
+			var candidates = GetHtmFileCandidates(folder);
 			if (candidates.Count() == 1)
 				return candidates.First();
 			else
@@ -104,7 +95,22 @@ namespace Bloom.Book
 				ErrorReport.NotifyUserOfProblem(msg.ToString());
 				throw new ApplicationException();
 			}
+		}
 
+		private static IEnumerable<string> GetHtmFileCandidates(string folder)
+		{
+		    // BL-4160 don't put an asterisk after the .htm. It is unnecessary as this search pattern
+			// already returns both *.htm and *.html, but NOT *.htm.xyz [returns *.html only for Windows]
+			// For both, "*.htm?" should work, but it doesn't return *.htm on Linux [Mono4 bug?].
+			var candidates = from x in Directory.GetFiles(folder, "*.htm")
+							 where !(Path.GetFileName(x).ToLowerInvariant().StartsWith("configuration.htm") ||
+									 IsPathToReadMeHtm(x))
+							 select x;
+			if (!candidates.Any())
+				candidates = from x in Directory.GetFiles(folder, "*.html")
+							 where !(Path.GetFileName(x).ToLowerInvariant().StartsWith("configuration.html"))
+							 select x;
+			return candidates;
 		}
 
 		private static bool IsPathToReadMeHtm(string path)
@@ -219,7 +225,8 @@ namespace Bloom.Book
 			int multilingualLevel = int.Parse(GetMetaValue(storage.Dom.RawDom, "defaultMultilingualLevel", "1"));
 			TranslationGroupManager.SetInitialMultilingualSetting(bookData, multilingualLevel);
 
-			var sourceDom = XmlHtmlConverter.GetXmlDomFromHtmlFile(sourceFolderPath.CombineForPath(Path.GetFileName(GetPathToHtmlFile(sourceFolderPath))), false);
+			var sourceDom = XmlHtmlConverter.GetXmlDomFromHtmlFile(sourceFolderPath.CombineForPath(
+				Path.GetFileName(GetPathToSingleHtmlFileOrReport(sourceFolderPath))), false);
 
 			//If this is a shell book, make elements to hold the vernacular
 			foreach (XmlElement div in storage.Dom.RawDom.SafeSelectNodes("//div[contains(@class,'bloom-page')]"))

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -1553,22 +1553,9 @@ namespace Bloom.Book
 			// BL-8893 Sometimes users can get into a state where a template directory Bloom thinks it should
 			// look in is closed to Bloom by system permissions. In that case, skip that directory.
 			// This is the location that threw an exception in the case of the original user's problem.
-			List<string> candidates = null;
-			try
-			{
-				candidates = new List<string>(
-					Directory.GetFiles(folderPath)
-
-						// Although GetFiles supports simple pattern matching, it doesn't support enforcing end-of-string matches...
-						// So let's do the filtering this way instead, to make sure we don't get any extensions that start with "htm" but aren't exact matches.
-						.Where(name => name.EndsWith(".htm") || name.EndsWith(".html"))
-				);
-			}
-			catch (UnauthorizedAccessException uaex)
-			{
-				Logger.WriteError("Bloom folder access problem: ", uaex);
+			var candidates = GetAllHtmCandidates(folderPath).ToList();
+			if (candidates.Count == 0)
 				return string.Empty;
-			}
 
 			var decoyMarkers = new[] {"configuration",
 				PrefixForCorruptHtmFiles, // Used to rename corrupt htm files before restoring backup
@@ -1590,6 +1577,52 @@ namespace Bloom.Book
 
 			return String.Empty;
 		}
+
+		private static IEnumerable<string> GetAllHtmCandidates(string folderPath)
+		{
+			try
+			{
+				return Directory.GetFiles(folderPath)
+
+						// Although GetFiles supports simple pattern matching, it doesn't support enforcing end-of-string matches...
+						// So let's do the filtering this way instead, to make sure we don't get any extensions that start with "htm" but aren't exact matches.
+						.Where(name => name.EndsWith(".htm") || name.EndsWith(".html"));
+			}
+			catch (UnauthorizedAccessException uaex)
+			{
+				Logger.WriteError("Bloom folder access problem: ", uaex);
+				return new List<string>();
+			}
+		}
+
+		/// <summary>
+		/// This method finds any .htm or .html files in the book folder that should not be published.
+		/// </summary>
+		/// <param name="folderPath"></param>
+		/// <remarks>Internal for testing.</remarks>
+		internal static IEnumerable<string> FindDeletableHtmFiles(string folderPath)
+		{
+			var theRealOne = FindBookHtmlInFolder(folderPath);
+			var okayFiles = new List<string> { theRealOne, Path.Combine(folderPath,"configuration.htm") };
+			var allCandidates = GetAllHtmCandidates(folderPath).ToList();
+			allCandidates.RemoveAll(f => okayFiles.Contains(f));
+			return allCandidates.Where(f => !Path.GetFileName(f).ToLowerInvariant().StartsWith("readme-"));
+		}
+
+		/// <summary>
+		/// PublishHelper (ePUB and Android) and BloomS3Client (Upload) call this after copying a book
+		/// to a staging folder.
+		/// </summary>
+		internal static void EnsureSingleHtmFile(string folderPath)
+		{
+			var badHtmFilesToDelete = FindDeletableHtmFiles(
+				folderPath);
+			foreach (string badFilePath in badHtmFilesToDelete)
+			{
+				RobustFile.Delete(badFilePath);
+			}
+		}
+
 
 		public static void SetBaseForRelativePaths(HtmlDom dom, string folderPath)
 		{

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -411,6 +411,7 @@ namespace Bloom.Publish
 			HashSet<string> omittedPageLabels = null)
 		{
 			BookStorage.CopyDirectory(bookFolderPath, tempFolderPath);
+			BookStorage.EnsureSingleHtmFile(tempFolderPath);
 			// We can always save in a temp book
 			var bookInfo = new BookInfo(tempFolderPath, true, new AlwaysEditSaveContext()) {UseDeviceXMatter = !isTemplateBook};
 			var modifiedBook = bookServer.GetBookFromBookInfo(bookInfo);

--- a/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
@@ -242,6 +242,8 @@ namespace Bloom.WebLibraryIntegration
 			var destDirName = Path.Combine(wrapperPath, Path.GetFileName(pathToBloomBookDirectory));
 			CopyDirectory(pathToBloomBookDirectory, destDirName);
 
+			BookStorage.EnsureSingleHtmFile(destDirName);
+
 			RemoveUnwantedVideoFiles(destDirName, videoFilesToInclude);
 			ProcessVideosInTempDirectory(destDirName);
 

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -1444,5 +1444,34 @@ namespace BloomTests.Book
 				Assert.Throws(typeof(System.ArgumentException), systemUnderTest);
 			}
 		}
+
+		[Test]
+		[TestCase("foo.html", true)]
+		[TestCase("foo.htm", true)]
+		[TestCase("My Htm file test book1.htm", true)]
+		[TestCase("My Htm file test book1.html", true)]
+		[TestCase("ReadMe-en.htm", false)]
+		[TestCase("Readme-fr.htm", false)]
+		[TestCase("configuration.htm", false)]
+		public void FindDeletableHtmFiles_DeletesTheRightFiles(string fileName, bool expectToDelete)
+		{
+			const string folderAndCorrectFilename = "My Htm file test book";
+			using (var directory = new TemporaryFolder("BookStorageTests_FindDeletableHtmFiles_DeletesTheRightFiles"))
+			{
+				var bookFolderPath = Path.Combine(directory.Path, folderAndCorrectFilename);
+				Directory.CreateDirectory(bookFolderPath);
+				var correctFilePath = Path.Combine(bookFolderPath, folderAndCorrectFilename + ".htm");
+				File.WriteAllText(correctFilePath,
+					"This is the correct filename and directory for this test book.");
+				var testFilePath = Path.Combine(bookFolderPath, fileName);
+				File.WriteAllText(testFilePath, "This is the contents for the current testcase file.");
+
+				// SUT
+				var results = BookStorage.FindDeletableHtmFiles(bookFolderPath);
+
+				Assert.IsFalse(results.Contains(correctFilePath)); // don't delete the right .htm file!
+				Assert.IsTrue(expectToDelete ? results.Contains(testFilePath) : !results.Contains(testFilePath));
+			}
+		}
 	}
 }


### PR DESCRIPTION
* initial refactor
* delete all .htm/.html files in book folder other than the
   one we need for the book and configuration.htm and any
   readme files.
* Was initially concerned that this PR doesn't apply to bulk upload, but
   bulk upload only uploads books with only one .htm file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4868)
<!-- Reviewable:end -->
