### PR TITLE
[5.5] BL-12675 Keep white space in Title during audio

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -19,6 +19,7 @@
 .Title-On-Cover-style
     span.ui-audioCurrent:not(.ui-suppressHighlight):not(.ui-disableHighlight) {
     display: inline-block;
+    white-space: pre-wrap;
 }
 
 span.ui-audioCurrent:not(.ui-suppressHighlight):not(.ui-disableHighlight),


### PR DESCRIPTION
This is 1 of 2 PRs. The second does the same thing, but in bloom-player.less

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6106)
<!-- Reviewable:end -->
