### PR TITLE
Ensure the tooltip for the active field shows on top (BL-11745)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -185,6 +185,46 @@ export default class BloomField {
             $(".removeMe").remove();
         });
 
+        // The focus and blur event handlers ensure that the qtip tooltip for the
+        // currently focused editor element is on top of any other qtip tooltips
+        // such as Source Bubbles.
+        // These tooltips are not to be confused with Source Bubbles.  The editor
+        // element here is a single div.bloom-editable where the focus applies, possibly
+        // enclosed by a div.bloom-translationGroup.  A Source Bubble qtip is attached
+        // to the parent div.bloom-translationGroup if it exists.
+        // See https://issues.bloomlibrary.org/youtrack/issue/BL-11745.
+        // NOTE:
+        // * qtipOverrides.less handles the z-index for active-tooltip and styling for
+        //   passive-bubble tooltips
+        // * sourceBubbles.less handles the z-index for passive-bubble for Source Bubbles
+        //   (for other tooltips, this defaults to what qtip places on the element itself)
+        // * BloomSourceBubbles.SetupTooltips() has focus and blur handlers for Source Bubbles
+        //   which remove or add the passive-bubble class.
+        ckeditor.on("focus", event => {
+            const qtipId = event.editor?.element?.getAttribute(
+                "aria-describedby"
+            );
+            if (qtipId) {
+                const tipElement = $(`#${qtipId}`);
+                if (tipElement) {
+                    tipElement.removeClass("passive-bubble");
+                    tipElement.addClass("active-tooltip");
+                }
+            }
+        });
+        ckeditor.on("blur", event => {
+            const qtipId = event.editor?.element?.getAttribute(
+                "aria-describedby"
+            );
+            if (qtipId) {
+                const tipElement = $(`#${qtipId}`);
+                if (tipElement) {
+                    tipElement.removeClass("active-tooltip");
+                    tipElement.addClass("passive-bubble");
+                }
+            }
+        });
+
         ckeditor.addCommand("pasteHyperlink", {
             exec: function(edt) {
                 BloomApi.get("common/clipboardText", result => {

--- a/src/BloomBrowserUI/bookEdit/css/qtipOverrides.less
+++ b/src/BloomBrowserUI/bookEdit/css/qtipOverrides.less
@@ -29,3 +29,6 @@
         }
     }
 }
+.qtip.active-tooltip {
+    z-index: 20000 !important;
+}

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.tsx
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.tsx
@@ -673,6 +673,9 @@ export default class BloomSourceBubbles {
             //     "DEBUG BloomSourceBubbles.SetupTooltips/setting focus and blur handlers on " +
             //         elt.outerHTML
             // );
+            // BloomField.WireToCKEditor() has focus and blur handlers to add/remove the
+            // passive-bubble class on qtip tooltips that are *not* Source Bubbles.
+            // See https://issues.bloomlibrary.org/youtrack/issue/BL-11745.
             $(elt).focus(event => {
                 // BloomApi.postDebugMessage(
                 //     "DEBUG BloomSourceBubbles.SetupTooltips/on focus - element=" +


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5535)
<!-- Reviewable:end -->
