### PR TITLE
BL-10849 Fix message box

### DIFF
--- a/src/BloomBrowserUI/react_components/bloomButton.tsx
+++ b/src/BloomBrowserUI/react_components/bloomButton.tsx
@@ -5,15 +5,13 @@ import {
     ILocalizationState,
     LocalizableElement
 } from "./l10nComponents";
-import Button from "@material-ui/core/Button";
+import Button, { ButtonProps } from "@material-ui/core/Button";
 
-export interface IBloomButtonProps extends ILocalizationProps {
-    id?: string;
+export interface IBloomButtonProps extends ILocalizationProps, ButtonProps {
     enabled: boolean;
     clickApiEndpoint?: string;
     onClick?: () => void;
     transparent?: boolean;
-    variant?: "text" | "outlined" | "contained" | undefined; // see https://material-ui.com/api/button/
     mightNavigate?: boolean; // true if the post of clickEndpoint might navigate to a new page.
     hasText?: boolean; // default is undefined which we take to mean "yes". This allows us to define buttons with only images and no text.
     // If neither enabled or disabled image file is provided, no image will show.
@@ -23,9 +21,6 @@ export interface IBloomButtonProps extends ILocalizationProps {
     l10nTipEnglishEnabled?: string; // existence of these two strings (or one of them) enables tooltips on the button.
     l10nTipEnglishDisabled?: string;
     iconBeforeText?: React.ReactNode;
-    size?: "small" | "medium" | "large" | undefined;
-    color?: "primary" | "secondary" | undefined;
-    href?: string;
 }
 
 // A button that takes a Bloom API endpoint to post() when clicked
@@ -99,6 +94,7 @@ export default class BloomButton extends LocalizableElement<
                 size={this.props.size}
                 href={this.props.href}
                 {...extraCssFromContainer} // allows defining more css rules from container
+                {...this.props} // bring in other props like disableRipple
             >
                 {commonChildren}
             </Button>

--- a/src/BloomBrowserUI/utils/BloomMessageBox.tsx
+++ b/src/BloomBrowserUI/utils/BloomMessageBox.tsx
@@ -3,7 +3,6 @@ import { jsx, css } from "@emotion/core";
 
 import * as React from "react";
 import { WireUpForWinforms } from "../utils/WireUpWinform";
-import { DialogContent, DialogContentText } from "@material-ui/core";
 import BloomButton from "../react_components/bloomButton";
 import { BloomApi } from "./bloomApi";
 import WarningOutlinedIcon from "@material-ui/icons/WarningOutlined";
@@ -11,9 +10,10 @@ import {
     BloomDialog,
     IBloomDialogEnvironmentParams,
     useSetupBloomDialog,
-    DialogBottomButtons
+    DialogBottomButtons,
+    DialogMiddle,
+    DialogTitle
 } from "../react_components/BloomDialog/BloomDialog";
-import { useEffect } from "react";
 
 export interface MessageBoxButton {
     text: string;
@@ -54,6 +54,7 @@ export const BloomMessageBox: React.FunctionComponent<{
             hasText={true}
             variant={button.default ? "contained" : "outlined"}
             onClick={() => closeDialogForButton(button.id)}
+            disableRipple // I have nothing against ripple, but when a default buttons shows with a ripple even though your'e not clicking or even pointing at it... it looks dumb.
         >
             {button.text}
         </BloomButton>
@@ -61,7 +62,9 @@ export const BloomMessageBox: React.FunctionComponent<{
 
     return (
         <BloomDialog {...propsForBloomDialog}>
-            <DialogContent>
+            {/* We need a element title to make things space correctly because BloomDialog expects to have one, even though at the moment we aren't including a title */}
+            <DialogTitle title={""}></DialogTitle>
+            <DialogMiddle>
                 <div
                     id="root"
                     css={css`
@@ -78,14 +81,19 @@ export const BloomMessageBox: React.FunctionComponent<{
                             `}
                         />
                     )}
-                    <DialogContentText
-                        className="allowSelect"
+                    <div
+                        css={css`
+                            -moz-user-select: text; // Firefox before v69
+                            user-select: text;
+                            margin-left: 20px;
+                            padding-top: 7px;
+                        `}
                         dangerouslySetInnerHTML={{
                             __html: props.messageHtml || ""
                         }}
                     />
                 </div>
-            </DialogContent>
+            </DialogMiddle>
             <DialogBottomButtons>{rightButtons}</DialogBottomButtons>
         </BloomDialog>
     );


### PR DESCRIPTION
* allow BloomButton to take normal button props
* add disable ripple to all the buttons
* use the BloomDialog's innards instead of Materials, which was giving us gray text
* add an empty title element so that things are still spaced well
* add some space between the icon and the text
* push the text down a wee bit w.r.t. the icon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4917)
<!-- Reviewable:end -->
