### PR TITLE
Restore the old settings dialog (BL-12777)

### DIFF
--- a/src/BloomExe/CollectionTab/CollectionTabView.Designer.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.Designer.cs
@@ -145,10 +145,10 @@ namespace Bloom.CollectionTab
             this._L10NSharpExtender.SetLocalizableToolTip(this._legacySettingsButton, null);
             this._L10NSharpExtender.SetLocalizationComment(this._legacySettingsButton, null);
             this._L10NSharpExtender.SetLocalizationPriority(this._legacySettingsButton, L10NSharp.LocalizationPriority.NotLocalizable);
-            this._L10NSharpExtender.SetLocalizingId(this._legacySettingsButton, "._legacySettingsButton");
+            this._L10NSharpExtender.SetLocalizingId(this._legacySettingsButton, "CollectionTab.SettingsButton");
             this._legacySettingsButton.Name = "_legacySettingsButton";
             this._legacySettingsButton.Size = new System.Drawing.Size(75, 66);
-            this._legacySettingsButton.Text = "Legacy Settings";
+            this._legacySettingsButton.Text = "Settings";
             this._legacySettingsButton.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
             this._legacySettingsButton.Click += new System.EventHandler(this._legacySettingsButton_Click);
 			// 

--- a/src/BloomExe/CollectionTab/CollectionTabView.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.cs
@@ -44,6 +44,7 @@ namespace Bloom.CollectionTab
 
 			InitializeComponent();
 			_reactControl.SetLocalizationChangedEvent(localizationChangedEvent); // after InitializeComponent, which creates it.
+			_settingsButton.Visible = false;	// Hide for now. We'll bring it back in 5.7.
 			BackColor = _reactControl.BackColor = Palette.GeneralBackground;
 			_toolStrip.Renderer = new NoBorderToolStripRenderer();
 			_toolStripLeft.Renderer = new NoBorderToolStripRenderer();
@@ -259,7 +260,7 @@ namespace Bloom.CollectionTab
 		{
 			//we have a couple of buttons which don't make sense for the remote (therefore vulnerable) low-end user
 			settingsLauncherHelper.ManageComponent(_legacySettingsButton);
-			settingsLauncherHelper.ManageComponent(_settingsButton);
+			//comment out until 5.7 settingsLauncherHelper.ManageComponent(_settingsButton);
 
 			//NB: this isn't really a setting, but we're using that feature to simplify this menu down to what makes sense for the easily-confused user
 			settingsLauncherHelper.ManageComponent(_openCreateCollectionButton);


### PR DESCRIPTION
The new button and dialog are merely hidden.  The partial work on that dialog is still there, but inaccessible to the user interface.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6153)
<!-- Reviewable:end -->
