### PR TITLE
Fix the ePUB button display location on Linux (20220607)

### DIFF
--- a/src/BloomExe/Publish/PublishView.Designer.cs
+++ b/src/BloomExe/Publish/PublishView.Designer.cs
@@ -188,7 +188,8 @@ namespace Bloom.Publish
 			this.tableLayoutPanel1.ForeColor = System.Drawing.Color.White;
 			this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
 			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-			this.tableLayoutPanel1.RowCount = 10;
+			this.tableLayoutPanel1.RowCount = 11;
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());


### PR DESCRIPTION
Without this, the ePUB button is shoved all the way to the bottom on
Linux, possibly offscreen if the the window is resized to be smaller.
This has no apparent effect on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5208)
<!-- Reviewable:end -->
