### PR TITLE
Clean bloom-player directory

### DIFF
--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -29,7 +29,7 @@
         "// You can use yarn link to symlink bloom-player. But also, bloom needs a copy in output/!": " ",
         "// note that ls -l node_modules | grep ^l will tell you what packages you are currently linking to": " ",
         "// note that this wants to be 'watch', but on windows cpx doesn't actually notice changes from a BP build, symlinked by yarn link": " ",
-        "bp-to-output": "cpx \"./node_modules/bloom-player/dist/*.*\" ../../output/browser/bloom-player/dist -v",
+        "bp-to-output": "cpx \"./node_modules/bloom-player/dist/*.*\" ../../output/browser/bloom-player/dist -v --clean",
         "watchBookEditLess": "less-watch-compiler bookEdit ../../output/browser/bookEdit",
         "watchPageChooserLess": "less-watch-compiler pageChooser ../../output/browser/pageChooser",
         "watchProblemDialogLess": "less-watch-compiler problemDialog ../../output/browser/problemDialog",


### PR DESCRIPTION
In theory, old files should be removed when copying bloom-player to the output folder to avoid some subtle bug possibilities.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloomdesktop/5577)
<!-- Reviewable:end -->
