### PR TITLE
Fix upload error when originalTitle is undefined (BL-11027)

### DIFF
--- a/src/BloomExe/Publish/BloomLibrary/BloomLibraryUploadControl.cs
+++ b/src/BloomExe/Publish/BloomLibrary/BloomLibraryUploadControl.cs
@@ -508,7 +508,7 @@ namespace Bloom.Publish.BloomLibrary
 			var existingBookInfo = _model.ConflictingBookInfo;
 			var updatedDateTime = (DateTime) existingBookInfo.updatedAt;
 			var createdDateTime = (DateTime) existingBookInfo.createdAt;
-			var originalTitle = existingBookInfo.originalTitle.Value;
+			var originalTitle = existingBookInfo.originalTitle?.Value;
 			var existingId = existingBookInfo.objectId.ToString();
 			var existingBookUrl = BloomLibraryUrlPrefix + "/book/" + existingId;
 


### PR DESCRIPTION
This fixes the crash that prevents upload, but is not ideal because it leaves an empty title.