### PR TITLE
BL-12621 title wysiwyg in bloom reader

### DIFF
--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -72,8 +72,8 @@
 
 .Browser-Reset();
 
-// BloomReader uses a scoped style element, so everything on body is ignored. Must be applied to
-// div.bloomPlayer-page also in order to be WYSIWYG in BloomReader.
+// bloom-player uses a scoped style element, so everything on body is ignored. Must be applied to
+// div.bloomPlayer-page also in order to be WYSIWYG in bloom-player.
 body,
 div.bloomPlayer-page {
     /*

--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -72,7 +72,10 @@
 
 .Browser-Reset();
 
-body {
+// BloomReader uses a scoped style element, so everything on body is ignored. Must be applied to
+// div.bloomPlayer-page also in order to be WYSIWYG in BloomReader.
+body,
+div.bloomPlayer-page {
     /*
     We used to set font-size slightly larger in editPaneGlobal.less, to handle a mismatch between webkit
     pdf generation and geckofx edit mode. That no longer seems to be necessary and the Browser-Reset() above


### PR DESCRIPTION
fixes bug where title breaks differently in editor vs. bloom reader due to different font size

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6055)
<!-- Reviewable:end -->
