### PR TITLE
Restore book information panes for template previews (BL-11190)

### DIFF
--- a/src/BloomBrowserUI/app/selectedBook.ts
+++ b/src/BloomBrowserUI/app/selectedBook.ts
@@ -6,6 +6,7 @@ export interface ISelectedBookInfo {
     id: string | undefined;
     saveable: boolean; // changes can safely be saved, including considering whether checked out if necessary
     collectionKind: "main" | "factory" | "error" | "other"; //error indicates the book is not usable for anything.
+    aboutBookInfoUrl: string | undefined;
 }
 
 // Anything that uses this will always have the current book info. The first render will see the default
@@ -17,7 +18,8 @@ export function useMonitorBookSelection(): ISelectedBookInfo {
         {
             id: undefined,
             saveable: false,
-            collectionKind: "error" // better to see no button at all until we know which it is
+            collectionKind: "error", // better to see no button at all until we know which it is
+            aboutBookInfoUrl: undefined
         }
     );
 

--- a/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
@@ -44,7 +44,8 @@ export const CollectionsTabBookPane: React.FunctionComponent<{
     const {
         id: selectedBookId,
         saveable,
-        collectionKind
+        collectionKind,
+        aboutBookInfoUrl
     } = useMonitorBookSelection();
 
     React.useEffect(() => {
@@ -280,6 +281,18 @@ export const CollectionsTabBookPane: React.FunctionComponent<{
                                         border: none;
                                     `}
                                     ref={iframeRef}
+                                />
+                            )}
+                            {aboutBookInfoUrl && selectedBookId && (
+                                <iframe
+                                    src={aboutBookInfoUrl}
+                                    height="100%"
+                                    width="100%"
+                                    css={css`
+                                        margin-top: 5px;
+                                        flex-grow: 1;
+                                        border: none;
+                                    `}
                                 />
                             )}
                         </div>

--- a/src/BloomExe/Workspace/WorkspaceView.Designer.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.Designer.cs
@@ -20,7 +20,12 @@ namespace Bloom.Workspace
             {
 	            components.Dispose();
             }
-            base.Dispose(disposing);
+			if (_tempBookInfoHtmlPath != null && SIL.IO.RobustFile.Exists(_tempBookInfoHtmlPath))
+			{
+				SIL.IO.RobustFile.Delete(_tempBookInfoHtmlPath);
+				_tempBookInfoHtmlPath = null;
+			}
+			base.Dispose(disposing);
         }
 
         #region Component Designer generated code


### PR DESCRIPTION
The only remaining regression is no adjustable split between the book preview and information panes.  This would require more knowledge of how splitters work in React, and probably be much more complicated in implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5161)
<!-- Reviewable:end -->
