### PR TITLE
BL-10974 new font control in Collection Settings

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -917,6 +917,11 @@
         <note>ID: Common.BackButton</note>
         <note>In a wizard, this button takes you to the previous step.</note>
       </trans-unit>
+      <trans-unit id="Common.BloomEnterpriseFeature">
+        <source xml:lang="en">Bloom Enterprise Feature</source>
+        <note>ID: Common.BloomEnterpriseFeature</note>
+        <note>This tooltip shows over the Bloom Enterprise icon.</note>
+      </trans-unit>
       <trans-unit id="Common.Cancel">
         <source xml:lang="en">Cancel</source>
         <note>This is shown at the bottom of a dialog box. It is paired with an action button like "OK" and it means "do not do the action".  In English, this is the same as "Common.CancelProcess", but could be different in your language.</note>

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.less
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.less
@@ -29,7 +29,7 @@
         margin-left: 5px;
         & + .select2 {
             // match the size of the FontSelectComponent
-            margin-top: 8px;
+            margin-top: 2px;
             margin-bottom: 4px;
         }
     }

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/stories.tsx
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/stories.tsx
@@ -2,46 +2,10 @@
 import { jsx, css } from "@emotion/core";
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
-import FontSelectComponent, { IFontMetaData } from "./fontSelectComponent";
+import FontSelectComponent from "./fontSelectComponent";
 import FontInformationPane from "../../react_components/fontInformationPane";
+import { IFontMetaData } from "./fontSelectComponent";
 import { Typography } from "@material-ui/core";
-
-const font1: IFontMetaData = {
-    name: "Arial",
-    determinedSuitability: "ok",
-    variants: ["regular", "bold", "italic", "bold italic"],
-    designer: "Monotype",
-    fsType: "0",
-    designerURL: "http://www.google.com"
-};
-const font2: IFontMetaData = {
-    name: "Chiller",
-    determinedSuitability: "unknown"
-};
-const font3: IFontMetaData = {
-    name: "Microsoft YaHei",
-    determinedSuitability: "unsuitable",
-    determinedSuitabilityNotes: "Bloom does not support TTC fonts."
-};
-const font4: IFontMetaData = {
-    name: "Back Issues BB",
-    version: "6.0.0",
-    licenseURL: "https://foo.com",
-    copyright: "foo 2004-2005",
-    manufacturer: "Nate Piekos",
-    manufacturerURL: "https://Blambot.com",
-    fsType: "Print and preview",
-    variants: ["regular"],
-    determinedSuitability: "unknown",
-    determinedSuitabilityNotes:
-        "Has a good fsType, but as this is an unvetted manufacturer, we cannot know unambiguously what is allowed without studying the license."
-};
-
-const metadata: IFontMetaData[] = [];
-metadata.push(font1);
-metadata.push(font2);
-metadata.push(font3);
-metadata.push(font4);
 
 const Frame: React.FunctionComponent = ({ children }) => (
     <div
@@ -56,13 +20,51 @@ const Frame: React.FunctionComponent = ({ children }) => (
     </div>
 );
 
+const suitableFont: IFontMetaData = {
+    name: "Arial",
+    determinedSuitability: "ok",
+    variants: ["regular", "bold", "italic", "bold italic"],
+    designer: "Monotype",
+    fsType: "0",
+    designerURL: "http://www.google.com"
+};
+const unknownFont: IFontMetaData = {
+    name: "Chiller",
+    determinedSuitability: "unknown"
+};
+const unsuitableFont: IFontMetaData = {
+    name: "Microsoft YaHei",
+    determinedSuitability: "unsuitable",
+    determinedSuitabilityNotes: "Bloom does not support TTC fonts."
+};
+const moreCompleteUnknownFont: IFontMetaData = {
+    name: "Back Issues BB",
+    version: "Version 6.0.0",
+    licenseURL: "https://foo.com",
+    copyright: "foo 2004-2005",
+    manufacturer: "Nate Piekos",
+    manufacturerURL: "https://Blambot.com",
+    fsType: "Print and preview",
+    variants: ["regular"],
+    determinedSuitability: "unknown",
+    determinedSuitabilityNotes:
+        "Has a good fsType, but as this is an unvetted manufacturer, we cannot know unambiguously what is allowed without studying the license."
+};
+
+const fontTestData = [
+    suitableFont,
+    unknownFont,
+    unsuitableFont,
+    moreCompleteUnknownFont
+];
+
 storiesOf("Format dialog", module)
     .add("Font Select-current ok", () => {
         return React.createElement(() => (
             <Frame>
                 <FontSelectComponent
-                    fontMetadata={metadata}
-                    currentFontName={font1.name}
+                    fontMetadata={fontTestData}
+                    currentFontName={suitableFont.name}
                 />
             </Frame>
         ));
@@ -71,18 +73,19 @@ storiesOf("Format dialog", module)
         return React.createElement(() => (
             <Frame>
                 <FontSelectComponent
-                    fontMetadata={metadata}
-                    currentFontName={font2.name}
+                    fontMetadata={fontTestData}
+                    currentFontName={unknownFont.name}
                 />
             </Frame>
         ));
     })
-    .add("Font Select-current unsuitable", () => {
+    .add("Font Select-current unsuitable-pop left side", () => {
         return React.createElement(() => (
             <Frame>
                 <FontSelectComponent
-                    fontMetadata={metadata}
-                    currentFontName={font3.name}
+                    fontMetadata={fontTestData}
+                    currentFontName={unsuitableFont.name}
+                    anchorPopoverLeft={true}
                 />
             </Frame>
         ));
@@ -90,7 +93,7 @@ storiesOf("Format dialog", module)
     .add("FontInformationPane unsuitable", () => {
         return React.createElement(() => (
             <Frame>
-                <FontInformationPane metadata={font3} />
+                <FontInformationPane metadata={fontTestData[2]} />
                 <Typography variant="h6">
                     For some reason, this test needs refreshing to size itself
                     correctly.

--- a/src/BloomBrowserUI/collection/fontScriptSettingsControl.tsx
+++ b/src/BloomBrowserUI/collection/fontScriptSettingsControl.tsx
@@ -1,0 +1,108 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
+
+import * as React from "react";
+import { BloomApi } from "../utils/bloomApi";
+import { lightTheme } from "../bloomMaterialUITheme";
+import { ThemeProvider } from "@material-ui/styles";
+import { IFontMetaData } from "../bookEdit/StyleEditor/fontSelectComponent";
+import { WireUpForWinforms } from "../utils/WireUpWinform";
+import { useEffect, useState } from "react";
+import SingleFontSection from "../react_components/singleFontSection";
+
+// This component is the chooser for the collection's fonts and script settings, on the left side
+// of the "Book Making" tab of the Settings dialog. Eventually the whole tab and whole dialog
+// should move to HTML, but currently this is the root of a ReactDialog.
+export const FontScriptSettingsControl: React.FunctionComponent = () => {
+    const [fontMetadata, setFontMetadata] = useState<
+        IFontMetaData[] | undefined
+    >(undefined);
+    const [language1Name, setLanguage1Name] = useState<string | undefined>(
+        undefined
+    );
+    const [language2Name, setLanguage2Name] = useState<string | undefined>(
+        undefined
+    );
+    const [language3Name, setLanguage3Name] = useState<string | undefined>(
+        undefined
+    );
+    const [language1Font, setLanguage1Font] = useState<string | undefined>(
+        undefined
+    );
+    const [language2Font, setLanguage2Font] = useState<string | undefined>(
+        undefined
+    );
+    const [language3Font, setLanguage3Font] = useState<string | undefined>(
+        undefined
+    );
+
+    useEffect(() => {
+        BloomApi.get("settings/currentFontData", result => {
+            // fontData should be 2 or 3 tuples of (language display name and current font name)
+            const fontData = result.data.langData;
+            // Language 1 data
+            setLanguage1Name(fontData[0].Item1);
+            setLanguage1Font(fontData[0].Item2);
+            // Language 2 data
+            setLanguage2Name(fontData[1].Item1);
+            setLanguage2Font(fontData[1].Item2);
+            // Language 3 data - possibly undefined
+            setLanguage3Name(fontData[2]?.Item1);
+            setLanguage3Font(fontData[2]?.Item2);
+        });
+    }, []);
+
+    useEffect(() => {
+        BloomApi.get("fonts/metadata", result => {
+            const fontMetadata: IFontMetaData[] = result.data;
+            setFontMetadata(fontMetadata);
+        });
+    }, []);
+
+    return (
+        <ThemeProvider theme={lightTheme}>
+            <div
+                // Partly copied from DefaultBookshelfControl, which also tries to imitate winForms.
+                css={css`
+                    font-family: "Segoe UI";
+                    font-size: 10pt;
+                    display: flex;
+                    flex: 1;
+                    flex-direction: column;
+                `}
+            >
+                {/* Language 1 section */}
+                {language1Name && language1Font && (
+                    <SingleFontSection
+                        languageNumber={1}
+                        languageName={language1Name}
+                        currentFontName={language1Font}
+                        fontMetadata={fontMetadata}
+                    />
+                )}
+                {/* Language 2 section */}
+                {language2Name && language2Font && (
+                    <SingleFontSection
+                        languageNumber={2}
+                        languageName={language2Name}
+                        currentFontName={language2Font}
+                        fontMetadata={fontMetadata}
+                    />
+                )}
+                {/* Language 3 section */}
+                {language3Name && language3Font && (
+                    <SingleFontSection
+                        languageNumber={3}
+                        languageName={language3Name}
+                        currentFontName={language3Font}
+                        fontMetadata={fontMetadata}
+                    />
+                )}
+            </div>
+        </ThemeProvider>
+    );
+};
+
+export default FontScriptSettingsControl;
+
+WireUpForWinforms(FontScriptSettingsControl);

--- a/src/BloomBrowserUI/react_components/AutoUpdateSoftwareDialog.tsx
+++ b/src/BloomBrowserUI/react_components/AutoUpdateSoftwareDialog.tsx
@@ -24,7 +24,7 @@ export const AutoUpdateSoftwareDialog: React.FunctionComponent = () => {
         setChosenRadio(event.target.value);
     };
 
-    const isAutoUpdate: boolean = chosenRadio == "automatic";
+    const isAutoUpdate: boolean = chosenRadio === "automatic";
 
     return (
         <ThemeProvider theme={lightTheme}>

--- a/src/BloomBrowserUI/react_components/fontDisplayBar.tsx
+++ b/src/BloomBrowserUI/react_components/fontDisplayBar.tsx
@@ -50,7 +50,8 @@ const FontDisplayBar: React.FunctionComponent<FontDisplayBarProps> = props => {
     const getIconForFont = (): JSX.Element => (
         <div
             css={css`
-                padding-right: 15px;
+                padding-top: 3px !important;
+                padding-right: 3px !important;
             `}
         >
             {suitability === "ok" && (
@@ -88,11 +89,13 @@ const FontDisplayBar: React.FunctionComponent<FontDisplayBarProps> = props => {
 
     return (
         <div
+            className="font-display-bar"
             css={css`
-                display: flex;
-                flex: 1;
-                flex-direction: row;
+                display: flex !important;
+                flex: 1 !important;
+                flex-direction: row !important;
                 justify-content: space-between !important;
+                align-items: center !important;
             `}
         >
             <Typography

--- a/src/BloomBrowserUI/react_components/fontInformationPane.tsx
+++ b/src/BloomBrowserUI/react_components/fontInformationPane.tsx
@@ -1,12 +1,13 @@
 /** @jsx jsx **/
 import { jsx, css } from "@emotion/core";
 import * as React from "react";
-import { Link, Typography } from "@material-ui/core";
+import { Button, Link, Typography } from "@material-ui/core";
 
 import { IFontMetaData } from "../bookEdit/StyleEditor/fontSelectComponent";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 import { useL10n } from "./l10nHooks";
-import { kDisabledControlGray } from "../bloomMaterialUITheme";
+import { kBloomBlue, kDisabledControlGray } from "../bloomMaterialUITheme";
+import CloseIcon from "@material-ui/icons/Close";
 
 const FontInformationPane: React.FunctionComponent<{
     metadata: IFontMetaData | undefined;
@@ -98,7 +99,30 @@ const FontInformationPane: React.FunctionComponent<{
     );
 
     return (
-        <React.Fragment>
+        <div
+            css={css`
+                display: flex;
+                flex-direction: row;
+                align-items: flex-start;
+            `}
+        >
+            <Button
+                startIcon={<CloseIcon htmlColor="white" />}
+                size="small"
+                // Clicking anywhere on the pane works, but w/o the button the user might not know this.
+                onClick={() => {}}
+                css={css`
+                    order: 1; // put icon in upper right corner
+                    padding: 2px !important;
+                    min-width: unset !important;
+                    background-color: ${kBloomBlue} !important;
+                    margin-top: 2px !important;
+                    margin-right: 2px !important;
+                    span span {
+                        margin: 0 !important;
+                    }
+                `}
+            />
             {!props.metadata || (
                 <div
                     css={css`
@@ -106,7 +130,8 @@ const FontInformationPane: React.FunctionComponent<{
                         flex: 1;
                         flex-direction: column;
                         padding: 10px;
-                        max-width: 240px;
+                        padding-right: 2px; // because close icon takes up space
+                        width: 200px;
                     `}
                 >
                     {/* Primary text message */}
@@ -196,7 +221,7 @@ const FontInformationPane: React.FunctionComponent<{
                     )}
                 </div>
             )}
-        </React.Fragment>
+        </div>
     );
 };
 

--- a/src/BloomBrowserUI/react_components/requiresBloomEnterprise.tsx
+++ b/src/BloomBrowserUI/react_components/requiresBloomEnterprise.tsx
@@ -110,10 +110,7 @@ export const BloomEnterpriseIcon = props => {
 
     // Note: currently the tooltip only appears over the icon itself. But it might be nice if it could go over the children too?
     const tooltip = enterpriseAvailable
-        ? useL10n(
-              "Bloom Enterprise Feature",
-              "PublishTab.BulkBloomPub.BloomEnterpriseFeature"
-          )
+        ? useL10n("Bloom Enterprise Feature", "Common.BloomEnterpriseFeature")
         : useL10n(
               "To use this feature, you'll need to enable Bloom Enterprise.",
               "EditTab.RequiresEnterprise"

--- a/src/BloomBrowserUI/react_components/singleFontSection.tsx
+++ b/src/BloomBrowserUI/react_components/singleFontSection.tsx
@@ -1,0 +1,77 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
+
+import * as React from "react";
+import { BloomApi } from "../utils/bloomApi";
+import FontSelectComponent, {
+    IFontMetaData
+} from "../bookEdit/StyleEditor/fontSelectComponent";
+import { Div } from "./l10nComponents";
+import { Link } from "./link";
+
+const SingleFontSection: React.FunctionComponent<{
+    languageNumber: number;
+    languageName: string;
+    currentFontName: string;
+    fontMetadata?: IFontMetaData[];
+}> = props => {
+    const linkData = {
+        languageNumber: props.languageNumber,
+        languageName: props.languageName
+    };
+
+    const fontChangeHandler = (fontName: string) => {
+        BloomApi.postData("settings/setFontForLanguage", {
+            languageNumber: props.languageNumber,
+            fontName: fontName
+        });
+    };
+
+    return (
+        <React.Fragment>
+            <div
+                css={css`
+                    font-family: "Segoe UI Semibold";
+                `}
+            >
+                <Div
+                    l10nKey="CollectionSettingsDialog.BookMakingTab.DefaultFontFor"
+                    l10nParam0={props.languageName}
+                >
+                    Default Font for {0}
+                </Div>
+            </div>
+            <FontSelectComponent
+                key={props.languageNumber}
+                fontMetadata={props.fontMetadata}
+                currentFontName={props.currentFontName}
+                // The popover will left-justify itself, since there are blocking controls to the right.
+                // Once the whole tab becomes a React control, we can probably do away with this.
+                anchorPopoverLeft={true}
+                onChangeFont={fontChangeHandler}
+                css={css`
+                    width: 200px;
+                    margin-top: 0 !important;
+                `}
+            />
+            <Link
+                css={css`
+                    text-decoration: underline !important;
+                    color: blue !important;
+                    margin-bottom: 16px !important;
+                `}
+                l10nKey="CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink"
+                onClick={() => {
+                    BloomApi.postData(
+                        "settings/specialScriptSettings",
+                        linkData
+                    );
+                }}
+            >
+                Special Script Settings
+            </Link>
+        </React.Fragment>
+    );
+};
+
+export default SingleFontSection;

--- a/src/BloomBrowserUI/react_components/stories.tsx
+++ b/src/BloomBrowserUI/react_components/stories.tsx
@@ -36,6 +36,7 @@ import {
     LocalizableNestedMenuItem
 } from "./localizableMenuItem";
 import { Button, Divider, Menu } from "@material-ui/core";
+import FontScriptSettingsControl from "../collection/fontScriptSettingsControl";
 
 storiesOf("Localizable Widgets", module)
     .add("Expandable", () => (
@@ -414,6 +415,20 @@ storiesOf("Misc", module)
             );
         })
     );
+
+const frameDivStyle: React.CSSProperties = {
+    width: "300px",
+    height: "290px",
+    border: "1px solid green"
+};
+
+storiesOf("Misc/Collection Settings", module).add("Font-Script Control", () =>
+    React.createElement(() => (
+        <div style={frameDivStyle}>
+            <FontScriptSettingsControl />
+        </div>
+    ))
+);
 
 const playbackControlsDivStyles: React.CSSProperties = {
     width: "150px",

--- a/src/BloomBrowserUI/webpack.common.js
+++ b/src/BloomBrowserUI/webpack.common.js
@@ -67,6 +67,7 @@ module.exports = merge(core, {
         messageBoxBundle: "./utils/BloomMessageBox.tsx",
         defaultBookshelfControlBundle:
             "./react_components/DefaultBookshelfControl.tsx",
+        fontScriptControlBundle: "./collection/fontScriptSettingsControl.tsx",
         progressDialogBundle: "./react_components/Progress/ProgressDialog.tsx",
         requiresBloomEnterpriseBundle:
             "./react_components/requiresBloomEnterprise.tsx",

--- a/src/BloomExe/Collection/CollectionSettingsDialog.Designer.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.Designer.cs
@@ -51,17 +51,8 @@ namespace Bloom.Collection
 			this.tabPage2 = new System.Windows.Forms.TabPage();
 			this._numberStyleCombo = new System.Windows.Forms.ComboBox();
 			this.label3 = new System.Windows.Forms.Label();
-			this._fontSettings3Link = new System.Windows.Forms.LinkLabel();
-			this._fontSettings2Link = new System.Windows.Forms.LinkLabel();
-			this._fontSettings1Link = new System.Windows.Forms.LinkLabel();
 			this._xmatterList = new System.Windows.Forms.ListView();
 			this._xmatterDescription = new System.Windows.Forms.TextBox();
-			this._fontComboLanguage3 = new System.Windows.Forms.ComboBox();
-			this._fontComboLanguage2 = new System.Windows.Forms.ComboBox();
-			this._fontComboLanguage1 = new System.Windows.Forms.ComboBox();
-			this._language3FontLabel = new System.Windows.Forms.Label();
-			this._language2FontLabel = new System.Windows.Forms.Label();
-			this._language1FontLabel = new System.Windows.Forms.Label();
 			this._xmatterPackLabel = new System.Windows.Forms.Label();
 			this.tabPage3 = new System.Windows.Forms.TabPage();
 			this._noRenameTeamCollectionLabel = new System.Windows.Forms.Label();
@@ -342,17 +333,8 @@ namespace Bloom.Collection
 			// 
 			this.tabPage2.Controls.Add(this._numberStyleCombo);
 			this.tabPage2.Controls.Add(this.label3);
-			this.tabPage2.Controls.Add(this._fontSettings3Link);
-			this.tabPage2.Controls.Add(this._fontSettings2Link);
-			this.tabPage2.Controls.Add(this._fontSettings1Link);
 			this.tabPage2.Controls.Add(this._xmatterList);
 			this.tabPage2.Controls.Add(this._xmatterDescription);
-			this.tabPage2.Controls.Add(this._fontComboLanguage3);
-			this.tabPage2.Controls.Add(this._fontComboLanguage2);
-			this.tabPage2.Controls.Add(this._fontComboLanguage1);
-			this.tabPage2.Controls.Add(this._language3FontLabel);
-			this.tabPage2.Controls.Add(this._language2FontLabel);
-			this.tabPage2.Controls.Add(this._language1FontLabel);
 			this.tabPage2.Controls.Add(this._xmatterPackLabel);
 			this._L10NSharpExtender.SetLocalizableToolTip(this.tabPage2, null);
 			this._L10NSharpExtender.SetLocalizationComment(this.tabPage2, null);
@@ -374,7 +356,7 @@ namespace Bloom.Collection
 			this._L10NSharpExtender.SetLocalizationComment(this._numberStyleCombo, null);
 			this._L10NSharpExtender.SetLocalizationPriority(this._numberStyleCombo, L10NSharp.LocalizationPriority.NotLocalizable);
 			this._L10NSharpExtender.SetLocalizingId(this._numberStyleCombo, "CollectionSettingsDialog._numberStyleCombo");
-			this._numberStyleCombo.Location = new System.Drawing.Point(32, 302);
+			this._numberStyleCombo.Location = new System.Drawing.Point(32, 322);
 			this._numberStyleCombo.Name = "_numberStyleCombo";
 			this._numberStyleCombo.Size = new System.Drawing.Size(189, 25);
 			this._numberStyleCombo.TabIndex = 35;
@@ -388,53 +370,11 @@ namespace Bloom.Collection
 			this._L10NSharpExtender.SetLocalizationComment(this.label3, null);
 			this._L10NSharpExtender.SetLocalizingId(this.label3, "CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.PageNumberingStyleLabel" +
         "");
-			this.label3.Location = new System.Drawing.Point(28, 280);
+			this.label3.Location = new System.Drawing.Point(28, 300);
 			this.label3.Name = "label3";
 			this.label3.Size = new System.Drawing.Size(149, 19);
 			this.label3.TabIndex = 34;
 			this.label3.Text = "Page Numbering Style";
-			// 
-			// _fontSettings3Link
-			// 
-			this._fontSettings3Link.AutoSize = true;
-			this._L10NSharpExtender.SetLocalizableToolTip(this._fontSettings3Link, null);
-			this._L10NSharpExtender.SetLocalizationComment(this._fontSettings3Link, null);
-			this._L10NSharpExtender.SetLocalizingId(this._fontSettings3Link, "CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink");
-			this._fontSettings3Link.Location = new System.Drawing.Point(28, 248);
-			this._fontSettings3Link.Name = "_fontSettings3Link";
-			this._fontSettings3Link.Size = new System.Drawing.Size(141, 19);
-			this._fontSettings3Link.TabIndex = 33;
-			this._fontSettings3Link.TabStop = true;
-			this._fontSettings3Link.Text = "Special Script Settings";
-			this._fontSettings3Link.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this._fontSettings3Link_LinkClicked);
-			// 
-			// _fontSettings2Link
-			// 
-			this._fontSettings2Link.AutoSize = true;
-			this._L10NSharpExtender.SetLocalizableToolTip(this._fontSettings2Link, null);
-			this._L10NSharpExtender.SetLocalizationComment(this._fontSettings2Link, null);
-			this._L10NSharpExtender.SetLocalizingId(this._fontSettings2Link, "CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink");
-			this._fontSettings2Link.Location = new System.Drawing.Point(28, 161);
-			this._fontSettings2Link.Name = "_fontSettings2Link";
-			this._fontSettings2Link.Size = new System.Drawing.Size(141, 19);
-			this._fontSettings2Link.TabIndex = 32;
-			this._fontSettings2Link.TabStop = true;
-			this._fontSettings2Link.Text = "Special Script Settings";
-			this._fontSettings2Link.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this._fontSettings2Link_LinkClicked);
-			// 
-			// _fontSettings1Link
-			// 
-			this._fontSettings1Link.AutoSize = true;
-			this._L10NSharpExtender.SetLocalizableToolTip(this._fontSettings1Link, null);
-			this._L10NSharpExtender.SetLocalizationComment(this._fontSettings1Link, null);
-			this._L10NSharpExtender.SetLocalizingId(this._fontSettings1Link, "CollectionSettingsDialog.BookMakingTab.SpecialScriptSettingsLink");
-			this._fontSettings1Link.Location = new System.Drawing.Point(28, 74);
-			this._fontSettings1Link.Name = "_fontSettings1Link";
-			this._fontSettings1Link.Size = new System.Drawing.Size(141, 19);
-			this._fontSettings1Link.TabIndex = 31;
-			this._fontSettings1Link.TabStop = true;
-			this._fontSettings1Link.Text = "Special Script Settings";
-			this._fontSettings1Link.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this._fontSettings1Link_LinkClicked);
 			// 
 			// _xmatterList
 			// 
@@ -461,83 +401,6 @@ namespace Bloom.Collection
 			this._xmatterDescription.Name = "_xmatterDescription";
 			this._xmatterDescription.Size = new System.Drawing.Size(310, 68);
 			this._xmatterDescription.TabIndex = 29;
-			// 
-			// _fontComboLanguage3
-			// 
-			this._fontComboLanguage3.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this._fontComboLanguage3.FormattingEnabled = true;
-			this._L10NSharpExtender.SetLocalizableToolTip(this._fontComboLanguage3, null);
-			this._L10NSharpExtender.SetLocalizationComment(this._fontComboLanguage3, null);
-			this._L10NSharpExtender.SetLocalizingId(this._fontComboLanguage3, "CollectionSettingsDialog._fontComboLanguage3");
-			this._fontComboLanguage3.Location = new System.Drawing.Point(31, 220);
-			this._fontComboLanguage3.Name = "_fontComboLanguage3";
-			this._fontComboLanguage3.Size = new System.Drawing.Size(190, 25);
-			this._fontComboLanguage3.TabIndex = 25;
-			this._fontComboLanguage3.SelectedIndexChanged += new System.EventHandler(this._fontComboLanguage3_SelectedIndexChanged);
-			// 
-			// _fontComboLanguage2
-			// 
-			this._fontComboLanguage2.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this._fontComboLanguage2.FormattingEnabled = true;
-			this._L10NSharpExtender.SetLocalizableToolTip(this._fontComboLanguage2, null);
-			this._L10NSharpExtender.SetLocalizationComment(this._fontComboLanguage2, null);
-			this._L10NSharpExtender.SetLocalizingId(this._fontComboLanguage2, "CollectionSettingsDialog._fontComboLanguage2");
-			this._fontComboLanguage2.Location = new System.Drawing.Point(31, 133);
-			this._fontComboLanguage2.Name = "_fontComboLanguage2";
-			this._fontComboLanguage2.Size = new System.Drawing.Size(190, 25);
-			this._fontComboLanguage2.TabIndex = 23;
-			this._fontComboLanguage2.SelectedIndexChanged += new System.EventHandler(this._fontComboLanguage2_SelectedIndexChanged);
-			// 
-			// _fontComboLanguage1
-			// 
-			this._fontComboLanguage1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this._fontComboLanguage1.FormattingEnabled = true;
-			this._L10NSharpExtender.SetLocalizableToolTip(this._fontComboLanguage1, null);
-			this._L10NSharpExtender.SetLocalizationComment(this._fontComboLanguage1, null);
-			this._L10NSharpExtender.SetLocalizingId(this._fontComboLanguage1, "CollectionSettingsDialog._fontComboLanguage1");
-			this._fontComboLanguage1.Location = new System.Drawing.Point(31, 46);
-			this._fontComboLanguage1.Name = "_fontComboLanguage1";
-			this._fontComboLanguage1.Size = new System.Drawing.Size(190, 25);
-			this._fontComboLanguage1.TabIndex = 21;
-			this._fontComboLanguage1.SelectedIndexChanged += new System.EventHandler(this._fontComboLanguage1_SelectedIndexChanged);
-			// 
-			// _language3FontLabel
-			// 
-			this._language3FontLabel.AutoSize = true;
-			this._language3FontLabel.Font = new System.Drawing.Font("Segoe UI Semibold", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this._L10NSharpExtender.SetLocalizableToolTip(this._language3FontLabel, null);
-			this._L10NSharpExtender.SetLocalizationComment(this._language3FontLabel, "{0} is a language name.");
-			this._L10NSharpExtender.SetLocalizingId(this._language3FontLabel, "CollectionSettingsDialog.BookMakingTab.DefaultFontFor");
-			this._language3FontLabel.Location = new System.Drawing.Point(27, 198);
-			this._language3FontLabel.Name = "_language3FontLabel";
-			this._language3FontLabel.Size = new System.Drawing.Size(131, 19);
-			this._language3FontLabel.TabIndex = 24;
-			this._language3FontLabel.Text = "Default Font for {0}";
-			// 
-			// _language2FontLabel
-			// 
-			this._language2FontLabel.AutoSize = true;
-			this._language2FontLabel.Font = new System.Drawing.Font("Segoe UI Semibold", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this._L10NSharpExtender.SetLocalizableToolTip(this._language2FontLabel, null);
-			this._L10NSharpExtender.SetLocalizationComment(this._language2FontLabel, "{0} is a language name.");
-			this._L10NSharpExtender.SetLocalizingId(this._language2FontLabel, "CollectionSettingsDialog.BookMakingTab.DefaultFontFor");
-			this._language2FontLabel.Location = new System.Drawing.Point(27, 111);
-			this._language2FontLabel.Name = "_language2FontLabel";
-			this._language2FontLabel.Size = new System.Drawing.Size(131, 19);
-			this._language2FontLabel.TabIndex = 23;
-			this._language2FontLabel.Text = "Default Font for {0}";
-			// 
-			// _language1FontLabel
-			// 
-			this._language1FontLabel.Font = new System.Drawing.Font("Segoe UI Semibold", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this._L10NSharpExtender.SetLocalizableToolTip(this._language1FontLabel, null);
-			this._L10NSharpExtender.SetLocalizationComment(this._language1FontLabel, "{0} is a language name.");
-			this._L10NSharpExtender.SetLocalizingId(this._language1FontLabel, "CollectionSettingsDialog.BookMakingTab.DefaultFontFor");
-			this._language1FontLabel.Location = new System.Drawing.Point(27, 24);
-			this._language1FontLabel.Name = "_language1FontLabel";
-			this._language1FontLabel.Size = new System.Drawing.Size(250, 19);
-			this._language1FontLabel.TabIndex = 22;
-			this._language1FontLabel.Text = "Default Font for {0}";
 			// 
 			// _xmatterPackLabel
 			// 
@@ -988,12 +851,6 @@ namespace Bloom.Collection
         private System.Windows.Forms.TextBox _bloomCollectionName;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button _cancelButton;
-        private System.Windows.Forms.Label _language1FontLabel;
-        private System.Windows.Forms.ComboBox _fontComboLanguage1;
-		private System.Windows.Forms.Label _language2FontLabel;
-		private System.Windows.Forms.ComboBox _fontComboLanguage2;
-		private System.Windows.Forms.Label _language3FontLabel;
-		private System.Windows.Forms.ComboBox _fontComboLanguage3;
 		private CheckBox _automaticallyUpdate;
 		private Label label2;
 		private System.Windows.Forms.CheckBox _showExperimentalBookSources;
@@ -1004,9 +861,6 @@ namespace Bloom.Collection
 		private Button _helpButton;
 		private TextBox _xmatterDescription;
 		private ListView _xmatterList;
-		private LinkLabel _fontSettings3Link;
-		private LinkLabel _fontSettings2Link;
-		private LinkLabel _fontSettings1Link;
 		private ComboBox _numberStyleCombo;
 		private Label label3;
 		private TabPage _enterpriseTab;

--- a/src/BloomExe/FontProcessing/FontsApi.cs
+++ b/src/BloomExe/FontProcessing/FontsApi.cs
@@ -18,8 +18,8 @@ namespace Bloom.FontProcessing
 
 		public void RegisterWithApiHandler(BloomApiHandler apiHandler)
 		{
-			apiHandler.RegisterEndpointLegacy(kApiUrlPart + "names", HandleNamesRequest, false);
-			apiHandler.RegisterEndpointLegacy(kApiUrlPart + "metadata", HandleMetadataRequest, false);
+			apiHandler.RegisterEndpointHandler(kApiUrlPart + "names", HandleNamesRequest, false);
+			apiHandler.RegisterEndpointHandler(kApiUrlPart + "metadata", HandleMetadataRequest, false);
 		}
 
 		/// <summary>

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -789,7 +789,7 @@ namespace Bloom.Workspace
 						ErrorReport.NotifyUserOfProblem(MustBeAdminMessage);
 						return DialogResult.Cancel;
 					}
-					using (var dlg = _settingsDialogFactory ())
+					using (var dlg = _settingsDialogFactory())
 					{
 						_currentlyOpenSettingsDialog = dlg;
 						dlg.SetDesiredTab(tab);


### PR DESCRIPTION
* move font test data to a separate file
* add control to storybook
* remove old controls from Collection Settings Dialog
* refactor to pull out SingleFontSection that groups the
   controls for each language
* get script settings link working
* remove more old stuff in C#
* only display font control when it has a font
* use FontsApi to get font data to new control
* correct a localization Id in requiresBloomEnterprise
* allow font script control to display before font metadata
   "arrives"
* update some api endpoints
* add close icon to font information pane
* finish up dialog updates

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5042)
<!-- Reviewable:end -->
