### PR TITLE
Cannot have image description on page in fixed mode (BL-11498)

### DIFF
--- a/src/BloomBrowserUI/publish/ePUBPublish/ePUBSettingsGroup.tsx
+++ b/src/BloomBrowserUI/publish/ePUBPublish/ePUBSettingsGroup.tsx
@@ -167,7 +167,8 @@ export const EPUBSettingsGroup: React.FunctionComponent<{
                     english="Include image descriptions on page"
                     apiEndpoint="publish/epub/imageDescriptionSetting"
                     l10nKey="PublishTab.Epub.IncludeOnPage"
-                    disabled={false}
+                    disabled={props.mode === "fixed"}
+                    forceDisabledValue={false}
                     onChange={props.onChange}
                 />
 

--- a/src/BloomBrowserUI/react_components/ApiCheckbox.tsx
+++ b/src/BloomBrowserUI/react_components/ApiCheckbox.tsx
@@ -10,6 +10,9 @@ export const ApiCheckbox: React.FunctionComponent<{
     l10nComment?: string;
     apiEndpoint: string;
     disabled?: boolean;
+    // If defined, the checkbox should have this value when disabled,
+    // whatever value we get from the API.
+    forceDisabledValue?: boolean;
     onChange?: () => void;
 }> = props => {
     const [checked, setChecked] = BloomApi.useApiBoolean(
@@ -17,9 +20,14 @@ export const ApiCheckbox: React.FunctionComponent<{
         false
     );
 
+    let showChecked = checked;
+    if (props.disabled && props.forceDisabledValue !== undefined) {
+        showChecked = props.forceDisabledValue;
+    }
+
     return (
         <MuiCheckbox
-            checked={checked}
+            checked={showChecked}
             disabled={props.disabled}
             label={props.english}
             l10nKey={props.l10nKey}

--- a/src/BloomExe/Publish/Epub/PublishEpubApi.cs
+++ b/src/BloomExe/Publish/Epub/PublishEpubApi.cs
@@ -294,7 +294,8 @@ namespace Bloom.Publish.Epub
 			PrepareToStageEpub();
 			// Initialize the settings to affect the first epub preview.  See https://issues.bloomlibrary.org/youtrack/issue/BL-7316.
 			var settings = _bookSelection.CurrentSelection.BookInfo.PublishSettings.Epub;
-			EpubMaker.PublishImageDescriptions = settings.HowToPublishImageDescriptions;
+			// We can't visibly publish image descriptions in fixed mode.
+			EpubMaker.PublishImageDescriptions = (settings.Mode == "fixed" ? BookInfo.HowToPublishImageDescriptions.None : settings.HowToPublishImageDescriptions);
 			EpubMaker.RemoveFontSizes = settings.RemoveFontSizes;
 			return SetupEpubControlContent();
 		}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5454)
<!-- Reviewable:end -->
