### PR TITLE
Fix the Linux packages.config for new libpalaso version (20230227)

### DIFF
--- a/src/BloomExe/Linux/packages.config
+++ b/src/BloomExe/Linux/packages.config
@@ -68,6 +68,7 @@
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net472" />
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Memory" version="4.5.4" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
   <package id="System.Reflection.Metadata" version="5.0.0" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net461" />
@@ -78,7 +79,7 @@
   <package id="System.Text.Encodings.Web" version="5.0.1" targetFramework="net461" />
   <package id="System.Text.Json" version="5.0.2" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
-  <package id="TagLibSharp" version="2.2.0" targetFramework="net461" />
+  <package id="TagLibSharp" version="2.3.0" targetFramework="net461" />
   <package id="TechTalk.JiraRestClient.RestSharp105" version="2.3.0.1" targetFramework="net461" />
   <!-- Linux specific packages.  Changes above this line must be copied to ../packages.config -->
   <package id="Geckofx60.64.Linux" version="60.0.51" targetFramework="net461" />


### PR DESCRIPTION
This is for Bloom 5.4, the last version supported by Linux (for now).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5668)
<!-- Reviewable:end -->
