### PR TITLE
BL-12116 More Polite Preview pane

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1096,6 +1096,7 @@
         <source xml:lang="en">Refresh</source>
         <note>ID: Common.Refresh</note>
         <note>Sense of refreshing a web page.</note>
+        <note>Obsolete as of Bloom 5.5</note>
       </trans-unit>
       <trans-unit id="Common.Replace">
         <source xml:lang="en">Replace</source>

--- a/src/BloomBrowserUI/publish/commonPublish/DeviceAndControls.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/DeviceAndControls.tsx
@@ -3,12 +3,8 @@ import { jsx, css } from "@emotion/react";
 import * as React from "react";
 import "./DeviceFrame.less";
 import { useState, useEffect } from "react";
-import { useL10n } from "../../react_components/l10nHooks";
 import { useDrawAttention } from "../../react_components/UseDrawAttention";
-import { useTheme, Theme, Typography } from "@mui/material";
-import IconButton from "@mui/material/IconButton";
-import RefreshIcon from "@mui/icons-material/Refresh";
-
+import BloomButton from "../../react_components/bloomButton";
 /*
   Example usage:
   <DeviceFrame defaultLandscape={true}>
@@ -16,26 +12,42 @@ import RefreshIcon from "@mui/icons-material/Refresh";
   </DeviceFrame>
 */
 
+const commonDeviceFrameCss = `
+background: rgb(241, 241, 241);
+// Our width & height are sizing the screen (the glass). All the bezel and stuff doesn't count.
+box-sizing: content-box;
+border-width: 10px;
+border-style: solid;
+border-color: #636363;
+border-top-width: 20px;
+border-bottom-width: 20px;
+border-radius: 15px;
+position: relative;
+flex-direction: column;
+flex-shrink: 0;
+display: flex !important;
+transition: all 200ms;
+`;
+
 export const DeviceAndControls: React.FunctionComponent<{
     defaultLandscape: boolean;
     canRotate: boolean;
     url: string;
     iframeClass?: string;
-    showRefresh?: boolean;
-    highlightRefreshIcon?: boolean;
-    onRefresh?: () => void;
+    showPreviewButton?: boolean;
+    highlightPreviewButton?: boolean;
+    onPreviewButtonClicked?: () => void;
 }> = props => {
     const [landscape, setLandscape] = useState(props.defaultLandscape);
-    const theme: Theme = useTheme();
+
     useEffect(() => {
         setLandscape(props.defaultLandscape);
     }, [props]);
-    const refreshText = useL10n("Refresh", "Common.Refresh");
 
     const attentionClass = useDrawAttention(
-        props.highlightRefreshIcon ? 1 : 0,
+        props.highlightPreviewButton ? 1 : 0,
         () => {
-            return !props.highlightRefreshIcon;
+            return !props.highlightPreviewButton;
         }
     );
 
@@ -44,68 +56,81 @@ export const DeviceAndControls: React.FunctionComponent<{
             className="deviceAndControls"
             css={css`
                 min-width: 400px;
+                display: flex;
+                flex-direction: column;
             `}
         >
+            {props.showPreviewButton && (
+                <div
+                    css={css`
+                        display: flex;
+                        flex-direction: row;
+                        padding: 15px 0;
+                        // It seems counter-intuitive to put a height on this row, but if we don't, the
+                        // "large" orientation buttons that are scaled down, take up the whole rest of the
+                        // screen, throwing off the layout of the preview below.
+                        height: ${props.canRotate ? "70px" : "40px"};
+                    `}
+                    className={
+                        "preview-controls-row" +
+                        (landscape ? " landscape" : "") +
+                        (props.canRotate ? " with-orientation-buttons" : "")
+                    }
+                >
+                    <BloomButton
+                        aria-label="refresh preview"
+                        className={"refresh-icon " + attentionClass}
+                        css={css`
+                            min-width: 120px;
+                            height: 40px;
+                        `}
+                        l10nKey="Common.Preview"
+                        enabled={true}
+                        onClick={() => props.onPreviewButtonClicked?.()}
+                        hasText={true}
+                        size="large"
+                    >
+                        Preview
+                    </BloomButton>
+                    {props.canRotate && (
+                        <React.Fragment>
+                            <OrientationButton
+                                selected={!landscape}
+                                landscape={false}
+                                onClick={() => setLandscape(false)}
+                            />
+                            <OrientationButton
+                                selected={landscape}
+                                landscape={true}
+                                onClick={() => setLandscape(true)}
+                            />
+                        </React.Fragment>
+                    )}
+                </div>
+            )}
             <div
+                // Need a small tweak here if we have orientation buttons above us.
+                css={css`
+                    ${commonDeviceFrameCss}
+                    ${props.canRotate ? "margin-top: -15px;" : ""}
+                `}
                 className={
                     "deviceFrame fullSize " +
                     (landscape ? "landscape" : "portrait")
                 }
             >
                 <iframe
+                    css={css`
+                        background-color: black;
+                        border: none;
+                        flex-shrink: 0; // without this, the height doesn't grow
+                        transform-origin: top left;
+                    `}
                     title="book preview"
                     src={props.url}
                     className={props.iframeClass}
                 />
             </div>
-            {props.canRotate && (
-                <React.Fragment>
-                    <OrientationButton
-                        selected={!landscape}
-                        landscape={false}
-                        onClick={() => setLandscape(false)}
-                    />
-                    <OrientationButton
-                        selected={landscape}
-                        landscape={true}
-                        onClick={() => setLandscape(true)}
-                    />
-                </React.Fragment>
-            )}
-            {props.showRefresh && (
-                <div
-                    className={
-                        "refresh-button-row" +
-                        (landscape ? " landscape" : "") +
-                        (props.canRotate ? " with-orientation-buttons" : "")
-                    }
-                    onClick={() => props.onRefresh && props.onRefresh()}
-                >
-                    <IconButton
-                        aria-label="refresh preview"
-                        className={"refresh-icon " + attentionClass}
-                        size="large"
-                    >
-                        <RefreshIcon
-                            fontSize="large"
-                            htmlColor={
-                                props.highlightRefreshIcon
-                                    ? theme.palette.primary.main
-                                    : theme.palette.text.secondary
-                            }
-                        />
-                    </IconButton>
-                    <Typography
-                        color={
-                            props.highlightRefreshIcon
-                                ? "primary"
-                                : "textSecondary"
-                        }
-                    >
-                        {refreshText}
-                    </Typography>
-                </div>
-            )}
         </div>
     );
 };
@@ -116,15 +141,17 @@ const OrientationButton: React.FunctionComponent<{
     onClick: (landscape: boolean) => void;
 }> = props => (
     <div
+        css={css`
+            ${commonDeviceFrameCss}
+            margin-top: -10px;
+            margin-left: -55px;
+        `}
         className={
             "deviceFrame orientation-button " +
-            //  (props.selected ? "disabled " : "") +
             (props.landscape ? "landscape" : "portrait")
         }
         onClick={() => {
-            //if (!props.selected) {
             props.onClick(props.landscape);
-            //}
         }}
     >
         <div className={props.selected ? "selectedOrientation" : ""} />

--- a/src/BloomBrowserUI/publish/commonPublish/DeviceFrame.less
+++ b/src/BloomBrowserUI/publish/commonPublish/DeviceFrame.less
@@ -10,7 +10,7 @@
 @scale: 25;
 @screenWidth: 9px * @scale;
 @screenHeight: 16px * @scale;
-@buttonScale: 0.2;
+@buttonScale: 0.15;
 // gets filled by the components children, if there are any
 
 // Desktop pixels are much larger, so things come out bloated.
@@ -18,81 +18,19 @@
 // then shrink it all.
 @pixelDensityMultiplier: 2;
 
-// These first few rules actually apply to other elements of the deviceAndControls, outside the
-// various device frames.
-.deviceAndControls {
-    display: flex;
-    flex-direction: row;
-
-    .refresh-button-row {
-        // The elements of the deviceAndControls are displayed as a flex row.
-        // the refresh-button-row is an optional extra child.
-        // It doesn't actually want to be in the row, but rather, aligned below the
-        // left orientation button and right of the bottom of the preview.
-        // But the actual positions of the other three elements are a complex
-        // function of transforms involving both scale and position.
-        // Rather than try to figure out some way of re-organizing the row into
-        // nested rows and columns, it's easier just to use yet another transform
-        // to put this one where we want it, even though it takes two more rules
-        // below to put it in different places when there are orientation buttons
-        // and/or we're in landscape
-        transform: translate(220px, 420px); // landscape, no rotation buttons
-        display: flex;
-        flex-direction: row;
-        cursor: pointer;
-        .refresh-icon {
-            padding: 0;
-            height: 1.7em;
-            width: 1.7em;
-            margin-top: -8px;
-        }
-        &.with-orientation-buttons {
-            transform: translate(-332px, 420px); // portrait, rotation buttons
-            &.landscape {
-                transform: translate(
-                    -332px,
-                    225px
-                ); // landscape, rotation buttons
-            }
-        }
-        &.landscape {
-            transform: translate(220px, 225px); // portrait, no rotation buttons
-        }
-        // We don't know why this gets the height of its parent, but it does without this.
-        // We need to limit the height so we don't get extraneous vertical scroll bars.
-        height: 50px;
-    }
-}
-
 .deviceFrame {
-    background: rgb(241, 241, 241);
-    box-sizing: content-box; // Our width & height are sizing the screen (the glass). All the bezel and stuff doesn't count.
     width: @screenWidth;
     height: @screenHeight;
-    border-width: @bezelWidth;
-    border-style: solid;
-    border-color: #636363;
-    border-top-width: 20px;
-    border-bottom-width: 20px;
-    border-radius: 15px;
-
-    position: relative;
-    flex-direction: column;
-    flex-shrink: 0;
-
-    display: flex !important;
     --scale: 1;
 
     &.orientation-button {
         --scale: @buttonScale;
         transform-origin: top;
         &.portrait {
-            margin-right: -60px;
-            margin-left: 150px;
-            transform: translate(0, 65px) scale(@buttonScale);
+            transform: scale(@buttonScale);
         }
         &.landscape {
-            transform: translate(0, 117px) rotate(-90deg /*counter clockwise*/)
+            transform: translate(0, 50px) rotate(-90deg /*counter clockwise*/)
                 scale(@buttonScale);
         }
         &.disabled {
@@ -107,19 +45,9 @@
             border-width: 7px;
         }
     }
-    transition: all 200ms;
-
-    iframe {
-        background-color: black;
-
-        border: none;
-
-        flex-shrink: 0; // without this, the height doesn't grow
-        transform-origin: top left;
-    }
     &.portrait {
         &.fullSize {
-            transform: translate(143px, 0);
+            transform: translate(80px, 0px);
         }
         iframe {
             width: @pixelDensityMultiplier * 100% !important;
@@ -130,8 +58,8 @@
 
     &.landscape {
         transform-origin: top left;
-        transform: translate(0, @screenWidth+ (2 * @bezelWidth) /* down*/)
-            rotate(-90deg /*counter clockwise*/) scale(var(--scale));
+        transform: translate(0, 245px) rotate(-90deg /*counter clockwise*/)
+            scale(var(--scale));
         /*@bezelWidth*/
         iframe {
             height: (@pixelDensityMultiplier * 900% / 16); //  9/16

--- a/src/BloomBrowserUI/publish/commonPublish/PublishScreenBaseComponents.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/PublishScreenBaseComponents.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import Typography from "@mui/material/Typography";
 import "./PublishScreenBaseComponents.less";
 import { LocalizedString } from "../../react_components/l10nComponents";
+import { kOptionPanelBackgroundColor } from "../../bloomMaterialUITheme";
 
 // This file contains a collection of components which works together with the PublishScreenTemplate
 // to create the basic layout of a publishing screen in Bloom.
@@ -14,12 +15,7 @@ export const PreviewPanel: React.FunctionComponent<{
     return (
         <section
             css={css`
-                background: radial-gradient(
-                        641.32px at 29.05% 29.83%,
-                        rgba(112, 112, 112, 0) 0%,
-                        #0c0c0c 100%
-                    ),
-                    #2d2d2d;
+                background-color: ${kOptionPanelBackgroundColor};
                 padding-left: 20px;
                 padding-top: 10px;
                 box-sizing: border-box;

--- a/src/BloomBrowserUI/publish/ePUBPublish/ePUBPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ePUBPublish/ePUBPublishScreen.tsx
@@ -11,7 +11,7 @@ import {
 import PublishScreenTemplate from "../commonPublish/PublishScreenTemplate";
 import { DeviceAndControls } from "../commonPublish/DeviceAndControls";
 import * as ReactDOM from "react-dom";
-import { darkTheme, lightTheme } from "../../bloomMaterialUITheme";
+import { lightTheme } from "../../bloomMaterialUITheme";
 import { StorybookContext } from "../../.storybook/StoryBookContext";
 import {
     useSubscribeToWebSocketForStringMessage,
@@ -31,7 +31,7 @@ import {
     useWatchBooleanEvent
 } from "../../utils/bloomApi";
 import { NoteBox } from "../../react_components/BloomDialog/commonDialogComponents";
-import { Div, P } from "../../react_components/l10nComponents";
+import { P } from "../../react_components/l10nComponents";
 import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
 
 export const EPUBPublishScreen = () => {
@@ -60,6 +60,7 @@ export const EPUBPublishScreen = () => {
             onReset={() => {
                 setKeyForReset(keyForReset + 1);
             }}
+            showPreview={keyForReset > 0}
             epubMode={epubMode}
             setEpubMode={(mode: string) => {
                 setEpubmode(mode);
@@ -71,13 +72,15 @@ export const EPUBPublishScreen = () => {
 
 const EPUBPublishScreenInternal: React.FunctionComponent<{
     onReset: () => void;
+    showPreview: boolean;
     epubMode: string;
     setEpubMode: (mode: string) => void;
 }> = props => {
     const inStorybookMode = useContext(StorybookContext);
     const [closePending, setClosePending] = useState(false);
     const [highlightRefresh, setHighlightRefresh] = useState(false);
-    const [progressState, setProgressState] = useState(ProgressState.Working);
+    // Starting in ProgressState.Done hides the progress dialog initially.
+    const [progressState, setProgressState] = useState(ProgressState.Done);
     const [bookUrl, setBookUrl] = useState(
         inStorybookMode
             ? window.location.protocol +
@@ -205,28 +208,14 @@ const EPUBPublishScreenInternal: React.FunctionComponent<{
                 </div>
             </PublishPanel>
             <PreviewPanel>
-                <StyledEngineProvider injectFirst>
-                    <ThemeProvider theme={darkTheme}>
-                        <Div
-                            css={css`
-                                color: white;
-                                font-weight: bold;
-                                flex-shrink: 1;
-                            `}
-                            l10nKey="Common.Preview"
-                        >
-                            Preview
-                        </Div>
-                        <DeviceAndControls
-                            defaultLandscape={landscape}
-                            canRotate={false}
-                            url={bookUrl}
-                            showRefresh={true}
-                            highlightRefreshIcon={highlightRefresh}
-                            onRefresh={() => props.onReset()}
-                        />
-                    </ThemeProvider>
-                </StyledEngineProvider>
+                <DeviceAndControls
+                    defaultLandscape={landscape}
+                    canRotate={false}
+                    url={bookUrl}
+                    showPreviewButton={true}
+                    highlightPreviewButton={highlightRefresh}
+                    onPreviewButtonClicked={() => props.onReset()}
+                />
             </PreviewPanel>
         </div>
     );
@@ -248,6 +237,11 @@ const EPUBPublishScreenInternal: React.FunctionComponent<{
         </SettingsPanel>
     );
 
+    const creatingHeading = useL10n(
+        "Creating ePUB",
+        "PublishTab.Epub.Creating"
+    );
+
     return (
         <React.Fragment>
             <PublishScreenTemplate
@@ -259,15 +253,17 @@ const EPUBPublishScreenInternal: React.FunctionComponent<{
             >
                 {mainPanel}
             </PublishScreenTemplate>
-            <PublishProgressDialog
-                heading={useL10n("Creating ePUB", "PublishTab.Epub.Creating")}
-                webSocketClientContext="publish-epub"
-                startApiEndpoint="publish/epub/updatePreview"
-                progressState={progressState}
-                setProgressState={setProgressState}
-                closePending={closePending}
-                setClosePending={setClosePending}
-            />
+            {props.showPreview && (
+                <PublishProgressDialog
+                    heading={creatingHeading}
+                    webSocketClientContext="publish-epub"
+                    startApiEndpoint="publish/epub/updatePreview"
+                    progressState={progressState}
+                    setProgressState={setProgressState}
+                    closePending={closePending}
+                    setClosePending={setClosePending}
+                />
+            )}
             <BookMetadataDialog />
         </React.Fragment>
     );

--- a/src/BloomBrowserUI/publish/stories.tsx
+++ b/src/BloomBrowserUI/publish/stories.tsx
@@ -94,7 +94,7 @@ storiesOf("Publish/DeviceFrame", module)
             defaultLandscape={true}
             canRotate={false}
             url=""
-            showRefresh={true}
+            showPreviewButton={true}
         >
             Landscape
         </DeviceAndControls>
@@ -104,8 +104,8 @@ storiesOf("Publish/DeviceFrame", module)
             defaultLandscape={true}
             canRotate={false}
             url=""
-            showRefresh={true}
-            highlightRefreshIcon={true}
+            showPreviewButton={true}
+            highlightPreviewButton={true}
         >
             Landscape
         </DeviceAndControls>


### PR DESCRIPTION
* Don't auto start preview; wait for button click
* Fix up layout of preview and orientation buttons
* Move some basic CSS to Emotion
* Leave BPlayer preview blank until Preview button is
   pressed (it actually doesn't even load BPlayer)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5791)
<!-- Reviewable:end -->
