### PR TITLE
BL-12553 Save Draft status immediately on change

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -4039,9 +4039,13 @@ namespace Bloom.Book
 						WantVideo = true,
 						WantMusic = true
 					};
-					filter.AlwaysReject("meta.json");		// ignore since this stores currentTool and toolboxIsOpen, which are irrelevant
-					filter.AlwaysReject("video-placeholder.svg");	// ignore since placeholder file is provided as needed
-					filter.AlwaysReject("thumbnail.png");	// ignore since it seems to vary gratuitously (still check other thumbnail images)
+					// Ignore 'meta.json' since this stores currentTool and toolboxIsOpen, which are irrelevant to whether
+					// the book has changed. OTOH, we need to do something about Draft status and Features which are not irrelevant.
+					filter.AlwaysReject("meta.json");
+					// Ignore video placeholder since this file is provided as needed.
+					filter.AlwaysReject("video-placeholder.svg");
+					// Ignore 'thumbnail.png' since it seems to vary gratuitously (still check other thumbnail images).
+					filter.AlwaysReject("thumbnail.png");
 					// Order must be predictable but does not otherwise matter.
 					foreach (var path in Directory.GetFiles(folder, "*", SearchOption.AllDirectories).OrderBy(x => x))
 					{

--- a/src/BloomExe/web/controllers/LibraryPublishApi.cs
+++ b/src/BloomExe/web/controllers/LibraryPublishApi.cs
@@ -269,11 +269,6 @@ namespace Bloom.web.controllers
 		{
 			if (!ValidateBookshelfBeforeBulkUpload()) { request.PostSucceeded(); return; }
 
-			// BL-12553: It's possible the user changed some settings (features, draft status, etc.) in the publish screen
-			// for the current book. If we just directly go to uploading the collection without saving those settings,
-			// they will be lost. So we save them here.
-			if (Model?.Book?.BookInfo != null)
-				Model.Book.BookInfo.Save();
 			Model.BulkUpload(Model.Book.CollectionSettings.FolderPath, _progress);
 			request.PostSucceeded();
 		}
@@ -282,11 +277,6 @@ namespace Bloom.web.controllers
 		{
 			if (!ValidateBookshelfBeforeBulkUpload()) { request.PostSucceeded(); return; }
 
-			// BL-12553: It's possible the user changed some settings (features, draft status, etc.) in the publish screen
-			// for the current book. If we just directly go to uploading the collection without saving those settings,
-			// they will be lost. So we save them here.
-			if (Model?.Book?.BookInfo != null)
-				Model.Book.BookInfo.Save();
 			var folderPath = request.RequiredPostString();
 			if (!string.IsNullOrEmpty(folderPath) && Directory.Exists(folderPath))
 				Model.BulkUpload(folderPath, _progress);

--- a/src/BloomExe/web/controllers/PublishApi.cs
+++ b/src/BloomExe/web/controllers/PublishApi.cs
@@ -111,7 +111,7 @@ namespace Bloom.web.controllers
 						   Model.L1SupportsVisuallyImpaired,
 				(request, val) =>
 				{
-					Model.L1SupportsVisuallyImpaired = val;
+					Model.L1SupportsVisuallyImpaired = val; // Saves the BookInfo with the new value
 				}, true);
 
 			apiHandler.RegisterBooleanEndpointHandler("publish/canHaveMotionMode",
@@ -269,6 +269,7 @@ namespace Bloom.web.controllers
 				(writeRequest, value) =>
 				{
 					writeRequest.CurrentBook.BookInfo.MetaData.Draft = value;
+					writeRequest.CurrentBook.BookInfo.Save(); // We updated the BookInfo, so need to persist the changes. (but only the bookInfo is necessary, not the whole book)
 				}, false);
 		}
 


### PR DESCRIPTION
* also reverts an earlier 'hammer' change that was mostly not needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6093)
<!-- Reviewable:end -->
