### PR TITLE
BL-11993 Make MXB Printing History a non-derived field

### DIFF
--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -6,7 +6,6 @@ using Bloom;
 using Bloom.Book;
 using Bloom.Collection;
 using Bloom.Edit;
-using Moq;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using SIL.Extensions;

--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBCommon-XMatter.pug
@@ -60,7 +60,7 @@ mixin mxb-nationalSummaryCreditsPage-back-title-page-contents
 		+editable(kLanguageForPrototypeOnly).OriginalAcknowledgments-style.bloom-copyFromOtherLanguageIfNecessary(data-book='originalAcknowledgments')
 			| {Original Acknowledgments}
 	+field-ISBN
-	+field-prototypeDeclaredExplicity("N1")#printingHistory
+	+field-prototypeDeclaredExplicity("N1")#printingHistory.bloom-clearWhenMakingDerivative
 		label.bubble Use this for Printing History (1st Edition, etc.)
 		+editable(kLanguageForPrototypeOnly).PrintingHistory-style.bloom-copyFromOtherLanguageIfNecessary(data-book='printingInfo')
 

--- a/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.pug
@@ -80,7 +80,7 @@ mixin mxb-creditsPage-scripture-contents
 		+editable(kLanguageForPrototypeOnly).OriginalAcknowledgments-style.bloom-copyFromOtherLanguageIfNecessary(data-book='originalAcknowledgments')
 			| {Original Acknowledgments}
 	+field-ISBN
-	+field-prototypeDeclaredExplicity("N1")#printingHistory
+	+field-prototypeDeclaredExplicity("N1")#printingHistory.bloom-clearWhenMakingDerivative
 		label.bubble Use this for Printing History (1st Edition, etc.)
 		+editable(kLanguageForPrototypeOnly).PrintingHistory-style.bloom-copyFromOtherLanguageIfNecessary(data-book='printingInfo')
 


### PR DESCRIPTION
* added .bloom-removeWhenMakingDerivative class to the
   translation group
* added code in BookStarter that looks for this class and an
   associated 'data-book' key and removes the bloom-editable
   contents from the book and the datadiv.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5697)
<!-- Reviewable:end -->
