### PR TITLE
Prevent Bloom locking up when typing the Alt key in Edit tab (BL-12614)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/editViewFrame.ts
+++ b/src/BloomBrowserUI/bookEdit/editViewFrame.ts
@@ -156,19 +156,23 @@ export function doWhenToolboxLoaded(
 
 //Called by c# using editTabBundle.canUndo()
 export function canUndo(): string {
-    // See comments on handleUndo()
-    const contentWindow = getEditablePageBundleExports();
-    if (contentWindow && (<any>contentWindow).origamiCanUndo()) {
-        return "yes";
+    try {
+        // See comments on handleUndo()
+        const contentWindow = getEditablePageBundleExports();
+        if (contentWindow && (<any>contentWindow).origamiCanUndo()) {
+            return "yes";
+        }
+        const toolboxWindow = getToolboxBundleExports();
+        if (toolboxWindow && toolboxWindow.canUndo && toolboxWindow.canUndo()) {
+            return "yes";
+        }
+        if (contentWindow && contentWindow.ckeditorCanUndo()) {
+            return "yes";
+        }
+        return "fail"; //can't undo in Javascript, possibly something in C# can?
+    } catch {
+        return "fail";
     }
-    const toolboxWindow = getToolboxBundleExports();
-    if (toolboxWindow && toolboxWindow.canUndo && toolboxWindow.canUndo()) {
-        return "yes";
-    }
-    if (contentWindow && contentWindow.ckeditorCanUndo()) {
-        return "yes";
-    }
-    return "fail"; //can't undo in Javascript, possibly something in C# can?
 }
 
 //noinspection JSUnusedGlobalSymbols

--- a/src/BloomBrowserUI/bookEdit/editablePage.ts
+++ b/src/BloomBrowserUI/bookEdit/editablePage.ts
@@ -152,7 +152,10 @@ $(document).ready(() => {
     // Note that to receive this, the c# code must be listening on this iframe.
     // We can remove this in 5.6, or whenever we replace the winforms context menu with a react menu.
     $(window).click(() => {
-        (window as any).chrome.webview.postMessage("browser-clicked");
+        (window as any).chrome.webview.postMessage({
+            "message-type": "event",
+            "event-name": "browser-clicked"
+        });
     });
 });
 

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -50,6 +50,7 @@ import {
 } from "../../react_components/color-picking/bloomPalette";
 import { ckeditableSelector } from "../../utils/shared";
 import { EditableDivUtils } from "./editableDivUtils";
+import { canUndo } from "../editViewFrame";
 
 // Allows toolbox code to make an element properly in the context of this iframe.
 export function makeElement(
@@ -1145,6 +1146,15 @@ export function bootstrap() {
     $.fn.reverse = function() {
         return this.pushStack(this.get().reverse(), arguments);
     };
+
+    WebSocketManager.addListener("edit", data => {
+        if (data.id === "report-can-undo") {
+            (window as any).chrome.webview.postMessage({
+                "message-type": "can-undo-result",
+                result: canUndo()
+            });
+        }
+    });
 
     document.addEventListener("selectionchange", () => {
         const textSelected = isTextSelected();

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -1468,6 +1468,8 @@ export class BubbleManager {
      */
     public tryApplyResizingUI(container: HTMLElement) {
         const mouseEvent = this.lastMoveEvent;
+        if (!mouseEvent) return; // User may not have moved the mouse over the browser by the time he hits the Alt key. See BL-12614.
+
         const hoveredBubble = this.getBubbleUnderMouse(mouseEvent, container);
         if (!hoveredBubble) {
             return;

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.tsx
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.tsx
@@ -410,7 +410,10 @@ $(window).ready(() => {
 });
 
 function NotifyCSharpOfClick() {
-    (window as any).chrome.webview.postMessage("browser-clicked");
+    (window as any).chrome.webview.postMessage({
+        "message-type": "event",
+        "event-name": "browser-clicked"
+    });
 }
 
 // Function invoked when dragging a page ends. Note that it is often

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -520,7 +520,7 @@ namespace Bloom.Edit
 				GC.WaitForPendingFinalizers();
 			}
 			var endPageLoad = DateTime.Now;
-			Logger.WriteEvent($"update page elapsed time = {endPageLoad - _beginPageLoad} (garbage collect took {endPageLoad - beginGarbageCollect}");
+			Logger.WriteEvent($"update page elapsed time = {endPageLoad - _beginPageLoad} (garbage collect took {endPageLoad - beginGarbageCollect})");
 			//#if MEMORYCHECK
 			// Check memory for the benefit of developers.
 			Bloom.Utils.MemoryManagement.CheckMemory(false, "EditingView - display page updated", false);


### PR DESCRIPTION
Reimplements the canUndo request/report feature to use a web socket and web message instead of RunJavascript.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6095)
<!-- Reviewable:end -->
