### PR TITLE
BL-10638 Reset bookshelf when switching status

### DIFF
--- a/src/BloomBrowserUI/react_components/DefaultBookshelfControl.tsx
+++ b/src/BloomBrowserUI/react_components/DefaultBookshelfControl.tsx
@@ -35,6 +35,11 @@ export const DefaultBookshelfControl: React.FunctionComponent = () => {
         </MenuItem>
     ));
 
+    const disableControl =
+        !validBookshelves ||
+        validBookshelves.length === 0 ||
+        (validBookshelves.length === 1 && validBookshelves[0].value === "none");
+
     const BLBookshelfLabel = useL10n(
         "Bloom Library Bookshelf",
         "CollectionSettingsDialog.BloomLibraryBookshelf",
@@ -164,9 +169,7 @@ export const DefaultBookshelfControl: React.FunctionComponent = () => {
                             }
                         }}
                         // If we can't get the options from contentful, or there are none, disable.
-                        disabled={
-                            !validBookshelves || validBookshelves.length == 0
-                        }
+                        disabled={disableControl}
                         onChange={event => {
                             const newShelf = event.target.value as string;
                             setProjectBookshelfUrlKey(newShelf);

--- a/src/BloomExe/web/controllers/CollectionSettingsApi.cs
+++ b/src/BloomExe/web/controllers/CollectionSettingsApi.cs
@@ -90,9 +90,11 @@ namespace Bloom.web.controllers
 					if (_enterpriseStatus == EnterpriseStatus.None)
 					{
 						_knownBrandingInSubscriptionCode = true;
+						ResetBookshelf();
 						BrandingChangeHandler("Default", null);
 					} else if (_enterpriseStatus == EnterpriseStatus.Community)
 					{
+						ResetBookshelf();
 						BrandingChangeHandler("Local-Community", null);
 					}
 					else
@@ -120,10 +122,9 @@ namespace Bloom.web.controllers
 					// generally want to clear out the Bookshelf. But if the BrandingKey is the same as the old one,
 					// we'll leave it alone, since they probably renewed for another year or so and want to use the
 					// same bookshelf.
-					if (DialogBeingEdited != null &&
-						SubscriptionCode != _collectionSettings.SubscriptionCode &&
+					if (SubscriptionCode != _collectionSettings.SubscriptionCode &&
 						newBranding != oldBranding)
-							DialogBeingEdited.PendingDefaultBookshelf = "";
+							ResetBookshelf();
 					if (_enterpriseExpiry < DateTime.Now) // expired or invalid
 					{
 						BrandingChangeHandler("Default", null);
@@ -264,6 +265,12 @@ namespace Bloom.web.controllers
 
 			apiHandler.RegisterEndpointHandler(kApiUrlPart + "getCustomPaletteColors", HandleGetCustomColorsRequest, false);
 			apiHandler.RegisterEndpointHandler(kApiUrlPart + "addCustomPaletteColor", HandleAddCustomColor, false);
+		}
+
+		private void ResetBookshelf()
+		{
+			if (DialogBeingEdited != null)
+				DialogBeingEdited.PendingDefaultBookshelf = "";
 		}
 
 		private void HandleGetCustomColorsRequest(ApiRequest request)


### PR DESCRIPTION
* handles the case of down-grading to Local Community or
   None Enterprise status
* disable bookshelf control if the only option is "none"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5777)
<!-- Reviewable:end -->
