### PR TITLE
BL-10388 Improved font UI for Format dialog

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2833,6 +2833,36 @@
         <source xml:lang="en">Bloom cannot start properly, and this symptom has been observed on machines with ZoneAlarm installed. Note: disabling ZoneAlarm does not help. Nor does restarting with it turned off. Something about the installation of ZoneAlarm causes the problem, and so far only uninstalling ZoneAlarm has been shown to fix the problem.</source>
         <note>ID: Errors.ZoneAlarm</note>
       </trans-unit>
+      <trans-unit id="FontInformationPane.FontOkay">
+        <source xml:lang="en">The metadata inside this font indicates that it is legal to use for all Bloom purposes.</source>
+        <note>ID: FontInformationPane.FontOkay</note>
+        <note>This shows in the popup when hovering over a useable font.</note>
+      </trans-unit>
+      <trans-unit id="FontInformationPane.FontUnknown">
+        <source xml:lang="en">Bloom cannot determine what rules govern the use of this font. Please read the license and make sure it allows embedding in ebooks and the web. Before publishing to bloomlibrary.org, you will probably have to make a special request to the Bloom team to investigate this font so that we can make sure we won't get in trouble for hosting it.</source>
+        <note>ID: FontInformationPane.FontUnknown</note>
+        <note>This shows in the popup when hovering over a font when Bloom can't determine if it is useable legally.</note>
+      </trans-unit>
+      <trans-unit id="FontInformationPane.FontUnsuitable">
+        <source xml:lang="en">The metadata inside this font tells us that it may not be embedded for free in ebooks and the web. Please use a different font.</source>
+        <note>ID: FontInformationPane.FontUnsuitable</note>
+        <note>This shows in the popup when hovering over a font that Bloom can't legally host on its website.</note>
+      </trans-unit>
+      <trans-unit id="FontInformationPane.License">
+        <source xml:lang="en">License</source>
+        <note>ID: FontInformationPane.License</note>
+        <note>This shows in the popup as a link to the font's license.</note>
+      </trans-unit>
+      <trans-unit id="FontInformationPane.Styles">
+        <source xml:lang="en">Styles</source>
+        <note>ID: FontInformationPane.Styles</note>
+        <note>This shows in the popup before the types of variants in the font (e.g. bold, italic).</note>
+      </trans-unit>
+      <trans-unit id="FontInformationPane.Version">
+        <source xml:lang="en">Version</source>
+        <note>ID: FontInformationPane.Version</note>
+        <note>This shows in the popup before the font's version number.</note>
+      </trans-unit>
       <trans-unit id="HelpMenu.AskAQuestionMenuItem">
         <source xml:lang="en">Ask a Question</source>
         <note>ID: HelpMenu.AskAQuestionMenuItem</note>

--- a/src/BloomBrowserUI/bloomMaterialUITheme.ts
+++ b/src/BloomBrowserUI/bloomMaterialUITheme.ts
@@ -12,6 +12,7 @@ export const kLogBackgroundColor = "#fcfcfc";
 export const kBloomYellow = "#FEBF00";
 export const kPanelBackground = "#2e2e2e";
 export const kDarkestBackground = "#1a1a1a";
+export const kDisabledControlGray = "#bbb";
 export const kVerticalSpacingBetweenDialogSections = "20px";
 
 // Should match @UIFontStack in bloomWebFonts.less

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.less
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.less
@@ -18,6 +18,10 @@
     .spacing-fudge {
         margin: 0px 0px -2px 0px;
     }
+    .control-section {
+        display: flex;
+        align-items: center;
+    }
     #size-select {
         width: 43px;
         margin-left: 5px;
@@ -81,9 +85,11 @@
     }
 }
 
-//the select2 dropdown gets appended to the body, not to our dialog, so its z-index must be at least as high as the dialog's z-index
-.select2-container {
-    z-index: @dialogZindexPlusOne;
+// The select2 dropdown gets appended to the body, not to our dialog, so its z-index must be at least as high as the dialog's z-index.
+// The same sort of thing applies to the Popover popup list of fonts in the FontSelectComponent.
+.select2-container,
+.MuiPopover-root {
+    z-index: @dialogZindexPlusOne !important; // important is necessary for the popover case
 }
 
 #spacingRow {
@@ -117,13 +123,11 @@
 }
 #size-select + .select2-container {
     width: 60px !important;
+    padding-bottom: 5px; // line up with the new FontSelectComponent
 }
 #para-spacing-select + .select2-container {
     width: 60px !important;
 }
-// #font-select + .select2-container{
-// 	width: 120px;
-// }
 
 .select2-container--open .select2-selection__rendered {
     background-color: lightblue;

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.pug
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.pug
@@ -22,13 +22,13 @@ mixin img(filename)
 						button#create-button(data-i18n="EditTab.FormatDialog.Create" disabled) Create
 					#please-use-alpha(style="color: red;" data-i18n="EditTab.FormatDialog.PleaseUseAlpha") Please use only alphabetical characters. Numbers at the end are ok, as in "part2".
 					#already-exists(style="color: red;" data-i18n="EditTab.FormatDialog.AlreadyExists") That style already exists. Please choose another name.
-		#formatPage.tab-page
+		.tab-page
 			h2.tab(data-i18n="EditTab.FormatDialog.CharactersTab") Characters
 			.bloomDialogMainPage
 				div
 					div(data-i18n="EditTab.FormatDialog.Font") Font
 					.control-section
-						select#font-select
+						#fontSelectComponent
 						select#size-select.allowCustom
 					.spacing-fudge(data-i18n="EditTab.FormatDialog.Spacing") Spacing
 					#spacingRow

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/fontSelectComponent.tsx
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/fontSelectComponent.tsx
@@ -1,0 +1,143 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
+import * as React from "react";
+import { useState } from "react";
+import { ThemeProvider } from "@material-ui/styles";
+import { lightTheme } from "../../bloomMaterialUITheme";
+import { FormControl, MenuItem, Popover, Select } from "@material-ui/core";
+import FontDisplayBar from "../../react_components/fontDisplayBar";
+import FontInformationPane from "../../react_components/fontInformationPane";
+
+export interface IFontMetaData {
+    name: string;
+    version?: string;
+    license?: string;
+    licenseURL?: string;
+    copyright?: string;
+    manufacturer?: string;
+    manufacturerURL?: string;
+    fsType?: string;
+    variants?: string[];
+    designer?: string;
+    designerURL?: string;
+    trademark?: string;
+    determinedSuitability: "ok" | "unknown" | "unsuitable";
+    determinedSuitabilityNotes?: string;
+}
+
+interface FontSelectProps {
+    fontMetadata: IFontMetaData[];
+    currentFontName: string;
+    onChangeFont?: (fontname: string) => void;
+}
+
+const FontSelectComponent: React.FunctionComponent<FontSelectProps> = props => {
+    const getFontDataFromName = (fontName: string) => {
+        return props.fontMetadata.find(f => f.name === fontName);
+    };
+    const [fontChoice, setFontChoice] = useState(
+        getFontDataFromName(props.currentFontName)
+    );
+
+    const [popoverFont, setPopoverFont] = useState<IFontMetaData | undefined>(
+        undefined
+    );
+
+    const [popoverAnchorElement, setPopoverAnchorElement] = useState<
+        HTMLElement | undefined
+    >(undefined);
+
+    const handlePopoverOpen = (event, metadata: IFontMetaData) => {
+        setPopoverAnchorElement(event.currentTarget as HTMLElement);
+        setPopoverFont(metadata);
+    };
+
+    const handlePopoverClose = () => {
+        setPopoverAnchorElement(undefined);
+        setPopoverFont(undefined);
+    };
+
+    const isPopoverOpen = Boolean(popoverAnchorElement);
+
+    const getMenuItemsFromFontMetaData = (): JSX.Element[] => {
+        return props.fontMetadata.map((font, index) => {
+            return (
+                <MenuItem
+                    key={index}
+                    value={font.name}
+                    disabled={false} // do not use, because it disables the popover too
+                >
+                    <FontDisplayBar
+                        fontMetadata={font}
+                        inDropdownList={font !== fontChoice}
+                        isPopoverOpen
+                        onHover={handlePopoverOpen}
+                    />
+                </MenuItem>
+            );
+        });
+    };
+
+    const handleFontChange = event => {
+        const fontName: string = event.target.value;
+        setFontChoice(getFontDataFromName(event.target.value));
+        if (props.onChangeFont) {
+            props.onChangeFont(fontName);
+        }
+    };
+
+    return (
+        <ThemeProvider theme={lightTheme}>
+            <FormControl
+                variant="outlined"
+                margin="dense"
+                error={fontChoice?.determinedSuitability === "unsuitable"}
+                css={css`
+                    // the following "!important" doesn't seem to be needed in production,
+                    // only in storybook!
+                    min-width: 180px !important;
+                    margin-top: -2px;
+                    margin-right: 10px;
+                `}
+            >
+                <Select
+                    id="font-select"
+                    value={fontChoice?.name}
+                    onChange={handleFontChange}
+                    IconComponent={() => <React.Fragment></React.Fragment>} // no down-arrow needed
+                    css={css`
+                        #font-select {
+                            display: flex;
+                            flex: 1;
+                            flex-direction: row;
+                            justify-content: space-between;
+                            padding-right: 15px;
+                        }
+                    `}
+                >
+                    {getMenuItemsFromFontMetaData()}
+                </Select>
+                <Popover
+                    id="mouse-over-popover"
+                    open={isPopoverOpen}
+                    anchorEl={popoverAnchorElement}
+                    // Popver puts its top-left corner in the center of the round suitability icon.
+                    anchorOrigin={{
+                        vertical: "center",
+                        horizontal: "center"
+                    }}
+                    transformOrigin={{
+                        vertical: "top",
+                        horizontal: "left"
+                    }}
+                    disableRestoreFocus
+                    onClick={handlePopoverClose}
+                >
+                    <FontInformationPane metadata={popoverFont} />
+                </Popover>
+            </FormControl>
+        </ThemeProvider>
+    );
+};
+
+export default FontSelectComponent;

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/stories.tsx
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/stories.tsx
@@ -1,0 +1,100 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import FontSelectComponent, { IFontMetaData } from "./fontSelectComponent";
+import FontInformationPane from "../../react_components/fontInformationPane";
+import { Typography } from "@material-ui/core";
+
+const font1: IFontMetaData = {
+    name: "Arial",
+    determinedSuitability: "ok",
+    variants: ["regular", "bold", "italic", "bold italic"],
+    designer: "Monotype",
+    fsType: "0",
+    designerURL: "http://www.google.com"
+};
+const font2: IFontMetaData = {
+    name: "Chiller",
+    determinedSuitability: "unknown"
+};
+const font3: IFontMetaData = {
+    name: "Microsoft YaHei",
+    determinedSuitability: "unsuitable",
+    determinedSuitabilityNotes: "Bloom does not support TTC fonts."
+};
+const font4: IFontMetaData = {
+    name: "Back Issues BB",
+    version: "6.0.0",
+    licenseURL: "https://foo.com",
+    copyright: "foo 2004-2005",
+    manufacturer: "Nate Piekos",
+    manufacturerURL: "https://Blambot.com",
+    fsType: "Print and preview",
+    variants: ["regular"],
+    determinedSuitability: "unknown",
+    determinedSuitabilityNotes:
+        "Has a good fsType, but as this is an unvetted manufacturer, we cannot know unambiguously what is allowed without studying the license."
+};
+
+const metadata: IFontMetaData[] = [];
+metadata.push(font1);
+metadata.push(font2);
+metadata.push(font3);
+metadata.push(font4);
+
+const Frame: React.FunctionComponent = ({ children }) => (
+    <div
+        css={css`
+            width: 320px;
+            height: 320px;
+            border: 1px solid green;
+            padding: 20px;
+        `}
+    >
+        {children}
+    </div>
+);
+
+storiesOf("Format dialog", module)
+    .add("Font Select-current ok", () => {
+        return React.createElement(() => (
+            <Frame>
+                <FontSelectComponent
+                    fontMetadata={metadata}
+                    currentFontName={font1.name}
+                />
+            </Frame>
+        ));
+    })
+    .add("Font Select-current unknown", () => {
+        return React.createElement(() => (
+            <Frame>
+                <FontSelectComponent
+                    fontMetadata={metadata}
+                    currentFontName={font2.name}
+                />
+            </Frame>
+        ));
+    })
+    .add("Font Select-current unsuitable", () => {
+        return React.createElement(() => (
+            <Frame>
+                <FontSelectComponent
+                    fontMetadata={metadata}
+                    currentFontName={font3.name}
+                />
+            </Frame>
+        ));
+    })
+    .add("FontInformationPane unsuitable", () => {
+        return React.createElement(() => (
+            <Frame>
+                <FontInformationPane metadata={font3} />
+                <Typography variant="h6">
+                    For some reason, this test needs refreshing to size itself
+                    correctly.
+                </Typography>
+            </Frame>
+        ));
+    });

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -36,14 +36,6 @@ import { BloomApi } from "../../utils/bloomApi";
 import { showRequestStringDialog } from "../../react_components/RequestStringDialog";
 import { fixUpDownArrowEventHandler } from "./arrowKeyWorkaroundManager";
 
-export function GetDifferenceBetweenHeightAndParentHeight(jqueryNode) {
-    // function also declared and used in StyleEditor
-    if (!jqueryNode) {
-        return 0;
-    }
-    return jqueryNode.parent().height() - jqueryNode.height();
-}
-
 // Allows toolbox code to make an element properly in the context of this iframe.
 export function makeElement(
     html: string,

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -138,9 +138,10 @@ export class EditableDivUtils {
             dialogBox[0].offsetHeight;
         const adjustmentFactor = 30;
         const pxAdjToScale = (adjustmentFactor / scale).toFixed(); // rounded to nearest integer
-        const myOptionValue = "left+" + pxAdjToScale + " top-" + pxAdjToScale;
+        const myOptionValue =
+            "left+" + pxAdjToScale + " center-" + pxAdjToScale;
 
-        // Set the dialog 30px (adjusted for 'scale') to the right and up from the gear icon.
+        // Set the dialog 30px (adjusted for 'scale') to the right and somewhat up from the gear icon.
         // If it won't fit there for some reason, .position() will 'fit' it in by moving it away from the viewport edges.
         dialogBox.position({
             my: myOptionValue,
@@ -161,9 +162,8 @@ export class EditableDivUtils {
     }
 
     public static getPageFrame(): HTMLIFrameElement | null {
-        return <HTMLIFrameElement | null>(
-            window.top.document.getElementById("page")
-        );
+        var doc = window.top?.document;
+        return doc ? <HTMLIFrameElement>doc.getElementById("page") : null;
     }
 
     // The body of the editable page, a root for searching for document content.

--- a/src/BloomBrowserUI/collectionsTab/BookButton.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BookButton.tsx
@@ -16,7 +16,7 @@ import {
     kBloomGold,
     kBloomLightBlue,
     kBloomPurple
-} from "../bloomMaterialUITheme.ts";
+} from "../bloomMaterialUITheme";
 import { useRef, useState, useEffect } from "react";
 import { useSubscribeToWebSocketForEvent } from "../utils/WebSocketManager";
 import { BookSelectionManager, useIsSelected } from "./bookSelectionManager";

--- a/src/BloomBrowserUI/react_components/fontDisplayBar.tsx
+++ b/src/BloomBrowserUI/react_components/fontDisplayBar.tsx
@@ -1,0 +1,92 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
+import * as React from "react";
+import { IFontMetaData } from "../bookEdit/StyleEditor/fontSelectComponent";
+import {
+    kBloomBlue,
+    kBloomGold,
+    kErrorColor,
+    kDisabledControlGray
+} from "../bloomMaterialUITheme";
+import { Typography } from "@material-ui/core";
+import OkIcon from "@material-ui/icons/CheckCircle";
+import UnsuitableIcon from "@material-ui/icons/Error";
+import UnknownIcon from "@material-ui/icons/Help";
+
+interface FontDisplayBarProps {
+    fontMetadata: IFontMetaData;
+    inDropdownList: boolean;
+    isPopoverOpen: boolean;
+    onHover?: (event: any, metadata: IFontMetaData) => void;
+}
+
+const FontDisplayBar: React.FunctionComponent<FontDisplayBarProps> = props => {
+    const suitability = props.fontMetadata.determinedSuitability;
+    const ariaOwns = props.isPopoverOpen ? "mouse-over-popover" : undefined;
+
+    const commonProps = {
+        "aria-owns": ariaOwns,
+        "aria-haspop": "true",
+        onMouseEnter: event => {
+            if (props.onHover) props.onHover(event, props.fontMetadata);
+        }
+    };
+
+    const getIconForFont = (): JSX.Element => (
+        <React.Fragment>
+            {suitability === "ok" && (
+                <OkIcon htmlColor={kBloomBlue} {...commonProps} />
+            )}
+            {suitability === "unknown" && (
+                <UnknownIcon
+                    htmlColor={
+                        props.inDropdownList ? kDisabledControlGray : kBloomGold
+                    }
+                    {...commonProps}
+                />
+            )}
+            {suitability === "unsuitable" && (
+                <UnsuitableIcon
+                    htmlColor={
+                        props.inDropdownList
+                            ? kDisabledControlGray
+                            : kErrorColor
+                    }
+                    {...commonProps}
+                />
+            )}
+        </React.Fragment>
+    );
+
+    const shouldGrayOutText = (): boolean => {
+        return props.inDropdownList && suitability !== "ok";
+    };
+    const textColor = `color: ${
+        shouldGrayOutText() ? kDisabledControlGray : "black"
+    };`;
+
+    const cssString = `font-family: "${props.fontMetadata.name}", "Roboto", "Arial" !important;`;
+
+    return (
+        <div
+            css={css`
+                display: flex;
+                flex: 1;
+                flex-direction: row;
+                justify-content: space-between !important;
+            `}
+        >
+            <Typography
+                css={css`
+                    ${cssString}
+                    ${textColor}
+                `}
+            >
+                {props.fontMetadata.name}
+            </Typography>
+            {getIconForFont()}
+        </div>
+    );
+};
+
+export default FontDisplayBar;

--- a/src/BloomBrowserUI/react_components/fontInformationPane.tsx
+++ b/src/BloomBrowserUI/react_components/fontInformationPane.tsx
@@ -1,0 +1,203 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
+import * as React from "react";
+import { Link, Typography } from "@material-ui/core";
+
+import { IFontMetaData } from "../bookEdit/StyleEditor/fontSelectComponent";
+import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
+import { useL10n } from "./l10nHooks";
+import { kDisabledControlGray } from "../bloomMaterialUITheme";
+
+const FontInformationPane: React.FunctionComponent<{
+    metadata: IFontMetaData | undefined;
+}> = props => {
+    const variantString =
+        props.metadata && props.metadata.variants
+            ? props.metadata.variants.join(", ")
+            : undefined;
+
+    const suitability = props.metadata?.determinedSuitability;
+
+    const textColor =
+        suitability === "ok"
+            ? "primary" // BloomBlue
+            : suitability === "unknown"
+            ? "textPrimary" // black
+            : "error"; // red
+
+    const OkayFontMessage = useL10n(
+        "The metadata inside this font indicates that it is legal to use for all Bloom purposes.",
+        "FontInformationPane.FontOkay",
+        "This shows in the popup when hovering over a useable font."
+    );
+
+    const UnknownFontMessage = useL10n(
+        "Bloom cannot determine what rules govern the use of this font. Please read the license and make sure it allows embedding in ebooks and the web. Before publishing to bloomlibrary.org, you will probably have to make a special request to the Bloom team to investigate this font so that we can make sure we won't get in trouble for hosting it.",
+        "FontInformationPane.FontUnknown",
+        "This shows in the popup when hovering over a font when Bloom can't determine if it is useable legally."
+    );
+
+    const UnsuitableFontMessage = useL10n(
+        "The metadata inside this font tells us that it may not be embedded for free in ebooks and the web. Please use a different font.",
+        "FontInformationPane.FontUnsuitable",
+        "This shows in the popup when hovering over a font that Bloom can't legally host on its website."
+    );
+
+    const mainMessage =
+        suitability === "ok"
+            ? OkayFontMessage
+            : suitability === "unknown"
+            ? UnknownFontMessage
+            : UnsuitableFontMessage;
+
+    const styleWording = useL10n(
+        "Styles",
+        "FontInformationPane.Styles",
+        "This shows in the popup before the types of variants in the font (e.g. bold, italic)."
+    );
+
+    const versionWording = useL10n(
+        "Version",
+        "FontInformationPane.Version",
+        "This shows in the popup before the font's version number."
+    );
+
+    // There is one other 'License' in BookMetaData, but I would like to have the comment here.
+    // The other option would be to put it in Common and maybe port the BookMetaData one to Common too.
+    const licenseWording = useL10n(
+        "License",
+        "FontInformationPane.License",
+        "This shows in the popup as a link to the font's license."
+    );
+
+    const showFontDeveloperData = (fontData: IFontMetaData | undefined) => {
+        if (!fontData) return;
+        let message = `name: ${fontData.name}\n`;
+        message += `version: ${fontData.version}\n`;
+        message += `license: ${fontData.license}\n`;
+        message += `licenseURL: ${fontData.licenseURL}\n`;
+        message += `copyright: ${fontData.copyright}\n`;
+        message += `designer: ${fontData.designer}\n`;
+        message += `designerURL: ${fontData.designerURL}\n`;
+        message += `manufacturer: ${fontData.manufacturer}\n`;
+        message += `manufacturerURL: ${fontData.manufacturerURL}\n`;
+        message += `fsType: ${fontData.fsType}\n`;
+        message += `styles: ${fontData.variants?.toString()}\n`;
+        message += `determinedSuitability: ${fontData.determinedSuitability}\n`;
+        message += `determinedSuitabilityNotes: ${fontData.determinedSuitabilityNotes}\n`;
+        alert(message);
+    };
+
+    const SmallLink: React.FunctionComponent<{
+        href: string;
+        linkText: string;
+    }> = props => (
+        <Link variant="body2" underline="always" href={props.href}>
+            {props.linkText}
+        </Link>
+    );
+
+    return (
+        <React.Fragment>
+            {!props.metadata || (
+                <div
+                    css={css`
+                        display: flex;
+                        flex: 1;
+                        flex-direction: column;
+                        padding: 10px;
+                        max-width: 240px;
+                    `}
+                >
+                    {/* Primary text message */}
+                    <Typography
+                        color={textColor}
+                        variant="body2"
+                        css={css`
+                            margin-bottom: 10px !important;
+                        `}
+                    >
+                        {mainMessage}
+                    </Typography>
+                    {/* Font name */}
+                    <Typography
+                        variant="subtitle2"
+                        css={css`
+                            // 'subtitle2' variant ought to be enough, but wasn't; encourage actual bolding
+                            font-weight: 800;
+                        `}
+                    >
+                        {props.metadata.name}
+                    </Typography>
+                    {/* Variant style (bold, italic, etc.) */}
+                    {variantString && (
+                        <Typography variant="body2">
+                            {styleWording}: {variantString}
+                        </Typography>
+                    )}
+                    {/* Designer and DesignerURL */}
+                    {props.metadata.designerURL && props.metadata.designer ? (
+                        <SmallLink
+                            href={props.metadata.designerURL}
+                            linkText={props.metadata.designer}
+                        />
+                    ) : props.metadata.designer ? (
+                        <Typography variant="body2">
+                            {props.metadata.designer}
+                        </Typography>
+                    ) : (
+                        <SmallLink
+                            href={props.metadata.designerURL!}
+                            linkText={props.metadata.designerURL!}
+                        />
+                    )}
+                    {/* Manufacturer and ManufacturerURL */}
+                    {props.metadata.manufacturerURL &&
+                    props.metadata.manufacturer ? (
+                        <SmallLink
+                            href={props.metadata.manufacturerURL}
+                            linkText={props.metadata.manufacturer}
+                        />
+                    ) : props.metadata.manufacturer ? (
+                        <Typography variant="body2">
+                            {props.metadata.manufacturer}
+                        </Typography>
+                    ) : (
+                        <SmallLink
+                            href={props.metadata.manufacturerURL!}
+                            linkText={props.metadata.manufacturerURL!}
+                        />
+                    )}
+                    {/* Font version number */}
+                    {props.metadata.version && (
+                        <Typography variant="body2">
+                            {versionWording} {props.metadata.version}
+                        </Typography>
+                    )}
+                    {/* LicenseURL */}
+                    {props.metadata.licenseURL && (
+                        <SmallLink
+                            href={props.metadata.licenseURL}
+                            linkText={licenseWording}
+                        />
+                    )}
+                    {suitability !== "ok" && (
+                        <InfoOutlinedIcon
+                            htmlColor={kDisabledControlGray}
+                            css={css`
+                                position: absolute !important;
+                                bottom: 4px;
+                                right: 4px;
+                            `}
+                            onClick={() =>
+                                showFontDeveloperData(props.metadata)
+                            }
+                        />
+                    )}
+                </div>
+            )}
+        </React.Fragment>
+    );
+};
+
+export default FontInformationPane;

--- a/src/BloomExe/FontProcessing/FontFileFinder.cs
+++ b/src/BloomExe/FontProcessing/FontFileFinder.cs
@@ -133,23 +133,15 @@ namespace Bloom.FontProcessing
 					continue; // file is somehow corrupt or not really a font file? Just ignore it.
 				}
 
-				switch (gtf.EmbeddingRights)
+				// Our font UI allows any font on the computer, but gives the user indications that some are more
+				// useable in publishing Bloom books. The NoteFontsWeCantInstall prop is only true when we call this
+				// from BloomPubMaker so that it can note that certain fonts are unsuitable for embedding in ePUBs.
+				if (!FontIsEmbeddable(gtf.EmbeddingRights) && NoteFontsWeCantInstall)
 				{
-					case FontEmbeddingRight.Editable:
-					case FontEmbeddingRight.EditableButNoSubsetting:
-					case FontEmbeddingRight.Installable:
-					case FontEmbeddingRight.InstallableButNoSubsetting:
-					case FontEmbeddingRight.PreviewAndPrint:
-					case FontEmbeddingRight.PreviewAndPrintButNoSubsetting:
-						break;
-					default:
-						if (NoteFontsWeCantInstall)
-						{
-							string name1 = GetFontNameFromFile(fontFile);
-							if (name1 != null)
-								FontsWeCantInstall.Add(name1);
-						}
-						continue; // not allowed to embed
+					string name1 = GetFontNameFromFile(fontFile);
+					if (name1 != null)
+						FontsWeCantInstall.Add(name1);
+					continue; // not allowed to embed in ePUB
 				}
 
 				string name = GetFontNameFromFile(fontFile);
@@ -165,6 +157,21 @@ namespace Bloom.FontProcessing
 				files.Add(gtf, fontFile);
 			}
 #endif
+		}
+
+		private bool FontIsEmbeddable(FontEmbeddingRight rights)
+		{
+			switch (rights)
+			{
+				case FontEmbeddingRight.Editable:
+				case FontEmbeddingRight.EditableButNoSubsetting:
+				case FontEmbeddingRight.Installable:
+				case FontEmbeddingRight.InstallableButNoSubsetting:
+				case FontEmbeddingRight.PreviewAndPrint:
+				case FontEmbeddingRight.PreviewAndPrintButNoSubsetting:
+					return true;
+			}
+			return false;
 		}
 
 		private static string GetFontNameFromFile(string fontFile)
@@ -214,18 +221,19 @@ namespace Bloom.FontProcessing
 					fontFiles.AddRange(FindFontsInFolder(subfolder));
 				foreach (var file in Directory.GetFiles(folder))
 				{
-					// ePUB only understands these types, so skip anything else.
-					switch (Path.GetExtension(file).ToLowerInvariant())
+					var extension = Path.GetExtension(file).ToLowerInvariant();
+					if (FontMetadata.fontFileTypesBloomKnows.Contains(extension))
 					{
-						case ".ttf":
-						case ".otf":
-						case ".woff":
-						case ".woff2":
-							fontFiles.Add(file);
-							break;
-						default:
-							break;
+						// ePUB only understands (and will embed) these types.
+						fontFiles.Add(file);
 					}
+					if (extension == ".compositefont" || extension == ".ttc")
+					{
+						// These will get marked as "unsuitable" in FontMetadata.cs, since Bloom
+						// does not understand them and can't embed them.
+						fontFiles.Add(file);
+					}
+					// All other files in the font folder we skip:
 				}
 			}
 			return fontFiles;

--- a/src/BloomExe/FontProcessing/FontMetadata.cs
+++ b/src/BloomExe/FontProcessing/FontMetadata.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 #if __MonoCS__
 using System.Diagnostics;
@@ -26,6 +28,9 @@ namespace Bloom.FontProcessing
 		public string trademark { get; private set; }
 		public string determinedSuitability { get; private set; }
 		public string determinedSuitabilityNotes { get; private set; }
+
+		public static HashSet<string> fontFileTypesBloomKnows = new HashSet<string>() { ".ttf", ".otf", ".woff", ".woff2" };
+
 
 		/// <summary>
 		/// On Window, we can use System.Windows.Media (which provides the GlyphTypeface class) to
@@ -201,6 +206,16 @@ namespace Bloom.FontProcessing
 			variants = group.GetAvailableVariants().ToArray();
 
 			// Now for the hard part: setting DeterminedSuitability
+			// First we declare unsuitable font types that we don't know how to handle (like .ttc)
+			var fontExtension = Path.GetExtension(gtf.FontUri.AbsolutePath);
+			var bloomKnows = fontFileTypesBloomKnows.Contains(fontExtension.ToLowerInvariant());
+			if (!bloomKnows)
+			{
+				determinedSuitability = "unsuitable";
+				determinedSuitabilityNotes = "Bloom does not support " + fontExtension.ToUpper() + " fonts.";
+				return;
+			}
+			// Now we check out the license information.
 			if (!String.IsNullOrEmpty(license))
 			{
 				if (license.Contains("Open Font License") || license.Contains("OFL") ||


### PR DESCRIPTION
* finally talk getPageFrame() into not complaining
   in VS Code
* wire up new React panel for Format dialog
* add story to Storybook
* get select menu items from fontdata
* get font list to overlay main dialog
* get current font to show correctly
* show font in that font face
* show colored badge to right
* get font change to actually propagate to text
* get popover working
* get a more complete font list, but marked for suitability
* add stories
* add FontDisplayBar as a separate component
* differentiate between fonts in dropdown and selected
* turn input red if unsuitable
* feed hovered font into popover (FontInformationPane)
* don't use disabled on MenuItems; still gray out not-OK
* get info pane formatted correctly
* close popover on any click instead of mouse leave
* add info button and font detail alert
* localize FontInformationPane

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/4996)
<!-- Reviewable:end -->
