### PR TITLE
Add BloomTooltip placement capabilities and default L10n use (BL-12096)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -4115,7 +4115,7 @@
         <note>The parenthesized word indicates the negative effect of using this option. This text is for a menu item.</note>
       </trans-unit>
       <trans-unit id="PublishTab.NoBookletsMessage">
-        <source xml:lang="en">Bloom cannot make booklets using the current page size.</source>
+        <source xml:lang="en">This is disabled because Bloom cannot make booklets using the current size and orientation.</source>
         <note>ID: PublishTab.NoBookletsMessage</note>
         <note>If a book has a paper size that is too big (like A4), Bloom does not know how to make booklets with it. So the controls for booklets get disabled and this message is shown.</note>
       </trans-unit>

--- a/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
@@ -814,18 +814,9 @@ function getRemovableCollectionHeaderDiv(
             >
                 <BloomTooltip
                     id={tooltipId}
-                    tooltipBackColor={kBloomBlue}
                     side="right"
-                    tooltipContent={
-                        <Div
-                            l10nKey={tooltipL10nKey}
-                            css={css`
-                                max-width: 200px;
-                            `}
-                        >
-                            {tooltipText}
-                        </Div>
-                    }
+                    tooltipL10nKey={tooltipL10nKey}
+                    tooltipText={tooltipText}
                 >
                     {icon}
                 </BloomTooltip>

--- a/src/BloomBrowserUI/publish/PDFPrintPublish/PDFPrintFeaturesGroup.tsx
+++ b/src/BloomBrowserUI/publish/PDFPrintPublish/PDFPrintFeaturesGroup.tsx
@@ -6,7 +6,7 @@ import { SettingsGroup } from "../commonPublish/PublishScreenBaseComponents";
 import { useL10n } from "../../react_components/l10nHooks";
 import { useSubscribeToWebSocketForObject } from "../../utils/WebSocketManager";
 import { post, useApiBoolean } from "../../utils/bloomApi";
-import Button from "@mui/material/Button";
+import { BloomTooltip } from "../../react_components/BloomToolTip";
 import { kBloomBlue, kBloomDisabledText } from "../../utils/colorUtils";
 import { useState } from "react";
 import { ApiCheckbox } from "../../react_components/ApiCheckbox";
@@ -36,10 +36,6 @@ export const PDFPrintFeaturesGroup: React.FunctionComponent<{
         }
     );
     const [activeButton, setActiveButton] = useState("");
-    const noBookletsMessage = useL10n(
-        "Bloom cannot make booklets using the current page size.",
-        "PublishTab.NoBookletsMessage"
-    );
     const [allowBooklet] = useApiBoolean("publish/pdf/allowBooklet", true);
     // Eventually this may have more options and will no longer be boolean.
     // But at this point even the underlying model in C# is boolean, so I decided
@@ -51,6 +47,17 @@ export const PDFPrintFeaturesGroup: React.FunctionComponent<{
         "PublishTab.PdfMaker.PdfWithCmykSwopV2"
     );
     const [allowFullBleed] = useApiBoolean("publish/pdf/allowFullBleed", false);
+
+    // These are used to allow the tooltips to appear only when booklets are disabled.
+    const [
+        coverTooltipAnchor,
+        setCoverTooltipAnchor
+    ] = useState<HTMLElement | null>(null);
+    const [
+        insideTooltipAnchor,
+        setInsideTooltipAnchor
+    ] = useState<HTMLElement | null>(null);
+
     return (
         <div
             css={css`
@@ -77,36 +84,66 @@ export const PDFPrintFeaturesGroup: React.FunctionComponent<{
                         descId="PublishTab.OnePagePerPaper-description"
                         selected={activeButton === "simple"}
                     />
-                    <FeatureButton
-                        imgSrc="/bloom/images/coverOnly.svg"
-                        onClick={() => {
-                            post("publish/pdf/cover");
-                            setActiveButton("cover");
-                            props.onChange?.("cover");
-                        }}
-                        label="Booklet cover"
-                        labelId="PublishTab.CoverOnlyRadio"
-                        desc="The cover, ready to print on colored paper."
-                        descId="PublishTab.CoverOnly-description"
-                        selected={activeButton === "cover"}
-                        disabled={!allowBooklet}
-                        title={allowBooklet ? "" : noBookletsMessage}
-                    />
-                    <FeatureButton
-                        imgSrc="/bloom/images/insideBookletPages.svg"
-                        onClick={() => {
-                            post("publish/pdf/pages");
-                            setActiveButton("pages");
-                            props.onChange?.("pages");
-                        }}
-                        label="Booklet Insides"
-                        labelId="PublishTab.BodyOnlyRadio"
-                        desc="The inside pages, re-arranged so that when folded, you get a booklet ready to staple."
-                        descId="PublishTab.BodyOnly-description"
-                        selected={activeButton === "pages"}
-                        disabled={!allowBooklet}
-                        title={allowBooklet ? "" : noBookletsMessage}
-                    />
+                    <BloomTooltip
+                        id="cover-disabled"
+                        side="left"
+                        sideVerticalOrigin={30}
+                        sideHorizontalOrigin={10}
+                        arrowLoc="middle"
+                        tooltipL10nKey="PublishTab.NoBookletsMessage"
+                        tooltipText="This is disabled because Bloom cannot make booklets using the current size and orientation."
+                        popupAnchorElement={coverTooltipAnchor}
+                        changePopupAnchor={val =>
+                            allowBooklet
+                                ? setCoverTooltipAnchor(null) // don't show if enabled
+                                : setCoverTooltipAnchor(val)
+                        }
+                    >
+                        <FeatureButton
+                            imgSrc="/bloom/images/coverOnly.svg"
+                            onClick={() => {
+                                post("publish/pdf/cover");
+                                setActiveButton("cover");
+                                props.onChange?.("cover");
+                            }}
+                            label="Booklet cover"
+                            labelId="PublishTab.CoverOnlyRadio"
+                            desc="The cover, ready to print on colored paper."
+                            descId="PublishTab.CoverOnly-description"
+                            selected={activeButton === "cover"}
+                            disabled={!allowBooklet}
+                        />
+                    </BloomTooltip>
+                    <BloomTooltip
+                        id="cover-disabled"
+                        side="left"
+                        sideVerticalOrigin={30}
+                        sideHorizontalOrigin={10}
+                        arrowLoc="middle"
+                        tooltipL10nKey="PublishTab.NoBookletsMessage"
+                        tooltipText="This is disabled because Bloom cannot make booklets using the current size and orientation."
+                        popupAnchorElement={insideTooltipAnchor}
+                        changePopupAnchor={val =>
+                            allowBooklet
+                                ? setInsideTooltipAnchor(null) // don't show if enabled
+                                : setInsideTooltipAnchor(val)
+                        }
+                    >
+                        <FeatureButton
+                            imgSrc="/bloom/images/insideBookletPages.svg"
+                            onClick={() => {
+                                post("publish/pdf/pages");
+                                setActiveButton("pages");
+                                props.onChange?.("pages");
+                            }}
+                            label="Booklet Insides"
+                            labelId="PublishTab.BodyOnlyRadio"
+                            desc="The inside pages, re-arranged so that when folded, you get a booklet ready to staple."
+                            descId="PublishTab.BodyOnly-description"
+                            selected={activeButton === "pages"}
+                            disabled={!allowBooklet}
+                        />
+                    </BloomTooltip>
                 </FormGroup>
             </SettingsGroup>
             <SettingsGroup

--- a/src/BloomBrowserUI/publish/ePUBPublish/ePUBSettingsGroup.tsx
+++ b/src/BloomBrowserUI/publish/ePUBPublish/ePUBSettingsGroup.tsx
@@ -20,7 +20,7 @@ import {
     Select,
     Typography
 } from "@mui/material";
-import { kBloomBlue, kSelectCss } from "../../bloomMaterialUITheme";
+import { kSelectCss } from "../../bloomMaterialUITheme";
 import { useState } from "react";
 import { BloomTooltip } from "../../react_components/BloomToolTip";
 import { kBloomDisabledText } from "../../utils/colorUtils";
@@ -240,33 +240,15 @@ interface IProps extends IEpubMode {
 
 const EpubModeItem: React.FunctionComponent<IProps> = props => {
     const id = "mouse-over-popover-" + props.mode;
-    const popupColor = kBloomBlue;
 
     return (
         <BloomTooltip
             id={id}
-            tooltipBackColor={popupColor}
             popupAnchorElement={props.popupAnchorElement}
             changePopupAnchor={props.changePopupAnchor}
             side="left"
-            tooltipContent={
-                <div
-                    css={css`
-                        display: flex;
-                        flex-direction: column;
-                        align-items: center;
-                    `}
-                >
-                    <Div
-                        l10nKey={props.descriptionL10nKey}
-                        css={css`
-                            max-width: 200px;
-                        `}
-                    >
-                        {props.description}
-                    </Div>
-                </div>
-            }
+            tooltipL10nKey={props.descriptionL10nKey}
+            tooltipText={props.description}
         >
             <div
                 css={css`

--- a/src/BloomBrowserUI/publish/video/AudioVideoOptionsGroup.tsx
+++ b/src/BloomBrowserUI/publish/video/AudioVideoOptionsGroup.tsx
@@ -463,12 +463,10 @@ export const AudioVideoOptionsGroup: React.FunctionComponent<{
 
 const VideoFormatItem: React.FunctionComponent<IProps> = props => {
     const id = "mouse-over-popover-" + props.format;
-    const popupColor = kBloomBlue;
 
     return (
         <BloomTooltip
             id={id}
-            tooltipBackColor={popupColor}
             popupAnchorElement={props.popupAnchorElement}
             changePopupAnchor={props.changePopupAnchor}
             tooltipContent={


### PR DESCRIPTION
Also use BloomTooltip to provide nicer looking tooltips (with a somewhat better message) for disabled PDF booklet buttons.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5755)
<!-- Reviewable:end -->
