### PR TITLE
Hide the up/down control on the year field (BL-6259)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightPanel.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightPanel.tsx
@@ -153,6 +153,11 @@ export const CopyrightPanel: React.FunctionComponent<{
                 css={css`
                     width: 150px; // Enough for slightly longer translations of the label; English only needs 100px
                     margin-bottom: 20px !important;
+
+                    // Hide the up/down control
+                    input {
+                        -moz-appearance: textfield;
+                    }
                 `}
             />
             <MuiTextField


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5073)
<!-- Reviewable:end -->
