### PR TITLE
Populate stack trace in fake error report dialogs

### DIFF
--- a/src/BloomExe/ErrorReporter/ErrorReportUtils.cs
+++ b/src/BloomExe/ErrorReporter/ErrorReportUtils.cs
@@ -97,7 +97,17 @@ namespace Bloom.ErrorReporter
 		private static void CheckForFakeTestErrors(string title)
 		{
 			const string fakeProblemMessage = "Fake problem for development/testing purposes";
-			var fakeException = new ApplicationException("Fake exception for development/testing purposes");
+			Exception fakeException;
+
+			// Throwing/catching the exception populates the stack trace
+			try
+			{
+				throw new ApplicationException("Fake exception for development/testing purposes");
+			}
+			catch (ApplicationException e)
+			{
+				fakeException = e;
+			}
 			
 			if (title == "Error NotifyUser NoReport")
 			{


### PR DESCRIPTION
All this does is give slightly more realistic behavior in the fake error report dialogs used for development/testing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5209)
<!-- Reviewable:end -->
