### PR TITLE
Fix when a WinForms ProgressDialog is not initially open (BL-12171)

### DIFF
--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -2168,6 +2168,7 @@ namespace Bloom.TeamCollection
 					// props to send to the react component
 					new
 					{
+						open=true,
 						title,
 						titleIcon = "/bloom/TeamCollection/Team Collection.svg",
 						titleColor = "white",


### PR DESCRIPTION
This compensates for a recent change to ProgressDialog that prevented the progress showing up and thus prevented TeamCollections from syncing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5820)
<!-- Reviewable:end -->
