### PR TITLE
Handle if overlay contains a non-overlay-image bubble

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -225,6 +225,14 @@ export function removeImageEditingButtons(containerDiv: HTMLElement): void {
     });
 }
 
+export function tryRemoveImageEditingButtons(
+    containerDiv: HTMLElement | undefined
+): void {
+    if (containerDiv) {
+        removeImageEditingButtons(containerDiv);
+    }
+}
+
 // Bloom "imageContainer"s are <div>'s which wrap an <img>, and automatically proportionally resize
 // the img to fit the available space.
 // Precondition: containerDiv must be just a single HTMLElement

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -22,7 +22,7 @@ import { getRgbaColorStringFromColorAndOpacity } from "../../utils/colorUtils";
 import { SetupElements, attachToCkEditor } from "./bloomEditing";
 import {
     addImageEditingButtons,
-    removeImageEditingButtons
+    tryRemoveImageEditingButtons
 } from "./bloomImages";
 
 const kComicalGeneratedClass: string = "comical-generated";
@@ -662,10 +662,10 @@ export class BubbleManager {
             return;
         }
         if (this.activeElement) {
-            removeImageEditingButtons(
+            tryRemoveImageEditingButtons(
                 this.activeElement.getElementsByClassName(
                     "bloom-imageContainer"
-                )[0] as HTMLElement
+                )[0] as HTMLElement | undefined
             );
         }
         this.activeElement = element;
@@ -1146,10 +1146,10 @@ export class BubbleManager {
             // Cleanup the previous iteration's state
             this.cleanupMouseMoveHover(container);
             if (this.activeElement) {
-                removeImageEditingButtons(
+                tryRemoveImageEditingButtons(
                     this.activeElement.getElementsByClassName(
                         "bloom-imageContainer"
-                    )[0] as HTMLElement
+                    )[0] as HTMLElement | undefined
                 );
             }
             return;


### PR DESCRIPTION
I don't think it actually causes any errors at this current commit (because Jquery), but if you were to start doing vanilla JS assuming that containerDiv is not undefined as the types state, you'd be sorry :(

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5494)
<!-- Reviewable:end -->
