### PR TITLE
Fix "no-empty-function" eslint  warnings

### DIFF
--- a/src/BloomBrowserUI/.eslintrc.js
+++ b/src/BloomBrowserUI/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
         ],
         // turned these on when first using eslint. TODO: Review these
         "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-empty-function": "warn",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-unused-vars": "off",
         "react/no-unescaped-entities": "off", // review

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/LicensePanel.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/LicensePanel.tsx
@@ -187,7 +187,9 @@ export const LicensePanel: React.FunctionComponent<{
                             checked={
                                 licenseType === LicenseType.CreativeCommons
                             }
-                            onCheckChanged={() => {}}
+                            onCheckChanged={() => {
+                                // No handler needed because the checkbox is disabled.
+                            }}
                         />
                         <MuiCheckbox
                             label={`use the ${getBookOrImage()} in a commercial way`}
@@ -351,8 +353,7 @@ const Radio: React.FunctionComponent<{
         <MuiRadio
             label={props.label}
             l10nKey={props.l10nKey}
-            onChanged={() => {}}
             value={props.value}
-        ></MuiRadio>
+        />
     );
 };

--- a/src/BloomBrowserUI/bookEdit/js/arrowKeyWorkaroundManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/arrowKeyWorkaroundManager.ts
@@ -22,7 +22,6 @@ export class ArrowKeyWorkaroundManager {
     private debug: boolean = false;
 
     private direction: "up" | "down";
-    public constructor() {}
 
     // Checks a keyboard event to see if we want to modify the behavior.
     // If so, calls moveAnchor() and stops the event's default behavior.

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.tsx
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.tsx
@@ -211,14 +211,10 @@ const PageList: React.FunctionComponent<{ pageSize: string }> = props => {
                 const pageElt = e.currentTarget.closest("[id]")!;
                 const pageId = pageElt.getAttribute("id");
                 const caption = pageElt.getAttribute("data-caption");
-                BloomApi.postJson(
-                    "pageList/pageClicked",
-                    {
-                        pageId,
-                        detail: caption
-                    },
-                    () => {}
-                );
+                BloomApi.postJson("pageList/pageClicked", {
+                    pageId,
+                    detail: caption
+                });
             }
         }
     };
@@ -407,21 +403,16 @@ function onDragStop(
         // the page clicked. (Note however that this seems to get fired on any click,
         // even just closing a popup menu, so it's possible that we might get more
         // click events than we really want.)
-        BloomApi.postJson(
-            "pageList/pageClicked",
-            { pageId: movedPageId, detail: "unknown" },
-            () => {}
-        );
+        BloomApi.postJson("pageList/pageClicked", {
+            pageId: movedPageId,
+            detail: "unknown"
+        });
         return;
     }
     // Needs more smarts if we ever do other than two columns.
     const newIndex = newItem.y * 2 + newItem.x;
 
-    BloomApi.postJson(
-        "pageList/pageMoved",
-        { movedPageId, newIndex },
-        () => {}
-    );
+    BloomApi.postJson("pageList/pageMoved", { movedPageId, newIndex });
 }
 
 function ContinueAutomatedPageClicking(

--- a/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettings.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/bookSettings/bookSettings.ts
@@ -58,9 +58,8 @@ export class BookSettings implements ITool {
         return false;
     }
     // We need these to implement the interface, but don't need them to do anything.
-    /* tslint:disable:no-empty */ public configureElements(
-        container: HTMLElement
-    ) {}
+    /* eslint-disable @typescript-eslint/no-empty-function */
+    public configureElements(container: HTMLElement) {}
     public showTool() {}
     public hideTool() {}
     public updateMarkup() {}
@@ -73,5 +72,5 @@ export class BookSettings implements ITool {
     public newPageReady() {}
     public detachFromPage() {}
     public finishToolLocalization(pane: HTMLElement) {}
-    /* tslint:enable:no-empty */
+    /* eslint-enable @typescript-eslint/no-empty-function */
 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/decodableReader/decodableReaderToolboxTool.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/decodableReader/decodableReaderToolboxTool.ts
@@ -173,7 +173,7 @@ export class DecodableReaderToolboxTool implements ITool {
     }
     public async updateMarkupAsync() {
         throw "not implemented...use updateMarkup";
-        return () => {};
+        return () => undefined;
     }
 
     public isUpdateMarkupAsync(): boolean {

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/leveledReaderToolboxTool.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/leveledReaderToolboxTool.ts
@@ -34,7 +34,9 @@ export class LeveledReaderToolboxTool implements ITool {
         });
     }
 
-    public configureElements(container: HTMLElement) {}
+    public configureElements(container: HTMLElement) {
+        // Implements ITool interface, but no work needs to be done.
+    }
     public isAlwaysEnabled(): boolean {
         return false;
     }
@@ -71,7 +73,7 @@ export class LeveledReaderToolboxTool implements ITool {
     }
     public async updateMarkupAsync() {
         throw "not implemented...use updateMarkup";
-        return () => {};
+        return () => undefined;
     }
 
     public isUpdateMarkupAsync(): boolean {

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -90,7 +90,9 @@ export class ReaderToolsModel {
     /**
      * @summary Performs synchronous initialization. Call initAsync() after constructor to do the asynchronous initialization
      */
-    public constructor() {}
+    public constructor() {
+        // Nothing needed here anymore, everything happens in initAsync now.
+    }
 
     // Should be called after the constructor.
     // Performs any initialization that should happen in the constructor, but is asynchronous.

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -2560,16 +2560,19 @@ export default class AudioRecording {
         if (editables.length === 0) {
             // no editable text on this page.
             this.changeStateAndSetExpectedAsync("");
-            return () => {};
+            return () => {
+                // No updates needed because no editables
+            };
         }
 
         // First, see if we should update the Current Highlight to the element with the active focus instead.
         await this.moveCurrentTextboxIfNeededAsync();
         const currentTextBox = this.getCurrentTextBox();
         if (!currentTextBox) {
-            // This could be reached if you create a new page with the talking book tool open.
-            // It's fine. Don't bother doing anything.
-            return () => {};
+            return () => {
+                // This could be reached if you create a new page with the talking book tool open.
+                // It's fine. Don't bother doing anything.
+            };
         }
 
         // Now we can carry on with changing the HTML markup with the audio-sentence classes, ids, etc.
@@ -2649,10 +2652,11 @@ export default class AudioRecording {
                 playbackMode
             );
         } else {
-            // Just keep the code from changing the splits.
-            // No notification right now, which I think in many cases would be fine
-            // But if you want to add some notification UI, it can go here.
-            return () => {};
+            return () => {
+                // Just keep the code from changing the splits.
+                // No notification right now, which I think in many cases would be fine
+                // But if you want to add some notification UI, it can go here.
+            };
         }
     }
 
@@ -4048,6 +4052,7 @@ export default class AudioRecording {
 
     public processAutoSegmentResponse(
         result: AxiosResponse<any>,
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
         doneCallback = () => {}
     ): void {
         const isSuccess = result && result.data;

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
@@ -21,7 +21,9 @@ export default class TalkingBookTool implements ITool {
         return false;
     }
 
-    public configureElements(container: HTMLElement) {}
+    public configureElements(container: HTMLElement) {
+        // Implements ITool interface, but we don't need to do anything
+    }
 
     // When are showTool, newPageReady, and updateMarkup called?
     // Some scenarios:

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolboxToolReactAdaptor.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolboxToolReactAdaptor.tsx
@@ -33,6 +33,8 @@ export default abstract class ToolboxToolReactAdaptor
         result.resolve();
         return result;
     }
+    // We need these to implement the interface, but don't need them to do anything.
+    /* eslint-disable @typescript-eslint/no-empty-function */
     public showTool() {}
     public hideTool() {}
     public updateMarkup() {}
@@ -47,6 +49,7 @@ export default abstract class ToolboxToolReactAdaptor
     public detachFromPage() {}
     public configureElements(container: HTMLElement) {}
     public finishToolLocalization(pane: HTMLElement) {}
+    /* eslint-enable @typescript-eslint/no-empty-function */
 
     public static getPageFrame(): HTMLIFrameElement {
         return parent.window.document.getElementById(

--- a/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
@@ -512,8 +512,9 @@ export const makeMenuItems = (
                     <LocalizableCheckboxMenuItem
                         english={spec.label}
                         l10nId={spec.l10nId!}
-                        // We deliberately do NOT close the menu, so the user can see it really got checked.
-                        onClick={() => {}}
+                        onClick={() => {
+                            // We deliberately do NOT close the menu, so the user can see it really got checked.
+                        }}
                         apiEndpoint={spec.command!}
                     ></LocalizableCheckboxMenuItem>
                 );

--- a/src/BloomBrowserUI/lib/localizationManager/localizationManagerSpec.ts
+++ b/src/BloomBrowserUI/lib/localizationManager/localizationManagerSpec.ts
@@ -5,11 +5,9 @@ import theOneLocalizationManager from "./localizationManager";
 "use strict";
 
 describe("localizationManager", () => {
-    beforeEach(() => {});
-
     /* This doesn't work. The old version would never fail, because it didn't actually account for how to handle
         async calls. I've adjusted it to be apparently correct, but now we run into the problem that the method under
-        test here actually fails in some non-understoodway.  See BL-3554.
+        test here actually fails in some non-understood way.  See BL-3554.
 
             it("asyncGetTextInLang returns English if in a unit test environment", function (done) {
                     theOneLocalizationManager.asyncGetTextInLang('theKey','someEnglishWord', 'fr').done(result => {

--- a/src/BloomBrowserUI/publish/LibraryPublish/LoginDialog.tsx
+++ b/src/BloomBrowserUI/publish/LibraryPublish/LoginDialog.tsx
@@ -140,7 +140,7 @@ export const LoginDialog: React.FunctionComponent<{}> = props => {
                 //Sentry.captureException(error); // probably won't happen, nothing seems to bring us here
                 console.error("!!!!!!!!!!! signInFailure");
                 alert("signInFailure");
-                return new Promise((r, x) => {});
+                return;
             },
             // The API supports these, but I haven't found them to do anything.
             // Terms of service url.

--- a/src/BloomBrowserUI/publish/commonPublish/PublishProgressDialog.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/PublishProgressDialog.tsx
@@ -124,7 +124,6 @@ export const PublishProgressDialog: React.FunctionComponent<{
             messages={accumulatedMessages}
             progressState={props.progressState}
             onUserStopped={() => props.onUserStopped && props.onUserStopped()}
-            onUserCanceled={() => {}}
             onUserClosed={() => {
                 setAccumulatedMessages("");
                 setErrorEncountered(false);

--- a/src/BloomBrowserUI/publish/commonPublish/PublishProgressDialogInner.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/PublishProgressDialogInner.tsx
@@ -29,7 +29,7 @@ export const ProgressDialogInner: React.FunctionComponent<{
     errorEncountered?: boolean; // do something visual to indicate there was a problem
     onUserClosed: () => void;
     onUserStopped: () => void;
-    onUserCanceled: () => void;
+    // onUserCanceled: () => void;  // Not implemented yet
 }> = props => {
     const messagesDivRef = React.useRef<HTMLDivElement>(null);
     const messageEndRef = React.useRef<HTMLDivElement>(null);

--- a/src/BloomBrowserUI/publish/metadata/BookMetadataTable.tsx
+++ b/src/BloomBrowserUI/publish/metadata/BookMetadataTable.tsx
@@ -29,7 +29,6 @@ export default class BookMetadataTable extends React.Component<IProps> {
     constructor(props) {
         super(props);
     }
-    public componentDidMount() {}
     public render() {
         return (
             <div>

--- a/src/BloomBrowserUI/publish/stories.tsx
+++ b/src/BloomBrowserUI/publish/stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import { lightTheme } from "../bloomMaterialUITheme";
 import * as React from "react";
 import { ThemeProvider } from "@material-ui/styles";
@@ -49,7 +50,6 @@ storiesOf("Publish/ProgressDialog", module)
                 heading={"Working hard..."}
                 instruction={"Just sit there and watch it spin."}
                 onUserClosed={() => {}}
-                onUserCanceled={() => {}}
                 onUserStopped={() => {}}
             />
         </div>
@@ -60,7 +60,6 @@ storiesOf("Publish/ProgressDialog", module)
                 progressState={ProgressState.Done}
                 messages={testText}
                 onUserClosed={() => {}}
-                onUserCanceled={() => {}}
                 onUserStopped={() => {}}
             />
         </div>
@@ -73,7 +72,6 @@ storiesOf("Publish/ProgressDialog", module)
                 messages={testText}
                 heading={"Sky is falling"}
                 onUserClosed={() => {}}
-                onUserCanceled={() => {}}
                 onUserStopped={() => {}}
             />
         </div>

--- a/src/BloomBrowserUI/react_components/BloomDialog/commonDialogComponents.tsx
+++ b/src/BloomBrowserUI/react_components/BloomDialog/commonDialogComponents.tsx
@@ -78,13 +78,11 @@ export const DialogFolderChooserWithApi: React.FunctionComponent<{
                 variant="text"
                 onClick={() =>
                     BloomApi.post(
-                        props.apiCommandToChooseAndSetFolder,
+                        props.apiCommandToChooseAndSetFolder
                         // nothing to do either on success or failure, including possible timeout,
                         // or the user canceling. This is because the "result" comes back to browser-land
                         // via a websocket that sets the new result. This approach is needed because otherwise
                         // the browser would time out while waiting for the user to finish using the system folder-choosing dialog.
-                        () => {},
-                        () => {}
                     )
                 }
             >

--- a/src/BloomBrowserUI/react_components/fontInformationPane.tsx
+++ b/src/BloomBrowserUI/react_components/fontInformationPane.tsx
@@ -112,7 +112,9 @@ const FontInformationPane: React.FunctionComponent<{
                 startIcon={<CloseIcon htmlColor="white" />}
                 size="small"
                 // Clicking anywhere on the pane works, but w/o the button the user might not know this.
-                onClick={() => {}}
+                onClick={() => {
+                    // Do nothing
+                }}
                 css={css`
                     order: 1; // put icon in upper right corner
                     padding: 2px !important;

--- a/src/BloomBrowserUI/react_components/helpLink.tsx
+++ b/src/BloomBrowserUI/react_components/helpLink.tsx
@@ -60,7 +60,6 @@ export const WhatsThisBlock: React.FunctionComponent<{
                 variant="text"
                 enabled={true}
                 l10nKey="Common.WhatsThis"
-                onClick={() => {}}
                 css={css`
                     position: absolute !important;
                     right: 0;

--- a/src/BloomBrowserUI/react_components/htmlHelpLink.tsx
+++ b/src/BloomBrowserUI/react_components/htmlHelpLink.tsx
@@ -25,7 +25,11 @@ export default class HtmlHelpLink extends LocalizableElement<
             // the correct behavior.
             <Link
                 target="_blank"
-                onClick={() => BloomApi.getString(this.target, dummy => {})}
+                onClick={() =>
+                    BloomApi.getString(this.target, dummy => {
+                        // Do nothing
+                    })
+                }
             >
                 {this.getLocalizedContent()}
             </Link>

--- a/src/BloomBrowserUI/react_components/muiRadio.tsx
+++ b/src/BloomBrowserUI/react_components/muiRadio.tsx
@@ -11,7 +11,7 @@ export const MuiRadio: React.FunctionComponent<ILocalizationProps & {
     label: string;
     value?: string;
     disabled?: boolean;
-    onChanged: (v: boolean | undefined) => void;
+    onChanged?: (v: boolean | undefined) => void;
 }> = props => {
     const localizedLabel = useL10n(
         props.label,
@@ -40,7 +40,9 @@ export const MuiRadio: React.FunctionComponent<ILocalizationProps & {
                         value={props.value}
                         disabled={props.disabled}
                         onChange={(e, newState) => {
-                            props.onChanged(newState);
+                            if (props.onChanged) {
+                                props.onChanged(newState);
+                            }
                         }}
                         color="primary"
                     />

--- a/src/BloomBrowserUI/react_components/stories.tsx
+++ b/src/BloomBrowserUI/react_components/stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 /** @jsxFrag React.Fragment */
 /** @jsx jsx **/
 import { jsx, css } from "@emotion/core";
@@ -291,7 +292,6 @@ storiesOf("Localizable Widgets/MuiRadio", module).add("MuiRadio", () =>
                     "Bacon ipsum dolor amet ribeye spare ribs bresaola t-bone. Strip steak turkey shankle pig ground round, biltong t-bone kevin alcatra flank ribeye beef ribs meatloaf filet mignon. Buffalo ham t-bone short ribs. Sausage alcatra tail, sirloin andouille pork belly corned beef shoulder meatloaf venison rump frankfurter bresaola chicken. Ball tip strip steak burgdoggen spare ribs picanha, turducken filet mignon ham hock short loin porchetta rump andouille t-bone boudin."
                 }
                 l10nKey={""}
-                onChanged={() => {}}
             />
             <hr />
             original mui radio:
@@ -309,7 +309,7 @@ storiesOf("Localizable Widgets/MuiRadio", module).add("MuiRadio", () =>
                     display: flex;
                 `}
             >
-                <MuiRadio label={"short"} l10nKey={""} onChanged={() => {}} />
+                <MuiRadio label={"short"} l10nKey={""} />
                 <FormControlLabel control={<Radio />} label={"short"} />
             </div>
         </MuiRadioGroup>

--- a/src/BloomBrowserUI/teamCollection/ForceUnlockDialog.tsx
+++ b/src/BloomBrowserUI/teamCollection/ForceUnlockDialog.tsx
@@ -106,11 +106,7 @@ export const ForceUnlockDialog: React.FunctionComponent<{
                         onClick={() => {
                             props.close();
                             // Do nothing here on either success or failure. (C# code will have already reported failure).
-                            BloomApi.post(
-                                "teamCollection/forceUnlock",
-                                () => {},
-                                () => {}
-                            );
+                            BloomApi.post("teamCollection/forceUnlock");
                         }}
                         hasText={true}
                     >

--- a/src/BloomBrowserUI/teamCollection/ForgetChangesDialog.tsx
+++ b/src/BloomBrowserUI/teamCollection/ForgetChangesDialog.tsx
@@ -71,9 +71,7 @@ export const ForgetChangesDialog: React.FunctionComponent<{
                             props.close();
                             // Do nothing here on either success or failure. (C# code will have already reported failure).
                             BloomApi.post(
-                                "teamCollection/forgetChangesInSelectedBook",
-                                () => {},
-                                () => {}
+                                "teamCollection/forgetChangesInSelectedBook"
                             );
                         }}
                         hasText={true}

--- a/src/BloomBrowserUI/teamCollection/stories.tsx
+++ b/src/BloomBrowserUI/teamCollection/stories.tsx
@@ -322,7 +322,7 @@ const menuItems: (SimpleMenuItem | "-")[] = [
     {
         text: "About my Avatar...",
         l10nKey: "TeamCollection.AboutAvatar",
-        action: () => {}
+        action: () => undefined
     }
 ];
 const menuBoxStyles: React.CSSProperties = {
@@ -349,7 +349,7 @@ storiesOf("Team Collection components/Menu component", module).add(
 );
 
 storiesOf("BloomDialog", module).add("Test drag & resize", () => (
-    <BloomDialog onClose={() => {}} open={true}>
+    <BloomDialog onClose={() => undefined} open={true}>
         <DialogTitle title="Drag Me" />
         <DialogMiddle>
             <p>Blah</p>
@@ -364,7 +364,7 @@ storiesOf("BloomDialog", module).add("Test drag & resize", () => (
             <p>Blah</p>
         </DialogMiddle>
         <DialogBottomButtons>
-            <DialogCancelButton onClick={() => {}} />
+            <DialogCancelButton onClick={() => undefined} />
         </DialogBottomButtons>
     </BloomDialog>
 ));

--- a/src/BloomBrowserUI/utils/bloomApi.ts
+++ b/src/BloomBrowserUI/utils/bloomApi.ts
@@ -410,7 +410,7 @@ export class BloomApi {
                         "Content-Type": "text/plain"
                     }
                 })
-                .then(successCallback ? successCallback : () => {})
+                .then(successCallback)
         );
     }
 
@@ -442,7 +442,7 @@ export class BloomApi {
         BloomApi.wrapAxios(
             axios
                 .post(getBloomApiPrefix() + urlSuffix)
-                .then(successCallback ? successCallback : () => {}) // do nothing on success if no callback
+                .then(successCallback) // (no-ops if successCallback is undefined)
                 .catch(
                     failureCallback
                         ? failureCallback
@@ -483,7 +483,7 @@ export class BloomApi {
         return BloomApi.wrapAxios(
             axios
                 .post(getBloomApiPrefix() + urlSuffix, data)
-                .then(successCallback ? successCallback : () => {})
+                .then(successCallback)
                 .catch(r => {
                     if (errorCallback) {
                         errorCallback(r);


### PR DESCRIPTION
This warning is in eslint's recommended list.
eslint doesn't like it supposedly because:

1. Hard to tell if it was intentional or mistake
2. Hard to tell if it's an empty function or returning an empty object.

Solutions:

1. eslint recommends adding a comment in the body explicitly explaining that you want to "do nothing", etc.
2. () => undefined technically also works, although idk that it's any more clear
3. disabling the rule (temporarily or globally) also works...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5265)
<!-- Reviewable:end -->
