### PR TITLE
Don't write unchanged defaultLangStyles.css file (BL-12767)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1615,6 +1615,7 @@ namespace Bloom.Book
 
 			var collectionStylesCss = CollectionSettings.GetCollectionStylesCss(false);
 			var cssBuilder = new StringBuilder(collectionStylesCss);
+			string existingContent = null;
 			if (doesAlreadyExist)
 			{
 				// We want to use the current CSS from our collection, which we already added to the
@@ -1631,6 +1632,7 @@ namespace Bloom.Book
 					languagesWeAlreadyHave.Add(CollectionSettings.Language3Tag);
 
 				var cssLines = RobustFile.ReadAllLines(path);
+				existingContent = string.Join(Environment.NewLine, cssLines);
 				const string kLangTag = "[lang='";
 				var copyCurrentRule = false;
 				for (var index = 0 ; index < cssLines.Length; ++index)
@@ -1659,7 +1661,9 @@ namespace Bloom.Book
 			}
 			try
 			{
-				RobustFile.WriteAllText(path, cssBuilder.ToString());
+				var newContent = cssBuilder.ToString();
+				if (newContent.Trim() != existingContent.Trim())
+					RobustFile.WriteAllText(path, newContent);
 			}
 			catch (UnauthorizedAccessException e)
 			{


### PR DESCRIPTION
This doesn't directly address the question of why the file was locked for the user, but it sidesteps the problem by not writing the file if its content hasn't changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6189)
<!-- Reviewable:end -->
