### PR TITLE
Pull out react hooks from BloomApi

### DIFF
--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.tsx
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.tsx
@@ -19,6 +19,7 @@ import "errorHandler";
 import WebSocketManager from "../../utils/WebSocketManager";
 import { Responsive } from "react-grid-layout";
 import { BloomApi } from "../../utils/bloomApi";
+import { useApiData } from "../../utils/bloomApiHooks";
 import { PageThumbnail } from "./PageThumbnail";
 import LazyLoad, { forceCheck } from "react-lazyload";
 
@@ -77,7 +78,7 @@ const PageList: React.FunctionComponent<{ pageSize: string }> = props => {
     const [twoColumns, setTwoColumns] = useState(true);
 
     const [selectedPageId, setSelectedPageId] = useState("");
-    const bookAttributesThatMayAffectDisplay = BloomApi.useApiData<any>(
+    const bookAttributesThatMayAffectDisplay = useApiData<any>(
         "pageList/bookAttributesThatMayAffectDisplay",
         {}
     );

--- a/src/BloomBrowserUI/collectionsTab/BookButton.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BookButton.tsx
@@ -3,6 +3,7 @@ import { jsx, css } from "@emotion/core";
 
 import * as React from "react";
 import { BloomApi } from "../utils/bloomApi";
+import { useWatchString } from "../utils/bloomApiHooks";
 import { Button, Menu } from "@material-ui/core";
 import TruncateMarkup from "react-truncate-markup";
 import { useTColBookStatus } from "../teamCollection/teamCollectionApi";
@@ -36,7 +37,7 @@ export const BookButton: React.FunctionComponent<{
         | undefined
     >();
     const selected = useIsSelected(props.manager, props.book.id);
-    const bookLabel = BloomApi.useWatchString(
+    const bookLabel = useWatchString(
         props.book.title,
         // These must correspond to what BookCommandsApi.UpdateButtonTitle sends
         "book",

--- a/src/BloomBrowserUI/collectionsTab/BooksOfCollection.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BooksOfCollection.tsx
@@ -4,7 +4,7 @@ import { jsx, css } from "@emotion/core";
 import Grid from "@material-ui/core/Grid";
 import React = require("react");
 import "BooksOfCollection.less";
-import { BloomApi } from "../utils/bloomApi";
+import { useApiData, useWatchApiData } from "../utils/bloomApiHooks";
 import { BookButton, bookButtonHeight, bookButtonWidth } from "./BookButton";
 import { BookSelectionManager } from "./bookSelectionManager";
 import LazyLoad from "react-lazyload";
@@ -42,7 +42,7 @@ export const BooksOfCollection: React.FunctionComponent<{
         props.collectionId
     )}`;
 
-    const books = BloomApi.useWatchApiData<Array<IBookInfo>>(
+    const books = useWatchApiData<Array<IBookInfo>>(
         `collections/books?${collectionQuery}`,
         [],
         "editableCollectionList",
@@ -50,7 +50,7 @@ export const BooksOfCollection: React.FunctionComponent<{
     );
 
     //const selectedBookInfo = useMonitorBookSelection();
-    const collection: ICollection = BloomApi.useApiData(
+    const collection: ICollection = useApiData(
         `collections/collectionProps?${collectionQuery}`,
         {
             isEditableCollection: props.isEditableCollection,

--- a/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
@@ -3,6 +3,7 @@ import { jsx, css } from "@emotion/core";
 
 import React = require("react");
 import { BloomApi } from "../utils/bloomApi";
+import { useApiJson } from "../utils/bloomApiHooks";
 import { BooksOfCollection } from "./BooksOfCollection";
 import { Transition } from "react-transition-group";
 import { SplitPane } from "react-collapse-pane";
@@ -31,7 +32,7 @@ import { EmbeddedProgressDialog } from "../react_components/Progress/ProgressDia
 const kResizerSize = 10;
 
 export const CollectionsTabPane: React.FunctionComponent<{}> = () => {
-    const collections = BloomApi.useApiJson("collections/list");
+    const collections = useApiJson("collections/list");
 
     const [draggingSplitter, setDraggingSplitter] = useState(false);
     const [

--- a/src/BloomBrowserUI/performance/PerformanceLogPage.tsx
+++ b/src/BloomBrowserUI/performance/PerformanceLogPage.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import { BloomApi } from "../utils/bloomApi";
+import { useApiData, useApiStringState } from "../utils/bloomApiHooks";
 import { useSubscribeToWebSocketForObjectInMessageParam } from "../utils/WebSocketManager";
 import "./PerformanceLogPage.less";
 import { ScatterPlot } from "@nivo/scatterplot";
@@ -23,12 +24,12 @@ export const PerformanceLogPage: React.FunctionComponent<{
         props.initialPoints || []
     );
 
-    const [applicationInfo] = BloomApi.useApiStringState(
+    const [applicationInfo] = useApiStringState(
         "performance/applicationInfo",
         ""
     );
 
-    const earlierMeasurements = BloomApi.useApiData<IMeasurement[]>(
+    const earlierMeasurements = useApiData<IMeasurement[]>(
         "performance/allMeasurements",
         []
     );

--- a/src/BloomBrowserUI/problemDialog/PrivacyScreen.tsx
+++ b/src/BloomBrowserUI/problemDialog/PrivacyScreen.tsx
@@ -2,9 +2,9 @@ import * as React from "react";
 import { Typography } from "@material-ui/core";
 import "./ProblemDialog.less";
 import ArrowBack from "@material-ui/icons/ArrowBack";
-import { BloomApi } from "../utils/bloomApi";
 import { useL10n } from "../react_components/l10nHooks";
 import BloomButton from "../react_components/bloomButton";
+import { useApiStringState } from "../utils/bloomApiHooks";
 
 export const PrivacyScreen: React.FunctionComponent<{
     includeBook: boolean;
@@ -17,7 +17,7 @@ export const PrivacyScreen: React.FunctionComponent<{
         "Common.Loading",
         "This is shown when Bloom is slowly loading something, so the user doesn't worry about why they don't see the result immediately."
     );
-    const log = BloomApi.useApiStringState(
+    const log = useApiStringState(
         `problemReport/diagnosticInfo?includeBook=${
             props.includeBook ? "true" : "false"
         }&email=${props.email}&userInput=${props.userInput}`,

--- a/src/BloomBrowserUI/problemDialog/ReportDialog.tsx
+++ b/src/BloomBrowserUI/problemDialog/ReportDialog.tsx
@@ -9,6 +9,7 @@ import {
     Typography
 } from "@material-ui/core";
 import { BloomApi } from "../utils/bloomApi";
+import { useApiStringState } from "../utils/bloomApiHooks";
 import { ThemeProvider } from "@material-ui/styles";
 import "./ProblemDialog.less";
 import BloomButton from "../react_components/bloomButton";
@@ -40,21 +41,18 @@ export const ReportDialog: React.FunctionComponent<{
 
     // Precondition: The returned string from BloomServer must already encode any special characters
     // which are not meant to be treated as HTML code.
-    const [reportHeadingHtml] = BloomApi.useApiStringState(
+    const [reportHeadingHtml] = useApiStringState(
         "problemReport/reportHeadingHtml",
         ""
     );
-    const [email, setEmail] = BloomApi.useApiStringState(
+    const [email, setEmail] = useApiStringState(
         "problemReport/emailAddress",
         ""
     );
     const [submitAttempts, setSubmitAttempts] = useState(0);
     const theme = makeTheme(props.kind);
     const [whatDoing, setWhatDoing] = useState("");
-    const [bookName] = BloomApi.useApiStringState(
-        "problemReport/bookName",
-        "??"
-    );
+    const [bookName] = useApiStringState("problemReport/bookName", "??");
 
     // When submitted, this will contain the url of the YouTrack issue.
     const [issueLink, setIssueLink] = useState("");

--- a/src/BloomBrowserUI/publish/ReaderPublish/BulkBloomPub/BulkBloomPubDialog.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/BulkBloomPub/BulkBloomPubDialog.tsx
@@ -18,6 +18,7 @@ import { BloomPalette } from "../../../react_components/color-picking/bloomPalet
 import { ColorDisplayButton } from "../../../react_components/color-picking/colorPickerDialog";
 import { ConditionallyEnabledBlock } from "../../../react_components/ConditionallyEnabledBlock";
 import { BloomApi } from "../../../utils/bloomApi";
+import { useApiData, useApiOneWayState } from "../../../utils/bloomApiHooks";
 import { useGetLabelForCollection } from "../../../contentful/UseContentful";
 import { Div } from "../../../react_components/l10nComponents";
 import { kMutedTextGray } from "../../../bloomMaterialUITheme";
@@ -64,14 +65,12 @@ export const InnerBulkBloomPubDialog: React.FunctionComponent<{
 }> = props => {
     // We get the state from the server, but we don't inform it every time the user touches a control.
     // We'll send the new state of the parameters if and when they click the "make" button.
-    const [params, setParams] = BloomApi.useApiOneWayState<
+    const [params, setParams] = useApiOneWayState<
         IBulkBloomPUBPublishParams | undefined
     >("publish/android/file/bulkSaveBloomPubsParams", undefined);
 
-    const bookshelfUrlKey = BloomApi.useApiData<any>(
-        "settings/bookShelfData",
-        ""
-    )?.defaultBookshelfUrlKey;
+    const bookshelfUrlKey = useApiData<any>("settings/bookShelfData", "")
+        ?.defaultBookshelfUrlKey;
 
     // the server doesn't actually know the label for the bookshelf, just its urlKey. So we have to look that up ourselves.
     const bookshelfLabel = useGetLabelForCollection(bookshelfUrlKey, "");

--- a/src/BloomBrowserUI/publish/ReaderPublish/CoverColorGroup.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/CoverColorGroup.tsx
@@ -6,7 +6,10 @@ import {
     ColorDisplayButton,
     DialogResult
 } from "../../react_components/color-picking/colorPickerDialog";
-import { BloomApi } from "../../utils/bloomApi";
+import {
+    useApiBoolean,
+    useApiStringStatePromise
+} from "../../utils/bloomApiHooks";
 import { StorybookContext } from "../../.storybook/StoryBookContext";
 import { useL10n } from "../../react_components/l10nHooks";
 import { useContext } from "react";
@@ -32,23 +35,23 @@ const CoverColorControl: React.FunctionComponent<{
 }> = props => {
     // The old default cover color was "white". This made it impossible to tell if the color had been
     // updated or not. This works well. This api always returns SOME cover color.
-    const [
-        bookCoverColor,
-        setBookCoverColor
-    ] = BloomApi.useApiStringStatePromise("publish/android/backColor", "");
+    const [bookCoverColor, setBookCoverColor] = useApiStringStatePromise(
+        "publish/android/backColor",
+        ""
+    );
 
     // I (gjm) was thinking this had to do with if a book is "unlocked", but apparently it's more to do
     // with whether it checked out in Team Collections or not.
     // Currently, there is no UI difference to indicate that the control is disabled. It just won't do
     // anything if the user clicks on it.
-    const [canModifyCurrentBook] = BloomApi.useApiBoolean(
+    const [canModifyCurrentBook] = useApiBoolean(
         "common/canModifyCurrentBook",
         false
     );
 
     // The 2 comic templates and the Video template have black covers and a 'meta' tag that preserves
     // the cover color, so it doesn't get changed. The color picker shouldn't function on these.
-    const [hasPreserveCoverColor] = BloomApi.useApiBoolean(
+    const [hasPreserveCoverColor] = useApiBoolean(
         "common/hasPreserveCoverColor",
         false
     );

--- a/src/BloomBrowserUI/publish/ReaderPublish/MethodChooser.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/MethodChooser.tsx
@@ -2,9 +2,12 @@
 import { jsx, css } from "@emotion/core";
 
 import * as React from "react";
+import {
+    useApiStringState,
+    useWatchBooleanEvent
+} from "../../utils/bloomApiHooks";
 import { RadioGroup } from "../../react_components/RadioGroup";
 import BloomButton from "../../react_components/bloomButton";
-import { BloomApi } from "../../utils/bloomApi";
 import { isLinux } from "../../utils/isLinux";
 import { useL10n } from "../../react_components/l10nHooks";
 import Typography from "@material-ui/core/Typography";
@@ -23,11 +26,11 @@ const methodNameToImageFileName = {
 // Lets the user choose how they want to "publish" the bloompub, along with a button to start that process.
 // This is a set of radio buttons and image that goes with each choice, plus a button to start off the sharing/saving
 export const MethodChooser: React.FunctionComponent = () => {
-    const [method, setMethod] = BloomApi.useApiStringState(
+    const [method, setMethod] = useApiStringState(
         "publish/android/method",
         "wifi"
     );
-    const isLicenseOK = BloomApi.useWatchBooleanEvent(
+    const isLicenseOK = useWatchBooleanEvent(
         true,
         "publish-android",
         "publish/licenseOK"

--- a/src/BloomBrowserUI/publish/ReaderPublish/PublishFeaturesGroup.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/PublishFeaturesGroup.tsx
@@ -3,12 +3,12 @@ import FormGroup from "@material-ui/core/FormGroup";
 import { ApiCheckbox } from "../../react_components/ApiCheckbox";
 import { SettingsGroup } from "../commonPublish/PublishScreenBaseComponents";
 import { useL10n } from "../../react_components/l10nHooks";
-import { BloomApi } from "../../utils/bloomApi";
+import { useApiBoolean } from "../../utils/bloomApiHooks";
 
 export const PublishFeaturesGroup: React.FunctionComponent<{
     onChange?: () => void;
 }> = props => {
-    const [motionEnabled] = BloomApi.useApiBoolean(
+    const [motionEnabled] = useApiBoolean(
         "publish/android/canHaveMotionMode",
         false
     );

--- a/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
@@ -24,6 +24,7 @@ import {
     useSubscribeToWebSocketForEvent
 } from "../../utils/WebSocketManager";
 import { BloomApi } from "../../utils/bloomApi";
+import { useApiBoolean } from "../../utils/bloomApiHooks";
 import HelpLink from "../../react_components/helpLink";
 import { Link, LinkWithDisabledStyles } from "../../react_components/link";
 import {
@@ -82,14 +83,11 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
               "working"
     );
 
-    const [defaultLandscape] = BloomApi.useApiBoolean(
+    const [defaultLandscape] = useApiBoolean(
         "publish/android/defaultLandscape",
         false
     );
-    const [canRotate] = BloomApi.useApiBoolean(
-        "publish/android/canRotate",
-        false
-    );
+    const [canRotate] = useApiBoolean("publish/android/canRotate", false);
     useSubscribeToWebSocketForStringMessage(
         "publish-android",
         "androidPreview",

--- a/src/BloomBrowserUI/publish/ePUBPublish/ePUBPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ePUBPublish/ePUBPublishScreen.tsx
@@ -26,10 +26,14 @@ import { PublishProgressDialog } from "../commonPublish/PublishProgressDialog";
 import BookMetadataDialog from "../metadata/BookMetadataDialog";
 import { useL10n } from "../../react_components/l10nHooks";
 import { ProgressState } from "../commonPublish/PublishProgressDialogInner";
-import { BloomApi } from "../../utils/bloomApi";
 import { hookupLinkHandler } from "../../utils/linkHandler";
 import { NoteBox } from "../../react_components/BloomDialog/commonDialogComponents";
 import { P } from "../../react_components/l10nComponents";
+import {
+    useApiBoolean,
+    useApiStringState,
+    useWatchBooleanEvent
+} from "../../utils/bloomApiHooks";
 
 export const EPUBPublishScreen = () => {
     // When the user changes some features, included languages, etc., we
@@ -46,7 +50,7 @@ export const EPUBPublishScreen = () => {
     // not destroyed during refresh.  See comments toward the end of
     // https://issues.bloomlibrary.org/youtrack/issue/BL-11043.
     const defaultEpubModeRef = React.useRef("fixed");
-    const [epubMode, setEpubmode] = BloomApi.useApiStringState(
+    const [epubMode, setEpubmode] = useApiStringState(
         "publish/epub/epubMode",
         defaultEpubModeRef.current
     );
@@ -85,7 +89,7 @@ const EPUBPublishScreenInternal: React.FunctionComponent<{
             : "" // otherwise, wait for the websocket to deliver a url when the c# has finished creating the epub
     );
 
-    const [landscape] = BloomApi.useApiBoolean("publish/epub/landscape", false);
+    const [landscape] = useApiBoolean("publish/epub/landscape", false);
 
     useSubscribeToWebSocketForEvent(
         "publish-epub",
@@ -107,7 +111,7 @@ const EPUBPublishScreenInternal: React.FunctionComponent<{
             setHighlightRefresh(false);
         }
     );
-    const isLicenseOK = BloomApi.useWatchBooleanEvent(
+    const isLicenseOK = useWatchBooleanEvent(
         true,
         "publish-epub",
         "publish/licenseOK"

--- a/src/BloomBrowserUI/publish/ePUBPublish/ePUBSettingsGroup.tsx
+++ b/src/BloomBrowserUI/publish/ePUBPublish/ePUBSettingsGroup.tsx
@@ -3,6 +3,10 @@ import { jsx, css } from "@emotion/core";
 import React = require("react");
 import BookMetadataDialog from "../metadata/BookMetadataDialog";
 import { BloomApi } from "../../utils/bloomApi";
+import {
+    useApiBoolean,
+    useCanModifyCurrentBook
+} from "../../utils/bloomApiHooks";
 import { ApiCheckbox } from "../../react_components/ApiCheckbox";
 import { Link } from "../../react_components/link";
 import { SettingsGroup } from "../commonPublish/PublishScreenBaseComponents";
@@ -47,7 +51,7 @@ export const EPUBSettingsGroup: React.FunctionComponent<{
     setMode: (mode: string) => void;
 }> = props => {
     //const [includeImageDescriptionOnPage,setIncludeImageDescriptionOnPage] = BloomApi.useApiBoolean("publish/epub/imageDescriptionSetting", true);
-    const canModifyCurrentBook = BloomApi.useCanModifyCurrentBook();
+    const canModifyCurrentBook = useCanModifyCurrentBook();
     const linkCss = "margin-top: 1em !important; display: block;";
     const disabledLinkCss = canModifyCurrentBook
         ? ""
@@ -61,7 +65,7 @@ export const EPUBSettingsGroup: React.FunctionComponent<{
         null
     );
 
-    const [hasOverlays] = BloomApi.useApiBoolean("publish/epub/overlays", true);
+    const [hasOverlays] = useApiBoolean("publish/epub/overlays", true);
 
     return (
         <div>

--- a/src/BloomBrowserUI/publish/video/AudioVideoOptionsGroup.tsx
+++ b/src/BloomBrowserUI/publish/video/AudioVideoOptionsGroup.tsx
@@ -5,6 +5,7 @@ import FormGroup from "@material-ui/core/FormGroup";
 import { SettingsGroup } from "../commonPublish/PublishScreenBaseComponents";
 import { useL10n } from "../../react_components/l10nHooks";
 import { BloomApi } from "../../utils/bloomApi";
+import { useApiBoolean, useApiData } from "../../utils/bloomApiHooks";
 import { Div } from "../../react_components/l10nComponents";
 import { FormControl, MenuItem, Select, Typography } from "@material-ui/core";
 import Slider from "@material-ui/core/Slider";
@@ -59,7 +60,7 @@ export const AudioVideoOptionsGroup: React.FunctionComponent<{
 }> = props => {
     // Stores which formats should be non-selectable.
     const [disabledFormats, setDisabledFormats] = useState<string[]>([]);
-    const [motionEnabled] = BloomApi.useApiBoolean(
+    const [motionEnabled] = useApiBoolean(
         "publish/android/canHaveMotionMode",
         false
     );
@@ -193,7 +194,7 @@ export const AudioVideoOptionsGroup: React.FunctionComponent<{
         }
     ]);
 
-    const updatedFormatDimensionsList = BloomApi.useApiData<
+    const updatedFormatDimensionsList = useApiData<
         IFormatDimensionsResponseEntry[] | undefined
     >(`publish/av/getUpdatedFormatDimensions`, undefined);
 

--- a/src/BloomBrowserUI/react_components/ApiCheckbox.tsx
+++ b/src/BloomBrowserUI/react_components/ApiCheckbox.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { MuiCheckbox } from "./muiCheckBox";
-import { BloomApi } from "../utils/bloomApi";
+import { useApiBoolean } from "../utils/bloomApiHooks";
 
 // A localized checkbox that is backed by a boolean API get/set
 // This is a "uncontrolled component".
@@ -15,10 +15,7 @@ export const ApiCheckbox: React.FunctionComponent<{
     forceDisabledValue?: boolean;
     onChange?: () => void;
 }> = props => {
-    const [checked, setChecked] = BloomApi.useApiBoolean(
-        props.apiEndpoint,
-        false
-    );
+    const [checked, setChecked] = useApiBoolean(props.apiEndpoint, false);
 
     let showChecked = checked;
     if (props.disabled && props.forceDisabledValue !== undefined) {

--- a/src/BloomBrowserUI/react_components/bookProblem.tsx
+++ b/src/BloomBrowserUI/react_components/bookProblem.tsx
@@ -2,7 +2,7 @@
 import { jsx, css } from "@emotion/core";
 
 import * as React from "react";
-import { BloomApi } from "../utils/bloomApi";
+import { useApiString } from "../utils/bloomApiHooks";
 import { IconHeadingBodyMenuPanel } from "./iconHeadingBodyMenuPanel";
 
 // A block (currently sized to fit in the TeamCollectionBookStatusPanel, we could generalize)
@@ -18,12 +18,12 @@ export const BookProblem: React.FunctionComponent<{
     clickHereArg: string;
     className?: string; // also supports Emotion
 }> = props => {
-    const bookProblemMessage = BloomApi.useApiString(
+    const bookProblemMessage = useApiString(
         "common/problemWithBookMessage",
         "There was a problem with the current book in the Team Collection System"
     );
 
-    const clickHereForHelpMessage = BloomApi.useApiString(
+    const clickHereForHelpMessage = useApiString(
         "common/clickHereForHelp?problem=" + props.clickHereArg,
         "Please click here to get help from the Bloom support team."
     );

--- a/src/BloomBrowserUI/react_components/requiresCheckoutInfo.tsx
+++ b/src/BloomBrowserUI/react_components/requiresCheckoutInfo.tsx
@@ -1,7 +1,5 @@
-/** @jsx jsx **/
-import { jsx, css } from "@emotion/core";
 import React = require("react");
-import { BloomApi } from "../utils/bloomApi";
+import { useCanModifyCurrentBook } from "../utils/bloomApiHooks";
 import { InfoTooltip } from "./icons/InfoTooltip";
 
 // Displays an info icon if the current book needs to be checked out before it
@@ -10,7 +8,7 @@ import { InfoTooltip } from "./icons/InfoTooltip";
 export const RequiresCheckoutInfo: React.FunctionComponent<{
     className?: string;
 }> = props => {
-    const canModifyCurrentBook = BloomApi.useCanModifyCurrentBook();
+    const canModifyCurrentBook = useCanModifyCurrentBook();
     return (
         <React.Fragment>
             {canModifyCurrentBook || (

--- a/src/BloomBrowserUI/teamCollection/CollectionHistoryTable.tsx
+++ b/src/BloomBrowserUI/teamCollection/CollectionHistoryTable.tsx
@@ -2,7 +2,7 @@
 import { jsx, css } from "@emotion/core";
 
 import * as React from "react";
-import { BloomApi } from "../utils/bloomApi";
+import { useApiData } from "../utils/bloomApiHooks";
 import { BloomAvatar } from "../react_components/bloomAvatar";
 import { useEffect, useState } from "react";
 import { useSubscribeToWebSocketForEvent } from "../utils/WebSocketManager";
@@ -73,7 +73,7 @@ export const CollectionHistoryTable: React.FunctionComponent<{
     useSubscribeToWebSocketForEvent("bookHistory", "eventAdded", () =>
         setGeneration(gen => gen + 1)
     );
-    const events = BloomApi.useApiData<IBookHistoryEvent[]>(
+    const events = useApiData<IBookHistoryEvent[]>(
         "teamCollection/getHistory" +
             (currentBookOnly
                 ? "?currentBookOnly=true&generation=" + generation

--- a/src/BloomBrowserUI/teamCollection/CreateTeamCollection.tsx
+++ b/src/BloomBrowserUI/teamCollection/CreateTeamCollection.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { useState } from "react";
 
 import { BloomApi } from "../utils/bloomApi";
+import { useApiStringState } from "../utils/bloomApiHooks";
 import { useSubscribeToWebSocketForEvent } from "../utils/WebSocketManager";
 import BloomButton from "../react_components/bloomButton";
 import { Div, P } from "../react_components/l10nComponents";
@@ -66,7 +67,7 @@ export const CreateTeamCollectionDialog: React.FunctionComponent<{
         true
     );
 
-    const [collectionName] = BloomApi.useApiStringState(
+    const [collectionName] = useApiStringState(
         "teamCollection/getCollectionName",
         ""
     );

--- a/src/BloomBrowserUI/teamCollection/TeamCollectionDialog.tsx
+++ b/src/BloomBrowserUI/teamCollection/TeamCollectionDialog.tsx
@@ -4,6 +4,7 @@ import { jsx, css } from "@emotion/core";
 import * as React from "react";
 import BloomButton from "../react_components/bloomButton";
 import { BloomApi } from "../utils/bloomApi";
+import { useApiData } from "../utils/bloomApiHooks";
 import "./TeamCollectionDialog.less";
 import { useL10n } from "../react_components/l10nHooks";
 import { ProgressBox } from "../react_components/Progress/progressBox";
@@ -19,7 +20,7 @@ import {
 } from "../react_components/BloomDialog/BloomDialog";
 import { DialogCloseButton } from "../react_components/BloomDialog/commonDialogComponents";
 import { CollectionHistoryTable } from "./CollectionHistoryTable";
-import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
+import { Tab, TabList, TabPanel } from "react-tabs";
 import { LocalizedString } from "../react_components/l10nComponents";
 import { ThemeProvider } from "@material-ui/styles";
 import { lightTheme } from "../bloomMaterialUITheme";
@@ -54,7 +55,7 @@ const TeamCollectionDialog: React.FunctionComponent<{
         "TeamCollection.TeamCollection"
     );
 
-    const events = BloomApi.useApiData<IBloomWebSocketProgressEvent[]>(
+    const events = useApiData<IBloomWebSocketProgressEvent[]>(
         "teamCollection/getLog",
         []
     );

--- a/src/BloomBrowserUI/teamCollection/TeamCollectionSettingsPanel.tsx
+++ b/src/BloomBrowserUI/teamCollection/TeamCollectionSettingsPanel.tsx
@@ -3,6 +3,7 @@ import { jsx, css } from "@emotion/core";
 
 import * as React from "react";
 import { BloomApi } from "../utils/bloomApi";
+import { useApiStringState } from "../utils/bloomApiHooks";
 import { P } from "../react_components/l10nComponents";
 import { RequiresBloomEnterpriseOverlayWrapper } from "../react_components/requiresBloomEnterprise";
 import "./TeamCollectionSettingsPanel.less";
@@ -17,7 +18,7 @@ import { WireUpForWinforms } from "../utils/WireUpWinform";
 // The contents of the Team Collection panel of the Settings dialog.
 
 export const TeamCollectionSettingsPanel: React.FunctionComponent = props => {
-    const [repoFolderPath] = BloomApi.useApiStringState(
+    const [repoFolderPath] = useApiStringState(
         "teamCollection/repoFolderPath",
         ""
     );

--- a/src/BloomBrowserUI/utils/bloomApi.ts
+++ b/src/BloomBrowserUI/utils/bloomApi.ts
@@ -1,14 +1,6 @@
-import axios, {
-    AxiosResponse,
-    AxiosRequestConfig,
-    AxiosPromise,
-    AxiosError
-} from "axios";
+import axios, { AxiosResponse, AxiosRequestConfig, AxiosError } from "axios";
 import * as StackTrace from "stacktrace-js";
 import { reportError, reportPreliminaryError } from "../lib/errorHandler";
-import React = require("react");
-import { useState } from "react";
-import { useSubscribeToWebSocketForEvent } from "./WebSocketManager";
 
 // You can modify mockReplies in order to work on UI components without the Bloom backed... namely, storybook.
 // It's surely too fragile for use in unit tests.
@@ -30,10 +22,11 @@ function isRunningStorybook(): boolean {
     return false;
 }
 
-export function getBloomApiPrefix(): string {
-    if (isRunningStorybook()) return "http://localhost:8089/bloom/api/";
+export function getBloomApiPrefix(includeApi: boolean = true): string {
+    const apiPart = includeApi ? "api/" : "";
+    if (isRunningStorybook()) return `http://localhost:8089/bloom/${apiPart}`;
 
-    return "/bloom/api/";
+    return `/bloom/${apiPart}`;
 }
 
 export const mockReplies = {};
@@ -190,244 +183,6 @@ export class BloomApi {
         );
     }
 
-    // A react hook for controlling an API-backed boolean from a React pure functional component
-    // Returns a tuple of [theCurrentValue, aFunctionForChangingTheValue(newValue)]
-    // When you call the returned function, two things happen: 1) we POST the value to the Bloom API
-    // and 2) we tell react that the value changed. It will then re-render the component;
-    // the component will call this again, but this time the tuple will contain the new value.
-    public static useApiBoolean(
-        urlSuffix: string,
-        defaultValue: boolean
-    ): [boolean, (value: boolean) => void] {
-        const [value, setValue] = React.useState(defaultValue);
-        React.useEffect(() => {
-            BloomApi.getBoolean(urlSuffix, c => {
-                setValue(c);
-            });
-        }, []);
-
-        const fn = (value: boolean) => {
-            BloomApi.postBoolean(urlSuffix, value);
-            setValue(value);
-        };
-        return [value, fn];
-    }
-
-    public static useCanModifyCurrentBook(): boolean {
-        const [canModifyCurrentBook] = BloomApi.useApiBoolean(
-            "common/canModifyCurrentBook",
-            false
-        );
-        return canModifyCurrentBook;
-    }
-
-    public static useApiData<T>(urlSuffix: string, defaultValue: T): T {
-        return this.useApiDataInternal(urlSuffix, defaultValue);
-    }
-
-    // Shared code for useApiData and useWatchApiData. If you are tempted to use it directly,
-    // you should probably be using useWatchApiData.
-    // The generation argument is a value that can be incremented to force redoing the main
-    // query, typically because an event we were watching for was sent from the server.
-    private static useApiDataInternal<T>(
-        urlSuffix: string,
-        defaultValue: T,
-        generation?: number
-    ): T {
-        const [value, setValue] = React.useState<T>(defaultValue);
-        React.useEffect(() => {
-            BloomApi.get(urlSuffix, c => {
-                setValue(c.data);
-            });
-        }, [generation, urlSuffix]);
-        return value;
-    }
-
-    // Conceptually returns the result of BloomApi.get(urlSuffix).
-    // When initially called, returns defaultValue, but a new render will be forced
-    // when the query returns the data.
-    // Also monitors our web socket for the specified event occurring in the specified
-    // context, and forces another render from a fresh call to BloomApi.get when the
-    // event occurs.
-    public static useWatchApiData<T>(
-        urlSuffix: string,
-        defaultValue: T,
-        clientContext: string,
-        eventId: string
-    ): T {
-        const [generation, setGeneration] = useState(0);
-        // Force a reload when the specified event happens.
-        useSubscribeToWebSocketForEvent(clientContext, eventId, () => {
-            setGeneration(old => old + 1);
-        });
-        return this.useApiDataInternal(urlSuffix, defaultValue, generation);
-    }
-
-    public static useWatchBooleanEvent(
-        defaultValue: boolean,
-        clientContext: string,
-        eventId: string
-    ) {
-        const [val, setVal] = useState(defaultValue);
-        useSubscribeToWebSocketForEvent(clientContext, eventId, data => {
-            setVal(data.message === "true");
-        });
-        return val;
-    }
-
-    // Manages a state that is initially defaultValue, but subscribes to the specified web
-    // socket, and when it arrives, set the state to its message.
-    public static useWatchString(
-        defaultValue: string,
-        clientContext: string,
-        eventId: string
-    ): string {
-        const [val, setVal] = useState(defaultValue);
-        useSubscribeToWebSocketForEvent(clientContext, eventId, data => {
-            setVal(data.message!);
-        });
-        // If we get re-rendered with a different defaultValue, update our result to that.
-        React.useEffect(() => {
-            if (val != defaultValue) {
-                setVal(defaultValue);
-            }
-        }, [defaultValue]);
-        return val;
-    }
-
-    public static useApiString(
-        urlSuffix: string,
-        defaultValue: string
-    ): string {
-        return BloomApi.useApiData<string>(urlSuffix, defaultValue);
-    }
-
-    // Like UseApiData, except you also get a function for changing the state on the server.
-    public static useApiState<T>(
-        urlSuffix: string,
-        defaultValue: T
-    ): [T, (value: T) => void] {
-        const [value, setValue] = React.useState<T>(defaultValue);
-        React.useEffect(() => {
-            BloomApi.get(urlSuffix, c => {
-                setValue(c.data);
-            });
-        }, []);
-
-        const setFunction = (value: T) => {
-            BloomApi.postData(urlSuffix, value);
-            setValue(value);
-        };
-        return [value, setFunction];
-    }
-
-    // Like useApiState, except it doesn't send the state back to the server when something changes.
-    // This is useful when you're going to wait for the user to click "OK" before sending all the
-    // state back.
-    public static useApiOneWayState<T>(
-        urlSuffix: string,
-        defaultValue: T
-    ): [T, (value: T) => void] {
-        const [value, setValue] = React.useState<T>(defaultValue);
-        React.useEffect(() => {
-            BloomApi.get(urlSuffix, c => {
-                setValue(c.data);
-            });
-        }, []);
-        return [value, setValue];
-    }
-
-    // A react hook for controlling an API-backed string from a React pure functional component
-    // Returns a tuple of [theCurrentValue, aFunctionForChangingTheValue(newValue)]
-    // When you call the returned function, two things happen: 1) we POST the value to the Bloom API
-    // and 2) we tell react that the value changed. It will then re-render the component;
-    // the component will call this again, but this time the tuple will contain the new value.
-    //
-    // The conditional parameter is optional.
-    // If defined, the string will be retrieved only if calling conditional() returns true.
-    public static useApiStringState(
-        urlSuffix: string,
-        defaultValue: string,
-        conditional?: () => boolean
-    ) {
-        const generateSetStateWrapper = (
-            setState: React.Dispatch<React.SetStateAction<string>>
-        ) => {
-            const setStateWrapper = (value: string) => {
-                BloomApi.postString(urlSuffix, value);
-                setState(value);
-            };
-
-            return setStateWrapper;
-        };
-
-        return this.useApiStringStateInternal(
-            urlSuffix,
-            defaultValue,
-            conditional,
-            generateSetStateWrapper
-        );
-    }
-
-    /**
-     * A react hook very much like useApiStringState, but with two timing-related differences:
-     * 1) waits for the POST request to succeed before setting the value.
-     * 2) The setter function returns a Promise so that the caller can wait until setting is fully complete.
-     */
-    public static useApiStringStatePromise(
-        urlSuffix: string,
-        defaultValue: string,
-        conditional?: () => boolean
-    ) {
-        const generateSetStateWrapper = (
-            setState: React.Dispatch<React.SetStateAction<string>>
-        ) => {
-            // Note that this returns Promise<void> instead of void
-            const setStateWrapper = async (value: string) => {
-                await BloomApi.postString(urlSuffix, value);
-                setState(value);
-            };
-
-            return setStateWrapper;
-        };
-
-        return this.useApiStringStateInternal(
-            urlSuffix,
-            defaultValue,
-            conditional,
-            generateSetStateWrapper
-        );
-    }
-
-    /**
-     * Internal helper method to handle shared code of useApiStringState and useApiStringStatePromise
-     *
-     * In addition to the shared parameters, this Internal function adds a generateSetStateWrapper parameter.
-     * This param is a function which generates the "setStateWrapper" which wraps up the standard setState function from React.useHook with some other functionality.
-     * The sole parameter to generateSetStateWrapperFunction is the underlying setState from React's useState hook.
-     * The return value should be a function that can be used in place of the underlying setState from React's useState hook.
-     */
-    private static useApiStringStateInternal<T>(
-        urlSuffix: string,
-        defaultValue: string,
-        conditional: (() => boolean) | undefined,
-        generateSetStateWrapper: (
-            setValue: React.Dispatch<React.SetStateAction<string>>
-        ) => T
-    ): [string, T] {
-        const [value, setValue] = React.useState(defaultValue);
-        React.useEffect(() => {
-            if (!conditional || conditional()) {
-                BloomApi.getString(urlSuffix, c => {
-                    setValue(c);
-                });
-            }
-        }, []);
-
-        const setterWrapperFunction = generateSetStateWrapper(setValue);
-        return [value, setterWrapperFunction];
-    }
-
     public static getBoolean(
         urlSuffix: string,
         successCallback: (value: boolean) => void
@@ -435,16 +190,6 @@ export class BloomApi {
         return BloomApi.get(urlSuffix, result => {
             successCallback(result.data);
         });
-    }
-
-    public static useApiJson(urlSuffix: string): [any | undefined] {
-        const [value, setValue] = React.useState<any | undefined>();
-        React.useEffect(() => {
-            BloomApi.get(urlSuffix, c => {
-                setValue(c.data);
-            });
-        }, []);
-        return value;
     }
 
     // This method is used to get a result from Bloom, passing parameters to the nested axios call.

--- a/src/BloomBrowserUI/utils/bloomApiHooks.ts
+++ b/src/BloomBrowserUI/utils/bloomApiHooks.ts
@@ -1,0 +1,266 @@
+// React hooks cannot be used inside of a "class" component like BloomApi, so we've moved them out here.
+import React = require("react");
+import { useState } from "react";
+import { useSubscribeToWebSocketForEvent } from "./WebSocketManager";
+import { BloomApi } from "./bloomApi";
+
+// List of exported React hooks:
+// useApiData<T>(urlSuffix: string, defaultValue: T)
+// useApiBoolean(urlSuffix: string, defaultValue: boolean)
+// useCanModifyCurrentBook()
+// useWatchApiData<T>(urlSuffix: string, defaultValue: T, clientContext: string, eventId: string)
+// useWatchBooleanEvent(defaultValue: boolean, clientContext: string, eventId: string)
+// useWatchString(defaultValue: string, clientContext: string, eventId: string)
+// useApiString(urlSuffix: string, defaultValue: string)
+// useApiState<T>(urlSuffix: string, defaultValue: T)
+// useApiOneWayState<T>(urlSuffix: string, defaultValue: T)
+// useApiStringState(urlSuffix: string, defaultValue: string, conditional?: () => boolean)
+// useApiStringStatePromise(urlSuffix: string, defaultValue: string, conditional?: () => boolean)
+// useApiJson(urlSuffix: string)
+
+// Shared code for useApiData and useWatchApiData. If you are tempted to use it directly,
+// you should probably be using useWatchApiData. (This one's not exported for a reason.)
+// The generation argument is a value that can be incremented to force redoing the main
+// query, typically because an event we were watching for was sent from the server.
+function useApiDataInternal<T>(
+    urlSuffix: string,
+    defaultValue: T,
+    generation?: number
+): T {
+    const [value, setValue] = React.useState<T>(defaultValue);
+    React.useEffect(() => {
+        BloomApi.get(urlSuffix, c => {
+            setValue(c.data);
+        });
+    }, [generation, urlSuffix]);
+    return value;
+}
+
+export function useApiData<T>(urlSuffix: string, defaultValue: T): T {
+    return useApiDataInternal(urlSuffix, defaultValue);
+}
+
+// A react hook for controlling an API-backed boolean from a React pure functional component
+// Returns a tuple of [theCurrentValue, aFunctionForChangingTheValue(newValue)]
+// When you call the returned function, two things happen: 1) we POST the value to the Bloom API
+// and 2) we tell react that the value changed. It will then re-render the component;
+// the component will call this again, but this time the tuple will contain the new value.
+export function useApiBoolean(
+    urlSuffix: string,
+    defaultValue: boolean
+): [boolean, (value: boolean) => void] {
+    const [value, setValue] = React.useState(defaultValue);
+    React.useEffect(() => {
+        BloomApi.getBoolean(urlSuffix, c => {
+            setValue(c);
+        });
+    }, [urlSuffix]);
+
+    const fn = (value: boolean) => {
+        BloomApi.postBoolean(urlSuffix, value);
+        setValue(value);
+    };
+    return [value, fn];
+}
+
+export function useCanModifyCurrentBook(): boolean {
+    const [canModifyCurrentBook] = useApiBoolean(
+        "common/canModifyCurrentBook",
+        false
+    );
+    return canModifyCurrentBook;
+}
+
+// Conceptually returns the result of BloomApi.get(urlSuffix).
+// When initially called, returns defaultValue, but a new render will be forced
+// when the query returns the data.
+// Also monitors our web socket for the specified event occurring in the specified
+// context, and forces another render from a fresh call to BloomApi.get when the
+// event occurs.
+export function useWatchApiData<T>(
+    urlSuffix: string,
+    defaultValue: T,
+    clientContext: string,
+    eventId: string
+): T {
+    const [generation, setGeneration] = useState(0);
+    // Force a reload when the specified event happens.
+    useSubscribeToWebSocketForEvent(clientContext, eventId, () => {
+        setGeneration(old => old + 1);
+    });
+    return useApiDataInternal(urlSuffix, defaultValue, generation);
+}
+
+export function useWatchBooleanEvent(
+    defaultValue: boolean,
+    clientContext: string,
+    eventId: string
+) {
+    const [val, setVal] = useState(defaultValue);
+    useSubscribeToWebSocketForEvent(clientContext, eventId, data => {
+        setVal(data.message === "true");
+    });
+    return val;
+}
+
+// Manages a state that is initially defaultValue, but subscribes to the specified web
+// socket, and when it arrives, set the state to its message.
+export function useWatchString(
+    defaultValue: string,
+    clientContext: string,
+    eventId: string
+): string {
+    const [val, setVal] = useState(defaultValue);
+    useSubscribeToWebSocketForEvent(clientContext, eventId, data => {
+        if (data.message) {
+            setVal(data.message!);
+        }
+    });
+    // If we get re-rendered with a different defaultValue, update our result to that.
+    React.useEffect(() => {
+        if (val != defaultValue) {
+            setVal(defaultValue);
+        }
+    }, [defaultValue, val]);
+    return val;
+}
+
+export function useApiString(urlSuffix: string, defaultValue: string): string {
+    return useApiData<string>(urlSuffix, defaultValue);
+}
+
+// Like UseApiData, except you also get a function for changing the state on the server.
+export function useApiState<T>(
+    urlSuffix: string,
+    defaultValue: T
+): [T, (value: T) => void] {
+    const [value, setValue] = React.useState<T>(defaultValue);
+    React.useEffect(() => {
+        BloomApi.get(urlSuffix, c => {
+            setValue(c.data);
+        });
+    }, [urlSuffix]);
+
+    const setFunction = (value: T) => {
+        BloomApi.postData(urlSuffix, value);
+        setValue(value);
+    };
+    return [value, setFunction];
+}
+
+// Like useApiState, except it doesn't send the state back to the server when something changes.
+// This is useful when you're going to wait for the user to click "OK" before sending all the
+// state back.
+export function useApiOneWayState<T>(
+    urlSuffix: string,
+    defaultValue: T
+): [T, (value: T) => void] {
+    const [value, setValue] = React.useState<T>(defaultValue);
+    React.useEffect(() => {
+        BloomApi.get(urlSuffix, c => {
+            setValue(c.data);
+        });
+    }, [urlSuffix]);
+    return [value, setValue];
+}
+
+// A react hook for controlling an API-backed string from a React pure functional component
+// Returns a tuple of [theCurrentValue, aFunctionForChangingTheValue(newValue)]
+// When you call the returned function, two things happen: 1) we POST the value to the Bloom API
+// and 2) we tell react that the value changed. It will then re-render the component;
+// the component will call this again, but this time the tuple will contain the new value.
+//
+// The conditional parameter is optional.
+// If defined, the string will be retrieved only if calling conditional() returns true.
+export function useApiStringState(
+    urlSuffix: string,
+    defaultValue: string,
+    conditional?: () => boolean
+) {
+    const generateSetStateWrapper = (
+        setState: React.Dispatch<React.SetStateAction<string>>
+    ) => {
+        const setStateWrapper = (value: string) => {
+            BloomApi.postString(urlSuffix, value);
+            setState(value);
+        };
+
+        return setStateWrapper;
+    };
+
+    return useApiStringStateInternal(
+        urlSuffix,
+        defaultValue,
+        conditional,
+        generateSetStateWrapper
+    );
+}
+
+/**
+ * A react hook very much like useApiStringState, but with two timing-related differences:
+ * 1) waits for the POST request to succeed before setting the value.
+ * 2) The setter function returns a Promise so that the caller can wait until setting is fully complete.
+ */
+export function useApiStringStatePromise(
+    urlSuffix: string,
+    defaultValue: string,
+    conditional?: () => boolean
+) {
+    const generateSetStateWrapper = (
+        setState: React.Dispatch<React.SetStateAction<string>>
+    ) => {
+        // Note that this returns Promise<void> instead of void
+        const setStateWrapper = async (value: string) => {
+            await BloomApi.postString(urlSuffix, value);
+            setState(value);
+        };
+
+        return setStateWrapper;
+    };
+
+    return useApiStringStateInternal(
+        urlSuffix,
+        defaultValue,
+        conditional,
+        generateSetStateWrapper
+    );
+}
+
+/**
+ * Internal helper method to handle shared code of useApiStringState and useApiStringStatePromise
+ *
+ * In addition to the shared parameters, this Internal function adds a generateSetStateWrapper parameter.
+ * This param is a function which generates the "setStateWrapper" which wraps up the standard setState function from React.useHook with some other functionality.
+ * The sole parameter to generateSetStateWrapperFunction is the underlying setState from React's useState hook.
+ * The return value should be a function that can be used in place of the underlying setState from React's useState hook.
+ */
+function useApiStringStateInternal<T>(
+    urlSuffix: string,
+    defaultValue: string,
+    conditional: (() => boolean) | undefined,
+    generateSetStateWrapper: (
+        setValue: React.Dispatch<React.SetStateAction<string>>
+    ) => T
+): [string, T] {
+    const [value, setValue] = React.useState(defaultValue);
+    React.useEffect(() => {
+        if (!conditional || conditional()) {
+            BloomApi.getString(urlSuffix, c => {
+                setValue(c);
+            });
+        }
+    }, [conditional, urlSuffix]);
+
+    const setterWrapperFunction = generateSetStateWrapper(setValue);
+    return [value, setterWrapperFunction];
+}
+
+export function useApiJson(urlSuffix: string): [any | undefined] {
+    const [value, setValue] = React.useState<any | undefined>();
+    React.useEffect(() => {
+        BloomApi.get(urlSuffix, c => {
+            setValue(c.data);
+        });
+    }, [urlSuffix]);
+    return value;
+}


### PR DESCRIPTION
* Can't have react hooks inside a class.
* Pulled them out to bloomApiHooks.ts.
* This made any changes to bloomApi.ts impossible to
   commit (because of our commit hooks).
* I wouldn't be surprised if the React hooks weren't very
   reliable because of this either.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5591)
<!-- Reviewable:end -->
