### PR TITLE
Fix PDF print screen height to be 100% (BL-12156)

### DIFF
--- a/src/BloomBrowserUI/publish/PDFPrintPublish/PDFPrintPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/PDFPrintPublish/PDFPrintPublishScreen.tsx
@@ -311,7 +311,12 @@ export const PDFPrintPublishScreen = () => {
 
     return (
         <React.Fragment>
-            <div onClick={() => setHelpVisible(false)}>
+            <div
+                onClick={() => setHelpVisible(false)}
+                css={css`
+                    height: 100%;
+                `}
+            >
                 <PublishScreenTemplate
                     bannerTitleEnglish="Publish to PDF &amp; Print"
                     bannerTitleL10nId="PublishTab.PdfPrint.BannerTitle"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5824)
<!-- Reviewable:end -->
