### PR TITLE
BL-12436 failed spreadsheet shouldnt open

### DIFF
--- a/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
@@ -747,6 +747,13 @@ namespace Bloom.Spreadsheet
 						ProgressKind.Error, _outputFolder);
 				}
 			}
+			catch (Exception e)
+			{
+				progress.MessageWithParams("Spreadsheet.ExportFailed", "{0} is a placeholder for the exception message",
+					"Export failed: {0}", ProgressKind.Error, e.Message);
+
+			}
+
 			outputPath = null;
 			return null; // some error occurred and was caught
 		}

--- a/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
@@ -747,10 +747,10 @@ namespace Bloom.Spreadsheet
 			}
 			catch (Exception e)
 			{
-				var msg = LocalizationManager.GetString("Spreadsheet:ExportFailed", "Export failed: ");
-				Console.WriteLine(msg);
+				Console.WriteLine("Export failed: ");
 				Console.WriteLine(e);
-				progress.Message("Spreadsheet:ExportFailed", "", msg + e.Message, ProgressKind.Error);
+				progress.MessageWithParams("Spreadsheet.ExportFailed", "{0} is a placeholder for the exception message",
+					"Export failed: {0}", ProgressKind.Error, e.Message);
 			}
 
 			outputPath = null;

--- a/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
@@ -80,12 +80,6 @@ namespace Bloom.Spreadsheet
 			{
 				resultCallback(outputFilePath);
 			}
-			else if (!progress.HaveProblemsBeenReported)
-			{
-				// Export failed but we have no progress problem messages. Make sure there is at least some error message
-				// so we aren't just failing silently
-				progress.MessageWithParams("Spreadsheet.ExportFailed", "", "Export failed: {0}", ProgressKind.Error, "");
-			}
 			return progress.HaveProblemsBeenReported;
 		},"collectionTab", "Exporting Spreadsheet", showCancelButton: false);
 		}
@@ -736,12 +730,16 @@ namespace Bloom.Spreadsheet
 			{
 				if (e is IOException && (e.HResult & 0x0000FFFF) == 32) //ERROR_SHARING_VIOLATION
 				{
+					Console.WriteLine("Writing Spreadsheet failed. Do you have it open in another program?");
+					Console.WriteLine(e);
 					progress?.Message("Spreadsheet.SpreadsheetLocked", "",
 						"Bloom could not write to the spreadsheet because another program has it locked. Do you have it open in another program?",
 						ProgressKind.Error);
 				}
 				else
 				{
+					Console.WriteLine(String.Format("Bloom had problems writing files to that location ({0}). Check that you have permission to write there.", _outputFolder));
+					Console.WriteLine(e);
 					progress.MessageWithParams("Spreadsheet.WriteFailed", "",
 						"Bloom had problems writing files to that location ({0}). Check that you have permission to write there.",
 						ProgressKind.Error, _outputFolder);
@@ -749,9 +747,10 @@ namespace Bloom.Spreadsheet
 			}
 			catch (Exception e)
 			{
-				progress.MessageWithParams("Spreadsheet.ExportFailed", "{0} is a placeholder for the exception message",
-					"Export failed: {0}", ProgressKind.Error, e.Message);
-
+				var msg = LocalizationManager.GetString("Spreadsheet:ExportFailed", "Export failed: ");
+				Console.WriteLine(msg);
+				Console.WriteLine(e);
+				progress.Message("Spreadsheet:ExportFailed", "", msg + e.Message, ProgressKind.Error);
 			}
 
 			outputPath = null;

--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -228,26 +228,9 @@ namespace Bloom.Spreadsheet
 					SetBackgroundColorOfColumn(worksheet, iColumn1Based, InternalSpreadsheet.HiddenColor);
 				}
 
-				try
-				{
-					RobustFile.Delete(outputPath);
-					var xlFile = new FileInfo(outputPath);
-					package.SaveAs(xlFile);
-				}
-				catch (IOException ex) when ((ex.HResult & 0x0000FFFF) == 32) //ERROR_SHARING_VIOLATION
-				{
-					Console.WriteLine("Writing Spreadsheet failed. Do you have it open in another program?");
-					Console.WriteLine(ex);
-
-					progress?.Message("Spreadsheet.SpreadsheetLocked", "",
-						"Bloom could not write to the spreadsheet because another program has it locked. Do you have it open in another program?",
-						ProgressKind.Error);
-				}
-				catch (Exception ex)
-				{
-					progress?.MessageWithParams("Spreadsheet.ExportFailed", "{0} is a placeholder for the exception message",
-						"Export failed: {0}", ProgressKind.Error, ex.Message);
-				}
+				RobustFile.Delete(outputPath);
+				var xlFile = new FileInfo(outputPath);
+				package.SaveAs(xlFile);
 			}
 		}
 


### PR DESCRIPTION
If you export to spreadsheet and it fails because e.g. you have that spreadsheet still open in excel, you get an error message but that spreadsheet comes to the foreground anyway, so it seems like it succeeded until you navigate back to bloom and see the error message. 
We should not open/foreground the spreadsheet path if export failed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5984)
<!-- Reviewable:end -->
