### PR TITLE
Hide format gear icon when its text box is not focused (BL-11603)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -723,3 +723,15 @@ body.simulateColorBlindness {
         }
     }
 }
+
+// Hide the gear button unless the text box is focused for editing.
+// ck-editor takes care of inserting/removing the cke_focus class in
+// the parent text box div.  (See BL-11603.)
+#formatButton {
+    display: none;
+}
+.cke_focus {
+    #formatButton {
+        display: inherit;
+    }
+}


### PR DESCRIPTION
This is a cherry-pick from master.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5470)
<!-- Reviewable:end -->
