### PR TITLE
Prevent recording video when display is actively scaled (BL-11880)

### DIFF
--- a/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
+++ b/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
@@ -516,7 +516,11 @@ const PublishAudioVideoInternalInternal: React.FunctionComponent<{
                                     </ErrorBox>
                                 )}
                                 <BloomButton
-                                    enabled={!recording && isLicenseOK}
+                                    enabled={
+                                        !recording &&
+                                        isLicenseOK &&
+                                        !isScalingActive
+                                    }
                                     l10nKey="PublishTab.RecordVideo.Record"
                                     l10nComment="'Record' as in 'Record a video recording'"
                                     clickApiEndpoint="publish/av/recordVideo"


### PR DESCRIPTION
This is not a cherry-pick because the commit that included this line did not apply cleanly and included other changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5644)
<!-- Reviewable:end -->
