### PR TITLE
BL-11754 Fix upload of custom Sign Language name

### DIFF
--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -2200,7 +2200,7 @@ namespace Bloom.Book
 		internal LanguageDescriptor[] MakeLanguageUploadData(string[] langTags)
 		{
 			var result = new LanguageDescriptor[langTags.Length];
-			var bookLangs = GetBasicBookLanguages();
+			var bookLangs = GetBasicBookLanguages(true, true);
 			for (int i = 0; i < langTags.Length; i++)
 			{
 				var code = langTags[i];


### PR DESCRIPTION
* this fixes the language name on parse.com which affects
   the language name on the Book Detail page online

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5548)
<!-- Reviewable:end -->
