### PR TITLE
Fix upload whitelist for books with periods in title (BL-12649)

### DIFF
--- a/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
+++ b/src/BloomExe/WebLibraryIntegration/BloomS3Client.cs
@@ -249,7 +249,10 @@ namespace Bloom.WebLibraryIntegration
 			};
 			if (pdfToInclude != null)
 				filter.AlwaysAccept(pdfToInclude);
-			filter.AlwaysAccept(Path.GetFileNameWithoutExtension(pathToBloomBookDirectory) + BookInfo.BookOrderExtension);
+			// The book folder name is the same as the book file name, but without an extension.  The book
+			// name may contain periods, so we certainly don't want to use Path.GetFileNameWithoutExtension.
+			// See https://issues.bloomlibrary.org/youtrack/issue/BL-12649/.
+			filter.AlwaysAccept(Path.GetFileName(pathToBloomBookDirectory) + BookInfo.BookOrderExtension);
 			if (isForBulkUpload)
 				filter.AlwaysAccept(".lastUploadInfo");
 			filter.CopyBookFolderFiltered(destDirName);


### PR DESCRIPTION
Upload would work for these books, but not download since the book's .BloomBookOrder file would not be uploaded.  This resulted in a null bookOrder field in the book's Parse data, preventing download.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6073)
<!-- Reviewable:end -->
