### PR TITLE
Fix when a WinForms ReactDialog is not initially open (BL-12171)

### DIFF
--- a/src/BloomExe/TeamCollection/FolderTeamCollection.cs
+++ b/src/BloomExe/TeamCollection/FolderTeamCollection.cs
@@ -873,8 +873,15 @@ namespace Bloom.TeamCollection
 			                          repoFolderPathFromLinkPath == repoFolder;
 			var joiningGuid = CollectionSettings.CollectionIdFromCollectionFolder(tcManager.CurrentCollection
 				.LocalCollectionFolder);
-			var localGuid = CollectionSettings.CollectionIdFromCollectionFolder(localCollectionFolder);
-			var isSameCollection = _joiningSameCollection = joiningGuid == localGuid;
+			var localGuid = joiningGuid;
+			var isSameCollection = true;
+			if (isCurrentCollection)
+			{
+				// If it's not a current collection at all, we can't get a local guid, and it can't be different.
+				localGuid = CollectionSettings.CollectionIdFromCollectionFolder(localCollectionFolder);
+				isSameCollection = _joiningSameCollection = joiningGuid == localGuid;
+			}
+
 			// If it's a different collection and associated with a TC that exists, we're going to
 			// not allow the user to join. But if the TC doesn't exist...we'll let them just go
 			// ahead and merge, as if it was never linked.

--- a/src/BloomExe/web/ReactControl.cs
+++ b/src/BloomExe/web/ReactControl.cs
@@ -134,7 +134,21 @@ namespace Bloom.web
 			var tempFile = TempFile.WithExtension("htm");
 			tempFile.Detach(); // the browser control will clean it up
 
-			var props = Props == null ? "{}" : JsonConvert.SerializeObject(Props);
+			// If we're launching a WinForms dialog to show this content, we want it to be visible.
+			// I'm not sure both of these are (always) necessary, but things got badly broken by a recent
+			// change to ProgressDialog, and I think this will make it more robust against breaking again.
+			string props;
+			if (Props == null)
+			{
+				props = "{\"open\":true, \"initiallyOpen\": true}";
+			}
+			else
+			{
+				props = JsonConvert.SerializeObject(Props);
+				props = "{\"open\":true, \"initiallyOpen\": true," + props.Substring(1);
+			}
+
+			//var props = Props == null ? "{open:true}" : JsonConvert.SerializeObject(Props);
 
 			if (_javascriptBundleName == null)
 			{


### PR DESCRIPTION

In particular, this corrects a recent change to ProgressDialog that prevented the progress showing up and thus prevented TeamCollections from syncing.
c99388

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5819)
<!-- Reviewable:end -->
