### PR TITLE
Bl 12406 Don't show error Dialog if mic access is off 

### DIFF
--- a/DistFiles/localization/en/BloomLowPriority.xlf
+++ b/DistFiles/localization/en/BloomLowPriority.xlf
@@ -172,6 +172,10 @@
             <trans-unit id="Activity.Editing.MultipleChoice.CorrectAnswer">
                 <source xml:lang="en">Put the correct answer in this button. Bloom will randomize the order later.</source>
             </trans-unit>
+          <trans-unit id="EditTab.Toolbox.TalkingBookTool.MicrophoneAccessProblem">
+            <source xml:lang="en">Bloom was not able to access a microphone.</source>
+            <note>ID: EditTab.Toolbox.TalkingBookTool.MicrophoneAccessProblem</note>
+          </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -7,7 +7,6 @@
 @sectionVerticalGap: 25px;
 @buttonColumnWidth: 40px;
 @splitAnimationTime: 300ms;
-@micProblemColor: @bloom-warning;
 @textOnLightBackground: black;
 @disablingOverlayZindex: 1001; // higher than #audio-devlist
 
@@ -464,18 +463,6 @@ body .cursor-progress {
 .toast-toolbox-bottom {
     left: 32px;
     bottom: 46px;
-}
-
-#mic-problem-message {
-    &.initiallyHidden {
-        display: none;
-    }
-
-    background-color: @micProblemColor;
-    color: @textOnLightBackground;
-    border-radius: 6px;
-    font-size: medium;
-    padding: 6px;
 }
 
 #audio-playbackOrderControl-wrapper {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -479,6 +479,7 @@ export default class AudioRecording {
         // you'll want your listeners to have been set up already.
         this.addAudioLevelListener();
         this.addAudioRecordStartListener();
+        this.addMicErrorListener();
     }
 
     // Called when the Talking Book Tool is chosen.
@@ -486,6 +487,15 @@ export default class AudioRecording {
         WebSocketManager.addListener(kWebsocketContext, e => {
             if (e.id == "peakAudioLevel")
                 this.setStaticPeakLevel(e.message ? e.message : "");
+        });
+    }
+    
+    public addMicErrorListener(): void {
+        WebSocketManager.addListener(kWebsocketContext, e => {
+            if (e.id == "micError")
+            {
+                toastr.error(e.message ? e.message : "");
+            }
         });
     }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -489,11 +489,10 @@ export default class AudioRecording {
                 this.setStaticPeakLevel(e.message ? e.message : "");
         });
     }
-    
+
     public addMicErrorListener(): void {
         WebSocketManager.addListener(kWebsocketContext, e => {
-            if (e.id == "micError")
-            {
+            if (e.id == "micError") {
                 toastr.error(e.message ? e.message : "");
             }
         });
@@ -1125,13 +1124,12 @@ export default class AudioRecording {
     // to determine) Bloom's fault.
     private addAudioRecordStartListener(): void {
         WebSocketManager.addListener(kWebsocketContext, e => {
-            if (e.id === "recordStartStatus") {
-                // handle e.message "failure" ("success is a no-op")
-                if (e.message === "failure") {
-                    this.setStatus("record", Status.Disabled);
-                    this.recording = false;
-                    $("#mic-problem-message").removeClass("initiallyHidden");
-                }
+            // if the recording did start, we will get a message with e.id === "recordStartSucceeded"
+            // do nothing in this case
+            if (e.id === "recordStartFailed") {
+                this.setStatus("record", Status.Disabled);
+                this.recording = false;
+                toastr.error(e.message ? e.message : "");
             }
         });
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -491,10 +491,17 @@ export default class AudioRecording {
 
     public addMicErrorListener(): void {
         WebSocketManager.addListener(kWebsocketContext, e => {
-            if (e.id === "micError") {
-                this.setStatus("record", Status.Disabled);
-                this.recording = false;
+            if (
+                e.id === "recordingStartError" ||
+                e.id === "monitoringStartError"
+            ) {
                 toastr.error(e.message ? e.message : "");
+            }
+            // Don't disable recording for a monitoring error, as right now when switching mics we may
+            // kick off monitoring for the wrong mic
+            if (e.id === "recordingStartError") {
+                this.recording = false;
+                this.setStatus("record", Status.Disabled);
             }
         });
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -478,7 +478,6 @@ export default class AudioRecording {
         // then the user changes the layout to add a text box, and then...
         // you'll want your listeners to have been set up already.
         this.addAudioLevelListener();
-        this.addAudioRecordStartListener();
         this.addMicErrorListener();
     }
 
@@ -492,7 +491,9 @@ export default class AudioRecording {
 
     public addMicErrorListener(): void {
         WebSocketManager.addListener(kWebsocketContext, e => {
-            if (e.id == "micError") {
+            if (e.id === "micError") {
+                this.setStatus("record", Status.Disabled);
+                this.recording = false;
                 toastr.error(e.message ? e.message : "");
             }
         });
@@ -1117,21 +1118,6 @@ export default class AudioRecording {
                 "&nocache=" +
                 new Date().getTime()
         );
-    }
-
-    // Gets a definitive indication from C#-land that the recording did or did not actually start.
-    // "failure" message comes from an instance of BL-7568 and isn't (as far as we've been able
-    // to determine) Bloom's fault.
-    private addAudioRecordStartListener(): void {
-        WebSocketManager.addListener(kWebsocketContext, e => {
-            // if the recording did start, we will get a message with e.id === "recordStartSucceeded"
-            // do nothing in this case
-            if (e.id === "recordStartFailed") {
-                this.setStatus("record", Status.Disabled);
-                this.recording = false;
-                toastr.error(e.message ? e.message : "");
-            }
-        });
     }
 
     public async startRecordCurrentAsync(): Promise<void> {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookToolboxTool.pug
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookToolboxTool.pug
@@ -41,7 +41,6 @@ html
 							canvas(id='audio-meter' width='80' height='15')
 					div.audio-label.talking-book-counter(id='audio-look-at' data-i18n='EditTab.Toolbox.TalkingBookTool.LookAtSentenceLabel') Look at the highlighted text
 					+buttonGroup('record', 'expected', 'talking-book-counter', '', 'Speak', 'SpeakLabel')
-					div.initiallyHidden(id='mic-problem-message' data-i18n='EditTab.Toolbox.TalkingBookTool.MicrophoneProblem') Bloom is having problems connecting to your microphone. Please restart your computer and try again.
 					+buttonGroup('play', 'disabled', 'talking-book-counter', '', 'Check', 'CheckLabel')
 					+buttonGroup('split', 'disabled', 'talking-book-counter', 'initial-state', 'Split', 'SplitLabel')
 					+buttonGroup('next', 'disabled', 'talking-book-counter', '', 'Next', 'NextLabel')

--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -241,16 +241,12 @@ namespace Bloom.Edit
 					Recorder.BeginMonitoring(catchAndReportExceptions: false);
 					_monitoringAudio = true;
 				}
-				catch (NAudio.MmException)
+				catch (Exception e)
 				{
+					Logger.WriteError("Could not begin monitoring microphone", e);
 					var msg = LocalizationManager.GetString("EditTab.Toolbox.TalkingBookTool.MicrophoneAccessProblem",
 						"Bloom was not able to access a microphone.");
 					_webSocketServer.SendString(kWebsocketContext, "micError", msg);
-				}
-				catch (Exception e)
-				{
-					ErrorReport.NotifyUserOfProblem(new ShowOncePerSessionBasedOnExactMessagePolicy(),
-						e, "There was a problem starting up volume monitoring.");
 				}
 			}
 		}
@@ -561,13 +557,16 @@ namespace Bloom.Edit
 			try
 			{
 				Recorder.BeginRecording(PathToTemporaryWav);
-				_webSocketServer.SendString(kWebsocketContext, "recordStartStatus", "success");
+				_webSocketServer.SendString(kWebsocketContext, "recordStartSucceeded", "success");
 			}
-			catch (InvalidOperationException)
+			catch (InvalidOperationException ex)
 			{
 				// Likely a case of BL-7568, which as far as we can figure isn't Bloom's fault.
 				// Show a friendly message in the TalkingBook toolbox.
-				_webSocketServer.SendString(kWebsocketContext, "recordStartStatus", "failure");
+				Logger.WriteError("Could not begin recording", ex);
+				var msg = LocalizationManager.GetString("EditTab.Toolbox.TalkingBook.MicrophoneProblem",
+					"Bloom is having problems connecting to your microphone. Please restart your computer and try again.");
+				_webSocketServer.SendString(kWebsocketContext, "recordStartFailed", msg);
 			}
 		}
 

--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -557,7 +557,6 @@ namespace Bloom.Edit
 			try
 			{
 				Recorder.BeginRecording(PathToTemporaryWav);
-				_webSocketServer.SendString(kWebsocketContext, "recordStartSucceeded", "success");
 			}
 			catch (InvalidOperationException ex)
 			{
@@ -566,7 +565,7 @@ namespace Bloom.Edit
 				Logger.WriteError("Could not begin recording", ex);
 				var msg = LocalizationManager.GetString("EditTab.Toolbox.TalkingBook.MicrophoneProblem",
 					"Bloom is having problems connecting to your microphone. Please restart your computer and try again.");
-				_webSocketServer.SendString(kWebsocketContext, "recordStartFailed", msg);
+				_webSocketServer.SendString(kWebsocketContext, "micError", msg);
 			}
 		}
 

--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -236,8 +236,22 @@ namespace Bloom.Edit
 			}
 			if (RecordingDevice != null)
 			{
-				Recorder.BeginMonitoring();
-				_monitoringAudio = true;
+				try
+				{
+					Recorder.BeginMonitoring(catchAndReportExceptions: false);
+					_monitoringAudio = true;
+				}
+				catch (NAudio.MmException)
+				{
+					var msg = LocalizationManager.GetString("EditTab.Toolbox.TalkingBookTool.MicrophoneAccessProblem",
+						"Bloom was not able to access a microphone.");
+					_webSocketServer.SendString(kWebsocketContext, "micError", msg);
+				}
+				catch (Exception e)
+				{
+					ErrorReport.NotifyUserOfProblem(new ShowOncePerSessionBasedOnExactMessagePolicy(),
+						e, "There was a problem starting up volume monitoring.");
+				}
 			}
 		}
 

--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -246,7 +246,7 @@ namespace Bloom.Edit
 					Logger.WriteError("Could not begin monitoring microphone", e);
 					var msg = LocalizationManager.GetString("EditTab.Toolbox.TalkingBookTool.MicrophoneAccessProblem",
 						"Bloom was not able to access a microphone.");
-					_webSocketServer.SendString(kWebsocketContext, "micError", msg);
+					_webSocketServer.SendString(kWebsocketContext, "monitoringStartError", msg);
 				}
 			}
 		}
@@ -565,7 +565,7 @@ namespace Bloom.Edit
 				Logger.WriteError("Could not begin recording", ex);
 				var msg = LocalizationManager.GetString("EditTab.Toolbox.TalkingBook.MicrophoneProblem",
 					"Bloom is having problems connecting to your microphone. Please restart your computer and try again.");
-				_webSocketServer.SendString(kWebsocketContext, "micError", msg);
+				_webSocketServer.SendString(kWebsocketContext, "recordingStartError", msg);
 			}
 		}
 


### PR DESCRIPTION
Show an popup message but not the error dialog if we can't access microphone.

This PR depends on Palaso changes: https://github.com/sillsdev/libpalaso/pull/1280

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6017)
<!-- Reviewable:end -->
