### PR TITLE
Fix a crash checking for unchanged defaultLangStyles.css file (BL-12767)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1662,7 +1662,7 @@ namespace Bloom.Book
 			try
 			{
 				var newContent = cssBuilder.ToString();
-				if (newContent.Trim() != existingContent.Trim())
+				if (newContent.Trim() != existingContent?.Trim())
 					RobustFile.WriteAllText(path, newContent);
 			}
 			catch (UnauthorizedAccessException e)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6193)
<!-- Reviewable:end -->
