### PR TITLE
BL-11273 MXB xmatter tweaks

### DIFF
--- a/src/content/branding/MXB-Book-Scripture/branding.less
+++ b/src/content/branding/MXB-Book-Scripture/branding.less
@@ -7,4 +7,5 @@
 
 [data-book="title-page-branding-bottom-html"] img {
     width: 50%;
+    height: 40px !important; // They want it about 3/8" tall
 }

--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.pug
@@ -6,36 +6,11 @@ mixin mxb-printerStatement-insideBackCover
 	+page-xmatter('Inside Back Cover').cover.coverColor.insideBackCover.bloom-backMatter(data-export='back-matter-inside-back-cover')&attributes(attributes)#839e8eee-5e1a-45a7-bb01-2c171b56f8a4
 		+field-mono-meta("N1","printerStatement").Printer-Statement-style.bloom-copyFromOtherLanguageIfNecessary
 			label.bubble Printer's Statement goes here.
-
-mixin mxb-frontCover
-	// Outside Front Cover
-	+page-cover('Front Cover')(data-export='front-matter-cover', data-xmatter-page='frontCover')&attributes(attributes).frontCover.outsideFrontCover#74731b2d-18b0-420f-ac96-6de20f659810
-		block cover-above-title
-			+cover-branding-top
-
-		block cover-title
-			+field-prototypeDeclaredExplicity("V,N1").bookTitle
-				label.bubble Book title in {lang}
-				+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style.bloom-padForOverflow(data-book='bookTitle')
-
-		block front-cover-image
-			+standard-cover-image
-
-		// 2 columns: first for an optional logo, then text content
-		.bottomBlock
-			+cover-branding-bottom-left.bottom-left-branding
-
-			// 2 rows
-			.bottomTextContent
-				block cover-bottom-credits
-					+mxb-frontCoverCredits
-				block cover-bottom-row-before-branding
-					.bottomRow
-						.coverBottomLangName.Cover-Default-style(data-derived='languagesOfBook')
-						+chooser-topic.coverBottomBookTopic
-				+cover-branding-bottom
-				block cover-bottom-row-after-branding
-		block front-cover-footer
+mixin mxb-languageNameTopic-field
+	block cover-bottom-row-before-branding
+		.bottomRow
+			.coverBottomLangName.L1-Name-style(data-derived='languagesOfBook')
+			+chooser-topic.coverBottomBookTopic
 
 mixin mxb-frontCoverCredits
 	//NB: don't convert this to an inline label; that interferes with the bloom-copyFromOtherLanguageIfNecessary,

--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBLiteracy-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBLiteracy-XMatter.pug
@@ -1,6 +1,34 @@
 
 include ./MXBCommon-XMatter.pug
 
+mixin mxb-frontCover-Literacy
+	// FRONT COVER
+	+page-cover('Front Cover')(data-export='front-matter-cover', data-xmatter-page='frontCover')&attributes(attributes).frontCover.outsideFrontCover#74731b2d-18b3-420f-ac96-6de20f659810
+		block cover-above-title
+			+cover-branding-top
+
+		block cover-title
+			+field-prototypeDeclaredExplicity("V,N1").bookTitle
+				label.bubble Book title in {lang}
+				+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style.bloom-padForOverflow(data-book='bookTitle')
+
+		block front-cover-image
+			+standard-cover-image
+
+		// 2 columns: first for an optional logo, then text content
+		.bottomBlock
+			+cover-branding-bottom-left.bottom-left-branding
+
+			// 2 rows
+			.bottomTextContent
+				block cover-bottom-credits
+					+mxb-frontCoverCredits
+				+mxb-languageNameTopic-field
+				+cover-branding-bottom
+				block cover-bottom-row-after-branding
+		block front-cover-footer
+
+
 doctype html
 html
 	head
@@ -11,7 +39,7 @@ html
 		block stylesheets
 			+stylesheets('MXBLiteracy-XMatter.css')
 	body
-		+factoryStandard-outsideFrontCover
+		+mxb-frontCover-Literacy
 
 		//- Allow Device version to override page order
 		block afterFrontCoverPages

--- a/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.less
@@ -18,6 +18,29 @@ ENDLAYOUTS
 
 @XMatterPackName: "MXB Scripture";
 
+.bloom-page {
+    &.outsideFrontCover {
+        // Make the front cover's Scripture reference field bold, centered and 16pt
+        .Reference-Cover-style {
+            font-size: 16pt;
+            font-weight: bold;
+            text-align: center;
+        }
+        // Make the default Spanish title not bold on the Cover
+        .bloom-translationGroup.bookTitle
+            .bloom-contentNational1.Title-On-Cover-style.bloom-editable {
+            font-weight: normal;
+        }
+    }
+    // Make the title page's Scripture reference field bold, (already centered) and 14pt
+    &.titlePage {
+        .Reference-TitlePage-style {
+            font-weight: bold;
+            font-size: 14pt;
+        }
+    }
+}
+
 .credits .licenseAndCopyrightBlock {
     margin-top: auto;
 }
@@ -25,7 +48,6 @@ ENDLAYOUTS
 .titlePage .creditsRow .smallCoverCredits.bloom-content1 {
     // for Scripture this is tucked up under the title and used for chapter/verse references
     margin-bottom: @MarginBetweenMajorItems;
-    font-size: 12pt;
 }
 
 .titlePage #titlePageTitleBlock {

--- a/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.pug
@@ -1,10 +1,15 @@
 
 include ../MXBLiteracy-XMatter/MXBCommon-XMatter.pug
 
-mixin mxb-chapterVerseRef
+mixin mxb-chapterVerseRef-FrontCover
 	.creditsRow(data-hint='Este espacio es para indicar la cita bíblica en lugar de atribuir al autor/ilustrador.')
 		+field-prototypeDeclaredExplicity("V")
-			+editable(kLanguageForPrototypeOnly).smallCoverCredits.Cover-Default-style(data-book='smallCoverCredits')
+			+editable(kLanguageForPrototypeOnly).smallCoverCredits.Reference-Cover-style(data-book='smallCoverCredits')
+
+mixin mxb-chapterVerseRef-TitlePage
+	.creditsRow(data-hint='Este espacio es para indicar la cita bíblica en lugar de atribuir al autor/ilustrador.')
+		+field-prototypeDeclaredExplicity("V")
+			+editable(kLanguageForPrototypeOnly).smallCoverCredits.Reference-TitlePage-style(data-book='smallCoverCredits')
 
 mixin mxb-contributions-scripture
 	+field-prototypeDeclaredExplicity("N1")#contributions
@@ -23,7 +28,7 @@ mixin mxb-frontCover-scripture
 				label.bubble Book title in {lang}
 				+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style.bloom-padForOverflow(data-book='bookTitle')
 
-		+mxb-chapterVerseRef
+		+mxb-chapterVerseRef-FrontCover
 
 		block front-cover-image
 			+standard-cover-image
@@ -34,10 +39,7 @@ mixin mxb-frontCover-scripture
 
 			// 1 row
 			.bottomTextContent
-				block cover-bottom-row-before-branding
-					.bottomRow
-						.coverBottomLangName.Cover-Default-style(data-derived='languagesOfBook')
-						+chooser-topic.coverBottomBookTopic
+				+mxb-languageNameTopic-field
 				+cover-branding-bottom
 				block cover-bottom-row-after-branding
 		block front-cover-footer
@@ -47,7 +49,7 @@ mixin mxb-titlePage-scripture-contents
 		label.bubble Book title in {lang}
 		+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Title-Page-style(data-book='bookTitle')
 
-	+mxb-chapterVerseRef
+	+mxb-chapterVerseRef-TitlePage
 
 	#languageInformation.Credits-Page-style('lang'='N1')
 		.languagesOfBook(data-derived='languagesOfBook')


### PR DESCRIPTION
* Both Literacy and Scripture: add L1-Name-style to front
   cover language name
* shrink LigaBiblica logo
* add Reference-Default-style to Scripture reference field
   and style as requested

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5411)
<!-- Reviewable:end -->
