### PR TITLE
Fix useEffect loop eating lots of CPU cycles (BL-12180, BL-12154)

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
@@ -71,14 +71,15 @@ export const CollectionsTabBookPane: React.FunctionComponent<{
                 const errorMessage =
                     err?.response?.statusText ??
                     "Bloom could not determine the status of this book";
-                setBookStatus({
-                    ...bookStatus,
+
+                setBookStatus(prevBookStatus => ({
+                    ...prevBookStatus,
                     disconnected: true,
                     error: errorMessage
-                });
+                }));
             }
         );
-    }, [selectedBookId, saveable, reload, reloadStatus, bookStatus]);
+    }, [selectedBookId, saveable, reload, reloadStatus]);
 
     const canMakeBook = collectionKind != "main";
     // History, and thus the tab controls, are only relevant if there's a selected book


### PR DESCRIPTION
Using an "updated function" instead of an object allows us to remove bookStatus from the dependencies array and remove the condition that causes the loop

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5829)
<!-- Reviewable:end -->
