### PR TITLE
Remove unintentional cancel button which does almost nothing (BL-12167)

### DIFF
--- a/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
@@ -75,7 +75,7 @@ namespace Bloom.Spreadsheet
 				progress);
 			resultCallback(outputFilePath);
 			return progress.HaveProblemsBeenReported;
-		},"collectionTab", "Exporting Spreadsheet");
+		},"collectionTab", "Exporting Spreadsheet", showCancelButton: false);
 		}
 
 		public SpreadsheetExportParams Params = new SpreadsheetExportParams();

--- a/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
@@ -118,7 +118,7 @@ namespace Bloom.Spreadsheet
 					SIL.IO.RobustIO.DeleteDirectoryAndContents(audioFolder);
 				Import(sheet, progress);
 				return true; // always leave the dialog up until the user chooses 'close'
-			}, "collectionTab", "Importing Spreadsheet", doWhenDialogCloses: doWhenProgressCloses);
+			}, "collectionTab", "Importing Spreadsheet", showCancelButton: false, doWhenDialogCloses: doWhenProgressCloses);
 		}
 
 		private Browser _browser;


### PR DESCRIPTION
Clicking the button does POST cancel and mark the worker as cancelled, but the SS code was never written to check for cancellation or to cancel itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5814)
<!-- Reviewable:end -->
