### PR TITLE
Cherrypick BL-12879 fix badges disappearing after duplicate book,

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/BooksOfCollection.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BooksOfCollection.tsx
@@ -14,7 +14,6 @@ import {
 import { BookSelectionManager } from "./bookSelectionManager";
 import LazyLoad, { forceVisible } from "react-lazyload";
 import { Link } from "../react_components/link";
-import { kBloomBlue } from "../bloomMaterialUITheme";
 
 export interface IBookInfo {
     id: string;
@@ -72,6 +71,15 @@ export const BooksOfCollection: React.FunctionComponent<{
         "editableCollectionList",
         "reload:" + props.collectionId
     );
+
+    useEffect(() => {
+        if (books.length > 0)
+        {
+            // once the books variable has been updated with the book-on-blorg statuses,
+            // unset the reloadParameter so we don't keep reloading the book-on-blorg statuses
+            setReloadParameter(""); 
+        }
+    }, [books])
 
     //const selectedBookInfo = useMonitorBookSelection();
     const collection: ICollection = useApiData(

--- a/src/BloomExe/Collection/BookCollection.cs
+++ b/src/BloomExe/Collection/BookCollection.cs
@@ -273,6 +273,10 @@ namespace Bloom.Collection
 								continue;
 							AddBookInfo(folder.FullName);
 						}
+						if (Type == CollectionType.TheOneEditableCollection)
+						{
+							UpdateBloomLibraryStatusOfBooks(_bookInfos, true);
+						}
 					}
 					finally
 					{


### PR DESCRIPTION
Cherrypicking to 5.6: Fix badge disappearing after duplication and uneccesary api calls after refresh (https://github.com/BloomBooks/BloomDesktop/pull/6229)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6239)
<!-- Reviewable:end -->
