### PR TITLE
Don't allow importing .wav music (background) audio files (BL-11481)

### DIFF
--- a/src/BloomExe/Publish/AudioProcessor.cs
+++ b/src/BloomExe/Publish/AudioProcessor.cs
@@ -20,7 +20,10 @@ namespace Bloom.Publish
 		public static readonly string[] NarrationAudioExtensions = {".wav", ".mp3"};
 
 		// Import only compressed forms of music (audio) files.  See BL-11481.
-		public static readonly string[] MusicFileExtensions = {".mp3", ".ogg"};
+		// If we change MusicFileExtensions to remove ".wav", then existing books with .wav background audio
+		// files would break due to those files being deleted on automatic cleanup.
+		public static readonly string[] MusicFileExtensionsToImport = {".mp3", ".ogg" };
+		public static readonly string[] MusicFileExtensions = {".mp3", ".ogg", ".wav"};
 
 		public static readonly string[] AudioFileExtensions = NarrationAudioExtensions.Union(MusicFileExtensions).ToArray();
 

--- a/src/BloomExe/web/controllers/MusicApi.cs
+++ b/src/BloomExe/web/controllers/MusicApi.cs
@@ -135,7 +135,7 @@ namespace Bloom.web.controllers
 
 		private string BuildFileFilter()
 		{
-			var lowerExtensionString = string.Join(";", AudioProcessor.MusicFileExtensions.Select(ext => "*" + ext));
+			var lowerExtensionString = string.Join(";", AudioProcessor.MusicFileExtensionsToImport.Select(ext => "*" + ext));
 			var upperExtensionString = lowerExtensionString.ToUpperInvariant();
 			return $"({lowerExtensionString})|{lowerExtensionString};{upperExtensionString}";
 		}


### PR DESCRIPTION
But allow existing .wav background audio files in existing books to hang around.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5381)
<!-- Reviewable:end -->
