### PR TITLE
Fix BL-12614

### DIFF
--- a/src/BloomExe/Edit/ConfigurationDialog.cs
+++ b/src/BloomExe/Edit/ConfigurationDialog.cs
@@ -53,7 +53,7 @@ namespace Bloom.Edit
 
 		private async void  _okButton_ClickAsync(object sender, EventArgs e)
 		{
-			FormData = await _browser.RunJavaScriptAsync("gatherSettings()");
+			FormData = await _browser.GetStringFromJavascriptAsync("gatherSettings()");
 			DialogResult = DialogResult.OK;
 			Close();
 

--- a/src/BloomExe/Edit/Configurator.cs
+++ b/src/BloomExe/Edit/Configurator.cs
@@ -155,7 +155,7 @@ namespace Bloom.Edit
 
 				//Now we call the method which takes that confuration data and adds/removes/updates pages.
 				//We have the data as json string, so first we turn it into object for the updateDom's convenience.
-				await b.RunJavaScriptAsync("runUpdate(" + GetAllData() + ")");
+				await b.GetStringFromJavascriptAsync("runUpdate(" + GetAllData() + ")");
 
 				//Ok, so we should have a modified DOM now, which we can save back over the top.
 

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -170,7 +170,7 @@ namespace Bloom.Edit
 			if (details.From == _view)
 			{
 				SaveNow();
-				_view.RunJavaScript("if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined') {editTabBundle.getEditablePageBundleExports().disconnectForGarbageCollection();}");
+				_view.RunJavascriptWithStringResult_Sync_Dangerous("if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined') {editTabBundle.getEditablePageBundleExports().disconnectForGarbageCollection();}");
 				// This bizarre behavior prevents BL-2313 and related problems.
 				// For some reason I cannot discover, switching tabs when focus is in the Browser window
 				// causes Bloom to get deactivated, which prevents various controls from working.
@@ -642,9 +642,9 @@ namespace Bloom.Edit
 			if (_view != null && !_inProcessOfDeleting && !_inProcessOfLoading)
 			{
 				_view.ChangingPages = true;
-				_view.RunJavaScript("if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined') {editTabBundle.getEditablePageBundleExports().pageSelectionChanging();}");
+				_view.RunJavascriptWithStringResult_Sync_Dangerous("if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined') {editTabBundle.getEditablePageBundleExports().pageSelectionChanging();}");
 				FinishSavingPage();
-				_view.RunJavaScript("if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined') {editTabBundle.getEditablePageBundleExports().disconnectForGarbageCollection();}");
+				_view.RunJavascriptWithStringResult_Sync_Dangerous("if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined') {editTabBundle.getEditablePageBundleExports().disconnectForGarbageCollection();}");
 			}
 		}
 

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -453,7 +453,7 @@ namespace Bloom.Edit
 					{
 						Logger.WriteEvent("changing page via editTabBundle.switchContentPage()");
 						var pageUrl = _model.GetUrlForCurrentPage();
-						RunJavaScript("editTabBundle.switchContentPage('" + pageUrl + "');");
+						RunJavascriptWithStringResult_Sync_Dangerous("editTabBundle.switchContentPage('" + pageUrl + "');");
 					}
 				}
 				else
@@ -537,9 +537,14 @@ namespace Bloom.Edit
 			_pageListView.SetBook(_model.CurrentBook);
 		}
 
-		internal string RunJavaScript(string script)
+		[Obsolete("This method is dangerous because it has to loop Application.DoEvents(). RunJavaScriptAsync() is preferred.")]
+		internal string RunJavascriptWithStringResult_Sync_Dangerous(string script)
 		{
-			return _browser1.RunJavaScript(script);
+			return _browser1.RunJavascriptWithStringResult_Sync_Dangerous(script);
+		}
+		internal async Task<string> GetStringFromJavascriptAsync(string script)
+		{
+			return await _browser1.GetStringFromJavascriptAsync(script);
 		}
 
 		private Metadata _originalImageMetadataFromImageToolbox;
@@ -1189,9 +1194,9 @@ namespace Bloom.Edit
 			// BL-9912 where the Leveled Reader Tool was prompted by some of this to call us back with a save to the
 			// tool state, but by then the editingModel had cleared out its knowledge of what book it had previously
 			// been editing, so there was an null.
-			RunJavaScript("typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getToolboxBundleExports()) !=='undefined' && editTabBundle.getToolboxBundleExports().removeToolboxMarkup()");
-			var bodyHtml = RunJavaScript("typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined' && editTabBundle.getEditablePageBundleExports().getBodyContentForSavePage()");
-			var userCssContent = RunJavaScript("typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined' && editTabBundle.getEditablePageBundleExports().userStylesheetContent()");
+			RunJavascriptWithStringResult_Sync_Dangerous("typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getToolboxBundleExports()) !=='undefined' && editTabBundle.getToolboxBundleExports().removeToolboxMarkup()");
+			var bodyHtml = RunJavascriptWithStringResult_Sync_Dangerous("typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined' && editTabBundle.getEditablePageBundleExports().getBodyContentForSavePage()");
+			var userCssContent = RunJavascriptWithStringResult_Sync_Dangerous("typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined' && editTabBundle.getEditablePageBundleExports().userStylesheetContent()");
 			_browser1.ReadEditableAreasNow(bodyHtml, userCssContent);
 		}
 
@@ -1463,7 +1468,7 @@ namespace Bloom.Edit
 			Application.Idle -= SaveWhenIdle; // don't need to do again till next Deactivate.
 			_model.SaveNow();
 			// Restore any tool state removed by CleanHtmlAndCopyToPageDom(), which is called by _model.SaveNow().
-			RunJavaScript("if (typeof(editTabBundle) !=='undefined') {editTabBundle.getToolboxBundleExports().applyToolboxStateToPage();}");
+			RunJavascriptWithStringResult_Sync_Dangerous("if (typeof(editTabBundle) !=='undefined') {editTabBundle.getToolboxBundleExports().applyToolboxStateToPage();}");
 		}
 
 		public string HelpTopicUrl => "/Tasks/Edit_tasks/Edit_tasks_overview.htm";
@@ -1497,14 +1502,14 @@ namespace Bloom.Edit
 		{
 			PageTemplatesApi.ForPageLayout = false;
 			//if the dialog is already showing, it is up to this method we're calling to detect that and ignore our request
-			RunJavaScript("editTabBundle.showPageChooserDialog(false);");
+			RunJavascriptWithStringResult_Sync_Dangerous("editTabBundle.showPageChooserDialog(false);");
 		}
 
 		internal void ShowChangeLayoutDialog()
 		{
 			PageTemplatesApi.ForPageLayout = true;
 			//if the dialog is already showing, it is up to this method we're calling to detect that and ignore our request
-			RunJavaScript("editTabBundle.showPageChooserDialog(true);");
+			RunJavascriptWithStringResult_Sync_Dangerous("editTabBundle.showPageChooserDialog(true);");
 		}
 
 		// The zoom factor that is shown in the top right of the toolbar (a percent).
@@ -1681,7 +1686,7 @@ namespace Bloom.Edit
 		private void _bookSettingsButton_Click(object sender, EventArgs e)
 		{
 			_model.SaveNow();
-			RunJavaScript("editTabBundle.showEditViewBookSettingsDialog();");
+			RunJavascriptWithStringResult_Sync_Dangerous("editTabBundle.showEditViewBookSettingsDialog();");
 		}
 	}
 }

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1332,7 +1332,7 @@ namespace Bloom.Edit
 			// Note that this method is called by a timer (probably about 110msec cycle).
 			if (!_browser1.Visible)
 				return;	
-			_browser1.UpdateEditButtons();
+			_browser1.UpdateEditButtonsAsync();
 			UpdateButtonEnabled(_cutButton, _cutCommand);
 			UpdateButtonEnabled(_copyButton, _copyCommand);
 			UpdateButtonEnabled(_pasteButton, _pasteCommand);
@@ -1348,7 +1348,7 @@ namespace Bloom.Edit
 
 		private void CycleEditButtons()
 		{
-			_browser1.UpdateEditButtons();
+			_browser1.UpdateEditButtonsAsync();
 			CycleOneButton(_cutButton, _cutCommand);
 			CycleOneButton(_copyButton, _copyCommand);
 			CycleOneButton(_pasteButton, _pasteCommand);

--- a/src/BloomExe/HtmlThumbNailer.cs
+++ b/src/BloomExe/HtmlThumbNailer.cs
@@ -302,9 +302,9 @@ namespace Bloom
 
 			var height =
 				(int)Math.Round(double.Parse(
-					browser.RunJavaScript("document.getElementsByClassName('bloom-page')[0].clientHeight.toString()")));
+					browser.RunJavascriptWithStringResult_Sync_Dangerous("document.getElementsByClassName('bloom-page')[0].clientHeight.toString()")));
 			var width = (int)Math.Round(
-				double.Parse(browser.RunJavaScript("document.getElementsByClassName('bloom-page')[0].clientWidth.toString()")));
+				double.Parse(browser.RunJavascriptWithStringResult_Sync_Dangerous("document.getElementsByClassName('bloom-page')[0].clientWidth.toString()")));
 
 			browser.Height = height;
 			browser.Width = width;
@@ -363,7 +363,7 @@ namespace Bloom
 				while (true)
 				{
 
-					using (var image = browser.GetPreview())
+					using (var image = browser.CapturePreview_Synchronous_Dangerous())
 					{
 						if (watch.ElapsedMilliseconds > 5000)
 						{
@@ -483,15 +483,15 @@ namespace Bloom
 					// There's probably some way to get all of this in a single RunJavaScript call, but note that ?. is not supported
 					// in GeckoFx60, and I've had some trouble with scripts of more than a single expression in WebView2.
 					var imageCount =
-						int.Parse(browser.RunJavaScript(
+						int.Parse(browser.RunJavascriptWithStringResult_Sync_Dangerous(
 							"document.getElementsByClassName('bloom-imageContainer').length.toString()"));
 					if (imageCount != 0)
 					{
 						topOfCoverImage = (int)Math.Round(double.Parse(
-							browser.RunJavaScript(
+							browser.RunJavascriptWithStringResult_Sync_Dangerous(
 								"document.getElementsByClassName('bloom-imageContainer')[0].offsetTop.toString()")));
 						bottomOfCoverImage = topOfCoverImage + (int)Math.Round(double.Parse(
-							browser.RunJavaScript(
+							browser.RunJavascriptWithStringResult_Sync_Dangerous(
 								"document.getElementsByClassName('bloom-imageContainer')[0].offsetHeight.toString()")));
 					}
 				}));

--- a/src/BloomExe/IBrowser.cs
+++ b/src/BloomExe/IBrowser.cs
@@ -76,7 +76,7 @@ namespace Bloom
 		/// Get a bitmap showing the current state of the browser. Caller should dispose.
 		/// </summary>
 		/// <returns></returns>
-		public abstract Bitmap GetPreview();
+		public abstract Bitmap CapturePreview_Synchronous_Dangerous();
 
 		/// <summary>
 		/// If it returns true these are in place of our standard extensions; if false, the
@@ -358,9 +358,11 @@ namespace Bloom
 			_pageEditDom.GetElementsByTagName("head")[0].InnerXml = HtmlDom.CreateUserModifiedStyles(userCssContent);
 		}
 
-		public abstract string RunJavaScript(string script);
+		[Obsolete("This method is dangerous because it has to loop Application.DoEvents(). RunJavaScriptAsync() is preferred.")]
+		public abstract string RunJavascriptWithStringResult_Sync_Dangerous(string script);
 
-		public abstract Task<string> RunJavaScriptAsync(string script);
+		public abstract Task<string> GetStringFromJavascriptAsync(string script);
+		public abstract Task RunJavascriptAsync(string script);
 
 		public abstract void SaveHTML(string path);
 

--- a/src/BloomExe/IBrowser.cs
+++ b/src/BloomExe/IBrowser.cs
@@ -372,7 +372,7 @@ namespace Bloom
 		}
 		public abstract void SetEditingCommands(CutCommand cutCommand, CopyCommand copyCommand, PasteCommand pasteCommand, UndoCommand undoCommand);
 		public abstract void ShowHtml(string html);
-		public abstract void UpdateEditButtons();
+		public abstract void UpdateEditButtonsAsync();
 
 		protected void AdjustContextMenu(IMenuItemAdder adder)
 		{

--- a/src/BloomExe/IBrowser.cs
+++ b/src/BloomExe/IBrowser.cs
@@ -14,7 +14,7 @@ using System.Xml;
 
 namespace Bloom
 {
-	// This is just a temporary thing to centralize switching during progressive coding and testing. 
+	// This is just a temporary thing to centralize switching during progressive coding and testing.
 	public class BrowserMaker
 	{
 		/// <summary>
@@ -409,12 +409,7 @@ namespace Bloom
 				OnOpenPageInEdge);
 		}
 
-		public abstract void SaveDocument(string path);
-
-		public async virtual Task SaveDocumentAsync(string path)
-		{
-			SaveDocument(path);
-		}
+		public abstract Task SaveDocumentAsync(string path);
 	}
 
 	public interface IMenuItemAdder

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -300,7 +300,7 @@ namespace Bloom.Publish
 				return;
 
 			// Get and store the display and font information for each element in the DOM.
-			var elementsInfo = BrowserForPageChecks.RunJavaScript(GetElementDisplayAndFontInfoJavascript);
+			var elementsInfo = BrowserForPageChecks.RunJavascriptWithStringResult_Sync_Dangerous(GetElementDisplayAndFontInfoJavascript);
 			var rawInfo = Newtonsoft.Json.JsonConvert.DeserializeObject<ElementInfoArray>(elementsInfo);
 			if (rawInfo != null)
 			{

--- a/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
@@ -176,7 +176,7 @@ namespace Bloom.Spreadsheet
 				_browser.Navigate(rootPage, false);
 				await signal.WaitAsync(); // Following code happens after browser has navigated
 				// This extra check that spreadsheetBundle actually exists might not be necessary.
-				while (await _browser.RunJavaScriptAsync($"spreadsheetBundle") == null)
+				while (await _browser.GetStringFromJavascriptAsync($"spreadsheetBundle") == null)
 					await Task.Delay(10);
 			}
 			return _browser;
@@ -1716,7 +1716,7 @@ namespace Bloom.Spreadsheet
 
 		protected virtual async Task<string[]> GetSentenceFragmentsAsync(string text)
 		{
-			return (await (await GetBrowserAsync()).RunJavaScriptAsync($"spreadsheetBundle.split('{text}')")).Split('\n');
+			return (await (await GetBrowserAsync()).GetStringFromJavascriptAsync($"spreadsheetBundle.split('{text}')")).Split('\n');
 		}
 
 
@@ -1806,7 +1806,7 @@ namespace Bloom.Spreadsheet
 				var result =  (Task<string>)ControlForInvoke.Invoke(new ElementStringTask(GetMd5Async), elt);
 				return await (result);
 			}
-			return await (await GetBrowserAsync()).RunJavaScriptAsync($"spreadsheetBundle.getMd5('{elt.InnerText.Replace("'", "\\'")}')");
+			return await (await GetBrowserAsync()).GetStringFromJavascriptAsync($"spreadsheetBundle.getMd5('{elt.InnerText.Replace("'", "\\'")}')");
 		}
 
 		internal static string SanitizeXHtmlId(string id)

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -411,7 +411,7 @@ namespace Bloom
 		public WebView2 InternalBrowser => _webview;
 
 		public override string Url => _webview.Source.ToString();
-		public override Bitmap GetPreview()
+		public override Bitmap CapturePreview_Synchronous_Dangerous()
 		{
 			var stream = new MemoryStream();
 			var task = _webview.CoreWebView2.CapturePreviewAsync(CoreWebView2CapturePreviewImageFormat.Png, stream);
@@ -426,13 +426,13 @@ namespace Bloom
 
 		public override void SaveDocument(string path)
 		{
-			var html = RunJavaScript("document.documentElement.outerHTML");
+			var html = RunJavascriptWithStringResult_Sync_Dangerous("document.documentElement.outerHTML");
 			RobustFile.WriteAllText(path, html, Encoding.UTF8);
 		}
 
 		public override async Task SaveDocumentAsync(string path)
 		{
-			var html = await RunJavaScriptAsync("document.documentElement.outerHTML");
+			var html = await GetStringFromJavascriptAsync("document.documentElement.outerHTML");
 			RobustFile.WriteAllText(path, html, Encoding.UTF8);
 		}
 		// Review: base class currently explicitly opens FireFox. Should we instead open Chrome,
@@ -441,14 +441,13 @@ namespace Bloom
 		//{
 		//	throw new NotImplementedException();
 		//}
-	
-		public override string RunJavaScript(string script)
+
+		[Obsolete("This method is dangerous because it has to loop Application.DoEvents(). RunJavaScriptAsync() is preferred.")]
+		public override string RunJavascriptWithStringResult_Sync_Dangerous(string script)
 		{
-			Task<string> task = RunJavaScriptAsync(script);
-			// I don't fully understand why this works and many other things I tried don't (typically deadlock,
-			// or complain that ExecuteScriptAsync must be done on the main thread).
+			Task<string> task = _webview.ExecuteScriptAsync(script);
+			// This is dangerous. E.g. it caused this bug: https://issues.bloomlibrary.org/youtrack/issue/BL-12614
 			// Came from an answer in https://stackoverflow.com/questions/65327263/how-to-get-sync-return-from-executescriptasync-in-webview2'
-			// The more elegant thing would be a drastic rewrite of many levels of callers to all be async.
 			while (!task.IsCompleted)
 			{
 				Application.DoEvents();
@@ -457,8 +456,11 @@ namespace Bloom
 			var result = task.Result;
 			return result;
 		}
-
-		public override async Task<string> RunJavaScriptAsync(string script)
+		public override async Task RunJavascriptAsync(string script)
+		{
+			await _webview.ExecuteScriptAsync(script);
+		}
+		public override async Task<string> GetStringFromJavascriptAsync(string script)
 		{
 			var result = await _webview.ExecuteScriptAsync(script);
 			// Whatever the javascript produces gets JSON encoded automatically by ExecuteScriptAsync.
@@ -487,22 +489,22 @@ namespace Bloom
 			// result (we only care about the side effects on the clipboard and document)
 			_cutCommand.Implementer = () =>
 			{
-				RunJavaScriptAsync("editTabBundle?.getEditablePageBundleExports()?.cutSelection()");
+				RunJavascriptAsync("editTabBundle?.getEditablePageBundleExports()?.cutSelection()");
 			};
 			_copyCommand.Implementer = () =>
 			{
-				RunJavaScriptAsync("editTabBundle?.getEditablePageBundleExports()?.copySelection()");
+				RunJavascriptAsync("editTabBundle?.getEditablePageBundleExports()?.copySelection()");
 			};
 			_pasteCommand.Implementer = () =>
 			{
-				RunJavaScriptAsync("editTabBundle?.getEditablePageBundleExports()?.pasteClipboardText()");
+				RunJavascriptAsync("editTabBundle?.getEditablePageBundleExports()?.pasteClipboardText()");
 
 			};
 			_undoCommand.Implementer = () =>
 			{
 				// Note: this is only used for the Undo button in the toolbar;
 				// ctrl-z is handled in JavaScript directly.
-				RunJavaScript("editTabBundle.handleUndo()");
+				RunJavascriptWithStringResult_Sync_Dangerous("editTabBundle.handleUndo()"); // I'm leaving this async for this late update to 5.5, but Can it by async?
 			};
 		}
 
@@ -574,7 +576,7 @@ namespace Bloom
 			try
 			{
 				_currentlyRunningCanUndo = true;
-				return "yes" == await RunJavaScriptAsync("editTabBundle?.canUndo?.()");
+				return "yes" == await GetStringFromJavascriptAsync("editTabBundle?.canUndo?.()");
 			}
 
 			finally

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -498,7 +498,7 @@ namespace Bloom
 			{
 				// Note: this is only used for the Undo button in the toolbar;
 				// ctrl-z is handled in JavaScript directly.
-				RunJavascriptWithStringResult_Sync_Dangerous("editTabBundle.handleUndo()"); // I'm leaving this async for this late update to 5.5, but Can it by async?
+				RunJavascriptWithStringResult_Sync_Dangerous("editTabBundle.handleUndo()"); // I'm leaving this async for this late update to 5.5, but can it be async?
 			};
 		}
 
@@ -519,7 +519,7 @@ namespace Bloom
 		}
 
 		bool _currentlyInUpdateButtons = false;
-		public override async void UpdateEditButtons()
+		public override async void UpdateEditButtonsAsync()
 		{
 			if (_currentlyInUpdateButtons)
 				return;
@@ -532,7 +532,7 @@ namespace Bloom
 
 				if (InvokeRequired)
 				{
-					Invoke(new Action(UpdateEditButtons));
+					Invoke(new Action(UpdateEditButtonsAsync));
 					return;
 				}
 
@@ -543,7 +543,7 @@ namespace Bloom
 					_copyCommand.Enabled = isTextSelection;
 					_pasteCommand.Enabled = PortableClipboard.ContainsText();
 
-					_undoCommand.Enabled = await CanUndo();
+					_undoCommand.Enabled = await CanUndoAsync();
 
 				}
 				catch (Exception)
@@ -562,7 +562,7 @@ namespace Bloom
 		}
 
 		bool _currentlyRunningCanUndo = false;
-		private async Task<bool> CanUndo()
+		private async Task<bool> CanUndoAsync()
 		{
 			// once we got a stackoverflow exception here, when, apparently, JS took longer to complete this than the timer interval
 			if (_currentlyRunningCanUndo)

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -445,7 +445,7 @@ namespace Bloom
 		[Obsolete("This method is dangerous because it has to loop Application.DoEvents(). RunJavaScriptAsync() is preferred.")]
 		public override string RunJavascriptWithStringResult_Sync_Dangerous(string script)
 		{
-			Task<string> task = _webview.ExecuteScriptAsync(script);
+			Task<string> task = GetStringFromJavascriptAsync(script);
 			// This is dangerous. E.g. it caused this bug: https://issues.bloomlibrary.org/youtrack/issue/BL-12614
 			// Came from an answer in https://stackoverflow.com/questions/65327263/how-to-get-sync-return-from-executescriptasync-in-webview2'
 			while (!task.IsCompleted)
@@ -453,8 +453,8 @@ namespace Bloom
 				Application.DoEvents();
 				System.Threading.Thread.Sleep(10);
 			}
-			var result = task.Result;
-			return result;
+
+			return task.Result;
 		}
 		public override async Task RunJavascriptAsync(string script)
 		{

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -424,12 +424,6 @@ namespace Bloom
 			return new Bitmap(stream);
 		}
 
-		public override void SaveDocument(string path)
-		{
-			var html = RunJavascriptWithStringResult_Sync_Dangerous("document.documentElement.outerHTML");
-			RobustFile.WriteAllText(path, html, Encoding.UTF8);
-		}
-
 		public override async Task SaveDocumentAsync(string path)
 		{
 			var html = await GetStringFromJavascriptAsync("document.documentElement.outerHTML");
@@ -569,7 +563,7 @@ namespace Bloom
 
 		bool _currentlyRunningCanUndo = false;
 		private async Task<bool> CanUndo()
-		{		
+		{
 			// once we got a stackoverflow exception here, when, apparently, JS took longer to complete this than the timer interval
 			if (_currentlyRunningCanUndo)
 				return true;
@@ -583,7 +577,7 @@ namespace Bloom
 			{
 				_currentlyRunningCanUndo = false;
 			}
-			
+
 		}
 	}
 


### PR DESCRIPTION
Makes the CanUndo() use the async call to javascript, removing the looping of Application.DoEvents()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6096)
<!-- Reviewable:end -->
