### PR TITLE
[5.3] BL-11273 MXB tweaks

### DIFF
--- a/src/BloomExe/Book/SizeAndOrientation.cs
+++ b/src/BloomExe/Book/SizeAndOrientation.cs
@@ -81,7 +81,7 @@ namespace Bloom.Book
 			{
 				var fileName = link.GetStringAttribute("href");
 				if (fileName.ToLowerInvariant().Contains("mode") || fileName.ToLowerInvariant().Contains("page") ||
-					fileName.ToLowerInvariant().Contains("matter") || fileName.ToLowerInvariant().Contains("languagedisplay") ||
+					fileName.ToLowerInvariant().Contains("languagedisplay") ||
 					fileName.ToLowerInvariant().Contains("origami") || fileName.ToLowerInvariant().Contains("defaultlangstyles") ||
 					fileName.ToLowerInvariant().Contains("customcollectionstyles") ||
 					// Ignore this obsolete styles file as well.  See https://issues.bloomlibrary.org/youtrack/issue/BL-9128.

--- a/src/content/branding/MXB-Book-Literacy/branding.json
+++ b/src/content/branding/MXB-Book-Literacy/branding.json
@@ -28,7 +28,7 @@
         {
             "data-book": "funding",
             "lang": "es",
-            "content": "Publicado por el <strong>Instituto Lingüístico de Verano, A. C.</strong> Oaxaca de Juárez",
+            "content": "Publicado por el<br /><strong>Instituto Lingüístico de Verano, A. C.</strong><br />Oaxaca de Juárez",
             "condition": "always"
         },
         {

--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-Device-XMatter/MXBLiteracy-Device-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-Device-XMatter/MXBLiteracy-Device-XMatter.less
@@ -1,0 +1,10 @@
+@import "../MXBLiteracy-XMatter/MXBLiteracy-XMatter.less";
+
+@XMatterPackName: "MXBLiteracy Device";
+
+//- On a phone, these will need to be smaller or they'll take up the whole page
+.licenseDetails,
+.bottomCredits,
+.brandingCredits {
+    font-size: small;
+}

--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-Device-XMatter/MXBLiteracy-Device-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-Device-XMatter/MXBLiteracy-Device-XMatter.pug
@@ -1,0 +1,4 @@
+extends ../MXBLiteracy-XMatter/MXBLiteracy-XMatter.pug
+
+block append stylesheets
+	+stylesheets('MXBLiteracy-Device-XMatter.css')

--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-Device-XMatter/description-en.txt
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-Device-XMatter/description-en.txt
@@ -1,0 +1,1 @@
+[V1]Used by ILV Mexico Branch, 2022.

--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.less
@@ -9,7 +9,7 @@
     margin-bottom: 0;
     .copyright,
     .licenseBlock {
-        margin-bottom: @contentMinimumHeight;
+        margin-bottom: 0;
     }
 }
 
@@ -88,7 +88,7 @@
         font-size: @fontSize;
         line-height: 1.2;
         display: block;
-        margin-top: @MarginBetweenMajorItems;
+        margin-top: 0;
     }
     // default values for license/copyright block and ISBN container
     .Credits-Page-style {

--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBLiteracy-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBLiteracy-XMatter.less
@@ -1,3 +1,19 @@
+/*
+This json comment in a default Bloom template "locks" the book to only these layouts,
+whereas in a branding-induced xmatter pack it only acts to make this the default layout for a new book.
+STARTLAYOUTS
+{
+  "layouts": [
+    {
+      "HalfLetterPortrait": {
+        "Styles": [ "Default" ]
+      }
+    }
+  ]
+}
+ENDLAYOUTS
+*/
+
 @import "./MXBCommon-XMatter.less";
 
 @XMatterPackName: "MXB Literacy";

--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBLiteracy-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBLiteracy-XMatter.pug
@@ -7,7 +7,9 @@ html
 		meta(charset='UTF-8')
 		meta(name='BloomFormatVersion', content='2.0')
 		title ILV Mexico Literacy Front & Back Matter
-		+stylesheets('MXBLiteracy-XMatter.css')
+		//- Make stylesheets adjustable for Device version
+		block stylesheets
+			+stylesheets('MXBLiteracy-XMatter.css')
 	body
 		+factoryStandard-outsideFrontCover
 		+factory-insideFrontCover

--- a/src/content/templates/xMatter/project-specific/MXBScripture-Device-XMatter/MXBScripture-Device-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/MXBScripture-Device-XMatter/MXBScripture-Device-XMatter.less
@@ -1,0 +1,10 @@
+@import "../MXBScripture-XMatter/MXBScripture-XMatter.less";
+
+@XMatterPackName: "MXBScripture Device";
+
+//- On a phone, these will need to be smaller or they'll take up the whole page
+.licenseDetails,
+.bottomCredits,
+.brandingCredits {
+    font-size: small;
+}

--- a/src/content/templates/xMatter/project-specific/MXBScripture-Device-XMatter/MXBScripture-Device-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBScripture-Device-XMatter/MXBScripture-Device-XMatter.pug
@@ -1,0 +1,4 @@
+extends ../MXBScripture-XMatter/MXBScripture-XMatter.pug
+
+block append stylesheets
+	+stylesheets('MXBScripture-Device-XMatter.css')

--- a/src/content/templates/xMatter/project-specific/MXBScripture-Device-XMatter/description-en.txt
+++ b/src/content/templates/xMatter/project-specific/MXBScripture-Device-XMatter/description-en.txt
@@ -1,0 +1,1 @@
+[V1]Used by ILV Mexico Branch, 2022.

--- a/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.less
@@ -1,10 +1,31 @@
+/*
+This json comment in a default Bloom template "locks" the book to only these layouts,
+whereas in a branding-induced xmatter pack it only acts to make this the default layout for a new book.
+STARTLAYOUTS
+{
+  "layouts": [
+    {
+      "HalfLetterPortrait": {
+        "Styles": [ "Default" ]
+      }
+    }
+  ]
+}
+ENDLAYOUTS
+*/
+
 @import "../MXBLiteracy-XMatter/MXBCommon-XMatter.less";
 
 @XMatterPackName: "MXB Scripture";
 
+.credits .licenseAndCopyrightBlock {
+    margin-top: auto;
+}
+
 .titlePage .creditsRow .smallCoverCredits.bloom-content1 {
     // for Scripture this is tucked up under the title and used for chapter/verse references
     margin-bottom: @MarginBetweenMajorItems;
+    font-size: 12pt;
 }
 
 .titlePage #titlePageTitleBlock {

--- a/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.pug
@@ -2,9 +2,15 @@
 include ../MXBLiteracy-XMatter/MXBCommon-XMatter.pug
 
 mixin mxb-chapterVerseRef
-	.creditsRow(data-hint='For Scripture books, use this space to indicate the Bible reference')
+	.creditsRow(data-hint='Para publicaciones de Escrituras, este espacio es para indicar la cita bíblica en lugar de atribuir el autor/ilustrador.')
 		+field-prototypeDeclaredExplicity("V")
 			+editable(kLanguageForPrototypeOnly).smallCoverCredits.Cover-Default-style(data-book='smallCoverCredits')
+
+mixin mxb-contributions-scripture
+	+field-prototypeDeclaredExplicity("N1")#contributions
+		label.bubble(data-link-text='Paste Image Credits' data-link-target='PasteImageCredits()')
+			| Para publicaciones de Escrituras, este espacio es para atribuir contribuidores como ilustradores o diseñadores. No se deben incluir atribuciones de autores o traductores en una publicación de Escrituras.
+		+editable(kLanguageForPrototypeOnly).contributions.OriginalContributions-style.bloom-copyFromOtherLanguageIfNecessary(data-book='originalContributions')
 
 mixin mxb-frontCover-scripture
 	// Outside Front Cover
@@ -50,17 +56,17 @@ mixin mxb-titlePage-scripture
 			.langName('data-library'='dialect')
 			.langName(data-library='languageLocation').bloom-writeOnly
 		+field-prototypeDeclaredExplicity("N1")#funding
-			label.bubble Normally leave this space blank for books published under the LigaBíblica logo.
+			label.bubble Este espacio normalmente debe quedar en blanco para libros publicados bajo el logo de LigaBíblica.
 			+editable(kLanguageForPrototypeOnly).funding.Funding-style.bloom-copyFromOtherLanguageIfNecessary(data-book='funding')
 		+title-page-branding-bottom
 
 mixin mxb-creditsPage-scripture
 	// Credits page back of Title page
 	+page-xmatter("Credits Page").bloom-frontMatter.credits(data-export='front-matter-credits', data-xmatter-page='credits')#69EF35AE-5BF1-49F1-89E7-2A932DAD932C
-		+mxb-contributions
+		+mxb-contributions-scripture
 		+field-prototypeDeclaredExplicity("N1")#localizedAcknowledgments
 			label.bubble
-				| Acknowledgments for this version, in {lang}. For example, give credit to the translator for this version.
+				| Para publicaciones de Escrituras, este espacio es para atribuir la publicación bíblica de donde se tomó el texto de esta publicación de Porciones bíblicas. No incluya ningún nombre personal como “autor” o “traductor”.
 			+editable(kLanguageForPrototypeOnly).versionAcknowledgments.LocalizedAcknowledgments-style.bloom-copyFromOtherLanguageIfNecessary(data-book="versionAcknowledgments")
 		+block-licenseAndCopyright
 		//- Here code puts in something like "From the original Copyright Pratham Books 2016. CC-BY. Any license notes here."
@@ -81,7 +87,9 @@ html
 		meta(charset='UTF-8')
 		meta(name='BloomFormatVersion', content='2.0')
 		title ILV Mexico Scripture Front & Back Matter
-		+stylesheets('MXBScripture-XMatter.css')
+		//- Make stylesheets adjustable for Device version
+		block stylesheets
+			+stylesheets('MXBScripture-XMatter.css')
 	body
 		+mxb-frontCover-scripture
 		+factory-insideFrontCover


### PR DESCRIPTION
* Set default HalfLetterPortrait page size
* fix "Funding Agency" line breaks
* add Device xmatters for Literacy and Scripture
* close up space under license block
* add custom spanish hint bubbles for various
   Scripture fields

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5323)
<!-- Reviewable:end -->
