### PR TITLE
Remove initial redundant BloomPub creating for saving books (BL-12694)

### DIFF
--- a/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
+++ b/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
@@ -100,13 +100,12 @@ namespace Bloom.Publish.BloomPub
 #if !__MonoCS__
 
 				SetState("UsbStarted");
-				// In 5.6, we should consider removing this UpdatePreviewIfNeeded line as it does not
-				// currently appear to be accomplishing anything. Also in "wifi/start" and 
-				// "file/save" endpoints below.
-				if (_publishApi.UpdatePreviewIfNeeded(request))
-				{ 
-					_usbPublisher.Connect(request.CurrentBook, _publishApi._thumbnailBackgroundColor, _publishApi.GetSettings());
-				} else
+				var publishSettings = _publishApi.GetSettings();
+				if (_publishApi.IsBookLicenseOK(request.CurrentBook, publishSettings, _progress))
+				{
+					_usbPublisher.Connect(request.CurrentBook, _publishApi._thumbnailBackgroundColor, publishSettings);
+				}
+				else
 				{
 					SetState("stopped");
 				}
@@ -125,9 +124,10 @@ namespace Bloom.Publish.BloomPub
 			apiHandler.RegisterEndpointHandler(kApiUrlPart + "wifi/start", request =>
 			{
 				SetState("ServingOnWifi");
-				if (_publishApi.UpdatePreviewIfNeeded(request))
+				var publishSettings = _publishApi.GetSettings();
+				if (_publishApi.IsBookLicenseOK(request.CurrentBook, publishSettings, _progress))
 				{
-					_wifiPublisher.Start(request.CurrentBook, request.CurrentCollectionSettings, _publishApi._thumbnailBackgroundColor, _publishApi.GetSettings());
+					_wifiPublisher.Start(request.CurrentBook, request.CurrentCollectionSettings, _publishApi._thumbnailBackgroundColor, publishSettings);
 				} else
 				{
 					SetState("stopped");
@@ -146,9 +146,10 @@ namespace Bloom.Publish.BloomPub
 			apiHandler.RegisterEndpointHandler(kApiUrlPart + "file/save", request =>
 			{
 				SetState("SavingFile");
-				if (_publishApi.UpdatePreviewIfNeeded(request))
+				var publishSettings = _publishApi.GetSettings();
+				if (_publishApi.IsBookLicenseOK(request.CurrentBook, publishSettings, _progress))
 				{
-					FilePublisher.Save(request.CurrentBook, _bookServer, _publishApi._thumbnailBackgroundColor, _progress, _publishApi.GetSettings());
+					FilePublisher.Save(request.CurrentBook, _bookServer, _publishApi._thumbnailBackgroundColor, _progress, publishSettings);
 				}
 				SetState("stopped");
 				request.PostSucceeded();

--- a/src/BloomExe/web/controllers/PublishApi.cs
+++ b/src/BloomExe/web/controllers/PublishApi.cs
@@ -423,6 +423,27 @@ namespace Bloom.web.controllers
 		}
 
 		/// <summary>
+		/// Check whether we are allowed to publish this book in this language (using LicenseChecker)
+		/// </summary>
+		internal bool IsBookLicenseOK(Book.Book book, BloomPubPublishSettings settings, WebSocketProgress progress)
+		{
+			if (settings?.LanguagesToInclude != null)
+			{
+				var message = new LicenseChecker().CheckBook(book, settings.LanguagesToInclude.ToArray());
+				if (message != null)
+				{
+					if (progress != null)
+						progress.MessageWithoutLocalizing(message, ProgressKind.Error);
+					LicenseOK = false;
+					_webSocketServer.SendString(kWebSocketContext, kWebsocketState_LicenseOK, "false");
+					return false;
+				}
+			}
+			LicenseOK = true;
+			return true;
+		}
+
+		/// <summary>
 		/// Generates an unzipped, staged BloomPUB from the book
 		/// </summary>
 		/// <returns>A valid, well-formed URL on localhost that points to the staged book's htm file,
@@ -430,18 +451,8 @@ namespace Bloom.web.controllers
 		public string MakeBloomPubForPreview(Book.Book book, BookServer bookServer, WebSocketProgress progress, Color backColor, BloomPubPublishSettings settings = null)
 		{
 			progress.Message("PublishTab.Epub.PreparingPreview", "Preparing Preview");  // message shared with Epub publishing
-			if (settings?.LanguagesToInclude != null)
-			{
-				var message = new LicenseChecker().CheckBook(book, settings.LanguagesToInclude.ToArray());
-				if (message != null)
-				{
-					progress.MessageWithoutLocalizing(message, ProgressKind.Error);
-					LicenseOK = false;
-					_webSocketServer.SendString(kWebSocketContext, kWebsocketState_LicenseOK, "false");
-					return null;
-				}
-			}
-			LicenseOK = true;
+			if (!IsBookLicenseOK(book, settings, progress))
+				return null;
 			_webSocketServer.SendString(kWebSocketContext, kWebsocketState_LicenseOK, "true");
 
 			_stagingFolder?.Dispose();


### PR DESCRIPTION
It has been suggested that this might go on 5.5, but it isn't a new problem with 5.5 as far as I can tell looking at the code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6119)
<!-- Reviewable:end -->
