### PR TITLE
Update ACE by Daisy Linux install script to use node 16 (20221031)

### DIFF
--- a/DistFiles/InstallAce.sh
+++ b/DistFiles/InstallAce.sh
@@ -13,7 +13,7 @@ fi
 sudo apt-get install -y curl
 
 # The next two lines come from https://nodejs.org/en/download/package-manager/.
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 # The next line comes from https://daisy.github.io/ace/help/troubleshooting/.


### PR DESCRIPTION
This should be cherry-picked to 5.3 as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5507)
<!-- Reviewable:end -->
