### PR TITLE
showCancel defaults to false now

### DIFF
--- a/src/BloomExe/MiscUI/BrowserProgressDialog.cs
+++ b/src/BloomExe/MiscUI/BrowserProgressDialog.cs
@@ -122,7 +122,7 @@ namespace Bloom.MiscUI
 			Func<IWebSocketProgress, BackgroundWorker, Task<bool>> doWhat,
 			string id,
 			string title,
-			bool showCancelButton = true,
+			bool showCancelButton = false,	// true will add a cancel button, but the caller is still responsible for handling the clicks (either here in C# via checking worker.CancellationPending or on the Javascript/React side)
 			Action doWhenMainActionFalse = null,
 			Action doWhenDialogCloses = null,
 			string titleIcon= null)

--- a/src/BloomExe/Publish/BloomPub/BulkBloomPubCreator.cs
+++ b/src/BloomExe/Publish/BloomPub/BulkBloomPubCreator.cs
@@ -98,7 +98,7 @@ namespace Bloom.Publish.BloomPub
 					Process.SafeStart(dest.FolderPath);
 					// true means wait for the user, don't close automatically
 					return true;
-				}, "readerPublish", "Bulk Save BloomPubs");
+				}, "readerPublish", "Bulk Save BloomPubs", showCancelButton: true);
 		}
 
 


### PR DESCRIPTION
https://github.com/BloomBooks/BloomDesktop/commit/06d0af1e1aafa4331a3c7dd442865f3fee0c8853 set the default to true, but since showing the cancel button does no good unless the caller implements a handler for the button, I think it makes more sense to default to false instead.