### PR TITLE
Set UI font to Roboto with NotoSans fallback (BL-12439)

### DIFF
--- a/src/BloomBrowserUI/bloomMaterialUITheme.ts
+++ b/src/BloomBrowserUI/bloomMaterialUITheme.ts
@@ -1,4 +1,5 @@
 import { createTheme, Theme } from "@mui/material/styles";
+import "./bloomWebFonts.less";
 import {
     kBloomDisabledOpacity,
     kBloomDisabledText,
@@ -42,7 +43,7 @@ export const kSelectCss = `
     .MuiSelect-select {padding: 7px 11px;}`;
 
 // Should match @UIFontStack in bloomWebFonts.less
-export const kUiFontStack = "NotoSans, Roboto, sans-serif";
+export const kUiFontStack = "Roboto, NotoSans, sans-serif";
 
 // the value that gets us to the 4.5 AA ratio depends on the background.
 // So the "aside"/features right-panel color effects this.

--- a/src/BloomBrowserUI/bloomUI.less
+++ b/src/BloomBrowserUI/bloomUI.less
@@ -1,4 +1,8 @@
 /* Common Bloom UI styling */
+
+// I (AP) don't think the following comment is accurate as of July 2023.
+//   Unless I'm missing something, UIFontStack *is* a constant and could be imported by reference.
+//   However, in order to get the fontface rules to work, you would need to import NOT by reference.
 // This import needs to NOT be by "(reference)", since the UIFontStack variable we need is not a constant.
 // That also means that if you want this bloomUI file to govern the font-family of your Less that
 // imports this file, it should do a normal full import of bloomUI.less.

--- a/src/BloomBrowserUI/bloomWebFonts.less
+++ b/src/BloomBrowserUI/bloomWebFonts.less
@@ -110,5 +110,6 @@
     font-weight: bold;
 }
 
-// Should match kUiFontStack in bloomMaterialUITheme.ts
-@UIFontStack: NotoSans, Roboto, sans-serif;
+// Should match kUiFontStack in bloomMaterialUITheme.ts.
+// And a rule in jquery-ui-1.8.16.custom.css.
+@UIFontStack: Roboto, NotoSans, sans-serif;

--- a/src/BloomBrowserUI/themes/bloom-jqueryui-theme/jquery-ui-1.8.16.custom.css
+++ b/src/BloomBrowserUI/themes/bloom-jqueryui-theme/jquery-ui-1.8.16.custom.css
@@ -1063,7 +1063,8 @@ IE/Win - Fix animation bug - #4615*/
     text-align: center;
     zoom: 1;
     overflow: visible;
-    font-family: NotoSans, Roboto, sans-serif;
+    /* Should match bloomWebFonts.less' @UIFontStack */
+    font-family: Roboto, NotoSans, sans-serif;
 }
 /*the overflow property removes extra width in IE*/
 .ui-button-icon-only {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5973)
<!-- Reviewable:end -->
