### PR TITLE
Replace Andika with Arial in typescript unit tests (BL-12321)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowFixture.pug
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowFixture.pug
@@ -24,21 +24,21 @@ body
 	+standardTestField(name="Default font bloom-editable with no styles doesn't overflow") Test texty
 
 	// Test#1
-	-var styles="font-family:Andika; font-size:large;height:18px;";
-	+standardTestField(name="Andika bloom-editable with large text and small height should overflow", style=styles).expectToOverflow Test texty
+	-var styles="font-family:Arial; font-size:x-large;height:18px;";
+	+standardTestField(name="Arial bloom-editable with x-large text and small height should overflow", style=styles).expectToOverflow Test texty
 
 	// Test#2
 	-var styles="font-size:20pt;height:21px;overflow:visible";
 	+standardTestField(name="Default font bloom-editable with large text and small height should overflow", style=styles).expectToOverflow Test texty
 
 	// Test#3
-	-var styles="font-family:Andika;";
-	+standardTestField(name="Andika bloom-editable with no other styles should not overflow", style=styles) Test texty
+	-var styles="font-family:Arial;";
+	+standardTestField(name="Arial bloom-editable with no other styles should not overflow", style=styles) Test texty
 
 	// Test#4
-	-var styles="font-family:Andika; height=50px";
-	+standardTestField(name="Andika bloom-editable with fixed height should not overflow", style=styles) Test texty
+	-var styles="font-family:Arial; height=50px";
+	+standardTestField(name="Arial bloom-editable with fixed height should not overflow", style=styles) Test texty
 
 	// Test#5
-	-var styles="font-family:Andika; padding: 2px;";
-	+standardTestField(name="Andika bloom-editable with only some padding should not overflow", style=styles) Test texty
+	-var styles="font-family:Arial; padding: 2px;";
+	+standardTestField(name="Arial bloom-editable with only some padding should not overflow", style=styles) Test texty

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowMarginFixture.pug
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowMarginFixture.pug
@@ -22,7 +22,7 @@ head
 body
 	// Test#0
 	-var margins="width:25em;height:45px";
-	-var styles="font-family:Andika; font-size:20pt";
+	-var styles="font-family:Arial; font-size:20pt";
 	.bloom-page
 		.marginBox(style=margins)
 			.bloom-translationGroup

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowSpec.ts
@@ -110,7 +110,7 @@ describe("Overflow Tests", () => {
     // Note: Ideally, nothing else should run between loadFixtures and actually running the test.
     // That means loadFixtures() needs to be inside the it().
 
-    it("Check test page for Self overflows (assumes Andika is installed)", () => {
+    it("Check test page for Self overflows (assumes Arial is installed)", () => {
         loadFixtures("OverflowFixture.html");
         expect($("#jasmine-fixtures")).toBeTruthy();
         if (window.console) {
@@ -120,7 +120,7 @@ describe("Overflow Tests", () => {
         $(".myTest").each((index, element) => RunTest(index, element));
     });
 
-    it("Check test page for Margin overflows (assumes Andika is installed)", () => {
+    it("Check test page for Margin overflows (assumes Arial is installed)", () => {
         loadFixtures("OverflowMarginFixture.html");
         expect($("#jasmine-fixtures")).toBeTruthy();
         if (window.console) {
@@ -132,7 +132,7 @@ describe("Overflow Tests", () => {
         );
     });
 
-    it("Check test page for Fixed Ancestor overflows (assumes Andika is installed)", () => {
+    it("Check test page for Fixed Ancestor overflows (assumes Arial is installed)", () => {
         loadFixtures("OverflowAncestorFixture.html");
         expect($("#jasmine-fixtures")).toBeTruthy();
         if (window.console) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5913)
<!-- Reviewable:end -->
