### PR TITLE
Fix upload new book then cancel makes zombie in Bloom Library (BL-10811)

### DIFF
--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -242,7 +242,7 @@ namespace Bloom.WebLibraryIntegration
 						metaMsg = "(Dry run) Would upload book metadata";	// TODO: localize?
 					progress.WriteStatus(metaMsg);
 					// Do this after uploading the books, since the ThumbnailUrl is generated in the course of the upload.
-					if (!IsDryRun)
+					if (!IsDryRun && !progress.CancelRequested)
 					{
 						var response = ParseClient.SetBookRecord(metadata.WebDataJson);
 						parseId = response.ResponseUri.LocalPath;


### PR DESCRIPTION
This fix will prevent a Parse entry from being created for the new book in Parse, and consequently prevent the book from showing up in BloomLibrary. It doesn't change the books on S3, but that doesn't matter. (Deleting a book only deletes the Parse entry, not S3 objects, so orphaned S3 objects are not a big disaster for us). This fix does not deal with the case that an uploaded book already exists, is re-uploaded and then cancelled. (The book will be left in a partial state)