### PR TITLE
Fix BL-11280 [5.2] Tweak boilerplate text in adaptation credits

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1582,7 +1582,7 @@
         <note>ID: EditTab.FrontMatter.EditOriginalTitlePlaceholder</note>
       </trans-unit>
       <trans-unit id="EditTab.FrontMatter.FullOriginalCopyrightLicenseSentence" sil:dynamic="true">
-        <source xml:lang="en">Adapted from original, {0}, {1}. Licensed under {2}.</source>
+        <source xml:lang="en">This book is an adaptation of original, {0}, {1}. Licensed under {2}.</source>
         <note>ID: EditTab.FrontMatter.FullOriginalCopyrightLicenseSentence</note>
         <note>On the Credits page of a book being translated, Bloom shows the original copyright. {0} is original title, {1} is original copyright, and {2} is license information.</note>
       </trans-unit>

--- a/src/BloomExe/Book/BookCopyrightAndLicense.cs
+++ b/src/BloomExe/Book/BookCopyrightAndLicense.cs
@@ -344,7 +344,8 @@ namespace Bloom.Book
 			// At the very least it's easier to localize into the format the language wants to use.
 			var fullFormatString = LocalizationManager.GetString(
 				"EditTab.FrontMatter.FullOriginalCopyrightLicenseSentence",
-				"Adapted from original, {0}, {1}. Licensed under {2}.",
+				//"Adapted from original, {0}, {1}. Licensed under {2}.",
+				"This book is an adaptation of original, {0}, {1}. Licensed under {2}.",
 				"On the Credits page of a book being translated, Bloom shows the original copyright. {0} is original title, {1} is original copyright, and {2} is license information.",
 				languagePriorityIdsNotLang1,
 				out string langUsed);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5199)
<!-- Reviewable:end -->
