### PR TITLE
Embed progress dialog in current page when possible (BL-11282)

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
@@ -26,6 +26,7 @@ import { SpreadsheetExportDialogLauncher } from "./spreadsheet/SpreadsheetExport
 import { H1 } from "../react_components/l10nComponents";
 import { useL10n } from "../react_components/l10nHooks";
 import { useSubscribeToWebSocketForEvent } from "../utils/WebSocketManager";
+import { EmbeddedProgressDialog } from "../react_components/Progress/ProgressDialog";
 
 const kResizerSize = 10;
 
@@ -418,6 +419,7 @@ export const CollectionsTabPane: React.FunctionComponent<{}> = () => {
             )}
             <TeamCollectionDialogLauncher />
             <SpreadsheetExportDialogLauncher />
+            <EmbeddedProgressDialog />
         </div>
     );
 };

--- a/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
@@ -8,7 +8,7 @@ import {
     PublishPanel,
     HelpGroup,
     SettingsPanel,
-    CommandsGroup,
+    CommandsGroup
 } from "../commonPublish/PublishScreenBaseComponents";
 import { MethodChooser } from "./MethodChooser";
 import { PublishFeaturesGroup } from "./PublishFeaturesGroup";
@@ -21,14 +21,14 @@ import { darkTheme, lightTheme } from "../../bloomMaterialUITheme";
 import { StorybookContext } from "../../.storybook/StoryBookContext";
 import {
     useSubscribeToWebSocketForStringMessage,
-    useSubscribeToWebSocketForEvent,
+    useSubscribeToWebSocketForEvent
 } from "../../utils/WebSocketManager";
 import { BloomApi } from "../../utils/bloomApi";
 import HelpLink from "../../react_components/helpLink";
 import { Link, LinkWithDisabledStyles } from "../../react_components/link";
 import {
     RequiresBloomEnterpriseAdjacentIconWrapper,
-    RequiresBloomEnterpriseDialog,
+    RequiresBloomEnterpriseDialog
 } from "../../react_components/requiresBloomEnterprise";
 import { PublishProgressDialog } from "../commonPublish/PublishProgressDialog";
 import { useL10n } from "../../react_components/l10nHooks";
@@ -36,8 +36,9 @@ import { ProgressState } from "../commonPublish/PublishProgressDialogInner";
 import { PublishLanguagesGroup } from "./PublishLanguagesGroup";
 import {
     BulkBloomPubDialog,
-    showBulkBloomPubDialog,
+    showBulkBloomPubDialog
 } from "./BulkBloomPub/BulkBloomPubDialog";
+import { EmbeddedProgressDialog } from "../../react_components/Progress/ProgressDialog";
 
 export const ReaderPublishScreen = () => {
     // When the user changes some features, included languages, etc., we
@@ -57,7 +58,7 @@ export const ReaderPublishScreen = () => {
 
 const ReaderPublishScreenInternal: React.FunctionComponent<{
     onReset: () => void;
-}> = (props) => {
+}> = props => {
     const inStorybookMode = useContext(StorybookContext);
     const [heading, setHeading] = useState(
         useL10n("Creating Digital Book", "PublishTab.Android.Creating")
@@ -90,10 +91,11 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
     useSubscribeToWebSocketForStringMessage(
         "publish-android",
         "androidPreview",
-        (url) => {
+        url => {
             setBookUrl(url);
         }
     );
+
     const pathToOutputBrowser = inStorybookMode ? "./" : "../../";
     const usbWorking = useL10n("Publishing", "PublishTab.Common.Publishing");
     const wifiWorking = useL10n("Publishing", "PublishTab.Common.Publishing");
@@ -101,7 +103,7 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
     useSubscribeToWebSocketForEvent(
         "publish-android",
         "publish/android/state",
-        (e) => {
+        e => {
             switch (e.message) {
                 case "stopped":
                     setClosePending(true);
@@ -258,6 +260,7 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
                     }}
                 />
             )}
+            <EmbeddedProgressDialog />
         </React.Fragment>
     );
 };

--- a/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
+++ b/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
@@ -51,6 +51,7 @@ import {
 import { useEffect } from "react";
 import { isLinux } from "../../utils/isLinux";
 import PublishScreenTemplate from "../commonPublish/PublishScreenTemplate";
+import { EmbeddedProgressDialog } from "../../react_components/Progress/ProgressDialog";
 
 export const PublishAudioVideo = () => {
     if (isLinux()) {
@@ -649,6 +650,7 @@ const PublishAudioVideoInternalInternal: React.FunctionComponent<{
                     }}
                 />
             )}
+            <EmbeddedProgressDialog />
         </Typography>
     );
 };

--- a/src/BloomBrowserUI/react_components/Progress/ProgressDialog.tsx
+++ b/src/BloomBrowserUI/react_components/Progress/ProgressDialog.tsx
@@ -3,10 +3,12 @@ import { jsx, css } from "@emotion/core";
 
 import { Button, CircularProgress } from "@material-ui/core";
 import * as React from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { BloomApi } from "../../utils/bloomApi";
 import WebSocketManager, {
-    IBloomWebSocketProgressEvent
+    IBloomWebSocketProgressEvent,
+    useSubscribeToWebSocketForEvent,
+    useSubscribeToWebSocketForObject
 } from "../../utils/WebSocketManager";
 import BloomButton from "../bloomButton";
 import { ProgressBox } from "./progressBox";
@@ -28,7 +30,7 @@ import {
     useSetupBloomDialog
 } from "../BloomDialog/BloomDialogPlumbing";
 
-export const ProgressDialog: React.FunctionComponent<{
+export interface IProgressDialogProps {
     title: string;
     titleColor?: string;
     titleIcon?: string;
@@ -36,12 +38,36 @@ export const ProgressDialog: React.FunctionComponent<{
     // defaults to "never"
     showReportButton?: "always" | "if-error" | "never";
     showCancelButton?: boolean;
-
-    webSocketContext: string;
     onReadyToReceive?: () => void;
+    // Be very careful how you use these. A typical pattern is that you want to pass a function
+    // which will save the show() or close() function to use later, possibly in a listener. The temptation
+    // is to save it in state, something like this:
+    // const [show, setShow] = useState<()=>void|undefined>();
+    // useEffect(() => something.addEventListener(..., () => show?()), []);
+    // ...
+    // <ProgressDialog ... setShowDialog={showFunc => setShow(showFunc)}...>
+    // This looks as though it will save the function passed to setShowDialog in the "show" state
+    // and use it when the event happens. But it actually fails in two different and baffling ways.
+    // First, because the state is a function, when you call setShow(func), it does not save func in show;
+    // it EXECUTES func immediately and saves the result, with the result that the progress dialog
+    // mysteriously appears at once. (When the argument to a state setter is a function, it is
+    // assumed to be an update function.) This could be fixed by passing a function that returns showFunc:
+    // <ProgressDialog ... setShowDialog={showFunc => setShow(() => showFunc)}...>.
+    // Now, () => showFunc is executed immediately, and the result (showFunc) is saved as we want...almost...
+    // But this still fails; bafflingly, all logging and the debugger show that "show" is a function, but
+    // in the listener it remains undefined. The listener was set up in the first render, when "show"
+    // had not yet been set! It "captured" the initial state.
+    // The right pattern is
+    // const show = useRef<()=>void|undefined>();
+    // useEffect(() => something.addEventListener(..., () => show.current?()), []);
+    // ...
+    // <ProgressDialog ... setShowDialog={showFunc => show.current = showFunc}...>
     setShowDialog?: (show: () => void) => void;
+    setCloseDialog?: (close: () => void) => void;
     dialogEnvironment?: IBloomDialogEnvironmentParams;
-}> = props => {
+}
+
+export const ProgressDialog: React.FunctionComponent<IProgressDialogProps> = props => {
     const {
         showDialog,
         closeDialog,
@@ -50,6 +76,9 @@ export const ProgressDialog: React.FunctionComponent<{
     if (props.setShowDialog) {
         props.setShowDialog(showDialog);
     }
+    if (props.setCloseDialog) {
+        props.setCloseDialog(closeDialog);
+    }
     const [showButtons, setShowButtons] = useState(false);
     const [sawAnError, setSawAnError] = useState(false);
     const [sawAWarning, setSawAWarning] = useState(false);
@@ -57,6 +86,20 @@ export const ProgressDialog: React.FunctionComponent<{
     const [messagesForErrorReporting, setMessagesForErrorReporting] = useState(
         ""
     );
+    const [messages, setMessages] = React.useState<Array<JSX.Element>>([]);
+
+    const [listenerReady, setListenerReady] = useState(false);
+    const [progressBoxReady, setProgressBoxReady] = useState(false);
+    useEffect(() => {
+        if (
+            listenerReady &&
+            progressBoxReady &&
+            props.onReadyToReceive &&
+            propsForBloomDialog.open
+        ) {
+            props.onReadyToReceive();
+        }
+    }, [listenerReady, progressBoxReady, propsForBloomDialog.open]);
 
     // Start off showing the spinner, then stop when we get a "finished" message.
     const [showSpinner, setShowSpinner] = useState(true);
@@ -87,11 +130,39 @@ export const ProgressDialog: React.FunctionComponent<{
                 setShowSpinner(false);
             }
         };
-        WebSocketManager.addListener(props.webSocketContext, listener);
+        WebSocketManager.addListener("progress", listener);
+        setListenerReady(true);
         // cleanup when this dialog unmounts (since this useEffect will only be called once)
-        return () =>
-            WebSocketManager.removeListener(props.webSocketContext, listener);
+        return () => {
+            WebSocketManager.removeListener("progress", listener);
+        };
     }, []);
+
+    // Any time we are closed and reopened we want to show a new set of messages.
+    const everOpened = useRef(false); // we don't need, or want, a change to this to trigger a render.
+    useEffect(() => {
+        if (propsForBloomDialog.open) {
+            everOpened.current = true;
+        } else {
+            // Once the dialog has been open, the only way this effect runs again is if it
+            // it's open state changes. But we don't want this to happen on the initial
+            // render, when it is closed and has never been open.
+            // (In particular, the post might have unintended consequences. But the other
+            // stuff will at least cause useless renders.)
+            // (We don't really need to clean it up until it opens again. But cleaning
+            // when it closes should free some memory and may help to prevent the old
+            // messages flickering into view  when it reopens. Also, the re-renders
+            // caused by the changed state are probably less expensive when it is closed.)
+            if (everOpened.current) {
+                setMessages([]);
+                setSawAnError(false);
+                setSawAWarning(false);
+                setSawFatalError(false);
+                setShowButtons(false);
+                BloomApi.post("progress/closed");
+            }
+        }
+    }, [propsForBloomDialog.open]);
 
     const buttonForSendingErrorReportIsRelevant =
         props.showReportButton == "always" ||
@@ -138,8 +209,8 @@ export const ProgressDialog: React.FunctionComponent<{
                 `}
             >
                 <ProgressBox
-                    webSocketContext={props.webSocketContext}
-                    onReadyToReceive={props.onReadyToReceive}
+                    webSocketContext="progress"
+                    onReadyToReceive={() => setProgressBoxReady(true)}
                     css={css`
                         // If we have dialogFrameProvidedExternally that means the dialog height is controlled by c#, so let the progress grow to fit it.
                         // Maybe we could have that approach *all* the time?
@@ -149,6 +220,12 @@ export const ProgressDialog: React.FunctionComponent<{
                             : "400px"};
                         min-width: 540px;
                     `}
+                    // This is utterly bizarre. When not wrapped in a material UI Dialog, ProgressBox happily
+                    // keeps track of its own messages. But Dialog repeatedly mounts and unmounts its children,
+                    // for no reason I can discover, resulting in loss of their state. So we must keep any state we need
+                    // outside the Dialog wrapper.
+                    messages={messages}
+                    setMessages={setMessages}
                 />
             </DialogMiddle>
             <DialogBottomButtons>
@@ -212,6 +289,55 @@ export const ProgressDialog: React.FunctionComponent<{
                 )}
             </DialogBottomButtons>
         </BloomDialog>
+    );
+};
+
+// Simply render one of these, with no props, at the top level of any document where the
+// C# code (or possibly one day JS code??) might want to show a progress dialog. Showing the
+// dialog and sending stuff to it is all managed by websocket events, and events initiated
+// by buttons in the dialog result in posts. It occupies no space and is invisible until
+// an event tells it to show up. See C# BrowserProgressDialog.
+export const EmbeddedProgressDialog: React.FunctionComponent = () => {
+    const [progressProps, setProgressProps] = useState<IProgressDialogProps>({
+        // just lets us know something is wrong if it shows up; a real title should
+        // be supplied by the code that causes it to become visible.
+        title: "This should not be seen",
+        dialogEnvironment: {
+            initiallyOpen: false,
+            dialogFrameProvidedExternally: false
+        }
+    });
+    // Used to store the functions that we get through ProgressDialog props callback functions
+    // for showing and closing the progress dialog.
+    const showProgress = useRef<() => void | undefined>();
+    const closeProgress = useRef<() => void | undefined>();
+    const openProgress = (args: IProgressDialogProps) => {
+        // Note, we can't get the dialog shown here by setting props to
+        // something with dialogEnvironment having initiallyOpen true;
+        // that initial value gets captured on the first render. We have to capture
+        // the function which the ProgressDialog hands out for showing itself.
+        // args are sent from the C# code that wants to open the dialog.
+        setProgressProps({
+            ...progressProps,
+            ...args
+        });
+        showProgress.current?.(); // better not be null, but lint insists
+    };
+    useSubscribeToWebSocketForObject(
+        "progress",
+        "open-progress",
+        (args: IProgressDialogProps) => openProgress(args)
+    );
+    useSubscribeToWebSocketForEvent("progress", "close-progress", () =>
+        closeProgress.current?.()
+    );
+    return (
+        <ProgressDialog
+            {...progressProps}
+            setShowDialog={showFunc => (showProgress.current = showFunc)}
+            setCloseDialog={closeFunc => (closeProgress.current = closeFunc)}
+            onReadyToReceive={() => BloomApi.post("progress/ready")}
+        />
     );
 };
 

--- a/src/BloomBrowserUI/react_components/Progress/stories.tsx
+++ b/src/BloomBrowserUI/react_components/Progress/stories.tsx
@@ -8,7 +8,6 @@ import { kBloomBlue } from "../../bloomMaterialUITheme";
 import { ProgressBox } from "./progressBox";
 import { normalDialogEnvironmentForStorybook } from "../BloomDialog/BloomDialogPlumbing";
 
-const kWebSocketMockContext = "mock_progress";
 interface IStoryMessage {
     id?: string;
     k?: "Error" | "Warning" | "Progress" | "Note" | "Instruction";
@@ -61,15 +60,12 @@ function sendNextEvent(events: Array<IStoryMessage>) {
         return;
     }
     const e = events.shift();
-    WebSocketManager.mockSend<IBloomWebSocketProgressEvent>(
-        kWebSocketMockContext,
-        {
-            clientContext: kWebSocketMockContext,
-            id: e!.id || "message",
-            progressKind: e!.k,
-            message: e!.m
-        }
-    );
+    WebSocketManager.mockSend<IBloomWebSocketProgressEvent>("progress", {
+        clientContext: "progress",
+        id: e!.id || "message",
+        progressKind: e!.k,
+        message: e!.m
+    });
 
     if (events.length)
         window.setTimeout(() => {
@@ -175,7 +171,6 @@ storiesOf("Progress Dialog", module)
                     titleColor="white"
                     titleBackgroundColor={kBloomBlue}
                     titleIcon="Team Collection.svg"
-                    webSocketContext={kWebSocketMockContext}
                     showReportButton={"if-error"}
                     onReadyToReceive={() =>
                         sendEvents([
@@ -217,7 +212,6 @@ storiesOf("Progress Dialog", module)
                     title="A Long Progress Dialog"
                     titleColor="black"
                     titleBackgroundColor="transparent"
-                    webSocketContext={kWebSocketMockContext}
                     showReportButton={"never"}
                     onReadyToReceive={() => sendEvents(kLongListOfAllTypes)}
                     dialogEnvironment={normalDialogEnvironmentForStorybook}
@@ -232,7 +226,6 @@ storiesOf("Progress Dialog", module)
                     title="Not wrapped in a material dialog (i.e. as when wrapped by winform dialog)"
                     titleColor="white"
                     titleBackgroundColor="green"
-                    webSocketContext={kWebSocketMockContext}
                     showReportButton={"never"}
                     onReadyToReceive={() =>
                         sendEvents([
@@ -272,7 +265,6 @@ storiesOf("Progress Dialog", module)
                     title="Not wrapped in a material dialog (i.e. as when wrapped by winform dialog)"
                     titleColor="white"
                     titleBackgroundColor="green"
-                    webSocketContext={kWebSocketMockContext}
                     showReportButton={"never"}
                     onReadyToReceive={() => sendEvents(kLongListOfAllTypes)}
                     {...noFrameProps}

--- a/src/BloomBrowserUI/utils/WebSocketManager.ts
+++ b/src/BloomBrowserUI/utils/WebSocketManager.ts
@@ -81,12 +81,16 @@ export function useSubscribeToWebSocketForObject<T>(
     listener: (message: T) => void
 ) {
     useEffect(() => {
-        WebSocketManager.addListener(clientContext, e => {
+        const websocketListener = e => {
             if (e.id === eventId) {
                 listener((e as unknown) as T);
             }
-        });
-    }, []);
+        };
+        WebSocketManager.addListener(clientContext, websocketListener);
+        return () => {
+            WebSocketManager.removeListener(clientContext, websocketListener);
+        };
+    }, [clientContext]);
 }
 
 // Subscribe to an event where the "message" string is holding a JSON object
@@ -254,7 +258,7 @@ export default class WebSocketManager {
         WebSocketManager.clientContextCallbacks[
             clientContext
         ] = WebSocketManager.clientContextCallbacks[clientContext].filter(
-            l => l === listener
+            l => l !== listener
         );
     }
 

--- a/src/BloomExe/Publish/Android/BulkBloomPubCreator.cs
+++ b/src/BloomExe/Publish/Android/BulkBloomPubCreator.cs
@@ -36,7 +36,7 @@ namespace Bloom.Publish.Android
 		// Precondition: bulkSaveSettings must be non-null
 		public void PublishAllBooks(BulkBloomPubPublishSettings bulkSaveSettings)
 		{
-			BrowserProgressDialog.DoWorkWithProgressDialog(_webSocketServer, "Bulk Save BloomPubs",
+			BrowserProgressDialog.DoWorkWithProgressDialog(_webSocketServer,
 				(progress, worker) =>
 				{
 					var dest = new TemporaryFolder("BloomPubs");
@@ -97,7 +97,7 @@ namespace Bloom.Publish.Android
 					Process.SafeStart(dest.FolderPath);
 					// true means wait for the user, don't close automatically
 					return true;
-				});
+				}, "Bulk Save BloomPubs");
 		}
 
 

--- a/src/BloomExe/Publish/Video/RecordVideoWindow.cs
+++ b/src/BloomExe/Publish/Video/RecordVideoWindow.cs
@@ -346,7 +346,6 @@ namespace Bloom.Publish.Video
 
 			BrowserProgressDialog.DoWorkWithProgressDialog(
 				_webSocketServer,
-				"Processing Video",
 				(progress, worker) =>
 				{
 					StopRecordingInternal(progress, soundLogJson);
@@ -358,9 +357,7 @@ namespace Bloom.Publish.Video
 					// if we want to close it automatically if there are no errors:
 					//return progress.HaveProblemsBeenReported;
 				},
-				null,
-				Shell.GetShellOrOtherOpenForm(),
-				height: 400,
+				"Processing Video",
 				showCancelButton: false);
 		}
 

--- a/src/BloomExe/Spreadsheet/SpreadsheetApi.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetApi.cs
@@ -111,15 +111,17 @@ namespace Bloom.web.controllers
 				}
 
 				var importer = new SpreadsheetImporter(_webSocketServer, book, Path.GetDirectoryName(inputFilepath));
-				importer.ImportWithProgress(inputFilepath);
+				importer.ImportWithProgress(inputFilepath, () =>
+				{
 
-				// The importer now does BringBookUpToDate() which accomplishes everything this did,
-				// plus it may have actually changed the folder (and subsequent 'bookPath')
-				// due to a newly imported title. That would cause this call to fail.
-				//XmlHtmlConverter.SaveDOMAsHtml5(book.OurHtmlDom.RawDom, bookPath);
-				book.ReloadFromDisk(null);
-				BookHistory.AddEvent(book, TeamCollection.BookHistoryEventType.ImportSpreadsheet);
-				_bookSelection.InvokeSelectionChanged(false);
+					// The importer now does BringBookUpToDate() which accomplishes everything this did,
+					// plus it may have actually changed the folder (and subsequent 'bookPath')
+					// due to a newly imported title. That would cause this call to fail.
+					//XmlHtmlConverter.SaveDOMAsHtml5(book.OurHtmlDom.RawDom, bookPath);
+					book.ReloadFromDisk(null);
+					BookHistory.AddEvent(book, TeamCollection.BookHistoryEventType.ImportSpreadsheet);
+					_bookSelection.InvokeSelectionChanged(false);
+				});
 			}
 			catch (Exception ex)
 			{

--- a/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
@@ -68,27 +68,13 @@ namespace Bloom.Spreadsheet
 		public void ExportToFolderWithProgress(HtmlDom dom, string imagesFolderPath, string outputFolder,
 			Action<string> resultCallback)
 		{
-			var mainShell = Application.OpenForms.Cast<Form>().FirstOrDefault(f => f is Shell);
-			BrowserProgressDialog.DoWorkWithProgressDialog(_webSocketServer, "spreadsheet-export", () =>
-				new ReactDialog("progressDialogBundle",
-						// props to send to the react component
-						new
-						{
-							title = "Exporting Spreadsheet",
-							titleIcon = "", // enhance: add icon if wanted
-							titleColor = "white",
-							titleBackgroundColor = Palette.kBloomBlueHex,
-							webSocketContext = "spreadsheet-export",
-							showReportButton = "if-error"
-						}, "Export Spreadsheet")
-				// winforms dialog properties
-				{ Width = 620, Height = 550 }, (progress, worker) =>
+			BrowserProgressDialog.DoWorkWithProgressDialog(_webSocketServer, (progress, worker) =>
 		{
 			var spreadsheet = ExportToFolder(dom, imagesFolderPath, outputFolder, out string outputFilePath,
 				progress);
 			resultCallback(outputFilePath);
 			return progress.HaveProblemsBeenReported;
-		}, null, mainShell);
+		}, "Exporting Spreadsheet");
 		}
 
 		public SpreadsheetExportParams Params = new SpreadsheetExportParams();

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -2008,18 +2008,19 @@ namespace Bloom.TeamCollection
 			return true;
 		}
 
-		// must match what is in ProgressDialog.tsx passed as clientContext to ProgressBox.
-		// (At least until we generalize that dialog for different Progress tasks...then, it will need
-		// to be configured to use this.)
-		internal const string kWebSocketContext = "TeamCollectionProgress";
-
 		public BloomWebSocketServer SocketServer;
 		public TeamCollectionManager TCManager;
 		private FileSystemWatcher _localFolderWatcher;
 
 		protected void ShowProgressDialog(string title, Func<IWebSocketProgress,BackgroundWorker, bool> doWhat, Action<Form> doWhenMainActionFalse = null)
 		{
-			BrowserProgressDialog.DoWorkWithProgressDialog(SocketServer, TeamCollection.kWebSocketContext,
+			// If you want to change this to use the new overload where the ProgressDialog is embedded in
+			// the open window, remember:
+			// - there has to be an HTML window open that has an EmbeddedProgressDialog somewhere
+			// - the new overload returns before doWhat finishes, so you will have to modify callers
+			// and turn whatever happens after this method returns into an action that can be passed
+			// as doWhenDialogCloses.
+			BrowserProgressDialog.DoWorkWithProgressDialog(SocketServer,
 				() => new ReactDialog("progressDialogBundle",
 					// props to send to the react component
 					new
@@ -2028,7 +2029,6 @@ namespace Bloom.TeamCollection
 						titleIcon = "Team Collection.svg",
 						titleColor = "white",
 						titleBackgroundColor = Palette.kBloomBlueHex,
-						webSocketContext = TeamCollection.kWebSocketContext,
 						showReportButton = "if-error"
 		}, "Sync Team Collection")
 					// winforms dialog properties

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -501,10 +501,19 @@ namespace Bloom.Api
 				// GetBrowserFile adds output to the path on developer machines, but not user installs.
 				return ProcessContent(info, localPath);
 			}
+
+			// As of July 2022, map files are typically found with the corresponding JS bundle files
+			// in output/debug. The browser correctly includes that part of the path to the JS file
+			// when deriving a URL for the map, and removing it prevents the map file being found
+			// and greatly complicates debugging.
+			// The only reason I'm not completely deleting this code is I don't understand why
+			// it was ever needed or what changed so that it became harmful, so PERHAPS leaving
+			// it here commented out will provide a clue if we ever again encounter the situation
+			// where it was helpful.
 			//Firefox debugger, looking for a source map, was prefixing in this unexpected
 			//way.
-			if(localPath.EndsWith("map"))
-				localPath = localPath.Replace("output/browser/", "");
+			//if(localPath.EndsWith("map"))
+			//	localPath = localPath.Replace("output/browser/", "");
 
 			if (localPath == "")
 			{

--- a/src/BloomExe/web/controllers/ProgressDialogApi.cs
+++ b/src/BloomExe/web/controllers/ProgressDialogApi.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Windows.Forms;
 using Bloom.Api;
 using Bloom.Book;
+using Bloom.MiscUI;
 using Bloom.Publish;
 using Bloom.Utils;
 using SIL.IO;
@@ -17,9 +18,12 @@ namespace Bloom.web.controllers
 		{
 			_cancelHandler = cancelHandler;
 		}
+
 		public void RegisterWithApiHandler(BloomApiHandler apiHandler)
 		{
 			apiHandler.RegisterEndpointLegacy("progress/cancel", Cancel, false, false);
+			apiHandler.RegisterEndpointHandler("progress/closed", BrowserProgressDialog.HandleProgressDialogClosed, false);
+			apiHandler.RegisterEndpointHandler("progress/ready", BrowserProgressDialog.HandleProgressReady, false);
 		}
 
 		private void Cancel(ApiRequest request)


### PR DESCRIPTION
Also fixes a bug in BloomServer that was preventing the browser from finding .map files, and one in WebSocketManager that was at least preventing proper cleanup of listeners and sometimes causing other listeners to be lost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5311)
<!-- Reviewable:end -->
