### PR TITLE
Try to keep controls from sticking out in settings dialog (BL-10973)

### DIFF
--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -139,9 +139,9 @@ namespace Bloom.Collection
 
 			_defaultBookshelfControl = ReactControl.Create("defaultBookshelfControlBundle");
 
-			// Ensure these controls stand out against the current tab.  (BL-10973)
-			_xmatterDescription.BackColor = SystemColors.Control;	// standard control background color
-			_defaultBookshelfControl.BackColor = SystemColors.Control;
+			// Try to ensure these controls do not stand out against the current tab.  (BL-10973)
+			_defaultBookshelfControl.BackColor = tabPage2.BackColor;    // maybe transparent which TextBox won't allow
+			_xmatterDescription.BackColor = Color.FromArgb(255, tabPage2.BackColor);
 
 			tabPage2.Controls.Add(_defaultBookshelfControl);
 			_defaultBookshelfControl.Location = new Point(_xmatterDescription.Left, _xmatterDescription.Bottom + 30);


### PR DESCRIPTION
Try to ensure that controls don't stand out against the background of the current tab page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5010)
<!-- Reviewable:end -->
