### PR TITLE
Prevent crashes and warn users about .ttc font files (BH-6108)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -3411,6 +3411,11 @@
         <note>ID: PublishTab.Android.File.Progress.Embedding</note>
         <note>{1} is a number with one decimal place, the number of megabytes the font file takes up</note>
       </trans-unit>
+      <trans-unit id="PublishTab.Android.File.Progress.IncompatibleFontFileFormat" sil:dynamic="true">
+        <source xml:lang="en">This book has text in a font named \"{0}\". Bloom cannot use a font in this font's file format.</source>
+        <note>ID: PublishTab.Android.File.Progress.IncompatibleFontFileFormat</note>
+        <note>{0} is a font name</note>
+      </trans-unit>
       <trans-unit id="PublishTab.Android.File.Progress.LicenseForbids" sil:dynamic="true">
         <source xml:lang="en">This book has text in a font named \"{0}\". The license for \"{0}\" does not permit Bloom to embed the font in the book.</source>
         <note>ID: PublishTab.Android.File.Progress.LicenseForbids</note>

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -361,7 +361,7 @@ namespace Bloom.Publish
 			var fonts = fontFamily.Split(new[]{','}, StringSplitOptions.RemoveEmptyEntries);
 			// Fonts whose names contain spaces are quoted: remove the quotes.
 			var font = fonts[0].Replace("\"", "");
-			//Console.WriteLine("DEBUG font=\"{0}\", fontFamily=\"{1}\"", font, fontFamily);
+			//Console.WriteLine("DEBUG PublishHelper.StoreFontUsed(): font=\"{0}\", fontFamily=\"{1}\"", font, fontFamily);
 			FontsUsed.Add(font);
 		}
 


### PR DESCRIPTION
ePUBs were crashing and bloomPubs weren't warning users that these fonts
can't be published.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5017)
<!-- Reviewable:end -->
