### PR TITLE
Restore missing SIL.Windows.Forms.GeckoBrowserAdapter to Linux build

### DIFF
--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -46,6 +46,7 @@
   <package id="SIL.Media" version="10.0.0-beta0081" targetFramework="net472" />
   <package id="SIL.TestUtilities" version="10.0.0-beta0081" targetFramework="net472" />
   <package id="SIL.Windows.Forms" version="10.0.0-beta0081" targetFramework="net472" />
+  <package id="SIL.Windows.Forms.GeckoBrowserAdapter" version="10.0.0-beta0081" targetFramework="net472" />
   <package id="SIL.Windows.Forms.Keyboarding" version="10.0.0-beta0081" targetFramework="net472" />
   <package id="SIL.Windows.Forms.WritingSystems" version="10.0.0-beta0081" targetFramework="net472" />
   <package id="SIL.WritingSystems" version="10.0.0-beta0081" targetFramework="net472" />


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5315)
<!-- Reviewable:end -->
