### PR TITLE
BL-12379 disable unhelpful react-avatar caching and fix offline avatar default initials

### DIFF
--- a/src/BloomBrowserUI/react_components/bloomAvatar.tsx
+++ b/src/BloomBrowserUI/react_components/bloomAvatar.tsx
@@ -2,7 +2,7 @@
 import { jsx, css } from "@emotion/react";
 
 import React = require("react");
-import Avatar from "react-avatar";
+import Avatar, { Cache, ConfigProvider } from "react-avatar";
 import { getMd5 } from "../bookEdit/toolbox/talkingBook/md5Util";
 
 export const BloomAvatar: React.FunctionComponent<{
@@ -19,6 +19,15 @@ export const BloomAvatar: React.FunctionComponent<{
     const borderStyle = props.borderColor
         ? `${borderSizeInt}px solid ${props.borderColor}`
         : undefined;
+
+    // react-avatar does not cache actual avatars. It only caches which gravatar urls failed
+    // (whether because user was offline or doesn't have a gravatar),
+    // and then doesn't retry the failed urls so long as they are valid in cache.
+    // We do want it to retry retrieving gravatars, so keep its cache empty
+    const cache = new Cache({
+        sourceTTL: 0, // retain for 0 milliseconds
+        sourceSize: 0 // retain a maximum of 0 items in cache
+    });
     return (
         <React.Suspense fallback={<React.Fragment />}>
             <div
@@ -35,15 +44,17 @@ export const BloomAvatar: React.FunctionComponent<{
                     background-color: ${props.borderColor};
                 `}
             >
-                <Avatar
-                    md5Email={getMd5(props.email)}
-                    name={props.name}
-                    size={avatarSize}
-                    maxInitials={3}
+                <ConfigProvider cache={cache}>
+                    <Avatar
+                        md5Email={getMd5(props.email)}
+                        name={props.name}
+                        size={avatarSize}
+                        maxInitials={3}
 
-                    // If you do this instead of styling the outer div, you can't put a border around the circle, only the square
-                    //round={true}
-                />
+                        // If you do this instead of styling the outer div, you can't put a border around the circle, only the square
+                        //round={true}
+                    />
+                </ConfigProvider>
             </div>
         </React.Suspense>
     );

--- a/src/BloomExe/TeamCollection/TeamCollectionApi.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionApi.cs
@@ -393,8 +393,8 @@ namespace Bloom.TeamCollection
 				{
 					// Keep this in sync with IBookTeamCollectionStatus defined in TeamCollectionApi.tsx
 					who = whoHasBookLocked,
-					whoFirstName = _tcManager.CurrentCollection?.WhoHasBookLockedFirstName(bookFolderName),
-					whoSurname = _tcManager.CurrentCollection?.WhoHasBookLockedSurname(bookFolderName),
+					whoFirstName = _tcManager.CurrentCollectionEvenIfDisconnected?.WhoHasBookLockedFirstName(bookFolderName),
+					whoSurname = _tcManager.CurrentCollectionEvenIfDisconnected?.WhoHasBookLockedSurname(bookFolderName),
 					when = whenLocked.ToLocalTime().ToShortDateString(),
 					where = _tcManager.CurrentCollectionEvenIfDisconnected?.WhatComputerHasBookLocked(bookFolderName),
 					currentUser = CurrentUser,


### PR DESCRIPTION
By default react-avatar caches which gravatar urls failed (whether because the user was offline or did not have a gravatar) in local storage and then doesn’t retry the cached failed urls for a week. This PR turns off this undesireable failed url caching. It also fixes the default avatars when the user is offline.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5950)
<!-- Reviewable:end -->
