### PR TITLE
BL-10805 A4Landscape regression

### DIFF
--- a/src/BloomBrowserUI/bookLayout/basePage.less
+++ b/src/BloomBrowserUI/bookLayout/basePage.less
@@ -366,7 +366,12 @@ Changes here generally require similar changes in EpubMaker.FixPictureSizes() an
         min-height: @B5Portrait-Height;
         max-height: @B5Portrait-Height;
     }
-    &.A4Landscape,
+    &.A4Landscape {
+        min-width: @A4Landscape-Width;
+        max-width: @A4Landscape-Width;
+        min-height: @A4Landscape-Height;
+        max-height: @A4Landscape-Height;
+    }
     &.A4Portrait {
         min-width: @A4Portrait-Width;
         max-width: @A4Portrait-Width;


### PR DESCRIPTION
* problem was an accidental conflation of rules when
   removing side-by-side

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4895)
<!-- Reviewable:end -->
