### PR TITLE
Bl-12758 book status to api

### DIFF
--- a/src/BloomExe/web/controllers/CollectionApi.cs
+++ b/src/BloomExe/web/controllers/CollectionApi.cs
@@ -275,17 +275,17 @@ namespace Bloom.web.controllers
 				return; // should be Get
 			var langTag = string.IsNullOrEmpty(_settings.SignLanguageTag) ? _settings.Language1Tag : _settings.SignLanguageTag;
 			var bloomLibraryApiClient = new BloomLibraryBookApiClient();
-			string count;
+			int count;
 			try
 			{
-				count = bloomLibraryApiClient.getBookCountByLanguage(langTag);
+				count = bloomLibraryApiClient.GetBookCountByLanguage(langTag);
 			}
 			catch
 			{
-				count = "-1";
+				count = -1;
 			}
 
-			request.ReplyWithText(count);
+			request.ReplyWithText(count.ToString());
 		}
 
 		internal void CheckForCollectionUpdates()

--- a/src/BloomExe/web/controllers/CollectionApi.cs
+++ b/src/BloomExe/web/controllers/CollectionApi.cs
@@ -273,11 +273,19 @@ namespace Bloom.web.controllers
 		{
 			if (request.HttpMethod == HttpMethods.Post)
 				return; // should be Get
-
-			var client = new BloomLibraryBookApiClient();
 			var langTag = string.IsNullOrEmpty(_settings.SignLanguageTag) ? _settings.Language1Tag : _settings.SignLanguageTag;
-			var count = client.GetBookCountByLanguage(langTag);
-			request.ReplyWithText(count.ToString());
+			var bloomLibraryApiClient = new BloomLibraryBookApiClient();
+			string count;
+			try
+			{
+				count = bloomLibraryApiClient.getBookCountByLanguage(langTag);
+			}
+			catch
+			{
+				count = "-1";
+			}
+
+			request.ReplyWithText(count);
 		}
 
 		internal void CheckForCollectionUpdates()


### PR DESCRIPTION
Hide Parse behind API: Book Status

Part of the larger project to replace direct calls to Parse with calls to azure fns, so that we reduce our lockin to Parse.

**Depends on https://github.com/BloomBooks/bloom-azure-functions/pull/68**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6226)
<!-- Reviewable:end -->
