### PR TITLE
BL-12495 improve show invisibles again - tooltips

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/showInvisibles.ts
+++ b/src/BloomBrowserUI/bookEdit/js/showInvisibles.ts
@@ -126,8 +126,8 @@ export function showInvisibles(e) {
             );
             $this.qtip({
                 position: {
-                    my: "top right",
-                    at: "bottom left",
+                    my: "top left",
+                    at: "bottom right",
                     container: bloomQtipUtils.qtipZoomContainer()
                 },
                 content: $this.attr("data-name-of-invisible"),
@@ -135,7 +135,10 @@ export function showInvisibles(e) {
                     ready: true
                 },
                 hide: {
-                    leave: false
+                    inactive: 2000,
+                    effect: function() {
+                        $(this).fadeOut(250);
+                    }
                 }
             });
         }


### PR DESCRIPTION
move tooltips to other side, make them fade out after 2 seconds

Note that if you move your mouse onto one during those two seconds, it will restart the two second countdown for that tooltip

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6117)
<!-- Reviewable:end -->
