### PR TITLE
Get checkbox to display in middle for content language menu (BL-12839)

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1249,6 +1249,7 @@ namespace Bloom.Edit
 					item.Enabled = !l.Selected || nSelected > 1;
 					item.Checked = l.Selected;
 					item.CheckOnClick = true;
+					item.ImageScaling = ToolStripItemImageScaling.None;
 					item.CheckedChanged += new EventHandler(OnContentLanguageDropdownItem_CheckedChanged);
 				}
 


### PR DESCRIPTION
No, I don't understand why this works or why it is needed in Version5.5 and later, but not earlier.  But it's the only thing I've found which affects the display of the check mark.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6202)
<!-- Reviewable:end -->
