### PR TITLE
BL-12256 fix preview dialog from being done/closeable too early

### DIFF
--- a/src/BloomBrowserUI/publish/commonPublish/PublishProgressDialog.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/PublishProgressDialog.tsx
@@ -67,6 +67,7 @@ export const PublishProgressDialog: React.FunctionComponent<{
             // But the alternative gets complicated too... the weirdness here is that we need to
             // do something (change the state of the dialog) when the postData's promise is satisfied.
             // (That is, when the preview construction is complete).
+            props.setProgressState(ProgressState.Working);
             postData(
                 props.startApiEndpoint,
                 {},

--- a/src/BloomBrowserUI/publish/commonPublish/PublishProgressDialog.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/PublishProgressDialog.tsx
@@ -58,6 +58,7 @@ export const PublishProgressDialog: React.FunctionComponent<{
     }, [props.closePending]);
 
     React.useEffect(() => {
+        props.setProgressState(ProgressState.Working);
         // we need to be ready to listen to progress messages from the server,
         // before we kick anything off on the server.
         WebSocketManager.notifyReady(props.webSocketClientContext, () => {
@@ -67,7 +68,6 @@ export const PublishProgressDialog: React.FunctionComponent<{
             // But the alternative gets complicated too... the weirdness here is that we need to
             // do something (change the state of the dialog) when the postData's promise is satisfied.
             // (That is, when the preview construction is complete).
-            props.setProgressState(ProgressState.Working);
             postData(
                 props.startApiEndpoint,
                 {},


### PR DESCRIPTION
[5.5 Regression] Publish BloomPUB - When updating preview, Publish Progress Dialog appears done prematurely 

Repro Steps:

    [5.5.3006 BetaInternal](https://bloomlibrary.org/installersBetaInternal/BloomInstaller.5.5.3006.BetaInternal.exe) or similar version
    Select a book
    Publish -> BloomPUB
    Click "Preview"

Observed:

The Publish Progress Dialog pops up. A "Close button" appears immediately. Clicking it will close the Publish Progress Dialog, but it will not cancel the updatePreview operation. (If you debug behind the scenes, you can see that the component has ProgressState = Done even while the updatePreview is in progress.

Expected:
In 5.4, the Publish Progress Dialog looks like it's in a working state [No "Close" button"] while the updatePreview operation is ongoing. After the update preview finishes, it closes automatically (probably only if there are no errors).

[Did not implement] Or (if cheap), John Hatton said it can have some kind of Stop / Cancel functionality while the updatePreview is in progress, but I don't think updatePreview has ever had an idea of being cancellable so I'm doubtful we should bite that off for 5.5.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5880)
<!-- Reviewable:end -->
