### PR TITLE
Reduce min height for DialogMiddle (BL-11224)

### DIFF
--- a/src/BloomBrowserUI/react_components/BloomDialog/BloomDialog.tsx
+++ b/src/BloomBrowserUI/react_components/BloomDialog/BloomDialog.tsx
@@ -228,7 +228,9 @@ export const DialogMiddle: React.FunctionComponent<{}> = props => {
                     margin-block-end: 1em;
                 }
 
-                min-height: 100px;
+                // This was 100px. Not sure why we need it at all, but 100px is too much for
+                // dialogs like the number-of-duplciates dialogs or simple message boxes.
+                min-height: 50px;
             `}
             {...props}
         >


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5175)
<!-- Reviewable:end -->
