### PR TITLE
Fix pasting (from Word) to remove useless spans (BL-12861)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bloomField/bloomFieldSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/bloomFieldSpec.ts
@@ -501,3 +501,34 @@ describe("fixPasteData", () => {
         );
     });
 });
+
+describe("removeUselessSpanMarkup", () => {
+    it("removes span with no attributes", () => {
+        expect(
+            BloomField.removeUselessSpanMarkup(
+                "<p><em><span>This is a test.</span></em></p>"
+            )
+        ).toBe("<p><em>This is a test.</em></p>");
+    });
+    it("does not remove span with attribute", () => {
+        expect(
+            BloomField.removeUselessSpanMarkup(
+                "<p><span id='s1'>This is a test.</span></p>"
+            )
+        ).toBe("<p><span id='s1'>This is a test.</span></p>");
+    });
+    it("handles input without spans", () => {
+        expect(
+            BloomField.removeUselessSpanMarkup(
+                "<p><em>This is a test.</em></p>"
+            )
+        ).toBe("<p><em>This is a test.</em></p>");
+    });
+    it("handles span with embedded markup elements", () => {
+        expect(
+            BloomField.removeUselessSpanMarkup(
+                "<p><span>This <strong>is</strong> a <em>test</em>.</span></p>"
+            )
+        ).toBe("<p>This <strong>is</strong> a <em>test</em>.</p>");
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -81,15 +81,15 @@ div.ui-audioCurrent p {
     // Note: This highlighting is expected to persist across sessions, but to be hidden (displayed with the yellow color) while each segment is playing.
     //       This is accomplished because this rule temporarily drops out of effect when .ui-audioCurrent is moved to the span as that segment plays.
     //       (The rule requires a span BELOW the .ui-audioCurrent, so it drops out of effect the span IS the .ui-audioCurrent).
-    span:nth-child(3n + 1) {
+    span:nth-child(3n + 1 of .bloom-highlightSegment) {
         background-color: #bfedf3;
     }
 
-    span:nth-child(3n + 2) {
+    span:nth-child(3n + 2 of .bloom-highlightSegment) {
         background-color: #7fdae6;
     }
 
-    span:nth-child(3n + 3) {
+    span:nth-child(3n + 3 of .bloom-highlightSegment) {
         background-color: #29c2d6;
     }
 


### PR DESCRIPTION
This might be simple enough to cherry-pick back to 5.5 if we think it's robust enough.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6224)
<!-- Reviewable:end -->
