### PR TITLE
BL-11162 Fix toasts for missing branding files

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1422,6 +1422,8 @@ namespace Bloom.Book
 			// To allow migration, pretend it has no ID if there is not yet a meta.json.
 			bookDOM.RemoveMetaElement("bloomBookId", () => (RobustFile.Exists(BookInfo.MetaDataPath) ? BookInfo.Id : null),
 				val => BookInfo.Id = val);
+			// BL-11162 Repair existing books, if they didn't have this reference.
+			bookDOM.AddStyleSheetIfMissing("branding.css");
 
 			// Title should be replicated in json
 			//if (!string.IsNullOrWhiteSpace(Title)) // check just in case we somehow have more useful info in json.

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -474,13 +474,17 @@ namespace Bloom.Api
 				return true;
 			}
 
-			if (localPath.StartsWith(OriginalImageMarker) && IsImageTypeThatCanBeDegraded(localPath))
-			{
+			if (localPath.StartsWith(OriginalImageMarker)) {
 				// Path relative to simulated page file, and we want the file contents without modification.
 				// (Note that the simulated page file's own URL starts with this, so it's important to check
 				// for that BEFORE we do this check.)
+				// BL-11162 If we get here with the 'OriginalImageMarker' prefix and it's not an image type
+				// that can be degraded, there's no point in continuing on with the prefix!
 				localPath = localPath.Substring(OriginalImageMarker.Length + 1);
-				return ProcessAnyFileContent(info, localPath);
+				if (IsImageTypeThatCanBeDegraded(localPath))
+				{
+					return ProcessAnyFileContent(info, localPath);
+				}
 			}
 
 			if (localPath.StartsWith("localhost/", StringComparison.InvariantCulture))
@@ -1415,9 +1419,16 @@ namespace Bloom.Api
 				return false;
 
 			var localPath = GetLocalPathWithoutQuery(info);
-			// We don't need even a toast for missing files in the book folder. That's the user's problem and should be adequately
-			// documented by the browser message saying the file is missing.
-			if (currentBookFolderPath != null && localPath.StartsWith(currentBookFolderPath.Replace("\\", "/")))
+			var localFolderTestPath = localPath;
+			// We don't need even a toast for missing files in the book folder. That's the user's problem
+			// and should be adequately documented by the browser message saying the file is missing.
+			// BL-11162 This includes showing up here with "OriginalImages" prefixed to the url for
+			// publishing.
+			if (localFolderTestPath.StartsWith(OriginalImageMarker))
+			{
+				localFolderTestPath = localFolderTestPath.Substring(OriginalImageMarker.Length + 1);
+			}
+			if (currentBookFolderPath != null && localFolderTestPath.StartsWith(currentBookFolderPath.Replace("\\", "/")))
 				return false;
 			// Likewise if it's part of the current book we're publishing. If we didn't give a message about something being
 			// missing while creating the book, it's just confusing to do so when they create a publication preview. See BL-9738

--- a/src/content/templates/bloom-foundation-mixins.pug
+++ b/src/content/templates/bloom-foundation-mixins.pug
@@ -19,6 +19,7 @@ mixin core-stylesheets
 	+stylesheet('editMode.css')
 	+stylesheet('editPaneGlobal.css')
 	+stylesheet('origami.css')
+	+stylesheet('branding.css')
 
 mixin stylesheets(nameOfTemplateSpecificCSS)
 	+core-stylesheets


### PR DESCRIPTION
* Ensure reference for 'branding.css' so branding files
   are handled correctly
* Keep missing and unneeded logo file from reporting