### PR TITLE
[5.6] BL-12811 Fix out-of-date bloomPUB message

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -3901,7 +3901,7 @@
         <note>Button that tells Bloom to begin offering this book on the wifi network.</note>
       </trans-unit>
       <trans-unit id="PublishTab.Android.WrongLayout.Message">
-        <source xml:lang="en">The layout of this book is currently "{0}". Bloom Reader will display it using "{1}", so text might not fit. To see if anything needs adjusting, go back to the Edit Tab and change the layout to "{1}".</source>
+        <source xml:lang="en">The layout of this book is currently "{0}". Bloom Reader will display it using "{1}", which may cause text to scroll. To see if anything needs adjusting, go back to the Edit Tab and change the layout to "{1}".</source>
         <note>ID: PublishTab.Android.WrongLayout.Message</note>
         <note>{0} and {1} are book layout tags.</note>
       </trans-unit>

--- a/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
+++ b/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
@@ -304,7 +304,7 @@ namespace Bloom.Publish.BloomPub
 //					"Note", "A heading shown above some messages.");
 //				progress.MessageWithoutLocalizing(msgFormat, ProgressKind.Note);
 				 var msgFormat = L10NSharp.LocalizationManager.GetString("PublishTab.Android.WrongLayout.Message",
-					"The layout of this book is currently \"{0}\". Bloom Reader will display it using \"{1}\", so text might not fit. To see if anything needs adjusting, go back to the Edit Tab and change the layout to \"{1}\".",
+					"The layout of this book is currently \"{0}\". Bloom Reader will display it using \"{1}\", which may cause text to scroll. To see if anything needs adjusting, go back to the Edit Tab and change the layout to \"{1}\".",
 					"{0} and {1} are book layout tags.");
 				var desiredLayout = desiredLayoutSize + layout.SizeAndOrientation.OrientationName;
 				var msg = String.Format(msgFormat, layout.SizeAndOrientation.ToString(), desiredLayout, Environment.NewLine);


### PR DESCRIPTION
* replaced "so text might not fit" with "which may cause text to scroll"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6177)
<!-- Reviewable:end -->
