### PR TITLE
BL-12597 fix thumbnail layout during book rename in collections tab

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/BookButton.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BookButton.tsx
@@ -441,7 +441,8 @@ export const BookButton: React.FunctionComponent<{
                     </div>
                 }
             >
-                {renaming || label}
+                {(renaming && <span className="bookButton-label"></span>) ||
+                    label}
             </Button>
 
             {contextMousePoint && items.length > 0 && (


### PR DESCRIPTION
5.5 regression: When you rename a book in Bloom 5.5 or 5.6, the thumbnail drops down underneath the textbox. Making the text unreadable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6052)
<!-- Reviewable:end -->
