### PR TITLE
Fix persistent blank images for generated template thumbnails (BL-11855)

### DIFF
--- a/src/BloomExe/web/IRequestInfo.cs
+++ b/src/BloomExe/web/IRequestInfo.cs
@@ -22,9 +22,9 @@ namespace Bloom.Api
 		string RawUrl { get; }
 		bool HaveOutput { get; }
 		void WriteCompleteOutput(string s);
-		void ReplyWithFileContent(string path, string originalPath = null);
+		void ReplyWithFileContent(string path, string originalPath = null, bool dontCache = false);
 		void ReplyWithStreamContent(Stream input, string responseType);
-		void ReplyWithImage(string path, string originalPath = null);
+		void ReplyWithImage(string path, string originalPath = null, bool dontCache = false);
 		void WriteError(int errorCode);
 		void WriteError(int errorCode, string errorDescription);
 		System.Collections.Specialized.NameValueCollection GetQueryParameters();

--- a/src/BloomExe/web/RequestInfo.cs
+++ b/src/BloomExe/web/RequestInfo.cs
@@ -119,7 +119,7 @@ namespace Bloom.Api
 
 		public bool HaveOutput { get; private set; }
 
-		public void ReplyWithFileContent(string path, string originalPath = null)
+		public void ReplyWithFileContent(string path, string originalPath = null, bool dontCache = false)
 		{
 			//Deal with BL-3153, where the file was still open in another thread
 			FileStream fs;
@@ -158,8 +158,10 @@ namespace Bloom.Api
 				// I think 10s is short enough for stale builds and images not to be a problem, but it may be long enough to prevent
 				// some wasteful reloading of assets which are rapidly reused like avatars.
 				var maxAge = ShouldCache(path, originalPath) ? 600000 : 10;
+				// When generating thumbnail images, we don't want any caching of initial dummy images.
+				string cacheControl = dontCache ? "no-store" : $"max-age={maxAge}";
 				_actualContext.Response.AppendHeader("Cache-Control",
-					$"max-age={maxAge}");
+					cacheControl);
 
 					// A HEAD request (rather than a GET or POST request) is a request for just headers, and nothing can be written
 				// to the OutputStream. It is normally used to check if the contents of the file have changed without taking the
@@ -319,7 +321,7 @@ namespace Bloom.Api
 			return _cacheableExtensions.Contains(Path.GetExtension(path));
 		}
 
-		public void ReplyWithImage(string path, string originalPath = null)
+		public void ReplyWithImage(string path, string originalPath = null, bool dontCache = false)
 		{
 			if (path != null)
 			{
@@ -327,7 +329,7 @@ namespace Bloom.Api
 				if (pos > 0)
 					_actualContext.Response.ContentType = BloomServer.GetContentType(path.Substring(pos));
 			}
-			ReplyWithFileContent(path, originalPath);
+			ReplyWithFileContent(path, originalPath, dontCache);
 		}
 
 		public void WriteError(int errorCode, string errorDescription)

--- a/src/BloomExe/web/controllers/ApiRequest.cs
+++ b/src/BloomExe/web/controllers/ApiRequest.cs
@@ -153,9 +153,9 @@ namespace Bloom.Api
 			_requestInfo.WriteCompleteOutput(JsonConvert.SerializeObject(objectToMakeJson));
 		}
 
-		public void ReplyWithImage(string imagePath)
+		public void ReplyWithImage(string imagePath, bool dontCache = false)
 		{
-			_requestInfo.ReplyWithImage(imagePath);
+			_requestInfo.ReplyWithImage(imagePath, dontCache: dontCache);
 		}
 
 		public void ReplyWithStreamContent(Stream input, string responseType)

--- a/src/BloomTests/PretendRequestInfo.cs
+++ b/src/BloomTests/PretendRequestInfo.cs
@@ -61,7 +61,7 @@ namespace Bloom.Api
 			HaveOutput = true;
 		}
 
-		public void ReplyWithFileContent(string path, string originalPath = null)
+		public void ReplyWithFileContent(string path, string originalPath = null, bool dontCache = false)
 		{
 			ReplyImagePath = path;
 			WriteCompleteOutput(RobustFile.ReadAllText(path));
@@ -73,7 +73,7 @@ namespace Bloom.Api
 			throw new NotImplementedException();
 		}
 
-		public void ReplyWithImage(string path, string originalPath = null)
+		public void ReplyWithImage(string path, string originalPath = null, bool dontCache = false)
 		{
 			ReplyImagePath = path;
 		}


### PR DESCRIPTION
This isn't the original issue, but came up when testing the fix for the original problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5823)
<!-- Reviewable:end -->
