### PR TITLE
Restore pasting of formatted text (BL-11325)

### DIFF
--- a/src/BloomBrowserUI/lib/ckeditor/config.js
+++ b/src/BloomBrowserUI/lib/ckeditor/config.js
@@ -69,7 +69,7 @@ CKEDITOR.editorConfig = function(config) {
     // indicates that an href is required, not that it is forbidden. (Without annotations, listing a tag
     // means it may be pasted, but any attributes in the original will be removed.)
     // Therefore for now we're limiting pasting to things that a translator could also do:
-    config.pasteFilter = "p b br em i strong sup u a[!href];";
+    config.pasteFilter = "p b br em i strong sup u; a[!href];";
 
     //BL-3009: don't remove empty spans, since we use <span class="bloom-linebreak"></span> when you press shift-enter.
     //http://stackoverflow.com/a/23983357/723299


### PR DESCRIPTION
It's sad what missing a silly semicolon can do...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5237)
<!-- Reviewable:end -->
