### PR TITLE
Fix BloomPUB preview when book file name has parentheses (BL-11352)

### DIFF
--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -594,9 +594,9 @@ namespace Bloom.Publish.Android
 		internal bool LicenseOK;
 
 		/// <summary>
-		/// Generates a .bloompub file from the book
+		/// Generates an unzipped, staged BloomPUB from the book
 		/// </summary>
-		/// <returns>A valid, well-formed URL on localhost that points to the bloompub</returns>
+		/// <returns>A valid, well-formed URL on localhost that points to the staged book's htm file</returns>
 		public string MakeBloomPubForPreview(Book.Book book, BookServer bookServer, WebSocketProgress progress, Color backColor, AndroidPublishSettings settings = null)
 		{
 			progress.Message("PublishTab.Epub.PreparingPreview", "Preparing Preview");	// message shared with Epub publishing
@@ -652,7 +652,7 @@ namespace Bloom.Publish.Android
 				_webSocketServer.SendBundle("publishPageLabels", "ready", messageBundle);
 			}
 
-			return modifiedBook.FolderPath.ToLocalhost();
+			return modifiedBook.GetPathHtmlFile().ToLocalhost();
 		}
 
 		/// <summary>

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -443,14 +443,14 @@ namespace Bloom.Api
 			if (ProcessImageFileRequest(info))
 				return true;
 
-			if(localPath.Contains("CURRENTPAGE")) //useful when debugging. E.g. http://localhost:8091/bloom/CURRENTPAGE.htm will always show the page we're on.
+			if(localPath.Contains("CURRENTPAGE")) //useful when debugging. E.g. http://localhost:8089/bloom/CURRENTPAGE.htm will always show the page we're on.
 			{
 				localPath = _keyToCurrentPage;
 			}
-			if (localPath.ToLower().Contains("current-bloompub-url")) //useful when debugging. E.g. http://localhost:8091/bloom/current-bloompub-url.htm will always show the page we're on.
+			if (localPath.ToLower().Contains("current-bloompub-url")) //useful when debugging. E.g. http://localhost:8089/bloom/current-bloompub-url will always show the page we're on.
 			{
-				info.ResponseContentType = "text/plain";
-				info.WriteCompleteOutput(PublishToAndroidApi.PreviewUrl);
+				info.ResponseContentType = "text/html";
+				info.WriteCompleteOutput($"<meta http-equiv=\"Refresh\" content=\"0; url='{PublishToAndroidApi.PreviewUrl}'\" />");
 				return true;
 			}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5253)
<!-- Reviewable:end -->
