### PR TITLE
BL-12479 Fix message when SL uploading fails

### DIFF
--- a/src/BloomExe/web/controllers/LibraryPublishApi.cs
+++ b/src/BloomExe/web/controllers/LibraryPublishApi.cs
@@ -182,10 +182,11 @@ namespace Bloom.web.controllers
 				else if (string.IsNullOrEmpty(uploadResult))
 				{
 					// Something went wrong, possibly already reported.
-					if (!Model.PdfGenerationSucceeded)
-						ReportPdfGenerationFailed();
-					else
+					// If the book has sign language videos, we don't create a PDF, so we don't want to report a PDF generation failure.
+					if (Model.PdfGenerationSucceeded || Model.Book.HasSignLanguageVideos())
 						ReportTryAgainDuringUpload();
+					else
+						ReportPdfGenerationFailed();
 				}
 				else
 				{


### PR DESCRIPTION
* should not give message about PDF generation failing if we didn't try to
   create a PDF because we have SL video!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5995)
<!-- Reviewable:end -->
