### PR TITLE
Allow bubble handles on top of other bubbles (BL-11184)

### DIFF
--- a/src/content/bookLayout/bubble.less
+++ b/src/content/bookLayout/bubble.less
@@ -72,10 +72,6 @@
         .bloom-dragHandle {
             cursor: grab;
 
-            &:not(.ui-draggable-handle) {
-                cursor: text;
-            }
-
             &.grabbing {
                 cursor: grabbing;
             }
@@ -133,17 +129,8 @@
             width: 22px;
             height: 22px;
             top: -15px;
-
-            &.visible {
-                // This z-index should be below the canvas
-                z-index: @dragHandleVisibleZIndex;
-            }
-
-            &.transparent {
-                // This z-index should be above the canvas
-                z-index: @dragHandleEventZIndex;
-                opacity: 0; // Fully transparent (aka invisible)
-            }
+            // This z-index should be above the canvas
+            z-index: @dragHandleEventZIndex;
         }
 
         // Overrides the inherited values from editMode.less, which are a slightly different shade of blue.


### PR DESCRIPTION
This fixes some oddities introduced by the first change for BL-11184, in the process achieveing a different solution to BL-7907

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5334)
<!-- Reviewable:end -->
