### PR TITLE
Use common code for creating/remembering output filenames (BL-11996)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -416,6 +416,7 @@
     <Compile Include="History\HistoryEvent.cs" />
     <Compile Include="Utils\AsyncUtil.cs" />
     <Compile Include="Publish\PDF\PublishPdfApi.cs" />
+    <Compile Include="Utils\OutputFilenames.cs" />
     <Compile Include="WebView2Browser.cs" Condition="'$(OS)'=='Windows_NT'">
       <SubType>UserControl</SubType>
     </Compile>

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -3806,7 +3806,7 @@ namespace Bloom.Book
 			return _bookData.GetMultiTextVariableOrEmpty(name);
 		}
 
-		internal IBookStorage Storage { get; }
+		public virtual IBookStorage Storage { get; }
 
 		/// <summary>
 		/// This gets called as a result of a UI action. It sets the new topic in our data,

--- a/src/BloomExe/Book/BookInfo.cs
+++ b/src/BloomExe/Book/BookInfo.cs
@@ -96,7 +96,7 @@ namespace Bloom.Book
 			None, OnPage	//Removed Links in Bloom 4.6 on June 28, 2019.
 		}
 
-		public string Id
+		public virtual string Id
 		{
 			get { return MetaData.Id; }
 			set { MetaData.Id = value; }

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -144,7 +144,7 @@ namespace Bloom.Book
 		public string InitialLoadErrors { get; private set; }
 		public bool ErrorAllowsReporting { get; private set; }    // True if we want to display a Report to Bloom Support button
 
-		public BookInfo BookInfo
+		public virtual BookInfo BookInfo
 		{
 			get
 			{
@@ -153,6 +153,12 @@ namespace Bloom.Book
 				return _metaData;
 			}
 			set { _metaData = value; }
+		}
+
+		public BookStorage()
+		{
+			if (!Program.RunningUnitTests)
+				throw new ApplicationException("Parameterless BookStorage constructor is allowed only in unit tests!");
 		}
 
 		public BookStorage(string folderPath, IChangeableFileLocator baseFileLocator,

--- a/src/BloomExe/CollectionTab/CollectionModel.cs
+++ b/src/BloomExe/CollectionTab/CollectionModel.cs
@@ -282,20 +282,15 @@ namespace Bloom.CollectionTab
 
 		private Form MainShell => Application.OpenForms.Cast<Form>().FirstOrDefault(f => f is Shell);
 
-		private string _bloomPackFolder;
-
 		// Not entirely happy that this method which launches a dialog is in the Model.
 		// but with the Collection UI moving to JS I don't see a good alternative
 		public void MakeBloomPack(bool forReaderTools)
 		{
-			var folder = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-			if (!string.IsNullOrEmpty(_bloomPackFolder) && Directory.Exists(_bloomPackFolder))
-				folder = _bloomPackFolder;
-			var initialPath = Path.Combine(folder, GetSuggestedBloomPackPath());
+			var initialPath = OutputFilenames.GetOutputFilePath(TheOneEditableCollection, ".BloomPack");
 			var destFileName = MiscUtils.GetOutputFilePathOutsideCollectionFolder(initialPath, "BloomPack files|*.BloomPack");
 			if (!string.IsNullOrEmpty(destFileName))
 			{
-				_bloomPackFolder = Path.GetDirectoryName(destFileName);
+				OutputFilenames.RememberOutputFilePath(TheOneEditableCollection, ".BloomPack", destFileName);
 				MakeBloomPack(destFileName, forReaderTools);
 			}
 		}

--- a/src/BloomExe/Publish/Android/file/FilePublisher.cs
+++ b/src/BloomExe/Publish/Android/file/FilePublisher.cs
@@ -10,6 +10,7 @@ using Bloom.Book;
 using Bloom.Properties;
 using Bloom.web;
 using L10NSharp;
+using Bloom.Utils;
 
 namespace Bloom.Publish.Android.file
 {
@@ -22,10 +23,7 @@ namespace Bloom.Publish.Android.file
 		{
 			var progressWithL10N = progress.WithL10NPrefix("PublishTab.Android.File.Progress.");
 
-			var folder = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-			if (!string.IsNullOrWhiteSpace(Settings.Default.BloomDeviceFileExportFolder) && Directory.Exists(Settings.Default.BloomDeviceFileExportFolder))
-				folder = Settings.Default.BloomDeviceFileExportFolder;
-			var initialPath = Path.Combine(folder, book.Storage.FolderName + BloomPubMaker.BloomPubExtensionWithDot);
+			var initialPath = OutputFilenames.GetOutputFilePath(book, BloomPubMaker.BloomPubExtensionWithDot, Settings.Default.BloomDeviceFileExportFolder);
 
 			var bloomdFileDescription = LocalizationManager.GetString("PublishTab.Android.bloomdFileFormatLabel", "Bloom Book for Devices",
 				"This is shown in the 'Save' dialog when you save a bloom book in the format that works with the Bloom Reader Android App");
@@ -35,6 +33,7 @@ namespace Bloom.Publish.Android.file
 			if (String.IsNullOrEmpty(destFileName))
 				return;
 
+			OutputFilenames.RememberOutputFilePath(book, BloomPubMaker.BloomPubExtensionWithDot, destFileName);
 			Settings.Default.BloomDeviceFileExportFolder = Path.GetDirectoryName(destFileName);
 			PublishToAndroidApi.CheckBookLayout(book, progress);
 			PublishToAndroidApi.SendBook(book, bookServer, destFileName, null,

--- a/src/BloomExe/Publish/Epub/PublishEpubApi.cs
+++ b/src/BloomExe/Publish/Epub/PublishEpubApi.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using Bloom.Api;
 using Bloom.Book;
 using Bloom.Collection;
+using Bloom.Utils;
 using Bloom.web;
 using DesktopAnalytics;
 using L10NSharp;
@@ -71,8 +72,6 @@ namespace Bloom.Publish.Epub
 
 		// This constant must match the ID used for the useWatchString called by the React component EPUBPublishScreenInternal.
 		private const string kWebsocketState_LicenseOK = "publish/licenseOK";
-
-		private string _lastDirectory; // where we saved the most recent previous epub, if any
 
 		// Holds the path the user has selected to save the results of the preview until it is actually saved.
 		// If the preview is complete at the time the user selects the file, it will hold it only very briefly
@@ -163,16 +162,11 @@ namespace Bloom.Publish.Epub
 
 		private void HandleEpubSave(ApiRequest request)
 		{
-			string suggestedName = string.Format("{0}-{1}.epub", Path.GetFileName(_bookSelection.CurrentSelection.FolderPath),
-				_bookSelection.CurrentSelection.BookData.Language1.GetNameInLanguage("en"));
-			var folder = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-			if (!string.IsNullOrEmpty(_lastDirectory) && Directory.Exists(_lastDirectory))
-				folder = _lastDirectory;
-			var initialPath = Path.Combine(folder, suggestedName);
+			var initialPath = OutputFilenames.GetOutputFilePath(_bookSelection.CurrentSelection, ".epub");
 			var destFileName = Utils.MiscUtils.GetOutputFilePathOutsideCollectionFolder(initialPath, "ePUB files|*.epub");
 			if (!string.IsNullOrEmpty(destFileName))
 			{
-				_lastDirectory = Path.GetDirectoryName(destFileName);
+				OutputFilenames.RememberOutputFilePath(_bookSelection.CurrentSelection, ".epub", destFileName);
 				lock (_epubMakerLock)
 				{
 					_pendingSaveAsPath = destFileName;

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -22,6 +22,7 @@ using Bloom.ToPalaso.Experimental;
 using Newtonsoft.Json;
 using SIL.Extensions;
 using SIL.Reporting;
+using Bloom.Utils;
 
 namespace Bloom.Publish
 {
@@ -461,7 +462,8 @@ namespace Bloom.Publish
 					_currentlyLoadedBook.UserPrefs.CmykPdf || _currentlyLoadedBook.UserPrefs.FullBleed
 						? "-printshop"
 						: "";
-				string suggestedName = string.Format($"{Path.GetFileName(_currentlyLoadedBook.FolderPath)}-{_currentlyLoadedBook.GetFilesafeLanguage1Name("en")}-{portion}{forPrintShop}.pdf");
+				var extraTag = $"{_currentlyLoadedBook.GetFilesafeLanguage1Name("en")}-{portion}{forPrintShop}";
+				var suggestedName = $"{Path.GetFileName(_currentlyLoadedBook.FolderPath)}-{extraTag}";
 				var pdfFileLabel = L10NSharp.LocalizationManager.GetString(@"PublishTab.PdfMaker.PdfFile",
 					"PDF File",
 					@"displayed as file type for Save File dialog.");
@@ -469,16 +471,15 @@ namespace Bloom.Publish
 				pdfFileLabel = pdfFileLabel.Replace("|", "");
 				var pdfFilter = String.Format("{0}|*.pdf", pdfFileLabel);
 
-				var startingFolder = (!string.IsNullOrEmpty(_lastDirectory) && Directory.Exists(_lastDirectory)) ?
-							_lastDirectory :
-							Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-				var initialPath = Path.Combine(startingFolder, suggestedName);
+				var initialPath = OutputFilenames.GetOutputFilePath(_currentlyLoadedBook, ".pdf", suggestedName, extraTag, _lastDirectory);
 
 				var destFileName = Utils.MiscUtils.GetOutputFilePathOutsideCollectionFolder(initialPath, pdfFilter);
 				if (String.IsNullOrEmpty(destFileName))
 					return;
 
+				OutputFilenames.RememberOutputFilePath(_currentlyLoadedBook, ".pdf", destFileName, extraTag);
 				_lastDirectory = Path.GetDirectoryName(destFileName);
+
 				if (_currentlyLoadedBook.UserPrefs.CmykPdf)
 				{
 					// PDF for Printshop (CMYK US Web Coated V2)

--- a/src/BloomExe/Publish/Video/RecordVideoWindow.cs
+++ b/src/BloomExe/Publish/Video/RecordVideoWindow.cs
@@ -1035,9 +1035,10 @@ namespace Bloom.Publish.Video
 
 		/// <summary>
 		/// Gets the suggested file basename to use in the save file dialog
+		/// If possible, this is based on the selected language and corresponding title of the book.
 		/// </summary>
 		/// <returns>The base name (the filename WITHOUT THE EXTENSION nor the path)</returns>
-		public string GetSuggestedSaveFileNameBase()
+		public string GetSuggestedSaveFileNameBase(out string langTag)
 		{
 			// If _videoSettingsFromPreview has been set (e.g. on multilingual books),
 			// check the video settings from the Bloom Player preview to see
@@ -1064,6 +1065,7 @@ namespace Bloom.Publish.Video
 					var allTitlesDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(_book.BookInfo.AllTitles);
 					if (allTitlesDict.TryGetValue(langCode, out string titleForRequestedLangCode))
 					{
+						langTag = langCode;
 						return titleForRequestedLangCode;
 					}
 				}
@@ -1071,11 +1073,10 @@ namespace Bloom.Publish.Video
 				// In case of any unexpected errors above, just fallback to the legacy way which just uses the path to the book.
 			}
 
+			langTag = null;
 			// Default method
 			return Path.GetFileName(_pathToRealBook);
 		}
-
-		string _previousVideoFolder;
 
 		// Note: this method is normally called after the window is closed and therefore disposed.
 		public void SaveVideo()
@@ -1084,11 +1085,8 @@ namespace Bloom.Publish.Video
 			if (!GotFullRecording)
 				return; // nothing to save, this shouldn't have happened.
 			var extension = _codec.ToExtension();
-			string suggestedName = $"{GetSuggestedSaveFileNameBase()}{extension}";
-			var folder = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-			if (!String.IsNullOrEmpty(_previousVideoFolder) && Directory.Exists(_previousVideoFolder))
-				folder = _previousVideoFolder;
-			var initialPath = Path.Combine(folder, suggestedName);
+			var filename = GetSuggestedSaveFileNameBase(out string langTag);
+			var initialPath = OutputFilenames.GetOutputFilePath(_book, extension, filename, langTag);
 			var outputFileLabel = L10NSharp.LocalizationManager.GetString(@"PublishTab.RecordVideo.VideoFile",
 				"Video File",
 				@"displayed as file type for Save File dialog");
@@ -1104,7 +1102,7 @@ namespace Bloom.Publish.Video
 			var destFileName = MiscUtils.GetOutputFilePathOutsideCollectionFolder(initialPath, filter);
 			if (!String.IsNullOrEmpty(destFileName))
 			{
-				_previousVideoFolder = Path.GetDirectoryName(destFileName);
+				OutputFilenames.RememberOutputFilePath(_book, extension, destFileName, langTag);
 				RobustFile.Copy(_finalVideo.Path, destFileName, true);
 			}
 		}

--- a/src/BloomExe/Utils/OutputFilenames.cs
+++ b/src/BloomExe/Utils/OutputFilenames.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Bloom.Utils
+{
+	public static class OutputFilenames
+	{
+		// map from the book ID and file type (extension + possible extra tag) to the most recent full file pathname
+		static Dictionary<Tuple<string, string>, string> _savedOutputFilePaths = new Dictionary<Tuple<string, string>, string>();
+		// map from the file type (extension only) to the most recently used folder for that file type
+		static Dictionary<string, string> _savedOutputFolders = new Dictionary<string, string>();
+
+		/// <summary>
+		/// Get the output file path for the given book and output type provided by the extension (plus extraTag)
+		/// The default is to use the folder name from the book for the filename (with the extension added) and
+		/// the user's Documents folder for where to put the file.
+		/// Call this before invoking a file open/save dialog to provide an initial path.
+		/// </summary>
+		/// <param name="book">The Book object</param>
+		/// <param name="extension">output type extension (".pdf", ".epub", ".mp4", etc.</param>
+		/// <param name="proposedName">A name proposed for the book's output file (optional).  Should not include the extension.
+		/// Not used if a path is remembered.</param>
+		/// <param name="extraTag">Additional information for variant of output such as language tag or PDF type of output (optional).
+		/// Must match corresponding RememberOutputFilePath call.  If this parameter is used, then proposed name should also be used
+		/// although it may be ignored after the first time.  (The proposed name may or may not include the extra tag information as
+		/// part of the name.)</param>
+		/// <param name="proposedFolder">A folder proposed for the book's output file (optional).  It must exist to be used.  Not used
+		/// if a path is remembered.</param>
+		/// <returns>full path of a proposed output file, possibly remembered from an earlier call to RememberOutputFilePath</returns>
+		/// <remarks>
+		/// This method does not store any information, but does look up any relevent stored data.
+		/// </remarks>
+		public static string GetOutputFilePath(Book.Book book, string extension,
+			string proposedName = null, string extraTag = "", string proposedFolder = null)
+		{
+			if (_savedOutputFilePaths.TryGetValue(GetCompoundTag(book.ID, extension, extraTag), out string path))
+				return path;
+			string startingFolder;
+			if (!_savedOutputFolders.TryGetValue(extension, out startingFolder))
+			{
+				if (!String.IsNullOrEmpty(proposedFolder) && Directory.Exists(proposedFolder))
+					startingFolder = proposedFolder;
+				else
+					startingFolder = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+			}
+			if (!String.IsNullOrEmpty(proposedName))
+				return (Path.Combine(startingFolder, $"{proposedName}{extension}"));
+			return Path.Combine(startingFolder, $"{Path.GetFileName(book.FolderPath)}{extension}");
+		}
+
+		/// <summary>
+		/// Remember an output file path for the given book and output type provided by the extension (plus extraTag).
+		/// Call this with the value returned from a file open/save dialog.
+		/// </summary>
+		/// <param name="book">The Book Object</param>
+		/// <param name="extension">output type extension (".pdf", ".epub", ".mp4", etc.</param>
+		/// <param name="outputFilePath">full path of the output file including directories and extension</param>
+		/// <param name="extraTag">Additional information for variant of output such as language tag or PDF type of output (optional).  Must match corresponding GetOutputFilePath call.</param>
+		/// <remarks>
+		/// extraTag is used as part of the key for remembering the full file path, but NOT for remembering the folder.
+		/// I'm not sure what the best approach is for granularity of remembering the folder, and opted for less granular.
+		/// It doesn't even use the book's ID in the key, just the extension.
+		/// </remarks>
+		public static void RememberOutputFilePath(Book.Book book, string extension, string outputFilePath, string extraTag = "")
+		{
+			_savedOutputFilePaths[GetCompoundTag(book.ID, extension, extraTag)] = outputFilePath;
+			_savedOutputFolders[extension] = Path.GetDirectoryName(outputFilePath);
+		}
+
+		private static Tuple<string,string> GetCompoundTag(string id, string extension, string extraTag)
+		{
+			return Tuple.Create(id, $"{extraTag}{extension}");
+		}
+		public static string GetOutputFilePath(Collection.BookCollection collection, string extension)
+		{
+			if (_savedOutputFilePaths.TryGetValue(GetCompoundTag(collection.PathToDirectory, extension, ""), out string path))
+				return path;
+			string startingFolder;
+			if (!_savedOutputFolders.TryGetValue(extension, out startingFolder))
+			{
+				startingFolder = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+			}
+			return Path.Combine(startingFolder, $"{collection.Name}{extension}");
+		}
+
+		public static void RememberOutputFilePath(Collection.BookCollection collection, string extension, string outputFilePath)
+		{
+			_savedOutputFilePaths[GetCompoundTag(collection.PathToDirectory, extension, "")] = outputFilePath;
+			_savedOutputFolders[extension] = Path.GetDirectoryName(outputFilePath);
+		}
+
+		public static void ResetOutputFilenamesMemory()
+		{
+			if (!Program.RunningUnitTests)
+				throw new ApplicationException("ResetOutputFilenamesMemory() can be called only by unit tests!");
+			_savedOutputFilePaths.Clear();
+			_savedOutputFolders.Clear();
+		}
+	}
+}

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -408,6 +408,7 @@
     <Compile Include="UpdateVersionTableTests.cs" />
     <Compile Include="Utilities.cs" />
     <Compile Include="Utils\MiscUtilsTests.cs" />
+    <Compile Include="Utils\OutputFilenamesTests.cs" />
     <Compile Include="Utils\TextUtilsTests.cs" />
     <Compile Include="Utils\ZipUtils.cs" />
     <Compile Include="WebLibraryIntegration\BloomLinkArgsTests.cs" />

--- a/src/BloomTests/Publish/Video/RecordVideoWindowTests.cs
+++ b/src/BloomTests/Publish/Video/RecordVideoWindowTests.cs
@@ -102,9 +102,10 @@ namespace BloomTests.Publish.Video
 			var obj = new RecordVideoWindow(null);
 			var invoker = new PrivateObject(obj);
 			invoker.SetFieldOrProperty("_pathToRealBook", @"C:\MyCollection\bookTitleL1");
-			var result = obj.GetSuggestedSaveFileNameBase();
+			var result = obj.GetSuggestedSaveFileNameBase(out string langTag);
 
 			Assert.AreEqual("bookTitleL1", result);
+			Assert.IsNull(langTag);
 		}
 
 		[Test]
@@ -132,12 +133,13 @@ namespace BloomTests.Publish.Video
 			///////////////////////
 			// System Under Test //
 			///////////////////////
-			var result = obj.GetSuggestedSaveFileNameBase();
+			var result = obj.GetSuggestedSaveFileNameBase(out string langTag);
 
 			//////////////////
 			// Verification //
 			//////////////////
 			Assert.AreEqual("bookTitleL2", result);
+			Assert.AreEqual("l2", langTag);
 		}
 
 		[Test]

--- a/src/BloomTests/Utils/OutputFilenamesTests.cs
+++ b/src/BloomTests/Utils/OutputFilenamesTests.cs
@@ -1,0 +1,147 @@
+﻿using Moq;
+using Assert = NUnit.Framework.Assert;
+using NUnit.Framework;
+using Bloom.Utils;
+using System;
+using System.IO;
+using BloomTemp;
+
+namespace BloomTests.Utils
+{
+	[TestFixture]
+	internal class OutputFilenamesTests
+	{
+		Mock<Bloom.Book.Book> _mockBook1;
+		Mock<Bloom.Book.Book> _mockBook2;
+		Mock<Bloom.Book.Book> _mockBook3;
+		string _userDocumentFolder;
+
+		[SetUp]
+		public void SetUp()
+		{
+			OutputFilenames.ResetOutputFilenamesMemory();
+			_userDocumentFolder = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+			_mockBook1 = CreateMockBook("536ff975-1bd7-49ca-bcc8-937f8e4b8c9f", Path.Combine(_userDocumentFolder, "Bloom", "Plants"));
+			_mockBook2 = CreateMockBook("536ff975-1bd7-49ca-bcc8-937f8e4b8cA0", Path.Combine(_userDocumentFolder, "Bloom", "Animals"));
+			_mockBook3 = CreateMockBook("536ff975-1bd7-49ca-bcc8-937f8e4b8cA1", Path.Combine(_userDocumentFolder, "Bloom", "Minerals"));
+		}
+
+		[Test]
+		public void SimplestUseCaseWorks()
+		{
+			// Test the code with none of the optional parameters in use.
+
+			// The standard default folder is used for output.
+			var pdfFile = OutputFilenames.GetOutputFilePath(_mockBook1.Object, ".epub");
+			Assert.That(pdfFile, Is.EqualTo(Path.Combine(_userDocumentFolder, "Plants.epub")));
+			pdfFile = OutputFilenames.GetOutputFilePath(_mockBook2.Object, ".epub");
+			Assert.That(pdfFile, Is.EqualTo(Path.Combine(_userDocumentFolder, "Animals.epub")));
+			pdfFile = OutputFilenames.GetOutputFilePath(_mockBook3.Object, ".epub");
+			Assert.That(pdfFile, Is.EqualTo(Path.Combine(_userDocumentFolder, "Minerals.epub")));
+
+			// Explicitly remember a different path for two of these books.  (These folders/files don't need to exist.)
+			OutputFilenames.RememberOutputFilePath(_mockBook1.Object, ".epub", @"D:\output\epub\Eat Your Vegetables.epub");
+			OutputFilenames.RememberOutputFilePath(_mockBook2.Object, ".epub", @"D:\output\epub-2\Cute Furry Animals.epub");
+
+			// The explicit paths are remembered for these books.
+			pdfFile = OutputFilenames.GetOutputFilePath(_mockBook1.Object, ".epub");
+			Assert.That(pdfFile, Is.EqualTo(@"D:\output\epub\Eat Your Vegetables.epub"));
+			pdfFile = OutputFilenames.GetOutputFilePath(_mockBook2.Object, ".epub");
+			Assert.That(pdfFile, Is.EqualTo(@"D:\output\epub-2\Cute Furry Animals.epub"));
+
+			// The most recent folder used for a remembered book is used for the next book
+			// that has not been remembered.
+			pdfFile = OutputFilenames.GetOutputFilePath(_mockBook3.Object, ".epub");
+			Assert.That(pdfFile, Is.EqualTo(@"D:\output\epub-2\Minerals.epub"));
+
+			// But it is not remembered for a different type of book.
+			pdfFile = OutputFilenames.GetOutputFilePath(_mockBook3.Object, ".bloompub");
+			Assert.That(pdfFile, Is.EqualTo(Path.Combine(_userDocumentFolder, "Minerals.bloompub")));
+		}
+
+		[Test]
+		public void UsingADefaultFolderWorks()
+		{
+			// Test the code with the optional folder parameter in use, but none of the other optional parameters being used.
+
+			using (var tempFolder = new TemporaryFolder(Path.Combine(Path.GetTempPath(), "DefaultFor_UsingADefaultFolderWorks")))
+			{
+				// The provided default folder is used (if it exists).
+				var pdfFile = OutputFilenames.GetOutputFilePath(_mockBook1.Object, ".pdf", proposedFolder: tempFolder.FolderPath);
+				Assert.That(pdfFile, Is.EqualTo(Path.Combine(tempFolder.FolderPath,"Plants.pdf")));
+				// The provided default folder is not remembered unless RememberOutputFilePath is called.
+				var pdfFile2 = OutputFilenames.GetOutputFilePath(_mockBook2.Object, ".pdf");
+				Assert.That(pdfFile2, Is.EqualTo(Path.Combine(_userDocumentFolder, "Animals.pdf")));
+
+				// Remembering the first output path saves its folder for the next book.
+				OutputFilenames.RememberOutputFilePath(_mockBook1.Object, ".pdf", pdfFile);
+				pdfFile2 = OutputFilenames.GetOutputFilePath(_mockBook2.Object, ".pdf");
+				Assert.That(pdfFile2, Is.EqualTo(Path.Combine(tempFolder.FolderPath, "Animals.pdf")));
+
+				// Remember a different path for a book.  (This path isn't actually checked for existence.)
+				OutputFilenames.RememberOutputFilePath(_mockBook1.Object, ".pdf", @"D:\tmp\pdf\Plants-All.pdf");
+
+				// The explicit path for the book is remembered despite a different default folder value being provided.
+				pdfFile = OutputFilenames.GetOutputFilePath(_mockBook1.Object, ".pdf", proposedFolder: tempFolder.FolderPath);
+				Assert.That(pdfFile, Is.EqualTo(@"D:\tmp\pdf\Plants-All.pdf"));
+
+				// The folder from the explicit path is remembered and used for the other book as well.  Note that the
+				// RememberOutputFilePath() has to be explicitly called to remember the previous setting.
+				pdfFile = OutputFilenames.GetOutputFilePath(_mockBook2.Object, ".pdf");
+				Assert.That(pdfFile, Is.EqualTo(@"D:\tmp\pdf\Animals.pdf"));
+			}
+		}
+
+		[Test]
+		public void ComplexUsesWork()
+		{
+			// Test the code with all three optional parameters being used: folder, name, and extra tag.
+
+			using (var tempFolder = new TemporaryFolder(Path.Combine(Path.GetTempPath(), "DefaultFor_ComplexUsesWork")))
+			{
+				// The provided default folder is used (if it exists).
+				var pdfFile = OutputFilenames.GetOutputFilePath(_mockBook1.Object, ".pdf", "Plants-English-Pages-printshop", "English-Pages-printshop", tempFolder.FolderPath);
+				Assert.That(pdfFile, Is.EqualTo(Path.Combine(tempFolder.FolderPath, "Plants-English-Pages-printshop.pdf")));
+				// The provided default folder is not remembered unless RememberOutputFilePath is called.
+				var pdfFile2 = OutputFilenames.GetOutputFilePath(_mockBook2.Object, ".pdf", "Animals-French-Cover", "French-Cover");
+				Assert.That(pdfFile2, Is.EqualTo(Path.Combine(_userDocumentFolder, "Animals-French-Cover.pdf")));
+
+				// Remembering the first output path saves its folder for the next book.
+				OutputFilenames.RememberOutputFilePath(_mockBook1.Object, ".pdf", pdfFile, "English-Pages-printshop");
+				pdfFile2 = OutputFilenames.GetOutputFilePath(_mockBook2.Object, ".pdf", "Animals-Spanish-Inside", "Spanish-Inside");
+				Assert.That(pdfFile2, Is.EqualTo(Path.Combine(tempFolder.FolderPath, "Animals-Spanish-Inside.pdf")));
+
+				// Remember a different path for a book.  (This path isn't actually checked for existence.)
+				OutputFilenames.RememberOutputFilePath(_mockBook1.Object, ".pdf", @"D:\tmp\pdf\Plants-All.pdf", "English-Pages-printshop");
+
+				// The explicit path for the book is remembered despite different default name and folder values being provided.
+				pdfFile = OutputFilenames.GetOutputFilePath(_mockBook1.Object, ".pdf", "Plants-AllPages", "English-Pages-printshop", tempFolder.FolderPath);
+				Assert.That(pdfFile, Is.EqualTo(@"D:\tmp\pdf\Plants-All.pdf"));
+
+				// Changing the extraTag value uses the new provided name, but not the folder since the stored value overrides.
+				pdfFile = OutputFilenames.GetOutputFilePath(_mockBook1.Object, ".pdf", "Plants-English-Pages", "English-Pages", tempFolder.FolderPath);
+				Assert.That(pdfFile, Is.EqualTo(@"D:\tmp\pdf\Plants-English-Pages.pdf"));
+			}
+		}
+
+		/// <summary>
+		/// Create a mock book with only the book's id and folder path instantiated.
+		/// </summary>
+		/// <remarks>
+		/// Creating this method required adding a parameterless contructor for BookStorage and
+		/// adding the virtual keyword to the Book.Storage, BookInfo.Id, and BookStorage.BookInfo
+		/// properties.
+		/// </remarks>
+		Mock<Bloom.Book.Book> CreateMockBook(string bookId, string bookFolder)
+		{
+			var mockBook = new Mock<Bloom.Book.Book>();
+			var mockBookInfo = new Mock<Bloom.Book.BookInfo>();
+			var mockStorage = new Mock<Bloom.Book.BookStorage>();
+			mockBook.Setup(book => book.Storage).Returns(mockStorage.Object);
+			mockBook.Setup(book => book.FolderPath).Returns(bookFolder);
+			mockBookInfo.Setup(info => info.Id).Returns(bookId);
+			mockStorage.Setup(storage => storage.BookInfo).Returns(mockBookInfo.Object);
+			return mockBook;
+		}
+	}
+}


### PR DESCRIPTION
This changeset does not deal with spreadsheets, which look for folder paths instead of file paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5724)
<!-- Reviewable:end -->
