### PR TITLE
Fix loss of style button in ISBN field (BL-11803)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -725,12 +725,11 @@ body.simulateColorBlindness {
 }
 
 // Hide the gear button unless the text box is focused for editing.
-// ck-editor takes care of inserting/removing the cke_focus class in
-// the parent text box div.  (See BL-11603.)
 #formatButton {
     display: none;
 }
-.cke_focus {
+// using :focus-within works better than .cke-focus (See BL-11803.)
+.bloom-editable:focus-within {
     #formatButton {
         display: inherit;
     }


### PR DESCRIPTION
This essentially redoes the fix for BL-11603 in a better way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5559)
<!-- Reviewable:end -->
