### PR TITLE
Fix BL-11290, remove full-bleed if branding no longer requests it

### DIFF
--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -1867,7 +1867,11 @@ namespace Bloom.Book
 			// old stuff hanging around.
 			foreach (var key in _dataset.TextVariables.Keys.ToArray())
 			{
-				if (key.ToLowerInvariant().Contains("branding"))
+				// About "fullBleed": see https://issues.bloomlibrary.org/youtrack/issue/BL-11290. This key
+				// didn't have the word "branding" in it because logically it didn't belong
+				// in there, but nevertheless it created the same problems.
+
+				if (key.ToLowerInvariant().Contains("branding") || key == "fullBleed")
 				{
 					RemoveAllForms(key);
 				}

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -2897,6 +2897,10 @@ namespace Bloom.Book
 		public static void InsertFullBleedMarkup(XmlElement body)
 		{
 			AddClassIfMissing(body, "bloom-fullBleed");
+			// Note: at the moment, as far as I can tell, this is a runtime-only structure change. It does not get saved
+			// because we only save at the div.bloom-page level, and this div.bloom-mediaBox is a wrapper around the page.
+			// This is important in the scenario where a book was full-bleed, but then is re-purposed elsewhere.
+			// See https://issues.bloomlibrary.org/youtrack/issue/BL-11290
 			foreach (XmlElement page in body.SafeSelectNodes("//div[contains(@class, 'bloom-page')]").Cast<XmlElement>().ToArray())
 			{
 				var mediaBoxDiv = page.OwnerDocument.CreateElement("div");

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -735,6 +735,56 @@ namespace BloomTests.Book
 			}
 		}
 
+
+		[Test]
+		public void MergeBrandingSettings_HasPreviousBrandingData_Removed()
+		{
+			HtmlDom bookDom = new HtmlDom(@"<html><head></head><body>
+				<div id='bloomDataDiv'>
+						<div data-book='branding-foo' lang='*'>foo</div>
+				</div>
+			 </body></html>");
+			using (var tempFolder = new TemporaryFolder("MergeBrandingSettings_HasPreviousBrandingData_Removed"))
+			{
+				File.WriteAllText(Path.Combine(tempFolder.Path, "branding.json"),
+					@"{
+	""presets"": [{
+		""data-book"": ""branding-blah"",
+		""lang"": ""*"",
+		""content"": ""blah"",
+		""condition"":""always""
+	}]
+}");
+				var data = new BookData(bookDom, _collectionSettings, null);
+				data.MergeBrandingSettings(tempFolder.Path);
+				Assert.That(data.GetVariableOrNull("branding-foo", "*").Xml, Is.Null); // removed because it wasn't mentioned in the new branding
+				Assert.That(data.GetVariableOrNull("branding-blah", "*").Xml, Is.EqualTo("blah"));
+			}
+		}
+
+		[Test]
+		public void MergeBrandingSettings_HasPreviousFullBleedFlag_Removed()
+		{
+			// About "fullBleed": see https://issues.bloomlibrary.org/youtrack/issue/BL-11290. This key
+			// didn't have the word "branding" in it because logically it didn't belong
+			// in there, but nevertheless it created the same problems.
+
+			HtmlDom bookDom = new HtmlDom(@"<html><head></head><body>
+				<div id='bloomDataDiv'>
+						<div data-book='fullBleed' lang='*'>true</div>
+				</div>
+			 </body></html>");
+			using (var tempFolder = new TemporaryFolder("MergeBrandingSettings_HasPreviousBrandingData_Removed"))
+			{
+				File.WriteAllText(Path.Combine(tempFolder.Path, "branding.json"),
+					@"{	""presets"": [{	}]}");
+				var data = new BookData(bookDom, _collectionSettings, null);
+				data.MergeBrandingSettings(tempFolder.Path);
+				Assert.That(data.GetVariableOrNull("fullBleed", "*").Xml, Is.Null); // removed because it wasn't mentioned in the new branding
+			}
+		}
+
+
 		[Test]
 		public void
 			SuckInDataFromEditedDom_XmatterPageAttributeAddedToXmatterPage_XmatterPageAttributeAddedToBookDataAndDataDiv()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5225)
<!-- Reviewable:end -->
