### PR TITLE
Tweak width of button labels and multi-line handling (BL-10959)

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/BookButton.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BookButton.tsx
@@ -227,8 +227,11 @@ export const BookButton: React.FunctionComponent<{
         }
     }, [renaming, renameDiv.current]);
 
+    // If the label is less than 14 characters, assume it will fit on two lines; this saves some
+    // rendering cycles in TruncateMarkup. If it's longer, TruncateMarkup will carefully
+    // measure what will fit on two lines and truncate nicely if necessary.
     const label =
-        bookLabel.length > 20 ? (
+        bookLabel.length > 14 ? (
             <TruncateMarkup lines={2}>
                 <span>{bookLabel}</span>
             </TruncateMarkup>
@@ -293,8 +296,15 @@ export const BookButton: React.FunctionComponent<{
 
             className="book-button"
             // relative so the absolutely positioned rename div will be relative to this.
+            // We tweak the padding (Material UI speifies 7px 21px) to be consistent
+            // with rules that make the main content of the button 70px and the whole
+            // thing 90. With more than 10px here, the numbers don't add up, and the browser
+            // sometimes shrinks things too far, making labels not fit well.
             css={css`
                 position: relative;
+                .MuiButton-outlinedSizeLarge {
+                    padding: 7px 10px;
+                }
             `}
             // This is the div that looks like the button, so it is the one that counts as
             // this book if clicked.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4989)
<!-- Reviewable:end -->
