### PR TITLE
[5.4] BL-11621 Move Overlay text color to editable

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -1782,7 +1782,7 @@ export default class StyleEditor {
         }
         const rule = this.getStyleRule(false);
         if (rule != null) {
-            rule.style.setProperty("color", color, "important");
+            rule.style.setProperty("color", color);
             this.cleanupAfterStyleChange();
         }
         this.setColorButtonColor(color);

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -686,6 +686,7 @@ export class BubbleManager {
     }
 
     // Set the color of the text in all of the active bubble family's TextOverPicture boxes.
+    // If hexOrRgbColor is empty string, we are setting the bubble to use the style default.
     public setTextColor(hexOrRgbColor: string) {
         const activeEl = theOneBubbleManager.getActiveElement();
         if (activeEl) {
@@ -702,10 +703,18 @@ export class BubbleManager {
     }
 
     private setTextColorInternal(hexOrRgbColor: string, element: HTMLElement) {
+        // BL-11621: We are in the process of moving to putting the Overlay text color on the inner
+        // bloom-editables. So we clear any color on the textOverPicture div and set it on all of the
+        // inner bloom-editables.
         const topBox = element.closest(
             kTextOverPictureSelector
         ) as HTMLDivElement;
-        topBox.style.color = hexOrRgbColor;
+        topBox.style.color = "";
+        const editables = topBox.getElementsByClassName("bloom-editable");
+        for (let i = 0; i < editables.length; i++) {
+            const editableElement = editables[i] as HTMLElement;
+            editableElement.style.color = hexOrRgbColor;
+        }
     }
 
     public getTextColorInformation(): ITextColorInfo {
@@ -716,6 +725,9 @@ export class BubbleManager {
             const topBox = activeEl.closest(
                 kTextOverPictureSelector
             ) as HTMLDivElement;
+            // const allUserStyles = StyleEditor.GetFormattingStyleRules(
+            //     topBox.ownerDocument
+            // );
             const style = topBox.style;
             textColor = style && style.color ? style.color : "";
             // We are in the process of moving to putting the Overlay text color on the inner

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -25,6 +25,11 @@ import {
     tryRemoveImageEditingButtons
 } from "./bloomImages";
 
+export interface ITextColorInfo {
+    color: string;
+    isDefault: boolean;
+}
+
 const kComicalGeneratedClass: string = "comical-generated";
 // We could rename this class to "bloom-overPictureElement", but that would involve a migration.
 // For now we're keeping this name for backwards-compatibility, even though now the element could be
@@ -703,17 +708,40 @@ export class BubbleManager {
         topBox.style.color = hexOrRgbColor;
     }
 
-    public getTextColor(): string {
+    public getTextColorInformation(): ITextColorInfo {
         const activeEl = theOneBubbleManager.getActiveElement();
         let textColor = "";
+        let isDefaultStyleColor = false;
         if (activeEl) {
             const topBox = activeEl.closest(
                 kTextOverPictureSelector
             ) as HTMLDivElement;
             const style = topBox.style;
             textColor = style && style.color ? style.color : "";
+            // We are in the process of moving to putting the Overlay text color on the inner
+            // bloom-editables. So if the textOverPicture div didn't have a color, check the inner
+            // bloom-editables.
+            if (textColor === "") {
+                const firstEditable = topBox.getElementsByClassName(
+                    "bloom-editable"
+                )[0] as HTMLElement;
+                const colorStyle = firstEditable.style.color;
+                if (colorStyle) {
+                    textColor = colorStyle;
+                } else {
+                    textColor = this.getDefaultStyleTextColor(firstEditable);
+                    isDefaultStyleColor = true;
+                }
+            }
         }
-        return textColor;
+        return { color: textColor, isDefault: isDefaultStyleColor };
+    }
+
+    // Returns the computed color of the text, which in the absence of a color style from the
+    // Overlay Tool will be from the Bubble-style (set in the StyleEditor).
+    // An unfortunate, but greatly simplifying, use of JQuery.
+    public getDefaultStyleTextColor(firstEditable: HTMLElement): string {
+        return $(firstEditable).css("color");
     }
 
     // This gives us the patriarch (farthest ancestor) bubble of a family of bubbles.
@@ -1908,9 +1936,9 @@ export class BubbleManager {
         // Make sure that the child inherits any non-default text color from the parent bubble
         // (which must be the active element).
         this.setActiveElement(parentElement);
-        const parentTextColor = this.getTextColor();
-        if (parentTextColor !== "") {
-            this.setTextColorInternal(parentTextColor, childElement);
+        const parentTextColor = this.getTextColorInformation();
+        if (!parentTextColor.isDefault) {
+            this.setTextColorInternal(parentTextColor.color, childElement);
         }
 
         Comical.initializeChild(childElement, parentElement);

--- a/src/BloomBrowserUI/bookEdit/toolbox/overlay/colorBar.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/overlay/colorBar.tsx
@@ -1,11 +1,14 @@
+/** @jsx jsx **/
+import { jsx, css } from "@emotion/core";
 import * as React from "react";
 import Typography from "@material-ui/core/Typography";
-import {
+import ColorSwatch, {
     IColorInfo,
     getBackgroundColorCssFromColorInfo
 } from "../../../react_components/color-picking/colorSwatch";
 import * as tinycolor from "tinycolor2";
 import { CSSProperties } from "react";
+import { useL10n } from "../../../react_components/l10nHooks";
 
 export interface IColorBarProps {
     id: string;
@@ -14,16 +17,24 @@ export interface IColorBarProps {
     text?: string;
     onClick: () => void;
     colorInfo: IColorInfo;
+    isDefault?: boolean;
 }
 // Displays a color bar menu item with optional localizable text.
 export const ColorBar: React.FunctionComponent<IColorBarProps> = (
     props: IColorBarProps
 ) => {
+    const defaultStyleLabel = useL10n(
+        "Default for style",
+        "EditTab.DirectFormatting.labelForDefaultColor"
+    );
+
     const baseColor = props.colorInfo.colors; // An array of strings representing colors
 
     const backgroundColorString = getBackgroundColorCssFromColorInfo(
         props.colorInfo
     );
+
+    const toolboxPanelBackground = "#2e2e2e";
 
     const isDark = (colorString: string): boolean => {
         const color = tinycolor(colorString); // handles named colors, rgba() and hex strings!!!
@@ -45,18 +56,58 @@ export const ColorBar: React.FunctionComponent<IColorBarProps> = (
 
     const barStyles: CSSProperties = {
         minHeight: 30,
-        background: backgroundColorString,
+        background: props.isDefault
+            ? toolboxPanelBackground
+            : backgroundColorString,
         border: "1px solid",
         borderColor: bloomToolboxWhite,
         borderRadius: 4,
         display: "flex",
-        justifyContent: "center"
+        justifyContent: props.isDefault ? "flex-start" : "center"
     };
 
     const textStyles: CSSProperties = {
         color: textColor,
         paddingTop: 4
     };
+
+    const defaultColor = [backgroundColorString];
+
+    const defaultImplementation: JSX.Element = (
+        <div
+            css={css`
+                display: flex;
+                flex-direction: row;
+                margin: auto 0 auto 6px;
+                height: 17px;
+                align-items: center;
+            `}
+        >
+            <div
+                css={css`
+                    border: 1px solid ${bloomToolboxWhite};
+                    margin-right: 4px;
+                    .color-swatch {
+                        margin: 0;
+                    }
+                `}
+            >
+                <ColorSwatch
+                    colors={defaultColor}
+                    opacity={1}
+                    width={25}
+                    height={15}
+                />
+            </div>
+            <Typography
+                css={css`
+                    color: ${bloomToolboxWhite};
+                `}
+            >
+                {defaultStyleLabel}
+            </Typography>
+        </div>
+    );
 
     // 'MuiInput-formControl' may seem like an odd class to give my homegrown div, but some of the toolbox's
     // spacing rules depend on it being one of these.
@@ -66,9 +117,10 @@ export const ColorBar: React.FunctionComponent<IColorBarProps> = (
             style={barStyles}
             onClick={props.onClick}
         >
-            <Typography color="textPrimary" style={textStyles}>
-                {props.text}
-            </Typography>
+            {props.isDefault && defaultImplementation}
+            {!props.isDefault && props.text && (
+                <Typography style={textStyles}>{props.text}</Typography>
+            )}
         </div>
     );
 };

--- a/src/BloomBrowserUI/bookEdit/toolbox/overlay/colorBar.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/overlay/colorBar.tsx
@@ -86,22 +86,34 @@ export const ColorBar: React.FunctionComponent<IColorBarProps> = (
             <div
                 css={css`
                     border: 1px solid ${bloomToolboxWhite};
+                    box-sizing: border-box;
                     margin-right: 4px;
-                    .color-swatch {
+                    /* .color-swatch {
                         margin: 0;
-                    }
+                    } background below is temporary */
+                    background: linear-gradient(
+                        to top left,
+                        ${toolboxPanelBackground} 0%,
+                        ${toolboxPanelBackground} calc(50% - 0.8px),
+                        ${bloomToolboxWhite} 50%,
+                        ${toolboxPanelBackground} calc(50% + 0.8px),
+                        ${toolboxPanelBackground} 100%
+                    );
+                    width: 14px;
+                    height: 14px;
                 `}
             >
-                <ColorSwatch
+                {/* <ColorSwatch
                     colors={defaultColor}
                     opacity={1}
                     width={25}
                     height={15}
-                />
+                /> */}
             </div>
             <Typography
                 css={css`
                     color: ${bloomToolboxWhite};
+                    font-size: 0.9rem !important;
                 `}
             >
                 {defaultStyleLabel}

--- a/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
@@ -297,6 +297,15 @@ const OverlayToolControls: React.FunctionComponent = () => {
         }
     };
 
+    const defaultTextColorClicked = () => {
+        const bubbleMgr = OverlayTool.bubbleManager();
+        if (bubbleMgr) {
+            setTextColorIsDefault(true);
+            bubbleMgr.setTextColor(""); // sets bubble to use style default
+            updateReactFromComical(bubbleMgr);
+        }
+    };
+
     const noteInputFocused = (input: HTMLElement) =>
         OverlayTool.bubbleManager()?.setThingToFocusAfterSettingColor(input);
 
@@ -458,7 +467,10 @@ const OverlayToolControls: React.FunctionComponent = () => {
             palette: BloomPalette.Text,
             isForOverlay: true,
             onChange: color => updateTextColor(color),
-            onInputFocus: noteInputFocused
+            onInputFocus: noteInputFocused,
+            includeDefault: true,
+            onDefaultClick: defaultTextColorClicked
+            //defaultColor???
         };
         getEditTabBundleExports().showColorPickerDialog(colorPickerDialogProps);
     };

--- a/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
@@ -10,7 +10,7 @@ import {
     getEditablePageBundleExports,
     getEditTabBundleExports
 } from "../../js/bloomFrames";
-import { BubbleManager } from "../../js/bubbleManager";
+import { BubbleManager, ITextColorInfo } from "../../js/bubbleManager";
 import { BubbleSpec, TailSpec } from "comicaljs";
 import { ToolBottomHelpLink } from "../../../react_components/helpLink";
 import FormControl from "@material-ui/core/FormControl";
@@ -90,6 +90,7 @@ const OverlayToolControls: React.FunctionComponent = () => {
     const [textColorSwatch, setTextColorSwatch] = useState(
         defaultTextColors[0]
     );
+    const [textColorIsDefault, setTextColorIsDefault] = useState(true);
 
     // Background color swatch
     // defaults to "white" background color
@@ -166,9 +167,10 @@ const OverlayToolControls: React.FunctionComponent = () => {
             setBubbleType(getBubbleType(bubbleMgr));
             if (bubbleMgr) {
                 // Get the current bubble's textColor and set it
-                const bubbleTextColor = bubbleMgr.getTextColor();
+                const bubbleTextColorInformation: ITextColorInfo = bubbleMgr.getTextColorInformation();
+                setTextColorIsDefault(bubbleTextColorInformation.isDefault);
                 const newSwatch = getColorInfoFromSpecialNameOrColorString(
-                    bubbleTextColor
+                    bubbleTextColorInformation.color
                 );
                 setTextColorSwatch(newSwatch);
             }
@@ -671,6 +673,7 @@ const OverlayToolControls: React.FunctionComponent = () => {
                                 id="text-color-bar"
                                 onClick={launchTextColorChooser}
                                 colorInfo={textColorSwatch}
+                                isDefault={textColorIsDefault}
                             />
                         </FormControl>
                         <FormControl>

--- a/src/BloomBrowserUI/react_components/color-picking/colorPicker.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/colorPicker.tsx
@@ -7,6 +7,8 @@ import BloomSketchPicker from "./bloomSketchPicker";
 import ColorSwatch, { IColorInfo } from "./colorSwatch";
 import * as tinycolor from "tinycolor2";
 import { HexColorInput } from "./hexColorInput";
+import { useL10n } from "../l10nHooks";
+import { Typography } from "@material-ui/core";
 
 // We are combining parts of the 'react-color' component set with our own list of swatches.
 // The reason for using our own swatches is so we can support swatches with gradients and alpha.
@@ -17,10 +19,16 @@ interface IColorPickerProps {
     onChange: (color: IColorInfo) => void;
     currentColor: IColorInfo;
     swatchColors: IColorInfo[];
+    defaultColor?: IColorInfo;
 }
 
 export const ColorPicker: React.FunctionComponent<IColorPickerProps> = props => {
     const [colorChoice, setColorChoice] = useState(props.currentColor);
+
+    const defaultStyleLabel = useL10n(
+        "Default for style",
+        "EditTab.DirectFormatting.labelForDefaultColor"
+    );
 
     const changeColor = (swatchColor: IColorInfo) => {
         setColorChoice(swatchColor);
@@ -144,14 +152,43 @@ export const ColorPicker: React.FunctionComponent<IColorPickerProps> = props => 
                     margin-top: 20px;
                     display: flex;
                     flex: 2;
-                    flex-direction: row;
+                    flex-direction: column;
                     flex-wrap: wrap;
                     padding: 0 0 0 8px;
                     max-width: 209px; // 225px less margin and padding of 8px each
                 `}
-                className="swatch-row"
+                className="swatch-section"
             >
-                {getColorSwatches()}
+                {props.defaultColor && (
+                    <div
+                        css={css`
+                            display: flex;
+                            flex-direction: row;
+                        `}
+                    >
+                        <ColorSwatch
+                            colors={props.defaultColor.colors}
+                            opacity={props.defaultColor.opacity}
+                            onClick={() => {}}
+                        />
+                        <Typography
+                            css={css`
+                                margin-left: 6px !important;
+                            `}
+                        >
+                            {defaultStyleLabel}
+                        </Typography>
+                    </div>
+                )}
+                <div
+                    css={css`
+                        display: flex;
+                        flex-direction: row;
+                    `}
+                    className="swatch-row"
+                >
+                    {getColorSwatches()}
+                </div>
             </div>
         </div>
     );

--- a/src/BloomBrowserUI/react_components/color-picking/colorPicker.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/colorPicker.tsx
@@ -19,7 +19,9 @@ interface IColorPickerProps {
     onChange: (color: IColorInfo) => void;
     currentColor: IColorInfo;
     swatchColors: IColorInfo[];
-    defaultColor?: IColorInfo;
+    includeDefault?: boolean;
+    onDefaultClick?: () => void;
+    //defaultColor?: IColorInfo;  will eventually need this
 }
 
 export const ColorPicker: React.FunctionComponent<IColorPickerProps> = props => {
@@ -153,24 +155,47 @@ export const ColorPicker: React.FunctionComponent<IColorPickerProps> = props => 
                     display: flex;
                     flex: 2;
                     flex-direction: column;
-                    flex-wrap: wrap;
                     padding: 0 0 0 8px;
                     max-width: 209px; // 225px less margin and padding of 8px each
                 `}
                 className="swatch-section"
             >
-                {props.defaultColor && (
+                {props.includeDefault && (
                     <div
                         css={css`
                             display: flex;
                             flex-direction: row;
+                            margin-left: 8px;
                         `}
+                        onClick={() => {
+                            if (props.onDefaultClick) props.onDefaultClick();
+                        }}
                     >
-                        <ColorSwatch
+                        {/* Temporary substitution until we know the default style color. */}
+                        <div
+                            css={css`
+                                width: 20px;
+                                height: 20px;
+                                border: 1px solid black;
+                                box-sizing: border-box;
+                                background: linear-gradient(
+                                    to top left,
+                                    rgba(255, 255, 255, 1) 0%,
+                                    rgba(255, 255, 255, 1) calc(50% - 0.8px),
+                                    rgba(0, 0, 0, 1) 50%,
+                                    rgba(255, 255, 255, 1) calc(50% + 0.8px),
+                                    rgba(255, 255, 255, 1) 100%
+                                );
+                            `}
+                        />
+                        {/* <ColorSwatch
                             colors={props.defaultColor.colors}
                             opacity={props.defaultColor.opacity}
-                            onClick={() => {}}
-                        />
+                            onClick={() => {
+                                if (props.onDefaultClick)
+                                    props.onDefaultClick();
+                            }}
+                        /> */}
                         <Typography
                             css={css`
                                 margin-left: 6px !important;
@@ -184,6 +209,7 @@ export const ColorPicker: React.FunctionComponent<IColorPickerProps> = props => 
                     css={css`
                         display: flex;
                         flex-direction: row;
+                        flex-wrap: wrap;
                     `}
                     className="swatch-row"
                 >

--- a/src/BloomBrowserUI/react_components/color-picking/colorPickerDialog.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/colorPickerDialog.tsx
@@ -40,6 +40,7 @@ export interface IColorPickerDialogProps {
     isForOverlay?: boolean;
     onChange: (color: IColorInfo) => void;
     onInputFocus: (input: HTMLElement) => void;
+    defaultColor?: IColorInfo;
 }
 
 let externalSetOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -301,6 +302,7 @@ const ColorPickerDialog: React.FC<IColorPickerDialogProps> = props => {
                         swatchColors={swatchColorArray}
                         noAlphaSlider={props.noAlphaSlider}
                         noGradientSwatches={props.noGradientSwatches}
+                        defaultColor={props.defaultColor}
                     />
                 </DialogMiddle>
                 <DialogBottomButtons>

--- a/src/BloomBrowserUI/react_components/color-picking/colorPickerDialog.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/colorPickerDialog.tsx
@@ -39,8 +39,10 @@ export interface IColorPickerDialogProps {
     palette: BloomPalette;
     isForOverlay?: boolean;
     onChange: (color: IColorInfo) => void;
+    onDefaultClick?: () => void;
     onInputFocus: (input: HTMLElement) => void;
-    defaultColor?: IColorInfo;
+    includeDefault?: boolean;
+    //defaultColor?: IColorInfo; eventually we'll need this
 }
 
 let externalSetOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -302,7 +304,9 @@ const ColorPickerDialog: React.FC<IColorPickerDialogProps> = props => {
                         swatchColors={swatchColorArray}
                         noAlphaSlider={props.noAlphaSlider}
                         noGradientSwatches={props.noGradientSwatches}
-                        defaultColor={props.defaultColor}
+                        includeDefault={props.includeDefault}
+                        onDefaultClick={props.onDefaultClick}
+                        //defaultColor={props.defaultColor}
                     />
                 </DialogMiddle>
                 <DialogBottomButtons>

--- a/src/BloomBrowserUI/react_components/color-picking/colorSwatch.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/colorSwatch.tsx
@@ -2,7 +2,6 @@
 import { jsx, css } from "@emotion/core";
 import * as React from "react";
 import { Checkboard } from "react-color/lib/components/common";
-import { CSSProperties } from "@material-ui/styles";
 import * as tinycolor from "tinycolor2";
 
 // External definition of a color swatch

--- a/src/BloomBrowserUI/react_components/color-picking/stories.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/stories.tsx
@@ -264,7 +264,11 @@ storiesOf("Colors", module)
                 palette: BloomPalette.Text,
                 onChange: color => handleColorChange(color),
                 onInputFocus: () => {},
-                defaultColor: defaultColorInfo
+                includeDefault: true,
+                onDefaultClick: () => {
+                    alert("clicked Default");
+                }
+                //defaultColor: defaultColorInfo
             };
 
             return (

--- a/src/BloomBrowserUI/react_components/color-picking/stories.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/stories.tsx
@@ -18,8 +18,9 @@ import { BloomPalette, TextBackgroundColors } from "./bloomPalette";
 import BloomSketchPicker from "./bloomSketchPicker";
 import tinycolor = require("tinycolor2");
 import { ColorResult } from "react-color";
-import { Typography } from "@material-ui/core";
+import { FormControl, InputLabel, Typography } from "@material-ui/core";
 import { HexColorInput } from "./hexColorInput";
+import { ColorBar } from "../../bookEdit/toolbox/overlay/colorBar";
 
 const mainBlockStyles: React.CSSProperties = {
     width: 300,
@@ -52,11 +53,12 @@ const initialOverDivStyles: React.CSSProperties = {
     position: "absolute",
     top: 10,
     left: 15,
-    width: 120,
+    width: 140,
     height: 70,
     border: "1px solid red",
     zIndex: 2,
-    background: "#fff"
+    background: "#fff",
+    color: "black"
 };
 
 storiesOf("Colors", module)
@@ -206,7 +208,7 @@ storiesOf("Colors", module)
                         test transparency.
                     </div>
                     <div id="set-my-background" style={overDivStyles}>
-                        Set my text and background colors with the button
+                        Set my background colors with the button
                     </div>
                     <div id="modal-container" />
                     <BloomButton
@@ -222,6 +224,197 @@ storiesOf("Colors", module)
                     >
                         Open Color Picker Dialog
                     </BloomButton>
+                </div>
+            );
+        })
+    )
+    .add("Color Picker w/Default", () =>
+        React.createElement(() => {
+            const [overDivStyles, setOverDivStyles] = useState(
+                initialOverDivStyles
+            );
+            const defaultColorInfo: IColorInfo = {
+                colors: ["#ffbf00"],
+                opacity: 1
+            };
+            const [
+                chooserCurrentTextColor,
+                setChooserCurrentTextColor
+            ] = useState<IColorInfo>({
+                name: "black",
+                colors: ["#000000"],
+                opacity: 1
+            });
+            const handleColorChange = (color: IColorInfo) => {
+                console.log("Color change:");
+                console.log(
+                    `  ${color.name}: ${color.colors[0]}, ${color.colors[1]}, ${color.opacity}`
+                );
+                // set text color
+                setOverDivStyles({
+                    ...overDivStyles,
+                    color: getBackgroundColorCssFromColorInfo(color)
+                });
+                setChooserCurrentTextColor(color);
+            };
+
+            const colorPickerDialogProps: IColorPickerDialogProps = {
+                localizedTitle: "Color Picker w/ Default",
+                initialColor: chooserCurrentTextColor,
+                palette: BloomPalette.Text,
+                onChange: color => handleColorChange(color),
+                onInputFocus: () => {},
+                defaultColor: defaultColorInfo
+            };
+
+            return (
+                <div style={mainBlockStyles}>
+                    <div id="background-image" style={backDivStyles}>
+                        I am a background "image" with lots of text so we can
+                        test transparency.
+                    </div>
+                    <div id="set-my-background" style={overDivStyles}>
+                        Set my text color with the button
+                    </div>
+                    <div id="modal-container" />
+                    <BloomButton
+                        onClick={() =>
+                            showColorPickerDialog(
+                                colorPickerDialogProps,
+                                document.getElementById("modal-container")
+                            )
+                        }
+                        enabled={true}
+                        hasText={true}
+                        l10nKey={"dummyKey"}
+                    >
+                        Open Color Picker Dialog
+                    </BloomButton>
+                </div>
+            );
+        })
+    )
+    .add("Color Bars", () =>
+        React.createElement(() => {
+            const transparentColorInfo = {
+                colors: ["#000"],
+                opacity: 0
+            };
+            const partialTransparentColorInfo = {
+                colors: ["#d00a00"],
+                opacity: 0.6
+            };
+            const defaultTextColorInfo: IColorInfo = {
+                colors: ["#ffbf00"],
+                opacity: 1
+            };
+
+            return (
+                <div
+                    css={css`
+                        display: flex;
+                        flex-direction: column;
+                        width: 300px;
+                        height: 400px;
+                    `}
+                >
+                    <div
+                        id="toolbox-background"
+                        css={css`
+                            position: relative;
+                            background: rgb(46, 46, 46);
+                            width: 200px;
+                            height: 100%;
+                            border: 1px solid black;
+                        `}
+                    />
+                    <form
+                        css={css`
+                            position: absolute;
+                            top: 20px;
+                            width: 188px;
+                            margin-left: 6px;
+                            display: flex;
+                            flex-direction: column;
+                            div {
+                                display: inline-flex;
+                            }
+                            & > div {
+                                margin-top: 10px;
+                                label {
+                                    position: unset;
+                                }
+                            }
+                        `}
+                    >
+                        <FormControl>
+                            <InputLabel
+                                css={css`
+                                    color: white !important;
+                                `}
+                                shrink={true}
+                                htmlFor="background-color-bar"
+                            >
+                                Background Color
+                            </InputLabel>
+                            <ColorBar
+                                id="background-color-bar"
+                                onClick={() => {}}
+                                colorInfo={transparentColorInfo}
+                                text="100% Transparent"
+                            />
+                        </FormControl>
+                        <FormControl>
+                            <InputLabel
+                                css={css`
+                                    color: white !important;
+                                `}
+                                shrink={true}
+                                htmlFor="partial-background-color-bar"
+                            >
+                                Background Color
+                            </InputLabel>
+                            <ColorBar
+                                id="partial-background-color-bar"
+                                onClick={() => {}}
+                                colorInfo={partialTransparentColorInfo}
+                                text="40% Transparent"
+                            />
+                        </FormControl>
+                        <FormControl>
+                            <InputLabel
+                                css={css`
+                                    color: white !important;
+                                `}
+                                shrink={true}
+                                htmlFor="text-color-bar"
+                            >
+                                Text Color
+                            </InputLabel>
+                            <ColorBar
+                                id="text-color-bar"
+                                onClick={() => {}}
+                                colorInfo={defaultTextColorInfo}
+                            />
+                        </FormControl>
+                        <FormControl>
+                            <InputLabel
+                                css={css`
+                                    color: white !important;
+                                `}
+                                shrink={true}
+                                htmlFor="default-color-bar"
+                            >
+                                Text Color
+                            </InputLabel>
+                            <ColorBar
+                                id="default-color-bar"
+                                onClick={() => {}}
+                                colorInfo={defaultTextColorInfo}
+                                isDefault={true}
+                            />
+                        </FormControl>
+                    </form>
                 </div>
             );
         })


### PR DESCRIPTION
* introduces the concept of a default style text color
* setting the style of a bubble w/StyleEditor can be overridden
   by setting the Overlay tool text color.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5500)
<!-- Reviewable:end -->
