### PR TITLE
Make new collection tab show new download

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -949,6 +949,7 @@
       <DependentUpon>PublishView.cs</DependentUpon>
     </Compile>
     <Compile Include="Program.cs" />
+    <Compile Include="Workspace\WorkspaceTabSelection.cs" />
     <Compile Include="Workspace\WorkspaceView.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/src/BloomExe/Book/BookSelection.cs
+++ b/src/BloomExe/Book/BookSelection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Bloom.Api;
+using Bloom.Collection;
 using Bloom.Properties;
 using SIL.Progress;
 
@@ -33,6 +34,9 @@ namespace Bloom.Book
 		{
 			if (_currentSelection == book)
 				return;
+			// We don't need to reload the collection just because we make changes bringing the book up to date.
+			if (book != null)
+				BookCollection.TemporariliyIgnoreChangesToFolder(book.FolderPath);
 
 			// The bookdata null test prevents doing this on books not sufficiently initialized to
 			// BringUpToDate, typically only in unit tests.

--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Windows.Forms;
+using Bloom.Api;
 using Bloom.Book;
 using Bloom.TeamCollection;
+using Bloom.ToPalaso;
 using SIL.IO;
 using SIL.Reporting;
 using SIL.Windows.Forms.FileSystem;
@@ -27,6 +30,11 @@ namespace Bloom.Collection
 		private TeamCollectionManager _tcManager;
 
 		private readonly BookSelection _bookSelection;
+		private Timer _folderChangeDebounceTimer;
+		private static HashSet<string> _changingFolders = new HashSet<string>();
+		private BloomWebSocketServer _webSocketServer;
+
+		public static event EventHandler CollectionCreated;
 
 		//for moq only
 		public BookCollection()
@@ -40,11 +48,12 @@ namespace Bloom.Collection
 		}
 
 		public BookCollection(string path, CollectionType collectionType,
-			BookSelection bookSelection, TeamCollectionManager tcm = null)
+			BookSelection bookSelection, TeamCollectionManager tcm = null, BloomWebSocketServer webSocketServer = null)
 		{
 			_path = path;
 			_bookSelection = bookSelection;
 			_tcManager = tcm;
+			_webSocketServer = webSocketServer;
 
 			Type = collectionType;
 
@@ -52,6 +61,104 @@ namespace Bloom.Collection
 			{
 				MakeCollectionCSSIfMissing();
 			}
+
+			CollectionCreated?.Invoke(this, new EventArgs());
+
+			if (ContainsDownloadedBooks)
+			{
+				WatchDirectory();
+			}
+		}
+
+		/// <summary>
+		/// Called when a file system watcher notices a new book (or some similar change) in our downloaded books folder.
+		/// This will happen on a thread-pool thread.
+		/// Since we are updating the UI in response we want to deal with it on the main thread.
+		/// That also has the effect of a lock, preventing multiple threads trying to respond to changes.
+		/// The main purpose of this method is to debounce such changes, since lots of them may
+		/// happen in succession while downloading a book, and also some that we don't want
+		/// to process may happen while we are selecting one. Debounced changes result in a websocket message
+		/// that acts as an event for Javascript, and also raising a C# event.
+		/// </summary>
+		private void DebounceFolderChanged(string fullPath)
+		{
+			var shell = Application.OpenForms.Cast<Form>().FirstOrDefault(f => f is Shell);
+			SafeInvoke.InvokeIfPossible("update downloaded books", shell, true, (Action)(() =>
+			{
+				// We may notice a change to the downloaded books directory before the other Bloom instance has finished
+				// copying the new book there. Finishing should not take long, because the download is done...at worst
+				// we have to copy the book on our own filesystem. Typically we only have to move the directory.
+				// As a safeguard, wait half a second before we update things.
+				if (_folderChangeDebounceTimer != null)
+				{
+					// Things changed again before we started the update! Forget the old update and wait until things
+					// are stable for the required interval.
+					_folderChangeDebounceTimer.Stop();
+					_folderChangeDebounceTimer.Dispose();
+				}
+				_folderChangeDebounceTimer = new Timer();
+				_folderChangeDebounceTimer.Tick += (o, args) =>
+				{
+					_folderChangeDebounceTimer.Stop();
+					_folderChangeDebounceTimer.Dispose();
+					_folderChangeDebounceTimer = null;
+
+					// Updating the books involves selecting the modified book, which might involve changing
+					// some files (e.g., adding a branding image, BL-4914), which could trigger this again.
+					// So don't allow it to be triggered by changes to a folder we're already sending
+					// notifications about.
+					// (It's PROBABLY overkill to maintain a set of these...don't expect a notification about
+					// one folder to trigger a change to another...but better safe than sorry.)
+					// (Note that we don't need synchronized access to this dictionary, because all this
+					// happens only on the UI thread.)
+					if (!_changingFolders.Contains(fullPath))
+					{
+						try
+						{
+							_changingFolders.Add(fullPath);
+							_webSocketServer.SendEvent("editableCollectionList", "reload:" + PathToDirectory);
+							if (FolderContentChanged != null)
+								FolderContentChanged(this, new ProjectChangedEventArgs() { Path = fullPath });
+						}
+						finally
+						{
+							// Now we need to arrange to remove it again. Not right now, because
+							// whatever changes might be made during event handling may get noticed slightly later.
+							// But we don't want to miss it if the book gets downloaded again.
+							RemoveFromChangingFoldersLater(fullPath);
+						}
+					}
+				};
+				_folderChangeDebounceTimer.Interval = 500;
+				_folderChangeDebounceTimer.Start();
+			}));
+		}
+
+		// Arrange that the specified path should be removed from changingFolders after 10s.
+		// This means for 10s we wont pay attention to new changes to
+		// this folder. Probably excessive, but this monitor is meant to catch new downloads;
+		// it's unlikely the same book can be downloaded again within 10 seconds.
+		private static void RemoveFromChangingFoldersLater(string fullPath)
+		{
+			var waitTimer = new Timer();
+			waitTimer.Interval = 10000;
+			waitTimer.Tick += (sender1, args1) =>
+			{
+				_changingFolders.Remove(fullPath);
+				waitTimer.Stop();
+				waitTimer.Dispose();
+			};
+			waitTimer.Start();
+		}
+
+		// We will ignore changes to this folder for 10s. This is typically because it
+		// has just been selected. That may result in file mods as the book is brought
+		// up to date, but we don't want to treat those changes like a new book or
+		// version of a book arriving from BL.
+		public static void TemporariliyIgnoreChangesToFolder(string fullPath)
+		{
+			_changingFolders.Add(fullPath);
+			RemoveFromChangingFoldersLater(fullPath);
 		}
 
 		private void MakeCollectionCSSIfMissing()
@@ -78,8 +185,10 @@ namespace Bloom.Collection
 				return;
 
 			Logger.WriteEvent("After BookStorage.DeleteBook({0})", bookInfo.FolderPath);
+			var infoToDelete = _bookInfos.FirstOrDefault(b => b.FolderPath == bookInfo.FolderPath);
 			//Debug.Assert(_bookInfos.Contains(bookInfo)); this will occur if we delete a book from the BloomLibrary section
-			_bookInfos.Remove(bookInfo);
+			if (infoToDelete != null) // for paranoia. We shouldn't be trying to delete a book that isn't there.
+				_bookInfos.Remove(infoToDelete);
 
 			if (CollectionChanged != null)
 				CollectionChanged.Invoke(this, null);
@@ -295,8 +404,7 @@ namespace Bloom.Collection
 			if (_watcherIsDisabled)
 				return;
 			_bookInfos = null; // Possibly obsolete; next request will update it.
-			if (FolderContentChanged != null)
-				FolderContentChanged(this, new ProjectChangedEventArgs() { Path = fileSystemEventArgs.FullPath });
+			DebounceFolderChanged(fileSystemEventArgs.FullPath);
 		}
 	}
 

--- a/src/BloomExe/CollectionTab/ReactCollectionTabView.Designer.cs
+++ b/src/BloomExe/CollectionTab/ReactCollectionTabView.Designer.cs
@@ -1,4 +1,5 @@
-﻿using Bloom.TeamCollection;
+﻿using Bloom.Collection;
+using Bloom.TeamCollection;
 using Bloom.web;
 
 namespace Bloom.CollectionTab
@@ -18,6 +19,7 @@ namespace Bloom.CollectionTab
 		{
 			if (disposing && (components != null))
 			{
+				BookCollection.CollectionCreated -= OnBookCollectionCreated;
 				components.Dispose();
 			}
 			base.Dispose(disposing);

--- a/src/BloomExe/CollectionTab/ReactCollectionTabView.cs
+++ b/src/BloomExe/CollectionTab/ReactCollectionTabView.cs
@@ -7,6 +7,7 @@ using L10NSharp;
 using SIL.Reporting;
 using System.Drawing;
 using Bloom.Book;
+using Bloom.Collection;
 using Bloom.MiscUI;
 using Bloom.TeamCollection;
 using Bloom.ToPalaso;
@@ -18,15 +19,23 @@ namespace Bloom.CollectionTab
 	public partial class ReactCollectionTabView : UserControl, IBloomTabArea
 	{
 		private readonly LibraryModel _model;
+		private WorkspaceTabSelection _tabSelection;
+		private BookSelection _bookSelection;
 
 		public delegate ReactCollectionTabView Factory();//autofac uses this
 
 		public ReactCollectionTabView(LibraryModel model,
 			SelectedTabChangedEvent selectedTabChangedEvent,
 			SendReceiveCommand sendReceiveCommand,
-			TeamCollectionManager tcManager, BookSelection bookSelection)
+			TeamCollectionManager tcManager, BookSelection bookSelection,
+			WorkspaceTabSelection tabSelection)
 		{
 			_model = model;
+			_tabSelection = tabSelection;
+			_bookSelection = bookSelection;
+
+			BookCollection.CollectionCreated += OnBookCollectionCreated;
+
 			InitializeComponent();
 			BackColor = _reactControl.BackColor = Palette.GeneralBackground;
 			_toolStrip.Renderer = new NoBorderToolStripRenderer();
@@ -107,6 +116,30 @@ namespace Bloom.CollectionTab
 				_model.UpdateThumbnailAsync(book);
 				_model.UpdateLabelOfBookInEditableCollection(book);
 			};
+		}
+		private void OnBookCollectionCreated(object collection, EventArgs args)
+		{
+			var c = collection as BookCollection;
+			if (c.ContainsDownloadedBooks)
+			{
+				c.FolderContentChanged += (sender, eventArgs) =>
+				{
+					if (IsDisposed)
+						return;
+					if (_tabSelection.ActiveTab == WorkspaceTab.collection)
+					{
+						// We got a new or modified book in the downloaded books collection.
+						// If this (collection) tab is active, we want to select it.
+						// (If we're in the middle of editing or publishing some book, we
+						// don't want to change that.)
+						// One day we may enhance it so that we switch tabs and show it,
+						// but there are states where that would be dangerous.
+						var newBook = new BookInfo(eventArgs.Path, false);
+						var book = _model.GetBookFromBookInfo(newBook, true);
+						_bookSelection.SelectBook(book, false);
+					}
+				};
+			}
 		}
 
 		public void ReadyToShowCollections()

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -169,7 +169,8 @@ namespace Bloom
 							typeof(FontsApi),
 							typeof(BulkBloomPubCreator),
 							typeof(LibraryPublishApi),
-							typeof(WorkspaceApi)
+							typeof(WorkspaceApi),
+							typeof(WorkspaceTabSelection)
 						}.Contains(t));
 
 					builder.RegisterAssemblyTypes(Assembly.GetExecutingAssembly())

--- a/src/BloomExe/Workspace/WorkspaceTabSelection.cs
+++ b/src/BloomExe/Workspace/WorkspaceTabSelection.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bloom.Workspace
+{
+	public enum WorkspaceTab
+	{
+		collection,
+		edit,
+		publish
+	}
+
+	/// <summary>
+	/// An AutoFac-created object can obtain the one instance of this by requesting one in its
+	/// constructor if it needs to know which tab is currently active in the Workspace.
+	/// Enhance: if necessary we can add a change event.
+	/// </summary>
+	public class WorkspaceTabSelection
+	{
+		public WorkspaceTab ActiveTab;
+	}
+}

--- a/src/BloomExe/Workspace/WorkspaceView.Designer.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace Bloom.Workspace
+﻿using Bloom.Collection;
+
+namespace Bloom.Workspace
 {
 
 	partial class WorkspaceView
@@ -16,7 +18,8 @@
         {
             if (disposing && (components != null))
             {
-                components.Dispose();
+	            BookCollection.CollectionCreated -= OnBookCollectionCreated;
+	            components.Dispose();
             }
             base.Dispose(disposing);
         }

--- a/src/BloomExe/Workspace/WorkspaceView.Designer.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.Designer.cs
@@ -18,7 +18,6 @@ namespace Bloom.Workspace
         {
             if (disposing && (components != null))
             {
-	            BookCollection.CollectionCreated -= OnBookCollectionCreated;
 	            components.Dispose();
             }
             base.Dispose(disposing);


### PR DESCRIPTION
- Responsibility for knowing to watch the downloaded books folder moved from LibraryLIstView to BookCollection
- Responsibility to debounce changes to the folder moved likewise
- Responsibility to decide whether a change to the folder should cause selecting the changed or added book moved to WorkspaceView
- new event when collection created allows WorkspaceView to attach to the folder changed event on the collection
- fixed other issues with deleting a book and side effects of selecting one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4928)
<!-- Reviewable:end -->
