### PR TITLE
Don't mark empty "words" in decodable reader (BL-12460)

### DIFF
--- a/src/BloomBrowserUI/.eslintrc.js
+++ b/src/BloomBrowserUI/.eslintrc.js
@@ -1,7 +1,9 @@
 module.exports = {
     env: {
         browser: true,
-        es2021: true
+        es2021: true,
+        jasmine: true,
+        jQuery: true
     },
     extends: [
         "eslint:recommended",

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
@@ -245,4 +245,36 @@ describe("jquery.text-markup", function() {
         );
         expect(out5).toBe(" This is a test, this is only a test. ");
     });
+
+    it("checkWrapWordsExtraIgnoresEmptyItems", function() {
+        const cssWordNotFound = "word-not-found";
+        const cssPossibleWord = "possible-word";
+        const html = "<p>This is a test.</p>";
+        const notFound = ["", "test", "", "is", ""];
+        const newHtml = theOneLibSynphony.wrap_words_extra(
+            html,
+            notFound,
+            cssWordNotFound,
+            ' data-segment="word"'
+        );
+        expect(newHtml).toBe(
+            '<p>This <span class="word-not-found" data-segment="word">is</span> a <span class="word-not-found" data-segment="word">test</span>.</p>'
+        );
+    });
+
+    it("checkWrapWordsExtraHandlesExtraWhitespace", function() {
+        const cssWordNotFound = "word-not-found";
+        const cssPossibleWord = "possible-word";
+        const html = "<p> This<em> is </em>a test.</p>";
+        const notFound = ["this", "is", ""];
+        const newHtml = theOneLibSynphony.wrap_words_extra(
+            html,
+            notFound,
+            cssWordNotFound,
+            ' data-segment="word"'
+        );
+        expect(newHtml).toBe(
+            '<p> <span class="word-not-found" data-segment="word">This</span><em> <span class="word-not-found" data-segment="word">is</span> </em>a test.</p>'
+        );
+    });
 });

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.js
@@ -712,14 +712,19 @@ LibSynphony.prototype.wrap_words_extra = function(
 ) {
     if (aWords === undefined || aWords.length === 0) return storyHTML;
 
+    // Remove empty strings from the aWords array.  And if the array is then
+    // empty, return the original storyHTML.
+    aWords = aWords.filter(x => x);
+    if (aWords.length === 0) return storyHTML;
+
     if (storyHTML.trim().length === 0) return storyHTML;
 
     // make sure extra starts with a space
     if (extra.length > 0 && extra.substring(0, 1) !== " ") extra = " " + extra;
 
-    var beforeWord = "(^|>|[\\s\\p{Z}]|\\p{P}|&nbsp;)"; // word beginning delimiter
+    var beforeWord = "(^\\s*|>\\s*|[\\s\\p{Z}]|\\p{P}|&nbsp;)"; // word beginning delimiter
     var afterWord =
-        "(?=($|<|[\\s\\p{Z}]|\\p{P}+\\s|\\p{P}+<br|[\\s]*&nbsp;|\\p{P}+&nbsp;|\\p{P}+$))"; // word ending delimiter
+        "(?=(\\s*$|\\s*<|[\\s\\p{Z}]|\\p{P}+\\s|\\p{P}+<br|[\\s]*&nbsp;|\\p{P}+&nbsp;|\\p{P}+$))"; // word ending delimiter
 
     // escape special characters
     var escapedWords = aWords.map(RegExp.quote);


### PR DESCRIPTION
This seems to help with the empty paragraph generation bug as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/5996)
<!-- Reviewable:end -->
