### PR TITLE
Revert SanitizeNameForFileSystem to allow multiple spaces (BL-12300)

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -2520,8 +2520,14 @@ namespace Bloom.Book
 			dom.RemoveFileProtocolFromStyleSheetLinks();
 		}
 
-
-		public static string SanitizeNameForFileSystem(string name, string defaultName = null)
+		/// <summary>
+		/// Sanitize a book's title for use as a file (or folder) name.
+		/// The title is normalized to Unicode Normalization Form C.
+		/// If the title contains invalid characters, they are replaced with spaces.
+		/// If a title is too long, it is truncated.
+		/// If the title is empty, "Book" (or the localized equivalent) is returned.
+		/// </summary>
+		public static string SanitizeNameForFileSystem(string name)
 		{
 			// We want NFC to prevent Dropbox complaining about encoding conflicts.
 			// May as well do that first as it may result in less truncation.
@@ -2529,12 +2535,6 @@ namespace Bloom.Book
 			// Then replace invalid characters with spaces and trim off characters
 			// that shouldn't start or finish a directory name.
 			name = RemoveDangerousCharacters(name);
-			// Multiple spaces are prone to being collapsed in HTML, particularly if the name ends up in
-			// the content of some element like a data-div one, such as the coverImage src. See BL-9145 and BL-12261.
-			// Even if that doesn't happen, it's hard for humans to tell filenames like "a  b" and "a   b" apart,
-			// especially with variable width fonts. So we will just collapse them while sanitizing the name.
-			while (name.Contains("  "))
-				name = name.Replace("  ", " ");
 			// Then make sure it's not too long.
 			if (name.Length > MaxFilenameLength)
 			{
@@ -2544,17 +2544,10 @@ namespace Bloom.Book
 			}
 			if (String.IsNullOrWhiteSpace(name))
 			{
-				if (String.IsNullOrWhiteSpace(defaultName))
-				{
-					// The localized default book name could itself have dangerous characters.
-					name = RemoveDangerousCharacters(BookStarter.UntitledBookName);
-					if (name.Length == 0)
-						name = "Book";  // This should absolutely never be needed, but let's be paranoid.
-				}
-				else
-				{
-					name = defaultName;
-				}
+				// The localized default book name could itself have dangerous characters.
+				name = RemoveDangerousCharacters(BookStarter.UntitledBookName);
+				if (name.Length == 0)
+					name = "Book";  // This should absolutely never be needed, but let's be paranoid.
 			}
 			return name;
 		}

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -410,11 +410,14 @@ namespace Bloom.ImageProcessing
 		/// <summary>
 		/// Get an unused filename in the given folder based on the basename and extension. "extension" must
 		/// start with a period. As well as being unused, the name will be truncated enough to minimize
-		/// the danger of exceeding the maximum path length for Windows.
+		/// the danger of exceeding the maximum path length for Windows.  Multiple consecutive spaces will
+		/// be collapsed to a single space, and leading and trailing spaces will be removed.
 		/// </summary>
 		internal static string GetUnusedFilename(string bookFolderPath, string basenameIn, string extension, string defaultName = "image")
 		{
-			var basename = BookStorage.SanitizeNameForFileSystem(basenameIn, defaultName);
+			if (extension == null)
+				extension = "";
+			var basename = MiscUtils.TruncateFileBasename(basenameIn, extension, defaultName);
 			// basename may already end in one or more digits. Try to strip off digits, parse and increment.
 			try
 			{

--- a/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
@@ -21,6 +21,7 @@ using Bloom.Collection;
 using Bloom.History;
 using Bloom.ImageProcessing;
 using Bloom.web.controllers;
+using Bloom.Utils;
 
 namespace Bloom.Spreadsheet
 {
@@ -1733,7 +1734,8 @@ namespace Bloom.Spreadsheet
 				HtmlDom.SetNewHtmlIdValue(elt);
 				return "0";
 			}
-			var id = SanitizeXHtmlId(BookStorage.SanitizeNameForFileSystem(Path.GetFileNameWithoutExtension(audioFile), "sound"));
+			var id = SanitizeXHtmlId(
+				MiscUtils.TruncateFileBasename(Path.GetFileNameWithoutExtension(audioFile), Path.GetExtension(audioFile), "sound"));
 			var destFile = id + Path.GetExtension(audioFile);
 			// We may as well set this; elements with class audio-sentence are supposed to have
 			// ids, even if there is no corresponding file.

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -859,7 +859,7 @@ namespace BloomTests.Book
 		public void SetBookName_SanitizedName_JunkMidFoo_ChangesFolder()
 		{
 			using (var x = new TemporaryFolder(_folder, "foo"))
-			using (var y = new TemporaryFolder(_folder, "fo o"))
+			using (var y = new TemporaryFolder(_folder, "fo         o"))
 			using (var projectFolder = new TemporaryFolder("BookStorage_ProjectCollection"))
 			{
 				File.WriteAllText(Path.Combine(x.Path, "foo.htm"), "<html><head> href='file://blahblah\\editMode.css' type='text/css' /></head><body><div class='bloom-page'></div></body></html>");
@@ -872,8 +872,7 @@ namespace BloomTests.Book
 				// BL-7816 We added some new characters to the sanitization routine
 				const string newBookName = "fo?:&<>\'\"{}o";
 				storage.SetBookName(newBookName);
-				//BL-12261 We now collapse multiple spaces to one
-				var newPath = y.Combine("fo o.htm");
+				var newPath = y.Combine("fo         o.htm");
 				Assert.IsTrue(Directory.Exists(y.Path), "Expected folder:" + y.Path);
 				Assert.IsTrue(File.Exists(newPath), "Expected file:" + newPath);
 			}


### PR DESCRIPTION
A new method TruncateFileBasename is used for image and sound files, which are assumed to already be valid filenames.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5896)
<!-- Reviewable:end -->
