### PR TITLE
Change maximum image size to 3840x2800 to allow Ultra HD (BL-12130)

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -2828,7 +2828,8 @@ namespace Bloom.Book
 				// this.
 
 				// Bloom 4.9 and later limit images used by Bloom books to be no larger than 3500x2550 in
-				// order to avoid out of memory errors that can happen with really large images.  Some older
+				// order to avoid out of memory errors that can happen with really large images.
+				// Bloom 5.6 changed this to 3840x2800 to accomodate Ultra HD (aka "4K"). Some older
 				// books have images larger than this that can cause these out of memory problems.  This
 				// method is used to fix these overlarge images before the user starts to edit or publish
 				// the book.  The method also ensures that the images are all opaque since some old versions

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1101,8 +1101,16 @@ namespace Bloom.Edit
 				var taglibMetadata = metaInfo.GetValue(palasoImage.Metadata);
 				var widthInfo = taglibMetadata.GetType().GetField("width", bindFlags);
 				var heightInfo = taglibMetadata.GetType().GetField("height", bindFlags);
-				width = (int)widthInfo.GetValue(taglibMetadata);
-				height = (int)heightInfo.GetValue(taglibMetadata);
+				var widthObj = widthInfo.GetValue(taglibMetadata);
+				if (widthObj is short || widthObj is ushort || widthObj is int || widthObj is uint)
+					width = Convert.ToInt32(widthObj);
+				else
+					return false;
+				var heightObj = heightInfo.GetValue(taglibMetadata);
+				if (heightObj is short || heightObj is ushort || heightObj is int || heightObj is uint)
+					height = Convert.ToInt32(heightObj);
+				else
+					return false;
 				return true;
 			}
 			catch

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -30,10 +30,10 @@ namespace Bloom.ImageProcessing
 {
 	static class ImageUtils
 	{
-		public const int MaxLength = 3500;		// 8 pixels less than length of A4 at 300dpi (max width for landscape, height for portrait)
-		public const int MaxBreadth = 2550;		// = 8.5 inches at 300dpi (max height for landscape, width for portrait)
-		public const double MaxImageAspectPortrait = 3500.0 / 2550.0;
-		public const double MaxImageAspectLandscape = 2550.0 / 3500.0;
+		public const int MaxLength = 3840;		// equals Ultra HD ("4K") long dimension (max width for landscape, height for portrait)
+		public const int MaxBreadth = 2800;     // balanced lesser size for print, larger than Ultra HD short dimension (max height for landscape, width for portrait)
+		public const double MaxImageAspectPortrait = 3840.0 / 2800.0;
+		public const double MaxImageAspectLandscape = 2800.0 / 3840.0;
 
 		public static bool AppearsToBeJpeg(PalasoImage imageInfo)
 		{
@@ -597,7 +597,7 @@ namespace Bloom.ImageProcessing
 		}
 
 		/// <summary>
-		/// Shrink any images in the folder that are bigger than our maximum reasonable size (3500x2550)
+		/// Shrink any images in the folder that are bigger than our maximum reasonable size (3840x2800)
 		/// to fit within that size.
 		/// Also remove transparency on desired images (which there usually won't be any).
 		/// </summary>
@@ -880,6 +880,7 @@ namespace Bloom.ImageProcessing
 					{
 						if(new FileInfo(destPath).Length > new FileInfo(sourcePath).Length){
 							// The new file is actually larger (BL-11441) so bail out
+							Debug.WriteLine($"New file for {Path.GetFileName(sourcePath)} at {size} is larger than original at {imageInfo.Image.Size}.");
 							return null;
 						}
 						imageInfo.SetCurrentFilePath(destPath);

--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -138,26 +138,26 @@ namespace BloomTests.ImageProcessing
 		}
 
 		[Test]
-		[TestCase(3500, 2550, 3500, 2550)]	// maximum size landscape
-		[TestCase(2550, 3500, 2550, 3500)]	// maximum size portrait
+		[TestCase(3840, 2800, 3840, 2800)]	// maximum size landscape
+		[TestCase(2800, 3840, 2800, 3840)]	// maximum size portrait
 		[TestCase(3400, 2500, 3400, 2500)]	// smaller than bounds landscape
 		[TestCase(2500, 3400, 2500, 3400)]	// smaller than bounds portrait
-		[TestCase(3000, 3000, 2550, 2550)]	// square too large
-		[TestCase(4000, 3000, 3400, 2550)]	// landscape, both too large squashed
-		[TestCase(5250, 3825, 3500, 2550)]	// landscape, both too large same aspect ratio
-		[TestCase(5000, 3000, 3500, 2100)]	// landscape, both too large elongated
-		[TestCase(3000, 4000, 2550, 3400)]	// portrait, both too large squashed
-		[TestCase(3825, 5250, 2550, 3500)]	// portrait, both too large same aspect ratio
-		[TestCase(3000, 5000, 2100, 3500)]	// portrait, both too large elongated
-		[TestCase(2500, 5000, 1750, 3500)]	// portrait, height too large
-		[TestCase(5000, 2500, 3500, 1750)]	// landscape, width too large
-		[TestCase(3400, 2700, 3211, 2550)]	// landscape, height too large
-		[TestCase(2700, 3400, 2550, 3211)]	// portrait, width too large
+		[TestCase(3000, 3000, 2800, 2800)]	// square too large
+		[TestCase(4000, 3000, 3733, 2800)]	// landscape, both too large squashed
+		[TestCase(5376, 3920, 3840, 2800)]	// landscape, both too large same aspect ratio
+		[TestCase(5000, 3000, 3840, 2304)]	// landscape, both too large elongated
+		[TestCase(3000, 4000, 2800, 3733)]	// portrait, both too large squashed
+		[TestCase(3920, 5376, 2800, 3840)]	// portrait, both too large same aspect ratio
+		[TestCase(3000, 5000, 2304, 3840)]	// portrait, both too large elongated
+		[TestCase(2500, 5000, 1920, 3840)]	// portrait, height too large
+		[TestCase(5000, 2500, 3840, 1920)]	// landscape, width too large
+		[TestCase(3800, 3000, 3546, 2800)]	// landscape, height too large
+		[TestCase(3000, 3800, 2800, 3546)]	// portrait, width too large
 		public static void TestGetImageSizes(int width, int height, int newWidth, int newHeight)
 		{
 			var size = ImageUtils.GetDesiredImageSize(width, height);
-			Assert.AreEqual(size.Width, newWidth, $"Computed width for {width},{height} is correct.");
-			Assert.AreEqual(size.Height, newHeight, $"Computed height for {width},{height} is correct.");
+			Assert.AreEqual(newWidth, size.Width, $"Computed width for {width},{height} is correct.");
+			Assert.AreEqual(newHeight, size.Height, $"Computed height for {width},{height} is correct.");
 		}
 
 		[Test]


### PR DESCRIPTION
The bound is larger than Ultra HD on the smaller dimension to accommodate paper printing which can have less elongated images.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6167)
<!-- Reviewable:end -->
