### PR TITLE
BL-11676 Make Format dialog conform

### DIFF
--- a/src/BloomBrowserUI/bloomUI.less
+++ b/src/BloomBrowserUI/bloomUI.less
@@ -38,6 +38,7 @@
 // Bloom's web palette
 @bloom-blue: #1d94a4; // used in decodable reader and various text backgrounds and Paste Image button
 @bloom-lightblue: #b0dee4; // used in a few highlight and hover situations
+@bloom-bluetransparent: #8ecad280; // BloomBlue50Transparent from Bloom MuiTheme
 @bloom-yellow: #febf00;
 
 @bloom-lightgray: lightgray;

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.less
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.less
@@ -1,6 +1,5 @@
-//putting (less) here makes it actually start this file off with the contents of the select2.css,
-//which we're doing for convenience so that we don't have to get it in the installer and then import it explictly
-@import (less) "../../node_modules/select2/dist/css/select2.css";
+// We don't need to import select2 here, since it's already imported in TextBoxProperties.less.
+//@import (less) "../../node_modules/select2/dist/css/select2.css";
 @import (reference) "../css/bloomDialog.less"; // needed for @dialogZindexPlusOne
 
 @styleSelectWidth: 190px;

--- a/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.less
+++ b/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.less
@@ -1,7 +1,9 @@
-//putting (less) here makes it actually start this file off with the contents of the select2.css,
-//which we're doing for convenience so that we don't have to get it in the installer and then import it explictly
+// Putting (less) here makes it actually start this file off with the contents of the select2.css,
+// which we're doing for convenience so that we don't have to get it in the installer and then import
+// it explictly. This also allows us to modify the colors for our palette. Importing it here covers both
+// the TextBoxProperties dialog AND the StyleEditor dialog.
 @import (less) "../../node_modules/select2/dist/css/select2.css";
-@import (reference) "../css/bloomDialog.less"; // needed for @dialogZindexPlusOne
+@import (reference) "../css/bloomDialog.less"; // needed for @dialogZindexPlusOne and @bloom-lightblue
 
 @hint-tab-indent: 20px;
 @main-label-width: 420px; // currently controls width of hint bubbles tab
@@ -35,7 +37,11 @@
 }
 
 .select2-container--open .select2-selection__rendered {
-    background-color: lightblue;
+    background-color: @bloom-lightblue;
+}
+.select2-container--default
+    .select2-results__option--highlighted[aria-selected] {
+    background-color: @bloom-blue;
 }
 
 #text-properties-dialog {

--- a/src/BloomBrowserUI/bookEdit/css/bloomDialog.less
+++ b/src/BloomBrowserUI/bookEdit/css/bloomDialog.less
@@ -1,12 +1,13 @@
 @import "../../bloomWebFonts.less";
+@import (reference) "../../bloomUI.less"; // for various bloom colors
 // Common styles to be applied to htm-js-css dialogs in Bloom
 @backgroundColorWhite: rgb(255, 255, 255);
 @backgroundColorLight: rgb(240, 240, 240);
 @backgroundColorDark: rgb(230, 230, 230);
-@backgroundColorTitleBar: rgb(140, 183, 220);
+@backgroundColorTitleBar: @bloom-blue;
 @backgroundColorHoverLight: rgb(236, 244, 252);
-@backgroundColorHoverDark: rgb(220, 236, 252);
-@buttonBorder: rgb(138, 187, 244);
+@backgroundColorHoverDark: @bloom-bluetransparent;
+@buttonBorder: @bloom-lightblue;
 @buttonShadow: rgb(136, 136, 136);
 @disabledText: rgb(211, 211, 211);
 @preferredBackgroundGray: hsl(0, 0%, 86%);
@@ -32,7 +33,17 @@
 // dialog's z-index.  (See http://issues.bloomlibrary.org/youtrack/issue/BL-4386.)
 @dialogZindexPlusOne: 60001;
 
+.bdRounded {
+    border-radius: 4px;
+}
+
 .bloomDialogContainer {
+    background-color: @backgroundColorWhite;
+    opacity: 1;
+    z-index: @dialogZindex;
+    position: absolute;
+    line-height: 1.8;
+    font-family: @UIFontStack;
     h2.tab {
         font-size: 10pt;
     }
@@ -51,31 +62,34 @@
             margin-top: 1px;
         }
     }
+    .selectedIcon {
+        background-color: @bloom-blue;
+        border: 1px solid @bloom-bluetransparent;
+        .bdRounded;
+    }
+    .iconLetter {
+        width: 19px;
+        height: 19px;
+        display: inline-block;
+        padding: 2px 2px 2px 2px;
+        text-align: center;
+    }
+    .icon16x16 {
+        width: 19px;
+        height: 19px;
+        display: inline-block;
+        padding: 2px;
+        img {
+            margin-top: 1px;
+            margin-left: 1px;
+            vertical-align: 5px;
+        }
+    }
+    a {
+        color: @bloom-blue;
+    }
 }
 
-.bloomDialogContainer .selectedIcon {
-    background-color: rgb(201, 224, 247);
-    border: 1px solid rgb(98, 162, 228);
-    .bdRounded;
-}
-.bloomDialogContainer .iconLetter {
-    width: 19px;
-    height: 19px;
-    display: inline-block;
-    padding: 2px 2px 2px 2px;
-    text-align: center;
-}
-.bloomDialogContainer .icon16x16 {
-    width: 19px;
-    height: 19px;
-    display: inline-block;
-    padding: 2px;
-}
-.bloomDialogContainer .icon16x16 img {
-    margin-top: 1px;
-    margin-left: 1px;
-    vertical-align: 5px;
-}
 .bloomDialogContainer .iconHtml {
     width: 22px;
     height: 22px;
@@ -125,9 +139,6 @@
     transform: translate(-50%, -50%);
     display: block;
 }
-.bdRounded {
-    border-radius: 4px;
-}
 .bloomDialogContainer .control-section {
     margin: 0 0 12px 0;
 }
@@ -166,14 +177,6 @@
         @backgroundColorHoverLight,
         @backgroundColorHoverDark
     );
-}
-.bloomDialogContainer {
-    background-color: @backgroundColorWhite;
-    opacity: 1;
-    z-index: @dialogZindex;
-    position: absolute;
-    line-height: 1.8;
-    font-family: @UIFontStack;
 }
 .bloomDialogContainer .bloomDialogTitleBar {
     background-color: @backgroundColorTitleBar;


### PR DESCRIPTION
* modify colors to use bloom palette
* fixes BOTH the StyleEditor (format dialog) AND the
   TextBox Properties dialog
* overrides colors from 3rd party select2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5565)
<!-- Reviewable:end -->
