### PR TITLE
Fix Linux build to use .net framework 4.7.1 (20220216)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ProjectGuid>{304D5612-167C-4725-AF27-B9F2BB788B57}</ProjectGuid>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(OS)'=='Windows_NT'">v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(OS)'!='Windows_NT'">v4.7.1</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>

--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -68,7 +68,6 @@
   <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net461" />
   <package id="System.Text.Encodings.Web" version="5.0.1" targetFramework="net461" />
   <package id="System.Text.Json" version="5.0.2" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
   <package id="TagLibSharp" version="2.2.0" targetFramework="net461" />
   <package id="TechTalk.JiraRestClient.RestSharp105" version="2.3.0.1" targetFramework="net461" />
   <!-- Linux specific packages.  Changes above this line must be copied to ../packages.config -->

--- a/src/BloomExe/packages.config
+++ b/src/BloomExe/packages.config
@@ -68,7 +68,6 @@
   <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net461" />
   <package id="System.Text.Encodings.Web" version="5.0.1" targetFramework="net461" />
   <package id="System.Text.Json" version="5.0.2" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" requireReinstallation="true" />
   <package id="TagLibSharp" version="2.2.0" targetFramework="net461" />
   <package id="TechTalk.JiraRestClient.RestSharp105" version="2.3.0.1" targetFramework="net461" />
   <!-- Windows specific packages.  Changes above this line must be copied to Linux/packages.config -->

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -10,7 +10,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BloomTests</RootNamespace>
     <AssemblyName>BloomTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(OS)'=='Windows_NT'">v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(OS)'!='Windows_NT'">v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/BloomTests/packages.config
+++ b/src/BloomTests/packages.config
@@ -54,6 +54,5 @@
   <package id="System.Security.AccessControl" version="4.7.0" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" requireReinstallation="true" />
   <package id="TagLibSharp" version="2.2.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
That's the last framework supported by mono5-sil (mono 5.16)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4971)
<!-- Reviewable:end -->
