### PR TITLE
Fix spurious path length errors from downloading books (BL-10333)

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -405,9 +405,19 @@ namespace Bloom
 
 
 						if (args.Length == 1 && !IsInstallerLaunch(args) && !IsLocalizationHarvestingLaunch(args)) {
-							
+							// Handle an old-style download request which comes as an order URL from BloomLibrary for path length check.
+							var argPath = args[0];
+							const string bloomLibraryHeader = "bloom://localhost/order?orderFile=BloomLibraryBooks/";
+							if (argPath.StartsWith(bloomLibraryHeader))
+							{
+								var argPathSub = argPath.Substring(bloomLibraryHeader.Length);
+								var argUrlPath = UrlPathString.CreateFromUrlEncodedString(argPathSub);
+								var argPathGoodSub = argUrlPath.NotEncoded;
+								if (argPathGoodSub.Length < argPathSub.Length)
+									argPath = bloomLibraryHeader + argPathGoodSub;
+							}
 							// See BL-10012. Windows File explorer will give us an 8.3 path with ".BLO" at the end, so might as well convert it now.
-							var path = Utils.LongPathAware.GetLongPath(args[0]);
+							var path = Utils.LongPathAware.GetLongPath(argPath);
 
 							// See BL-10012. We'll die eventually, might as well nip this in the bud.
 							if (Utils.LongPathAware.GetExceedsMaxPath(path))


### PR DESCRIPTION
The bug report in BL-10333 is not this, but its example book showed this bug, which I added as a comment while testing fix for the original problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5430)
<!-- Reviewable:end -->
