### PR TITLE
Constrain overlays so at least part is visible (BL-11617)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -103,7 +103,7 @@ export function GetButtonModifier(container) {
 }
 
 export function addImageEditingButtons(containerDiv: HTMLElement): void {
-    if (containerDiv.classList.contains("hoverUp")) {
+    if (!containerDiv || containerDiv.classList.contains("hoverUp")) {
         return;
     }
     let img = getImgFromContainer(this);

--- a/src/BloomBrowserUI/bookEdit/js/origami.ts
+++ b/src/BloomBrowserUI/bookEdit/js/origami.ts
@@ -5,6 +5,7 @@ import "split-pane/split-pane.js";
 import TextBoxProperties from "../TextBoxProperties/TextBoxProperties";
 import { BloomApi } from "../../utils/bloomApi";
 import { ElementQueries } from "css-element-queries";
+import { theOneBubbleManager } from "./bubbleManager";
 
 $(() => {
     $("div.split-pane").splitPane();
@@ -58,6 +59,7 @@ function isEmpty(el) {
     return temp === "";
 }
 function setupLayoutMode() {
+    theOneBubbleManager.suspendComicEditing("forTool");
     $(".split-pane-component-inner").each(function(): boolean {
         const $this = $(this);
         if ($this.find(".split-pane").length) {
@@ -135,6 +137,10 @@ function layoutToggleClickHandler() {
             dialog.AttachToBox(this); // put the gear button in each text box identifier div
         });
     } else {
+        // This line is currently redundant since we will reload the page, but in case we
+        // stop doing that, it will be important.
+        theOneBubbleManager.resumeComicEditing();
+
         marginBox.removeClass("origami-layout-mode");
         marginBox.find(".textBox-identifier").remove();
         origamiUndoStack.length = origamiUndoIndex = 0;

--- a/src/BloomBrowserUI/bookEdit/js/point.ts
+++ b/src/BloomBrowserUI/bookEdit/js/point.ts
@@ -12,6 +12,15 @@ export enum PointScaling {
 // Basically, I do this by forcing the caller to determine whether it is scaled or not at creation
 // From there, we internally represent everything as unscaled. Then we can do all our operations on the unscaled point.
 // When you want to get the x/y values back out, you can choose to get it out using getUnscaledX/Y() or getScaledX/Y() depending on your needs
+// For example: suppose the page is scaled to 120%.
+// Then, to get the top left of a box that is visually 120 pixels from the left of its container
+// and 240 from the top, you can do either
+// new Point (box.offsetLeft, box.offsetTop, PointScaling.Unscaled, "whatever")
+// (since offsetX methods are unscaled), or
+// new Point (box.getBoundingClientRect().left, box.getBoundingClientRect().top, Point.Scaled, "whatever")
+// (since getBoundingClientRect resurns values that are scaled, that is, they are affected by containing
+// transform:scale settings).
+// Both will result in a Point with x = 100, y = 200.
 export class Point {
     // These are internally represented as unscaled units
     private x: number;


### PR DESCRIPTION
Also reinitializes comical after origami drag, and fixes a glitch where overlay image controls could get turned on for the wrong bubble when  clicking on one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5467)
<!-- Reviewable:end -->
