### PR TITLE
Clean CSS of unwanted language rules in BloomPub publishing (BL-11108)

### DIFF
--- a/src/BloomExe/Publish/Android/BloomPubMaker.cs
+++ b/src/BloomExe/Publish/Android/BloomPubMaker.cs
@@ -126,7 +126,10 @@ namespace Bloom.Publish.Android
 
 
 			if (settings?.LanguagesToInclude != null)
+			{
 				PublishModel.RemoveUnwantedLanguageData(modifiedBook.OurHtmlDom, settings.LanguagesToInclude, modifiedBook.BookData.MetadataLanguage1IsoCode);
+				PublishModel.RemoveUnwantedLanguageRulesFromCssFiles(modifiedBook.FolderPath, settings.LanguagesToInclude);
+			}
 			else if (Program.RunningHarvesterMode && modifiedBook.OurHtmlDom.SelectSingleNode(BookStorage.ComicalXpath) != null)
 			{
 				// This indicates that we are harvesting a book with comic speech bubbles or other overlays (Overlay Tool).

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -260,8 +260,9 @@ namespace Bloom.Publish
 						elt.ParentNode.RemoveChild(elt);
 					}
 				}
-				// We need the font information for visible text elements as well.  This is a side-effect but related to
-				// unwanted elements in that we don't need fonts that are used only by unwanted elements.
+				// We need the font information for wanted text elements as well.  This is a side-effect but related to
+				// unwanted elements in that we don't need fonts that are used only by unwanted elements.  Note that
+				// elements don't need to be actually visible to provide computed style information such as font-family.
 				foreach (XmlElement elt in page.SafeSelectNodes(".//div"))
 				{
 					StoreFontUsed(elt);
@@ -349,6 +350,10 @@ namespace Bloom.Publish
 		/// <summary>
 		/// Stores the font used.  Note that unwanted elements should have been removed already.
 		/// </summary>
+		/// <remarks>
+		/// Elements that are made invisible by CSS still have their styles computed and can provide font information.
+		/// See https://issues.bloomlibrary.org/youtrack/issue/BL-11108 for a misunderstanding of this.
+		/// </remarks>
 		private void StoreFontUsed(XmlElement elt)
 		{
 			var id = elt.Attributes["id"].Value;

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -706,6 +706,20 @@ namespace Bloom.Publish
 			}
 		}
 
+		/// <summary>
+		/// Remove language specific style settings for unwanted languages from all CSS files in the given directory.
+		/// </summary>
+		public static void RemoveUnwantedLanguageRulesFromCssFiles(string dirName, IEnumerable<string> wantedLanguages)
+		{
+			foreach (var filepath in Directory.EnumerateFiles(dirName, "*.css"))
+			{
+				var cssTextOrig = RobustFile.ReadAllText(filepath);
+				var cssText = HtmlDom.RemoveUnwantedLanguageRulesFromCss(cssTextOrig, wantedLanguages);
+				if (cssText != cssTextOrig)
+					RobustFile.WriteAllText(filepath, cssText);
+			}
+		}
+
 		// This is a highly experimental export which may evolve as we work on this with Age of Learning.
 		public void ExportAudioFiles1PerPage()
 		{

--- a/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
@@ -345,15 +345,8 @@ namespace Bloom.WebLibraryIntegration
 				XmlHtmlConverter.SaveDOMAsHtml5(dom.RawDom, filepath);
 			}
 			// Remove language specific style settings from all CSS files for unwanted languages.
-			foreach (var filepath in Directory.EnumerateFiles(destDirName, "*.css"))
-			{
-				var cssTextOrig = RobustFile.ReadAllText(filepath);
-				var cssText = HtmlDom.RemoveUnwantedLanguageRulesFromCss(cssTextOrig, languagesToInclude);
-				if (cssText != cssTextOrig)
-					RobustFile.WriteAllText(filepath, cssText);
-			}
+			PublishModel.RemoveUnwantedLanguageRulesFromCssFiles(destDirName, languagesToInclude);
 		}
-
 
 		//Note: there is a similar list for BloomPacks, but it is not identical, so don't just copy/paste
 		private static readonly string[] excludedFileExtensionsLowerCase = { ".db", ".bloompack", ".bak", ".userprefs", ".md", ".map" };


### PR DESCRIPTION
Getting fonts for embedding is working okay already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5106)
<!-- Reviewable:end -->
