### PR TITLE
Improvements to "change to a different layout" (BL-11147)

### DIFF
--- a/src/BloomBrowserUI/pageChooser/page-chooser.ts
+++ b/src/BloomBrowserUI/pageChooser/page-chooser.ts
@@ -207,6 +207,13 @@ export class PageChooser {
             ),
             10
         );
+        const selectedTemplateWidgetCount = parseInt(
+            this.getAttributeStringSafely(
+                this._selectedGridItem,
+                "data-widgetCount"
+            ),
+            10
+        );
 
         const page = <HTMLIFrameElement>(
             window.parent.document.getElementById("page")
@@ -232,12 +239,16 @@ export class PageChooser {
         const currentVideoCount = current.getElementsByClassName(
             "bloom-videoContainer"
         ).length;
+        const currentWidgetCount = current.getElementsByClassName(
+            "bloom-widgetContainer"
+        ).length;
 
         return (
             selectedTemplateTranslationGroupCount <
                 currentTranslationGroupCount ||
             selectedTemplatePictureCount < currentPictureCount ||
-            selectedTemplateVideoCount < currentVideoCount
+            selectedTemplateVideoCount < currentVideoCount ||
+            selectedTemplateWidgetCount < currentWidgetCount
         );
     }
 
@@ -295,7 +306,9 @@ export class PageChooser {
                 {
                     pageId: pageId,
                     templateBookPath: templateBookPath,
-                    convertWholeBook: convertWholeBookChecked
+                    convertWholeBook: convertWholeBookChecked,
+                    numberToAdd: 1, // meaningless here, but prevents throwing an exception in C#
+                    allowDataLoss: convertAnywayChecked
                 },
                 PageChooser.closeup
             );
@@ -305,8 +318,9 @@ export class PageChooser {
                 {
                     templateBookPath: templateBookPath,
                     pageId: pageId,
-                    convertWholeBook: false,
-                    numberToAdd: numberToAdd
+                    convertWholeBook: false, // meaningless here, but keeps C# happy
+                    numberToAdd: numberToAdd,
+                    allowDataLoss: convertAnywayChecked // meaningless here, but keeps C# happy
                 },
                 PageChooser.closeup
             );
@@ -566,6 +580,12 @@ export class PageChooser {
                 "data-videoCount",
                 currentPageDiv
                     .getElementsByClassName("bloom-videoContainer")
+                    .length.toString()
+            );
+            currentGridItemHtml.setAttribute(
+                "data-widgetCount",
+                currentPageDiv
+                    .getElementsByClassName("bloom-widgetContainer")
                     .length.toString()
             );
             const helpLink = currentPageDiv.getAttribute("help-link");

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -1021,6 +1021,52 @@ namespace BloomTests.Book
 		}
 
 		[Test]
+		public void MigrateChildren_MigratesWidgets()
+		{
+			var pageDom = new HtmlDom(@"<html><head></head><body>
+					<div class='bloom-page' id='pageGuid'>
+						<div class='split-pane-component-inner'>
+							<div class='bloom-translationGroup'>
+								<div class='bloom-editable ' contenteditable='true' lang='en'>Contents</div>
+							</div>
+							<div class='bloom-widgetContainer'>
+								<iframe src='activities/balldragTouch/index.html'>Must have a closing tag in HTML</iframe>
+							</div>
+						</div>
+					</div>
+				</body></html>");
+			var templateDom = new HtmlDom(@"<html><head></head><body>
+					<div class='bloom-page' id='templateGuid'>
+						<div class='split-pane-component-inner'>
+							<div class='bloom-widgetContainer bloom-noWidgetSelected' />
+							<div class='bloom-translationGroup'>
+								<div class='bloom-editable ' contenteditable='true' lang='en'></div>
+							</div>
+						</div>
+					</div>
+				</body></html>");
+			bool didChange;
+			var lineage = "someGuid";
+			var pageElement = pageDom.SelectSingleNode("//div[@class='bloom-page']");
+			var templateElement = templateDom.SelectSingleNode("//div[@class='bloom-page']");
+
+			// SUT
+			pageDom.MigrateEditableData(pageElement, templateElement, lineage, false, out didChange);
+
+			// Verification
+			Assert.That(didChange, Is.True);
+			AssertThatXmlIn.Dom(pageDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@data-pagelineage='someGuid']", 1);
+			var textContentsXpath = "//div[contains(@class,'bloom-editable') and text()='Contents']";
+			var widgetXpath = "//iframe[@src='activities/balldragTouch/index.html']";
+			var noWidgetXpath = "//div[contains(@class,'bloom-noWidgetSelected')]";
+			AssertThatXmlIn.Dom(pageDom.RawDom).HasNoMatchForXpath("//div[@id='templateGuid']");
+			AssertThatXmlIn.Dom(pageDom.RawDom).HasSpecifiedNumberOfMatchesForXpath("//div[@id='pageGuid']", 1);
+			AssertThatXmlIn.Dom(pageDom.RawDom).HasSpecifiedNumberOfMatchesForXpath(textContentsXpath, 1);
+			AssertThatXmlIn.Dom(pageDom.RawDom).HasSpecifiedNumberOfMatchesForXpath(widgetXpath, 1);
+			AssertThatXmlIn.Dom(pageDom.RawDom).HasNoMatchForXpath(noWidgetXpath);
+		}
+
+		[Test]
 		public void RemoveComments_WorksForCssData()
 		{
 			const string cssContent = @"


### PR DESCRIPTION
- Change all similar pages won't change pages where data would be lost unless this was expected from the different layouts of the current and selected page
- It also won't change pages whose block counts are different from the current page, even if data loss is approved
- HTML widgets are transferred and counted in deciding whether data will be lost

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5150)
<!-- Reviewable:end -->
