### PR TITLE
[5.5] BL-12366 Fix Talking Book tooltips

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookAdvancedSection.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookAdvancedSection.tsx
@@ -48,8 +48,10 @@ export const TalkingBookAdvancedSection: React.FunctionComponent<{
     const enabledImportRecordingButton =
         props.recordingMode === RecordingMode.TextBox &&
         props.hasRecordableDivs;
+    // The toolbox is currently its own iframe, so we can't spill out to the left yet.
+    // Unfortunately, we can't spill out the bottom without bad side effects either (BL-12366), so we go topside.
     const commonTooltipProps = {
-        placement: "bottom-start" as TooltipProps["placement"] // toolbox is currently its own iframe, so we can't spill out to the left yet
+        placement: "top-start" as TooltipProps["placement"]
     };
 
     return (


### PR DESCRIPTION
* Making them appear above instead of below keeps them
   from causing scrolling issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5943)
<!-- Reviewable:end -->
