### PR TITLE
BL-10772 On SS import, image re-use generates new image

### DIFF
--- a/src/BloomExe/Book/ImageUpdater.cs
+++ b/src/BloomExe/Book/ImageUpdater.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml;
 using Bloom.Utils;
 using L10NSharp;
-using SIL.CommandLineProcessing;
 using SIL.IO;
 using SIL.Progress;
 using SIL.Reporting;
@@ -72,6 +70,13 @@ namespace Bloom.Book
 			{
 				UpdateImgMetadataAttributesToMatchImage(folderPath, img, progress, metadata);
 			}
+		}
+
+		private static readonly string[] _imagesThatShouldBeSingletons = new string[] { "placeholder.png", "license.png" };
+
+		public static bool IsPlaceholderOrLicense(string fileName)
+		{
+			return _imagesThatShouldBeSingletons.Contains(fileName.ToLowerInvariant());
 		}
 
 		private static readonly string[] ExcludedFiles = { "placeholder.png", "license.png", "thumbnail.png", "nonPaddedThumbnail.png" };
@@ -145,7 +150,7 @@ namespace Bloom.Book
 			//see also PageEditingModel.UpdateMetadataAttributesOnImage(), which does the same thing but on the browser dom
 			var url = HtmlDom.GetImageElementUrl(new ElementProxy(imgElement));
 			string fileName = url.PathOnly.NotEncoded;
-			if (fileName.ToLowerInvariant() == "placeholder.png" || fileName.ToLowerInvariant() == "license.png")
+			if (IsPlaceholderOrLicense(fileName))
 				return;
 			if (string.IsNullOrEmpty(fileName))
 			{

--- a/src/BloomTests/Spreadsheet/SpreadsheetImporterTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetImporterTests.cs
@@ -863,8 +863,8 @@ public static string PageWithJustText(int pageNumber, int tgNumber)
 		[TestCase(4, "ic4", "man.png")]
 		[TestCase(5, "ic5", "placeHolder.png")] // Todo: should be placeholder
 		[TestCase(5, "ic6", "shirt.png")]
-		[TestCase(11, "ic7", "Mars%203.png")]
-		[TestCase(13, "ic7", "shirt.png")]
+		[TestCase(11, "ic7", "Mars%204.png")]
+		[TestCase(13, "ic7", "shirt1.png")]
 		public void GotImageSourceOnPageN(int n, string tag, string text)
 		{
 			AssertThatXmlIn.Element(_contentPages[n]).HasSpecifiedNumberOfMatchesForXpath($".//div[@data-test-id='{tag}']/img[@src='{text}']", 1);
@@ -882,7 +882,7 @@ public static string PageWithJustText(int pageNumber, int tgNumber)
 
 		[TestCase(7, "this is something extra on a new page before 7", "LakePendOreille.jpg", "Copyright © 2012, Stephen McConnel")]
 		[TestCase(10, "this is something extra on a new page before 8", "levels.png", "Copyright © 2021, USAID \"Okuu keremet!\"")]
-		[TestCase(12, "this is something extra after all the original pages", "man.png", "")]
+		[TestCase(12, "this is something extra after all the original pages", "man1.png", "")]
 		public void PageAddedWithTextAndPicture(int n, string text, string src, string copyright)
 		{
 			AssertThatXmlIn.Element(_contentPages[n]).HasSpecifiedNumberOfMatchesForXpath($".//div[contains(@class, 'bloom-imageContainer')]/img[@src='{src}']", 1);
@@ -925,15 +925,25 @@ public static string PageWithJustText(int pageNumber, int tgNumber)
 		}
 
 		[TestCase("shirt.png")]
-		[TestCase("Mars 3.png")]
+		[TestCase("shirt1.png")]
 		[TestCase("man.png")]
+		[TestCase("man1.png")]
 		[TestCase("LakePendOreille.jpg")]
 		[TestCase("levels.png")]
 		[TestCase("lady24b.png")]
 		[TestCase("Othello 199.jpg")]
+		[TestCase("Mars 3.png")]
+		[TestCase("Mars 4.png")]
+		[TestCase("placeHolder.png")]
 		public void ImageCopiedToOutput(string fileName)
 		{
 			Assert.That(RobustFile.Exists(Path.Combine(_bookFolder.FolderPath, fileName)));
+		}
+
+		[TestCase("placeHolder1.png")]
+		public void ImageNotCopiedToOutput(string fileName)
+		{
+			Assert.That(!RobustFile.Exists(Path.Combine(_bookFolder.FolderPath, fileName)));
 		}
 
 		[Test]


### PR DESCRIPTION
* make unique copies of image files, if the image is re-used

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5742)
<!-- Reviewable:end -->
