### PR TITLE
Fix BL-1275 paragraph collision in overflowing vertically-aligned boxes

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -284,23 +284,26 @@ export default class OverflowChecker {
         }
         if (overflowY > 0 || overflowX > 0) {
             $box.addClass("overflow");
-            theOneLocalizationManager
-                .asyncGetText(
-                    "EditTab.Overflow",
-                    "This box has more text than will fit",
-                    ""
-                )
-                .done(overflowText => {
-                    $box.qtip({
-                        content:
-                            '<img data-overflow="true" height="20" width="20" style="vertical-align:middle" src="/bloom/images/Attention.svg">' +
-                            overflowText,
-                        show: { event: "mouseenter" },
-                        hide: { event: "mouseleave" },
-                        position: { my: "top right", at: "right bottom" },
-                        container: bloomQtipUtils.qtipZoomContainer()
+            if ($box.parents("[class*=Device]").length === 0) {
+                // don't show an overflow warning if we have scrolling available
+                theOneLocalizationManager
+                    .asyncGetText(
+                        "EditTab.Overflow",
+                        "This box has more text than will fit",
+                        ""
+                    )
+                    .done(overflowText => {
+                        $box.qtip({
+                            content:
+                                '<img data-overflow="true" height="20" width="20" style="vertical-align:middle" src="/bloom/images/Attention.svg">' +
+                                overflowText,
+                            show: { event: "mouseenter" },
+                            hide: { event: "mouseleave" },
+                            position: { my: "top right", at: "right bottom" },
+                            container: bloomQtipUtils.qtipZoomContainer()
+                        });
                     });
-                });
+            }
         }
 
         const container = $box.closest(".marginBox");

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -627,6 +627,13 @@ div.bloom-templateMode {
 .bloom-page[class*="Device"] {
     .bloom-editable.overflow {
         overflow-y: scroll;
+        display: block;
+
+        // the language label at the bottom gets messed up once scrolling is on, so anchor it to the top
+        &:after {
+            top: 0 !important;
+            bottom: unset !important;
+        }
     }
 }
 

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/PageThumbnail.tsx
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/PageThumbnail.tsx
@@ -68,6 +68,9 @@ export const PageThumbnail: React.FunctionComponent<{
     };
     const reForOverflow = /^[^>]*class="[^"]*pageOverflows/;
     const overflowing = reForOverflow.test(content); // enhance: memo?
+
+    const scrollingWillBeAvailable = props.pageSize.indexOf("Device") > -1;
+
     useEffect(() => {
         if (Math.abs(Date.now() - lastPageRequestTime) > 5000) {
             activePageRequestCount = 0; // something weird happened, don't block forever
@@ -95,7 +98,9 @@ export const PageThumbnail: React.FunctionComponent<{
                             onClick={props.onClick}
                             onContextMenu={props.onContextMenu}
                         />
-                        {overflowing && <div className="pageOverflowsIcon" />}
+                        {overflowing && !scrollingWillBeAvailable && (
+                            <div className="pageOverflowsIcon" />
+                        )}
                     </div>
                     <div className="thumbnailCaption">{props.page.caption}</div>
                 </>

--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -861,14 +861,20 @@ books may contain divs with box-header-off, so we need a rule to hide them.*/
 // would conflict with the rules that determine which of them are
 // visible. The rules that make them something other than display:none
 // must use display:flex. I think all of those are in langVisibility.less.
-.bloom-vertical-align-center {
+
+// The role of :not(:has(.overflow)) is to avoid an apparent bug where paragraphs will
+// be drawn on top of each other. If we're overflowing anyways, then vertical centering
+// has no meaning, so we can side-step that bug. See BL-12750
+.bloom-vertical-align-center:not(:has(.overflow)) {
     justify-content: center;
     &:not(.bloom-bilingual):not(.bloom-trilingual) .bloom-editable {
         justify-content: center;
     }
 }
-
-.bloom-vertical-align-bottom {
+// The role of :not(:has(.overflow)) is to avoid an apparent bug where paragraphs will
+// be drawn on top of each other. If we're overflowing anyways, then vertical centering
+// has no meaning, so we can side-step that bug. See BL-12750
+.bloom-vertical-align-bottom:not(:has(.overflow)) {
     justify-content: flex-end;
     &:not(.bloom-bilingual):not(.bloom-trilingual) .bloom-editable {
         justify-content: flex-end;


### PR DESCRIPTION
Also
* fixes two "false-alarm" overflow warnings when we have scrolling available
* works around a language-label problem when scrolling

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6144)
<!-- Reviewable:end -->
