### PR TITLE
Reduce number of synchronous calls to RunJavascript (BL-12691)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -4323,11 +4323,6 @@
         <source xml:lang="en">This is disabled because this book is not set up to be full bleed.</source>
         <note>ID: PublishTab.PdfMaker.FullBleed.DisableBecauseBookIsNotFullBleed</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PdfMaker.FullBleed">
-        <source xml:lang="en">Full Bleed</source>
-        <note>ID: PublishTab.PdfMaker.FullBleed</note>
-        <note>displayed as an option in the PDF Options menu in Publish tab. Be careful, "full bleed" is a technical term in printing, meaning to print into an area outside the main page content that is ideally trimmed off; do not translate literally</note>
-      </trans-unit>
       <trans-unit id="PublishTab.PdfMaker.MakingFromHtml">
         <source xml:lang="en">Making PDF from HTML</source>
         <note>ID: PublishTab.PdfMaker.MakingFromHtml</note>

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -170,7 +170,7 @@ namespace Bloom.Edit
 			if (details.From == _view)
 			{
 				SaveNow();
-				_view.RunJavascriptWithStringResult_Sync_Dangerous("if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined') {editTabBundle.getEditablePageBundleExports().disconnectForGarbageCollection();}");
+				_view.RunJavascriptAsync("if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined') {editTabBundle.getEditablePageBundleExports().disconnectForGarbageCollection();}");
 				// This bizarre behavior prevents BL-2313 and related problems.
 				// For some reason I cannot discover, switching tabs when focus is in the Browser window
 				// causes Bloom to get deactivated, which prevents various controls from working.
@@ -644,7 +644,7 @@ namespace Bloom.Edit
 				_view.ChangingPages = true;
 				_view.RunJavascriptWithStringResult_Sync_Dangerous("if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined') {editTabBundle.getEditablePageBundleExports().pageSelectionChanging();}");
 				FinishSavingPage();
-				_view.RunJavascriptWithStringResult_Sync_Dangerous("if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined') {editTabBundle.getEditablePageBundleExports().disconnectForGarbageCollection();}");
+				_view.RunJavascriptAsync("if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePageBundleExports()) !=='undefined') {editTabBundle.getEditablePageBundleExports().disconnectForGarbageCollection();}");
 			}
 		}
 

--- a/src/BloomExe/HtmlThumbNailer.cs
+++ b/src/BloomExe/HtmlThumbNailer.cs
@@ -299,12 +299,12 @@ namespace Bloom
 				NonFatalProblem.Report(ModalIf.None, PassiveIf.Alpha, "Could not make thumbnail", "Ref bl-524", e);
 				return new Size(0, 0); // this tells the caller we failed
 			}
-
-			var height =
-				(int)Math.Round(double.Parse(
-					browser.RunJavascriptWithStringResult_Sync_Dangerous("document.getElementsByClassName('bloom-page')[0].clientHeight.toString()")));
-			var width = (int)Math.Round(
-				double.Parse(browser.RunJavascriptWithStringResult_Sync_Dangerous("document.getElementsByClassName('bloom-page')[0].clientWidth.toString()")));
+			var script = @"
+const page = document.getElementsByClassName('bloom-page')[0]; page.clientHeight.toString() + ' ' + page.clientWidth.toString();";
+			var result = browser.RunJavascriptWithStringResult_Sync_Dangerous(script);
+			var parts = result.Split(' ');
+			var height = (int)Math.Round(double.Parse(parts[0]));
+			var width = (int)Math.Round(double.Parse(parts[1]));
 
 			browser.Height = height;
 			browser.Width = width;
@@ -480,19 +480,15 @@ namespace Bloom
 				int bottomOfCoverImage = -1;
 				_syncControl.Invoke((Action)(() =>
 				{
-					// There's probably some way to get all of this in a single RunJavaScript call, but note that ?. is not supported
-					// in GeckoFx60, and I've had some trouble with scripts of more than a single expression in WebView2.
-					var imageCount =
-						int.Parse(browser.RunJavascriptWithStringResult_Sync_Dangerous(
-							"document.getElementsByClassName('bloom-imageContainer').length.toString()"));
-					if (imageCount != 0)
+					var script = @"
+const containers = document.getElementsByClassName('bloom-imageContainer');
+if (containers.length) containers[0].offsetTop.toString() + ' ' + containers[0].offsetHeight.toString();";
+					var result = browser.RunJavascriptWithStringResult_Sync_Dangerous(script);
+					if (!String.IsNullOrWhiteSpace(result))
 					{
-						topOfCoverImage = (int)Math.Round(double.Parse(
-							browser.RunJavascriptWithStringResult_Sync_Dangerous(
-								"document.getElementsByClassName('bloom-imageContainer')[0].offsetTop.toString()")));
-						bottomOfCoverImage = topOfCoverImage + (int)Math.Round(double.Parse(
-							browser.RunJavascriptWithStringResult_Sync_Dangerous(
-								"document.getElementsByClassName('bloom-imageContainer')[0].offsetHeight.toString()")));
+						var parts = result.Split(' ');
+						topOfCoverImage = (int)Math.Round(double.Parse(parts[0]));
+						bottomOfCoverImage = topOfCoverImage + (int)Math.Round(double.Parse(parts[1]));
 					}
 				}));
 

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -439,7 +439,7 @@ namespace Bloom
 			while (!task.IsCompleted)
 			{
 				Application.DoEvents();
-				System.Threading.Thread.Sleep(10);
+				Thread.Sleep(10);
 			}
 
 			return task.Result;
@@ -492,7 +492,7 @@ namespace Bloom
 			{
 				// Note: this is only used for the Undo button in the toolbar;
 				// ctrl-z is handled in JavaScript directly.
-				RunJavascriptWithStringResult_Sync_Dangerous("editTabBundle.handleUndo()"); // I'm leaving this async for this late update to 5.5, but can it be async?
+				RunJavascriptAsync("editTabBundle.handleUndo()");	// works fine async in testing
 			};
 		}
 


### PR DESCRIPTION
Either switch to RunJavascriptAsync where feasible, or merge multiple consecutive calls to a single call to at least minimize exposure to problems with the synchronization code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6111)
<!-- Reviewable:end -->
