### PR TITLE
[5.4] BL-11992 Fix L1 name wrapping on MXB Cover

### DIFF
--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.less
@@ -221,6 +221,14 @@ body[bookcreationtype="translation"] {
     }
 }
 
+// If the L1 name is too long to fit on one line, and there is not Topic, we want the wrapped text centered.
+.frontCover
+    .bottomBlock
+    .bottomRow[data-have-topic="false"]
+    .coverBottomLangName {
+    text-align: center;
+}
+
 .L1-Name-Cover-style {
     font-size: 14pt;
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5684)
<!-- Reviewable:end -->
