### PR TITLE
Handle TagLibSharp exceptions better for some images (BL-11933)

### DIFF
--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -196,14 +196,14 @@ copy /Y "$(SolutionDir)\lib\dotnet\libtidy.dll" $(OutDir)
     <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="Sentry" Version="3.9.4" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SIL.Core" Version="13.0.0-beta0082" />
-    <PackageReference Include="SIL.Core.Desktop" Version="13.0.0-beta0082" />
+    <PackageReference Include="SIL.Core" Version="13.0.0-beta0084" />
+    <PackageReference Include="SIL.Core.Desktop" Version="13.0.0-beta0084" />
     <PackageReference Include="SIL.DesktopAnalytics" Version="4.0.4" />
-    <PackageReference Include="SIL.Media" Version="13.0.0-beta0082" />
-    <PackageReference Include="SIL.Windows.Forms" Version="13.0.0-beta0082" />
-    <PackageReference Include="SIL.Windows.Forms.Keyboarding" Version="13.0.0-beta0082" />
-    <PackageReference Include="SIL.Windows.Forms.WritingSystems" Version="13.0.0-beta0082" />
-    <PackageReference Include="SIL.WritingSystems" Version="13.0.0-beta0082" />
+    <PackageReference Include="SIL.Media" Version="13.0.0-beta0084" />
+    <PackageReference Include="SIL.Windows.Forms" Version="13.0.0-beta0084" />
+    <PackageReference Include="SIL.Windows.Forms.Keyboarding" Version="13.0.0-beta0084" />
+    <PackageReference Include="SIL.Windows.Forms.WritingSystems" Version="13.0.0-beta0084" />
+    <PackageReference Include="SIL.WritingSystems" Version="13.0.0-beta0084" />
     <PackageReference Include="sqlite-net-pcl" Version="1.7.335" />
     <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.0.3" />
     <PackageReference Include="SQLitePCLRaw.core" Version="2.0.3" />

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -94,11 +94,11 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SIL.Core" Version="13.0.0-beta0082" />
-    <PackageReference Include="SIL.Core.Desktop" Version="13.0.0-beta0082" />
-    <PackageReference Include="SIL.Media" Version="13.0.0-beta0082" />
-    <PackageReference Include="SIL.TestUtilities" Version="13.0.0-beta0082" />
-    <PackageReference Include="SIL.Windows.Forms" Version="13.0.0-beta0082" />
+    <PackageReference Include="SIL.Core" Version="13.0.0-beta0084" />
+    <PackageReference Include="SIL.Core.Desktop" Version="13.0.0-beta0084" />
+    <PackageReference Include="SIL.Media" Version="13.0.0-beta0084" />
+    <PackageReference Include="SIL.TestUtilities" Version="13.0.0-beta0084" />
+    <PackageReference Include="SIL.Windows.Forms" Version="13.0.0-beta0084" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
     <PackageReference Include="PolySharp" Version="1.13.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/WebView2PdfMaker/WebView2PdfMaker.csproj
+++ b/src/WebView2PdfMaker/WebView2PdfMaker.csproj
@@ -50,7 +50,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SIL.Core" Version="13.0.0-beta0082" />
+    <PackageReference Include="SIL.Core" Version="13.0.0-beta0084" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6215)
<!-- Reviewable:end -->
