### PR TITLE
Allow problem report dialog to capture exception info (BL-11788)

### DIFF
--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -433,7 +433,7 @@ namespace Bloom.Publish
 			}
 			catch (Exception err)
 			{
-				SIL.Reporting.ErrorReport.NotifyUserOfProblem("Bloom was not able to save the PDF.  {0}", err.Message);
+				SIL.Reporting.ErrorReport.NotifyUserOfProblem(err, "Bloom was not able to save the PDF.  {0}", err.Message);
 			}
 		}
 


### PR DESCRIPTION
Exception.Message is usually far too brief to be informative enough. This change will allow the exception stack trace and other information to show up in the problem report.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5552)
<!-- Reviewable:end -->
