### PR TITLE
More TeamCollection analytics (BL-11867)

### DIFF
--- a/src/BloomBrowserUI/teamCollection/CollectionHistoryTable.tsx
+++ b/src/BloomBrowserUI/teamCollection/CollectionHistoryTable.tsx
@@ -60,7 +60,8 @@ const kEventTypes = [
     "Uploaded",
     "Force Unlock",
     "Import Spreadsheet",
-    "Sync Problem"
+    "Sync Problem",
+    "Deleted"
 ]; // REVIEW maybe better to do this in c# and just send it over?
 
 export const CollectionHistoryTable: React.FunctionComponent<{

--- a/src/BloomBrowserUI/teamCollection/CollectionHistoryTable.tsx
+++ b/src/BloomBrowserUI/teamCollection/CollectionHistoryTable.tsx
@@ -59,7 +59,8 @@ const kEventTypes = [
     "Renamed",
     "Uploaded",
     "Force Unlock",
-    "Import Spreadsheet"
+    "Import Spreadsheet",
+    "Sync Problem"
 ]; // REVIEW maybe better to do this in c# and just send it over?
 
 export const CollectionHistoryTable: React.FunctionComponent<{

--- a/src/BloomExe/CollectionTab/CollectionModel.cs
+++ b/src/BloomExe/CollectionTab/CollectionModel.cs
@@ -354,6 +354,7 @@ namespace Bloom.CollectionTab
 					}
 				}
 				var bookName = _bookSelection.CurrentSelection.NameBestForUserDisplay;
+				var bookId = _bookSelection.CurrentSelection.ID;
 				var confirmRecycleDescription = L10NSharp.LocalizationManager.GetString("CollectionTab.ConfirmRecycleDescription", "The book '{0}'");
 				if (ConfirmRecycleDialog.JustConfirm(string.Format(confirmRecycleDescription, bookName), false, "Palaso"))
 				{
@@ -369,6 +370,7 @@ namespace Bloom.CollectionTab
 					if (collection == TheOneEditableCollection)
 						_tcManager.CurrentCollection?.DeleteBookFromRepo(book.FolderPath);
 					collection.DeleteBook(book.BookInfo);
+					CollectionHistory.AddBookEvent(collection.PathToDirectory,bookName, bookId, BookHistoryEventType.Deleted);
 					return true;
 				}
 			}

--- a/src/BloomExe/TeamCollection/BookHistory.cs
+++ b/src/BloomExe/TeamCollection/BookHistory.cs
@@ -37,22 +37,21 @@ namespace Bloom.TeamCollection
 		Uploaded,
 		ForcedUnlock,
 		ImportSpreadsheet,
-		SyncProblem
+		SyncProblem,
+		Deleted
 		// NB: add them here, too: teamCollection\CollectionHistoryTable.tsx
 	}
-
-	[Table("events")]
-	public class BookHistoryEvent
+	/// <summary>
+	/// This class represents the common fields of BookHistoryEvent and CollectionBookHistoryEvent.
+	/// Any fields added should also be added to BookHistoryEvent.FromCollectionBookHistoryEvent().
+	/// </summary>
+	public class HistoryEvent
 	{
-		// we don't put this in the database. We always show the current title.
-		public string Title;
-		public string ThumbnailPath;
-
 		[PrimaryKey, AutoIncrement]
 		public int Id { get; set; }
 
 		[Column("userid")] public string UserId { get; set; }
-		[Column(name:"username")] public string UserName { get; set; }
+		[Column(name: "username")] public string UserName { get; set; }
 		[Column("type")] public BookHistoryEventType Type { get; set; }
 		[Column("user_message")] public string Message { get; set; }
 
@@ -68,8 +67,49 @@ namespace Bloom.TeamCollection
 		[Indexed]
 		[Column("book_id")] public string BookId { get; set; }
 	}
+
+	[Table("events")]
+	public class BookHistoryEvent : HistoryEvent
+	{
+		// we don't put this in the book database. We always show the current title.
+		public string Title;
+		public string ThumbnailPath;
+
+		public static BookHistoryEvent FromCollectionBookHistoryEvent(CollectionBookHistoryEvent ch)
+		{
+			return new BookHistoryEvent()
+			{
+				Title = ch.Title,
+				BookId = ch.BookId,
+				Message = ch.Message,
+				UserId = ch.UserId,
+				UserName = ch.UserName,
+				Type = ch.Type,
+				When = ch.When
+			};
+		}
+	}
+
+	// These are very similar events but stored in the collection history.
+	// Title has to be duplicated because in this table we actually have to store it.
+	// Don't have any way to have a thumbnail of a book without actually having the
+	// book so that is left out. I'm using a different table name because one day
+	// we might want a table of events that affect the collection as a whole
+	// (like changing settings).
+	[Table("book_events")]
+	public class CollectionBookHistoryEvent : HistoryEvent
+	{
+		[Column("title")] public string Title { get; set; }
+	}
 }
 
+/// <summary>
+/// The collection history currently gives us a place to put events that don't belong to
+/// any existing book. Currently, these are events about books, but which can't be
+/// stored in the book's own history, typically because they involve the deletion of
+/// the book. This also gives us a place to put methods that related to the events
+/// of the whole collection.
+/// </summary>
 public class CollectionHistory
 {
 	public static IEnumerable<BookHistoryEvent> GetAllEvents(BookCollection collection)
@@ -90,8 +130,43 @@ public class CollectionHistory
 
 		// strip out, if there are no events
 		var booksWithHistory =  from b in all where b.Any() select b;
+		var collectionBookEvents = GetCollectionBookHistory(collection.PathToDirectory);
+		return booksWithHistory.SelectMany(e => e).Concat(collectionBookEvents);
+	}
 
-		return booksWithHistory.SelectMany(e => e);
+	public static void AddBookEvent(string collectionPath, string bookName, string bookId, BookHistoryEventType eventType, string message = "")
+	{
+		if (SIL.PlatformUtilities.Platform.IsLinux)
+			return;     // SQLiteConnection never works on Linux.
+		try
+		{
+			using (var db = GetConnection(collectionPath))
+			{
+				var evt = new CollectionBookHistoryEvent()
+				{
+					Title = bookName,
+					BookId = bookId,
+					Message = message,
+					UserId = TeamCollectionManager.CurrentUser,
+					UserName = TeamCollectionManager.CurrentUserFirstName,
+					Type = eventType,
+					// Be sure to use UTC, otherwise, order will not be preserved properly.
+					When = DateTime.UtcNow
+				};
+
+				db.Insert(evt);
+				db.Close();
+			}
+		}
+		catch (Exception e)
+		{
+
+			NonFatalProblem.Report(ModalIf.None, PassiveIf.All, "Problem writing book history", $"folder={collectionPath}",
+				e);
+			// swallow... we don't want to prevent whatever was about to happen.
+		}
+		// Instance should only be null in unit tests
+		BloomWebSocketServer.Instance?.SendEvent("bookHistory", "eventAdded");
 	}
 
 	public static List<BookHistoryEvent> GetBookEvents(BookInfo bookInfo)
@@ -104,6 +179,50 @@ public class CollectionHistory
 			e.ThumbnailPath = Path.Combine(bookInfo.FolderPath, "thumbnail.png").ToLocalhost();
 		});
 		return events;
+	}
+
+	/// <summary>
+	/// Although these events are stored as CollectionBookHistoryEvents, it is convenient to
+	/// retrieve them as BookHistoryEvents, since the main client wants to concatenate the two
+	/// lists. (We can't actually store them that way, because the two classes have different
+	/// directives about storing Title in the database.)
+	/// </summary>
+	/// <param name="collectionFolder"></param>
+	/// <returns></returns>
+	public static List<BookHistoryEvent> GetCollectionBookHistory(string collectionFolder)
+	{
+		if (SIL.PlatformUtilities.Platform.IsLinux)
+		{
+			// SQLiteConnection never works on Linux.
+			return new List<BookHistoryEvent>();
+		}
+
+		using (var db = GetConnection(collectionFolder))
+		{
+			var events = db.Table<CollectionBookHistoryEvent>()
+				.Select(ch => BookHistoryEvent.FromCollectionBookHistoryEvent(ch)).ToList();
+			db.Close();
+			return events;
+		}
+	}
+
+	private static SQLiteConnection GetConnection(string collectionFolder)
+	{
+		SQLiteConnection db = null;
+		var path = GetDatabasePath(collectionFolder);
+		RetryUtility.Retry(
+			() => db = new SQLiteConnection(path));
+		if (db == null)
+			throw new ApplicationException("Could not open history db for" + path);
+
+		// For now, we're keeping things simple by just not assuming *anything*, even that the tables are there.
+		// If we find that something is slow or sqllite dislikes this approach, we can do something more complicated.
+		db.CreateTable<CollectionBookHistoryEvent>();
+		return db;
+	}
+	private static string GetDatabasePath(string collectionFolder)
+	{
+		return Path.Combine(collectionFolder, "history.db");
 	}
 }
 

--- a/src/BloomExe/TeamCollection/FolderTeamCollection.cs
+++ b/src/BloomExe/TeamCollection/FolderTeamCollection.cs
@@ -941,14 +941,17 @@ namespace Bloom.TeamCollection
 		/// <summary>
 		/// Called when the user clicks the Join{ and Merge} button in the dialog.
 		/// </summary>
-		public static void JoinCollectionTeam()
+		/// <returns>an indication of the type of join for analytics</returns>
+		public static string JoinCollectionTeam()
 		{
 			var repoFolder = Path.GetDirectoryName(_joinCollectionPath);
 			var localCollectionFolder =
 				Path.Combine(NewCollectionWizard.DefaultParentDirectoryForCollections, _joinCollectionName);
 			var firstTimeJoin = true; // default assumption
+			var result = "create";
 			if (Directory.Exists(localCollectionFolder)) // if not, no merging, so value of firstTimeJoin doesn't matter.
 			{
+				result = "merge";
 				var tcLinkPath = TeamCollectionManager.GetTcLinkPathFromLcPath(localCollectionFolder);
 				if (RobustFile.Exists(tcLinkPath))
 				{
@@ -961,6 +964,7 @@ namespace Bloom.TeamCollection
 						// by mistake, or to fix things up after it moved. So we want to sync normally,
 						// not as if we're merging collections.
 						firstTimeJoin = false;
+						result = "open";
 					}
 
 				}
@@ -976,6 +980,7 @@ namespace Bloom.TeamCollection
 			// special behavior, but only if joining for the first time.
 			if (firstTimeJoin)
 				TeamCollectionManager.NextMergeIsFirstTimeJoinCollection = true;
+			return result;
 		}
 
 		/// <summary>

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -1584,6 +1584,19 @@ namespace Bloom.TeamCollection
 		}
 
 		/// <summary>
+		/// This overload reports the problem to the progress box, log, and Analytics, and also makes an entry in
+		/// the collection's book history. Use it when the problem will result in the book going away, so
+		/// it can't be recorded in the book's own history.
+		/// </summary>
+		void ReportProblemSyncingBook(string collectionPath, string bookName, string bookId, IWebSocketProgress progress, ProgressKind kind, string l10nIdSuffix, string message,
+			string param0 = null, string param1 = null)
+		{
+			ReportProblemSyncingBook(progress, kind, l10nIdSuffix, message, param0, param1);
+			var msg = string.Format(message, param0, param1);
+			CollectionHistory.AddBookEvent(collectionPath, bookName, bookId, BookHistoryEventType.SyncProblem, msg);
+		}
+
+		/// <summary>
 		/// A list of strings known to occur in filenames Dropbox generates when it resolves conflicting changes.
 		/// Not a completely reliable way to identify them, especially with an incomplete list of localizations,
 		/// but it's the best we can do.
@@ -1714,9 +1727,7 @@ namespace Bloom.TeamCollection
 								PutBook(path,inLostAndFound:true);
 								SIL.IO.RobustIO.DeleteDirectory(path, true);
 								hasProblems = true;
-								// Here we can't add the information to history, because we deleted the folder that contains the
-								// history. So just do the other kinds of report.
-								ReportProblemSyncingBook(progress, ProgressKind.Error, "TeamCollection.ConflictingIdMove",
+								ReportProblemSyncingBook(_localCollectionFolder, bookFolderName, id, progress, ProgressKind.Error, "TeamCollection.ConflictingIdMove",
 									"The book \"{0}\" was moved to Lost and Found, since it has the same ID as the book \"{1}\" in the team collection.",
 									bookFolderName, repoState.Item1);
 								// We will copy the conflicting book to local in the second loop.

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -1553,6 +1553,17 @@ namespace Bloom.TeamCollection
 				fullL10nId, message, param0, param1);
 		}
 
+		void ReportProgressLogAndAnalytics(IWebSocketProgress progress, ProgressKind kind, string l10nIdSuffix, string message,
+			string param0 = null, string param1 = null)
+		{
+			ReportProgressAndLog(progress, kind, l10nIdSuffix, message, param0, param1);
+			var msg = string.Format(message, param0, param1);
+			Analytics.Track("TeamCollectionError", new Dictionary<string, string>
+			{
+				{"message",msg}
+			});
+		}
+
 		/// <summary>
 		/// A list of strings known to occur in filenames Dropbox generates when it resolves conflicting changes.
 		/// Not a completely reliable way to identify them, especially with an incomplete list of localizations,
@@ -1684,8 +1695,8 @@ namespace Bloom.TeamCollection
 								PutBook(path,inLostAndFound:true);
 								SIL.IO.RobustIO.DeleteDirectory(path, true);
 								hasProblems = true;
-								ReportProgressAndLog(progress, ProgressKind.Error, "TeamCollection.ConflictingIdMove",
-									"The book \"{0}\" was moved to Lost & Found, since it has the same ID as the book \"{1}\" in the repo.",
+								ReportProgressLogAndAnalytics(progress, ProgressKind.Error, "TeamCollection.ConflictingIdMove",
+									"The book \"{0}\" was moved to Lost and Found, since it has the same ID as the book \"{1}\" in the repo.",
 									bookFolderName, repoState.Item1);
 								// We will copy the conflicting book to local in the second loop.
 								continue;
@@ -1849,7 +1860,7 @@ namespace Bloom.TeamCollection
 								hasProblems = true;
 								// Make the local folder match the repo (this is where 'they win')
 								CopyBookFromRepoToLocalAndReport(progress, bookName, () =>
-									ReportProgressAndLog(progress, ProgressKind.Error, "ConflictingCheckout",
+									ReportProgressLogAndAnalytics(progress, ProgressKind.Error, "ConflictingCheckout",
 										"Found different versions of '{0}' in both collections. The team version has been copied to your local collection, and the old local version to Lost and Found"
 										, bookName));
 								continue;
@@ -1934,7 +1945,7 @@ namespace Bloom.TeamCollection
 								hasProblems = true;
 								// Make the local folder match the repo (this is where 'they win')
 								CopyBookFromRepoToLocalAndReport(progress, bookName, () =>
-									ReportProgressAndLog(progress, ProgressKind.Error, "ConflictingCheckout",
+									ReportProgressLogAndAnalytics(progress, ProgressKind.Error, "ConflictingCheckout",
 										"The book '{0}', which you have checked out and edited, is checked out to someone else in the Team Collection. Your changes have been overwritten, but are saved to Lost-and-found.",
 										bookName));
 								continue;
@@ -1967,7 +1978,7 @@ namespace Bloom.TeamCollection
 						// warn the user
 						hasProblems = true;
 						CopyBookFromRepoToLocalAndReport(progress, bookName, () =>
-							ReportProgressAndLog(progress, ProgressKind.Error, "ConflictingEdit",
+							ReportProgressLogAndAnalytics(progress, ProgressKind.Error, "ConflictingEdit",
 								"The book '{0}', which you have checked out and edited, was modified in the Team Collection by someone else. Your changes have been overwritten, but are saved to Lost-and-found.",
 								bookName));
 

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -1613,14 +1613,16 @@ namespace Bloom.TeamCollection
 						SIL.Windows.Forms.Registration.Registration.Default.Surname);
 					var lostAndFoundUrl =
 						"https://docs.bloomlibrary.org/team-collections-advanced-topics/#2488e17a8a6140bebcef068046cc57b7";
+					var admins = string.Join(", ", (_tcManager?.Settings?.Administrators ?? new string[0])
+						.Select(e => ProblemReportApi.GetObfuscatedEmail(e)));
 					// Note: there is deliberately no period after {msg} since msg usually ends with one already.
 					var fullMsg =
-						$"{standardUserInfo}: There was a book synchronization problem that required putting a version in Lost and Found: {msg} See {lostAndFoundUrl}.";
+						$"{standardUserInfo} \n(Admins: {admins}):\n\nThere was a book synchronization problem that required putting a version in Lost and Found:\n{msg}\n\nSee {lostAndFoundUrl}.";
 					var issueId = issue.SubmitToYouTrack("Book synchronization failed", fullMsg);
 					var issueLink = "https://issues.bloomlibrary.org/youtrack/issue/" + issueId;
 					ReportProgressAndLog(progress, ProgressKind.Note, "ProblemReported",
-						"Bloom reported this problem to the developers. You can see the report at {0}. Also see {1}", issueLink, lostAndFoundUrl);
-					// Todo: figure out URL, report to progress.
+						"Bloom reported this problem to the developers.");
+					// Originally added " You can see the report at {0}. Also see {1}", issueLink, lostAndFoundUrl); but JohnH says not to (BL-11867)
 				}
 				catch (Exception e)
 				{

--- a/src/BloomExe/TeamCollection/TeamCollectionApi.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionApi.cs
@@ -218,7 +218,7 @@ namespace Bloom.TeamCollection
 		{
 			try
 			{
-				FolderTeamCollection.JoinCollectionTeam();
+				var joinType = FolderTeamCollection.JoinCollectionTeam();
 				ReactDialog.CloseCurrentModal();
 
 				Analytics.Track("TeamCollectionJoin",
@@ -226,7 +226,8 @@ namespace Bloom.TeamCollection
 						{"CollectionId", _settings?.CollectionId},
 						{"CollectionName", _settings?.CollectionName},
 						{"Backend", _tcManager?.CurrentCollection?.GetBackendType()},
-						{"User", CurrentUser}
+						{"User", CurrentUser},
+						{"JoinType", joinType} // create, open, or merge
 					});
 
 				request.PostSucceeded();

--- a/src/BloomExe/TeamCollection/TeamCollectionApi.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionApi.cs
@@ -646,9 +646,10 @@ namespace Bloom.TeamCollection
 					_tcManager.CurrentCollection.CopyBookFromRepoToLocal(bookName, dialogOnError:true);
 					// Force a full reload of the book from disk and update the UI to match.
 					_bookSelection.SelectBook(_bookServer.GetBookFromBookInfo(_bookSelection.CurrentSelection.BookInfo, true));
-					var msg = LocalizationManager.GetString("TeamCollection.ConflictingEditOrCheckout",
-						"Someone else has edited this book or checked it out even though you were editing it! Your changes have been saved to Lost and Found");
-					ErrorReport.NotifyUserOfProblem(msg);
+					var msgFmt = LocalizationManager.GetString("TeamCollection.ConflictingEditOrCheckout",
+						"Someone else has edited the book {0} or checked it out even though it was being editing here! Local changes have been saved to Lost and Found");
+					var msg = string.Format(msgFmt,
+						Path.GetFileNameWithoutExtension(_bookSelection.CurrentSelection.FolderPath));
 					Analytics.Track("TeamCollectionConflictingEditOrCheckout",
 						new Dictionary<string, string>() {
 							{"CollectionId", _settings?.CollectionId},
@@ -658,6 +659,8 @@ namespace Bloom.TeamCollection
 							{"BookId", _bookSelection?.CurrentSelection?.ID},
 							{"BookName", _bookSelection?.CurrentSelection?.Title}
 						});
+					BookHistory.AddEvent(_bookSelection.CurrentSelection, BookHistoryEventType.SyncProblem, msg);
+					ErrorReport.NotifyUserOfProblem(msg);
 				}
 				UpdateUiForBook();
 				request.PostSucceeded();

--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -87,7 +87,7 @@ namespace Bloom.web.controllers
 
 		private BloomZipFile _reportZipFile;
 		private TempFile _reportZipFileTemp;
-		protected string YouTrackProjectKey = "BL";
+		public static string YouTrackProjectKey = "BL";
 		const string kFailureResult = "failed";
 
 		/// <summary>
@@ -790,7 +790,7 @@ namespace Bloom.web.controllers
 			}
 		}
 
-		private static string GetObfuscatedEmail(string userEmail = "")
+		public static string GetObfuscatedEmail(string userEmail = "")
 		{
 			var email = string.IsNullOrWhiteSpace(userEmail) ?  _reportInfo?.UserEmail : userEmail;
 			string obfuscatedEmail;
@@ -811,10 +811,24 @@ namespace Bloom.web.controllers
 		{
 			var firstName = _reportInfo.UserFirstName;
 			var lastName = _reportInfo.UserSurname;
-			var nameString = GetNameString(firstName, lastName);			
+			var errorReportFrom = GetStandardUserInfo(userEmail, firstName, lastName);
+			bldr.AppendLine(errorReportFrom);
+		}
+
+		/// <summary>
+		/// Generates a standard representation of the user information we want to have in an error
+		/// report submitted to YouTrack. It's important that the fields be arranged (and obfusticated)
+		/// exactly like this, because we have code running on the YouTrack system that will recognize
+		/// data in this format and extract the unobfusticated email and the reporter name.
+		/// (I'm not sure exactly what details must not be changed, so don't change anything without
+		/// checking and testing.)
+		/// </summary>
+		public static string GetStandardUserInfo(string userEmail, string firstName, string lastName)
+		{
+			var nameString = GetNameString(firstName, lastName);
 			var obfuscatedEmail = GetObfuscatedEmail(userEmail);
 			var emailString = string.IsNullOrWhiteSpace(obfuscatedEmail) ? string.Empty : " (" + obfuscatedEmail + ")";
-			bldr.AppendLine("Error Report from " + nameString + emailString + " on " + DateTime.UtcNow.ToUniversalTime() + " UTC");
+			return "Error Report from " + nameString + emailString + " on " + DateTime.UtcNow.ToUniversalTime() + " UTC";
 		}
 
 		private static object GetNameString(string firstName, string lastName)

--- a/src/BloomTests/TeamCollection/SyncAtStartupTests.cs
+++ b/src/BloomTests/TeamCollection/SyncAtStartupTests.cs
@@ -302,9 +302,14 @@ namespace BloomTests.TeamCollection
 			var fixedLocalPath = Path.Combine(_collectionFolder.FolderPath, kRepoNameForIdConflict);
 			Assert.That(Directory.Exists(fixedLocalPath));
 			AssertLostAndFound(kLocalNameForIdConflict);
-			AssertProgress("The book \"{0}\" was moved to Lost and Found, since it has the same ID as the book \"{1}\" in the team collection.",
+
+			var message = "The book \"{0}\" was moved to Lost and Found, since it has the same ID as the book \"{1}\" in the team collection.";
+			AssertProgress(message,
 				kLocalNameForIdConflict, kRepoNameForIdConflict,MessageAndMilestoneType.ErrorNoReload);
 			AssertProgress("Fetching a new book '{0}' from the Team Collection", kRepoNameForIdConflict);
+			var history = CollectionHistory.GetCollectionBookHistory(_collectionFolder.FolderPath);
+			var msg = string.Format(message, kLocalNameForIdConflict, kRepoNameForIdConflict);
+			Assert.That(history, Has.Some.Matches<BookHistoryEvent>(item => item.Message == msg));
 		}
 		[Test]
 		public void SyncAtStartup_RemoteRename_RenamedLocally()

--- a/src/BloomTests/TeamCollection/SyncAtStartupTests.cs
+++ b/src/BloomTests/TeamCollection/SyncAtStartupTests.cs
@@ -301,7 +301,7 @@ namespace BloomTests.TeamCollection
 			var fixedLocalPath = Path.Combine(_collectionFolder.FolderPath, kRepoNameForIdConflict);
 			Assert.That(Directory.Exists(fixedLocalPath));
 			AssertLostAndFound(kLocalNameForIdConflict);
-			AssertProgress("The book \"{0}\" was moved to Lost & Found, since it has the same ID as the book \"{1}\" in the repo.",
+			AssertProgress("The book \"{0}\" was moved to Lost and Found, since it has the same ID as the book \"{1}\" in the repo.",
 				kLocalNameForIdConflict, kRepoNameForIdConflict,MessageAndMilestoneType.ErrorNoReload);
 			AssertProgress("Fetching a new book '{0}' from the Team Collection", kRepoNameForIdConflict);
 		}

--- a/src/BloomTests/app.config
+++ b/src/BloomTests/app.config
@@ -56,11 +56,7 @@
         <assemblyIdentity name="System.Resources.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
+        <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
       </dependentAssembly>


### PR DESCRIPTION
Joining a TC: reports whether we created a new local collection, opened an existing one normally, or did a first-time merge.
Errors that put things in Lost and Found now generate a TeamCollectionError analytics report.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5597)
<!-- Reviewable:end -->
