### PR TITLE
Remove the bright red WV2 label from the browser windows (BL-12085)

### DIFF
--- a/src/BloomExe/IBrowser.cs
+++ b/src/BloomExe/IBrowser.cs
@@ -66,20 +66,6 @@ namespace Bloom
 		public ControlKeyEvent ControlKeyEvent { get; set; }
 		int VerticalScrollDistance { get; set; }
 
-		public void FinishInitializing()
-		{
-			if (!Program.ShowDevelopmentOnlyUI)
-			{
-				// It would be more natural to default to hide and then show in this case,
-				// but that ends up positioning the labels in a different location.
-				// As this is temporary, it didn't seem worth bothering figuring it out.
-				// And I've never seen it flicker.
-				HideTemporaryLabelForDevelopment();
-			}
-		}
-
-		public abstract void HideTemporaryLabelForDevelopment();
-
 		public abstract void EnsureHandleCreated();
 
 		public event EventHandler BrowserReady;

--- a/src/BloomExe/WebView2Browser.Designer.cs
+++ b/src/BloomExe/WebView2Browser.Designer.cs
@@ -29,7 +29,6 @@ namespace Bloom
 		private void InitializeComponent()
 		{
             this._webview = new Microsoft.Web.WebView2.WinForms.WebView2();
-            this.label1 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this._webview)).BeginInit();
             this.SuspendLayout();
             // 
@@ -45,25 +44,11 @@ namespace Bloom
             this._webview.TabIndex = 0;
             this._webview.ZoomFactor = 1D;
             // 
-            // label1
-            // 
-            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.AutoSize = true;
-            this.label1.BackColor = System.Drawing.Color.Red;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.ForeColor = System.Drawing.Color.White;
-            this.label1.Location = new System.Drawing.Point(86, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(31, 13);
-            this.label1.TabIndex = 1;
-            this.label1.Text = "WV2";
-            // 
             // WebView2Browser
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.ActiveCaption;
-            this.Controls.Add(this.label1);
             this.Controls.Add(this._webview);
             this.Name = "WebView2Browser";
             ((System.ComponentModel.ISupportInitialize)(this._webview)).EndInit();
@@ -75,6 +60,5 @@ namespace Bloom
 		#endregion
 
 		private Microsoft.Web.WebView2.WinForms.WebView2 _webview;
-		private System.Windows.Forms.Label label1;
 	}
 }

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -61,13 +61,6 @@ namespace Bloom
 
 				_readyToNavigate = true;
 			};
-
-			FinishInitializing();
-		}
-
-		public override void HideTemporaryLabelForDevelopment()
-		{
-			label1.Visible = false;
 		}
 
 		private void ContextMenuRequested(object sender, CoreWebView2ContextMenuRequestedEventArgs e)


### PR DESCRIPTION
Maybe not part of the issue exactly, but seems like an obvious leftover from removing Geckofx which was.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5774)
<!-- Reviewable:end -->
