### PR TITLE
[5.3] BL-11754 fix Custom Sign Language Name problem

### DIFF
--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -400,7 +400,8 @@ namespace Bloom.Collection
 				var settingsContent = RobustFile.ReadAllText(SettingsFilePath, Encoding.UTF8);
 				var nameMigrations = new[]
 				{
-					new[] {"LanguageName", "Language1Name"},
+					new[] {"LanguageName", "Language1Name"}, // but NOT SignLanguageName -> SignLanguage1Name !!
+					new[] {"SignLanguage1Name", "SignLanguageName"}, // un-migrate SignLanguageName
 					new[] {"IsShellLibrary", "IsSourceCollection"},
 					new[] {"National1Iso639Code", "Language2Iso639Code"},
 					new[] {"National2Iso639Code", "Language3Iso639Code"},


### PR DESCRIPTION
* loading CollectionSettings was inadvertently "migrating"
   SignLanguageName to an invalid SignLanguage1Name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5539)
<!-- Reviewable:end -->
