### PR TITLE
Don't highlight correct answer in PDF output (BL-11726)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1285,6 +1285,7 @@ namespace Bloom.Book
 			}
 			RemoveObsoleteSoundAttributes(bookDOM);
 			RemoveObsoleteImageAttributes(bookDOM);
+			RemoveUnwantedClasses(bookDOM);
 			BringBookInfoUpToDate(oldMetaData);
 			FixErrorsEncounteredByUsers(bookDOM);
 			AddReaderBodyAttributes(bookDOM);
@@ -3859,6 +3860,15 @@ namespace Bloom.Book
 					img.SetAttribute("style", fixedStyle);
 				img.RemoveAttribute("width");
 				img.RemoveAttribute("height");
+			}
+		}
+
+		private void RemoveUnwantedClasses(HtmlDom htmlDom)
+		{
+			// chosen-correct reveals the answer in PDF output (BL-11726)
+			foreach (var div in htmlDom.RawDom.SafeSelectNodes("//div[contains(@class,'chosen-correct')]").Cast<XmlElement>())
+			{
+				HtmlDom.RemoveClass(div, "chosen-correct");
 			}
 		}
 

--- a/src/content/templates/template books/Activity/simple-dom-choice-activities.less
+++ b/src/content/templates/template books/Activity/simple-dom-choice-activities.less
@@ -259,6 +259,14 @@
             color: white;
             background-color: #ffb453;
         }
+        // highlight correct answer while editing
+        &[data-activityRole="correct-answer"] {
+            .cke_editable {
+                color: white;
+                background-color: #ffb453;
+                border-radius: 10px;
+            }
+        }
 
         &.chosen-wrong {
             color: white;

--- a/src/content/templates/template books/Activity/simple-dom-choice-activities.pug
+++ b/src/content/templates/template books/Activity/simple-dom-choice-activities.pug
@@ -20,8 +20,7 @@ mixin chooseWordFromPicture
 		.imageThenChoices
 			+image
 			.choices.player-shuffle-buttons
-				//- we put .chosen-correct on one button to turn on the styling during edit.
-				+textButtonChoice(data-activityRole="correct-answer").chosen-correct
+				+textButtonChoice(data-activityRole="correct-answer")
 					+correctAnswerBubble
 				each count in new Array(2)
 					+textButtonChoice(data-activityRole="wrong-answer")
@@ -33,8 +32,7 @@ mixin choosePictureFromWord
 		.wordThenChoices
 			+field("L1").bloom-ignoreOverflow.word-to-match.TextToMatch-style
 			.choices.player-shuffle-buttons
-				//- we put .chosen-correct on one button to turn on the styling during edit.
-				+imageButtonChoice(data-activityRole="correct-answer").chosen-correct
+				+imageButtonChoice(data-activityRole="correct-answer")
 					+correctAnswerBubble
 				each count in new Array(2)
 					+imageButtonChoice(data-activityRole="wrong-answer")


### PR DESCRIPTION
The first answer is always the correct answer anyway.  Solving this would be much more complicated.  bloom-player uses the .player-shuffle-buttons to apply javascript to shuffle the order.  PDF output doesn't have any intelligence along those lines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5528)
<!-- Reviewable:end -->
