### PR TITLE
Fix URL encoded filename stored for cover image (BL-11145)

### DIFF
--- a/src/BloomExe/UrlPathString.cs
+++ b/src/BloomExe/UrlPathString.cs
@@ -172,25 +172,32 @@ namespace Bloom
 
 		/// <summary>
 		/// Some library books have been uploaded with the cover image filename URL encoded in the file instead of HTML/XML encoded.
-		/// So if the file doesn't exist, try one more level of decoding to see if that may be the problem, but preserve the original
-		/// path in case an error message is still needed.
+		/// So if the file doesn't exist, try decoding to see if that may be the problem, but preserve the original path in case an
+		/// error message is still needed.
 		/// </summary>
 		/// <param name="directory">path of the containing folder</param>
 		/// <param name="filename">base filename to be combined with directory.  This may be modified by HttpUtility.UrlDecode().</param>
 		/// <remarks>
 		/// See https://silbloom.myjetbrains.com/youtrack/issue/BL-3901.
+		/// and https://issues.bloomlibrary.org/youtrack/issue/BH-6143.
+		/// and https://issues.bloomlibrary.org/youtrack/issue/BL-11145.
 		/// </remarks>
 		public static string GetFullyDecodedPath(string directory, ref string filename)
 		{
 			var path = System.IO.Path.Combine(directory, filename);
-			if (!SIL.IO.RobustFile.Exists(path) && filename.Contains("%"))
+			if (!SIL.IO.RobustFile.Exists(path))
 			{
-				var filename1 = System.Web.HttpUtility.UrlDecode(filename);
-				var path1 = System.IO.Path.Combine(directory, filename1);
-				if (SIL.IO.RobustFile.Exists(path1))
+				const string kUrlEncodedRegex = "%[0-9a-fA-F][0-9a-fA-F]";
+				var filename1 = filename;
+				while (Regex.IsMatch(filename1, kUrlEncodedRegex))
 				{
-					filename = filename1;
-					return path1;
+					filename1 = HttpUtility.UrlDecode(filename1);
+					var path1 = System.IO.Path.Combine(directory, filename1);
+					if (SIL.IO.RobustFile.Exists(path1))
+					{
+						filename = filename1;
+						return path1;
+					}
 				}
 			}
 			return path;


### PR DESCRIPTION
I thought we killed this bug years ago, but apparently not quite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5116)
<!-- Reviewable:end -->
