### PR TITLE
Use input quality for output quality in jpeg size reduction (BL-12808)

### DIFF
--- a/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
+++ b/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
@@ -112,7 +112,7 @@ BookServer bookServer,
 			return filter;
 		}
 
-		private static void CompressImages(string modifiedBookFolderPath, ImagePublishSettings imagePublishSettings, XmlDocument dom)
+		public static void CompressImages(string modifiedBookFolderPath, ImagePublishSettings imagePublishSettings, XmlDocument dom)
 		{
 			List<string> imagesToPreserveResolution;
 			List<string> imagesToGiveTransparentBackgrounds;
@@ -141,17 +141,30 @@ BookServer bookServer,
 						continue; // don't compress these
 								  // Cover images should be transparent if possible.  Others don't need to be.
 					var makeBackgroundTransparent = imagesToGiveTransparentBackgrounds.Contains(fileName);
-					var modifiedContent = BookCompressor.GetImageBytesForElectronicPub(filePath,
-						makeBackgroundTransparent,
-						imagePublishSettings);
-					// In a previous version, we did this during the compression, and therefore didn't have to
-					// write out a modified version. There's a small savings in this, but the price is
-					// a nasty leak of knowledge about making BloomPubs into a class responsible for
-					// compressing to zip files. If we really need this savings, we could refactor to
-					// use the overrides parameter of CompressDirectory.
-					RobustFile.WriteAllBytes(filePath, modifiedContent);
+					GetNewImageIfNeeded(filePath, imagePublishSettings, makeBackgroundTransparent);
 				}
 			}
+		}
+
+		private static void GetNewImageIfNeeded(string filePath, ImagePublishSettings imagePublishSettings, bool makeBackgroundTransparent)
+		{
+			using (var tagFile = RobustFileIO.CreateTaglibFile(filePath))
+			{
+				var currentWidth = tagFile.Properties.PhotoWidth;
+				var currentHeight = tagFile.Properties.PhotoHeight;
+				// We want to make sure that the image is not larger than the maximum width or height.
+				// We don't know whether the image is portrait or landscape, so we have to check both
+				// orientations.  The publish settings are known to be in landscape orientation, and
+				// the image has to fit into those bounds, but we don't care whether the actual display
+				// is portrait or landscape.
+				if (imagePublishSettings.MaxWidth >= currentWidth && imagePublishSettings.MaxHeight >= currentHeight ||
+					imagePublishSettings.MaxWidth >= currentHeight && imagePublishSettings.MaxHeight >= currentWidth)
+				{
+					if (!makeBackgroundTransparent)
+						return;		// current file is okay as is: small enough and no need to make transparent.
+				}
+			}
+			BookCompressor.CopyResizedImageFile(filePath, filePath, imagePublishSettings, makeBackgroundTransparent);
 		}
 
 		private const string kBackgroundImage = "background-image:url('";   // must match format string in HtmlDom.SetImageElementUrl()

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -2524,8 +2524,7 @@ namespace Bloom.Publish.Epub
 		{
 			if (limitImageDimensions && BookCompressor.CompressableImageFileExtensions.Contains(Path.GetExtension(srcPath).ToLowerInvariant()))
 			{
-				var imageBytes = BookCompressor.GetImageBytesForElectronicPub(srcPath, needTransparentBackground, imagePublishSettings);
-				RobustFile.WriteAllBytes(dstPath, imageBytes);
+				BookCompressor.CopyResizedImageFile(srcPath, dstPath, imagePublishSettings, needTransparentBackground);
 				return;
 			}
 			if (dstPath.Contains(kCssFolder) && dstPath.EndsWith(".css"))

--- a/src/BloomExe/web/controllers/PublishApi.cs
+++ b/src/BloomExe/web/controllers/PublishApi.cs
@@ -488,7 +488,7 @@ namespace Bloom.web.controllers
 		/// </summary>
 		/// <returns>A valid, well-formed URL on localhost that points to the staged book's htm file,
 		/// or null if we aren't allowed to publish this book in this language (LicenseChecker).</returns>
-		public string MakeBloomPubForPreview(Book.Book book, BookServer bookServer, WebSocketProgress progress, Color backColor, BloomPubPublishSettings settings = null)
+		public string MakeBloomPubForPreview(Book.Book book, BookServer bookServer, WebSocketProgress progress, Color backColor, BloomPubPublishSettings settings)
 		{
 			progress.Message("PublishTab.Epub.PreparingPreview", "Preparing Preview");  // message shared with Epub publishing
 			if (!IsBookLicenseOK(book, settings, progress))
@@ -510,6 +510,8 @@ namespace Bloom.web.controllers
 			// I believe we only ever have one book being made there, so it works.
 			CurrentPublicationFolder = _stagingFolder.FolderPath;
 			var modifiedBook = BloomPubMaker.PrepareBookForBloomReader(settings, bookFolderPath: book.FolderPath, bookServer: bookServer, temp: _stagingFolder, progress, isTemplateBook: book.IsTemplateBook);
+			// Compress images for preview as well as actual publish step.  See comments in BL-12130.
+			BloomPubMaker.CompressImages(modifiedBook.FolderPath, settings.ImagePublishSettings, modifiedBook.RawDom);
 			progress.Message("Common.Done", "Shown in a list of messages when Bloom has completed a task.", "Done");
 			if (settings?.WantPageLabels ?? false)
 			{


### PR DESCRIPTION
This seems to reliably result in smaller file sizes for smaller image dimensions.
I've added the fix for shrinking images for previewing BloomPUBs, and changed the code to use GraphicsMagick for the image manipulations whenever possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6175)
<!-- Reviewable:end -->
