### PR TITLE
Work around bizarre google doc clipboard markup (BL-11744)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -133,8 +133,31 @@ export default class BloomField {
             // Deal with sources that still use <b> and <i> instead of <strong> and <em>.
             // Check if any of these markers are present, and if so, fix all of them.
             // See https://issues.bloomlibrary.org/youtrack/issue/BL-8711.
+            console.log("correcting data" + event.data.dataValue);
             if (/<\/?[bi]>/i.test(event.data.dataValue)) {
-                const fixBold = event.data.dataValue.replace(
+                // Bizarrely, normal text copied from a google doc arrives as
+                // a <b> element with a style attribute setting font-weight normal.
+                // To allow us to prevent this showing up as bold in Bloom, or
+                // duplicating the bizarre markup, we configure CkEditor's pasteFilter
+                // (see config.js) to allow the font-weight style. (It won't allow
+                // any other styles or attributes through, which simplifies the regex.)
+                // If a bold element specifies font-weight:normal, we just remove it
+                // altogether (keeping only its content).
+                // For somewhat more completeness, we also treat font weights starting with
+                // a number less than 5 as normal.
+                // This code is intended to handle cases where there might be multiple
+                // such runs in the dataValue, but I haven't been able to produce such
+                // a case by copying from a google doc. Copying a bold word produces
+                // a <b> element...with font-weight:normal!! Copying a run of text in
+                // which some bold text is embedded produces...a single <b> element
+                // with font-weight:normal. So it seems there is no way to successfully
+                // copy text from a google doc and preserve boldness, but at least we
+                // can avoid spuriously introducing it.
+                const fixGoogleDocNormal = event.data.dataValue.replace(
+                    /<b style="font-weight: *(normal|[1234]).*?>(.*?)<\/b *>/g,
+                    "$2"
+                );
+                const fixBold = fixGoogleDocNormal.replace(
                     /<(\/?)b>/gi,
                     "<$1strong>"
                 );

--- a/src/BloomBrowserUI/lib/ckeditor/config.js
+++ b/src/BloomBrowserUI/lib/ckeditor/config.js
@@ -97,8 +97,10 @@ CKEDITOR.editorConfig = function(config) {
     // JohnT Oct 8 2021: added 'a[!href]' to allow pasting hyperlinks. Counter-intuitively, the [!href] annotation
     // indicates that an href is required, not that it is forbidden. (Without annotations, listing a tag
     // means it may be pasted, but any attributes in the original will be removed.)
-    // Therefore for now we're limiting pasting to things that a translator could also do:
-    config.pasteFilter = "p b br em i strong sup u; a[!href];";
+    // Therefore for now we're limiting pasting to things that a translator could also do.
+    // The {font-weight} annotation says that a <b> element's font-weight style may be pasted.
+    // Code in our paste handler deals with this so it doesn't end up in our documents.
+    config.pasteFilter = "p br em i strong sup u; b{font-weight}; a[!href];";
 
     //BL-3009: don't remove empty spans, since we use <span class="bloom-linebreak"></span> when you press shift-enter.
     //http://stackoverflow.com/a/23983357/723299


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5537)
<!-- Reviewable:end -->
