### PR TITLE
Re-do fix for titles with linebreaks (BL-11717)

### DIFF
--- a/src/BloomExe/Book/BookInfo.cs
+++ b/src/BloomExe/Book/BookInfo.cs
@@ -203,7 +203,7 @@ namespace Bloom.Book
 			get { return MetaData.Title; }
 			set
 			{
-				var titleStr = Book.RemoveXmlMarkup(value, Book.LineBreakSpanConversionMode.ToNewline);
+				var titleStr = Book.RemoveHtmlMarkup(value, Book.LineBreakSpanConversionMode.ToNewline);
 				MetaData.Title = titleStr;
 			}
 		}

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -4614,13 +4614,26 @@ namespace BloomTests.Book
 		}
 
 
-		[Test]
-		public void RemoveXmlMarkup_LinebreakButNoByteOrderMark_MarkupRemoved()
+		[TestCase(Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace)]
+		[TestCase(Bloom.Book.Book.LineBreakSpanConversionMode.ToNewline)]
+		[TestCase(Bloom.Book.Book.LineBreakSpanConversionMode.ToSimpleNewline)]
+		public void RemoveXmlMarkup_LinebreakButNoByteOrderMark_MarkupRemoved(Bloom.Book.Book.LineBreakSpanConversionMode conversionMode)
 		{
 			string input = "<p>Enter</p> <p>Shift-Enter<span class=\"bloom-linebreak\"></span>Last Line </p>";
-			var result = Bloom.Book.Book.RemoveHtmlMarkup(input, Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace);
-			
-			Assert.That(result, Is.EqualTo("Enter Shift-Enter Last Line "));
+			var result = Bloom.Book.Book.RemoveHtmlMarkup(input, conversionMode);
+
+			string replacement = " ";
+			switch (conversionMode) {
+				case Bloom.Book.Book.LineBreakSpanConversionMode.ToNewline:
+					replacement = Environment.NewLine;
+					break;
+				case Bloom.Book.Book.LineBreakSpanConversionMode.ToSimpleNewline:
+					replacement = "\n";
+					break;
+				default:
+					break;
+			}
+			Assert.That(result, Is.EqualTo($"Enter Shift-Enter{replacement}Last Line "));
 		}
 
 		[Test]

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -4608,7 +4608,7 @@ namespace BloomTests.Book
 		public void RemoveXmlMarkup_PlainText_NoChange()
 		{
 			string input = "Enter\nShift-Enter\nLast Line";
-			var result = Bloom.Book.Book.RemoveXmlMarkup(input, Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace);
+			var result = Bloom.Book.Book.RemoveHtmlMarkup(input, Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace);
 			
 			Assert.That(result, Is.EqualTo("Enter\nShift-Enter\nLast Line"));
 		}
@@ -4618,7 +4618,7 @@ namespace BloomTests.Book
 		public void RemoveXmlMarkup_LinebreakButNoByteOrderMark_MarkupRemoved()
 		{
 			string input = "<p>Enter</p> <p>Shift-Enter<span class=\"bloom-linebreak\"></span>Last Line </p>";
-			var result = Bloom.Book.Book.RemoveXmlMarkup(input, Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace);
+			var result = Bloom.Book.Book.RemoveHtmlMarkup(input, Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace);
 			
 			Assert.That(result, Is.EqualTo("Enter Shift-Enter Last Line "));
 		}
@@ -4627,7 +4627,7 @@ namespace BloomTests.Book
 		public void RemoveXmlMarkup_LinebreakAndByteOrderMark_MarkupAndByteOrderMarkRemoved()
 		{
 			string input = "<p>Enter</p> <p>Shift-Enter<span class=\"bloom-linebreak\"></span>\uFEFFLast Line </p>";
-			var result = Bloom.Book.Book.RemoveXmlMarkup(input, Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace);
+			var result = Bloom.Book.Book.RemoveHtmlMarkup(input, Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace);
 			
 			Assert.That(result, Is.EqualTo("Enter Shift-Enter Last Line "));
 		}


### PR DESCRIPTION
Addresses the failing unit test BloomTests.Book.BookInfoTests.TitleSetter_FixesTitleWithXml. The \r\n is handled different by XmlDocument vs XElement. (Also, that path was previously not trimmed)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5522)
<!-- Reviewable:end -->
