### PR TITLE
Fix book download not opening (BL-11326)

### DIFF
--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -399,7 +399,7 @@ namespace Bloom.Collection
 		}
 
 		/// <summary>
-		/// This could plausibly be a Dispose(), but I don't want to make BoolCollection Disposable, as most of them don't need it.
+		/// This could plausibly be a Dispose(), but I don't want to make BookCollection Disposable, as most of them don't need it.
 		/// </summary>
 		public void StopWatchingDirectory()
 		{

--- a/src/BloomExe/CollectionTab/CollectionTabView.Designer.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.Designer.cs
@@ -17,10 +17,16 @@ namespace Bloom.CollectionTab
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
 				BookCollection.CollectionCreated -= OnBookCollectionCreated;
-				components.Dispose();
+
+				var collections = _model?.GetBookCollections() ?? System.Linq.Enumerable.Empty<BookCollection>();
+				foreach (var collection in collections)
+					collection?.StopWatchingDirectory();
+
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/src/BloomExe/CollectionTab/CollectionTabView.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.cs
@@ -14,6 +14,7 @@ using Bloom.TeamCollection;
 using Bloom.ToPalaso;
 using Bloom.web;
 using SIL.Windows.Forms.SettingProtection;
+using System.Diagnostics;
 
 namespace Bloom.CollectionTab
 {
@@ -151,7 +152,10 @@ namespace Bloom.CollectionTab
 				c.FolderContentChanged += (sender, eventArgs) =>
 				{
 					if (IsDisposed)
+					{
+						Debug.Fail("FolderContentChanged handler invoked from a CollectionTabView that has already been disposed. Did the collection have cleanup such as StopWatchingDirectory() occur?");
 						return;
+					}
 					if (_tabSelection.ActiveTab == WorkspaceTab.collection)
 					{
 						// We got a new or modified book in the downloaded books collection.


### PR DESCRIPTION
The problem occurs after switching collections. There are 2 CollectionTabView instances and 2 BookCollection instances attempting to watch the same directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5257)
<!-- Reviewable:end -->
