### PR TITLE
Fix thumbnail.png locked intermittent errors

### DIFF
--- a/src/BloomExe/BookThumbNailer.cs
+++ b/src/BloomExe/BookThumbNailer.cs
@@ -235,13 +235,13 @@ namespace Bloom
 						ImageUtils.ResizeImageIfNecessary(new Size(size, size), coverImage.Image, shouldAddDashedBorder);
 					switch(Path.GetExtension(destFilePath).ToLowerInvariant())
 					{
-					case ".jpg":
-					case ".jpeg":
-						ImageUtils.SaveAsTopQualityJpeg(coverImage.Image, destFilePath);
-						break;
-					default:
-						coverImage.SaveImageRobustly(destFilePath, kExceptionsToRetryWhenSavingImage);
-						break;
+						case ".jpg":
+						case ".jpeg":
+							ImageUtils.SaveAsTopQualityJpeg(coverImage.Image, destFilePath);
+							break;
+						default:
+							coverImage.SaveImageRobustly(destFilePath, kExceptionsToRetryWhenSavingImage);
+							break;
 					}
 					if (callback != null)
 						callback(coverImage.Image.Clone() as Image);	// don't leave GC to chance

--- a/src/BloomExe/BookThumbNailer.cs
+++ b/src/BloomExe/BookThumbNailer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
@@ -185,6 +186,18 @@ namespace Bloom
 				return true;
 		}
 
+		private static readonly HashSet<Type> kExceptionsToRetryWhenSavingImage = new HashSet<Type>
+		{
+			Type.GetType("System.IO.IOException"),
+			Type.GetType("System.Runtime.InteropServices.ExternalException"),
+
+			// PalasoImage.SaveImageSafely can also throw ApplicationExceptions
+			// (See https://github.com/sillsdev/libpalaso/blob/f2482a5b3c6c75b50ec5672b1eb731b1a040a05a/SIL.Windows.Forms/ImageToolbox/PalasoImage.cs#L155)
+			// This very well may be temporary (if it's a different Bloom thread that has it locked) and retrying it would likely succeed.
+			// For ideas about more fundamental fixes, see https://issues.bloomlibrary.org/youtrack/issue/BL-12359/The-program-could-not-replace-the-image-C...Book-2thumbnail.png-perhaps-because-this-program-or-another-locked-it#focus=Comments-102-50093.0-0
+			Type.GetType("System.ApplicationException"),
+		};
+
 		/// <summary>
 		/// Creates a thumbnail of just the cover image (no title, language name, etc.)
 		/// </summary>
@@ -227,7 +240,7 @@ namespace Bloom
 						ImageUtils.SaveAsTopQualityJpeg(coverImage.Image, destFilePath);
 						break;
 					default:
-						PalasoImage.SaveImageRobustly(coverImage, destFilePath);
+						coverImage.SaveImageRobustly(destFilePath, kExceptionsToRetryWhenSavingImage);
 						break;
 					}
 					if (callback != null)

--- a/src/BloomExe/Extensions.cs
+++ b/src/BloomExe/Extensions.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Windows.Forms;
 using Bloom.Api;
 using Bloom.Utils;
+using SIL.Code;
 
 namespace Bloom
 {
@@ -196,6 +197,29 @@ namespace Bloom
 				result.Add(item);
 			}
 			return result;
+		}
+
+		/// <summary>
+		/// A re-implementation of PalasoImage.SaveImageRobustly, but with configurable parameters.
+		/// </summary>
+		/// <remarks>This is here because it's a lower risk way to introduce this change.
+		/// Longer-term, it'd make more sense to modify PalasoImage.SaveImageRobustly to provide this extra capability instead
+		/// </remarks>
+		public static void SaveImageRobustly(this SIL.Windows.Forms.ImageToolbox.PalasoImage image, string fileName, HashSet<Type> exceptionTypesToRetry, int maxRetryAttempts=RetryUtility.kDefaultMaxRetryAttempts, int retryDelay = RetryUtility.kDefaultRetryDelay)
+		{
+			if (exceptionTypesToRetry == null)
+			{
+				exceptionTypesToRetry = new HashSet<Type>
+				{
+					Type.GetType("System.IO.IOException"),
+					Type.GetType("System.Runtime.InteropServices.ExternalException")
+				};
+			}
+
+			RetryUtility.Retry(() => image.Save(fileName),
+				maxRetryAttempts,
+				retryDelay,
+				exceptionTypesToRetry);
 		}
 	}
 }


### PR DESCRIPTION
Multiple Bloom threads may be trying to build thumbnail.png simultaneously. Just a small workaround to retry it in that case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5933)
<!-- Reviewable:end -->
