### PR TITLE
Refactor Palette stuff, give ckeditor accesses to our colors

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -24,10 +24,10 @@ import * as ReactDOM from "react-dom";
 import FontSelectComponent, { IFontMetaData } from "./fontSelectComponent";
 import React = require("react");
 import {
-    BloomPalette,
     ISimpleColorPickerDialogProps,
     showSimpleColorPickerDialog
 } from "../../react_components/colorPickerDialog";
+import { BloomPalette } from "../../react_components/bloomPalette";
 
 // Controls the CSS text-align value
 // Note: CSS text-align W3 standard does not specify "start" or "end", but Firefox/Chrome/Edge do support it.

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -5,6 +5,12 @@ import AudioRecording from "../toolbox/talkingBook/audioRecording";
 import { BloomApi } from "../../utils/bloomApi";
 import BloomMessageBoxSupport from "../../utils/bloomMessageBoxSupport";
 
+import {
+    BloomPalette,
+    getHexColorsForPalette,
+    getDefaultColorsFromPalette
+} from "../../react_components/bloomPalette";
+
 // This class is actually just a group of static functions with a single public method. It does whatever we need to to make Firefox's contenteditable
 // element have the behavior we need.
 //
@@ -107,6 +113,9 @@ export default class BloomField {
         bloomEditableDiv: HTMLElement,
         ckeditor: CKEDITOR.editor
     ) {
+        getHexColorsForPalette(BloomPalette.Text).then(
+            r => (ckeditor.config.colorButton_colors = r.join(","))
+        );
         ckeditor.on("key", event => {
             if (event.data.keyCode === CKEDITOR.SHIFT + 13) {
                 BloomField.InsertLineBreak();

--- a/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
@@ -26,19 +26,19 @@ import { isLinux } from "../../../utils/isLinux";
 import { MuiCheckbox } from "../../../react_components/muiCheckBox";
 import { ColorBar } from "./colorBar";
 import { IColorInfo } from "../../../react_components/colorSwatch";
-import {
-    IColorPickerDialogProps,
-    getColorInfoFromSpecialNameOrColorString,
-    getSpecialColorName,
-    OverlayTextColorPalette,
-    OverlayBackgroundColors,
-    BloomPalette
-} from "../../../react_components/colorPickerDialog";
+import { IColorPickerDialogProps } from "../../../react_components/colorPickerDialog";
 import * as tinycolor from "tinycolor2";
 import { showSignLanguageTool } from "../../js/bloomVideo";
 import { kBloomBlue } from "../../../bloomMaterialUITheme";
 import { RequiresBloomEnterpriseOverlayWrapper } from "../../../react_components/requiresBloomEnterprise";
 import { kOverlayToolId } from "../toolIds";
+import {
+    BloomPalette,
+    getColorInfoFromSpecialNameOrColorString,
+    getSpecialColorName,
+    TextBackgroundColors,
+    TextColorPalette
+} from "../../../react_components/bloomPalette";
 
 const OverlayToolControls: React.FunctionComponent = () => {
     const l10nPrefix = "ColorPicker.";
@@ -80,7 +80,7 @@ const OverlayToolControls: React.FunctionComponent = () => {
         "EditTab.Toolbox.ComicTool.Options.BackgroundColor"
     );
 
-    const defaultTextColors: IColorInfo[] = OverlayTextColorPalette.map(color =>
+    const defaultTextColors: IColorInfo[] = TextColorPalette.map(color =>
         getColorInfoFromSpecialNameOrColorString(color)
     );
 
@@ -93,7 +93,7 @@ const OverlayToolControls: React.FunctionComponent = () => {
     // Background color swatch
     // defaults to "white" background color
     const [backgroundColorSwatch, setBackgroundColorSwatch] = useState(
-        OverlayBackgroundColors[1]
+        TextBackgroundColors[1]
     );
 
     // If bubbleType is not undefined, corresponds to the active bubble's family.
@@ -446,7 +446,7 @@ const OverlayToolControls: React.FunctionComponent = () => {
             noGradientSwatches: true,
             localizedTitle: textColorTitle,
             initialColor: textColorSwatch,
-            palette: BloomPalette.OverlayText,
+            palette: BloomPalette.Text,
             isForOverlay: true,
             onChange: color => updateTextColor(color),
             onInputFocus: noteInputFocused
@@ -462,7 +462,7 @@ const OverlayToolControls: React.FunctionComponent = () => {
             noAlphaSlider: noAlpha,
             localizedTitle: backgroundColorTitle,
             initialColor: backgroundColorSwatch,
-            palette: BloomPalette.OverlayBackground,
+            palette: BloomPalette.TextBackground,
             isForOverlay: true,
             onChange: color => updateBackgroundColor(color),
             onInputFocus: noteInputFocused

--- a/src/BloomBrowserUI/lib/ckeditor/plugins/colorbutton/plugin.js
+++ b/src/BloomBrowserUI/lib/ckeditor/plugins/colorbutton/plugin.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or http://ckeditor.com/license
  */
@@ -255,11 +255,8 @@ CKEDITOR.plugins.add( 'colorbutton', {
  * @cfg {String} [colorButton_colors=see source]
  * @member CKEDITOR.config
  */
-CKEDITOR.config.colorButton_colors = '000,800000,8B4513,2F4F4F,008080,000080,4B0082,696969,' +
-	'B22222,A52A2A,DAA520,006400,40E0D0,0000CD,800080,808080,' +
-	'F00,FF8C00,FFD700,008000,0FF,00F,EE82EE,A9A9A9,' +
-	'FFA07A,FFA500,FFFF00,00FF00,AFEEEE,ADD8E6,DDA0DD,D3D3D3,' +
-	'FFF0F5,FAEBD7,FFFFE0,F0FFF0,F0FFFF,F0F8FF,E6E6FA,FFF';
+
+// the available colors are set in BloomField
 
 /**
  * Stores the style definition that applies the text foreground color.

--- a/src/BloomBrowserUI/react_components/bloomPalette.ts
+++ b/src/BloomBrowserUI/react_components/bloomPalette.ts
@@ -1,0 +1,185 @@
+import React = require("react");
+import { IColorInfo, getColorInfoFromString } from "./colorSwatch";
+import "./colorPickerDialog.less";
+import { kBloomGray } from "../utils/colorUtils";
+import { debug } from "webpack";
+import { BloomApi } from "../utils/bloomApi";
+
+export enum BloomPalette {
+    Text = "text",
+    CoverBackground = "cover-background",
+    BloomReaderBookshelf = "bloom-reader-bookshelf",
+    TextBackground = "overlay-background"
+}
+
+// This array provides a useful default palette for the color picker dialog.
+// See the code below for mapping an array of strings like this into an array of
+// IColorInfo objects.
+export const TextColorPalette: string[] = [
+    //NB: do not use names, as some pickers may expect numbers only
+    // black to white
+    "#000000", // black
+    "#FFFFFF", // white
+    // red to purple
+    "#ff1616",
+    "#ff5757",
+    "#ff66c4",
+    "#cb6ce6",
+    "#8c52ff",
+    // teal to blue
+    "#03989e",
+    "#00c2cb",
+    "#5ce1e6",
+    "#5271ff",
+    "#004aad",
+    // green to orange
+    "#007f37",
+    "#7ed957",
+    "#c9e265",
+    "#ffde59",
+    "#ff914d"
+];
+
+// copied from colorChooser.tsx
+export const CoverBackgroundPalette: string[] = [
+    "#E48C84",
+    "#B0DEE4",
+    "#98D0B9",
+    "#C2A6BF",
+    "#FFFFA4",
+    "#FEBF00",
+    "#7BDCB5",
+    "#B2CC7D",
+    "#F8B576",
+    "#D29FEF",
+    "#ABB8C3",
+    "#C1EF93",
+    "#FFD4D4",
+    "#FFAAD4"
+];
+
+const specialColors: IColorInfo[] = [
+    // #DFB28B is the color Comical has been using as the default for captions.
+    // It's fairly close to the "Calico" color defined at https://www.htmlcsscolor.com/hex/D5B185 (#D5B185)
+    // so I decided it was the best choice for keeping that option.
+    {
+        name: "whiteToCalico",
+        colors: ["white", "#DFB28B"],
+        opacity: 1
+    },
+    // https://www.htmlcsscolor.com/hex/ACCCDD
+    {
+        name: "whiteToFrenchPass",
+        colors: ["white", "#ACCCDD"],
+        opacity: 1
+    },
+    // https://encycolorpedia.com/7b8eb8
+    {
+        name: "whiteToPortafino",
+        colors: ["white", "#7b8eb8"],
+        opacity: 1
+    }
+];
+const plainColors: IColorInfo[] = [
+    { name: "black", colors: ["black"], opacity: 1 },
+    { name: "white", colors: ["white"], opacity: 1 },
+    { name: "partialTransparent", colors: [kBloomGray], opacity: 0.5 }
+];
+
+// These colors are what the overlay tool has been using for the background color chooser.
+export const TextBackgroundColors: IColorInfo[] = plainColors.concat(
+    specialColors
+);
+
+// all colors, whether factory or "custom"
+// no leading "#", no gradients
+export async function getHexColorsForPalette(
+    palette: BloomPalette
+): Promise<string[]> {
+    let factoryColors: string[];
+    switch (palette) {
+        case BloomPalette.BloomReaderBookshelf:
+        case BloomPalette.CoverBackground:
+            factoryColors = CoverBackgroundPalette;
+            break;
+        case BloomPalette.Text:
+            factoryColors = TextColorPalette;
+            break;
+        case BloomPalette.TextBackground:
+            throw new Error(
+                "getColorHexNumbersFromPalette cannot currently handle TextBackground because it contains gradients"
+            );
+    }
+    return BloomApi.getWithPromise(
+        `settings/getCustomPaletteColors?palette=${palette}`
+    ).then(result => {
+        if (result) {
+            // {"data":[{"colors":["#0071ff"],"opacity":1},{"colors":["#0000ff"],"opacity":1}]
+            const customColors: string[] = (result.data as Array<{
+                colors: string[];
+            }>).map(c => c.colors[0]);
+            return [...factoryColors, ...customColors].map(c =>
+                c.replace("#", "")
+            );
+        } else throw new Error("Problem getting custom colors");
+    });
+}
+
+export function getDefaultColorsFromPalette(
+    paletteType: BloomPalette
+): IColorInfo[] {
+    if (paletteType === BloomPalette.TextBackground)
+        return JSON.parse(JSON.stringify(TextBackgroundColors));
+
+    let palette;
+    switch (paletteType) {
+        case BloomPalette.BloomReaderBookshelf:
+        case BloomPalette.CoverBackground:
+            palette = CoverBackgroundPalette;
+            break;
+        case BloomPalette.Text:
+            palette = TextColorPalette;
+            break;
+    }
+    return palette.map((color: string) =>
+        getColorInfoFromSpecialNameOrColorString(color)
+    );
+}
+
+// Handles all types of color strings: special-named, hex, rgb(), or rgba().
+// If color entails opacity, this string should be of the form "rgba(r, g, b, a)".
+export const getColorInfoFromSpecialNameOrColorString = (
+    specialNameOrColorString: string
+): IColorInfo => {
+    if (isSpecialColorName(specialNameOrColorString)) {
+        // A "special" color gradient, get our colorInfo from the definitions.
+        // It "has" to be there, because we just checked to see if the name was a special color!
+        return specialColors.find(
+            color => color.name === specialNameOrColorString
+        ) as IColorInfo;
+    }
+    return getColorInfoFromString(specialNameOrColorString);
+};
+
+const isSpecialColorName = (colorName: string): boolean =>
+    !!specialColors.find(item => item.name === colorName);
+
+export const getSpecialColorName = (
+    colorArray: string[]
+): string | undefined => {
+    const special = specialColors.find(
+        elem => elem.colors[1] === colorArray[1]
+    );
+    return special ? special.name : undefined;
+};
+
+// The following interface and function provide a simpler interface to the color
+// choose dialog which doesn't depend on IColorInfo.
+export interface ISimpleColorPickerDialogProps {
+    localizedTitle: string;
+    noAlphaSlider?: boolean;
+    initialColor: string;
+    palette: BloomPalette;
+    onChange: (color: string) => void;
+    onInputFocus: (input: HTMLElement) => void;
+}

--- a/src/BloomBrowserUI/react_components/colorChooser.tsx
+++ b/src/BloomBrowserUI/react_components/colorChooser.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useState } from "react";
 import ContentEditable from "./ContentEditable";
 import "./colorChooser.less";
-import { CoverBackgroundPalette } from "./colorPickerDialog";
+import { CoverBackgroundPalette } from "./bloomPalette";
 
 interface IColorChooserProps {
     imagePath?: string;

--- a/src/BloomBrowserUI/react_components/colorPickerDialog.tsx
+++ b/src/BloomBrowserUI/react_components/colorPickerDialog.tsx
@@ -19,28 +19,16 @@ import { lightTheme } from "../bloomMaterialUITheme";
 import { BloomApi } from "../utils/bloomApi";
 import CustomColorPicker from "./customColorPicker";
 import * as tinycolor from "tinycolor2";
-import {
-    IColorInfo,
-    getColorInfoFromString,
-    normalizeColorInfoColorsAsHex
-} from "./colorSwatch";
+import { IColorInfo, normalizeColorInfoColorsAsHex } from "./colorSwatch";
 import Draggable from "react-draggable";
 import "./colorPickerDialog.less";
+import { getRgbaColorStringFromColorAndOpacity } from "../utils/colorUtils";
 import {
-    getRgbaColorStringFromColorAndOpacity,
-    kBloomGray
-} from "../utils/colorUtils";
-
-export enum BloomPalette {
-    Text = "text",
-    CoverBackground = "cover-background",
-    BloomReaderBookshelf = "bloom-reader-bookshelf",
-    // REVIEW: my understanding is we only want one text palette, so this needs to be merged with "Text"
-    OverlayText = "overlay-text",
-    // REVIEW: I suggest we make this more generic like "text-background" with assumption that some day we may want
-    // other background colors for text besides overlays.
-    OverlayBackground = "overlay-background"
-}
+    BloomPalette,
+    getColorInfoFromSpecialNameOrColorString,
+    getDefaultColorsFromPalette,
+    getSpecialColorName
+} from "./bloomPalette";
 
 export interface IColorPickerDialogProps {
     open?: boolean;
@@ -384,143 +372,6 @@ const doRender = (
     } catch (error) {
         console.error(error);
     }
-};
-
-// This array provides a useful default palette for the color picker dialog.
-// See the code below for mapping an array of strings like this into an array of
-// IColorInfo objects.
-export const TextColorPalette: string[] = [
-    // black to white
-    "black",
-    //"gray",
-    //"lightgray",
-    "white",
-    // red to purple
-    "#ff1616",
-    "#ff5757",
-    "#ff66c4",
-    "#cb6ce6",
-    "#8c52ff",
-    // teal to blue
-    "#03989e",
-    "#00c2cb",
-    "#5ce1e6",
-    "#5271ff",
-    "#004aad",
-    // green to orange
-    "#007f37",
-    "#7ed957",
-    "#c9e265",
-    "#ffde59",
-    "#ff914d"
-];
-
-// copied from colorChooser.tsx
-export const CoverBackgroundPalette: string[] = [
-    "#E48C84",
-    "#B0DEE4",
-    "#98D0B9",
-    "#C2A6BF",
-    "#FFFFA4",
-    "#FEBF00",
-    "#7BDCB5",
-    "#B2CC7D",
-    "#F8B576",
-    "#D29FEF",
-    "#ABB8C3",
-    "#C1EF93",
-    "#FFD4D4",
-    "#FFAAD4"
-];
-
-// These colors are what the overlay tool has been using for the text color chooser.
-export const OverlayTextColorPalette: string[] = [
-    "black",
-    "gray",
-    "lightgray",
-    "white"
-];
-
-const specialColors: IColorInfo[] = [
-    // #DFB28B is the color Comical has been using as the default for captions.
-    // It's fairly close to the "Calico" color defined at https://www.htmlcsscolor.com/hex/D5B185 (#D5B185)
-    // so I decided it was the best choice for keeping that option.
-    {
-        name: "whiteToCalico",
-        colors: ["white", "#DFB28B"],
-        opacity: 1
-    },
-    // https://www.htmlcsscolor.com/hex/ACCCDD
-    {
-        name: "whiteToFrenchPass",
-        colors: ["white", "#ACCCDD"],
-        opacity: 1
-    },
-    // https://encycolorpedia.com/7b8eb8
-    {
-        name: "whiteToPortafino",
-        colors: ["white", "#7b8eb8"],
-        opacity: 1
-    }
-];
-const plainColors: IColorInfo[] = [
-    { name: "black", colors: ["black"], opacity: 1 },
-    { name: "white", colors: ["white"], opacity: 1 },
-    { name: "partialTransparent", colors: [kBloomGray], opacity: 0.5 }
-];
-
-// These colors are what the overlay tool has been using for the background color chooser.
-export const OverlayBackgroundColors: IColorInfo[] = plainColors.concat(
-    specialColors
-);
-
-function getDefaultColorsFromPalette(paletteType: BloomPalette): IColorInfo[] {
-    if (paletteType === BloomPalette.OverlayBackground)
-        return JSON.parse(JSON.stringify(OverlayBackgroundColors));
-
-    let palette;
-    switch (paletteType) {
-        case BloomPalette.BloomReaderBookshelf:
-        case BloomPalette.CoverBackground:
-            palette = CoverBackgroundPalette;
-            break;
-        case BloomPalette.OverlayText:
-            palette = OverlayTextColorPalette;
-            break;
-        case BloomPalette.Text:
-            palette = TextColorPalette;
-            break;
-    }
-    return palette.map((color: string) =>
-        getColorInfoFromSpecialNameOrColorString(color)
-    );
-}
-
-// Handles all types of color strings: special-named, hex, rgb(), or rgba().
-// If color entails opacity, this string should be of the form "rgba(r, g, b, a)".
-export const getColorInfoFromSpecialNameOrColorString = (
-    specialNameOrColorString: string
-): IColorInfo => {
-    if (isSpecialColorName(specialNameOrColorString)) {
-        // A "special" color gradient, get our colorInfo from the definitions.
-        // It "has" to be there, because we just checked to see if the name was a special color!
-        return specialColors.find(
-            color => color.name === specialNameOrColorString
-        ) as IColorInfo;
-    }
-    return getColorInfoFromString(specialNameOrColorString);
-};
-
-const isSpecialColorName = (colorName: string): boolean =>
-    !!specialColors.find(item => item.name === colorName);
-
-export const getSpecialColorName = (
-    colorArray: string[]
-): string | undefined => {
-    const special = specialColors.find(
-        elem => elem.colors[1] === colorArray[1]
-    );
-    return special ? special.name : undefined;
 };
 
 // The following interface and function provide a simpler interface to the color

--- a/src/BloomBrowserUI/react_components/stories.tsx
+++ b/src/BloomBrowserUI/react_components/stories.tsx
@@ -23,10 +23,9 @@ import CustomColorPicker from "./customColorPicker";
 import { IColorInfo, getBackgroundColorCssFromColorInfo } from "./colorSwatch";
 import {
     showColorPickerDialog,
-    DialogResult,
     IColorPickerDialogProps,
-    BloomPalette,
-    OverlayBackgroundColors
+    ColorDisplayButton,
+    DialogResult
 } from "./colorPickerDialog";
 import SmallNumberPicker from "./smallNumberPicker";
 import { BloomAvatar } from "./bloomAvatar";
@@ -55,10 +54,7 @@ import { RadioGroup } from "./RadioGroup";
 import { MuiRadio } from "./muiRadio";
 import WinFormsStyleSelect from "./winFormsStyleSelect";
 import BookMakingSettingsControl from "../collection/bookMakingSettingsControl";
-import {
-    ColorDisplayButton,
-    IColorDisplayButtonProps
-} from "../react_components/colorPickerDialog";
+import { BloomPalette, TextBackgroundColors } from "./bloomPalette";
 
 storiesOf("Localizable Widgets", module)
     .add("Expandable", () => (
@@ -831,7 +827,7 @@ storiesOf("Misc/ColorPicker", module)
                                         ? chooserCurrentBackgroundColor
                                         : chooserCurrentTextColor
                                 }
-                                swatchColors={OverlayBackgroundColors}
+                                swatchColors={TextBackgroundColors}
                                 noAlphaSlider={!backgroundChooser}
                                 noGradientSwatches={!backgroundChooser}
                             />
@@ -870,7 +866,7 @@ storiesOf("Misc/ColorPicker", module)
             const colorPickerDialogProps: IColorPickerDialogProps = {
                 localizedTitle: "Custom Color Picker",
                 initialColor: chooserCurrentBackgroundColor,
-                palette: BloomPalette.OverlayBackground,
+                palette: BloomPalette.TextBackground,
                 onChange: color => handleColorChange(color),
                 onInputFocus: () => {}
             };


### PR DESCRIPTION
Could have done more, but I chose to scope this to what I can do this afternoon.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5357)
<!-- Reviewable:end -->
