### PR TITLE
Unlock the collection file while syncing it (BL-11540)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -386,6 +386,7 @@
     <Compile Include="Book\PublishSettings.cs" />
     <Compile Include="Book\SaveContext.cs" />
     <Compile Include="Collection\BookCollectionHolder.cs" />
+    <Compile Include="Collection\CollectionLock.cs" />
     <Compile Include="ToPalaso\FontAnalytics.cs" />
     <Compile Include="ErrorReporter\BloomErrorReport.cs" />
     <Compile Include="ErrorReporter\IBloomErrorReporter.cs" />

--- a/src/BloomExe/Collection/CollectionLock.cs
+++ b/src/BloomExe/Collection/CollectionLock.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SIL.Code;
+
+namespace Bloom.Collection
+{
+	/// <summary>
+	/// Prevent the collection folder from being moved or renamed while we're running. We can't actually lock a folder,
+	/// so we do this by locking the .bloomCollectionFile. We do this in a way that allows others (and our own code)
+	/// to read and write to it, just not delete/rename/move it.  BL-11484
+	/// Some operations that don't look like moving it (e.g., unzipping a new version of it)
+	/// fail unexpectedly, so we provide a way to unlock temporarily for such operations.
+	/// </summary>
+	public class CollectionLock
+	{
+		private string _filePath;
+		private FileStream _streamToLockCollectionFile;
+
+		// For unit testing we may not need this locking, so can use a dummy lock.
+		public CollectionLock() {}
+		public CollectionLock(string filePath)
+		{
+			_filePath = filePath;
+		}
+
+		public void Lock()
+		{
+			if (_filePath == null) return;
+			// Prevent the collection folder from being moved or renamed while we're running. We can't actually lock a folder,
+			// so we do this by locking the .bloomCollectionFile. We do this in a way that allows others (and our own code)
+			// to read and write to it, just not delete/rename/move it.  BL-11484
+			try
+			{
+				RetryUtility.Retry(
+					() =>
+					{
+						_streamToLockCollectionFile = File.Open(_filePath, FileMode.Open, FileAccess.Read,
+							FileShare.ReadWrite);
+					}, 3);
+			}
+			catch (Exception err)
+			{
+#if DEBUG
+				throw err;
+#endif
+				// Swallow because this locking is totally optional and so not worth crashing over if for
+				// some reason something else also has it open.
+			}
+		}
+
+		public void Unlock()
+		{
+			if (_filePath == null) return;
+			try
+			{
+				_streamToLockCollectionFile.Close();
+			}
+			catch (Exception err)
+			{
+#if DEBUG
+				throw err;
+#endif
+				//swallow
+			}
+			_streamToLockCollectionFile = null;
+		}
+
+		// Unlock just while performing the specified task.
+		public void UnlockFor(Action task)
+		{
+			if (_streamToLockCollectionFile != null)
+			{
+				Unlock();
+				try
+				{
+					task();
+				}
+				finally
+				{
+					Lock();
+				}
+			}
+			else
+			{
+				task();
+			}
+		}
+	}
+}


### PR DESCRIPTION
A simpler fix for the immediate problem would be to push the locking later in the creation of the project context. But I want to be sure things get unlocked in ANY case where we're overwriting the file from the TC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5405)
<!-- Reviewable:end -->
