### PR TITLE
BL-11273 more MXB tweaks

### DIFF
--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.less
@@ -211,7 +211,11 @@ body[bookcreationtype="translation"] {
     }
 }
 
-.Credits-Page-style .languagesOfBook {
+.L1-Name-Cover-style {
+    font-size: 14pt;
+}
+
+.L1-Name-TitlePage-style {
     font-size: 12pt;
     width: 100%;
     text-align: center;

--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.pug
@@ -6,10 +6,11 @@ mixin mxb-printerStatement-insideBackCover
 	+page-xmatter('Inside Back Cover').cover.coverColor.insideBackCover.bloom-backMatter(data-export='back-matter-inside-back-cover')&attributes(attributes)#839e8eee-5e1a-45a7-bb01-2c171b56f8a4
 		+field-mono-meta("N1","printerStatement").Printer-Statement-style.bloom-copyFromOtherLanguageIfNecessary
 			label.bubble Printer's Statement goes here.
+
 mixin mxb-languageNameTopic-field
 	block cover-bottom-row-before-branding
 		.bottomRow
-			.coverBottomLangName.L1-Name-style(data-derived='languagesOfBook')
+			.coverBottomLangName.L1-Name-Cover-style(data-derived='languagesOfBook')
 			+chooser-topic.coverBottomBookTopic
 
 mixin mxb-frontCoverCredits
@@ -30,7 +31,7 @@ mixin mxb-titlePage-contents
 		label.bubble Book title in {lang}
 		+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Title-Page-style(data-book='bookTitle')
 	#languageInformation.Credits-Page-style('lang'='N1')
-		.languagesOfBook(data-derived='languagesOfBook')
+		.languagesOfBook.L1-Name-TitlePage-style(data-derived='languagesOfBook')
 		.langName('data-library'='dialect')
 		.langName(data-library='languageLocation').bloom-writeOnly
 	+mxb-contributions

--- a/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.pug
@@ -52,7 +52,7 @@ mixin mxb-titlePage-scripture-contents
 	+mxb-chapterVerseRef-TitlePage
 
 	#languageInformation.Credits-Page-style('lang'='N1')
-		.languagesOfBook(data-derived='languagesOfBook')
+		.languagesOfBook.L1-Name-TitlePage-style(data-derived='languagesOfBook')
 		//- review: can we get rid of these "langName" classes?
 		.langName('data-library'='dialect')
 		.langName(data-library='languageLocation').bloom-writeOnly


### PR DESCRIPTION
* added default rules for L1-Name-Cover and
   L1-Name-TitlePage styles, which allows them to show up
   in the styles dialog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5433)
<!-- Reviewable:end -->
