### PR TITLE
Make disabled status available to components wrapped by tooltip

### DIFF
--- a/src/BloomBrowserUI/publish/commonPublish/PublishFeaturesGroup.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/PublishFeaturesGroup.tsx
@@ -96,7 +96,7 @@ export const PublishFeaturesGroup: React.FunctionComponent<{
         "This is disabled because no “Talking Book Languages” are selected.",
         "PublishTab.Feature.TalkingBook.NoLanguagesSelected"
     );
-    const talkingBookTooltip = isTalkingBook
+    const talkingBookDisabledTooltip = isTalkingBook
         ? ""
         : couldBeTalkingBook
         ? NoLanguagesSelected
@@ -222,13 +222,17 @@ export const PublishFeaturesGroup: React.FunctionComponent<{
             label={useL10n("Features", "PublishTab.Android.Features")}
         >
             <FormGroup>
-                <BloomTooltip key={"tb-tooltip"} tip={talkingBookTooltip}>
+                <BloomTooltip
+                    key={"tb-tooltip"}
+                    tip={""}
+                    showDisabled={!isTalkingBook}
+                    tipWhenDisabled={talkingBookDisabledTooltip}
+                >
                     <BloomCheckbox
                         label="Talking Book"
                         l10nKey="PublishTab.TalkingBook"
                         icon={<TalkingBookIcon />}
                         iconScale={0.9}
-                        disabled={!isTalkingBook}
                         checked={isTalkingBook}
                         onCheckChanged={() => {}}
                         hideBox={true}

--- a/src/BloomBrowserUI/publish/commonPublish/PublishScreenBaseComponents.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/PublishScreenBaseComponents.tsx
@@ -5,6 +5,8 @@ import Typography from "@mui/material/Typography";
 import "./PublishScreenBaseComponents.less";
 import { LocalizedString } from "../../react_components/l10nComponents";
 import { kOptionPanelBackgroundColor } from "../../bloomMaterialUITheme";
+import { DisabledContext } from "../../react_components/BloomToolTip";
+import { kBloomDisabledOpacity } from "../../utils/colorUtils";
 
 // This file contains a collection of components which works together with the PublishScreenTemplate
 // to create the basic layout of a publishing screen in Bloom.
@@ -52,10 +54,14 @@ export const SettingsPanel: React.FunctionComponent = props => {
 export const SettingsGroup: React.FunctionComponent<{
     label: string;
 }> = props => {
+    const disabledContext = React.useContext(DisabledContext);
     return (
         <section
             css={css`
                 margin-top: 20px;
+                opacity: ${disabledContext.valueOf()
+                    ? kBloomDisabledOpacity
+                    : 1};
             `}
         >
             <Typography variant="h6">{props.label}</Typography>

--- a/src/BloomBrowserUI/react_components/BloomCheckBox.tsx
+++ b/src/BloomBrowserUI/react_components/BloomCheckBox.tsx
@@ -8,6 +8,7 @@ import { useL10n } from "./l10nHooks";
 import { LightTooltip } from "./lightTooltip";
 import { Check } from "@mui/icons-material";
 import { kBloomDisabledOpacity } from "../utils/colorUtils";
+import { DisabledContext } from "./BloomToolTip";
 
 // wrap up the complex material-ui checkbox in something simple and make it handle tristate
 export const BloomCheckbox: React.FunctionComponent<{
@@ -54,6 +55,9 @@ export const BloomCheckbox: React.FunctionComponent<{
         props.l10nParam1
     );
 
+    const disabled =
+        React.useContext(DisabledContext).valueOf() || props.disabled;
+
     // if the label is a string, we need to localize it. If it's a react node, we assume it's already localized.
     const labelComponent =
         typeof props.label === "string" ? localizedLabel : props.label;
@@ -78,7 +82,7 @@ export const BloomCheckbox: React.FunctionComponent<{
                         margin-left: -2px;
                     `}
                     className={props.className}
-                    disabled={props.disabled}
+                    disabled={disabled}
                     checked={!!props.checked}
                     indeterminate={props.checked == null}
                     //enhance; I would like  it to show a square with a question mark inside: indeterminateIcon={"?"}
@@ -134,14 +138,13 @@ export const BloomCheckbox: React.FunctionComponent<{
                     <UniformInlineIcon
                         icon={props.icon}
                         iconScale={props.iconScale}
-                        disabled={props.disabled}
+                        disabled={disabled}
                     />
                 )}
                 <div
                     className="bloom-checkbox-label" // this classname is to help overlay toolbox hack a fix
                     css={css`
-                        ${props.disabled &&
-                            `opacity: ${kBloomDisabledOpacity}`};
+                        ${disabled && `opacity: ${kBloomDisabledOpacity}`};
                         // this rule is about helping this to keep working even when font is small, as in the Overlay Tool
                         min-height: 15px;
                         //border: solid red 0.1px;

--- a/src/BloomBrowserUI/react_components/BloomToolTip.tsx
+++ b/src/BloomBrowserUI/react_components/BloomToolTip.tsx
@@ -32,6 +32,10 @@ function isL10nDefinition(obj: any): obj is l10nDefinition {
         typeof obj.l10nKey === "string"
     );
 }
+// To encourage the practice of always explaining why something is disabled using a tooltip,
+// we say that the way to disable things is to set disabled status on the tooltip. Then
+// the children of the tooltip consume that context and display/act appropriately.
+export const DisabledContext = React.createContext(false);
 
 export const BloomTooltip: React.FunctionComponent<IBloomToolTipProps> = props => {
     let tipContent: React.ReactNode;
@@ -63,7 +67,11 @@ export const BloomTooltip: React.FunctionComponent<IBloomToolTipProps> = props =
             className={props.className} // carry in the css props from the caller
         >
             {/* The added <span> here allows the tooltip to show even when the target control is disabled */}
-            <span>{props.children}</span>
+            <span>
+                <DisabledContext.Provider value={!!props.showDisabled}>
+                    {props.children}
+                </DisabledContext.Provider>
+            </span>
         </Tooltip>
     );
 };


### PR DESCRIPTION
Here I redid just one instance of checkbox (Sign Language) to use this system. Anything that already uses BloomTooltip `showDisabled` prop will get it for free.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6122)
<!-- Reviewable:end -->
