### PR TITLE
Adjust PNG compression from 100 to 75 for GraphicsMagick (BL-11441)

### DIFF
--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -827,8 +827,12 @@ namespace Bloom.ImageProcessing
 				argsBldr.AppendFormat("convert \"{0}\"", safeSourcePath);
 				if (makeOpaque)
 					argsBldr.Append(" -background white -extent 0x0 +matte");
+				// GraphicsMagick quality numbers: http://www.graphicsmagick.org/GraphicsMagick.html#details-quality
+				// For PNG files, "quality" really means "compression".  75 is the default value used in GraphicsMagick
+				// for .png files, and tests out as having a good balance between speed and resulting file size.
+				// See https://issues.bloomlibrary.org/youtrack/issue/BL-11441 for an extensive discussion of this.
 				if (destPath.EndsWith(".png", StringComparison.InvariantCultureIgnoreCase))
-					argsBldr.Append(" -quality 100"); // quality numbers: http://www.graphicsmagick.org/GraphicsMagick.html#details-quality
+					argsBldr.Append(" -quality 75");	// no lossage in output, use adaptive filter in changing image dimensions
 				else if (destPath.EndsWith(".jpg", StringComparison.InvariantCultureIgnoreCase))
 					argsBldr.Append(" -quality 99");	// still lossy, but not near as bad as the default (bigger file, however)
 				argsBldr.AppendFormat(" -scale {0}x{1} \"{2}\"", size.Width, size.Height, safeDestPath);


### PR DESCRIPTION
After extensive testing and discussion, we decided to speed up processing PNG files by a factor of 4 while increasing file sizes by maybe 4%.  (This applies to reducing image dimensions on importing image files.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5401)
<!-- Reviewable:end -->
