### PR TITLE
BL-11406 color picker fixes

### DIFF
--- a/src/BloomBrowserUI/publish/ReaderPublish/CoverColorGroup.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/CoverColorGroup.tsx
@@ -9,7 +9,7 @@ import {
 import { BloomApi } from "../../utils/bloomApi";
 import { StorybookContext } from "../../.storybook/StoryBookContext";
 import { useL10n } from "../../react_components/l10nHooks";
-import { useContext, useEffect, useState } from "react";
+import { useContext } from "react";
 import { BloomPalette } from "../../react_components/color-picking/bloomPalette";
 
 export const CoverColorGroup: React.FunctionComponent<{
@@ -37,8 +37,6 @@ const CoverColorControl: React.FunctionComponent<{
         setBookCoverColor
     ] = BloomApi.useApiStringStatePromise("publish/android/backColor", "");
 
-    const [internalColor, setInternalColor] = useState("");
-
     // I (gjm) was thinking this had to do with if a book is "unlocked", but apparently it's more to do
     // with whether it checked out in Team Collections or not.
     // Currently, there is no UI difference to indicate that the control is disabled. It just won't do
@@ -48,9 +46,12 @@ const CoverColorControl: React.FunctionComponent<{
         false
     );
 
-    useEffect(() => {
-        setInternalColor(bookCoverColor);
-    }, [bookCoverColor]);
+    // The 2 comic templates and the Video template have black covers and a 'meta' tag that preserves
+    // the cover color, so it doesn't get changed. The color picker shouldn't function on these.
+    const [hasPreserveCoverColor] = BloomApi.useApiBoolean(
+        "common/hasPreserveCoverColor",
+        false
+    );
 
     const inStorybookMode = useContext(StorybookContext);
 
@@ -79,13 +80,13 @@ const CoverColorControl: React.FunctionComponent<{
             `}
         >
             {/* Don't show the button until we get the background color */}
-            {internalColor !== "" && (
+            {bookCoverColor !== "" && (
                 <ColorDisplayButton
-                    initialColor={internalColor}
+                    initialColor={bookCoverColor}
                     width={94}
                     localizedTitle={props.localizedTitle}
                     noAlphaSlider={true}
-                    disabled={!canModifyCurrentBook}
+                    disabled={!canModifyCurrentBook || hasPreserveCoverColor}
                     palette={BloomPalette.CoverBackground}
                     onClose={(result, newColor) =>
                         handleOnClose(result, newColor)

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2652,14 +2652,16 @@ namespace Bloom.Book
 		{
 			foreach (XmlElement stylesheet in dom.SafeSelectNodes("//style"))
 			{
-				string content = stylesheet.InnerText;
+				var content = stylesheet.InnerText;
 				// Our XML representation of an HTML DOM doesn't seem to have any object structure we can
 				// work with. The Stylesheet content is just raw CDATA text.
-				var match = new Regex(@"DIV.bloom-page.coverColor\s*{\s*background-color:\s*(#[0-9a-fA-F]*)")
-					.Match(content);
+				// Regex updated to handle comments and lowercase 'div' in the cover color rule.
+				var match = new Regex(
+					@"(DIV|div).bloom-page.coverColor\s*{.*?background-color:\s*(#[0-9a-fA-F]*|[a-z]*)",
+					RegexOptions.Singleline).Match(content);
 				if (match.Success)
 				{
-					return match.Groups[1].Value;
+					return match.Groups[2].Value;
 				}
 			}
 			return "#FFFFFF";

--- a/src/BloomExe/HtmlThumbNailer.cs
+++ b/src/BloomExe/HtmlThumbNailer.cs
@@ -535,7 +535,7 @@ namespace Bloom
 
 			try
 			{
-				Logger.WriteMinorEvent("HtmlThumNailer.CreateThumbNail: (threadId={2}) width={0} height={1}", browserSize.Width,
+				Logger.WriteMinorEvent("HtmlThumbNailer.CreateThumbNail: (threadId={2}) width={0} height={1}", browserSize.Width,
 					(uint)browserSize.Height,
 					Thread.CurrentThread.ManagedThreadId);
 

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -1008,10 +1008,13 @@ namespace Bloom.ImageProcessing
 			}
 		}
 
+		/// <summary>
+		/// 'input' is usually '#' + 6 hex digits, but could also rarely be a color word, like 'black'.
+		/// </summary>
 		public static bool TryCssColorFromString(string input, out Color result)
 		{
 			result = Color.White; // some default in case of error.
-			if (!input.StartsWith("#") || input.Length != 7)
+			if (input.Length < 3) // I don't think there are any 2-letter color words.
 				return false; // arbitrary failure
 			try
 			{

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -55,7 +55,8 @@ namespace Bloom.web.controllers
 			apiHandler.RegisterEndpointLegacy("common/saveChangesAndRethinkPageEvent", RethinkPageAndReloadIt, true); // Move to EditingViewApi
 			apiHandler.RegisterEndpointLegacy("common/chooseFolder", HandleChooseFolder, true);
 			apiHandler.RegisterEndpointLegacy("common/showInFolder", HandleShowInFolderRequest, true); // Common
-			apiHandler.RegisterEndpointLegacy("common/canModifyCurrentBook", HandleCanModifyCurrentBook, true);
+			apiHandler.RegisterEndpointHandler("common/canModifyCurrentBook", HandleCanModifyCurrentBook, true);
+			apiHandler.RegisterEndpointHandler("common/hasPreserveCoverColor", HandleHasPreserveCoverColor,true);
 			apiHandler.RegisterEndpointLegacy("common/showSettingsDialog", HandleShowSettingsDialog, false); // Common
 			apiHandler.RegisterEndpointLegacy("common/problemWithBookMessage", request =>
 			{
@@ -184,6 +185,15 @@ namespace Bloom.web.controllers
 			request.ReplyWithBoolean(request.CurrentBook?.IsSaveable ?? false);
 		}
 
+		/// <summary>
+		/// The 2 Comic templates and the Video template insist on black cover color. They also have a meta tag
+		/// that tells Bloom to preserve that cover color. This method lets js-land find out about that tag so that
+		/// color pickers won't let the user change that color and so they'll know what color the cover is (black).
+		/// </summary>
+		private void HandleHasPreserveCoverColor(ApiRequest request)
+		{
+			request.ReplyWithBoolean(request.CurrentBook.OurHtmlDom.HasMetaElement("preserveCoverColor"));
+		}
 
 		public Action ReloadProjectAction { get; set; }
 

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -1444,6 +1444,68 @@ namespace BloomTests.Book
 			Assert.AreEqual(PublishModel.BookletLayoutMethod.Calendar, book.GetBookletLayoutMethod(A5Landscape));
 		}
 
+		[Test]
+		public void GetCoverColorFromDom_RegularHexCode_Works()
+		{
+			const string xml = @"<html><head>
+				<style type='text/css'>
+				    DIV.bloom-page.coverColor       {               background-color: #abcdef !important;   }
+				</style>
+			</head><body></body></html>";
+			var document = new XmlDocument();
+			document.LoadXml(xml);
+
+			// SUT
+			var result = Bloom.Book.Book.GetCoverColorFromDom(document);
+
+			Assert.AreEqual("#abcdef", result);
+		}
+
+		[Test]
+		public void GetCoverColorFromDom_ColorWordWithComment_Works()
+		{
+			// This is from the Digital Comic Book template. (lowercase 'div' and intervening comment)
+			const string xml = @"<html><head>
+				<meta name='preserveCoverColor' content='true'></meta>
+			    <style type='text/css'>
+				    div.bloom-page.coverColor {
+				        /* note that above, we have a meta ""preserveCoverColor"" tag to preserve this*/
+				        background-color: black !important;
+				    }
+			    </style>
+			</head><body></body></html>";
+			var document = new XmlDocument();
+			document.LoadXml(xml);
+
+			// SUT
+			var result = Bloom.Book.Book.GetCoverColorFromDom(document);
+
+			Assert.AreEqual("black", result);
+		}
+
+		[Test]
+		public void GetCoverColorFromDom_MoonAndCapVersion_Works()
+		{
+			// This is from the Moon and Cap example book. (lowercase 'div' and extraneous textarea rule)
+			const string xml = @"<html><head>
+			    <style type='text/css'>
+				    div.coverColor textarea {
+				    background-color: #ffd4d4 !important;
+				    }
+				    div.bloom-page.coverColor {
+				    background-color: #ffd4d4 !important;
+				    }
+			    </style>
+			</head><body></body></html>";
+			var document = new XmlDocument();
+			document.LoadXml(xml);
+
+			// SUT
+			var result = Bloom.Book.Book.GetCoverColorFromDom(document);
+
+			Assert.AreEqual("#ffd4d4", result);
+		}
+
 		private Layout A5Landscape => new Layout() {SizeAndOrientation = SizeAndOrientation.FromString("A5Landscape")};
 
 		[Test]


### PR DESCRIPTION
* fix Android cover color detection regex to handle
   lowercase 'div' rules from templates
* keep black color for templates with preserveCoverColor
   (Comics and Video)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5374)
<!-- Reviewable:end -->
