### PR TITLE
BL-12617 send events through blorg

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -621,7 +621,11 @@ namespace Bloom
 				"rw21mh2piu",
 				RegistrationDialog.GetAnalyticsUserInfo(),
 				propertiesThatGoWithEveryEvent,
-				false); // change to true if you want to test sending
+				allowTracking: false, // change to true if you want to test sending
+				retainPii: false,
+				clientType: DesktopAnalytics.ClientType.Segment,
+				host: "https://analytics.bloomlibrary.org"
+			);
 #else
 			var feedbackSetting = System.Environment.GetEnvironmentVariable("FEEDBACK");
 


### PR DESCRIPTION
Send analytics through analytics.bloomlibrary.org instead of directly to segment. Depends on https://github.com/sillsdev/DesktopAnalytics.net/pull/31