### PR TITLE
Fix bloom-player pages/buttons misaligned (BL-11497)

### DIFF
--- a/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
@@ -138,7 +138,9 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
                             "bloom-player/dist/bloomplayer.htm?centerVertically=true&url=" +
                             encodeURIComponent(bookUrl) + // Need to apply encoding to the bookUrl again as data to use it as a parameter of another URL
                             "&independent=false" + // you can temporarily comment this out to send BloomPlayer analytics from Bloom Editor
-                            "&host=bloomdesktop"
+                            "&host=bloomdesktop" +
+                            "&roundPageWidthToNearestK=2" + // Fractional pixels can cause a small sliver of the next page or background color to show (See BL-11497)
+                            "&roundMarginToNearestK=2" // Fractional pixels can cause a small sliver of the next page or background color to show (See BL-11497)
                         }
                         showRefresh={true}
                         highlightRefreshIcon={highlightRefresh}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5599)
<!-- Reviewable:end -->
