### PR TITLE
Stop multiplying languagesOfBook fields in bloomDataDiv (BL-12112)

### DIFF
--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -585,9 +585,10 @@ namespace Bloom.Book
 				return;
 			var elements = this._dom.SafeSelectNodes("//div[@data-derived='languagesOfBook']");
 
-			// We don't think this can happen because xmatter pages should get updated to have data-derived.
+			// Normally, this doesn't happen because xmatter pages should get updated to have data-derived.
+			// But some custom xmatters don't contain this field.
 			if (elements == null || elements.Count == 0)
-				elements = this._dom.SafeSelectNodes("//div[not(id='bloomDataDiv')]//div[@data-book='languagesOfBook']");
+				elements = this._dom.SafeSelectNodes("//div[not(@id='bloomDataDiv')]//div[@data-book='languagesOfBook']");				
 
 			if (elements == null || elements.Count == 0)
 				return;		// must be in a test...
@@ -595,12 +596,6 @@ namespace Bloom.Book
 			{
 				element.SetAttribute("lang", MetadataLanguage1Tag);
 				SetNodeXml("languagesOfBook", XmlString.FromXml(languagesXml), element );
-				// Was until April 2021
-				//element.InnerText = languages;
-				// This is wrong because languages, coming from data.TextVariables, is encoded.
-				// It would probably be OK to use element.InnerXml = languages, which is what
-				// SetNodeXml ends up doing; but it seems safest to use the routine made for the
-				// purpose of setting node contents.
 			}
 		}
 

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -1849,7 +1849,7 @@ namespace BloomTests.Book
 					<div class='languagesOfBook' data-derived='languagesOfBook' lang='en'>PlaceholderThatWillGetUpdated</div>
 				</div>
 				</body></html>");
-			
+
 			var data = new BookData(bookDom, _collectionSettings, null);
 
 			// For BL-9972, the languagesOfBook key was somehow set again via XMLString (which generates the entity reference version of "ö".
@@ -1863,6 +1863,30 @@ namespace BloomTests.Book
 			// Verification
 			var titlePageNode = bookDom.RawDom.SelectSingleNode("//div[@data-derived='languagesOfBook']");
 			Assert.AreEqual("Hakö", titlePageNode.InnerText);
+		}
+
+		[Test]
+		public void SetupDisplayOfLanguagesOfBook_XmatterHasNoLanguagesOfBookField_LanguagesOfBookInDataDivStaysLanguageNeutralAndSingular()
+		{
+			var bookDom = new HtmlDom(@"<html><body>
+				<div id='bloomDataDiv'>
+					<div data-book='languagesOfBook' lang='*'>English</div>
+				</div>
+				</body></html>");
+
+			var data = new BookData(bookDom, _collectionSettings, null);
+
+			// System Under Test
+			data.SetupDisplayOfLanguagesOfBook();
+
+			// Verification
+			var dataDivLanguagesOfBookNodes = bookDom.RawDom.SelectNodes("//div[@id='bloomDataDiv']//div[@data-book='languagesOfBook']");
+			// The live bug was also creating multiple copies of the languagesOfBook element.
+			// I can't figure out how to make that happen in a test, but the cause of it getting the wrong lang attribute
+			// and multiple copies was the same.
+			Assert.That(dataDivLanguagesOfBookNodes.Count, Is.EqualTo(1));
+			Assert.That(dataDivLanguagesOfBookNodes[0].GetStringAttribute("lang"), Is.EqualTo("*"));
+			Assert.AreEqual("English", dataDivLanguagesOfBookNodes[0].InnerText);
 		}
 
 		private bool AndikaNewBasicIsInstalled()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5762)
<!-- Reviewable:end -->
