### PR TITLE
[5.4] BL-12372 Delete book cmd should not be hidden

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/BookButton.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BookButton.tsx
@@ -219,12 +219,10 @@ export const BookButton: React.FunctionComponent<{
                 icon: <DeleteIcon></DeleteIcon>,
                 requiresSavePermission: true, // for consistency, but not used since shouldShow is defined
                 addEllipsis: true,
-                // Allowed for the downloaded books collection and the editable collection (provided the book is checked out, if applicable)
+                // Allowed for the downloaded books collection and the editable collection
                 shouldShow: () =>
                     props.collection.containsDownloadedBooks ||
-                    (props.collection.isEditableCollection &&
-                        (props.manager.getSelectedBookInfo()?.saveable ??
-                            false))
+                    props.collection.isEditableCollection
             },
             { label: "-" },
             {

--- a/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
@@ -495,23 +495,21 @@ export const makeMenuItems = (
                     undefined
                 );
             }
-            let disabled = false;
-            if (spec.shouldShow) {
-                if (!spec.shouldShow()) {
-                    return undefined;
-                }
-            } else {
-                // Default logic for whether to show or disable a command
-                if (isEditableCollection) {
-                    // Disable commands that require permission to change the book, if we don't have it.
-                    if (spec.requiresSavePermission && !isBookSavable) {
-                        disabled = true;
-                    }
-                } else {
-                    // outside that collection, commands can only be shown if they have a shouldShow function.
-                    return undefined;
-                }
+            // Default logic for whether to show a command at all
+            // Outside the editable collection, we only show commands that have a shouldShow function.
+            if (
+                (spec.shouldShow && !spec.shouldShow()) ||
+                (!spec.shouldShow && !isEditableCollection)
+            ) {
+                return undefined;
             }
+            // If we have determined that a command should be shown, this logic determines whether it should be
+            // disabled or not.
+            // We disable commands that require permission to change the book, if we don't have such permission.
+            const disabled =
+                isEditableCollection &&
+                spec.requiresSavePermission &&
+                !isBookSavable;
 
             if (spec.checkbox) {
                 return (


### PR DESCRIPTION
* in a user collection, the delete cmd is visible, but disabled
   if the book isn't checked out
* refactored code that determines whether a item is
   shown and whether an item that is shown is disabled

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5936)
<!-- Reviewable:end -->
