### PR TITLE
Prevent scrolled font menu from jumping (BL-11258)

### DIFF
--- a/src/BloomBrowserUI/react_components/winFormsStyleSelect.tsx
+++ b/src/BloomBrowserUI/react_components/winFormsStyleSelect.tsx
@@ -3,7 +3,7 @@ import { jsx, css } from "@emotion/core";
 import * as React from "react";
 import { makeStyles, ThemeProvider } from "@material-ui/styles";
 import { lightTheme } from "../bloomMaterialUITheme";
-import { FormControl, Select } from "@material-ui/core";
+import { FormControl, MenuProps, Select } from "@material-ui/core";
 
 // This seems to be the only way to affect the css of the popped up list, since it's a completely
 // separate html element from this component.
@@ -27,10 +27,13 @@ interface FormsSelectProps {
 const WinFormsStyleSelect: React.FunctionComponent<FormsSelectProps> = props => {
     const classes = useStyles();
 
-    const selectMenuProps = {
+    const selectMenuProps: Partial<MenuProps> = {
         classes: {
             paper: classes.menuPaper
-        }
+        },
+        // This works around a bug in MUI v4 (https://github.com/mui/material-ui/issues/19245)
+        // which caused the list to jump if it was scrolled and we re-rendered. See BL-11258.
+        getContentAnchorEl: null
     };
 
     lightTheme.overrides = {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5190)
<!-- Reviewable:end -->
