### PR TITLE
Fix bug in "deshrouding" phrase markers for talking book tool (BL-11632)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -2497,7 +2497,10 @@ export default class AudioRecording {
         }
     }
 
-    public async newPageReady(imageDescToolActive: boolean): Promise<void> {
+    public async newPageReady(
+        imageDescToolActive: boolean,
+        deshroudPhraseDelimiters?: (page: HTMLElement | null) => void
+    ): Promise<void> {
         // Changing the page causes the previous page's audio to stop playing (be "emptied").
         ++this.currentAudioSessionNum;
 
@@ -2521,6 +2524,8 @@ export default class AudioRecording {
             // no editable text on this page.
             return this.changeStateAndSetExpectedAsync("");
         } else {
+            if (deshroudPhraseDelimiters)
+                deshroudPhraseDelimiters(this.getPageDocBody());
             await this.setupAndUpdateMarkupAsync();
 
             // See comment on this method.

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBook.ts
@@ -48,10 +48,8 @@ export default class TalkingBookTool implements ITool {
     public async newPageReady(): Promise<void> {
         this.showImageDescriptionsIfAny();
         const pageReadyPromise = AudioRecorder.theOneAudioRecorder.newPageReady(
-            this.isImageDescriptionToolActive()
-        );
-        pageReadyPromise.then(() =>
-            TalkingBookTool.deshroudPhraseDelimiters(ToolBox.getPage())
+            this.isImageDescriptionToolActive(),
+            TalkingBookTool.deshroudPhraseDelimiters
         );
         return pageReadyPromise;
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5783)
<!-- Reviewable:end -->
