### PR TITLE
Add react-hooks/exhaustive-deps linting rule

### DIFF
--- a/src/BloomBrowserUI/.eslintrc.js
+++ b/src/BloomBrowserUI/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     extends: [
         "eslint:recommended",
         "plugin:react/recommended",
+        "plugin:react-hooks/recommended",
         "plugin:@typescript-eslint/recommended",
         "plugin:prettier/recommended"
     ],

--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -149,6 +149,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.30.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "file-loader": "^3.0.1",
         "globule": "^1.2.1",
         "gulp": "^4.0.1",

--- a/src/BloomBrowserUI/yarn.lock
+++ b/src/BloomBrowserUI/yarn.lock
@@ -8683,6 +8683,11 @@ eslint-plugin-prettier@^4.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
 eslint-plugin-react@^7.30.0:
   version "7.30.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz#8e7b1b2934b8426ac067a0febade1b13bd7064e3"


### PR DESCRIPTION
Currently, VSCode does not complain if you fail to add something to the dependencies array of something like useEffect, etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5557)
<!-- Reviewable:end -->
