### PR TITLE
Use BloomFolderChooser everywhere for choosing folders (BL-11166)

### DIFF
--- a/src/BloomExe/CollectionTab/CollectionModel.cs
+++ b/src/BloomExe/CollectionTab/CollectionModel.cs
@@ -300,16 +300,12 @@ namespace Bloom.CollectionTab
 
 		public void RescueMissingImages()
 		{
-			using (var dlg = new FolderBrowserDialog())
-			{
-				dlg.ShowNewFolderButton = false;
-				dlg.Description = "Select the folder where replacement images can be found";
-				if (DialogResult.OK == dlg.ShowDialog(MainShell))
-				{
-					AttemptMissingImageReplacements(dlg.SelectedPath);
-				}
-			}
+			var initialPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+			var selectedPath = BloomFolderChooser.ChooseFolder(initialPath, "Select the folder where replacement images can be found");
+			if (!string.IsNullOrEmpty(selectedPath))
+				AttemptMissingImageReplacements(selectedPath);
 		}
+
 		public void MakeReaderTemplateBloompack()
 		{
 			using (var dlg = new MakeReaderTemplateBloomPackDlg())

--- a/src/BloomExe/MiscUI/BloomFolderChooser.cs
+++ b/src/BloomExe/MiscUI/BloomFolderChooser.cs
@@ -14,25 +14,27 @@ namespace Bloom.MiscUI
 	/// </summary>
 	public static class BloomFolderChooser
 	{
-		public static string ChooseFolder(string initialFolderPath)
+		public static string ChooseFolder(string initialFolderPath, string description = null)
 		{
 			if (SIL.PlatformUtilities.Platform.IsWindows)
 			{
 				// Split into a separate method to prevent the Mono runtime from trying to
 				// reference Windows-only assemblies on Linux.
-				return SelectFolderOnWindows(initialFolderPath);
+				return SelectFolderOnWindows(initialFolderPath, description);
 			}
 			else
 			{
 				var dialog = new DialogAdapters.FolderBrowserDialogAdapter();
 				dialog.SelectedPath = initialFolderPath;
+				if (!string.IsNullOrEmpty(description))
+					dialog.Description = description;
 				if (dialog.ShowDialog() == DialogResult.OK)
 					return dialog.SelectedPath;
 			}
 			return null;
 		}
 
-		private static string SelectFolderOnWindows(string initialFolderPath)
+		private static string SelectFolderOnWindows(string initialFolderPath, string description)
 		{
 #if !__MonoCS__
 			// Note, this is Windows only.
@@ -41,6 +43,8 @@ namespace Bloom.MiscUI
 				InitialDirectory = initialFolderPath,
 				IsFolderPicker = true
 			};
+			if (!string.IsNullOrEmpty(description))
+				dialog.Title = description;
 			// If we can find Bloom's main window, bring the dialog up on that screen.
 			var rootForm = Application.OpenForms.Cast<Form>().FirstOrDefault(f => f is Shell);
 			var result = rootForm == null ? dialog.ShowDialog() : dialog.ShowDialog(rootForm.Handle);

--- a/src/BloomExe/Utils/MiscUtils.cs
+++ b/src/BloomExe/Utils/MiscUtils.cs
@@ -391,28 +391,19 @@ namespace Bloom.Utils
 			bool repeat = false;
 			do
 			{
-				using (var dlg = new FolderBrowserDialog())
+				resultPath = MiscUI.BloomFolderChooser.ChooseFolder(initialPath, description);
+				if (string.IsNullOrEmpty(resultPath))
+					return null;
+				string collectionFolder = string.Empty;
+				repeat = isForOutput && IsFolderInsideBloomCollection(resultPath, out collectionFolder);
+				if (repeat)
 				{
-					if (!String.IsNullOrEmpty(initialPath))
-						dlg.SelectedPath = initialPath;
-					dlg.ShowNewFolderButton = true;
-
-					if (!string.IsNullOrEmpty(description))
-						dlg.Description = description;
-
-					var success = dlg.ShowDialog() == DialogResult.OK;
-					resultPath = success ? dlg.SelectedPath : "";
-					string collectionFolder = string.Empty;
-					repeat = success && isForOutput && Utils.MiscUtils.IsFolderInsideBloomCollection(resultPath, out collectionFolder);
-					if (repeat)
-					{
-						Utils.MiscUtils.WarnUserOfInvalidFolderChoice(collectionFolder, resultPath);
-						// Change the initialFolder to just above the collection folder, or to the documents folder
-						// if that ends up empty.
-						initialPath = Path.GetDirectoryName(collectionFolder);
-						if (String.IsNullOrEmpty(initialPath))
-							initialPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-					}
+					WarnUserOfInvalidFolderChoice(collectionFolder, resultPath);
+					// Change the initialFolder to just above the collection folder, or to the documents folder
+					// if that ends up empty.
+					initialPath = Path.GetDirectoryName(collectionFolder);
+					if (string.IsNullOrEmpty(initialPath))
+						initialPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 				}
 			} while (repeat);
 			return resultPath;


### PR DESCRIPTION
This avoids the ugly, bad UX default folder chooser dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5281)
<!-- Reviewable:end -->
