### PR TITLE
Keep focus in color chooser inputs while editing (BL-9923)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -625,6 +625,7 @@ export class BubbleManager {
                 this.setTextColorInternal(hexOrRgbColor, bubble.content)
             );
         }
+        this.restoreFocus();
     }
 
     private setTextColorInternal(hexOrRgbColor: string, element: HTMLElement) {
@@ -680,6 +681,29 @@ export class BubbleManager {
         });
         // reset active element
         this.setActiveElement(originalActiveElement);
+        this.restoreFocus();
+    }
+
+    // Here we keep track of something (currently, typically, an input box in
+    // the color chooser) to which focus needs to be restored after we modify
+    // foreground or background color on the bubble, since those processes
+    // involve focusing the bubble and this is iconvenient when typing in the
+    // input boxes.
+    private thingToFocusAfterSettingColor: HTMLElement;
+    private restoreFocus() {
+        if (this.thingToFocusAfterSettingColor) {
+            this.thingToFocusAfterSettingColor.focus();
+            // I don't fully understand why we need this, but without it, the input
+            // doesn't end up focused. Apparently we just need to overcome whatever
+            // is stealing the focus before the next cycle.
+            setTimeout(() => {
+                this.thingToFocusAfterSettingColor.focus();
+            }, 0);
+        }
+    }
+
+    public setThingToFocusAfterSettingColor(x: HTMLElement): void {
+        this.thingToFocusAfterSettingColor = x;
     }
 
     public getBackgroundColorArray(familySpec: BubbleSpec): string[] {

--- a/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
@@ -283,6 +283,9 @@ const OverlayToolControls: React.FunctionComponent = () => {
         }
     };
 
+    const noteInputFocused = (input: HTMLElement) =>
+        OverlayTool.bubbleManager()?.setThingToFocusAfterSettingColor(input);
+
     // We come into this from chooser change
     const updateBackgroundColor = (newColorSwatch: ISwatchDefn) => {
         const bubbleMgr = OverlayTool.bubbleManager();
@@ -437,7 +440,8 @@ const OverlayToolControls: React.FunctionComponent = () => {
             localizedTitle: textColorTitle,
             initialColor: textColorSwatch,
             defaultSwatchColors: defaultTextColors,
-            onChange: color => updateTextColor(color)
+            onChange: color => updateTextColor(color),
+            onInputFocus: noteInputFocused
         };
         getEditTabBundleExports().showColorPickerDialog(colorPickerDialogProps);
     };
@@ -451,7 +455,8 @@ const OverlayToolControls: React.FunctionComponent = () => {
             localizedTitle: backgroundColorTitle,
             initialColor: backgroundColorSwatch,
             defaultSwatchColors: defaultBackgroundColors,
-            onChange: color => updateBackgroundColor(color)
+            onChange: color => updateBackgroundColor(color),
+            onInputFocus: noteInputFocused
         };
         // If the background color is fully transparent, change it to fully opaque
         // so that the user can choose a color immediately (and adjust opacity to

--- a/src/BloomBrowserUI/react_components/customColorPicker.tsx
+++ b/src/BloomBrowserUI/react_components/customColorPicker.tsx
@@ -1,7 +1,9 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
 import * as React from "react";
 import { useState } from "react";
 import {
-    ChromePicker,
+    SketchPicker,
     ColorChangeHandler,
     ColorResult,
     RGBColor
@@ -64,7 +66,7 @@ export const CustomColorPicker: React.FunctionComponent<ICustomPicker> = props =
     };
 
     const getSwatchColors = () => (
-        <>
+        <React.Fragment>
             {props.swatchColors
                 .filter(swatch => {
                     if (props.noGradientSwatches) {
@@ -85,7 +87,7 @@ export const CustomColorPicker: React.FunctionComponent<ICustomPicker> = props =
                         opacity={swatchDefn.opacity}
                     />
                 ))}
-        </>
+        </React.Fragment>
     );
 
     const getRgbOfCurrentSwatch = (): RGBColor => {
@@ -97,13 +99,24 @@ export const CustomColorPicker: React.FunctionComponent<ICustomPicker> = props =
 
     return (
         <div className="custom-color-picker">
-            <ChromePicker
+            <SketchPicker
                 disableAlpha={props.noAlphaSlider}
                 // if the current color choice happens to be a gradient, this will be 'white'.
                 color={getRgbOfCurrentSwatch()}
                 onChange={handleColorChange}
+                // We do want to show a set of color presets, but as far as I could discover
+                // the SketchPicker can't display gradients, so we'll leave out its own ones
+                // and use our own.
+                presetColors={[]}
             />
-            <div className="swatch-row">{getSwatchColors()}</div>
+            <div
+                css={css`
+                    margin-top: 10px;
+                `}
+                className="swatch-row"
+            >
+                {getSwatchColors()}
+            </div>
         </div>
     );
 };

--- a/src/BloomBrowserUI/react_components/stories.tsx
+++ b/src/BloomBrowserUI/react_components/stories.tsx
@@ -861,7 +861,8 @@ storiesOf("Custom Color Chooser", module)
                 localizedTitle: "Custom Color Picker",
                 initialColor: chooserCurrentBackgroundColor,
                 defaultSwatchColors: defaultSwatches,
-                onChange: color => handleColorChange(color)
+                onChange: color => handleColorChange(color),
+                onInputFocus: () => {}
             };
 
             return (


### PR DESCRIPTION
Also switches to a different basic picker design so we don't have to switch between hex and RGBA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5108)
<!-- Reviewable:end -->
