### PR TITLE
Add the missing tooltip for ePUB publishing mode selection (BL-12097)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -4107,6 +4107,10 @@
         <source xml:lang="en">Allow ePUB readers to lay out images and text however they want. The user is more likely to be able to increase font size. Custom page layouts will not look good. This mode is not available if your book has overlay pages (comics).</source>
         <note>ID: PublishTab.Epub.Flowable.Description</note>
       </trans-unit>
+      <trans-unit id="PublishTab.Epub.Flowable.DisabledTooltip">
+        <source xml:lang="en">This is disabled because an ePUB viewer in flowable mode would not be able to display the overlay pages (comics) in this book.</source>
+        <note>ID: PublishTab.Epub.Flowable.DisabledTooltip</note>
+      </trans-unit>
       <trans-unit id="PublishTab.Epub.Mode">
         <source xml:lang="en">ePUB mode</source>
         <note>ID: PublishTab.Epub.Mode</note>

--- a/src/BloomBrowserUI/publish/ePUBPublish/ePUBSettingsGroup.tsx
+++ b/src/BloomBrowserUI/publish/ePUBPublish/ePUBSettingsGroup.tsx
@@ -141,7 +141,9 @@ export const EPUBSettingsGroup: React.FunctionComponent<{
                                             showDisabled={true}
                                             tipWhenDisabled={{
                                                 l10nKey:
-                                                    "PublishTab.Epub.Flowable.DisabledTooltip"
+                                                    "PublishTab.Epub.Flowable.DisabledTooltip",
+                                                english:
+                                                    "This is disabled because an ePUB viewer in flowable mode would not be able to display the overlay pages (comics) in this book."
                                             }}
                                         >
                                             {menuItem}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5852)
<!-- Reviewable:end -->
