### PR TITLE
BL-10833 Fix broken links in Training Videos

### DIFF
--- a/DistFiles/localization/en/TrainingVideos.xlf
+++ b/DistFiles/localization/en/TrainingVideos.xlf
@@ -77,15 +77,22 @@
         <target />
         <note>ID: training.videos.download</note>
       </trans-unit>
+      <trans-unit id="training.videos.download.2">
+        <source xml:lang="en">Under the video that you want to download, there should be a Download button.</source>
+        <target />
+        <note>ID: training.videos.download.2</note>
+      </trans-unit>
       <trans-unit id="training.videos.hires">
         <source xml:lang="en"><g id="genid-10" ctype="x-html-a" html:href="http://tiny.cc/bloomHDVideos">High Resolution</g> (Large files)</source>
         <target />
         <note>ID: training.videos.hires</note>
+        <note>Obsolete for Bloom 5.3</note>
       </trans-unit>
       <trans-unit id="training.videos.lores">
         <source xml:lang="en"><g id="genid-11" ctype="x-html-a" html:href="http://tiny.cc/bloomSDVideos">Low Resolution</g> (Smaller files)</source>
         <target />
         <note>ID: training.videos.lores</note>
+        <note>Obsolete for Bloom 5.3</note>
       </trans-unit>
     </body>
   </file>

--- a/src/BloomBrowserUI/infoPages/TrainingVideos-en.md
+++ b/src/BloomBrowserUI/infoPages/TrainingVideos-en.md
@@ -22,5 +22,6 @@ If you are connected to the internet now, you can watch videos in your web brows
 
 If you would like to download any of these videos to show and share when there is no internet connection, you can download videos to your computer: {i18n="training.videos.download"}
 
-- [High Resolution](http://tiny.cc/bloomHDVideos) (Large files) {i18n="training.videos.hires"}
-- [Low Resolution](http://tiny.cc/bloomSDVideos) (Smaller files) {i18n="training.videos.lores"}
+Under the video that you want to download, there should be a Download button. {i18n="training.videos.download.2"}
+
+![](https://i.imgur.com/jZwpoZz.png "Vimeo download button")


### PR DESCRIPTION
* The tiny.cc links were also updated to point to the
   "All videos" link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5184)
<!-- Reviewable:end -->
