### PR TITLE
[5.4] BL-12106 Correct "No Topic" dialog load

### DIFF
--- a/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooserDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooserDialog.tsx
@@ -200,7 +200,10 @@ export function showTopicChooserDialog() {
             const topics = (topicsAndCurrent.Topics as string[]).map(t =>
                 JSON.parse(t)
             );
-            const currentTopic = topicsAndCurrent.Current;
+            const currentTopic =
+                topicsAndCurrent.Current === "No Topic"
+                    ? undefined
+                    : topicsAndCurrent.Current;
 
             // Here, topics will be an array with an entry for each known topic. Each topic is an
             // englishKey/translated pair.


### PR DESCRIPTION
* No Topic means 'currentTopic' is undefined

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5758)
<!-- Reviewable:end -->
