### PR TITLE
Tweak the fix for dropping images from overlay tool (BL-11620)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -959,43 +959,32 @@ function focusLastEditableTopBox(): boolean {
     const topBoxes = document.getElementsByClassName("bloom-textOverPicture");
     if (topBoxes.length == 0) return false;
     const lastTop = topBoxes[topBoxes.length - 1];
-    const visibleEditBoxesInLastTop = Array.from(
-        lastTop.getElementsByClassName("bloom-editable")
+    if (focusOnChildIfFound(lastTop, "bloom-editable")) return true;
+    // image and video boxes are also possibilities (BL-11620)
+    if (focusOnChildIfFound(lastTop, "bloom-imageContainer")) return true;
+    if (focusOnChildIfFound(lastTop, "bloom-videoContainer")) return true;
+    return false; // unexpected
+}
+
+function focusOnChildIfFound(lastTop: Element, className: string): boolean {
+    const visibleChildBoxesInLastTop = Array.from(
+        lastTop.getElementsByClassName(className)
     ).filter(
         // this is a crude check for visibility, but according to stack overflow
         // equivalent to the :visible check we were previously doing in jquery
         s => window.getComputedStyle(s).getPropertyValue("display") != "none"
     );
-    if (visibleEditBoxesInLastTop.length !== 0) {
+    if (visibleChildBoxesInLastTop.length !== 0) {
         // This doesn't work reliably if we just use the Element.focus(), so we use the JQuery version that
         // we set the eventhandler with in BloomSourceBubbles.SetupTooltips(). We've tried adding a "focusin"
         // eventhandler to the div, instead of the JQuery one, but it still didn't work when we used
         // the raw HTML focus() here, even if we changed the eventhandler to use currentTarget instead of target.
         // It may have something to do with the fact that JQuery calls trigger() on the event, rather than
         // calling the focus method. (BL-8726)
-        $(visibleEditBoxesInLastTop[0] as HTMLElement).focus();
+        $(visibleChildBoxesInLastTop[0] as HTMLElement).focus();
         return true;
     }
-    // image and video boxes are also possibilities (BL-11620)
-    const visibleImageBoxesInLastTop = Array.from(
-        lastTop.getElementsByClassName("bloom-imageContainer")
-    ).filter(
-        s => window.getComputedStyle(s).getPropertyValue("display") != "none"
-    );
-    if (visibleImageBoxesInLastTop.length !== 0) {
-        $(visibleImageBoxesInLastTop[0] as HTMLElement).focus();
-        return true;
-    }
-    const visibleVideoBoxesInLastTop = Array.from(
-        lastTop.getElementsByClassName("bloom-videoContainer")
-    ).filter(
-        s => window.getComputedStyle(s).getPropertyValue("display") != "none"
-    );
-    if (visibleVideoBoxesInLastTop.length !== 0) {
-        $(visibleVideoBoxesInLastTop[0] as HTMLElement).focus();
-        return true;
-    }
-    return false; // unexpected
+    return false;
 }
 
 // This function sets up a rule to display a prompt following the placeholder we insert for a missing

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -2044,7 +2044,8 @@ export class BubbleManager {
             imageContainerJQuery,
             transGroupHtml,
             location,
-            style
+            style,
+            false
         );
     }
 
@@ -2061,7 +2062,8 @@ export class BubbleManager {
             imageContainerJQuery,
             videoContainerHtml,
             location,
-            "none"
+            "none",
+            true
         );
     }
 
@@ -2083,7 +2085,8 @@ export class BubbleManager {
             imageContainerJQuery,
             imageContainerHtml,
             location,
-            "none"
+            "none",
+            true
         );
     }
 
@@ -2091,7 +2094,8 @@ export class BubbleManager {
         imageContainerJQuery: JQuery,
         internalHtml: string,
         location: Point,
-        style?: string
+        style?: string,
+        setElementActive?: boolean
     ): HTMLElement {
         // add OverPicture element as last child of .bloom-imageContainer (BL-7883)
         const lastContainerChild = imageContainerJQuery.children().last();
@@ -2114,11 +2118,20 @@ export class BubbleManager {
             location
         );
 
-        // We need to set this content active and notify overlay tool (BL-11620).
-        // But we don't want/need all the actions of setActiveElement().
-        this.activeElement = contentElement;
-        if (this.notifyBubbleChange) {
-            this.notifyBubbleChange(this.getSelectedFamilySpec());
+        // The following code would not be needed for Picture and Video bubbles if the focusin
+        // handler were reliably called after being attached by refreshBubbleEditing() below.
+        // However, calling the jquery.focus() method in bloomEditing.focusOnChildIfFound()
+        // causes the handler to fire ONLY for Text bubbles.  This is a complete mystery to me.
+        // Therefore, for Picture and Video bubbles, we set the content active and notify the
+        // overlay tool. But we don't need/want the actions of setActiveElement() which overlap
+        // with refreshBubbleEditing(). This code actually prevents bloomEditing.focusOnChildIfFound()
+        // from being called, but that doesn't really matter since calling it does no good.
+        // See https://issues.bloomlibrary.org/youtrack/issue/BL-11620.
+        if (setElementActive) {
+            this.activeElement = contentElement;
+            if (this.notifyBubbleChange) {
+                this.notifyBubbleChange(this.getSelectedFamilySpec());
+            }
         }
         const bubble = new Bubble(contentElement);
         const bubbleSpec: BubbleSpec = Bubble.getDefaultBubbleSpec(


### PR DESCRIPTION
This fixes the side-effect of setting text background to transparent. It also extracts a method from some repeated code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5480)
<!-- Reviewable:end -->
