### PR TITLE
[5.5] BL-12318 Scaling for Problem Report screenshots

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -806,6 +806,7 @@
     <Compile Include="web\UrlLookup.cs" />
     <Compile Include="web\WebSocketProgress.cs" />
     <Compile Include="web\YouTrackIssueSubmission.cs" />
+    <Compile Include="WindowsMonitorScaling.cs" />
     <Compile Include="Wizard\WinForms\WizardControl.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/src/BloomExe/WindowsMonitorScaling.cs
+++ b/src/BloomExe/WindowsMonitorScaling.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace Bloom
+{
+	/// <summary>
+	/// This class provides access to the Windows API for getting the scaling factor of the monitor that a control is on.
+	/// </summary>
+	internal static class WindowsMonitorScaling
+	{
+
+		[DllImport("Shcore.dll")]
+		private static extern int GetScaleFactorForMonitor(IntPtr hmonitor, out int pScale);
+
+		[DllImport("user32.dll")]
+		private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
+
+		private const int MONITOR_DEFAULTTONEAREST = 0x00000002;
+		[DllImport("Shcore.dll")]
+		private static extern int GetDpiForMonitor(IntPtr hmonitor, Monitor_DPI_Type dpiType, out uint dpiX, out uint dpiY);
+
+		public enum Monitor_DPI_Type
+		{
+			MDT_Effective_DPI = 0,
+			MDT_Angular_DPI = 1,
+			MDT_Raw_DPI = 2,
+			MDT_Default = MDT_Effective_DPI
+		}
+
+		internal static int GetMonitorScalingFactorFromControl(Control visibleControl)
+		{
+			if (visibleControl == null || !visibleControl.Visible)
+				return 100;
+			IntPtr hwnd = visibleControl.Handle;
+			// This MONITOR_DEFAULTTONEAREST flag says to use the monitor that the window is on, not the primary monitor.
+			// It actually works quite well, so that it uses the monitor that Bloom is on, even if it's not the primary monitor.
+			IntPtr hmonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+			GetDpiForMonitor(hmonitor, Monitor_DPI_Type.MDT_Effective_DPI, out uint dpiX, out uint dpiY);
+			GetScaleFactorForMonitor(hmonitor, out int percentScaleFactor);
+			return percentScaleFactor;
+		}
+
+		// Bloom uses this to scale a Problem Report screenshot if the display resolution is > 100%.
+		internal static Rectangle GetRectangleFromControlScaledToMonitorResolution(Control control)
+		{
+			int scalingFactorPercent = GetMonitorScalingFactorFromControl(control);
+			var unscaledBounds = control.Bounds;
+			return new Rectangle(
+				unscaledBounds.X * scalingFactorPercent / 100,
+				unscaledBounds.Y * scalingFactorPercent / 100,
+				unscaledBounds.Width * scalingFactorPercent / 100,
+				unscaledBounds.Height * scalingFactorPercent / 100);
+		}
+	}
+}

--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -687,17 +687,21 @@ namespace Bloom.web.controllers
 							}
 							else
 							{
-								var bounds = controlForScreenshotting.Bounds;
-								var screenshot = new Bitmap(bounds.Width, bounds.Height);
+#if !__MonoCS__
+								var scaledBounds = WindowsMonitorScaling.GetRectangleFromControlScaledToMonitorResolution(controlForScreenshotting);
+#else
+								var scaledBounds = controlForScreenshotting.Bounds;
+#endif
+								var screenshot = new Bitmap(scaledBounds.Width, scaledBounds.Height);
 								using (var g = Graphics.FromImage(screenshot))
 								{
 									if (controlForScreenshotting.Parent == null)
-										g.CopyFromScreen(bounds.Left, bounds.Top, 0, 0,
-											bounds.Size); // bounds already in screen coords
+										g.CopyFromScreen(scaledBounds.Left, scaledBounds.Top, 0, 0,
+											scaledBounds.Size); // bounds already in screen coords
 									else
 										g.CopyFromScreen(
-											controlForScreenshotting.PointToScreen(new Point(bounds.Left, bounds.Top)),
-											Point.Empty, bounds.Size);
+											controlForScreenshotting.PointToScreen(new Point(scaledBounds.Left, scaledBounds.Top)),
+											Point.Empty, scaledBounds.Size);
 								}
 
 								_reportInfo.ScreenshotTempFile = TempFile.WithFilename(ScreenshotName);


### PR DESCRIPTION
* adjusts size of screenshot if Windows display resolution
   has been set > 100%
* putting this in 5.5 because it's Windows-specific, if we decide to cherry-pick it
   back to 5.4, we'll need to add Windows only gating.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5934)
<!-- Reviewable:end -->
