### PR TITLE
Use the assigned font for BookButton labels (BL-12587)

### DIFF
--- a/src/BloomBrowserUI/bloomMaterialUITheme.ts
+++ b/src/BloomBrowserUI/bloomMaterialUITheme.ts
@@ -45,6 +45,8 @@ export const kSelectCss = `
 // Should match @UIFontStack in bloomWebFonts.less
 export const kUiFontStack = "Roboto, NotoSans, sans-serif";
 
+export const kDefaultLanguageFontStack = "Andika, sans-serif";
+
 // the value that gets us to the 4.5 AA ratio depends on the background.
 // So the "aside"/features right-panel color effects this.
 //const AACompliantBloomBlue = "#177c8a";

--- a/src/BloomBrowserUI/collectionsTab/BookButton.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BookButton.tsx
@@ -7,7 +7,12 @@ import { Button, Menu } from "@mui/material";
 import TruncateMarkup from "react-truncate-markup";
 import { useTColBookStatus } from "../teamCollection/teamCollectionApi";
 import { BloomAvatar } from "../react_components/bloomAvatar";
-import { kBloomBlue, kBloomGold, kBloomPurple } from "../bloomMaterialUITheme";
+import {
+    kBloomBlue,
+    kBloomGold,
+    kBloomPurple,
+    kDefaultLanguageFontStack
+} from "../bloomMaterialUITheme";
 import { useRef, useState, useEffect } from "react";
 import { useSubscribeToWebSocketForEvent } from "../utils/WebSocketManager";
 import { BookSelectionManager, useIsSelected } from "./bookSelectionManager";
@@ -291,6 +296,7 @@ export const BookButton: React.FunctionComponent<{
         color: white;
         text-transform: none;
         font-size: 12px;
+        font-family: ${kDefaultLanguageFontStack}, ${props.collection.languageFont};
         line-height: 14px;
         margin-top: 5px;
         width: 75px;

--- a/src/BloomBrowserUI/collectionsTab/BooksOfCollection.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BooksOfCollection.tsx
@@ -30,6 +30,7 @@ export interface ICollection {
     isFactoryInstalled: boolean;
     containsDownloadedBooks: boolean;
     id: string;
+    languageFont: string;
 }
 
 export const BooksOfCollection: React.FunctionComponent<{
@@ -62,7 +63,8 @@ export const BooksOfCollection: React.FunctionComponent<{
             isEditableCollection: props.isEditableCollection,
             isFactoryInstalled: true,
             containsDownloadedBooks: false,
-            id: props.collectionId
+            id: props.collectionId,
+            languageFont: "Andika"
         }
     );
     // not getting these from the api currently, and I'm not sure the initial defaults will carry over

--- a/src/BloomExe/web/controllers/CollectionApi.cs
+++ b/src/BloomExe/web/controllers/CollectionApi.cs
@@ -288,6 +288,8 @@ namespace Bloom.web.controllers
 			dynamic props = new ExpandoObject();
 			props.isFactoryInstalled = collection.IsFactoryInstalled;
 			props.containsDownloadedBooks = collection.ContainsDownloadedBooks;
+			if (collection.PathToDirectory == _settings.FolderPath)
+				props.languageFont = _settings.Language1.FontName;
 			request.ReplyWithJson(JsonConvert.SerializeObject(props));
 		}
 


### PR DESCRIPTION
This fixes a display anomaly revealed by the screenshots in BL-12587. The effect of the fix may have nothing to do with surrogate pairs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6152)
<!-- Reviewable:end -->
