### PR TITLE
BL-10944 Simplified menus

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -671,9 +671,21 @@
         <source xml:lang="en">Rename</source>
         <note>ID: CollectionTab.BookMenu.Rename</note>
       </trans-unit>
+      <trans-unit id="CollectionTab.BookMenu.RenameBook">
+        <source xml:lang="en">Rename Book</source>
+        <note>ID: CollectionTab.BookMenu.RenameBook</note>
+      </trans-unit>
+      <trans-unit id="CollectionTab.BookMenu.SaveAsBloomPackContextMenuItem">
+        <source xml:lang="en">Save as Bloom Pack (.bloomPack)</source>
+        <note>ID: CollectionTab.BookMenu.SaveAsBloomPackContextMenuItem</note>
+      </trans-unit>
       <trans-unit id="CollectionTab.BookMenu.SaveAsBloomToolStripMenuItem">
         <source xml:lang="en">Save as single file (.bloomSource)...</source>
         <note>ID: CollectionTab.BookMenu.SaveAsBloomToolStripMenuItem</note>
+      </trans-unit>
+      <trans-unit id="CollectionTab.BookMenu.ShowInFileExplorer">
+        <source xml:lang="en">Show in File Explorer</source>
+        <note>ID: CollectionTab.BookMenu.ShowInFileExplorer</note>
       </trans-unit>
       <trans-unit id="CollectionTab.BookMenu.UpdateFrontMatterToolStrip">
         <source xml:lang="en">Update Book</source>
@@ -731,9 +743,17 @@
         <source xml:lang="en">The book '{0}'</source>
         <note>ID: CollectionTab.ConfirmRecycleDescription</note>
       </trans-unit>
+      <trans-unit id="CollectionTab.ContextMenu.More">
+        <source xml:lang="en">More</source>
+        <note>ID: CollectionTab.ContextMenu.More</note>
+      </trans-unit>
       <trans-unit id="CollectionTab.ContextMenu.OpenFolderOnDisk">
         <source xml:lang="en">Open Folder on Disk</source>
         <note>ID: CollectionTab.ContextMenu.OpenFolderOnDisk</note>
+      </trans-unit>
+      <trans-unit id="CollectionTab.ContextMenu.Troubleshooting">
+        <source xml:lang="en">Troubleshooting</source>
+        <note>ID: CollectionTab.ContextMenu.Troubleshooting</note>
       </trans-unit>
       <trans-unit id="CollectionTab.EditBookButton">
         <source xml:lang="en">Edit this book</source>

--- a/src/BloomBrowserUI/collectionsTab/BookButton.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BookButton.tsx
@@ -1,15 +1,11 @@
 /** @jsx jsx **/
 import { jsx, css } from "@emotion/core";
 
-import Grid from "@material-ui/core/Grid";
 import * as React from "react";
 import { BloomApi } from "../utils/bloomApi";
 import { Button, Menu } from "@material-ui/core";
 import TruncateMarkup from "react-truncate-markup";
-import {
-    IBookTeamCollectionStatus,
-    useTColBookStatus
-} from "../teamCollection/teamCollectionApi";
+import { useTColBookStatus } from "../teamCollection/teamCollectionApi";
 import { BloomAvatar } from "../react_components/bloomAvatar";
 import {
     kBloomBlue,
@@ -135,93 +131,106 @@ export const BookButton: React.FunctionComponent<{
         setRenaming(true);
     };
 
+    const bookSubMenuItemsSpecs: MenuItemSpec[] = [
+        {
+            label: "Leveled Reader",
+            l10nId: "TemplateBooks.BookName.Leveled Reader", // not the most appropriate ID, but we have it already
+            command: "bookCommand/leveled",
+            requiresSavePermission: true,
+            checkbox: true
+        },
+        {
+            label: "Decodable Reader",
+            l10nId: "TemplateBooks.BookName.Decodable Reader", // not the most appropriate ID, but we have it already
+            command: "bookCommand/decodable",
+            requiresSavePermission: true,
+            checkbox: true
+        },
+        { label: "-" },
+        {
+            label: "Export to Word or LibreOffice...",
+            l10nId: "CollectionTab.BookMenu.ExportToWordOrLibreOffice",
+            command: "bookCommand/exportToWord"
+        },
+        {
+            label: "Export to Spreadsheet...",
+            l10nId: "CollectionTab.BookMenu.ExportToSpreadsheet",
+            command: "bookCommand/exportToSpreadsheet",
+            requiresEnterprise: true
+        },
+        {
+            label: "Import content from Spreadsheet...",
+            l10nId: "CollectionTab.BookMenu.ImportContentFromSpreadsheet",
+            command: "bookCommand/importSpreadsheetContent",
+            requiresSavePermission: true,
+            requiresEnterprise: true
+        },
+        { label: "-" },
+        {
+            label: "Save as single file (.bloomSource)...",
+            l10nId: "CollectionTab.BookMenu.SaveAsBloomToolStripMenuItem",
+            command: "bookCommand/saveAsDotBloomSource"
+        },
+        {
+            label: "Save as Bloom Pack (.bloomPack)",
+            l10nId: "CollectionTab.BookMenu.SaveAsBloomPackContextMenuItem",
+            command: "bookCommand/makeBloompack",
+            addEllipsis: true
+        },
+        { label: "-" },
+        {
+            label: "Update Thumbnail",
+            l10nId: "CollectionTab.BookMenu.UpdateThumbnail",
+            command: "bookCommand/updateThumbnail",
+            requiresSavePermission: true // marginal, but it does change the content of the book folder
+        },
+        {
+            label: "Update Book",
+            l10nId: "CollectionTab.BookMenu.UpdateFrontMatterToolStrip",
+            command: "bookCommand/updateBook",
+            requiresSavePermission: true // marginal, but it does change the content of the book folder
+        }
+    ];
+
     const getBookMenuItemsSpecs: () => MenuItemSpec[] = () => {
         return [
+            {
+                label: "Rename Book",
+                l10nId: "CollectionTab.BookMenu.RenameBook",
+                onClick: () => handleRename(),
+                requiresSavePermission: true,
+                addEllipsis: true
+            },
             {
                 label: "Duplicate Book",
                 l10nId: "CollectionTab.BookMenu.DuplicateBook",
                 command: "collections/duplicateBook"
             },
             {
-                label: "Make Bloom Pack",
-                l10nId: "CollectionTab.MakeBloomPackButton",
-                command: "bookCommand/makeBloompack"
-            },
-            {
-                label: "Open Folder on Disk",
-                l10nId: "CollectionTab.ContextMenu.OpenFolderOnDisk",
+                label: "Show in File Explorer",
+                l10nId: "CollectionTab.ContextMenu.ShowInFileExplorer",
                 command: "bookCommand/openFolderOnDisk",
                 shouldShow: () => true // show for all collections (except factory)
             },
-            { label: "-" },
-            {
-                label: "Export to Word or LibreOffice...",
-                l10nId: "CollectionTab.BookMenu.ExportToWordOrLibreOffice",
-                command: "bookCommand/exportToWord"
-            },
-            {
-                label: "Export to Spreadsheet...",
-                l10nId: "CollectionTab.BookMenu.ExportToSpreadsheet",
-                command: "bookCommand/exportToSpreadsheet"
-            },
-            {
-                label: "Import content from Spreadsheet...",
-                l10nId: "CollectionTab.BookMenu.ImportContentFromSpreadsheet",
-                command: "bookCommand/importSpreadsheetContent",
-                requiresSavePermission: true
-            },
-            {
-                label: "Save as single file (.bloomSource)...",
-                l10nId: "CollectionTab.BookMenu.SaveAsBloomToolStripMenuItem",
-                command: "bookCommand/saveAsDotBloomSource"
-            },
-            {
-                label: "Leveled Reader",
-                l10nId: "TemplateBooks.BookName.Leveled Reader", // not the most appropriate ID, but we have it already
-                command: "bookCommand/leveled",
-                requiresSavePermission: true,
-                checkbox: true
-            },
-            { label: "-" },
-            {
-                label: "Decodable Reader",
-                l10nId: "TemplateBooks.BookName.Decodable Reader", // not the most appropriate ID, but we have it already
-                command: "bookCommand/decodable",
-                requiresSavePermission: true,
-                checkbox: true
-            },
-            { label: "-" },
-            {
-                label: "Update Thumbnail",
-                l10nId: "CollectionTab.BookMenu.UpdateThumbnail",
-                command: "bookCommand/updateThumbnail",
-                requiresSavePermission: true // marginal, but it does change the content of the book folder
-            },
-            {
-                label: "Update Book",
-                l10nId: "CollectionTab.BookMenu.UpdateFrontMatterToolStrip",
-                command: "bookCommand/updateBook",
-                requiresSavePermission: true // marginal, but it does change the content of the book folder
-            },
-            {
-                label: "Rename",
-                l10nId: "CollectionTab.BookMenu.Rename",
-                onClick: () => handleRename(),
-                requiresSavePermission: true
-            },
-            { label: "-" },
             {
                 label: "Delete Book",
                 l10nId: "CollectionTab.BookMenu.DeleteBook",
                 command: "collections/deleteBook",
                 icon: <DeleteIcon></DeleteIcon>,
                 requiresSavePermission: true, // for consistency, but not used since shouldShow is defined
+                addEllipsis: true,
                 // Allowed for the downloaded books collection and the editable collection (provided the book is checked out, if applicable)
                 shouldShow: () =>
                     props.collection.containsDownloadedBooks ||
                     (props.collection.isEditableCollection &&
                         (props.manager.getSelectedBookInfo()?.saveable ??
                             false))
+            },
+            { label: "-" },
+            {
+                label: "More",
+                l10nId: "CollectionTab.ContextMenu.More",
+                submenu: bookSubMenuItemsSpecs
             }
         ];
     };
@@ -301,7 +310,7 @@ export const BookButton: React.FunctionComponent<{
     };
 
     const handleContextClick = (event: React.MouseEvent<HTMLElement>) => {
-        setAdjustedContextMenuPoint(event.clientX - 2, event.clientY - 4);
+        setAdjustedContextMenuPoint(event.clientX, event.clientY);
 
         handleClick(event);
     };

--- a/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
+++ b/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
@@ -1,0 +1,203 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
+
+import * as React from "react";
+import { ReactNode, useEffect, useState } from "react";
+import { useL10n } from "./l10nHooks";
+import {
+    Checkbox,
+    ListItemIcon,
+    ListItemText,
+    MenuItem,
+    TypographyProps
+} from "@material-ui/core";
+import NestedMenuItem from "material-ui-nested-menu-item";
+import CheckBoxOutlineBlankIcon from "@material-ui/icons/CheckBoxOutlineBlank";
+import CheckBoxIcon from "@material-ui/icons/CheckBox";
+import { BloomApi } from "../utils/bloomApi";
+import { useEnterpriseAvailable } from "./requiresBloomEnterprise";
+
+interface BaseLocalizableMenuItemProps {
+    english: string;
+    l10nId: string;
+}
+
+interface LocalizableMenuItemProps extends BaseLocalizableMenuItemProps {
+    onClick: React.MouseEventHandler;
+    icon?: ReactNode;
+    addEllipsis?: boolean;
+    requiresEnterprise?: boolean;
+}
+
+interface LocalizableCheckboxMenuItemProps
+    extends BaseLocalizableMenuItemProps {
+    onClick: React.MouseEventHandler;
+    apiEndpoint: string;
+}
+
+const kIconCheckboxAffordance = 28;
+const kEnterpriseStickerAffordance = 28;
+const typographyProps: TypographyProps = {
+    variant: "h6"
+};
+const menuItemGray = "rgba(0, 0, 0, 0.64)";
+
+export const LocalizableMenuItem: React.FunctionComponent<LocalizableMenuItemProps> = props => {
+    const label = useL10n(props.english, props.l10nId);
+    const enterpriseAvailable = useEnterpriseAvailable();
+
+    const iconElement = props.icon ? (
+        <ListItemIcon
+            css={css`
+                width: ${kIconCheckboxAffordance}px !important; // overrides MUI default that leaves way too much space
+                min-width: unset !important;
+            `}
+        >
+            {props.icon}
+        </ListItemIcon>
+    ) : (
+        <div
+            css={css`
+                width: ${kIconCheckboxAffordance}px !important;
+            `}
+        />
+    );
+
+    const ellipsis = props.addEllipsis ? <span>...</span> : <React.Fragment />;
+
+    const requiresEnterpriseTooltip = useL10n(
+        "To use this feature, you'll need to enable Bloom Enterprise.",
+        "CollectionSettingsDialog.RequiresEnterprise_ToolTip_"
+    );
+
+    const enterpriseElement = props.requiresEnterprise ? (
+        <img
+            css={css`
+                width: ${kEnterpriseStickerAffordance}px !important;
+                margin-left: 12px;
+            `}
+            src="../images/bloom-enterprise-badge.svg"
+            title={enterpriseAvailable ? undefined : requiresEnterpriseTooltip}
+        />
+    ) : (
+        <div
+            css={css`
+                width: ${kEnterpriseStickerAffordance}px !important;
+            `}
+        />
+    );
+
+    const openCollectionSettings = () =>
+        BloomApi.post("common/showSettingsDialog?tab=enterprise");
+
+    return (
+        <MenuItem
+            key={props.l10nId}
+            onClick={
+                enterpriseAvailable ? props.onClick : openCollectionSettings
+            }
+            dense
+            css={css`
+                padding: 0 6px !important; // eliminate top and bottom padding to make even denser
+            `}
+        >
+            <React.Fragment>
+                {iconElement}
+                <ListItemText
+                    css={css`
+                        span {
+                            font-weight: 400 !important; // H6 defaults to 500; too thick
+                            font-size: 1.1rem !important; // actually want something between H5 and H6
+                            color: ${menuItemGray} !important;
+                        }
+                    `}
+                    primaryTypographyProps={typographyProps}
+                >
+                    {label}
+                    {ellipsis}
+                </ListItemText>
+                {enterpriseElement}
+            </React.Fragment>
+        </MenuItem>
+    );
+};
+
+export const LocalizableCheckboxMenuItem: React.FunctionComponent<LocalizableCheckboxMenuItemProps> = props => {
+    const label = useL10n(props.english, props.l10nId);
+    const [checked, setChecked] = useState(false);
+    useEffect(() => {
+        BloomApi.getBoolean(props.apiEndpoint, value => {
+            setChecked(value);
+        });
+    }, []);
+
+    return (
+        <MenuItem
+            key={props.l10nId}
+            onClick={props.onClick}
+            dense
+            css={css`
+                padding: 0 6px !important; // eliminate top and bottom padding to make even denser
+            `}
+        >
+            <Checkbox
+                icon={<CheckBoxOutlineBlankIcon htmlColor={menuItemGray} />}
+                checkedIcon={<CheckBoxIcon htmlColor={menuItemGray} />}
+                checked={checked}
+                onChange={e => {
+                    BloomApi.postBoolean(props.apiEndpoint, e.target.checked);
+                }}
+                css={css`
+                    width: ${kIconCheckboxAffordance}px !important;
+                    padding: 0 !important;
+                    font-size: 1.2rem !important;
+                    margin-left: -2px !important; // adjust checkbox over a bit
+                    margin-right: 2px !important;
+                `}
+            ></Checkbox>
+            <ListItemText
+                css={css`
+                    span {
+                        font-weight: 400 !important; // H6 defaults to 500; too thick
+                        font-size: 1.1rem !important; // slightly larger text
+                        color: ${menuItemGray} !important;
+                    }
+                `}
+                primaryTypographyProps={typographyProps}
+            >
+                {label}
+            </ListItemText>
+        </MenuItem>
+    );
+};
+
+export const LocalizableNestedMenuItem: React.FunctionComponent<BaseLocalizableMenuItemProps> = props => {
+    const label = useL10n(props.english, props.l10nId);
+    if (!props.children) {
+        return <React.Fragment />;
+    }
+    return (
+        // Can't find any doc on parentMenuOpen. Examples set it to the same value
+        // as the open prop of the parent menu. But it seems to work fine just set
+        // to true. (If omitted, however, the child menu does not appear when the
+        // parent is hovered over.)
+        <NestedMenuItem
+            // Unfortunately, I can't figure out how to pass the same TypographyProps to this 3rd-party
+            // NestedMenuItem (it doesn't seem to use MUI Typography internally). And I can't get
+            // emotion to work on the MUI Menu item. So we have 2 ways to accomplish the same thing.
+            // Not ideal, but it works.
+            css={css`
+                margin-left: ${kIconCheckboxAffordance}px !important;
+                font-size: 1.1rem !important; // slightly larger text
+                color: ${menuItemGray} !important;
+                padding: 4px 6px 0 6px !important; // adjust for denser layout
+                justify-content: space-between !important; // move sub-menu arrow to right
+            `}
+            key={props.l10nId}
+            label={label}
+            parentMenuOpen={true}
+        >
+            {props.children}
+        </NestedMenuItem>
+    );
+};

--- a/src/BloomBrowserUI/react_components/requiresBloomEnterprise.tsx
+++ b/src/BloomBrowserUI/react_components/requiresBloomEnterprise.tsx
@@ -21,13 +21,13 @@ import {
     IBloomDialogEnvironmentParams,
     useSetupBloomDialog
 } from "./BloomDialog/BloomDialog";
-import { kUiFontStack } from "../bloomMaterialUITheme.ts";
+import { kUiFontStack } from "../bloomMaterialUITheme";
 
 /**
  * This function sets up the hooks to get the status of whether Bloom Enterprise is available or not
  * @returns A boolean, which is true if Bloom Enterprise is enabled and false otherwise
  */
-function useEnterpriseAvailable() {
+export function useEnterpriseAvailable() {
     const [enterpriseAvailable, setEnterpriseAvailable] = useState(true);
 
     useEffect(() => {

--- a/src/BloomBrowserUI/react_components/stories.tsx
+++ b/src/BloomBrowserUI/react_components/stories.tsx
@@ -1,3 +1,6 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
+
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { Expandable } from "./expandable";
@@ -26,6 +29,12 @@ import {
     RequiresBloomEnterpriseOverlayWrapper
 } from "./requiresBloomEnterprise";
 import { normalDialogEnvironmentForStorybook } from "./BloomDialog/BloomDialog";
+import {
+    LocalizableMenuItem,
+    LocalizableCheckboxMenuItem,
+    LocalizableNestedMenuItem
+} from "./localizableMenuItem";
+import { Button, Divider, Menu } from "@material-ui/core";
 
 storiesOf("Localizable Widgets", module)
     .add("Expandable", () => (
@@ -170,6 +179,106 @@ storiesOf("Localizable Widgets/ApiCheckbox", module).add("ApiCheckbox", () =>
     ))
 );
 
+const menuBox = (menuItems: JSX.Element[]) => {
+    const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | undefined>(
+        undefined
+    );
+    return (
+        <div
+            css={css`
+                width: 200px;
+                height: 100px;
+                background-color: tan;
+                display: flex;
+                flex-direction: row;
+                justify-content: center;
+                align-items: center;
+            `}
+        >
+            <Button
+                color="primary"
+                onClick={event =>
+                    setAnchorEl(event.target as HTMLButtonElement)
+                }
+                css={css`
+                    background-color: lightblue !important;
+                    width: 120px;
+                    height: 40px;
+                `}
+            >
+                Click Me!
+            </Button>
+            <Menu
+                anchorEl={anchorEl}
+                keepMounted
+                open={Boolean(anchorEl)}
+                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+                transformOrigin={{ vertical: "top", horizontal: "left" }}
+                onClose={() => {
+                    setAnchorEl(undefined);
+                }}
+            >
+                {menuItems}
+            </Menu>
+        </div>
+    );
+};
+
+const normalMenuItem = React.createElement(() => (
+    <LocalizableMenuItem
+        english="Motion Book"
+        l10nId="PublishTab.Android.MotionBookMode"
+        icon={<DeleteIcon />}
+        onClick={() => {}}
+    />
+));
+
+const checkboxMenuItem = React.createElement(() => (
+    <LocalizableCheckboxMenuItem
+        english="Decodable Reader"
+        l10nId="TemplateBooks.BookName.Decodable Reader"
+        apiEndpoint="some/api/endpoint"
+        onClick={() => {}}
+    />
+));
+
+const normalMenuItemWithEllipsisAndEnterprise = React.createElement(() => (
+    <LocalizableMenuItem
+        english="Open or Create Another Collection"
+        l10nId="CollectionTab.OpenCreateCollectionMenuItem"
+        addEllipsis={true}
+        requiresEnterprise={true}
+        onClick={() => {}}
+    />
+));
+
+const nestedMenu = React.createElement(() => (
+    <LocalizableNestedMenuItem
+        english="Troubleshooting"
+        l10nId="CollectionTab.ContextMenu.Troubleshooting"
+    >
+        {[
+            normalMenuItem,
+            checkboxMenuItem,
+            normalMenuItemWithEllipsisAndEnterprise
+        ]}
+    </LocalizableNestedMenuItem>
+));
+
+const divider = React.createElement(() => <Divider />);
+
+const testMenu = [
+    normalMenuItem,
+    normalMenuItemWithEllipsisAndEnterprise,
+    checkboxMenuItem,
+    divider,
+    nestedMenu
+];
+
+storiesOf("Localizable Widgets/Localizable Menu", module).add("test menu", () =>
+    menuBox(testMenu)
+);
+
 const confirmDialogProps: IConfirmDialogProps = {
     title: "Title",
     titleL10nKey: "",
@@ -275,7 +384,7 @@ storiesOf("Misc", module)
     .add("BloomAvatars", () =>
         React.createElement(() => {
             return (
-                <>
+                <React.Fragment>
                     <BloomAvatar
                         email="test@example.com"
                         name={"A B C D E F G"}
@@ -300,7 +409,7 @@ storiesOf("Misc", module)
                         name={"A B C"}
                         borderColor="#1d94a4"
                     />
-                </>
+                </React.Fragment>
             );
         })
     );
@@ -327,7 +436,7 @@ const bumpDown = (whichPositionToBump: number): void => {
 
 storiesOf("PlaybackOrderControls", module).add("PlaybackOrder buttons", () =>
     React.createElement(() => (
-        <>
+        <React.Fragment>
             <div style={playbackControlsDivStyles}>
                 <PlaybackOrderControls
                     maxOrder={3}
@@ -352,7 +461,7 @@ storiesOf("PlaybackOrderControls", module).add("PlaybackOrder buttons", () =>
                     onDecrease={bumpDown}
                 />
             </div>
-        </>
+        </React.Fragment>
     ))
 );
 

--- a/src/BloomBrowserUI/teamCollection/stories.tsx
+++ b/src/BloomBrowserUI/teamCollection/stories.tsx
@@ -14,6 +14,7 @@ import { TeamCollectionDialog } from "./TeamCollectionDialog";
 import { TeamCollectionSettingsPanel } from "./TeamCollectionSettingsPanel";
 import { CreateTeamCollectionDialog } from "./CreateTeamCollection";
 import { normalDialogEnvironmentForStorybook } from "../react_components/BloomDialog/BloomDialog";
+import { SimpleMenu, SimpleMenuItem } from "../react_components/simpleMenu";
 
 addDecorator(storyFn => (
     <ThemeProvider theme={lightTheme}>
@@ -276,3 +277,33 @@ storiesOf("Team Collection components/CreateTeamCollection", module)
             errorForTesting="Commodo veniam laboris ut ut ea laboris Lorem Lorem laborum enim minim velit."
         />
     ));
+
+const menuItems: (SimpleMenuItem | "-")[] = [
+    {
+        text: "About my Avatar...",
+        l10nKey: "TeamCollection.AboutAvatar",
+        action: () => {}
+    }
+];
+const menuBoxStyles: React.CSSProperties = {
+    display: "flex",
+    justifyContent: "flex-end",
+    border: "1px solid red",
+    padding: 20,
+    backgroundColor: "black",
+    width: 150
+};
+
+storiesOf("Team Collection components/Menu component", module).add(
+    "SimpleMenu test",
+    () => (
+        <div style={menuBoxStyles}>
+            <SimpleMenu
+                text="..."
+                l10nKey="Common.Ellipsis"
+                temporarilyDisableI18nWarning={true}
+                items={menuItems}
+            ></SimpleMenu>
+        </div>
+    )
+);


### PR DESCRIPTION
* add "More" submenu
* reorder menu items
* pull LocalizableMenuItem out to a separate file
* add Storybook stories for same
* homogenize the context menu point
* add requiresEnterprise and addEllipsis to menu spec
* tweaks to actual menu item text, including ellipses and
   Enterprise badge
* add tooltip for Enterprise badge (if no Enterprise)
* add consistent menu item gray color everywhere
* get checkbox api working
* clicking on Enterprise-only menu item when Enterprise
   is not active, opens CollectionSettings dlg to correct tab.