### PR TITLE
Fix glitches in regularized Save Path logic (BL-11996)

### DIFF
--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -141,6 +141,7 @@ namespace Bloom
 							typeof (ControlKeyEvent),
 							typeof (BookStatusChangeEvent),
 							typeof (EditingModel),
+							typeof (PublishModel),
 							typeof (AudioRecording),
 							typeof(BookSettingsApi),
 							typeof(SpreadsheetApi),

--- a/src/BloomExe/Publish/BloomPub/file/FilePublisher.cs
+++ b/src/BloomExe/Publish/BloomPub/file/FilePublisher.cs
@@ -23,7 +23,8 @@ namespace Bloom.Publish.BloomPub.file
 		{
 			var progressWithL10N = progress.WithL10NPrefix("PublishTab.Android.File.Progress.");
 
-			var initialPath = OutputFilenames.GetOutputFilePath(book, BloomPubMaker.BloomPubExtensionWithDot, Settings.Default.BloomDeviceFileExportFolder);
+			var initialPath = OutputFilenames.GetOutputFilePath(book, BloomPubMaker.BloomPubExtensionWithDot,
+				proposedFolder: Settings.Default.BloomDeviceFileExportFolder);
 
 			var bloomdFileDescription = LocalizationManager.GetString("PublishTab.Android.bloomdFileFormatLabel", "Bloom Book for Devices",
 				"This is shown in the 'Save' dialog when you save a bloom book in the format that works with the Bloom Reader Android App");


### PR DESCRIPTION
PublishModel was getting separate copies created for PublishView and PublishPdfApi.  The change in ProjectContext forces PublishModel to be a singleton.  This fixes the second glitch found by Colin in the issue.