### PR TITLE
Strengthen code to guard against spurious error (BL-11655)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/editViewFrame.ts
+++ b/src/BloomBrowserUI/bookEdit/editViewFrame.ts
@@ -63,7 +63,7 @@ export function switchContentPage(newSource: string) {
     try {
         if (
             this.getEditablePageBundleExports &&
-            this.getEditablePageBundleExports().pageUnloading
+            this.getEditablePageBundleExports()?.pageUnloading
         ) {
             this.getEditablePageBundleExports().pageUnloading();
         }


### PR DESCRIPTION
The code checking that it is ok to call getEditablePageBundleExports().pageUnloading() was not quite complete enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5496)
<!-- Reviewable:end -->
