### PR TITLE
Bl-12343 rightclick menu checkboxes

### DIFF
--- a/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
+++ b/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
@@ -190,7 +190,11 @@ export const LocalizableCheckboxMenuItem: React.FunctionComponent<ILocalizableCh
         <div title={props.disabled ? props.tooltipIfDisabled : undefined}>
             <MenuItem
                 key={props.l10nId}
-                onClick={props.onClick}
+                onClick={() => {
+                    const newCheckedState = !checked;
+                    postBoolean(props.apiEndpoint, newCheckedState);
+                    setChecked(newCheckedState);
+                }}
                 dense={true}
                 css={css`
                     padding: 0 6px !important; // eliminate top and bottom padding to make even denser


### PR DESCRIPTION
In collections tab, right click on a thumbnail > more. If you click the checkboxes next to "Leveled Reader" or "Decodable Reader" they toggle, but nothing happens if you click on the "Leveled Reader" or "Decodable Reader" text. This PR makes it so the checkbox toggles when you click on the text.