### PR TITLE
Fix a Harvester crash for trailing periods in title (BH-6097)

### DIFF
--- a/src/BloomExe/Publish/Android/BloomPubMaker.cs
+++ b/src/BloomExe/Publish/Android/BloomPubMaker.cs
@@ -93,7 +93,9 @@ namespace Bloom.Publish.Android
 			// MakeDeviceXmatterTempBook needs to be able to copy customCollectionStyles.css etc into parent of bookFolderPath
 			// And bloom-player expects folder name to match html file name.
 			var htmPath = BookStorage.FindBookHtmlInFolder(bookFolderPath);
-			var tentativeBookFolderPath = Path.Combine(temp.FolderPath, Path.GetFileNameWithoutExtension(htmPath));
+			var tentativeBookFolderPath = Path.Combine(temp.FolderPath,
+				// Windows directory names cannot have trailing periods, but FileNameWithoutExtension can have these.  (BH-6097)
+				BookStorage.SanitizeNameForFileSystem(Path.GetFileNameWithoutExtension(htmPath)));
 			Directory.CreateDirectory(tentativeBookFolderPath);
 			var modifiedBook = PublishHelper.MakeDeviceXmatterTempBook(bookFolderPath, bookServer,
 				tentativeBookFolderPath, isTemplateBook);

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -261,7 +261,7 @@ namespace Bloom.Publish
 			string path = null;
 
 			// Sanitize fileName first
-			string fileName = SanitizeFileName(fname);
+			string fileName = BookStorage.SanitizeNameForFileSystem(fname);
 
 			for (int i = 0; i < 100; i++)
 			{
@@ -280,21 +280,6 @@ namespace Bloom.Publish
 				}
 			}
 			return path;
-		}
-
-		/// <summary>
-		/// Ampersand in book title was causing Publish problems
-		/// </summary>
-		/// <param name="fileName"></param>
-		/// <returns></returns>
-		private static string SanitizeFileName(string fileName)
-		{
-			fileName = Path.GetInvalidFileNameChars().Aggregate(
-				fileName, (current, character) => current.Replace(character, ' '));
-			// I (GJM) set this up to keep ampersand out of the book title,
-			// but discovered that ampersand isn't one of the characters that GetInvalidFileNameChars returns!
-			fileName = fileName.Replace('&', ' ');
-			return fileName;
 		}
 
 		DisplayModes _currentDisplayMode = DisplayModes.WaitForUserToChooseSomething;


### PR DESCRIPTION
Also remove redundant (and slightly deficient) SanitizeFileName method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5015)
<!-- Reviewable:end -->
