### PR TITLE
Fix various problems with unreleased brandings (BL-11162)

### DIFF
--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -638,7 +638,6 @@ namespace Bloom.Collection
 			return folderName;
 		}
 
-
 		public string SubscriptionCode { get; set; }
 
 		public int OneTimeCheckVersionNumber { get; set; }

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -1044,7 +1044,7 @@ namespace Bloom.Publish.Epub
 				if(name == "fonts.css")
 					continue; // generated file for this book, already copied to output.
 				string path;
-				if (name == "customCollectionStyles.css" || name == "defaultLangStyles.css")
+				if (name == "customCollectionStyles.css" || name == "defaultLangStyles.css" || name == "branding.css")
 				{
 					// These files should be in the book's folder, not in some arbitrary place in our search path.
 					path = Path.Combine(_originalBook.FolderPath, name);
@@ -1148,11 +1148,8 @@ namespace Bloom.Publish.Epub
 				// See https://issues.bloomlibrary.org/youtrack/issue/BL-5495.
 				RemoveRegularStylesheets(pageDom);
 				pageDom.AddStyleSheet(Storage.GetFileLocator().LocateFileWithThrow(@"baseEPUB.css").ToLocalhost());
-				var brandingPath = Storage.GetFileLocator().LocateOptionalFile(@"branding.css");
-				if (!string.IsNullOrEmpty(brandingPath))
-				{
-					pageDom.AddStyleSheet(brandingPath.ToLocalhost());
-				}
+				var brandingPath = Path.Combine(Storage.FolderPath, "branding.css"); // should always exist in local folder.
+				pageDom.AddStyleSheet(brandingPath.ToLocalhost());
 			}
 			else
 			{
@@ -1543,6 +1540,10 @@ namespace Bloom.Publish.Epub
 						return false;
 				}
 			}
+			// Some elements we mark with this class because their content comes from CSS and will
+			// not be detected by normal algorithms.
+			if (pageElement.SafeSelectNodes(".//div[contains(@class, 'bloom-force-publish')]").Count > 0)
+				return false;
 			return true;
 		}
 

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -427,7 +427,7 @@ namespace Bloom.Publish
 				SignLanguageApi.ProcessVideos(videoContainerElements, modifiedBook.FolderPath);
 			}
 			modifiedBook.Save();
-			modifiedBook.Storage.UpdateSupportFiles();
+			modifiedBook.UpdateSupportFiles();
 			return modifiedBook;
 		}
 

--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -481,7 +481,7 @@ namespace Bloom.WebLibraryIntegration
 			PublishHelper.RemoveEnterpriseFeaturesIfNeeded(copiedBook, pages, warningMessages);
 			PublishHelper.SendBatchedWarningMessagesToProgress(warningMessages, progress);
 			copiedBook.Save();
-			copiedBook.Storage.UpdateSupportFiles();
+			copiedBook.UpdateSupportFiles();
 			book = copiedBook;
 			return true;
 
@@ -585,7 +585,7 @@ namespace Bloom.WebLibraryIntegration
 			finally
 			{
 				// Put back all the branding files which we removed above in the call to CleanupUnusedSupportFiles()
-				book.Storage.UpdateSupportFiles();
+				book.UpdateSupportFiles();
 
 				// NB: alternatively, we considered refactoring CleanupUnusedSupportFiles() to give us a list of files
 				// to not upload.

--- a/src/content/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/content/templates/xMatter/bloom-xmatter-mixins.pug
@@ -87,10 +87,13 @@ mixin outside-back-cover-branding-top
 		div(data-book='outside-back-cover-branding-top-html' lang="*")
 
 mixin outside-back-cover-branding-bottom
-	div(data-book='outside-back-cover-branding-bottom-html' lang="*")
-		//- this can be overridden in the branding.json file of any branding
-		img(src="full-bloom-logo-grey.svg")
-
+	//- we want to force any page that contains this to be published, because
+	//- when working with a new branding, we generate placeholder text for this
+	//- element in a CSS before: rule, and so it looks as though the element
+	//- is empty, which can lead to the page being omitted in various contexts.
+	//- This has no content by default, but it can be controlled by a data-book
+	//- value in the branding.json for any particular branding.
+	div.bloom-force-publish(data-book='outside-back-cover-branding-bottom-html' lang="*")
 
 //- -------------------------------------------------------------------------------
 //-	Unless every page of your xmatter pack needs to be different than the "factory"


### PR DESCRIPTION
* Update local branding.css when bringing book up to date, and always use exactly that one
* Keep missing and unneeded logo file from causing toast

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5188)
<!-- Reviewable:end -->
