### PR TITLE
Fix missing template crash

### DIFF
--- a/src/BloomExe/SourceCollectionsList.cs
+++ b/src/BloomExe/SourceCollectionsList.cs
@@ -65,7 +65,12 @@ namespace Bloom
 			// source collections we search. So just create it directly.
 			// This makes the method name somewhat deceptive. But I was trying not to
 			// disrupt things too badly. And there's still a consistency with the fileName version.
-			return CreateTemplateBookByFolderPath(Path.GetDirectoryName(path));
+			var folderPath = Path.GetDirectoryName(path);
+			if (!Directory.Exists(folderPath))
+				// This can happen if we're opening the AddPage dialog and the template that this book is
+				// derived from doesn't exist on this machine.
+				return null;
+			return CreateTemplateBookByFolderPath(folderPath);
 		}
 
 		private Book.Book CreateTemplateBookByFolderPath(string folderPath)


### PR DESCRIPTION
* If the template that a book is based on doesn't exist on this machine,
   this keeps the add page dialog from crashing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5698)
<!-- Reviewable:end -->
