### PR TITLE
BL-10974 Tweaks

### DIFF
--- a/src/BloomBrowserUI/react_components/DefaultBookshelfControl.tsx
+++ b/src/BloomBrowserUI/react_components/DefaultBookshelfControl.tsx
@@ -159,9 +159,6 @@ export const DefaultBookshelfControl: React.FunctionComponent = () => {
                 // a different behavior in Gecko and FF, though actually the difference
                 // is window width).
                 minHeight: "auto"
-            },
-            "& li:hover": {
-                color: "white"
             }
         }
     });

--- a/src/BloomExe/web/ReactControl.cs
+++ b/src/BloomExe/web/ReactControl.cs
@@ -160,7 +160,7 @@ namespace Bloom.web
 						}};
 					</script>					
 				</head>
-				<body style='margin:0; height:auto; background-color:{backColor};'>
+				<body style='margin:0; height:100%; display: flex; flex: 1; flex-direction: column; background-color:{backColor};'>
 					<div id='reactRoot' style='height:100%'>Javascript should have replaced this. Make sure that the javascript bundle '{bundleNameWithExtension}' includes a single call to WireUpForWinforms()</div>
 				</body>
 				</html>");


### PR DESCRIPTION
* Bookshelf dropdown hover fixed
* better css for ReactControl
   (we might be able to do w/o either or both of App.less
   and TeamCollection.less, but I wanted to get this working)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5120)
<!-- Reviewable:end -->
