### PR TITLE
Safely remove inserted BOM after span.bloom-linebreak (BL-11717)

### DIFF
--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -79,6 +79,24 @@ namespace BloomTests.Book
 		}
 
 		[Test]
+		public void TextOfInnerHtml_HandlesLinebreakSpanWithNoByteOrderMarkProperly()
+		{
+			// Markup should be removed, linebreak replaced with \n, whitespace should be trimmed.
+			var input = "<p>Enter</p> <p>Shift-Enter<span class=\"bloom-linebreak\"></span>Last Line </p>";
+			var output = BookData.TextOfInnerHtml(input);
+			Assert.That(output, Is.EqualTo("Enter Shift-Enter\nLast Line"));
+		}
+
+		[Test]
+		public void TextOfInnerHtml_HandlesLinebreakSpanWithByteOrderMarkProperly()
+		{
+			// Markup should be removed, linebreak replaced with \n, byte order mark should be removed, whitespace should be trimmed.
+			var input = "<p>Enter</p> <p>Shift-Enter<span class=\"bloom-linebreak\"></span>﻿Last Line </p>";
+			var output = BookData.TextOfInnerHtml(input);
+			Assert.That(output, Is.EqualTo("Enter Shift-Enter\nLast Line"));
+		}
+
+		[Test]
 		public void TextOfInnerHtml_HandlesXmlEscapesCorrectly()
 		{
 			var input =

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -4604,6 +4604,34 @@ namespace BloomTests.Book
 			Assert.That(Path.GetFileName(book.FolderPath), Is.EqualTo("dog"));
 		}
 
+		[Test]
+		public void RemoveXmlMarkup_PlainText_NoChange()
+		{
+			string input = "Enter\nShift-Enter\nLast Line";
+			var result = Bloom.Book.Book.RemoveXmlMarkup(input, Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace);
+			
+			Assert.That(result, Is.EqualTo("Enter\nShift-Enter\nLast Line"));
+		}
+
+
+		[Test]
+		public void RemoveXmlMarkup_LinebreakButNoByteOrderMark_MarkupRemoved()
+		{
+			string input = "<p>Enter</p> <p>Shift-Enter<span class=\"bloom-linebreak\"></span>Last Line </p>";
+			var result = Bloom.Book.Book.RemoveXmlMarkup(input, Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace);
+			
+			Assert.That(result, Is.EqualTo("Enter Shift-Enter Last Line "));
+		}
+
+		[Test]
+		public void RemoveXmlMarkup_LinebreakAndByteOrderMark_MarkupAndByteOrderMarkRemoved()
+		{
+			string input = "<p>Enter</p> <p>Shift-Enter<span class=\"bloom-linebreak\"></span>\uFEFFLast Line </p>";
+			var result = Bloom.Book.Book.RemoveXmlMarkup(input, Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace);
+			
+			Assert.That(result, Is.EqualTo("Enter Shift-Enter Last Line "));
+		}
+
 #if UserControlledTemplate
 		[Test]
 		public void SetType_WasPublicationSetToTemplate_HasTemplateFeatures()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5525)
<!-- Reviewable:end -->
