### PR TITLE
Fix hiding copyright button for placeholder images (BL-12700)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -178,7 +178,7 @@ export function addImageEditingButtons(containerDiv: HTMLElement): void {
     if (!containerDiv || containerDiv.classList.contains("hoverUp")) {
         return;
     }
-    let img = getImgFromContainer(this);
+    let img = getImgFromContainer(containerDiv);
     if (img.length === 0)
         // This case is probably a left over from some previous Bloom where
         // we were using background images instead of <img>? But it does


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6110)
<!-- Reviewable:end -->
