### PR TITLE
Fix l10n of page description in Add Page dialog for 5.4 (BL-12572)

### DIFF
--- a/src/BloomBrowserUI/pageChooser/selectedTemplatePageControls.tsx
+++ b/src/BloomBrowserUI/pageChooser/selectedTemplatePageControls.tsx
@@ -40,8 +40,7 @@ export const SelectedTemplatePageControls: React.FunctionComponent<ISelectedTemp
     const [numberToAdd, setNumberToAdd] = useState<number>(minimumPagesToAdd);
 
     const captionKey = "TemplateBooks.PageLabel." + props.caption;
-    const descriptionKey =
-        "TemplateBooks.PageDescription." + props.pageDescription;
+    const descriptionKey = "TemplateBooks.PageDescription." + props.caption;
     const buttonKey = props.forChangeLayout
         ? "EditTab.AddPageDialog.ChooseLayoutButton"
         : "EditTab.AddPageDialog.AddPageButton";


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6140)
<!-- Reviewable:end -->
