### PR TITLE
BL-12286 save epub without preview first fix

### DIFF
--- a/src/BloomExe/Book/PublishSettings.cs
+++ b/src/BloomExe/Book/PublishSettings.cs
@@ -394,51 +394,12 @@ namespace Bloom.Book
 		}
 
 		
-		#region We do a comparison of settings to determine whether the Epub files need to be regenerated
-		
-		public override bool Equals(object obj)
+		// We do a comparison of settings to determine whether the Epub files need to be regenerated
+		public bool RequiresDifferentPreviewThan(EpubSettings other)
 		{
-			var other = obj as EpubSettings;
-			if (other == null)
-				return false;
-			return Equals(other);
+			return other == null || HowToPublishImageDescriptions != other.HowToPublishImageDescriptions
+				|| RemoveFontSizes != other.RemoveFontSizes || Mode != other.Mode;
 		}
-
-		protected bool Equals(EpubSettings other)
-		{
-			return HowToPublishImageDescriptions == other.HowToPublishImageDescriptions && RemoveFontSizes == other.RemoveFontSizes && Mode == other.Mode;
-		}
-
-		public override int GetHashCode()
-		{
-			unchecked
-			{
-				var hashCode = (int)HowToPublishImageDescriptions;
-				hashCode = (hashCode * 397) ^ RemoveFontSizes.GetHashCode();
-				hashCode = (hashCode * 397) ^ (Mode != null ? Mode.GetHashCode() : 0);
-				return hashCode;
-			}
-		}
-
-		public static bool operator ==(EpubSettings a, EpubSettings b)
-		{
-			if (Object.ReferenceEquals(a, b)) return true; // same object, including both null
-			// If one is null, but not both, return false. The casts are needed to prevent
-			// calling this method again recursively (and infinitely).
-			if (((object)a == null) || ((object)b == null))
-			{
-				return false;
-			}
-
-			return a.Equals(b);
-		}
-
-		public static bool operator !=(EpubSettings a, EpubSettings b)
-		{
-			return !(a == b);
-		}
-
-		#endregion
 
 	}
 

--- a/src/BloomExe/Book/PublishSettings.cs
+++ b/src/BloomExe/Book/PublishSettings.cs
@@ -392,6 +392,31 @@ namespace Bloom.Book
 			var serialized = JsonConvert.SerializeObject(this);
 			return JsonConvert.DeserializeObject<EpubSettings>(serialized);
 		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (!(obj is EpubSettings)) return false;
+			var other = (EpubSettings)obj;
+			return HowToPublishImageDescriptions == other.HowToPublishImageDescriptions && RemoveFontSizes == other.RemoveFontSizes && Mode == other.Mode;
+		}
+
+		public static bool operator ==(EpubSettings a, EpubSettings b)
+		{
+			if (ReferenceEquals(null, a)) return false;
+			return a.Equals(b);
+		}
+
+		public static bool operator !=(EpubSettings a, EpubSettings b)
+		{
+			return !(a == b);
+		}
+
+		public override int GetHashCode()
+		{
+			return HowToPublishImageDescriptions.GetHashCode() + Mode.GetHashCode() + (RemoveFontSizes? 1 : 0);
+		}
 	}
 
 	public class BloomLibrarySettings

--- a/src/BloomExe/Book/PublishSettings.cs
+++ b/src/BloomExe/Book/PublishSettings.cs
@@ -393,18 +393,43 @@ namespace Bloom.Book
 			return JsonConvert.DeserializeObject<EpubSettings>(serialized);
 		}
 
+		
+		#region We do a comparison of settings to determine whether the Epub files need to be regenerated
+		
 		public override bool Equals(object obj)
 		{
-			if (ReferenceEquals(null, obj)) return false;
-			if (ReferenceEquals(this, obj)) return true;
-			if (!(obj is EpubSettings)) return false;
-			var other = (EpubSettings)obj;
+			var other = obj as EpubSettings;
+			if (other == null)
+				return false;
+			return Equals(other);
+		}
+
+		protected bool Equals(EpubSettings other)
+		{
 			return HowToPublishImageDescriptions == other.HowToPublishImageDescriptions && RemoveFontSizes == other.RemoveFontSizes && Mode == other.Mode;
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				var hashCode = (int)HowToPublishImageDescriptions;
+				hashCode = (hashCode * 397) ^ RemoveFontSizes.GetHashCode();
+				hashCode = (hashCode * 397) ^ (Mode != null ? Mode.GetHashCode() : 0);
+				return hashCode;
+			}
 		}
 
 		public static bool operator ==(EpubSettings a, EpubSettings b)
 		{
-			if (ReferenceEquals(null, a)) return false;
+			if (Object.ReferenceEquals(a, b)) return true; // same object, including both null
+			// If one is null, but not both, return false. The casts are needed to prevent
+			// calling this method again recursively (and infinitely).
+			if (((object)a == null) || ((object)b == null))
+			{
+				return false;
+			}
+
 			return a.Equals(b);
 		}
 
@@ -413,10 +438,8 @@ namespace Bloom.Book
 			return !(a == b);
 		}
 
-		public override int GetHashCode()
-		{
-			return HowToPublishImageDescriptions.GetHashCode() + Mode.GetHashCode() + (RemoveFontSizes? 1 : 0);
-		}
+		#endregion
+
 	}
 
 	public class BloomLibrarySettings

--- a/src/BloomExe/Publish/Epub/PublishEpubApi.cs
+++ b/src/BloomExe/Publish/Epub/PublishEpubApi.cs
@@ -132,12 +132,14 @@ namespace Bloom.Publish.Epub
 			}
 
 			if (string.IsNullOrEmpty(destPath))  {
-				// No output path was specified
+				// No output path means the user cancelled the file chooser dialog.
+				// Simply posting a success with no other messages will cause the UI to do nothing further.
 				request.PostSucceeded();
 				return;
 			}
 				
-			RefreshPreview(request.CurrentBook.BookInfo.PublishSettings.Epub, false);
+			// Will only update the staged ePUB files if needed
+			RefreshPreview(request.CurrentBook.BookInfo.PublishSettings.Epub, forceUpdate:false);
 			SaveAsEpub(destPath);
 			request.PostSucceeded();
 		}

--- a/src/BloomExe/Publish/Epub/PublishEpubApi.cs
+++ b/src/BloomExe/Publish/Epub/PublishEpubApi.cs
@@ -192,9 +192,6 @@ namespace Bloom.Publish.Epub
 					_pendingSaveAsPath = destFileName;
 
 				}
-
-				_standardProgress.Message("PublishTab.Epub.Done", "Done");
-				ReportAnalytics("Save ePUB");
 			}
 		}
 
@@ -275,6 +272,7 @@ namespace Bloom.Publish.Epub
 				EpubMaker.ZipAndSaveEpub(_pendingSaveAsPath, _progress);
 				_pendingSaveAsPath = null;
 				_bookSelection.CurrentSelection.ReportSimplisticFontAnalytics(FontAnalytics.FontEventType.PublishEbook,"ePUB");
+				ReportAnalytics("Save ePUB");
 			}
 		}
 


### PR DESCRIPTION
Fixes Publish epub throws NullReferenceException unless you first preview
Corrects progress modal behavior
Makes epub not regenerate if settings have not changed
Fixes progress messages that were not displaying in the progress modal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5903)
<!-- Reviewable:end -->
