### PR TITLE
Remove reliance on null for all Publish Settings

### DIFF
--- a/src/BloomExe/Book/BookCompressor.cs
+++ b/src/BloomExe/Book/BookCompressor.cs
@@ -48,11 +48,11 @@ namespace Bloom.Book
 				if (RobustFile.Exists(blankImage))
 					coverImagePath = blankImage;
 			}
-			if(coverImagePath != null)
+			if (coverImagePath != null)
 			{
 				var thumbPath = Path.Combine(destinationFolder, "thumbnail.png");
-				
-				RuntimeImageProcessor.GenerateEBookThumbnail(coverImagePath, thumbPath, heightAndWidth, heightAndWidth,System.Drawing.ColorTranslator.FromHtml(book.GetCoverColor()));
+
+				RuntimeImageProcessor.GenerateEBookThumbnail(coverImagePath, thumbPath, heightAndWidth, heightAndWidth, System.Drawing.ColorTranslator.FromHtml(book.GetCoverColor()));
 			}
 		}
 
@@ -176,7 +176,7 @@ namespace Bloom.Book
 			{
 				if (!filter.Filter(filePath))
 					continue;
-				
+
 				FileInfo fi = new FileInfo(filePath);
 
 				var entryName = dirNamePrefix + filePath.Substring(dirNameOffset);  // Makes the name in zip based on the folder
@@ -189,7 +189,7 @@ namespace Bloom.Book
 
 				byte[] modifiedContent = null;
 
-				if (overrides !=null && overrides.TryGetValue(filePath, out modifiedContent))
+				if (overrides != null && overrides.TryGetValue(filePath, out modifiedContent))
 					newEntry.Size = modifiedContent.Length;
 				else
 					newEntry.Size = fi.Length;
@@ -248,11 +248,11 @@ namespace Bloom.Book
 			dom.Load(filePath);
 			foreach (var node in dom.SafeSelectNodes("//SubscriptionCode").Cast<XmlElement>().ToArray())
 			{
-				node.RemoveAll();	// should happen at most once
+				node.RemoveAll();   // should happen at most once
 			}
 			foreach (var node in dom.SafeSelectNodes("//BrandingProjectName").Cast<XmlElement>().ToArray())
 			{
-				node.RemoveAll();	// should happen at most once
+				node.RemoveAll();   // should happen at most once
 				node.AppendChild(dom.CreateTextNode("Default"));
 			}
 			return dom.OuterXml;
@@ -290,7 +290,7 @@ namespace Bloom.Book
 					if (matchSuppress.Groups[3].Value.ToLower() != "true")
 					{
 						text = text.Substring(0, matchSuppress.Groups[3].Index) + "true"
-								+  text.Substring(matchSuppress.Groups[3].Index + matchSuppress.Groups[3].Length);
+								+ text.Substring(matchSuppress.Groups[3].Index + matchSuppress.Groups[3].Length);
 					}
 				}
 				else
@@ -322,11 +322,8 @@ namespace Bloom.Book
 		/// transparent backgrounds.
 		/// </remarks>
 		/// <returns>The bytes of the (possibly) adjusted image.</returns>
-		internal static byte[] GetImageBytesForElectronicPub(string filePath, bool needsTransparentBackground, ImagePublishSettings imagePublishSettings = null)
+		internal static byte[] GetImageBytesForElectronicPub(string filePath, bool needsTransparentBackground, ImagePublishSettings imagePublishSettings)
 		{
-			if (imagePublishSettings == null)
-				imagePublishSettings = ImagePublishSettings.Default;
-
 			var maxWidth = imagePublishSettings.MaxWidth;
 			var maxHeight = imagePublishSettings.MaxHeight;
 
@@ -360,11 +357,11 @@ namespace Bloom.Book
 						// we should keep the original just because it's a smaller file.
 						// - possibly we don't need a 32-bit bitmap? Unfortunately the 1bpp/4bpp/8bpp only tells us
 						// that the image uses two, 16, or 256 distinct colors, not what they are or what precision they have.
-							case PixelFormat.Format1bppIndexed:
-							case PixelFormat.Format4bppIndexed:
-							case PixelFormat.Format8bppIndexed:
+						case PixelFormat.Format1bppIndexed:
+						case PixelFormat.Format4bppIndexed:
+						case PixelFormat.Format8bppIndexed:
 							imagePixelFormat = PixelFormat.Format32bppArgb;
-								break;
+							break;
 					}
 					// OTOH, always using 32-bit format for .png files keeps us from having problems in BloomReader
 					// like BL-5740 (where 24bit format files came out in BR with black backgrounds).

--- a/src/BloomExe/Book/PublishSettings.cs
+++ b/src/BloomExe/Book/PublishSettings.cs
@@ -50,10 +50,14 @@ namespace Bloom.Book
 		}
 		public void LoadNewJson(string json)
 		{
-			JsonSerializerSettings settings = new JsonSerializerSettings();
 			try
 			{
-				JsonConvert.PopulateObject(json, this, settings);
+				JsonConvert.PopulateObject(json, this,
+					// Previously, various things could be null. As part of simplifying the use of PublishSettings,
+					// we now never have nulls; everything gets defaults when it is created.
+					// For backwards capabilty, if the json we are reading has a null for a value,
+					// do not override the default value that we already have loaded.
+					new JsonSerializerSettings() { NullValueHandling=NullValueHandling.Ignore});
 			}
 			catch (Exception e) { throw new ApplicationException("publish-settings of this book may be corrupt", e); }
 		}

--- a/src/BloomExe/CLI/CreateArtifactsCommand.cs
+++ b/src/BloomExe/CLI/CreateArtifactsCommand.cs
@@ -218,14 +218,13 @@ namespace Bloom.CLI
 					Directory.CreateDirectory(Path.GetDirectoryName(zippedBloomPubOutputPath));
 					// Make the bloompub
 					string unzippedPath = BloomPubMaker.CreateBloomPub(
-					zippedBloomPubOutputPath,
-					bookPath,
-					bookServer,
-					new Bloom.web.NullWebSocketProgress(),
-					folderForUnzipped,
-					creator,
-					isTemplateBook,
-					settings);
+						settings,
+						zippedBloomPubOutputPath,
+						bookPath,
+						bookServer,
+						new Bloom.web.NullWebSocketProgress(),
+						folderForUnzipped, creator, isTemplateBook
+						);
 
 					// Currently the zipping process does some things we actually need, like making the cover picture
 					// transparent (BL-7437). Eventually we plan to separate the preparation and zipping steps (BL-7445).

--- a/src/BloomExe/CLI/SendFontAnalyticsCommand.cs
+++ b/src/BloomExe/CLI/SendFontAnalyticsCommand.cs
@@ -108,8 +108,8 @@ namespace Bloom.CLI
 				bool isTemplateBook = _book.BookInfo.IsSuitableForMakingShells;
 				var settings = AndroidPublishSettings.GetPublishSettingsForBook(_projectContext.BookServer, _book.BookInfo);
 				// This method will gather up the desired font analytics as a side-effect.
-				BloomPubMaker.PrepareBookForBloomReader(options.BookPath, _projectContext.BookServer, stagingFolder,
-					new Bloom.web.NullWebSocketProgress(), isTemplateBook, settings: settings);
+				BloomPubMaker.PrepareBookForBloomReader(settings, bookFolderPath: options.BookPath, bookServer: _projectContext.BookServer, temp: stagingFolder,
+					progress: new Bloom.web.NullWebSocketProgress(), isTemplateBook: isTemplateBook);
 			}
 		}
 	}

--- a/src/BloomExe/CollectionTab/CollectionModel.cs
+++ b/src/BloomExe/CollectionTab/CollectionModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -108,7 +108,7 @@ namespace Bloom.CollectionTab
 
 		public string LanguageName
 		{
-			get { return _collectionSettings.Language1.Name; }	// collection tab still uses collection language settings
+			get { return _collectionSettings.Language1.Name; }  // collection tab still uses collection language settings
 		}
 
 		private object _bookCollectionLock = new object(); // Locks creation of _bookCollections
@@ -177,7 +177,7 @@ namespace Bloom.CollectionTab
 		{
 			// I hope we can get rid of this when we retire the old LibraryListView, but for now we need to keep both views up to date.
 			// optimize: we only need to reload the first (editable) collection; better yet, we only need to add the one new book to it.
-			ReloadCollections();       
+			ReloadCollections();
 		}
 
 		public void UpdateLabelOfBookInEditableCollection(Book.Book book)
@@ -208,7 +208,7 @@ namespace Bloom.CollectionTab
 			get { return GetBookCollections().First(c => c.Type == BookCollection.CollectionType.TheOneEditableCollection); }
 		}
 
-		
+
 		public string VernacularCollectionNamePhrase
 		{
 			get { return _collectionSettings.VernacularCollectionNamePhrase; }
@@ -321,9 +321,9 @@ namespace Bloom.CollectionTab
 			}
 		}
 
-		public  void SelectBook(Book.Book book)
+		public void SelectBook(Book.Book book)
 		{
-			 _bookSelection.SelectBook(book);
+			_bookSelection.SelectBook(book);
 		}
 		public Book.Book GetSelectedBookOrNull()
 		{
@@ -372,7 +372,7 @@ namespace Bloom.CollectionTab
 					if (collection == TheOneEditableCollection)
 						_tcManager.CurrentCollection?.DeleteBookFromRepo(book.FolderPath);
 					collection.DeleteBook(book.BookInfo);
-					CollectionHistory.AddBookEvent(collection.PathToDirectory,bookName, bookId, BookHistoryEventType.Deleted);
+					CollectionHistory.AddBookEvent(collection.PathToDirectory, bookName, bookId, BookHistoryEventType.Deleted);
 					return true;
 				}
 			}
@@ -417,7 +417,7 @@ namespace Bloom.CollectionTab
 			{
 				// Since the user explicitly told us to do this again, we will, even if we think
 				// it's already been done.
-				dlg.ShowAndDoWork(progress=>b.BringBookUpToDate(progress));
+				dlg.ShowAndDoWork(progress => b.BringBookUpToDate(progress));
 			}
 
 			_bookSelection.SelectBook(b);
@@ -429,7 +429,7 @@ namespace Bloom.CollectionTab
 			var pathToXnDesignXslt = FileLocationUtilities.GetFileDistributedWithApplication("xslts", "BloomXhtmlToDataForMergingIntoInDesign.xsl");
 
 #if DEBUG
-			 _bookSelection.CurrentSelection.OurHtmlDom.RawDom.Save(path.Replace(".xml",".xhtml"));
+			_bookSelection.CurrentSelection.OurHtmlDom.RawDom.Save(path.Replace(".xml", ".xhtml"));
 #endif
 
 			var dom = _bookSelection.CurrentSelection.OurHtmlDom.ApplyXSLT(pathToXnDesignXslt);
@@ -471,7 +471,8 @@ namespace Bloom.CollectionTab
 			{
 				body.SetAttribute("class", (classVal + " " + className).Trim());
 				_bookSelection.CurrentSelection.Save();
-			} else if (!shouldHaveClass && classVal.Contains(className))
+			}
+			else if (!shouldHaveClass && classVal.Contains(className))
 			{
 				body.SetAttribute("class", classVal.Replace(className, "").Trim());
 				_bookSelection.CurrentSelection.Save();
@@ -547,8 +548,8 @@ namespace Bloom.CollectionTab
 				"<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\">");
 			var xmlDoc = RepairWordVisibility(fixedContent);
 			XmlHtmlConverter.SaveDOMAsHtml5(xmlDoc, destDocPath); // writes file and returns path
-			// We need to copy the CSS and image files from the book's folder to the destination folder.
-			// We don't need other files from there for this export. (audio, video, etc)
+																  // We need to copy the CSS and image files from the book's folder to the destination folder.
+																  // We don't need other files from there for this export. (audio, video, etc)
 			var sourceFolder = Path.GetDirectoryName(sourcePath);
 			foreach (var sourceFilePath in Directory.EnumerateFiles(sourceFolder, "*.*"))
 			{
@@ -713,7 +714,8 @@ namespace Bloom.CollectionTab
 				NarrationLanguages = null, // all audio
 
 				WantMusic = true,
-				WantVideo = true};
+				WantVideo = true
+			};
 			// these are artifacts of uploading book to BloomLibrary.org and not useful in BloomPubs
 			filter.AlwaysReject(new Regex("^thumbnail-"));
 			return filter;
@@ -721,7 +723,7 @@ namespace Bloom.CollectionTab
 
 		public string GetSuggestedBloomPackPath()
 		{
-			return TheOneEditableCollection.Name+".BloomPack";
+			return TheOneEditableCollection.Name + ".BloomPack";
 		}
 
 		public void DoUpdatesOfAllBooks()
@@ -740,7 +742,7 @@ namespace Bloom.CollectionTab
 				i++;
 				var book = _bookServer.GetBookFromBookInfo(bookInfo);
 				//gets overwritten: progress.WriteStatus(book.NameBestForUserDisplay);
-				progress.WriteMessage("Processing " + book.NameBestForUserDisplay+ " " + i + "/" + TheOneEditableCollection.GetBookInfos().Count());
+				progress.WriteMessage("Processing " + book.NameBestForUserDisplay + " " + i + "/" + TheOneEditableCollection.GetBookInfos().Count());
 				// Since the user told us to do it, we'll do it even to books that we think are already
 				// up to date. (EnsureUpToDate would do so anyway, since these are newly created Book objects, even if they are
 				// for books we already have in memory.)
@@ -752,7 +754,7 @@ namespace Bloom.CollectionTab
 		{
 			using (var dlg = new ProgressDialogBackground())
 			{
-				dlg.ShowAndDoWork((progress, args) => DoChecksOfAllBooksBackgroundWork(dlg,null));
+				dlg.ShowAndDoWork((progress, args) => DoChecksOfAllBooksBackgroundWork(dlg, null));
 				if (dlg.Progress.ErrorEncountered || dlg.Progress.WarningsEncountered)
 				{
 					MessageBox.Show("Bloom will now open a list of problems it found.");
@@ -767,7 +769,7 @@ namespace Bloom.CollectionTab
 			}
 		}
 
-		public void AttemptMissingImageReplacements(string pathToFolderOfReplacementImages=null)
+		public void AttemptMissingImageReplacements(string pathToFolderOfReplacementImages = null)
 		{
 			using (var dlg = new ProgressDialogBackground())
 			{
@@ -807,7 +809,7 @@ namespace Bloom.CollectionTab
 			foreach (var bookInfo in bookInfos)
 			{
 				//not allowed in this thread: dialog.ProgressBar.Value++;
-				dialog.Progress.ProgressIndicator.PercentCompleted += 100/count;
+				dialog.Progress.ProgressIndicator.PercentCompleted += 100 / count;
 
 				var book = _bookServer.GetBookFromBookInfo(bookInfo);
 

--- a/src/BloomExe/Publish/Android/AndroidPublishSettings.cs
+++ b/src/BloomExe/Publish/Android/AndroidPublishSettings.cs
@@ -43,11 +43,18 @@ namespace Bloom.Publish.Android
 		// True to remove activities, quiz pages...stuff that's inappropriate for making videos.
 		public bool RemoveInteractivePages;
 
+		public AndroidPublishSettings()
+		{
+			ImagePublishSettings = new ImagePublishSettings();
+			LanguagesToInclude = new HashSet<string>();
+			AudioLanguagesToExclude = new HashSet<string>();
+		}
+
 		// Should we publish as a motion book?
 		// Note: rather than a default of false, this should normally be set to the PublishSettings.BloomPub.Motion
 		// value stored in the book's BookInfo. This happens automatically if creating one using ForBloomInfo.
 		// If you want a different value, for example, AudioVideo.Settings, be sure to set that up.
-		public bool Motion { get; set; }
+		public bool Motion;
 
 		public ImagePublishSettings ImagePublishSettings { get; set; }
 
@@ -125,9 +132,9 @@ namespace Bloom.Publish.Android
 			var languagesToInclude = GetLanguagesToInclude(bookInfo.PublishSettings);
 
 			HashSet<string> audioLanguagesToExclude;
-			if (bloomPubAudioLangs == null && libraryAudioLangs == null)
+			if (bloomPubAudioLangs.Count == 0 && libraryAudioLangs.Count == 0)
 			{
-				if (bloomPubTextLangs == null && libraryTextLangs == null)
+				if (bloomPubTextLangs.Count == 0 && libraryTextLangs.Count == 0)
 				{
 					// We really want to exclude all of them, but we don't know what all the possibilities are.
 					audioLanguagesToExclude = new HashSet<string>();
@@ -153,15 +160,15 @@ namespace Bloom.Publish.Android
 				AudioLanguagesToExclude = audioLanguagesToExclude,
 				// All the paths that use this are making settings for BloomPub, not Video.
 				Motion = bookInfo.PublishSettings.BloomPub.Motion,
-				ImagePublishSettings = bookInfo.PublishSettings.BloomPub.ImageSettings != null ? new ImagePublishSettings(bookInfo.PublishSettings.BloomPub.ImageSettings) : ImagePublishSettings.Default
+				ImagePublishSettings = bookInfo.PublishSettings.BloomPub.ImageSettings
 			};
 		}
 
 		public static AndroidPublishSettings GetPublishSettingsForBook(BookServer bookServer, BookInfo bookInfo)
 		{
 			// Normally this is setup by the Publish screen, but if you've never visited the Publish screen for this book,
-			// then this will be null. In that case, initialize it here.
-			if (bookInfo.PublishSettings.BloomPub.TextLangs == null)
+			// then this will be empty. In that case, initialize it here.
+			if (bookInfo.PublishSettings.BloomPub.TextLangs.Count == 0) // Review Feb 2022: previously it would be null, now count==0. Not exactly the same, since you could say "no text languages"?
 			{
 				var book = bookServer.GetBookFromBookInfo(bookInfo);
 				var allLanguages = book.AllPublishableLanguages(includeLangsOccurringOnlyInXmatter: true);

--- a/src/BloomExe/Publish/Android/AndroidPublishSettings.cs
+++ b/src/BloomExe/Publish/Android/AndroidPublishSettings.cs
@@ -168,7 +168,7 @@ namespace Bloom.Publish.Android
 		{
 			// Normally this is setup by the Publish screen, but if you've never visited the Publish screen for this book,
 			// then this will be empty. In that case, initialize it here.
-			if (bookInfo.PublishSettings.BloomPub.TextLangs.Count == 0) // Review Feb 2022: previously it would be null, now count==0. Not exactly the same, since you could say "no text languages"?
+			if (bookInfo.PublishSettings.BloomPub.TextLangs.Count == 0)
 			{
 				var book = bookServer.GetBookFromBookInfo(bookInfo);
 				var allLanguages = book.AllPublishableLanguages(includeLangsOccurringOnlyInXmatter: true);

--- a/src/BloomExe/Publish/Android/BloomPubMaker.cs
+++ b/src/BloomExe/Publish/Android/BloomPubMaker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -35,31 +35,32 @@ namespace Bloom.Publish.Android
 		public static string HashOfMostRecentlyCreatedBook { get; private set; }
 		public static Control ControlForInvoke { get; set; }
 
-		public static void CreateBloomPub(BookInfo bookInfo, AndroidPublishSettings settings, string outputFolder, BookServer bookServer, IWebSocketProgress progress )
+		public static void CreateBloomPub(AndroidPublishSettings settings, BookInfo bookInfo, string outputFolder, BookServer bookServer, IWebSocketProgress progress)
 		{
 			var outputPath = Path.Combine(outputFolder, Path.GetFileName(bookInfo.FolderPath) + BloomPubExtensionWithDot);
-			BloomPubMaker.CreateBloomPub(outputPath, bookInfo.FolderPath, bookServer, progress, bookInfo.IsSuitableForMakingShells, settings: settings);
+			BloomPubMaker.CreateBloomPub(settings: settings, outputPath: outputPath, bookFolderPath: bookInfo.FolderPath, bookServer: bookServer, progress: progress, isTemplateBook: bookInfo.IsSuitableForMakingShells);
 		}
-		public static void CreateBloomPub(string outputPath, Book.Book book, BookServer bookServer, IWebSocketProgress progress, AndroidPublishSettings settings = null)
+		public static void CreateBloomPub(AndroidPublishSettings settings, string outputPath, Book.Book book, BookServer bookServer, IWebSocketProgress progress)
 		{
-			CreateBloomPub(outputPath, book.FolderPath, bookServer, progress, book.IsTemplateBook, settings:settings);
+			CreateBloomPub(settings, outputPath, bookFolderPath: book.FolderPath, bookServer, progress: progress, isTemplateBook: book.IsTemplateBook);
 		}
 
 		// Create a BloomReader book while also creating the temporary folder for it (according to the specified parameter) and disposing of it
-		public static void CreateBloomPub(string outputPath, string bookFolderPath, BookServer bookServer,
-	
-			IWebSocketProgress progress, bool isTemplateBook, string tempFolderName = BRExportFolder,
-			string creator = kCreatorBloom, AndroidPublishSettings settings = null)
+		public static void CreateBloomPub(AndroidPublishSettings settings, string outputPath, string bookFolderPath,
+BookServer bookServer,
+			IWebSocketProgress progress, bool isTemplateBook,
+			string tempFolderName = BRExportFolder, string creator = kCreatorBloom)
 		{
 			using (var temp = new TemporaryFolder(tempFolderName))
 			{
-				CreateBloomPub(outputPath, bookFolderPath, bookServer, progress, temp, creator, isTemplateBook, settings);
+				CreateBloomPub(settings, outputPath, bookFolderPath, bookServer, progress, temp, creator, isTemplateBook);
 			}
 		}
 
 		/// <summary>
 		/// Create a Bloom Digital book (the zipped .bloompub file) as used by BloomReader (and Bloom Library etc)
 		/// </summary>
+		/// <param name="settings"></param>
 		/// <param name="outputPath">The path to create the zipped .bloompub output file at</param>
 		/// <param name="bookFolderPath">The path to the input book</param>
 		/// <param name="bookServer"></param>
@@ -67,20 +68,19 @@ namespace Bloom.Publish.Android
 		/// <param name="tempFolder">A temporary folder. This function will not dispose of it when done</param>
 		/// <param name="creator">value for &lt;meta name="creator" content="..."/&gt; (defaults to "bloom")</param>
 		/// <param name="isTemplateBook"></param>
-		/// <param name="settings"></param>
 		/// <returns>Path to the unzipped .bloompub</returns>
-		public static string CreateBloomPub(string outputPath, string bookFolderPath, BookServer bookServer,
-			IWebSocketProgress progress, TemporaryFolder tempFolder, string creator = kCreatorBloom, bool isTemplateBook=false,
-			AndroidPublishSettings settings = null)
+		public static string CreateBloomPub(AndroidPublishSettings settings, string outputPath, string bookFolderPath,
+			BookServer bookServer, IWebSocketProgress progress, TemporaryFolder tempFolder, string creator = kCreatorBloom,
+			bool isTemplateBook = false)
 		{
-			var modifiedBook = PrepareBookForBloomReader(bookFolderPath, bookServer, tempFolder, progress, isTemplateBook, creator, settings);
+			var modifiedBook = PrepareBookForBloomReader(settings, bookFolderPath, bookServer, tempFolder, progress, isTemplateBook, creator);
 			// We want at least 256 for Bloom Reader, because the screens have a high pixel density. And (at the moment) we are asking for
 			// 64dp in Bloom Reader.
 
 			BookCompressor.MakeSizedThumbnail(modifiedBook, modifiedBook.FolderPath, 256);
 
 			MakeSha(BookStorage.FindBookHtmlInFolder(bookFolderPath), modifiedBook.FolderPath);
-			CompressImages(modifiedBook.FolderPath, settings?.ImagePublishSettings ?? ImagePublishSettings.Default, modifiedBook.RawDom);
+			CompressImages(modifiedBook.FolderPath, settings.ImagePublishSettings, modifiedBook.RawDom);
 			SignLanguageApi.ProcessVideos(HtmlDom.SelectChildVideoElements(modifiedBook.RawDom.DocumentElement).Cast<XmlElement>(),
 				modifiedBook.FolderPath);
 			var newContent = XmlHtmlConverter.ConvertDomToHtml5(modifiedBook.RawDom);
@@ -139,7 +139,7 @@ namespace Bloom.Publish.Android
 					var fileName = Path.GetFileName(filePath);
 					if (imagesToPreserveResolution.Contains(fileName))
 						continue; // don't compress these
-					// Cover images should be transparent if possible.  Others don't need to be.
+								  // Cover images should be transparent if possible.  Others don't need to be.
 					var makeBackgroundTransparent = imagesToGiveTransparentBackgrounds.Contains(fileName);
 					var modifiedContent = BookCompressor.GetImageBytesForElectronicPub(filePath,
 						makeBackgroundTransparent,
@@ -214,11 +214,11 @@ namespace Bloom.Publish.Android
 
 		public static Dictionary<string, HashSet<string>> BloomPubFontsAndLangsUsed = null;
 
-		public static Book.Book PrepareBookForBloomReader(string bookFolderPath, BookServer bookServer,
-			TemporaryFolder temp,
-			IWebSocketProgress progress, bool isTemplateBook,
-			string creator = kCreatorBloom,
-			AndroidPublishSettings settings = null)
+		public static Book.Book PrepareBookForBloomReader(AndroidPublishSettings settings, string bookFolderPath,
+			BookServer bookServer,
+			TemporaryFolder temp, IWebSocketProgress progress,
+			bool isTemplateBook,
+			string creator = kCreatorBloom)
 		{
 			// MakeDeviceXmatterTempBook needs to be able to copy customCollectionStyles.css etc into parent of bookFolderPath
 			// And bloom-player expects folder name to match html file name.
@@ -294,7 +294,7 @@ namespace Bloom.Publish.Android
 				helper.ControlForInvoke = ControlForInvoke;
 				ISet<string> warningMessages = new HashSet<string>();
 				helper.RemoveUnwantedContent(modifiedBook.OurHtmlDom, modifiedBook, false,
-					warningMessages, keepPageLabels:settings?.WantPageLabels??false);
+					warningMessages, keepPageLabels: settings?.WantPageLabels ?? false);
 				PublishHelper.SendBatchedWarningMessagesToProgress(warningMessages, progress);
 				fontsUsed = helper.FontsUsed;
 				BloomPubFontsAndLangsUsed = helper.FontsAndLangsUsed;
@@ -324,7 +324,7 @@ namespace Bloom.Publish.Android
 				isSignLanguageEnabled: enableSignLanguage,
 				isTalkingBookEnabled: true, // talkingBook is only ever set automatically as far as I can tell.
 				allowedLanguages: null // allow all because we've already filtered out the unwanted ones from the dom above.
-				);	
+				);
 
 			modifiedBook.SetAnimationDurationsFromAudioDurations();
 
@@ -336,7 +336,7 @@ namespace Bloom.Publish.Android
 			StripImgIfWeCannotFindFile(modifiedBook.RawDom, bookFile);
 			StripContentEditableAndTabIndex(modifiedBook.RawDom);
 			InsertReaderStylesheet(modifiedBook.RawDom);
-			RobustFile.Copy(FileLocationUtilities.GetFileDistributedWithApplication(BloomFileLocator.BrowserRoot,"publish","ReaderPublish","readerStyles.css"),
+			RobustFile.Copy(FileLocationUtilities.GetFileDistributedWithApplication(BloomFileLocator.BrowserRoot, "publish", "ReaderPublish", "readerStyles.css"),
 				Path.Combine(modifiedBookFolderPath, "readerStyles.css"));
 			ConvertImagesToBackground(modifiedBook.RawDom);
 
@@ -351,7 +351,7 @@ namespace Bloom.Publish.Android
 		/// Add a `.distribution` file to the zip which will be reported on for analytics from Bloom Reader.
 		/// See https://issues.bloomlibrary.org/youtrack/issue/BL-8875.
 		/// </summary>
-		private static void AddDistributionFile(string bookFolder, string creator, AndroidPublishSettings settings=null)
+		private static void AddDistributionFile(string bookFolder, string creator, AndroidPublishSettings settings)
 		{
 			string distributionValue;
 			switch (creator)
@@ -361,7 +361,7 @@ namespace Bloom.Publish.Android
 					break;
 				case kCreatorBloom:
 					distributionValue = kDistributionBloomDirect;
-					if(settings!=null && !string.IsNullOrEmpty(settings.DistributionTag))
+					if (settings != null && !string.IsNullOrEmpty(settings.DistributionTag))
 						distributionValue = settings.DistributionTag;
 					break;
 				default: throw new ArgumentException("Unknown creator", creator);
@@ -422,17 +422,17 @@ namespace Bloom.Publish.Android
 			if (string.IsNullOrEmpty(lang))
 				return; // paranoia, bloom-editable without lang should not be content1
 
-			var group = new QuestionGroup() { lang = lang, onlyForBloomReader1 = true};
+			var group = new QuestionGroup() { lang = lang, onlyForBloomReader1 = true };
 			var question = new Question()
 			{
 				question = questionElt.InnerText.Trim(),
 				answers = answerElts.Select(a => new Answer()
 				{
-					text= a.InnerText.Trim(),
-					correct = ((a.ParentNode?.ParentNode as XmlElement)?.Attributes["class"]?.Value ??"").Contains("correct-answer")
+					text = a.InnerText.Trim(),
+					correct = ((a.ParentNode?.ParentNode as XmlElement)?.Attributes["class"]?.Value ?? "").Contains("correct-answer")
 				}).ToArray()
 			};
-			group.questions = new [] { question };
+			group.questions = new[] { question };
 
 			questions.Add(group);
 		}
@@ -616,10 +616,10 @@ namespace Bloom.Publish.Android
 		{
 			foreach (XmlElement source in page.SafeSelectNodes(".//div[contains(@class, 'bloom-editable')]"))
 			{
-				var lang = source.Attributes["lang"]?.Value??"";
+				var lang = source.Attributes["lang"]?.Value ?? "";
 				if (String.IsNullOrEmpty(lang) || lang == "z")
 					continue;
-				var group = new QuestionGroup() {lang = lang};
+				var group = new QuestionGroup() { lang = lang };
 				// this looks weird, but it's just driven by the test cases which are in turn collected
 				// from various ways of getting the questions on the page (typing, pasting).
 				// See BookReaderFileMakerTests.ExtractQuestionGroups_ParsesCorrectly()
@@ -637,8 +637,8 @@ namespace Bloom.Publish.Android
 				foreach (var line in lines)
 				{
 					var cleanLine = line.Replace("<p>", ""); // our split above just looks at the ends of paragraphs, ignores the starts.
-					// Similarly, our split above just looks at the ends of brs, ignores the starts
-					//(separate start vs. end br elements might not occur in real FF tests, see note above).
+															 // Similarly, our split above just looks at the ends of brs, ignores the starts
+															 //(separate start vs. end br elements might not occur in real FF tests, see note above).
 					cleanLine = cleanLine.Replace("<br>", "");
 					cleanLine = cleanLine.Replace("\u200c", "");
 					if (String.IsNullOrWhiteSpace(cleanLine))
@@ -652,13 +652,14 @@ namespace Bloom.Publish.Android
 							questions.Add(question);
 							question = null;
 						}
-					} else
+					}
+					else
 					{
 						var trimLine = cleanLine.Trim();
 						if (question == null)
 						{
 							// If we don't already have a question being built, this first line is the question.
-							question = new Question() { question=trimLine};
+							question = new Question() { question = trimLine };
 						}
 						else
 						{
@@ -669,7 +670,7 @@ namespace Bloom.Publish.Android
 							{
 								trimLine = trimLine.Substring(1).Trim();
 							}
-							answers.Add(new Answer() {text=trimLine, correct = correct});
+							answers.Add(new Answer() { text = trimLine, correct = correct });
 						}
 					}
 				}

--- a/src/BloomExe/Publish/Android/BulkBloomPubCreator.cs
+++ b/src/BloomExe/Publish/Android/BulkBloomPubCreator.cs
@@ -81,7 +81,7 @@ namespace Bloom.Publish.Android
 						{
 							settings.BookshelfTag = _collectionModel.CollectionSettings.DefaultBookshelf;
 						}
-						BloomPubMaker.CreateBloomPub(bookInfo, settings, dest.FolderPath, _bookServer, progress);
+						BloomPubMaker.CreateBloomPub(settings, bookInfo, dest.FolderPath, _bookServer, progress);
 					}
 
 					if (bulkSaveSettings.makeBloomBundle)

--- a/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
+++ b/src/BloomExe/Publish/Android/PublishToAndroidApi.cs
@@ -421,12 +421,6 @@ namespace Bloom.Publish.Android
 		{
 			Debug.Assert(bookInfo?.MetaData != null, "Precondition: MetaData must not be null");
 
-
-			if (bookInfo.PublishSettings.BloomPub.TextLangs == null)
-			{
-				bookInfo.PublishSettings.BloomPub.TextLangs = new Dictionary<string, InclusionSetting>();
-			}
-
 			// reinitialize our list of which languages to publish, defaulting to the ones
 			// that are complete.
 			foreach (var kvp in allLanguages)
@@ -456,9 +450,8 @@ namespace Bloom.Publish.Android
 			}
 
 			// Initialize the Talking Book Languages settings
-			if (bookInfo.PublishSettings.BloomPub.AudioLangs == null)
+			if (bookInfo.PublishSettings.BloomPub.AudioLangs.Count == 0)
 			{
-				bookInfo.PublishSettings.BloomPub.AudioLangs = new Dictionary<string, InclusionSetting>();
 				var allLangCodes = allLanguages.Select(x => x.Key);
 				foreach (var langCode in allLangCodes)
 				{
@@ -583,7 +576,7 @@ namespace Bloom.Publish.Android
 				// wifi or usb...make the .bloompub in a temp folder.
 				using (var bloomdTempFile = TempFile.WithFilenameInTempFolder(publishedFileName))
 				{
-					BloomPubMaker.CreateBloomPub(bloomdTempFile.Path, book, bookServer,  progress, settings);
+					BloomPubMaker.CreateBloomPub(settings, bloomdTempFile.Path, book, bookServer, progress);
 					sendAction(publishedFileName, bloomdTempFile.Path);
 					if (confirmFunction != null && !confirmFunction(publishedFileName))
 						throw new ApplicationException("Book does not exist after write operation.");
@@ -594,7 +587,7 @@ namespace Bloom.Publish.Android
 			{
 				// save file...user has supplied name, there is no further action.
 				Debug.Assert(sendAction == null, "further actions are not supported when passing a path name");
-				BloomPubMaker.CreateBloomPub(destFileName, book, bookServer,  progress, settings);
+				BloomPubMaker.CreateBloomPub(settings, destFileName, book, bookServer, progress);
 				progress.Message("PublishTab.Epub.Done", "Done", useL10nIdPrefix: false);	// share message string with epub publishing
 			}
 
@@ -639,7 +632,7 @@ namespace Bloom.Publish.Android
 			// I'd prefer this to include the book folder, but we need it before PrepareBookForBloomReader returns.
 			// I believe we only ever have one book being made there, so it works.
 			CurrentPublicationFolder = _stagingFolder.FolderPath;
-			var modifiedBook = BloomPubMaker.PrepareBookForBloomReader(book.FolderPath, bookServer, _stagingFolder, progress,book.IsTemplateBook, settings: settings);
+			var modifiedBook = BloomPubMaker.PrepareBookForBloomReader(settings, bookFolderPath: book.FolderPath, bookServer: bookServer, temp: _stagingFolder, progress,   isTemplateBook: book.IsTemplateBook);
 			progress.Message("Common.Done", "Shown in a list of messages when Bloom has completed a task.", "Done");
 			if (settings?.WantPageLabels ?? false)
 			{

--- a/src/BloomExe/Publish/BloomLibrary/BloomLibraryPublishModel.cs
+++ b/src/BloomExe/Publish/BloomLibrary/BloomLibraryPublishModel.cs
@@ -265,11 +265,6 @@ namespace Bloom.Publish.BloomLibrary
 			var bookInfo = book.BookInfo;
 			Debug.Assert(bookInfo?.MetaData != null, "Precondition: MetaData must not be null");
 
-			if (bookInfo.PublishSettings.BloomLibrary.TextLangs == null)
-			{
-				bookInfo.PublishSettings.BloomLibrary.TextLangs = new Dictionary<string, InclusionSetting>();
-			}
-
 			// reinitialize our list of which languages to publish, defaulting to the ones that are complete.
 			foreach (var kvp in allLanguages)
 			{
@@ -298,10 +293,6 @@ namespace Bloom.Publish.BloomLibrary
 			}
 
 			// Initialize the Talking Book Languages settings
-			if (bookInfo.PublishSettings.BloomLibrary.AudioLangs == null)
-			{
-				bookInfo.PublishSettings.BloomLibrary.AudioLangs = new Dictionary<string, InclusionSetting>();
-			}
 
 			var allLangCodes = allLanguages.Select(x => x.Key);
 
@@ -332,8 +323,6 @@ namespace Bloom.Publish.BloomLibrary
 					bookInfo.PublishSettings.BloomLibrary.AudioLangs[langCode] = settingForNewLang;
 			}
 
-			if (bookInfo.PublishSettings.BloomLibrary.SignLangs == null)
-			bookInfo.PublishSettings.BloomLibrary.SignLangs = new Dictionary<string, InclusionSetting>();
 			var collectionSignLangCode = book.CollectionSettings.SignLanguageTag;
 			// User may have unset or modified the sign language for the collection in which case we need to exclude the old one it if it was previously included.
 			foreach (var includedSignLangCode in bookInfo.PublishSettings.BloomLibrary.SignLangs.IncludedLanguages().ToList())

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -2441,7 +2441,8 @@ namespace Bloom.Publish.Epub
 				dstPath = SubfolderAdjustedContentPath(subfolder, fileName);
 			}
 			Directory.CreateDirectory (Path.GetDirectoryName (dstPath));
-			CopyFile (srcPath, dstPath, limitImageDimensions, needTransparentBackground);
+			// enhance: I'm preserving the old behavior here by making an new one with defaults, but why doesn't epubmaker have access to our settings?
+			CopyFile(srcPath, dstPath, new ImagePublishSettings(), limitImageDimensions, needTransparentBackground );
 			_manifestItems.Add(SubfolderAdjustedName(subfolder, fileName));
 			_mapSrcPathToDestFileName [srcPath] = dstPath;
 			return dstPath;
@@ -2512,11 +2513,11 @@ namespace Bloom.Publish.Epub
 		/// <summary>
 		/// This supports testing without actually copying files.
 		/// </summary>
-		internal virtual void CopyFile(string srcPath, string dstPath, bool limitImageDimensions=false, bool needTransparentBackground=false)
+		internal virtual void CopyFile(string srcPath, string dstPath, ImagePublishSettings imagePublishSettings, bool limitImageDimensions=false, bool needTransparentBackground=false)
 		{
 			if (limitImageDimensions && BookCompressor.CompressableImageFileExtensions.Contains(Path.GetExtension(srcPath).ToLowerInvariant()))
 			{
-				var imageBytes = BookCompressor.GetImageBytesForElectronicPub(srcPath, needTransparentBackground);
+				var imageBytes = BookCompressor.GetImageBytesForElectronicPub(srcPath, needTransparentBackground, imagePublishSettings);
 				RobustFile.WriteAllBytes(dstPath, imageBytes);
 				return;
 			}

--- a/src/BloomExe/Publish/Epub/PublishEpubApi.cs
+++ b/src/BloomExe/Publish/Epub/PublishEpubApi.cs
@@ -338,14 +338,6 @@ namespace Bloom.Publish.Epub
 			return iframeSource;
 		}
 
-		public void GetEpubSettingsForCurrentBook(EpubSettings epubPublishUiSettings)
-		{
-			var info = _bookSelection.CurrentSelection.BookInfo;
-			epubPublishUiSettings.HowToPublishImageDescriptions = info.PublishSettings.Epub.HowToPublishImageDescriptions;
-			epubPublishUiSettings.RemoveFontSizes = info.PublishSettings.Epub.RemoveFontSizes;
-			epubPublishUiSettings.Mode = info.PublishSettings.Epub.Mode;
-		}
-
 		public void UpdateAndSave(EpubSettings newSettings, string path, bool force, WebSocketProgress progress = null)
 		{
 			bool succeeded;

--- a/src/BloomExe/WebLibraryIntegration/BulkUploader.cs
+++ b/src/BloomExe/WebLibraryIntegration/BulkUploader.cs
@@ -343,7 +343,7 @@ namespace Bloom.WebLibraryIntegration
 			var view = new PublishView(publishModel, new SelectedTabChangedEvent(), new LocalizationChangedEvent(), _singleBookUploader, null, null, null, null, null);
 			var blPublishModel = new BloomLibraryPublishModel(_singleBookUploader, book, publishModel);
 
-			if (book.BookInfo.PublishSettings.BloomLibrary.TextLangs == null)
+			if (book.BookInfo.PublishSettings.BloomLibrary.TextLangs.Count == 0)
 			{
 				BloomLibraryPublishModel.InitializeLanguages(book);
 			}

--- a/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
+++ b/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
@@ -47,6 +47,7 @@ namespace Bloom.web.controllers
 
 		private bool _simulateCataracts;
 		private bool _simulateColorBlindness;
+		private BookSelection _bookSelection;
 
 		// These options must match the ones used in accessibileImage.tsx
 		public enum KindOfColorBlindness
@@ -60,6 +61,7 @@ namespace Bloom.web.controllers
 			BookRenamedEvent bookRenamedEvent, BookSavedEvent bookSavedEvent, EpubMaker.Factory epubMakerFactory,
 			PublishEpubApi epubApi)
 		{
+			_bookSelection = bookSelection;
 			_webSocketServer = webSocketServer;
 			var progress = new WebSocketProgress(_webSocketServer, kWebSocketContext);
 			_webSocketProgress = progress.WithL10NPrefix("AccessibilityCheck.");
@@ -304,8 +306,7 @@ namespace Bloom.web.controllers
 
 		private string MakeEpub(string parentDirectory, WebSocketProgress progress)
 		{
-			var settings = new EpubSettings();
-			_epubApi.GetEpubSettingsForCurrentBook(settings);
+			var settings = _bookSelection.CurrentSelection.BookInfo.PublishSettings.Epub;
 			var path = Path.Combine(parentDirectory, Guid.NewGuid().ToString() + ".epub");
 			_epubApi.UpdateAndSave(settings, path, true, _webSocketProgress.WithL10NPrefix("PublishTab.Epub."));
 			return path;

--- a/src/BloomExe/web/controllers/BookSettingsApi.cs
+++ b/src/BloomExe/web/controllers/BookSettingsApi.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Dynamic;
 using Bloom.Book;
+using Newtonsoft.Json;
 
 namespace Bloom.Api
 {
@@ -34,8 +35,15 @@ namespace Bloom.Api
 			switch (request.HttpMethod)
 			{
 				case HttpMethods.Get:
-					dynamic settings = new ExpandoObject();
-					settings.currentToolBoxTool = _bookSelection.CurrentSelection.BookInfo.CurrentTool;
+					var settings = new
+					{
+						currentToolBoxTool = _bookSelection.CurrentSelection.BookInfo.CurrentTool,
+						appearance = new { cover = new { coverColor = _bookSelection.CurrentSelection.GetCoverColor(), something = true } },
+						//bloomPUB = new { imageSettings = new { maxWidth= _bookSelection.CurrentSelection.BookInfo.PublishSettings.BloomPub.ImageSettings.MaxWidth, maxHeight= _bookSelection.CurrentSelection.BookInfo.PublishSettings.BloomPub.ImageSettings.MaxHeight} }
+						publish = _bookSelection.CurrentSelection.BookInfo.PublishSettings.Json
+					};
+					var jsonData = JsonConvert.SerializeObject(settings);
+
 #if UserControlledTemplate
 					settings.isTemplateBook = GetIsBookATemplate();
 #endif
@@ -44,9 +52,19 @@ namespace Bloom.Api
 				case HttpMethods.Post:
 					//note: since we only have this one value, it's not clear yet whether the panel involved here will be more of a
 					//an "edit settings", or a "book settings", or a combination of them.
-					//settings = DynamicJson.Parse(request.RequiredPostJson());
-					// This first refresh saves any changes.
-					//_pageRefreshEvent.Raise(PageRefreshEvent.SaveBehavior.SaveBeforeRefresh);
+					var json = request.RequiredPostJson();
+					dynamic newSettings = Newtonsoft.Json.Linq.JObject.Parse(json);
+					var c = newSettings.appearance.cover.coverColor;
+					_bookSelection.CurrentSelection.SetCoverColor(c.ToString());
+					// review: crazy bit here, that above I'm taking json, parsing it into and object, and grabbing part of it. But then
+					// here we take it back to json and pass it to this thing that is going to parse it agian. In this case, speed
+					// is irrelevant. The nice thing is, it retains the identity of PublishSettings in case someone is holing on it.
+					_bookSelection.CurrentSelection.BookInfo.PublishSettings.LoadNewJson(JsonConvert.DeserializeObject(newSettings.publish));
+					//_bookSelection.CurrentSelection.BookInfo.PublishSettings.BloomPub.ImageSettings.MaxWidth = newSettings.bloomPUB.imageSettings.maxWidth;
+					//_bookSelection.CurrentSelection.BookInfo.PublishSettings.BloomPub.ImageSettings.MaxHeight = newSettings.bloomPUB.imageSettings.maxHeight;
+
+					_pageRefreshEvent.Raise(PageRefreshEvent.SaveBehavior.JustRedisplay);
+
 #if UserControlledTemplate
 					UpdateBookTemplateMode(settings.isTemplateBook);
 					// Now we need to update the active version of the page with possible new template settings

--- a/src/BloomExe/web/controllers/BookSettingsApi.cs
+++ b/src/BloomExe/web/controllers/BookSettingsApi.cs
@@ -56,12 +56,10 @@ namespace Bloom.Api
 					dynamic newSettings = Newtonsoft.Json.Linq.JObject.Parse(json);
 					var c = newSettings.appearance.cover.coverColor;
 					_bookSelection.CurrentSelection.SetCoverColor(c.ToString());
-					// review: crazy bit here, that above I'm taking json, parsing it into and object, and grabbing part of it. But then
+					// review: crazy bit here, that above I'm taking json, parsing it into object, and grabbing part of it. But then
 					// here we take it back to json and pass it to this thing that is going to parse it agian. In this case, speed
-					// is irrelevant. The nice thing is, it retains the identity of PublishSettings in case someone is holing on it.
+					// is irrelevant. The nice thing is, it retains the identity of PublishSettings in case someone is holding on it.
 					_bookSelection.CurrentSelection.BookInfo.PublishSettings.LoadNewJson(JsonConvert.DeserializeObject(newSettings.publish));
-					//_bookSelection.CurrentSelection.BookInfo.PublishSettings.BloomPub.ImageSettings.MaxWidth = newSettings.bloomPUB.imageSettings.maxWidth;
-					//_bookSelection.CurrentSelection.BookInfo.PublishSettings.BloomPub.ImageSettings.MaxHeight = newSettings.bloomPUB.imageSettings.maxHeight;
 
 					_pageRefreshEvent.Raise(PageRefreshEvent.SaveBehavior.JustRedisplay);
 

--- a/src/BloomTests/Book/BookCompressorTests.cs
+++ b/src/BloomTests/Book/BookCompressorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Bloom.Book;
 using Bloom.Publish.Android;
@@ -24,7 +24,7 @@ namespace BloomTests.Book
 		[SetUp]
 		public void Setup()
 		{
-			_testFolder = new TemporaryFolder(GetTestFolderName());			
+			_testFolder = new TemporaryFolder(GetTestFolderName());
 		}
 
 		[TearDown]
@@ -105,9 +105,9 @@ namespace BloomTests.Book
 					File.WriteAllText(Path.Combine(audioDir, "musicfile1.mp3"), "dummy mp3 content");
 					File.WriteAllText(Path.Combine(audioDir, "musicfile2.ogg"), "dummy ogg content");
 					File.WriteAllText(Path.Combine(audioDir, "musicfile3.wav"), "dummy wav content");
-					File.WriteAllText(Path.Combine(audioDir, "narration.mp3"), "more dummy mp3 content");	// file should be included (since it is referenced)
-					File.WriteAllText(Path.Combine(audioDir, "narration.wav"), "more dummy wav content");	// file should not be included (only mp3 narration)
-					File.WriteAllText(Path.Combine(folderPath, "temp.tmp"), "dummy temporary file data");	// file should not be included
+					File.WriteAllText(Path.Combine(audioDir, "narration.mp3"), "more dummy mp3 content");   // file should be included (since it is referenced)
+					File.WriteAllText(Path.Combine(audioDir, "narration.wav"), "more dummy wav content");   // file should not be included (only mp3 narration)
+					File.WriteAllText(Path.Combine(folderPath, "temp.tmp"), "dummy temporary file data");   // file should not be included
 				});
 
 			// System Under Test //

--- a/src/BloomTests/Book/BookInfoTests.cs
+++ b/src/BloomTests/Book/BookInfoTests.cs
@@ -89,8 +89,23 @@ namespace BloomTests.Book
 			// Verification
 			CollectionAssert.AreEquivalent(new string[] {"bookshelf:value1" }, bi.MetaData.Tags);
 		}
-
 		[Test]
+		public void LoadPublishSettings_NullsInBloomPubReplaceWithDefault()
+		{
+			var input =
+				@"{'bloomPUB': {'motion': true, 'textLangs': null,
+						'audioLangs':null,
+						'signLangs': null,
+						'imageSettings':null},
+			}";
+			var ps = PublishSettings.FromString(input);
+			Assert.That(ps.BloomPub.TextLangs.Count, Is.EqualTo(0));
+			Assert.That(ps.BloomPub.AudioLangs.Count, Is.EqualTo(0));
+			Assert.That(ps.BloomPub.SignLangs.Count, Is.EqualTo(0));
+			Assert.That(ps.BloomPub.ImageSettings, Is.Not.Null);
+		}
+
+			[Test]
 		public void LoadPublishSettings_AllSettings_Works()
 		{
 			var input =

--- a/src/BloomTests/Book/BookInfoTests.cs
+++ b/src/BloomTests/Book/BookInfoTests.cs
@@ -70,12 +70,12 @@ namespace BloomTests.Book
 			Assert.That(bi.PublishSettings.AudioVideo.PageTurnDelay, Is.EqualTo(3000));
 			Assert.That(bi.PublishSettings.AudioVideo.PlayerSettings, Is.EqualTo(""));
 			Assert.That(bi.PublishSettings.BloomPub.Motion, Is.False);
-			Assert.That(bi.PublishSettings.BloomLibrary.TextLangs, Is.Null);
-			Assert.That(bi.PublishSettings.BloomPub.TextLangs, Is.Null);
-			Assert.That(bi.PublishSettings.BloomLibrary.AudioLangs, Is.Null);
-			Assert.That(bi.PublishSettings.BloomPub.AudioLangs, Is.Null);
-			Assert.That(bi.PublishSettings.BloomLibrary.SignLangs, Is.Null);
-			Assert.That(bi.PublishSettings.BloomPub.SignLangs, Is.Null);
+			Assert.That(bi.PublishSettings.BloomLibrary.TextLangs, Is.Not.Null);
+			Assert.That(bi.PublishSettings.BloomPub.TextLangs, Is.Not.Null);
+			Assert.That(bi.PublishSettings.BloomLibrary.AudioLangs, Is.Not.Null);
+			Assert.That(bi.PublishSettings.BloomPub.AudioLangs, Is.Not.Null);
+			Assert.That(bi.PublishSettings.BloomLibrary.SignLangs, Is.Not.Null);
+			Assert.That(bi.PublishSettings.BloomPub.SignLangs, Is.Not.Null);
 		}
 
 		[Test]
@@ -154,12 +154,12 @@ namespace BloomTests.Book
 			Assert.That(original.PublishSettings.AudioVideo.Motion, Is.False);
 			Assert.That(original.PublishSettings.Epub.HowToPublishImageDescriptions, Is.EqualTo(BookInfo.HowToPublishImageDescriptions.None));
 			Assert.That(original.PublishSettings.Epub.RemoveFontSizes, Is.False);
-			Assert.That(original.PublishSettings.BloomPub.TextLangs, Is.Null);
-			Assert.That(original.PublishSettings.BloomLibrary.TextLangs, Is.Null);
-			Assert.That(original.PublishSettings.BloomPub.AudioLangs, Is.Null);
-			Assert.That(original.PublishSettings.BloomLibrary.AudioLangs, Is.Null);
-			Assert.That(original.PublishSettings.BloomPub.SignLangs, Is.Null);
-			Assert.That(original.PublishSettings.BloomLibrary.SignLangs, Is.Null);
+			Assert.That(original.PublishSettings.BloomPub.TextLangs, Is.Not.Null);
+			Assert.That(original.PublishSettings.BloomLibrary.TextLangs, Is.Not.Null);
+			Assert.That(original.PublishSettings.BloomPub.AudioLangs, Is.Not.Null);
+			Assert.That(original.PublishSettings.BloomLibrary.AudioLangs, Is.Not.Null);
+			Assert.That(original.PublishSettings.BloomPub.SignLangs, Is.Not.Null);
+			Assert.That(original.PublishSettings.BloomLibrary.SignLangs, Is.Not.Null);
 
 			// oldMetaJson was produced by the following code, which depends on the obsolete properties:
 			//original.MetaData.Feature_Motion = true;

--- a/src/BloomTests/Publish/BloomReaderPublishTests.cs
+++ b/src/BloomTests/Publish/BloomReaderPublishTests.cs
@@ -66,7 +66,7 @@ namespace BloomTests.Publish
 
 			using (var bloomdTempFile = TempFile.WithFilenameInTempFolder(testBook.Title + BloomPubMaker.BloomPubExtensionWithDot))
 			{
-				BloomPubMaker.CreateBloomPub(bloomdTempFile.Path, testBook, _bookServer,  new NullWebSocketProgress());
+				BloomPubMaker.CreateBloomPub(new AndroidPublishSettings(), bloomdTempFile.Path, testBook, _bookServer, new NullWebSocketProgress());
 				Assert.AreEqual(testBook.Title + BloomPubMaker.BloomPubExtensionWithDot,
 					Path.GetFileName(bloomdTempFile.Path));
 			}
@@ -1017,7 +1017,7 @@ namespace BloomTests.Publish
 
 			var path = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "bird.png");
 			byte[] originalBytes = File.ReadAllBytes(path);
-			byte[] reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path,true);
+			byte[] reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path,true, new ImagePublishSettings());
 			Assert.That(reducedBytes, Is.Not.EqualTo(originalBytes)); // no easy way to check it was made transparent, but should be changed.
 			// Size should not change much.
 			if (Platform.IsLinux)
@@ -1057,7 +1057,7 @@ namespace BloomTests.Publish
 
 			var path = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "man.jpg");
 			var originalBytes = File.ReadAllBytes(path);
-			var reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path, true);
+			var reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path, true, new ImagePublishSettings());
 			Assert.AreEqual(originalBytes, reducedBytes, "man.jpg is already small enough (118x154)");
 			using (var tempFile = TempFile.WithExtension(Path.GetExtension(path)))
 			{
@@ -1085,7 +1085,7 @@ namespace BloomTests.Publish
 
 			var path = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "shirt.png");
 			var originalBytes = File.ReadAllBytes(path);
-			var reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path, true);
+			var reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path, true, new ImagePublishSettings());
 			Assert.Greater(originalBytes.Length, reducedBytes.Length, "shirt.png is reduced from 2208x2400");
 			using (var tempFile = TempFile.WithExtension(Path.GetExtension(path)))
 			{
@@ -1113,7 +1113,7 @@ namespace BloomTests.Publish
 			// non-transparent pixels are white (and need to stay that way!)
 			var path = FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "levels.png");
 			var originalBytes = File.ReadAllBytes(path);
-			var reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path, true);
+			var reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path, true, new ImagePublishSettings());
 			Assert.AreEqual(originalBytes.Length, reducedBytes.Length, "levels.png is not reduced");
 		}
 
@@ -1124,7 +1124,7 @@ namespace BloomTests.Publish
 
 			var path = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "LakePendOreille.jpg");
 			var originalBytes = File.ReadAllBytes(path);
-			var reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path, true);
+			var reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path, true, new ImagePublishSettings());
 			Assert.Greater(originalBytes.Length, reducedBytes.Length, "LakePendOreille.jpg is reduced from 3264x2448");
 			using (var tempFile = TempFile.WithExtension(Path.GetExtension(path)))
 			{
@@ -1152,7 +1152,7 @@ namespace BloomTests.Publish
 
 			var path = FileLocationUtilities.GetFileDistributedWithApplication(_pathToTestImages, "lady24b.png");
 			var originalBytes = File.ReadAllBytes(path);
-			var reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path, true);
+			var reducedBytes = BookCompressor.GetImageBytesForElectronicPub(path, true, new ImagePublishSettings());
 			// Is it reduced, even tho' we switched from 24bit depth to 32bit depth?
 			Assert.Greater(originalBytes.Length, reducedBytes.Length, "lady24b.png is reduced from 3632x3872");
 			using (var tempFile = TempFile.WithExtension(Path.GetExtension(path)))
@@ -1381,9 +1381,12 @@ namespace BloomTests.Publish
 
 			using (var bloomdTempFile = TempFile.WithFilenameInTempFolder(testBook.Title + BloomPubMaker.BloomPubExtensionWithDot))
 			{
-				BloomPubMaker.CreateBloomPub(bloomdTempFile.Path, testBook.FolderPath, _bookServer,  new NullWebSocketProgress(),
-					isTemplateBook: false, creator: creator, 
-					settings: new AndroidPublishSettings() {LanguagesToInclude = languagesToInclude, Motion = testBook.BookInfo.PublishSettings.BloomPub.Motion});
+				var androidPublishSettings = new AndroidPublishSettings() { Motion = testBook.BookInfo.PublishSettings.BloomPub.Motion};
+				if (languagesToInclude != null)
+					androidPublishSettings.LanguagesToInclude = languagesToInclude;
+				BloomPubMaker.CreateBloomPub(settings: androidPublishSettings, outputPath: bloomdTempFile.Path, bookFolderPath: testBook.FolderPath, bookServer: _bookServer,
+					progress: new NullWebSocketProgress(), isTemplateBook: false,
+					creator: creator);
 				var zip = new ZipFile(bloomdTempFile.Path);
 				var newHtml = GetEntryContents(zip, bookFileName);
 				var paramObj = new ZipHtmlObj(zip, newHtml);
@@ -1395,7 +1398,7 @@ namespace BloomTests.Publish
 					using (var extraTempFile =
 						TempFile.WithFilenameInTempFolder(testBook.Title + "2" + BloomPubMaker.BloomPubExtensionWithDot))
 					{
-						BloomPubMaker.CreateBloomPub(extraTempFile.Path, testBook, _bookServer,  new NullWebSocketProgress());
+						BloomPubMaker.CreateBloomPub(androidPublishSettings, extraTempFile.Path, testBook, _bookServer, new NullWebSocketProgress());
 						zip = new ZipFile(extraTempFile.Path);
 						assertionsOnRepeat(zip);
 					}

--- a/src/BloomTests/Publish/ExportEpubTests.cs
+++ b/src/BloomTests/Publish/ExportEpubTests.cs
@@ -1955,14 +1955,14 @@ $@"<div class='bloom-translationGroup'>
 			Book = book;
 		}
 
-		internal override void CopyFile(string srcPath, string dstPath, bool reduceImageIfPossible=false, bool needsTransparentBackground=false)
+		internal override void CopyFile(string srcPath, string dstPath, ImagePublishSettings imagePublishSettings, bool reduceImageIfPossible=false, bool needsTransparentBackground=false)
 		{
 			if (srcPath.Contains("notareallocation"))
 			{
 				File.WriteAllText(dstPath, "This is a test fake");
 				return;
 			}
-			base.CopyFile(srcPath, dstPath, reduceImageIfPossible, needsTransparentBackground);
+			base.CopyFile(srcPath, dstPath, imagePublishSettings, reduceImageIfPossible, needsTransparentBackground);
 		}
 	}
 }


### PR DESCRIPTION
* Make constructors for all classes which create all children
* For various language arrays, instead of checking for null, check for empty array
* In method arguments, stop making provision of settings optional
* When deserializing from json, do that on top of a fully constructed object

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5677)
<!-- Reviewable:end -->
