### PR TITLE
BL-10638 Clear Bookshelf if Enterp. code has changed

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -403,10 +403,6 @@
         <note>ID: CollectionSettingsDialog.BookMakingTab.Front/BackMatterPack.Video</note>
         <note>Name of a Front/Back Matter Pack that is used for talking/animating experiences</note>
       </trans-unit>
-      <!-- <trans-unit id="CollectionSettingsDialog.BookMakingTab.NoBookshelvesFromServer" sil:dynamic="true"> -->
-      <!-- <source xml:lang="en">Bloom could not reach server to get the list of bookshelves.</source> -->
-      <!-- <note>ID: CollectionSettingsDialog.BookMakingTab.NoBookshelvesFromServer</note> -->
-      <!-- </trans-unit> -->
       <trans-unit id="CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Arabic-Indic" sil:dynamic="true">
         <source xml:lang="en">Arabic-Indic</source>
         <note>ID: CollectionSettingsDialog.BookMakingTab.PageNumberingStyle.Arabic-Indic</note>

--- a/DistFiles/localization/en/BloomLowPriority.xlf
+++ b/DistFiles/localization/en/BloomLowPriority.xlf
@@ -7,6 +7,11 @@
                 <note>This isn't used by code, but rather we harvest some of these for use in making the GIF that shows when the software is installing.</note>
                 <note> In English, given the context, just "Installing..." is enough. But your translation can be verbose, like "Software Installation in Progress...".</note>
             </trans-unit>
+            <trans-unit id="CollectionSettingsDialog.BookMakingTab.NoBookshelvesFromServer" sil:dynamic="true" translate="no">
+              <!-- New in 5.5 -->
+              <source xml:lang="en">Bloom could not reach the server to get the list of bookshelves.</source>
+              <note>ID: CollectionSettingsDialog.BookMakingTab.NoBookshelvesFromServer</note>
+            </trans-unit>
             <trans-unit id="EditTab.Toolbox.TalkingBookTool.ESpeakPreview.ConversionFileUsed">
                 <source xml:lang="en">Conversion file used:</source>
                 <note>ID: EditTab.Toolbox.TalkingBookTool.ESpeakPreview.ConversionFileUsed</note>
@@ -43,6 +48,11 @@
             <trans-unit id="PublishTab.Upload.CheckEmailFailed">
                 <source xml:lang="en">Bloom needs to verify your email, but our attempt to resend the request failed, possibly because you made too many requests too close together. Please check your email, and if you can't find the message, try again later.</source>
                 <note>ID: PublishTab.Upload.CheckEmailFailed</note>
+            </trans-unit>
+            <trans-unit id="PublishTab.Upload.BookshelfError" translate="no">
+                <!-- New in 5.5-->
+                <source xml:lang="en">The collection's bookshelf was not on the list of bookshelves for this Enterprise subscription.</source>
+                <note>ID: PublishTab.Upload.BookshelfError</note>
             </trans-unit>
             <trans-unit id="Settings.Enterprise.Community">
                 <source xml:lang="en">Funded by the local community only</source>

--- a/src/BloomBrowserUI/collection/useGetEnterpriseBookshelves.tsx
+++ b/src/BloomBrowserUI/collection/useGetEnterpriseBookshelves.tsx
@@ -1,0 +1,118 @@
+import { useState, useEffect } from "react";
+import { get } from "../utils/bloomApi";
+import { useContentful } from "../contentful/UseContentful";
+
+export interface IBookshelf {
+    value: string;
+    label: string;
+    tooltip: string;
+}
+
+export function useGetEnterpriseBookshelves(): {
+    project: string;
+    defaultBookshelfUrlKey: string;
+    validBookshelves: IBookshelf[];
+    error: boolean;
+} {
+    // Things get tricky because we have to run two queries here to get the
+    // data we need, and the second depends on the results of the first.
+    // Doing this under the rules of hooks is difficult. The first query is
+    // to our local server, and obtains the project's branding name and any
+    // current default bookshelf. The second uses the project branding info
+    // to retrieve the actual contentful Enterprise Subscription
+    // complete with references to the collections we want.
+    // Besides keeping straight which of these queries has and has not completed,
+    // we must handle special cases when we cannot retrieve data from contentful
+    // and when the user has no enterprise subscription and can't use this
+    // feature.
+
+    // The defaultShelf retrieved from the settings/bookShelfData API, or 'none'
+    // if defaultShelf is falsy. Using 'none' as the value here in this control
+    // allows us to show a label 'None' when nothing is selected; passing it as
+    // the value when that option is chosen allows us to get around a restricion
+    // in our API which does not allow an empty string as the value of a
+    // required string value.
+    const [defaultBookshelfUrlKey, setDefaultBookshelfUrlKey] = useState("");
+    // The project or branding retrieved from the settings/bookShelfData API.
+    const [project, setProject] = useState("");
+    // First query: get the values of the two states above.
+    useEffect(() => {
+        get("settings/bookShelfData", data => {
+            const pn = data.data.brandingProjectName;
+            setProject(pn === "Default" ? "" : pn);
+            setDefaultBookshelfUrlKey(
+                data.data.defaultBookshelfUrlKey || "none"
+            );
+        });
+    }, []);
+
+    // Second query to get the contentful data
+    const { loading, result, error } = useContentful(
+        project
+            ? {
+                  content_type: "enterpriseSubscription",
+                  select: "fields.collections",
+                  include: 2, // depth: we want the bookshelf collection objects as part of this query
+                  "fields.id": `${project}`
+              }
+            : undefined // no project means we don't want useContentful to do a query
+    );
+
+    let bookshelves: IBookshelf[] = [
+        { value: "none", label: "None", tooltip: "" }
+    ];
+    if (!project) {
+        // If we don't (yet) have a project, we want a completely empty list of options
+        // to leave the combo blank.
+        bookshelves = [];
+    } else if (!loading && result && result.length > 0 && !error) {
+        if (result[0].fields && result[0].fields.collections) {
+            // The test above is needed because, apparently, if the enterpriseSubscription has no collections,
+            // we don't get fields.collections as an empty array; we get nothing at all for collections,
+            // and since that's the only field of the ES that we asked for, the result has 'fields' undefined.
+            // So trying to get result[0].fields.collections will crash.
+            const collections: any[] = result[0].fields.collections;
+            // If all is well and we've completed the contentful query, we got an object that
+            // has a list of collections connected to this branding, and will
+            // now generate the list of menu items (prepending the 'None' we already made).
+            bookshelves = bookshelves.concat(
+                collections.map<{
+                    value: string;
+                    label: string;
+                    tooltip: string;
+                }>((c: any) => ({
+                    value: c.fields.urlKey,
+                    // Note: the "label" here is the "url" key in Contentful. We
+                    //use to use the "label" field for label, but the label may
+                    //be optimized for how it will display, in context, on
+                    //Blorg. E.g. "books with a,b,c,d and e". But the person
+                    //choosing a bookshelf in Bloom Editor may need to also
+                    //select based on language, grade, etc. Example ABC
+                    //Philippines project. These bits of info are to be found in
+                    //the url key, so we switched to using it. If people
+                    //struggle with this, we could introduce a 3rd field just
+                    //for this choosing, like "selector label".
+                    label: c.fields.urlKey,
+                    tooltip: c.fields.label
+                }))
+            );
+        }
+    } else if (defaultBookshelfUrlKey && defaultBookshelfUrlKey !== "none") {
+        // 'bookshelves' already has "none", so don't add another "none".
+        // This will usually be overwritten soon, but if we can't get to contentful
+        // to get the actual list of possibilities we will leave it here.
+        // Note that as we don't yet have any better label, we use defaultBookshelfUrlKey.
+        bookshelves.push({
+            value: defaultBookshelfUrlKey,
+            label: defaultBookshelfUrlKey,
+            tooltip: ""
+        });
+    }
+
+    return {
+        project: project,
+        defaultBookshelfUrlKey: defaultBookshelfUrlKey,
+        validBookshelves: bookshelves,
+        error: error
+    };
+}

--- a/src/BloomBrowserUI/react_components/BloomToolTip.tsx
+++ b/src/BloomBrowserUI/react_components/BloomToolTip.tsx
@@ -157,79 +157,92 @@ export const BloomTooltip: React.FunctionComponent<{
         }
     };
 
+    const hasContent =
+        props.tooltipContent && props.tooltipContent.toString() !== ""
+            ? true
+            : props.tooltipText && props.tooltipText !== ""
+            ? true
+            : false;
+
     return (
-        <div
-            aria-owns={tooltipOpen ? props.id : undefined}
-            aria-haspopup="true"
-            onMouseEnter={handlePopoverOpen}
-            onMouseLeave={handlePopoverClose}
-        >
-            {props.children}
-            <Popover
-                id={"popover-info-tooltip"}
-                css={css`
-                    // This is just an informational popover, we don't need to suppress events outside it.
-                    // Even more importantly, we don't want to prevent the parent control from receiving
-                    // the mouse-move events that would indicate the mouse is no longer over the anchor
-                    // and so the popover should be removed!
-                    pointer-events: none;
-                    .MuiPopover-paper {
-                        // This allows the arrow to be seen. (If instead we try to make the arrow be
-                        // inside the main content area of the popover, it is impossible to get the
-                        // right background color to make the area either side of the arrow look right.
-                        // The popover div is added at the root level so that the whole thing doesn't
-                        // get clipped; therefore, a transparent background doesn't 'see' the thing that
-                        // it seems, visibly, to be on top of. And the background is very variable, as it
-                        // might be over a selected item, an unselected item, the shadow that gets created
-                        // around the popover, a combination of the above...)
-                        overflow: visible !important;
-                    }
-                `}
-                // This might be a better way to do it in material-ui 5? Not in V4 API, but in MUI examples.
-                // sx={{
-                //     pointerEvents: 'none',
-                //   }}
-                open={tooltipOpen}
-                anchorEl={anchorEl}
-                anchorOrigin={anchorOrigin}
-                transformOrigin={transformOrigin}
-                onClose={handlePopoverClose}
-                disableRestoreFocus // most MUI examples have this, not sure what it does.
-            >
-                <Typography
-                    // We need our standard Typography here because when rendered it's not an actual
-                    // child (in the DOM) of the thing its a (React) child of. It gets put in a popover
-                    // at the root level. So we need to pull in our standard text appearance.
-                    component="div"
-                    css={css`
-                        position: relative;
-                    `}
+        <React.Fragment>
+            {hasContent ? (
+                <div
+                    aria-owns={tooltipOpen ? props.id : undefined}
+                    aria-haspopup="true"
+                    onMouseEnter={handlePopoverOpen}
+                    onMouseLeave={handlePopoverClose}
                 >
-                    <div css={arrowCss}></div>
-                    <div
+                    {props.children}
+                    <Popover
+                        id={"popover-info-tooltip"}
                         css={css`
-                            background-color: ${popupBackColor};
-                            color: white;
-                            border-radius: 4px;
-                            padding: 4px 8px;
-                            position: relative;
+                            // This is just an informational popover, we don't need to suppress events outside it.
+                            // Even more importantly, we don't want to prevent the parent control from receiving
+                            // the mouse-move events that would indicate the mouse is no longer over the anchor
+                            // and so the popover should be removed!
+                            pointer-events: none;
+                            .MuiPopover-paper {
+                                // This allows the arrow to be seen. (If instead we try to make the arrow be
+                                // inside the main content area of the popover, it is impossible to get the
+                                // right background color to make the area either side of the arrow look right.
+                                // The popover div is added at the root level so that the whole thing doesn't
+                                // get clipped; therefore, a transparent background doesn't 'see' the thing that
+                                // it seems, visibly, to be on top of. And the background is very variable, as it
+                                // might be over a selected item, an unselected item, the shadow that gets created
+                                // around the popover, a combination of the above...)
+                                overflow: visible !important;
+                            }
                         `}
+                        // This might be a better way to do it in material-ui 5? Not in V4 API, but in MUI examples.
+                        // sx={{
+                        //     pointerEvents: 'none',
+                        //   }}
+                        open={tooltipOpen}
+                        anchorEl={anchorEl}
+                        anchorOrigin={anchorOrigin}
+                        transformOrigin={transformOrigin}
+                        onClose={handlePopoverClose}
+                        disableRestoreFocus // most MUI examples have this, not sure what it does.
                     >
-                        {props.tooltipContent ? (
-                            props.tooltipContent
-                        ) : (
-                            <Div
-                                l10nKey={props.tooltipL10nKey ?? ""}
+                        <Typography
+                            // We need our standard Typography here because when rendered it's not an actual
+                            // child (in the DOM) of the thing its a (React) child of. It gets put in a popover
+                            // at the root level. So we need to pull in our standard text appearance.
+                            component="div"
+                            css={css`
+                                position: relative;
+                            `}
+                        >
+                            <div css={arrowCss}></div>
+                            <div
                                 css={css`
-                                    max-width: 200px;
+                                    background-color: ${popupBackColor};
+                                    color: white;
+                                    border-radius: 4px;
+                                    padding: 4px 8px;
+                                    position: relative;
                                 `}
                             >
-                                {props.tooltipText}
-                            </Div>
-                        )}
-                    </div>
-                </Typography>
-            </Popover>
-        </div>
+                                {props.tooltipContent ? (
+                                    props.tooltipContent
+                                ) : (
+                                    <Div
+                                        l10nKey={props.tooltipL10nKey ?? ""}
+                                        css={css`
+                                            max-width: 200px;
+                                        `}
+                                    >
+                                        {props.tooltipText}
+                                    </Div>
+                                )}
+                            </div>
+                        </Typography>
+                    </Popover>
+                </div>
+            ) : (
+                <React.Fragment>{props.children}</React.Fragment>
+            )}
+        </React.Fragment>
     );
 };

--- a/src/BloomBrowserUI/react_components/DefaultBookshelfControl.tsx
+++ b/src/BloomBrowserUI/react_components/DefaultBookshelfControl.tsx
@@ -2,13 +2,13 @@
 import { jsx, css } from "@emotion/react";
 
 import * as React from "react";
-import { useState } from "react";
-import { get, postString } from "../utils/bloomApi";
+import { useEffect, useState } from "react";
+import { postString } from "../utils/bloomApi";
 import { lightTheme, kBloomYellow } from "../bloomMaterialUITheme";
 import { ThemeProvider, StyledEngineProvider } from "@mui/material/styles";
 import { MenuItem, Select, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { useContentful } from "../contentful/UseContentful";
+import { useGetEnterpriseBookshelves } from "../collection/useGetEnterpriseBookshelves";
 import { BloomEnterpriseIcon } from "./requiresBloomEnterprise";
 import { useL10n } from "./l10nHooks";
 
@@ -16,98 +16,20 @@ import { useL10n } from "./l10nHooks";
 // of the "Book Making" tab of the Settings dialog.
 
 export const DefaultBookshelfControl: React.FunctionComponent = () => {
-    // Things get tricky because we have to run two queries here to get the
-    // data we need, and the second depends on the results of the first.
-    // Doing this under the rules of hooks is difficult. The first query is
-    // to our local server, and obtains the project's branding name and any
-    // current default bookshelf. The second uses the project branding info
-    // to retrieve the actual contentful Enterprise Subscription
-    // complete with references to the collections we want.
-    // Besides keeping straight which of these queries has and has not completed,
-    // we must handle special cases when we cannot retrieve data from contentful
-    // and when we the user has no enterprise subscription and can't use this
-    // feature.
+    const [projectBookshelfUrlKey, setProjectBookshelfUrlKey] = useState("");
 
-    // The defaultShelf retrieved from the settings/bookShelfData API, or 'none'
-    // if defaultShelf is falsy. Using 'none' as the value here in this control
-    // allows us to show a label 'None' when nothing is selected; passing it as
-    // the value when that option is chosen allows us to get around a restricion
-    // in our API which does not allow an empty string as the value of a
-    // required string value.
-    const [defaultBookshelfUrlKey, setDefaultBookshelfUrlKey] = useState("");
-    // The project or branding retrieved from the settings/bookShelfData API.
-    const [project, setProject] = useState("");
-    // First query: get the values of the two states above.
-    React.useEffect(() => {
-        get("settings/bookShelfData", data => {
-            const pn = data.data.brandingProjectName;
-            setProject(pn === "Default" ? "" : pn);
-            setDefaultBookshelfUrlKey(
-                data.data.defaultBookshelfUrlKey || "none"
-            );
-        });
-    }, []);
+    const {
+        project, // not needed here, but we'll need it elsewhere.
+        defaultBookshelfUrlKey,
+        validBookshelves,
+        error
+    } = useGetEnterpriseBookshelves();
 
-    // Second query to get the contentful data
-    const { loading, result, error } = useContentful(
-        project
-            ? {
-                  content_type: "enterpriseSubscription",
-                  select: "fields.collections",
-                  include: 2, // depth: we want the bookshelf collection objects as part of this query
-                  "fields.id": `${project}`
-              }
-            : undefined // no project means we don't want useContentful to do a query
-    );
+    useEffect(() => {
+        setProjectBookshelfUrlKey(defaultBookshelfUrlKey);
+    }, [defaultBookshelfUrlKey]);
 
-    let bookshelves = [{ value: "none", label: "None", tooltip: "" }];
-    if (!project) {
-        // If we don't (yet) have a project, we want a completely empty list of options
-        // to leave the combo blank.
-        bookshelves = [];
-    } else if (!loading && result && result.length > 0 && !error) {
-        if (result[0].fields && result[0].fields.collections) {
-            // The test above is needed because, apparently, if the enterpriseSubscription has no collections,
-            // we don't get fields.collections as an empty array; we get nothing at all for collections,
-            // and since that's the only field of the ES that we asked for, the result has 'fields' undefined.
-            // So trying to get result[0].fields.collections will crash.
-            const collections: any[] = result[0].fields.collections;
-            // If all is well and we've completed the contentful query, we got an object that
-            // has a list of collections connected to this branding, and will
-            // now generate the list of menu items (prepending the 'None' we already made).
-            bookshelves = bookshelves.concat(
-                collections.map<{
-                    value: string;
-                    label: string;
-                    tooltip: string;
-                }>((c: any) => ({
-                    value: c.fields.urlKey,
-                    // Note: the "label" here is the "url" key in Contentful. We
-                    //use to use the "label" field for label, but the label may
-                    //be optimized for how it will display, in context, on
-                    //Blorg. E.g. "books with a,b,c,d and e". But the person
-                    //choosing a bookshelf in Bloom Editor may need to also
-                    //select based on language, grade, etc. Example ABC
-                    //Philippines project. These bits of info are to be found in
-                    //the url key, so we switched to using it. If people
-                    //struggle with this, we could introduce a 3rd field just
-                    //for this choosing, like "selector label".
-                    label: c.fields.urlKey,
-                    tooltip: c.fields.label
-                }))
-            );
-        }
-    } else if (defaultBookshelfUrlKey) {
-        // This will usually be overwritten soon, but if we can't get to contentful
-        // to get the actual list of possibilities we will leave it here.
-        // Note that as we don't yet have any better label, we use defaultShelf.
-        bookshelves.push({
-            value: defaultBookshelfUrlKey,
-            label: defaultBookshelfUrlKey,
-            tooltip: ""
-        });
-    }
-    const items = bookshelves.map(x => (
+    const items = validBookshelves.map(x => (
         <MenuItem key={x.value} value={x.value} title={x.tooltip}>
             {x.label}
         </MenuItem>
@@ -123,7 +45,7 @@ export const DefaultBookshelfControl: React.FunctionComponent = () => {
     );
 
     const errorCaseDescription = useL10n(
-        "Bloom could not reach server to get the list of bookshelves.",
+        "Bloom could not reach the server to get the list of bookshelves.",
         "CollectionSettingsDialog.BookMakingTab.NoBookshelvesFromServer",
         undefined,
         undefined,
@@ -229,7 +151,7 @@ export const DefaultBookshelfControl: React.FunctionComponent = () => {
                             }
                         `}
                         variant="standard"
-                        value={defaultBookshelfUrlKey}
+                        value={projectBookshelfUrlKey}
                         MenuProps={{
                             classes: { paper: classes.select },
                             anchorOrigin: {
@@ -242,10 +164,12 @@ export const DefaultBookshelfControl: React.FunctionComponent = () => {
                             }
                         }}
                         // If we can't get the options from contentful, or there are none, disable.
-                        disabled={!result || result.length == 0}
+                        disabled={
+                            !validBookshelves || validBookshelves.length == 0
+                        }
                         onChange={event => {
                             const newShelf = event.target.value as string;
-                            setDefaultBookshelfUrlKey(newShelf);
+                            setProjectBookshelfUrlKey(newShelf);
                             postString("settings/bookShelfData", newShelf);
                         }}
                     >

--- a/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
+++ b/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
@@ -54,8 +54,15 @@ const menuItemColor = "black";
 
 export const LocalizableMenuItem: React.FunctionComponent<ILocalizableMenuItemProps> = props => {
     const label = useL10n(props.english, props.l10nId);
+    // BL-10638 In the case of an expired subscription code, 'useEnterpriseAvailable()` returns false,
+    // but `useGetEnterpriseStatus()` returns "Subscription". That state of things is useful for the
+    // CollectionSettingsDialog, but not here in menu items. The absence of enterpriseAvailable needs to
+    // take precedence. But by rules of hooks we still need to run the hook and then modify the value.
     const enterpriseAvailable = useEnterpriseAvailable();
-    const enterpriseStatus = useGetEnterpriseStatus();
+    let enterpriseStatus = useGetEnterpriseStatus();
+    if (!enterpriseAvailable) {
+        enterpriseStatus = "None";
+    }
 
     const meetsEnterpriseRequirement = props.requiresEnterpriseSubscription
         ? enterpriseStatus === "Subscription"

--- a/src/BloomExe/ApplicationContainer.cs
+++ b/src/BloomExe/ApplicationContainer.cs
@@ -34,7 +34,7 @@ namespace Bloom
 
 				builder.Register(c => LocalizationManager).SingleInstance();
 				
-			if (Settings.Default.MruProjects==null)
+				if (Settings.Default.MruProjects==null)
 				{
 					Settings.Default.MruProjects = new MostRecentPathsList();
 				}

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -413,7 +413,6 @@ namespace Bloom.Collection
 				OneTimeCheckVersionNumber = ReadInteger(xml, "OneTimeCheckVersionNumber", 0);
 				BrandingProjectKey = ReadString(xml, "BrandingProjectName", "Default");
 				SubscriptionCode = ReadString(xml, "SubscriptionCode", null);
-
 				if (BrandingProjectKey != "Default" && BrandingProjectKey != "Local-Community" && !Program.RunningHarvesterMode)
 				{
 					// Validate branding, so things can't be circumvented by just typing something random into settings

--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -198,7 +198,15 @@ namespace Bloom.WebLibraryIntegration
 
 			if (!String.IsNullOrEmpty(collectionSettings?.DefaultBookshelf))
 			{
-				tags = tags.Concat(new [] {"bookshelf:" + collectionSettings.DefaultBookshelf});
+				if (collectionSettings.HaveEnterpriseFeatures)
+					tags = tags.Concat(new [] {"bookshelf:" + collectionSettings.DefaultBookshelf});
+				else
+				{
+					// At least at this point, we aren't localizing this message, because the people with Enterprise
+					// bookshelves likely know enough English to understand this message.
+					progress.WriteWarning("This book was not uploaded to the '" + collectionSettings.DefaultBookshelf +
+						"' bookshelf. Uploading to a bookshelf requires a valid Enterprise subscription.");
+				}
 			}
 			metadata.Tags = tags.ToArray();
 

--- a/src/BloomExe/web/controllers/LibraryPublishApi.cs
+++ b/src/BloomExe/web/controllers/LibraryPublishApi.cs
@@ -5,11 +5,9 @@ using Bloom.WebLibraryIntegration;
 using Bloom.Workspace;
 using SIL.Progress;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using Bloom.Collection;
 
 namespace Bloom.web.controllers
 {


### PR DESCRIPTION
* ApplicationContainer.cs and CollectionSettings.cs
   changes are just white-space.
* If Enterprise code changes, clear out Bookshelf unless
   the branding is still the same
* pull out custom hook to get current project and any
   associated bookshelves.
* put a progress warning in book upload, if there is not a
   valid subscription code, but a bookshelf is in the settings.
* disable menu items if they only apply to an expired code
* add a tooltip to BloomSplitButton that works when it is
   disabled
* disable the Upload button and put up an explanatory
   tooltip if the calls to the api error out or if the collection
   settings specify a bookshelf that isn't a valid one for the
   current (active) subscription (should be very rare)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5764)
<!-- Reviewable:end -->
