### PR TITLE
BL-12429 export audio segment markers

### DIFF
--- a/src/BloomBrowserUI/spreadsheet/spreadsheetBundleRoot.ts
+++ b/src/BloomBrowserUI/spreadsheet/spreadsheetBundleRoot.ts
@@ -9,9 +9,17 @@ import {
 } from "../bookEdit/toolbox/readers/libSynphony/bloomSynphonyExtensions";
 import AudioRecording from "../bookEdit/toolbox/talkingBook/audioRecording";
 
+// If a string only contains | and whitespace, it is a "segment" with no text
+// and should be skipped when matching to audio segments
+function isEmptySegment(s: string): boolean {
+    return s.search(/[^|\s]/) === -1;
+}
+
 export function split(text: string): string {
     const fragments: TextFragment[] = theOneLibSynphony.stringToSentences(text);
-    const sentences = fragments.map(f => (f.isSentence ? "s" : " ") + f.text);
+    const sentences = fragments.map(
+        f => (f.isSentence && !isEmptySegment(f.text) ? "s" : " ") + f.text
+    );
     return sentences.join("\n");
 }
 

--- a/src/BloomExe/Spreadsheet/MarkedUpText.cs
+++ b/src/BloomExe/Spreadsheet/MarkedUpText.cs
@@ -164,6 +164,13 @@ namespace Bloom.Spreadsheet
 				markedUpText = new MarkedUpText();
 				markedUpText._runList.Add(run);
 			}
+			// replace audio split markers with pipes to retain audio segment markers
+			else if (node.Name == "span" && (node.Attributes["class"]?.Value??"").Equals("bloom-audio-split-marker"))
+			{
+				MarkedUpTextRun run = new MarkedUpTextRun("|");
+				markedUpText = new MarkedUpText();
+				markedUpText._runList.Add(run);
+			}
 			else if (!node.HasChildNodes)
 			{
 				MarkedUpTextRun run = new MarkedUpTextRun(node.InnerText);

--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -513,7 +513,10 @@ namespace Bloom.Spreadsheet
 			else if (cellFormatting.Color.Rgb != null)
 			{
 				Color cellColor = ColorTranslator.FromHtml(cellFormatting.Color.LookupColor());
-				color = !IsBlack(cellColor) ? cellColor : color;
+				if (!IsBlack(cellColor))
+				{
+					color = cellColor;
+				}
 			}
 			// We do not import black coloration from Excel because Excel text is black by default
 			// and we cannot differentiate this from text the user specifically wants to be black.

--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -512,7 +512,8 @@ namespace Bloom.Spreadsheet
 			// whenever it is not overriden by inline coloration. But here's just in case
 			else if (cellFormatting.Color.Rgb != null)
 			{
-				color = ColorTranslator.FromHtml(cellFormatting.Color.LookupColor());
+				Color cellColor = ColorTranslator.FromHtml(cellFormatting.Color.LookupColor());
+				color = !IsBlack(cellColor) ? cellColor : color;
 			}
 			// We do not import black coloration from Excel because Excel text is black by default
 			// and we cannot differentiate this from text the user specifically wants to be black.


### PR DESCRIPTION
Spreadsheet export should not remove segment markers. We make audio segment markers become pipes in spreadsheet so that they can survive roundtrip. 

- also fixes a bug which extraneously marked some text as black on import from spreadsheet, leading to more instances of https://issues.bloomlibrary.org/youtrack/issue/BL-12435/Spreadsheet-import-with-both-audio-and-formatting-messes-up.

- Improves a bug where consecutive audio segment breaks with only whitespace in between (e.g. | at the end of a sentence or multiple | | would break roundtrip)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5980)
<!-- Reviewable:end -->
