### PR TITLE
BL-11949 Scroll In Device Layout

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -437,6 +437,13 @@ export default class OverflowChecker {
         return null;
     }
 
+    private static GetScrollInsteadOfOverflow(page: HTMLElement): boolean {
+        const $page = $(page);
+        return (
+            $page.hasClass("Device16x9Portrait") ||
+            $page.hasClass("Device16x9Landscape")
+        );
+    }
     // Make sure there are no boxes with class 'overflow' or 'thisOverflowingParent' on the page before removing
     // the page-level overflow marker 'pageOverflows', or add it if there are.
     private static UpdatePageOverflow(page) {
@@ -448,6 +455,12 @@ export default class OverflowChecker {
         )
             $page.removeClass("pageOverflows");
         else $page.addClass("pageOverflows");
+
+        // BL-11949: books with device layouts can ignore overflows because we'll show a scrollbar
+        if (this.GetScrollInsteadOfOverflow(page)) {
+            $page.removeClass("pageOverflows");
+            // note, we don't yet remove the bubble that says there is too much text. This code is already spaghetti enough, I didn't want to pay that price at this time. --JH
+        }
     }
 
     // Checks a couple of situations where we might need to modify min-height

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -539,7 +539,8 @@ div.pageLabel[contenteditable="true"] {
 }
 
 // NOTE: I don't think .coverColor textarea matches anything anymore. It and many of the textarea references may be able to be removed?
-.coverColor textarea,   /*need a darker border when we have a background color*/
+.coverColor textarea,
+/*need a darker border when we have a background color*/
 div.bloom-editable {
     // Allow book templates to define a custom borderColor, otherwise fallback to the default color
     border: thin solid
@@ -610,13 +611,22 @@ div.bloom-templateMode {
     border: 3px dashed black;
 }
 
-.overflow {
-    color: @OverflowColor !important;
-    border: solid thin @OverflowColor !important; //NB: can't afford to go "thick" because it throws off the calculation
+// We only make a big deal out of "overflow" if the layout is a *paper* size, rather than a *device* size.
+.bloom-page:not([class*="Device"]) {
+    .overflow {
+        color: @OverflowColor !important;
+        border: solid thin @OverflowColor !important; //NB: can't afford to go "thick" because it throws off the calculation
 
-    p:empty:after {
-        //br:after would be great but it doesn't work
-        content: "¶";
+        p:empty:after {
+            //br:after would be great but it doesn't work
+            content: "¶";
+        }
+    }
+}
+
+.bloom-page[class*="Device"] {
+    .bloom-editable.overflow {
+        overflow-y: scroll;
     }
 }
 
@@ -1002,15 +1012,19 @@ body {
             display: none !important;
         }
     }
+
     .ui-resizable-handle {
         display: none !important;
     }
+
     .bloom-dragHandle {
         display: none;
     }
+
     #formatButton {
         display: none;
     }
+
     .bloom-imageContainer {
         &:after {
             border: none; // overwrite rule from editMode.less
@@ -1033,6 +1047,7 @@ body {
                 &:hover {
                     background-color: white; // make it stand out more from the image behind
                 }
+
                 img {
                     // turns the cog purple to match other Comic affordances, without requiring
                     // a different SVG. (Don't do this to the whole button, it messes with
@@ -1041,6 +1056,7 @@ body {
                 }
             }
         }
+
         .bloom-dragHandle {
             filter: @ComicAffordanceFilter;
             position: absolute;
@@ -1061,11 +1077,13 @@ body {
     .bloom-dragHandle {
         right: calc(100% + 1.4px);
     }
+
     // we need to push the label left-ward to get out of the way of the fat part of the bubble
     [data-languageTipContent]:after {
         right: calc(100% + 14px) !important;
     }
 }
+
 [data-bubble*="caption"] {
     [data-languageTipContent]:after {
         right: calc(100% + 2.8px) !important;


### PR DESCRIPTION
On a device, we show a scrollbar instead of overflowing. This commit detect that we're in a device layout, enabled a simple scrollbar (not the fancy one we get in Bloom Player), and removes overflow indicators.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5951)
<!-- Reviewable:end -->
