### PR TITLE
Fix padding for PublishAudioVideo screen (BL-11820)

### DIFF
--- a/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
+++ b/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
@@ -313,8 +313,6 @@ const PublishAudioVideoInternalInternal: React.FunctionComponent<{
                 activeStep={activeStep}
                 orientation="vertical"
                 // We need to defeat Material-UI's attempt to make the step numbers and text look disabled.
-                // Also, we need to defeat the MUI Stepper's padding, which is already standardized
-                // by MainPanel.
                 css={css`
                     .MuiStepLabel-label {
                         color: black !important;
@@ -323,7 +321,6 @@ const PublishAudioVideoInternalInternal: React.FunctionComponent<{
                     .MuiStepIcon-root {
                         color: ${kBloomBlue} !important;
                     }
-                    padding: 0 !important;
                 `}
             >
                 <Step expanded={true}>


### PR DESCRIPTION
This fix applies to Version5.4.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5636)
<!-- Reviewable:end -->
