### PR TITLE
Enable generic browser debugging on Linux (20220321)

### DIFF
--- a/src/BloomExe/Browser.cs
+++ b/src/BloomExe/Browser.cs
@@ -498,7 +498,14 @@ namespace Bloom
 				Keys keyData = Keys.Control | Keys.N;
 				ControlKeyEvent.Raise(keyData);
 			}
+#if __MonoCS__
+			_controlPressed = e.CtrlKey && e.KeyChar == 'm';	// m for menu...
+#endif
 		}
+
+#if __MonoCS__
+		private bool _controlPressed;
+#endif
 
 		private void Paste()
 		{
@@ -529,8 +536,13 @@ namespace Bloom
 			// To allow Typescript code to implement right-click, we'll do our special developer menu
 			// only if the control key is down. Though, if ContextMenuProvider is non-null, we'll assume
 			// C# is supposed to handle the context menu here.
+#if __MonoCS__
+			if (!_controlPressed && ContextMenuProvider == null)
+				return;
+#else
 			if ((Control.ModifierKeys & Keys.Control) != Keys.Control && ContextMenuProvider == null)
 				return;
+#endif
 			MenuItem FFMenuItem = null;
 			Debug.Assert(!InvokeRequired);
 #if DEBUG


### PR DESCRIPTION
The Control.ModifierKeys property does not work on Linux when a Gecko
based browser is active.  This implements a simple state machine (on
Linux only) to enable the debugging menu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5048)
<!-- Reviewable:end -->
