### PR TITLE
BL-12205 disable spell checking in WV2

### DIFF
--- a/src/BloomBrowserUI/lib/ckeditor/config.js
+++ b/src/BloomBrowserUI/lib/ckeditor/config.js
@@ -80,6 +80,11 @@ CKEDITOR.editorConfig = function(config) {
     // See http://docs.ckeditor.com/#!/guide/dev_acf for a description of this setting.
     config.allowedContent = true;
 
+    // See https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-disableNativeSpellChecker
+    // This setting results in bloom-editable divs having an attribute 'spellcheck="false"'.
+    // No more red squiggles. (BL-12205)
+    config.disableNativeSpellChecker = true;
+
     // Filter out any html that might be dangerous.  Specifically, a div element might be copied from the same book and
     // could introduce duplicate ids.  See https://silbloom.myjetbrains.com/youtrack/issue/BL-3899.
     // Note that the first attempt to fix BL-3899 set allowedContent rather than pasteFilter, but that caused

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -57,6 +57,7 @@ namespace Bloom
 				//	}
 				//};
 				_webview.CoreWebView2.ContextMenuRequested += ContextMenuRequested;
+
 				// This is only really needed for the print tab. But it is harmless elsewhere.
 				// It removes some unwanted controls from the toolbar that WebView2 inserts when
 				// previewing a PDF file.


### PR DESCRIPTION
* Someday hopefully WV2 will improve their spell checking
   api, so we can check text based on the `lang` attribute

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5858)
<!-- Reviewable:end -->
