### PR TITLE
BL-11921 update Help URL in Collections tab

### DIFF
--- a/src/BloomExe/CollectionTab/CollectionTabView.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.cs
@@ -245,17 +245,7 @@ namespace Bloom.CollectionTab
 
 		public string HelpTopicUrl
 		{
-			get
-			{
-				if (_model.IsSourceCollection)
-				{
-					return "/Tasks/Source_Collection_tasks/Source_Collection_tasks_overview.htm";
-				}
-				else
-				{
-					return "/Tasks/Vernacular_Collection_tasks/Vernacular_Collection_tasks_overview.htm";
-				}
-			}
+			get { return "/Tasks/Collections_tab_tasks/Collections_tab_tasks_overview.htm"; }
 		}
 
 		public Control TopBarControl


### PR DESCRIPTION
* another change for the disappearance of Source/Vernacular collections

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5646)
<!-- Reviewable:end -->
