### PR TITLE
Fix sticky ui-audioCurrent class in dataDiv values (BL-12094)

### DIFF
--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -1436,6 +1436,13 @@ namespace Bloom.Book
 					var currentSet = new HashSet<string>(classes);
 					foreach (var newClass in newClasses)
 					{
+						// If "ui-audioCurrent" has managed to make its way into the class attribute, it needs
+						// to be removed (and not reinserted!).  See BL-12094.
+						if (newClass == "ui-audioCurrent")
+						{
+							classesToRemove.Add(newClass);
+							continue;
+						}
 						classesToRemove.Remove(newClass); // in the source, should not remove
 						if (!currentSet.Contains(newClass))
 							classes.Add(newClass);


### PR DESCRIPTION
These shouldn't happen in the normal course of events, but bugginess in the past has allowed some books to be infected with this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5797)
<!-- Reviewable:end -->
