### PR TITLE
Major rework of BringBookUpToDate and AppearanceSettings (BL-12853)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -5280,6 +5280,10 @@ Do you want to go ahead?</note>
         <source xml:lang="en">The book '{0}', which you have checked out and edited, was modified in the team collection by someone else. Your changes have been overwritten, but are saved to Lost-and-found.</source>
         <note>ID: TeamCollection.ConflictingEdit</note>
       </trans-unit>
+      <trans-unit id="TeamCollection.CheckoutRequired" sil:dynamic="true" translate="no">
+        <source xml:lang="en">CheckoutRequired</source>
+        <note>ID: TeamCollection.ConflictingEdit</note>
+      </trans-unit>
       <trans-unit id="TeamCollection.CreateTeamCollection" sil:dynamic="true">
         <source xml:lang="en">Create a Team Collection</source>
         <note>ID: TeamCollection.CreateTeamCollection</note>
@@ -5372,7 +5376,12 @@ Do you want to go ahead?</note>
         <note>ID: TeamCollection.CheckoutError</note>
         <note>{0} is the name of the book</note>
       </trans-unit>
+      <trans-unit id="TeamCollection.CheckoutRequiredExplanation" sil:dynamic="true" translate="no">
+        <source xml:lang="en">Please check out this book from the Team Collection before publishing it.</source>
+        <note>ID: TeamCollection.ConflictingEdit</note>
+      </trans-unit>
 -->
+
       <trans-unit id="TemplateBooks.BookName.Activity" sil:dynamic="true">
         <source xml:lang="en">Activity</source>
         <note>ID: TemplateBooks.BookName.Activity</note>

--- a/src/BloomBrowserUI/bookLayout/collection styles override template.css
+++ b/src/BloomBrowserUI/bookLayout/collection styles override template.css
@@ -5,7 +5,8 @@
     IN THE COLLECTION FOLDER:  changes made to a copy found in the book folder will be
     lost the next time the book is edited with Bloom!
 
- Note: you can also add a file named "customBookStyles.css" in the book folder,
+ Note: you can also add a file named "customBookStyles2.css" in the book folder,
+    (or "customBookStyles.css" if you are using the legacy theme)
     to limit the effects of the rules to just that one book.
 
     You can learn about CSS from hundreds of books, or online. However chances are, if

--- a/src/BloomBrowserUI/react_components/boxes.tsx
+++ b/src/BloomBrowserUI/react_components/boxes.tsx
@@ -14,7 +14,8 @@ import WarningIcon from "@mui/icons-material/Warning";
 import ErrorIcon from "@mui/icons-material/Error";
 import WaitIcon from "@mui/icons-material/HourglassEmpty";
 import { kBloomDarkTextOverWarning, kBloomWarning } from "../utils/colorUtils";
-import { Box } from "@mui/material";
+import { Box, SvgIconPropsSizeOverrides } from "@mui/material";
+import { OverridableStringUnion } from "@mui/types";
 
 export const kErrorBoxColor = "#eb3941";
 const kLightBlueBackground = "#F0FDFE";
@@ -89,11 +90,20 @@ export const NoteBoxSansBorder: React.FunctionComponent<IBoxProps> = props => {
 interface IBoxProps {
     l10Msg?: string;
     l10nKey?: string;
+    // The bizarre type below is chosen to match the fontSize property of the SvgIconProps interface.
+    iconSize?: OverridableStringUnion<
+        "inherit" | "large" | "medium" | "small",
+        SvgIconPropsSizeOverrides
+    >;
 }
 export const NoteBox: React.FunctionComponent<IBoxProps> = props => {
     const localizedMessage = useL10n(props.l10Msg || "", props.l10nKey || null);
     return (
-        <BoxWithIconAndText hasBorder={true} {...props}>
+        <BoxWithIconAndText
+            hasBorder={true}
+            icon={<InfoIcon fontSize={props.iconSize} />}
+            {...props}
+        >
             {localizedMessage || props.children}
         </BoxWithIconAndText>
     );
@@ -105,7 +115,7 @@ export const WaitBox: React.FunctionComponent<IBoxProps> = props => {
         <BoxWithIconAndText
             color="white"
             backgroundColor="#96668F"
-            icon={<WaitIcon />}
+            icon={<WaitIcon fontSize={props.iconSize} />}
             {...props}
         >
             {localizedMessage || props.children}
@@ -119,7 +129,7 @@ export const WarningBox: React.FunctionComponent<IBoxProps> = props => {
         <BoxWithIconAndText
             color={kBloomDarkTextOverWarning}
             backgroundColor={kBloomWarning}
-            icon={<WarningIcon />}
+            icon={<WarningIcon fontSize={props.iconSize} />}
             css={css`
                 font-weight: 500;
             `}
@@ -136,7 +146,7 @@ export const ErrorBox: React.FunctionComponent<IBoxProps> = props => {
         <BoxWithIconAndText
             color="white"
             backgroundColor={kErrorBoxColor}
-            icon={<ErrorIcon />}
+            icon={<ErrorIcon fontSize={props.iconSize} />}
             {...props}
         >
             {localizedMessage || props.children}

--- a/src/BloomExe/Book/AppearanceSettings.cs
+++ b/src/BloomExe/Book/AppearanceSettings.cs
@@ -1,8 +1,3 @@
-using Bloom;
-using Bloom.Book;
-using Newtonsoft.Json;
-using SIL.Extensions;
-using SIL.IO;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,12 +6,20 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Windows.Navigation;
+using Amazon.Auth.AccessControlPolicy;
+using Bloom;
+using Bloom.Book;
+using Bloom.web.controllers;
+using Newtonsoft.Json;
 using SIL.Code;
+using SIL.Extensions;
+using SIL.IO;
+using SIL.Reporting;
 
 /// <summary>
 /// This class manages the appearance settings for a book. This includes generating the appearance.css file that is used at display time.
 /// It also has responsibilities related to detecting and migrating problem legacy custom css files.
-/// TODO: needs major revision descibed in BL-12856. Accordingly, I have not tried to review or improve this old version.
 /// </summary>
 public class AppearanceSettings
 {
@@ -39,7 +42,21 @@ public class AppearanceSettings
     public static string kHideValueForDisplay = "none";
     public static string kOverrideGroupsArrayKey = "groupsToOverrideFromParent"; // e.g. "coverFields, xmatter"
     private static AppearanceCustomCssToThemeSubstitutinator _substitutinator;
+
+    // A representation of the content of Appearance.json
     internal dynamic _properties;
+
+    // Review: not sure we need to keep this. There is some danger in having multiple AppearanceSettings objects for the same book.
+    // If one has received the Initialize call, but another one (not initialized) is used, we can get wrong answers.
+    // But we don't have access to the needed information to do the full Initialize() in the constructor (and can't have, because
+    // it comes from BookStorage, whose constructor needs a BookInfo). So we are trying to arrange things so that
+    // BookInfos (and AppearanceSettings) that are part of the structure of a book or a BookCollection are so created
+    // and used that we only have one per book folder. BookInfos that are created for other purposes, mostly
+    // for brief use accessing one property of the metadata, are created without an AppearanceSettings.
+    // To help catch any remaining problems, in Debug builds we write to output if we detect multiple AppearanceSettings for the same
+    // book folder. Such an event isn't necessarily a bug, but it's worth looking into whether there is danger of
+    // using uninitialized appearance settings, or whether a BookInfo with NO appearance settings could be used
+    static Dictionary<string, AppearanceSettings> _instances = new();
 
     // it's a big hassle working directly with the ExpandoObject. By casting it this way, you can do the things you expect.
     internal IDictionary<string, object> Properties => (IDictionary<string, object>)_properties;
@@ -49,14 +66,44 @@ public class AppearanceSettings
         get { return _properties; }
     }
 
-    public string FirstPossiblyOffendingCssFile;
-    public string OffendingCssRule;
-    public string SubstitutedCssFile;
+    private string _firstPossiblyOffendingCssFile;
+    public string FirstPossiblyOffendingCssFile
+    {
+        get
+        {
+            Debug.Assert(
+                IsInitialized,
+                "Trying to get property of AppearanceSettings that requires Initialize, but it has not been called."
+            );
+            return _firstPossiblyOffendingCssFile;
+        }
+        set { _firstPossiblyOffendingCssFile = value; }
+    }
+
+    /// <summary>
+    /// If this becomes public, it should probably have a check like FirstPossiblyOffendingCssFile
+    /// Currently it is only used for logging.
+    /// </summary>
+    private string OffendingCssRule;
+
+    // Instance is typically created using UpdateFromFolder, which will set this to true if it found and loaded
+    // an existing appearance.json file.
+    // It is therefore false if the books is, or was created from, a book created by an earlier version of Bloom
+    // that does not use the appearance system. Such books are forced into the legacy-5-6 theme, except possibly
+    // when deriving a new book from them.
+    // It can also be set when WriteToFolder() updates the appearance files to be consistent with the current settings.
+    // This only gets called if Bloom is allowed to make changes to the folder, so it remains false
+    // if we are loading a legacy book in a folder we can't write.
+    private bool _areSettingsConsistentWithFiles;
+    public bool IsInitialized { get; private set; }
 
     // create an array of properties and fill it in
     private PropertyDef[] propertyDefinitions = new PropertyDef[]
     {
-        new StringPropertyDef("cssThemeName", "default", "cssThemeName"), // this one is special because it doesn't correspond to a CSS variable. Instead, we will copy the contents of named file as rules at the end of the CSS file.
+        // this one is special because it doesn't correspond to a CSS variable. Instead, we will copy the contents of named file as rules at the end of the CSS file.
+        // The default here is rarely if ever relevant. Usually a newly created instance will be initialized from a folder, and the default will be overwritten,
+        // either to whatever we find in appearance.json, or to "legacy-5-6" if there is no appearance.json.
+        new StringPropertyDef("cssThemeName", "default", "cssThemeName"),
         // Todo: when we implement this setting, we want to migrate the old record of color color.
         // See code commented out in BringBookUpToDateUnprotected.
         //new CssStringVariableDef("coverColor","yellow","colors"),
@@ -69,91 +116,280 @@ public class AppearanceSettings
     /// <summary>
     /// Note, we might not actually use this theme at runtime. If the book has css that is incompatible with the new system, we will use legacy-5-6 instead.
     /// </summary>
-    private string CssThemeNameSelectedByUser
+    public string CssThemeName
     {
         get { return _properties.cssThemeName; }
         set { _properties.cssThemeName = value; }
     }
 
-    public string BasePageCssName =>
-        CssThemeWeWillActuallyUse == "legacy-5-6" ? "basePage-legacy-5-6.css" : "basePage.css";
+    /// <summary>
+    /// Are we going to use the legacy theme? We MUST use it if we haven't been able to write out a consistent appearance.css file yet.
+    /// Otherwise, it generally depends on whether the user selected it, though when we first see a book we may decide to force it.
+    /// Review: an alternative is to put the appropriate CSS for the chosen theme into the Book supporting files cache.
+    /// But for now we decided on simple: migration to the new theme system only really happens when the user makes a new
+    /// book in Bloom 5.7 or later.
+    /// </summary>
+    public bool UsingLegacy => CssThemeName == "legacy-5-6" || !_areSettingsConsistentWithFiles;
+    public string BasePageCssName => UsingLegacy ? "basePage-legacy-5-6.css" : "basePage.css";
 
-    public string CssThemeWeWillActuallyUse;
+    // All of these are set (or cleared) by Initialize()
+    private bool _customBookStylesAreIncompatibleWithNewSystem;
+    private bool _customCollectionStylesAreIncompatibleWithNewSystem;
+    private bool _customBookStylesExists;
+    private bool _customBookStyles2Exists;
+    private bool _customCollectionStylesExists;
 
     /// <summary>
-    /// In version 5.7, we greatly simplified and modernize our basePage css. However, existing books that had custom css could rely on the old approach,
-    /// specifically for using margins (and possible other things like page nubmer size/location). Therefore we provide a CSS theme that
-    /// effectively just gives you the basePage.css that came with 5.6, now named "basePage-legacy-5-6.css"
+    /// Considering all factors, should the book have a link to a customBookStyles.css file?
     /// </summary>
-    ///
-    public void ComputeThemeAndBasePageCssVersionToUse(Tuple<string, string>[] cssFilesToCheck)
+    public bool ShouldUseCustomBookStyles
     {
-        // Note that just because a book *used* to conform to an Appearance version (i.e. get "default" for cssThemeName),
-        // a change in Enterprise status or Xmatter could mean that it no longer does, and may need to go back to "legacy".
-        this.CssThemeWeWillActuallyUse = CssThemeNameSelectedByUser;
-
-        // here we're kinda conflating the legacy theme name with the legacy basePage css version, because both are called "legacy-5-6"
-        if (CssThemeNameSelectedByUser.StartsWith("legacy"))
+        get
         {
-            Debug.WriteLine(
-                $"{CssThemeNameSelectedByUser} theme is explicitly set by user, so we'll use that for basePage"
-            );
-            return;
+            if (!_customBookStylesExists)
+                return false; // Waste to have the link if there is no file
+            if (UsingLegacy)
+                return true; // We're using the legacy theme, so we need the custom CSS that is part of it
+            // New themes generally use customBookStyles2.css (if any), but if we find a compatible customBookStyles.css
+            // we will use it also. This eases migration from the old system when there is no incompatibility.
+            // Review: alternatively, we could just rename the old file to customBookStyles2.css, but then we have
+            // a problem if the new book is opened in an old Bloom.
+            return !_customBookStylesAreIncompatibleWithNewSystem;
         }
-        bool foundUnsubstitutableCss = false;
+    }
 
-        // otherwise, we have to slog through all the css files that might be incompatible with the new system.
-        cssFilesToCheck
-            .Where(css => !string.IsNullOrWhiteSpace(css.Item2))
-            .AsParallel()
-            .FirstOrDefault(css =>
+    public bool ShouldUseCustomBookStyles2
+    {
+        get
+        {
+            if (!_customBookStyles2Exists)
+                return false; // Waste to have the link if there is no file
+            // This one is only for non-legacy themes
+            return !UsingLegacy;
+        }
+    }
+
+    /// <summary>
+    /// Considering all factors, should the book have a link to a customCollectionStyles.css file?
+    /// </summary>
+    public bool ShouldUseCustomCollectionStyles
+    {
+        get
+        {
+            if (!_customCollectionStylesExists)
+                return false; // Waste to have the link if there is no file
+            if (UsingLegacy)
+                return true; // We're using the legacy theme, so we need the custom CSS that is part of it
+            return !_customCollectionStylesAreIncompatibleWithNewSystem; // Using another theme, we want it only if it is compatible with the new system
+        }
+    }
+
+    /// <summary>
+    /// We want the appearance.css file unless we're in the legacy theme!
+    /// </summary>
+    public bool ShouldUseAppearanceCss => !UsingLegacy;
+
+    public List<string> AppearanceRelatedCssFiles(bool useLocalCollectionStyles)
+    {
+        var result = new List<string>();
+        if (ShouldUseAppearanceCss)
+            result.Add("appearance.css");
+        if (ShouldUseCustomBookStyles)
+            result.Add("customBookStyles.css");
+        if (ShouldUseCustomBookStyles2)
+            result.Add("customBookStyles2.css");
+        if (ShouldUseCustomCollectionStyles)
+            result.Add(BookStorage.RelativePathToCollectionStyles(useLocalCollectionStyles));
+        result.Add(BasePageCssName);
+        return result;
+    }
+
+    /// <summary>
+    /// List all the CSS files that AppearanceRelatedCssFiles might ever return
+    /// (for use in deleting the ones that it does not currently return).
+    /// </summary>
+    public static string[] PossibleAppearanceRelatedCssFiles
+    {
+        get
+        {
+            return new[]
             {
-                // Note: we can only cope with one subsitution, so if the customBookStyles and the customCollectionStyles both have a substitution
-                // we just can't subsitute at all. So we'll let the second one we encounter, which finds that it is incompatible, cause
-                // us to use the legacy theme.
-                var substitutionThemeName =
-                    // we aren't already trying to do a substitute...
-                    string.IsNullOrEmpty(SubstitutedCssFile)
-                    // and this is a substitutable file...
-                    && (
-                        css.Item1 == "customBookStyles.css"
-                        || css.Item1 == "customCollectionStyles.css"
-                    )
-                        ? _substitutinator.GetThemeThatSubstitutesForCustomCSS(css.Item2)
-                        : null;
-                if (substitutionThemeName != null)
-                {
-                    SubstitutedCssFile = css.Item1;
-                    CssThemeWeWillActuallyUse = substitutionThemeName; // don't celebrate just yet... any other css file could still be incompatible
-                    SIL.Reporting.Logger.WriteEvent(
-                        $"** Could use {CssThemeWeWillActuallyUse} BasePage and Theme"
-                    );
-                    return false;
-                }
-                else if (MayBeIncompatible(css.Item1, css.Item2, out OffendingCssRule))
-                {
-                    // ok, we can't substitute a theme for a custom css if some other css is incompatible with Appearance
-                    SubstitutedCssFile = null;
-                    foundUnsubstitutableCss = true;
-                    FirstPossiblyOffendingCssFile = css.Item1;
-                    CssThemeWeWillActuallyUse = "legacy-5-6";
-                    SIL.Reporting.Logger.WriteEvent(
-                        $"** Will use {CssThemeWeWillActuallyUse} BasePage and Theme"
-                    );
-                    return true;
-                }
-                return false;
-            });
+                "appearance.css",
+                "customBookStyles.css",
+                "customBookStyles2.css",
+                "customCollectionStyles.css",
+                "../customCollectionStyles.cs",
+                "basePage.css",
+                "basePage-legacy-5-6.css"
+            };
+        }
+    }
 
-        // If we found theme that was designed to substitute for the custom file they have,
-        // make it as though they had selected that theme. Note the the BookStorage is responsible for
-        // not adding a link the custom css matching the name of SubstitutedCssFile.
-        if (!string.IsNullOrEmpty(SubstitutedCssFile))
+    /// <summary>
+    /// Given a list of CSS files from a new book, typically customBookStyles.css and customCollectionStyles.css,
+    /// decide what theme the book should use, and if we need a specialized customBookStyles2.css file,
+    /// return a path to the file that should be copied there.
+    /// </summary>
+    public string GetThemeAndSubstituteCss(Tuple<string, string>[] cssFilesToCheck)
+    {
+        // This is currently only used when creating a new book. If the source book was already in the Appearance/Theme system,
+        // it will have an appearance.json file, and we will stick with whatever theme and related settings
+        // the original book had.
+        if (_areSettingsConsistentWithFiles)
+            return null;
+        // Otherwise, cssThemeName will already be set to "legacy-5-6" by UpdateFromFolder, but for new books we want to
+        // try to use the default or some substitute them, and only switch back to the legacy theme,
+        // if we don't know of a substitute theme and its associated customBookStyles2.css file.
+        CssThemeName = "default";
+        string substituteTheme = null;
+
+        foreach (var css in cssFilesToCheck.Where(css => !string.IsNullOrWhiteSpace(css.Item2)))
         {
-            Properties["cssThemeName"] = CssThemeWeWillActuallyUse;
+            // This is our first time initializing the appearance system for this book.
+            // Decide what to do about its custom css.
+            // We may know to substitute a particular theme/CSS combination for this particular custom css.
+            // We may force the legacy theme.
+
+            // Note: we can only cope with one substitution, so if the customBookStyles and the customCollectionStyles both have a substitution
+            // (and they aren't identical) we just can't substitute at all.
+            // So we'll let the second one we encounter, which finds that it is incompatible, cause
+            // us to use the legacy theme.
+            var substitutionThemeName = _substitutinator.GetThemeThatSubstitutesForCustomCSS(
+                css.Item2
+            );
+            if (
+                substitutionThemeName != null
+                && (substituteTheme == null || substituteTheme == substitutionThemeName)
+            )
+            {
+                // We may be able to use the substitute theme... don't celebrate just yet... any other css file could still be incompatible
+                substituteTheme = substitutionThemeName;
+                CssThemeName = substitutionThemeName;
+                SIL.Reporting.Logger.WriteEvent($"** Could use {CssThemeName} BasePage and Theme");
+                continue;
+            }
+
+            // No substitute found, or we already found a different one that needs a substitute. So we need to
+            // see if this one is incompatible.
+            if (TestCompatibility(css.Item1, css.Item2, out string _))
+            {
+                // We found a custom CSS we don't have a rule for, or possibly a second custom CSS different from one that already needed a substitution.
+                if (substituteTheme != null)
+                {
+                    // We process customBookStyles first. If we were planning to substitute for it, presumably it is also incompatible.
+                    _customBookStylesAreIncompatibleWithNewSystem = true;
+                }
+
+                substituteTheme = null;
+                // Don't use FirstPossiblyOffendingCssFile here, typically we haven't been Initialized, so it will throw.
+                _firstPossiblyOffendingCssFile = _firstPossiblyOffendingCssFile ?? css.Item1;
+                CssThemeName = "legacy-5-6";
+                SIL.Reporting.Logger.WriteEvent($"** Will use {CssThemeName} BasePage and Theme");
+            }
         }
 
-        Debug.WriteLine($"** Will use {CssThemeWeWillActuallyUse}");
+        Debug.WriteLine($"** Will use {CssThemeName}");
+        return substituteTheme == null
+            ? null
+            : Path.Combine(
+                BloomFileLocator.GetFolderContainingAppearanceThemeFiles(),
+                $"appearance-theme-{substituteTheme}.css"
+            );
+    }
+
+    /// <summary>
+    /// In version 5.7, we greatly simplified and modernized our basePage css. However, existing books that had custom css could rely on the old approach,
+    /// specifically for using margins (and possible other things like page nubmer size/location). Therefore we provide a CSS theme that
+    /// effectively just gives you the basePage.css that came with 5.6, now named "basePage-legacy-5-6.css".
+    /// As part of setting up a book, we initialize this settings object with a list of CSS files that might be in the book folder.
+    /// Return true if we found a problem and had to switch to the legacy theme.
+    /// Currently we also pass Css files from branding and xmatter, but we will report a problem if one of them isn't compatible.
+    /// When we get more confidence that we have migrated all the brandings and xmatters, we can stop passing them in.
+    /// </summary>
+    public bool Initialize(Tuple<string, string>[] cssFilesToCheck)
+    {
+        var result = false;
+        // in case we are reinitializing, clear out any old state
+        FirstPossiblyOffendingCssFile = null;
+        _customBookStylesExists = false;
+        _customBookStyles2Exists = false;
+        _customBookStylesAreIncompatibleWithNewSystem = false;
+        _customCollectionStylesAreIncompatibleWithNewSystem = false;
+        _customCollectionStylesExists = false;
+        IsInitialized = true;
+        // We have to slog through all the css files that might be incompatible with the new system.
+        // Even if the legacy theme is active, we still need to know if there are any incompatible files,
+        // because it affects the bookSettingsDialog UI
+        // Note: JohnH had this done in parallel, using a Where and AsParallel(), but that isn't safe, at least without
+        // some locking on FirstPossiblyOffendingCssFile. He also had a FirstOrDefault() in there, but because we're setting
+        // state on things like _customBookStylesExists and _customBookStylesAreIncompatibleWithNewSystem, we need to check them all.
+        foreach (var css in cssFilesToCheck.Where(css => !string.IsNullOrWhiteSpace(css.Item2)))
+        {
+            if (TestCompatibility(css.Item1, css.Item2, out string offendingCssRule))
+            {
+                if (FirstPossiblyOffendingCssFile == null)
+                {
+                    OffendingCssRule = offendingCssRule;
+                    FirstPossiblyOffendingCssFile = css.Item1;
+                }
+                if (!css.Item1.StartsWith("custom"))
+                {
+                    SIL.Reporting.ErrorReport.NotifyUserOfProblem(
+                        "Unexpectedly found a branding or xmatter CSS not compatible with appearance system: "
+                            + css.Item1
+                            + " problem rule is: "
+                            + OffendingCssRule
+                    );
+                    // This shouldn't happen, but is probably the best way to carry on if we must
+                    if (CssThemeName != "legacy-5-6")
+                    {
+                        CssThemeName = "legacy-5-6";
+                        result = true;
+                    }
+                }
+            }
+
+            Debug.WriteLine($"** Will use {CssThemeName}");
+        }
+
+        IndicatorInfoApi.NotifyIndicatorInfoChanged(); // In case the UI read the incomplete settings before we got here
+        return result;
+    }
+
+    /// <summary>
+    /// This is a wrapper for MayBeIncompatible that also sets some flags used by other functions.
+    /// It has the same arguments and results.
+    /// </summary>
+    /// <returns></returns>
+    bool TestCompatibility(string cssFileName, string cssFileContent, out string offendingRule)
+    {
+        if (string.IsNullOrEmpty(cssFileContent))
+        {
+            offendingRule = null;
+            return false;
+        }
+        else
+        {
+            if (cssFileName == "customBookStyles.css")
+                _customBookStylesExists = true;
+            else if (cssFileName == "customBookStyles2.css")
+                _customBookStyles2Exists = true;
+            else if (cssFileName == "customCollectionStyles.css")
+                _customCollectionStylesExists = true;
+        }
+        var result = MayBeIncompatible(cssFileName, cssFileContent, out offendingRule);
+        if (cssFileName == "customBookStyles.css")
+            _customBookStylesAreIncompatibleWithNewSystem = result;
+        else if (result && cssFileName == "customBookStyles2.css")
+        {
+            SIL.Reporting.ErrorReport.NotifyUserOfProblem(
+                new ShowOncePerSessionBasedOnExactMessagePolicy(),
+                "The customBookStyles2.css file is incompatible with this version of Bloom. It will probably cause problems."
+            );
+        }
+        else if (cssFileName == "customCollectionStyles.css")
+            _customCollectionStylesAreIncompatibleWithNewSystem = result;
+        return result;
     }
 
     internal static bool MayBeIncompatible(string label, string css, out string offendingRule)
@@ -177,9 +413,8 @@ public class AppearanceSettings
         // See if the css contains rules that nowadays should be using css variables, and would likely interfere with 5.6 and up
         const string kProbablyWillInterfere =
             @"\.marginBox\s*{[^}]*?"
-            + "(?<![-\\w])"
-            + // prevent matching things like --page-margin-left
-            "(padding[-:]|left:|top:|right:|bottom:|margin[-:]|width:|height:)[^}]*}";
+            + "(?<![-\\w])" // look-behind to prevent matching things like --page-margin-left
+            + "(padding[-:]|left:|top:|right:|bottom:|margin[-:]|width:|height:)[^}]*}";
         var match = Regex.Match(css, kProbablyWillInterfere, RegexOptions.IgnoreCase);
         if (match.Success)
         {
@@ -213,28 +448,63 @@ public class AppearanceSettings
     }
 
     /// <summary>
-    /// Make a AppearanceSettings by reading the json file in the book folder.
-    /// If some exception is thrown while trying to do that, or if it doesn't exist,
-    /// just return a default BookSettings.
+    /// Update the settings that come from the json file.
+    /// (Client still needs to call Initialize() to set up the things that depend on it.
+    /// It requires arguments we don't have here and can't easily get, and is too expensive
+    /// to do every time this is called.)
     /// </summary>
     /// <param name="bookFolderPath"></param>
     /// <returns></returns>
-    public static AppearanceSettings FromFolderOrNew(string bookFolderPath)
+    public void UpdateFromFolder(string bookFolderPath)
     {
+        // Review: possibly remove this once we are sure we have no more problems with this
+        // For one thing, it's too strong: I'm not sure we should NEVER do this. But I want to study when it happens.
+        // As of when I added it in Dec 2023, it doesn't trigger while starting up a simple collection or editing a book.
+        // But I would not be surprised if some form of publication or something in TeamCollection triggers it
+        // and requires us to remove it (or fix a problem).
+        if (_instances.TryGetValue(bookFolderPath, out AppearanceSettings existingSettings))
+            if (!Program.RunningUnitTests && existingSettings != this)
+            {
+                // There is one known case where this happens, when PageTemplateApi
+                // creates a template book for a book that is also in a current collection.
+                // Others should ideally be investigated to make sure we don't end up with
+                // an uninitialized AppearanceSettings for the current book in one of the
+                // main BookCollections.
+                Debug.WriteLine("Duplicate bookInfo created for " + bookFolderPath);
+                Debug.WriteLine(new Exception().StackTrace);
+            }
+            else
+            {
+                _instances[bookFolderPath] = this;
+            }
         var jsonPath = AppearanceJsonPath(bookFolderPath);
-        AppearanceSettings settings = new AppearanceSettings();
 
-        Debug.WriteLine($"--- FromFolderOrNew({bookFolderPath})");
         if (RobustFile.Exists(jsonPath))
         {
+            // We can't actually be absolutely sure that appearance.css is up to date with the json file;
+            // we'll risk assuming it is.
+            _areSettingsConsistentWithFiles = true;
+
             var json = RobustFile.ReadAllText(jsonPath);
-            settings.UpdateFromJson(json);
+            UpdateFromJson(json);
             Debug.WriteLine(
-                $"Found existing appearance json. CssThemeName is currently {settings.CssThemeNameSelectedByUser}"
+                $"Found existing appearance json. CssThemeName is currently {CssThemeName}"
             );
         }
+        else
+        {
+            // if we don't have a json file, we'll switch to legacy. This means we're in a book that has never been in
+            // the appearance system (never migrated to 5.7). We switch new books to the default theme if it's safe,
+            // but we don't think it's safe to switch existing books. If we decide to allow that after all, note
+            // that there are complications if we do so for a book where we can't write out appearance.css.
+            // It should be possible in such a case to push it into the BookStorage's _supportingFiles cache.
+            CssThemeName = "legacy-5-6";
+        }
+    }
 
-        return settings;
+    public void AllowLaterInstance(string bookFolderPath)
+    {
+        _instances.Remove(bookFolderPath);
     }
 
     /// <summary>
@@ -344,14 +614,7 @@ public class AppearanceSettings
         cssBuilder.AppendLine("/* From this book's appearance settings */");
         cssBuilder.AppendLine(GetCssRootDeclaration(null));
 
-        if (CssThemeWeWillActuallyUse == null)
-        {
-            Debug.WriteLine(
-                "** TODO Appearance.WriteToFolder() called before Appearance.ComputeThemeAndBasePageCssVersionToUse()"
-            );
-        }
-        // TODO: ideally, this is set before we get here. This is so hard!
-        var theme = CssThemeWeWillActuallyUse == null ? "default" : CssThemeWeWillActuallyUse;
+        var theme = CssThemeName;
 
         if (!theme.StartsWith("legacy"))
         {
@@ -399,10 +662,11 @@ public class AppearanceSettings
         var s = JsonConvert.SerializeObject(_properties, settings);
 
         RobustFile.WriteAllText(AppearanceJsonPath(folder), s);
+        _areSettingsConsistentWithFiles = true;
     }
 
     /// <summary>
-    /// Read in our settings from JSON
+    /// Read in our settings from JSON (typically from appearance.json in the book folder)
     /// </summary>
     internal void UpdateFromJson(string json)
     {
@@ -417,20 +681,14 @@ public class AppearanceSettings
         }
     }
 
+    /// <summary>
+    /// Read in our settings from a dynamic object (typically from Configr in the BookSettings dialog)
+    /// </summary>
     internal void UpdateFromDynamic(Newtonsoft.Json.Linq.JObject replacement)
     {
         foreach (var property in replacement)
         {
             ((IDictionary<string, object>)_properties)[property.Key] = property.Value;
-        }
-
-        // If we are forced to be in legacy mode, then we can ignore any change to the
-        // theme that the UI may have let through (currently it doesn't let you change it).
-        // But if we are not in legacy mode, then go ahead and change the theme to match
-        // whatever the UI asked for, no need to check all the css files again.
-        if (string.IsNullOrEmpty(FirstPossiblyOffendingCssFile))
-        {
-            this.CssThemeWeWillActuallyUse = this.CssThemeNameSelectedByUser;
         }
     }
 

--- a/src/BloomExe/Book/BookInfo.cs
+++ b/src/BloomExe/Book/BookInfo.cs
@@ -1,3 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Windows.Forms;
 using Bloom.Api;
 using Bloom.Edit;
 using Bloom.Utils;
@@ -9,16 +19,6 @@ using SIL.IO;
 using SIL.Reporting;
 using SIL.Text;
 using SIL.Windows.Forms.ClearShare;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Windows.Forms;
 
 namespace Bloom.Book
 {
@@ -106,7 +106,7 @@ namespace Bloom.Book
             }
 
             PublishSettings = PublishSettings.FromFolder(FolderPath);
-            AppearanceSettings = AppearanceSettings.FromFolderOrNew(FolderPath);
+            AppearanceSettings.UpdateFromFolder(FolderPath);
         }
 
         public enum HowToPublishImageDescriptions
@@ -646,10 +646,7 @@ namespace Bloom.Book
         /// </summary>
         internal bool ShowThisBookAsSource()
         {
-            return !IsExperimental
-                || ExperimentalFeatures.IsFeatureEnabled(
-                    ExperimentalFeatures.kExperimentalSourceBooks
-                );
+            return MetaData.ShowThisBookAsSource();
         }
 
         private static bool TagIsTopic(string tag)
@@ -689,37 +686,54 @@ namespace Bloom.Book
         /// </summary>
         public static string InstallFreshInstanceGuid(string bookFolder)
         {
-            // This is a temporary BookInfo that shouldn't get asked about saveability of the book.
-            // But, this method should not have been called unless we already verified that we can save
-            // changes legitimately.
-            var bookInfo = new BookInfo(bookFolder, true, new AlwaysEditSaveContext());
-            return bookInfo.InstallFreshGuidInternal();
-        }
-
-        private string InstallFreshGuidInternal()
-        {
+            var metaData = BookMetaData.FromFolder(bookFolder) ?? new BookMetaData();
             var freshGuidString = Guid.NewGuid().ToString();
-            Id = freshGuidString;
-            try
-            {
-                Save();
-                RobustFile.Delete(BookOrderPath(FolderPath));
-                RobustFile.Delete(BookMetaData.BackupFilePath(FolderPath));
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                // Don't display modal, always toast
-                NonFatalProblem.Report(
-                    ModalIf.None,
-                    PassiveIf.All,
-                    "Failed to repair duplicate id",
-                    "BookInfo.InstallFreshInstanceGuid() failed to repair duplicate id in locked meta.json file at "
-                        + FolderPath,
-                    e
-                );
-            }
+            metaData.Id = freshGuidString;
+            var count = 0;
 
-            return Id;
+            do
+            {
+                try
+                {
+                    metaData.WriteToFolder(bookFolder);
+                    RobustFile.Delete(BookOrderPath(bookFolder));
+                    RobustFile.Delete(BookMetaData.BackupFilePath(bookFolder));
+                    break;
+                }
+                catch (UnauthorizedAccessException e)
+                {
+                    // Don't display modal, always toast
+                    NonFatalProblem.Report(
+                        ModalIf.None,
+                        PassiveIf.All,
+                        "Failed to repair duplicate id",
+                        "BookInfo.InstallFreshInstanceGuid() failed to repair duplicate id in locked meta.json file at "
+                            + bookFolder,
+                        e
+                    );
+                    break; // retry is unlikely to help here, and we don't want repeated warning messages.
+                }
+                catch (IOException e)
+                {
+                    Thread.Sleep(500);
+                    count++;
+
+                    // stop trying after 5 attempts to save the file.
+                    if (count > 4)
+                    {
+                        Debug.Fail("Reproduction of BL-354 that we have taken steps to avoid");
+
+                        var msg = LocalizationManager.GetDynamicString(
+                            "Bloom",
+                            "BookEditor.ErrorSavingPage",
+                            "Bloom wasn't able to save the changes to the page."
+                        );
+                        ErrorReport.NotifyUserOfProblem(e, msg);
+                    }
+                }
+            } while (count < 5);
+
+            return freshGuidString;
         }
 
         /// <summary>
@@ -738,9 +752,7 @@ namespace Bloom.Book
             // meta.json file and the value is the filepath.
             var idToSortedFilepathsMap = new Dictionary<string, SortedList<DateTime, string>>();
             var currentFolder = pathToDirectory;
-
             GatherInstanceIdsRecursively(currentFolder, idToSortedFilepathsMap);
-
             // All the data is gathered, now to fix any problems. We assume that the first entry in the SortedList
             // is the original and we change the guid Id in all the copies.
             foreach (var kvp in idToSortedFilepathsMap)
@@ -819,8 +831,7 @@ namespace Bloom.Book
             }
             // Leaf node; we're in a book folder
             var metaFileLastWriteTime = RobustFile.GetLastWriteTimeUtc(metaJsonPath);
-            var bi = new BookInfo(currentFolder, false);
-            var id = bi.Id;
+            var id = (BookMetaData.FromFolder(currentFolder) ?? new BookMetaData()).Id;
             SafelyAddToIdSet(id, metaFileLastWriteTime, currentFolder, idToSortedFilepathsMap);
         }
 
@@ -1183,6 +1194,18 @@ namespace Bloom.Book
         //SeeAlso: commented IsExperimental on Book
         [JsonProperty("experimental")]
         public bool IsExperimental { get; set; }
+
+        /// <summary>
+        /// Check whether this book (or its pages) should be shown as a source.  If it is not experimental, the answer
+        /// is always "yes".  If it is experimental, then show it only if the user wants experimental sources.
+        /// </summary>
+        internal bool ShowThisBookAsSource()
+        {
+            return !IsExperimental
+                || ExperimentalFeatures.IsFeatureEnabled(
+                    ExperimentalFeatures.kExperimentalSourceBooks
+                );
+        }
 
         [JsonProperty("brandingProjectName")]
         public string BrandingProjectName { get; set; }

--- a/src/BloomExe/Book/BookSelection.cs
+++ b/src/BloomExe/Book/BookSelection.cs
@@ -41,7 +41,7 @@ namespace Bloom.Book
 
             // The bookdata null test prevents doing this on books not sufficiently initialized to
             // BringUpToDate, typically only in unit tests.
-            if (book != null && book.BookData != null && book.IsEditable)
+            if (book != null && book.BookData != null && book.IsSaveable)
             {
                 book.EnsureUpToDate();
             }

--- a/src/BloomExe/Book/BookServer.cs
+++ b/src/BloomExe/Book/BookServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Windows.Forms;
 using Bloom.Edit;
@@ -45,10 +45,7 @@ namespace Bloom.Book
                 );
             }
 
-            var book = _bookFactory(
-                bookInfo,
-                _storageFactory(bookInfo.FolderPath, fullyUpdateBookFiles)
-            );
+            var book = _bookFactory(bookInfo, _storageFactory(bookInfo, fullyUpdateBookFiles));
             return book;
         }
 

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -14,9 +15,10 @@ using Bloom.Api;
 using Bloom.Collection;
 using Bloom.ErrorReporter;
 using Bloom.ImageProcessing;
-using Bloom.Publish;
 using Bloom.MiscUI;
+using Bloom.Publish;
 using Bloom.ToPalaso;
+using Bloom.Utils;
 using Bloom.web;
 using Bloom.web.controllers;
 using L10NSharp;
@@ -24,14 +26,12 @@ using Newtonsoft.Json;
 using SIL.Code;
 using SIL.Extensions;
 using SIL.IO;
+using SIL.Linq;
 using SIL.PlatformUtilities;
 using SIL.Progress;
 using SIL.Reporting;
 using SIL.Xml;
-using Bloom.Utils;
 using Image = System.Drawing.Image;
-using SIL.Linq;
-using System.Collections;
 
 namespace Bloom.Book
 {
@@ -56,6 +56,7 @@ namespace Bloom.Book
         bool GetLooksOk();
         HtmlDom Dom { get; }
         void Save();
+
         void SaveForPageChanged(string pageId, XmlElement modifiedPage);
         HtmlDom GetRelocatableCopyOfDom();
         HtmlDom MakeDomRelocatable(HtmlDom dom);
@@ -88,10 +89,15 @@ namespace Bloom.Book
         string Duplicate();
         IEnumerable<string> GetNarrationAudioFileNamesReferencedInBook(bool includeWav);
         IEnumerable<string> GetBackgroundMusicFileNamesReferencedInBook();
+        string GetSupportingFile(string relativePath);
         void EnsureOriginalTitle();
+        bool LinkToLocalCollectionStyles { get; set; }
 
         IEnumerable<string> GetActivityFolderNamesReferencedInBook();
-        void PerformNecessaryMaintenanceOnBook();
+        void MigrateMaintenanceLevels();
+        void MigrateToMediaLevel1ShrinkLargeImages();
+        void MigrateToLevel2RemoveTransparentComicalSvgs();
+        void MigrateToLevel3PutImgFirst();
 
         CollectionSettings CollectionSettings { get; }
 
@@ -99,12 +105,16 @@ namespace Bloom.Book
 
         string[] GetCssFilesToLinkForPreview();
 
-        Tuple<string, string>[] GetCssFilesToCheckForAppearanceCompatibility();
+        Tuple<string, string>[] GetCssFilesToCheckForAppearanceCompatibility(
+            bool justOldCustomFiles = false
+        );
+
+        string PathToXMatterStylesheet { get; }
     }
 
     public class BookStorage : IBookStorage
     {
-        public delegate BookStorage Factory(string folderPath, bool fullyUpdateBookFiles = false); //autofac uses this
+        public delegate BookStorage Factory(BookInfo bookInfo, bool fullyUpdateBookFiles = false); //autofac uses this
 
         /// <summary>
         /// History of these numbers:
@@ -131,12 +141,21 @@ namespace Bloom.Book
         internal const string kMaxBloomFormatVersionToRead = "2.1";
 
         /// <summary>
-        /// History of this number:
+        /// These constants are not currently actually used in code, but indicate the largest
+        /// number currently used for some DOM metadata elements that keep track of how much
+        /// a book has been migrated.
+        /// History of these numbers:
         ///   Bloom 4.9: 1 = Ensure that all images are opaque and no larger than our desired maximum size.
         ///              2 = Remove any 'comical-generated' svgs that are transparent.
         ///				 3 = Ensure main img comes first in image container
+        ///   Bloom 5.7 added kMediaMaintenanceLevel so we could distinguish migrations that affect
+        ///   other files (typically images or media) in the book folder from ones that only affect
+        ///   the DOM and can safely be done in memory.
+        ///       0 = No media maintenance has been done
+        ///       1 = maintenanceLevel at least 1 (so images are opaque and not too big)
         /// </summary>
         public const int kMaintenanceLevel = 3;
+        public const int kMediaMaintenanceLevel = 1;
 
         public const string PrefixForCorruptHtmFiles = "_broken_";
         private IChangeableFileLocator _fileLocator;
@@ -145,7 +164,6 @@ namespace Bloom.Book
         private static bool _alreadyNotifiedAboutOneFailedCopy;
         private BookInfo _metaData;
         private bool _errorAlreadyContainsInstructions;
-
         public event EventHandler FolderPathChanged;
         public event EventHandler BookTitleChanged;
 
@@ -157,8 +175,7 @@ namespace Bloom.Book
         {
             get
             {
-                if (_metaData == null)
-                    _metaData = new BookInfo(FolderPath, false);
+                Debug.Assert(_metaData != null);
                 return _metaData;
             }
             set { _metaData = value; }
@@ -172,14 +189,42 @@ namespace Bloom.Book
                 );
         }
 
-        public BookStorage(
+        /// <summary>
+        /// Historically, we used this constructor, but every call resulted in initializing a new BookInfo
+        /// during ExpensiveInitialization. Then, right after we finish constructing it, we set the BookInfo
+        /// we really want. That became more of a problem in 5.7, when we started doing more expensive
+        /// initialization of AppearanceSettings and could get in trouble working with one that was not
+        /// fully initialized. So now we use the other constructor, which takes the BookInfo
+        /// we really want to use. This one is retained only for convenience of old unit tests.
+        /// </summary>
+        internal BookStorage(
             string folderPath,
             IChangeableFileLocator baseFileLocator,
             BookRenamedEvent bookRenamedEvent,
             CollectionSettings collectionSettings
         )
+            : this(
+                new BookInfo(folderPath, false),
+                baseFileLocator,
+                bookRenamedEvent,
+                collectionSettings
+            )
         {
-            FolderPath = folderPath;
+            if (!Program.RunningUnitTests)
+                throw new ApplicationException(
+                    "BookStorage constructor passing folder name instead of bookInfo is allowed only in unit tests!"
+                );
+        }
+
+        public BookStorage(
+            BookInfo bookInfo,
+            IChangeableFileLocator baseFileLocator,
+            BookRenamedEvent bookRenamedEvent,
+            CollectionSettings collectionSettings
+        )
+        {
+            FolderPath = bookInfo.FolderPath;
+            _metaData = bookInfo;
 
             // We clone this because we'll be customizing it for use by just this book
             _fileLocator = (IChangeableFileLocator)
@@ -194,6 +239,29 @@ namespace Bloom.Book
 
         private string _cachedFolderPath;
         private string _cachedPathToHtml;
+
+        public string GetSupportingFile(string relativePath)
+        {
+            var localPath = Path.Combine(FolderPath, relativePath);
+            if (BookStorage.CssFilesThatAreDynamicallyUpdated.Contains(relativePath))
+            {
+                if (RobustFile.Exists(localPath))
+                {
+                    return localPath;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            if (relativePath == Path.GetFileName(PathToXMatterStylesheet))
+            {
+                return PathToXMatterStylesheet;
+            }
+
+            return _fileLocator.LocateFile(relativePath);
+        }
 
         public static void RemoveLocalOnlyFiles(string folderPath)
         {
@@ -1995,14 +2063,28 @@ namespace Bloom.Book
 
         #endregion
 
-        // ExpensiveInitialization is called repeatedly during idle time and thus can check the
-        // same book for errors repeatedly.  This could result in dozens of open error message dialogs
+
+        // It is remotely possible (see comment on ExpensiveInitialization) that this might be
+        // called repeatedly on the same book. This could result in many open error message dialogs
         // at the same time reporting the same error.  So we keep track of what we've complained about
         // already to prevent this from happening.
         private static HashSet<string> _booksWithMultipleHtmlFiles = new HashSet<string>();
 
         /// <summary>
-        /// Do whatever is needed to do more than just show a title and thumbnail
+        /// An old comment says that ExpensiveInitialization is called repeatedly during idle time, but
+        /// a quick test (Dec 2023) indicates this is not the case; it is called whenever we create a book
+        /// object, but we generally only do that for the selected book. One exception is when the book folder
+        /// does not contain a thumbnail; we create a book object in order to find the cover image.
+        /// However, it should be very rare for this to be missing.
+        /// Another is when we create a template book in order to display its pages in the Add Page dialog.
+        /// Thus, the main reason to call this is when we are selecting a book and about to show its
+        /// preview. This means it has basically the same purpose as Book.BringBookUpToDateMemory().
+        /// We would like to fold its functionality into that method, so don't add new functionality
+        /// here, at least without checking with JohnT, JohnH, or Andrew.
+        /// Note that this routine is theoretically bound by the same constraint as Book.BringBookUpToDatePreview(),
+        /// that it ought not to modify anything in the book folder, at least not if we're not allowed
+        /// to save the book.  Ideally this routine should not modify anything in the book folder.
+        /// For now, we're making an exception if things are so bad that we need to restore a backup.
         /// </summary>
         private void ExpensiveInitialization()
         {
@@ -2242,8 +2324,6 @@ namespace Bloom.Book
 
                 // probably not needed at runtime if !fullyUpdateBookFiles, but one unit test relies on it having been done, and is very fast, so ok.
                 Dom.UpdatePageDivs();
-                UpdateSupportFiles();
-                CleanupUnusedSupportFiles(false);
             }
         }
 
@@ -2408,7 +2488,8 @@ namespace Bloom.Book
         }
 
         /// <summary>
-        /// we update these so that the file continues to look the same when you just open it in the browser
+        /// Update our cache to contain all the support files, so Save will update all of them.
+        /// May also note some that should be deleted when we can Save.
         /// </summary>
         public void UpdateSupportFiles()
         {
@@ -2420,79 +2501,79 @@ namespace Bloom.Book
                     "Not updating files in folder {0} because the directory is read-only.",
                     FolderPath
                 );
+                return;
             }
-            else
-            {
-                var supportFilesToAlwaysUpdate = new[]
+
+            // We want current shipping versions of these copied into the destination folder always.
+            var supportFilesToUpdate = new List<string>(
+                new[]
                 {
                     "placeHolder.png",
                     BookInfo.AppearanceSettings.BasePageCssName,
                     "previewMode.css",
                     "origami.css"
-                };
-                foreach (var supportFile in supportFilesToAlwaysUpdate)
-                {
-                    Update(supportFile);
                 }
+            );
 
-                // Now we want to look for any other .css files, besides those listed above and update them.
-                // There are a few we want to skip, however.
-                // In BL-5824, we got bit by design decisions we made that allow stylesheets installed via
-                // bloompack and by new Bloom versions to replace local ones. This was done so that we could
-                // send out new Bloom implementation stylesheets via bloompack and in new Bloom versions
-                // and have those used in all the books. This works well for most stylesheets.
-                //
-                // But customBookStyles.css  and customCollectionStyles.css are exceptions;
-                // their whole purpose is to let the local book or collection override Bloom's normal
-                // behavior or anything in a bloompack.
-                //
-                // And defaultLangStyles.css is another file that should not be updated because it is always
-                // generated from the local collection settings.
-                //
-                // Also, we don't want to update branding.css here because the default update process may pull it from
-                // who knows where; it doesn't come from one of the directories we search early.
-                // Instead, normally one is fetched from the right branding in CopyBrandingFiles,
-                // or if the branding is under development we generate a placeholder, or if there is no branding
-                // we generate an empty placeholder.
-                var cssFilesToSkipInThisPhase = new ArrayList()
-                {
-                    // Files we just updated
-                    this.BookInfo
-                        .AppearanceSettings
-                        . // Files we just updated
-                        BasePageCssName,
-                    "previewmode.css",
-                    "origami.css"
-                };
-                cssFilesToSkipInThisPhase.AddRange(BookStorage.CssFilesThatAreDynamicallyUpdated);
+            // Now we want to look for any other .css files already in the book folder and update them.
+            // There are a few we want to skip, however.
+            // In BL-5824, we got bit by design decisions we made that allow stylesheets installed via
+            // bloompack and by new Bloom versions to replace local ones. This was done so that we could
+            // send out new Bloom implementation stylesheets via bloompack and in new Bloom versions
+            // and have those used in all the books. This works well for most stylesheets.
+            //
+            // But customBookStyles.css, customBookStyles2.css,  and customCollectionStyles.css are exceptions;
+            // their whole purpose is to let the local book or collection override Bloom's normal
+            // behavior or anything in a bloompack.
+            //
+            // And defaultLangStyles.css is another file that should not be updated because it is always
+            // generated from the local collection settings.
+            //
+            // Also, we don't want to update branding.css here because the default update process may pull it from
+            // who knows where; it doesn't come from one of the directories we search early.
+            // Instead, normally one is fetched from the right branding in LoadCurrentBrandingFilesIntoBookFolder,
+            // or if the branding is under development we generate a placeholder, or if there is no branding
+            // we generate an empty placeholder.
+            var cssFilesToSkipInThisPhase = new HashSet<string>();
+            cssFilesToSkipInThisPhase.AddRange(BookStorage.CssFilesThatAreDynamicallyUpdated);
+            // We don't need to consider these now because they are already listed to be copied in.
+            cssFilesToSkipInThisPhase.AddRange(supportFilesToUpdate);
+            // In this phase of scanning the book directory, we will delete most xmatter stylesheets.
+            // But not the current one! That we DO want to copy in.
+            var xmatterCss = Path.GetFileName(XMatterHelper.PathToXMatterStylesheet);
+            cssFilesToSkipInThisPhase.Add(xmatterCss); // prevent deleting it
+            supportFilesToUpdate.Add(xmatterCss); // make sure it gets copied in
 
-                foreach (var path in Directory.GetFiles(FolderPath, "*.css"))
-                {
-                    var file = Path.GetFileName(path);
-                    if (cssFilesToSkipInThisPhase.Contains(file.ToLowerInvariant()))
-                        continue;
-
-                    Update(file);
-                }
-            }
-
-            try
+            foreach (var path in Directory.GetFiles(FolderPath, "*.css"))
             {
-                var path = PathToXMatterStylesheet;
-                Update(Path.GetFileName(path), path);
-            }
-            catch (Exception error)
-            {
-                ErrorMessagesHtml = WebUtility.HtmlEncode(error.Message);
-                ErrorAllowsReporting = true;
+                var file = Path.GetFileName(path);
+                if (cssFilesToSkipInThisPhase.Contains(file))
+                    continue;
+                // clean up any unwanted Xmatter CSS files. The one we want is already skipped.
+                // Get rid of any versions of basePage.css that aren't in cssFilesToSkipInThisPhase
+                if (file.EndsWith("XMatter.css") || file.StartsWith("basePage"))
+                    RobustFile.Delete(path);
+                else
+                    supportFilesToUpdate.Add(file);
             }
 
-            CopyBrandingFiles();
+            // This will pull them into the book folder.
+            foreach (var file in supportFilesToUpdate)
+            {
+                var sourcePath = GetSupportingFile(file);
+                var destPath = Path.Combine(FolderPath, file);
+                if (sourcePath == destPath)
+                    continue; // don't copy from ourselves
+                if (!string.IsNullOrEmpty(sourcePath) && RobustFile.Exists(sourcePath))
+                    RobustFile.Copy(sourcePath, destPath, true);
+            }
+
+            LoadCurrentBrandingFilesIntoBookFolder();
         }
 
         // Brandings come with logos and such... we want them in the book folder itself so that they work
         // apart from Bloom and in web browsing, ePUB, and BloomPUB contexts.
-        private void CopyBrandingFiles()
+        private void LoadCurrentBrandingFilesIntoBookFolder()
         {
             _brandingImageNames.Clear();
             try
@@ -2502,6 +2583,8 @@ namespace Bloom.Book
                 // (like "FactoryTemplateBookDirectory" or "SampleShellsDirectory").  If Bloom is installed "for all users" on Windows,
                 // it is also impossible to copy files there.  Copying files to those locations would allow Bloom to show branding for
                 // a template preview or a sample shell preview, which seems rather unimportant.
+                // Review: the above is no longer a problem, because we're keeping the branding files in memory.
+                // Do we WANT our factory templates to show what they will look like in the current branding? If so we can just remove this.
                 if (
                     FolderPath.StartsWith(
                         BloomFileLocator.FactoryCollectionsDirectory,
@@ -2533,43 +2616,33 @@ namespace Bloom.Book
                                 .Split(',')
                                 .Contains(Path.GetExtension(path).ToLowerInvariant())
                     );
-
+                var gotBrandingCss = false;
                 foreach (var sourcePath in filesToCopy)
                 {
                     var fileName = Path.GetFileName(sourcePath);
                     var destPath = Path.Combine(FolderPath, fileName);
-                    try
+                    Utils.LongPathAware.ThrowIfExceedsMaxPath(destPath); //example: BL-8284
+                    RobustFile.Copy(sourcePath, destPath, true);
+                    if (fileName.EndsWith(".css"))
                     {
-                        Utils.LongPathAware.ThrowIfExceedsMaxPath(destPath); //example: BL-8284
-                        RobustFile.Copy(sourcePath, destPath, true);
+                        gotBrandingCss |= fileName == "branding.css";
                     }
-                    catch (UnauthorizedAccessException err)
+                    else
                     {
-                        if (RobustFile.Exists(destPath))
-                        {
-                            // It's probably a minor problem if we just can't update it but already have it.
-                            ReportCantUpdateSupportFile(sourcePath, destPath);
-                        }
-                        else
-                        {
-                            throw new BloomUnauthorizedAccessException(destPath, err);
-                        }
+                        _brandingImageNames.Add(fileName);
                     }
-
-                    _brandingImageNames.Add(fileName);
                 }
 
                 // Typically the above will copy a branding.css into the book folder.
                 // Check that, and attempt to recover if it didn't happen.
-                var brandingPath = Path.Combine(FolderPath, "branding.css");
-                if (!RobustFile.Exists(brandingPath))
+                if (!gotBrandingCss)
                 {
                     Debug.Fail("Brandings MUST provide a branding.css");
                     // An empty branding.css is better than having the file server search who-knows-where
                     // and coming up with some arbitrary branding.css. At least all Bloom installations,
                     // including the evil dev one that introduced a branding without the required file,
                     // will behave the same.
-                    RobustFile.WriteAllText(brandingPath, "");
+                    RobustFile.WriteAllText(Path.Combine(FolderPath, "branding.css"), "");
                 }
             }
             catch (Exception err)
@@ -2624,7 +2697,7 @@ namespace Bloom.Book
             }
         }
 
-        private string PathToXMatterStylesheet => XMatterHelper.PathToXMatterStylesheet;
+        public string PathToXMatterStylesheet => XMatterHelper.PathToXMatterStylesheet;
 
         private bool IsPathReadonly(string path)
         {
@@ -2719,6 +2792,8 @@ namespace Bloom.Book
                         RemoveExistingFilesBySuffix("XMatter.css");
 
                     RobustFile.Copy(sourcePathIncludingFileName, documentPath);
+                    //if the source was locked, don't copy the lock over
+                    RobustFile.SetAttributes(documentPath, FileAttributes.Normal);
                     return;
                 }
                 // due to BL-2166, we no longer compare times since downloaded books often have
@@ -2851,35 +2926,23 @@ namespace Bloom.Book
             Dom.RemoveNormalStyleSheetsLinks();
             EnsureHasLinkToStyleSheet(dom, Path.GetFileName(PathToXMatterStylesheet));
 
-            getMinimalCssFilesFromInstallThatDoNotChangeAtRuntime()
-                .ForEach(x =>
-                {
-                    EnsureHasLinkToStyleSheet(dom, x);
-                });
-            BookStorage.CssFilesThatAreDynamicallyUpdated.ForEach(x =>
+            CssFilesThatAreAlwaysWanted.ForEach(x =>
+            {
+                EnsureHasLinkToStyleSheet(dom, x);
+            });
+            var appearanceRelatedCssFiles = BookInfo.AppearanceSettings.AppearanceRelatedCssFiles(
+                LinkToLocalCollectionStyles
+            );
+            appearanceRelatedCssFiles.ForEach(x =>
             {
                 EnsureHasLinkToStyleSheet(dom, x);
             });
 
-            // the link will be added above as we go through DynamicallyUpdatedLocalBookCssInOrder,
-            // but for tidyness, let's take the link out if we don't have the file.
-            if (
-                !RobustFile.Exists(Path.Combine(FolderPath, "customBookStyles.css"))
-                // if we're substituting a theme for this customBookStyles.css, we don't want to the link to it
-                || BookInfo.AppearanceSettings.SubstitutedCssFile == "customBookStyles.css"
-            )
-            {
-                EnsureDoesntHaveLinkToStyleSheet(dom, "customBookStyles.css");
-            }
+            // If we're not supposed to have these links, make sure we don't.
+            AppearanceSettings.PossibleAppearanceRelatedCssFiles
+                .Except(appearanceRelatedCssFiles)
+                .ForEach(file => EnsureDoesNotHaveLinkToStyleSheet(dom, file));
 
-            // if we're substituting a theme for this customBookStyles.css or customCollectionStyles.css, we don't want to the link to it
-            if (!string.IsNullOrEmpty(BookInfo.AppearanceSettings.SubstitutedCssFile))
-            {
-                EnsureDoesntHaveLinkToStyleSheet(
-                    dom,
-                    BookInfo.AppearanceSettings.SubstitutedCssFile
-                );
-            }
             dom.SortStyleSheetLinks();
         }
 
@@ -2890,7 +2953,7 @@ namespace Bloom.Book
             if (currentXmatterName != nameOfXMatterPack)
             {
                 const string xmatterSuffix = "-XMatter.css";
-                EnsureDoesntHaveLinkToStyleSheet(dom, nameOfXMatterPack + xmatterSuffix);
+                EnsureDoesNotHaveLinkToStyleSheet(dom, nameOfXMatterPack + xmatterSuffix);
                 EnsureHasLinkToStyleSheet(dom, nameOfXMatterPack + xmatterSuffix);
                 // Since HtmlDom.GetMetaValue() is always called with the collection's xmatter pack as default,
                 // we can just remove this wrong meta element.
@@ -2899,7 +2962,7 @@ namespace Bloom.Book
             return currentXmatterName;
         }
 
-        private void EnsureDoesntHaveLinkToStyleSheet(HtmlDom dom, string path)
+        private void EnsureDoesNotHaveLinkToStyleSheet(HtmlDom dom, string path)
         {
             foreach (XmlElement link in dom.SafeSelectNodes("//link[@rel='stylesheet']"))
             {
@@ -2927,6 +2990,11 @@ namespace Bloom.Book
             dom.AddStyleSheetIfMissing(path);
         }
 
+        public string[] CssFilesThatAreAlwaysWanted
+        {
+            get { return new[] { "origami.css", "branding.css", "defaultLangStyles.css" }; }
+        }
+
         // note: order is not significant here. We apply our standard stylesheet sorter later.
         // Enhance: it would be cleaner if most of these were in a common list, and this method just knew
         // what extra ones we need for a preview. Note also that (at least) MakeCssLinksAppropriateForStoredFile(),
@@ -2936,14 +3004,14 @@ namespace Bloom.Book
         // (Possibly cleaner still to have way fewer stylesheets, and turn rules on with classes.)
         public string[] GetCssFilesToLinkForPreview()
         {
-            return new string[]
-            {
-                this.BookInfo.AppearanceSettings.BasePageCssName,
-                "previewMode.css",
-                "origami.css",
-                "branding.css",
-                "appearance.css"
-            };
+            return new[] { "previewMode.css" }
+                .Concat(CssFilesThatAreAlwaysWanted)
+                .Concat(
+                    this.BookInfo.AppearanceSettings.AppearanceRelatedCssFiles(
+                        LinkToLocalCollectionStyles
+                    )
+                )
+                .ToArray();
         }
 
         // While in Bloom, we could have an edit style sheet or (someday) other modes. But when stored,
@@ -3279,16 +3347,42 @@ namespace Bloom.Book
         }
 
         /// <summary>
-        /// Perform expensive updates that new versions of Bloom can perform on older books that don't
-        /// involve actual book format changes.
+        /// Prior to Bloom 5.7, we had a single metadata element called "maintenanceLevel" that was used to
+        /// keep track of whether a book had been updated to the latest version of Bloom in certain somewhat
+        /// time-consuming ways. (BringBookUpToDate does other migrations, too, but we just run them every time.)
+        /// We did not distinguish between changes that only affect the DOM and ones we could only make in
+        /// folders where we can write, nor between ones that must be done before editing, ones that must be
+        /// done before we do anything with the book, or ones that are optional.
+        /// In 5.7 we introduced a new metadata element called "mediaMaintenanceLevel" that is used to keep
+        /// track of migrations that affect files other than the main HTML one. This function,
+        /// which must be called before any of the ones that might change the old maintenanceLevel metadata,
+        /// initializes the new mediaMaintenanceLevel to the appropriate value based on the old maintenanceLevel
+        /// if it does not already exist.
         /// </summary>
-        public void PerformNecessaryMaintenanceOnBook()
+        public void MigrateMaintenanceLevels()
         {
-            var levelString = Dom.GetMetaValue("maintenanceLevel", "0");
+            var mediaLevelString = Dom.GetMetaValue("mediaMaintenanceLevel", "bad");
+            if (int.TryParse(mediaLevelString, out int mediaLevel))
+                return; // already have mediaMaintenanceLevel
+
+            // If mediaMaintenanceLevel is missing, it should be set to zero if the old maintenanceLevel
+            // indicates we have not done MigrateToMediaLevel1ShrinkLargeImages, and to 1 if we have.
+            Dom.UpdateMetaElement("mediaMaintenanceLevel", GetMaintenanceLevel() >= 1 ? "1" : "0");
+            ;
+        }
+
+        /// <summary>
+        /// In very old books (before 4.9) we did not shrink even very large images before adding them to
+        /// books. When we encounter such a book, we go ahead and shrink them. This is probably less
+        /// necessary than in Gecko days, when super-large images were prone to make Bloom run out of
+        /// memory. However, it is still helpful for performance and reducing published file sizes.
+        /// Does nothing if mediaMaintenanceLevel indicates it has already been done.
+        /// </summary>
+        public void MigrateToMediaLevel1ShrinkLargeImages()
+        {
+            var levelString = Dom.GetMetaValue("mediaMaintenanceLevel", "0");
             if (!int.TryParse(levelString, out int level))
                 level = 0;
-            if (level >= kMaintenanceLevel)
-                return;
             if (level < 1 && ImageUtils.NeedToShrinkImages(FolderPath))
             {
                 // If the book contains overlarge images, we want to fix those before editing because this can lead
@@ -3334,16 +3428,32 @@ namespace Bloom.Book
                 }
             }
 
-            if (level < 2)
+            Dom.UpdateMetaElement("mediaMaintenanceLevel", "1");
+        }
+
+        private int GetMaintenanceLevel()
+        {
+            var levelString = Dom.GetMetaValue("maintenanceLevel", "0");
+            if (!int.TryParse(levelString, out int level))
+                level = 0;
+            return level;
+        }
+
+        /// <summary>
+        /// Bloom 4.9 and later (a bit later than the above 4.9 and therefore a separate maintenance
+        /// level) will only put comical-generated svgs in Bloom imageContainers if they are
+        /// non-transparent. Since our test for whether a book is Comical for Publishing restrictions
+        /// will now be a simple scan for these svgs, we here remove legacy svgs whose bubble style
+        /// was "none", implying transparency.
+        /// In Bloom 5.0, we renamed the Comic Tool -> Overlay Tool, but "comical" refers to the comical.js
+        /// npm project which creates the svgs. It and the "Comic" feature have not been renamed for backward
+        /// compatibility.
+        /// This does nothing if maintenanceLevel indicates it has already been done.
+        /// </summary>
+        public void MigrateToLevel2RemoveTransparentComicalSvgs()
+        {
+            if (GetMaintenanceLevel() < 2)
             {
-                // Bloom 4.9 and later (a bit later than the above 4.9 and therefore a separate maintenance
-                // level) will only put comical-generated svgs in Bloom imageContainers if they are
-                // non-transparent. Since our test for whether a book is Comical for Publishing restrictions
-                // will now be a simple scan for these svgs, we here remove legacy svgs whose bubble style
-                // was "none", implying transparency.
-                // In Bloom 5.0, we renamed the Comic Tool -> Overlay Tool, but "comical" refers to the comical.js
-                // npm project which creates the svgs. It and the "Comic" feature have not been renamed for backward
-                // compatibility.
                 var comicalSvgs = Dom.SafeSelectNodes(ComicalXpath).Cast<XmlElement>();
                 var elementsToSave = new HashSet<XmlElement>();
                 foreach (var svgElement in comicalSvgs)
@@ -3370,6 +3480,7 @@ namespace Bloom.Book
                         break;
                     }
                 }
+
                 // Now delete the SVGs that only have bubbles of style 'none'.
                 var dirty = false;
                 foreach (var svgElement in comicalSvgs.ToArray())
@@ -3394,7 +3505,12 @@ namespace Bloom.Book
                 }
             }
 
-            if (level < 3)
+            Dom.UpdateMetaElement("maintenanceLevel", "2");
+        }
+
+        public void MigrateToLevel3PutImgFirst()
+        {
+            if (GetMaintenanceLevel() < 3)
             {
                 // Make sure that in every image container, the first element is the img.
                 // This is important because, since 5.4, we don't use a z-index to put overlays above the base image
@@ -3424,11 +3540,8 @@ namespace Bloom.Book
                 }
             }
 
-            // future additional levels will add additional "if (level < N)" blocks.
-            Dom.UpdateMetaElement(
-                "maintenanceLevel",
-                kMaintenanceLevel.ToString(CultureInfo.InvariantCulture)
-            );
+            // We only want to update the maintenance level if we finished the job.
+            Dom.UpdateMetaElement("maintenanceLevel", "3");
         }
 
         public CollectionSettings CollectionSettings => _collectionSettings;
@@ -3510,7 +3623,8 @@ namespace Bloom.Book
             "defaultLangStyles.css",
             "customCollectionStyles.css",
             "appearance.css",
-            "customBookStyles.css"
+            "customBookStyles.css",
+            "customBookStyles2.css"
         };
 
         /// <summary>
@@ -3527,48 +3641,71 @@ namespace Bloom.Book
         }
 
         /// <summary>
+        /// Should we look for customCollectionStyles.css in the book folder itself, or in the parent folder?
+        /// Normally we look in the parent folder, but if we are making a bloomPub or similar copy,
+        /// we copy it into the book folder itself, and that's where we should look.
+        /// </summary>
+        public bool LinkToLocalCollectionStyles { get; set; }
+
+        /// <summary>
         /// Files that might contain rules that conflict with the new appearance model (currently, that is if they affect
         /// the size and position of the marginBox).
         /// In the resulting list, the first item is the file name, and the second is content.
+        /// Note that this routine must find and use the files that UpdateSupportingFiles will copy into the book.
+        /// It has to be called before UpdateSupportingFiles, because it is used to initialize the
+        /// appearanceSettings that determines which files UpdateSupportingFiles will copy.
         /// </summary>
         /// <returns></returns>
-        public Tuple<string, string>[] GetCssFilesToCheckForAppearanceCompatibility()
+        public Tuple<string, string>[] GetCssFilesToCheckForAppearanceCompatibility(
+            bool justOldCustomFiles = false
+        )
         {
-            // This is right on the edge of deserving a method to make a tuple or a loop over a list of files.
-            // Don't add more duplicates of lines like these. But two of the four are a little bit different.
-            var brandingCssPath = FolderPath.CombineForPath("branding.css");
-            var brandingCss = RobustFile.Exists(brandingCssPath)
-                ? RobustFile.ReadAllText(brandingCssPath)
-                : null;
+            var result = new List<Tuple<string, string>>();
 
-            var customBookStylesPath = FolderPath.CombineForPath("customBookStyles.css");
-            var customBookCss = RobustFile.Exists(customBookStylesPath)
-                ? RobustFile.ReadAllText(customBookStylesPath)
-                : null;
-
-            // this is sometimes copied into the book folder, but that's not reliable except in BloomPubs. Check the version actually used
-            // in the parent folder.
+            // Must come before customCollectionStyles.css (see AppearanceSettings.Initialize).
+            result.Add(
+                Tuple.Create(
+                    "customBookStyles.css",
+                    GetSupportingFileString("customBookStyles.css")
+                )
+            );
+            // this is sometimes copied into the book folder, but that's not reliable except in BloomPubs.
+            // A flag in AppearanceSettings allows it to tell us which of them we should use for this book.
             var customCollectionStylesPath = FolderPath.CombineForPath(
-                "../",
-                "customCollectionStyles.css"
+                RelativePathToCollectionStyles(LinkToLocalCollectionStyles)
             );
             var customCollectionCss = RobustFile.Exists(customCollectionStylesPath)
                 ? RobustFile.ReadAllText(customCollectionStylesPath)
                 : null;
+            result.Add(Tuple.Create("customCollectionStyles.css", customCollectionCss));
 
-            // find the first file in FolderPath that ends in "xmatter.css".
-            var xmatterPath = Directory.GetFiles(FolderPath, "*xmatter.css").FirstOrDefault();
-            var xmatterFileName = xmatterPath != null ? Path.GetFileName(xmatterPath) : "";
-            var xmatterCss = xmatterPath != null ? RobustFile.ReadAllText(xmatterPath) : "";
-
-            return new Tuple<string, string>[]
+            if (!justOldCustomFiles)
             {
-                // note, the first item here is actually for user consumption in error messages.
-                new Tuple<string, string>("customCollectionStyles.css", customCollectionCss),
-                new Tuple<string, string>("customBookStyles.css", customBookCss),
-                new Tuple<string, string>("branding.css", brandingCss),
-                new Tuple<string, string>(xmatterFileName, xmatterCss)
-            };
+                result.Add(Tuple.Create("branding.css", GetSupportingFileString("branding.css")));
+                result.Add(
+                    Tuple.Create(
+                        "customBookStyles2.css",
+                        GetSupportingFileString("customBookStyles2.css")
+                    )
+                );
+                result.Add(
+                    Tuple.Create("appearance.css", GetSupportingFileString("appearance.css"))
+                );
+
+                var xmatterFileName = Path.GetFileName(PathToXMatterStylesheet);
+                result.Add(Tuple.Create(xmatterFileName, GetSupportingFileString(xmatterFileName)));
+            }
+            return result.ToArray();
+        }
+
+        private string GetSupportingFileString(string file)
+        {
+            // Do the search for the file that UpdateSupportingFiles will copy into the book
+            // folder, since this is called BEFORE we do that.
+            var path = GetSupportingFile(file);
+            if (RobustFile.Exists(path))
+                return RobustFile.ReadAllText(path);
+            return null;
         }
 
         public static readonly string[] CssFilesThatAreObsolete =
@@ -3591,7 +3728,21 @@ namespace Bloom.Book
             "defaultLangStyles.css",
             "customCollectionStyles.css",
             "appearance.css",
+            // We don't usually have both of these, and I don't have a clear idea why one should come before
+            // the other. But the order should be consistent, and if both are there, typically customBookStyles2.css
+            // came from our system, while the other was added by the user. So allow the user one to win.
+            "customBookStyles2.css",
             "customBookStyles.css"
         };
+
+        /// <summary>
+        /// Relative to the book folder, where should we find the customCollectionStyles.css file?
+        /// Normally we look in the parent folder, but if we are making a bloomPub or similar copy,
+        /// we copy it into the book folder itself, and that's where we should look.
+        /// </summary>
+        public static string RelativePathToCollectionStyles(bool useLocalCollectionStyles)
+        {
+            return (useLocalCollectionStyles ? "" : "../") + "customCollectionStyles.css";
+        }
     }
 }

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -685,6 +685,13 @@ namespace Bloom.Book
             return !stylesheetsToIgnoreAdding.Contains(path);
         }
 
+        /// <summary>
+        /// We're trying to get names of style sheets that need to be copied from one book to another.
+        /// So not the standard ones that every book has, but things like one specific to the particular
+        /// template the source was made from, or that got added becuase we used an Activity page that
+        /// has an associated one.
+        /// </summary>
+        /// <returns></returns>
         public virtual IEnumerable<string> GetTemplateStyleSheets()
         {
             var stylesheetsToIgnore = new List<string>();

--- a/src/BloomExe/CLI/ChangeLayoutCommand.cs
+++ b/src/BloomExe/CLI/ChangeLayoutCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -131,7 +131,7 @@ namespace Bloom.CLI
             var templateBook = new Book.Book(
                 templateBookInfo,
                 new BookStorage(
-                    templateBookInfo.FolderPath,
+                    templateBookInfo,
                     locator,
                     new BookRenamedEvent(),
                     collectionSettings
@@ -162,7 +162,7 @@ namespace Bloom.CLI
                     var book = new Book.Book(
                         bookInfo,
                         new BookStorage(
-                            bookInfo.FolderPath,
+                            bookInfo,
                             locator,
                             new BookRenamedEvent(),
                             collectionSettings

--- a/src/BloomExe/CLI/HydrateBookCommand.cs
+++ b/src/BloomExe/CLI/HydrateBookCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -86,7 +86,7 @@ namespace Bloom.CLI
             var bookInfo = new BookInfo(options.Path, true, new AlwaysEditSaveContext());
             var book = new Book.Book(
                 bookInfo,
-                new BookStorage(options.Path, locator, new BookRenamedEvent(), collectionSettings),
+                new BookStorage(bookInfo, locator, new BookRenamedEvent(), collectionSettings),
                 null,
                 collectionSettings,
                 null,

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -14,12 +14,12 @@ using Bloom.Publish.BloomPub;
 using Bloom.web.controllers;
 using DesktopAnalytics;
 using L10NSharp;
-using SIL.Reporting;
-using SIL.WritingSystems;
+using SIL.Code;
 using SIL.Extensions;
 using SIL.IO;
+using SIL.Reporting;
+using SIL.WritingSystems;
 using Directory = System.IO.Directory;
-using SIL.Code;
 
 namespace Bloom.Collection
 {
@@ -309,7 +309,7 @@ namespace Bloom.Collection
                 "/* *** DO NOT EDIT! ***   These styles are controlled by the Settings dialog box in Bloom. */"
             );
             sb.AppendLine(
-                "/* They may be over-ridden by rules in customCollectionStyles.css, appearance.css or customBookStyles.css */"
+                "/* They may be over-ridden by rules in customCollectionStyles.css, appearance.css or customBookStyles[2].css */"
             );
             // note: css pseudo elements  cannot have a @lang attribute. So this is needed to show page numbers in scripts not covered by Andika New Basic.
             WritingSystem.AddSelectorCssRule(

--- a/src/BloomExe/CollectionTab/CollectionModel.cs
+++ b/src/BloomExe/CollectionTab/CollectionModel.cs
@@ -866,8 +866,9 @@ namespace Bloom.CollectionTab
                 );
                 // Since the user told us to do it, we'll do it even to books that we think are already
                 // up to date. (EnsureUpToDate would do so anyway, since these are newly created Book objects, even if they are
-                // for books we already have in memory.)
-                book.BringBookUpToDate(progress);
+                // for books we already have in memory.) But not to ones where saving is disabled (in a TC).
+                if (book.IsSaveable)
+                    book.BringBookUpToDate(progress);
             }
         }
 
@@ -1004,6 +1005,16 @@ namespace Bloom.CollectionTab
                     "Bloom ran into an error while creating that book. (Sorry!)"
                 );
             }
+        }
+
+        public BookInfo GetBookInfoByFolderPath(string path)
+        {
+            var collectionPath = Path.GetDirectoryName(path);
+            var collection = GetBookCollections()
+                .FirstOrDefault(c => c.PathToDirectory == collectionPath);
+            if (collection == null)
+                return null;
+            return collection.GetBookInfoByFolderPath(path);
         }
 
         public Book.Book GetBookFromBookInfo(BookInfo bookInfo, bool fullyUpdateBookFiles = false)

--- a/src/BloomExe/CollectionTab/CollectionTabView.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.cs
@@ -1,21 +1,21 @@
 using System;
-using System.Windows.Forms;
-using Bloom.Properties;
-using Bloom.Workspace;
-using L10NSharp;
-using SIL.Reporting;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Linq;
+using System.Windows.Forms;
 using Bloom.Api;
 using Bloom.Book;
 using Bloom.Collection;
 using Bloom.MiscUI;
+using Bloom.Properties;
 using Bloom.TeamCollection;
 using Bloom.ToPalaso;
 using Bloom.web;
+using Bloom.Workspace;
+using L10NSharp;
+using SIL.Reporting;
 using SIL.Windows.Forms.SettingProtection;
-using System.Diagnostics;
-using System.Linq;
 
 namespace Bloom.CollectionTab
 {
@@ -155,6 +155,21 @@ namespace Bloom.CollectionTab
                     _bookChangesPending = true;
                 }
             };
+        }
+
+        /// <summary>
+        /// Review: this doesn't feel comfortable here. But the Workspace needs it, and it has
+        /// a reference to this and not to the model. The alternative would be to have a public
+        /// Model property. I think this is better, at least until we have more reasons to
+        /// make the model public.
+        /// This should be thread safe, since the methods that create collections and BookInfos
+        /// are locked.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public BookInfo GetBookInfoByFolderPath(string path)
+        {
+            return _model.GetBookInfoByFolderPath(path);
         }
 
         private void UpdateForBookChanges(Book.Book book)

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -9,11 +9,13 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using System.Xml;
+using Bloom.Api;
 using Bloom.Book;
 using Bloom.Collection;
-using Bloom.ToPalaso.Experimental;
-using Bloom.Api;
+using Bloom.ErrorReporter;
+using Bloom.FontProcessing;
 using Bloom.MiscUI;
+using Bloom.ToPalaso.Experimental;
 using Bloom.Utils;
 using DesktopAnalytics;
 using L10NSharp;
@@ -22,10 +24,8 @@ using SIL.Progress;
 using SIL.Reporting;
 using SIL.Windows.Forms.ClearShare;
 using SIL.Windows.Forms.ImageToolbox;
-using SIL.Xml;
-using Bloom.ErrorReporter;
 using SIL.Windows.Forms.Miscellaneous;
-using Bloom.FontProcessing;
+using SIL.Xml;
 
 namespace Bloom.Edit
 {
@@ -633,12 +633,6 @@ namespace Bloom.Edit
                 var contentLanguages = GetMultilingualContentLanguages();
                 CurrentBook.SetMultilingualContentLanguages(contentLanguages);
                 CurrentBook.PrepareForEditing();
-                // As of 4.9, we are adding a hook here to do one-time maintenance to books, based on a
-                // metadata 'maintenanceLevel'.
-                // 0 -> 1 Deal with overlarge images.
-                // 1 -> 2 Remove comical SVGs associated with 'none' style textboxes.
-                // Takes almost no time if the maintenanceLevel has been set for this book.
-                CurrentBook.Storage.PerformNecessaryMaintenanceOnBook();
             }
 
             _currentlyDisplayedBook = CurrentBook;

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -6,16 +6,13 @@ using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
 using Autofac;
+using Bloom.Api;
 using Bloom.Book;
 using Bloom.Collection;
 using Bloom.CollectionTab;
 using Bloom.Edit;
 using Bloom.FontProcessing;
 using Bloom.ImageProcessing;
-using Bloom.WebLibraryIntegration;
-using Bloom.Workspace;
-using Bloom.Api;
-using Bloom.TeamCollection;
 using Bloom.Publish;
 using Bloom.Publish.AccessibilityChecker;
 using Bloom.Publish.BloomPub;
@@ -23,15 +20,18 @@ using Bloom.Publish.Epub;
 using Bloom.Publish.PDF;
 using Bloom.Publish.Video;
 using Bloom.Spreadsheet;
+using Bloom.TeamCollection;
+using Bloom.ToPalaso;
 using Bloom.Utils;
 using Bloom.web;
 using Bloom.web.controllers;
+using Bloom.WebLibraryIntegration;
+using Bloom.Workspace;
 using BloomTests.web.controllers;
+using SIL.Code;
 using SIL.Extensions;
 using SIL.IO;
 using SIL.Reporting;
-using Bloom.ToPalaso;
-using SIL.Code;
 
 namespace Bloom
 {
@@ -653,8 +653,8 @@ namespace Bloom
             bool result;
             if (_mapPathToIsTemplateFolder.TryGetValue(path, out result))
                 return result;
-            var info = new BookInfo(path, false);
-            result = info.IsSuitableForMakingShells || info.IsSuitableForMakingTemplates;
+            var metaData = BookMetaData.FromFolder(path);
+            result = metaData.IsSuitableForMakingShells || metaData.IsSuitableForMakingTemplates;
             _mapPathToIsTemplateFolder[path] = result;
             return result;
         }

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -3,20 +3,20 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using Bloom.Book;
 using System.Windows.Forms;
 using System.Xml;
 using Bloom.Api;
-using SIL.Reporting;
-using SIL.Xml;
+using Bloom.Book;
+using Bloom.FontProcessing;
 using Bloom.Publish.Epub;
 using Bloom.web;
 using Bloom.web.controllers;
+using Bloom.Workspace;
 using L10NSharp;
 using SIL.IO;
 using SIL.Progress;
-using Bloom.FontProcessing;
-using Bloom.Workspace;
+using SIL.Reporting;
+using SIL.Xml;
 
 namespace Bloom.Publish
 {
@@ -622,12 +622,29 @@ namespace Bloom.Publish
                 WantMusic = true
             };
             filter.CopyBookFolderFiltered(tempFolderPath);
+            var collectionStylesSource = Path.Combine(
+                Path.GetDirectoryName(bookFolderPath),
+                "customCollectionStyles.css"
+            );
+            var collectionStylesDest = Path.Combine(tempFolderPath, "customCollectionStyles.css");
+            if (RobustFile.Exists(collectionStylesSource))
+            {
+                RobustFile.Copy(collectionStylesSource, collectionStylesDest, true);
+            }
+            else
+            {
+                RobustFile.Delete(collectionStylesDest);
+            }
             // We can always save in a temp book
             var bookInfo = new BookInfo(tempFolderPath, true, new AlwaysEditSaveContext())
             {
                 UseDeviceXMatter = !isTemplateBook
             };
+
             var modifiedBook = bookServer.GetBookFromBookInfo(bookInfo);
+            // This book has to stand alone. If it needs a customCollectionStyles.css, it will have to use the one we just
+            // copied into the actual book folder, not one in a parent folder.
+            modifiedBook.Storage.LinkToLocalCollectionStyles = true;
             modifiedBook.WriteFontFaces = wantFontFaceDeclarations;
             modifiedBook.BringBookUpToDate(new NullProgress(), true);
             modifiedBook.RemoveNonPublishablePages(omittedPageLabels);

--- a/src/BloomExe/SourceCollectionsList.cs
+++ b/src/BloomExe/SourceCollectionsList.cs
@@ -85,7 +85,8 @@ namespace Bloom
 
         private Book.Book CreateTemplateBookByFolderPath(string folderPath)
         {
-            return _bookFactory(new BookInfo(folderPath, false), _storageFactory(folderPath));
+            var bookInfo = new BookInfo(folderPath, false);
+            return _bookFactory(bookInfo, _storageFactory(bookInfo));
         }
 
         public Book.Book FindAndCreateTemplateBook(Func<string, bool> predicate)

--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -4,21 +4,21 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Windows.Forms;
+using System.Xml;
 using Amazon.Runtime;
 using Amazon.S3;
 using Bloom.Book;
 using Bloom.Collection;
 using Bloom.Publish;
+using Bloom.web;
 using DesktopAnalytics;
 using L10NSharp;
 using SIL.Extensions;
 using SIL.IO;
 using SIL.Progress;
 using SIL.Reporting;
-using System.Xml;
-using System.Text;
-using Bloom.web;
 
 namespace Bloom.WebLibraryIntegration
 {

--- a/src/BloomExe/web/BloomWebSocketServer.cs
+++ b/src/BloomExe/web/BloomWebSocketServer.cs
@@ -303,8 +303,12 @@ namespace Bloom.Api
                 socket == null
                     ? "web socket is null; "
                     : $"web socket is not available, {connectionInfoDetail}; ";
+            // JT Dec 2023: getting so many of these they drive me crazy, and sometimes manange to deadlock our server.
+            // I'm becoming more and more convinced that we're just including sockets on pages that we have navigated away from
+            // or even opened by browser windows we have closed. I do note that they seem more common when the system has been asleep
+            // while Bloom is running.
             NonFatalProblem.Report(
-                ModalIf.Alpha,
+                ModalIf.None,
                 PassiveIf.Alpha,
                 "web socket is not available when trying to send",
                 $"{socketDetail} bundle clientContext: {eventObject.clientContext}, eventId: {eventObject.id}, eventBundle: {eventBundle}",

--- a/src/BloomExe/web/controllers/BookCommandsApi.cs
+++ b/src/BloomExe/web/controllers/BookCommandsApi.cs
@@ -394,7 +394,13 @@ namespace Bloom.web.controllers
 
         internal void HandleSaveAsDotBloomSource(Book.Book book)
         {
-            book.EnsureUpToDate();
+            // If the book is not saveable, we can't legitimately bring it all-the-way up to date,
+            // with all the supporting files updated in the book folder. Better to just save
+            // what we have, which should at least be consistent.
+            // Since it's already the selected book, usually this won't do anything. However,
+            // the user might have checked it out since selecting it.
+            if (book.IsSaveable)
+                book.EnsureUpToDate();
 
             const string bloomFilter =
                 "Bloom Source files (*.bloomSource)|*.bloomSource|All files (*.*)|*.*";

--- a/src/BloomExe/web/controllers/BookSettingsApi.cs
+++ b/src/BloomExe/web/controllers/BookSettingsApi.cs
@@ -1,10 +1,12 @@
-using Bloom.Book;
-using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Linq;
 using Bloom.Book;
+using Bloom.Book;
+using Bloom.web.controllers;
 using Newtonsoft.Json;
+using Newtonsoft.Json;
+using SIL.IO;
 
 namespace Bloom.Api
 {
@@ -42,6 +44,22 @@ namespace Bloom.Api
                 HandleGetAvailableAppearanceUIOptions,
                 false
             );
+            apiHandler.RegisterEndpointHandler(
+                "book/settings/deleteCustomBookStyles",
+                HandleDeleteCustomBookStyles,
+                false
+            );
+        }
+
+        private void HandleDeleteCustomBookStyles(ApiRequest request)
+        {
+            RobustFile.Delete(
+                Path.Combine(_bookSelection.CurrentSelection.FolderPath, "customBookStyles.css")
+            );
+            _bookSelection.CurrentSelection.SettingsUpdated();
+            // We should only delete it when it's not in use, so we should not need to refresh the page.
+            IndicatorInfoApi.NotifyIndicatorInfoChanged();
+            request.PostSucceeded();
         }
 
         private void HandleGetAvailableAppearanceUIOptions(ApiRequest request)
@@ -99,6 +117,7 @@ namespace Bloom.Api
                     _pageRefreshEvent.Raise(
                         PageRefreshEvent.SaveBehavior.SaveBeforeRefreshFullSave
                     );
+                    IndicatorInfoApi.NotifyIndicatorInfoChanged();
 
                     request.PostSucceeded();
                     break;

--- a/src/BloomExe/web/controllers/CollectionApi.cs
+++ b/src/BloomExe/web/controllers/CollectionApi.cs
@@ -335,10 +335,13 @@ namespace Bloom.web.controllers
                 GetBookOnBloomBadgeInfo,
                 false
             );
+            // This one can take quite a long time and lock up the browser if no other thread can do anything. And it doesn't manipulate any
+            // shared data. So we'll allow it to run on a background thread without locking.
             apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "getBookCountByLanguage",
                 HandleGetBookCountByLanguage,
-                true
+                true,
+                false
             );
         }
 

--- a/src/BloomExe/web/controllers/CollectionSettingsApi.cs
+++ b/src/BloomExe/web/controllers/CollectionSettingsApi.cs
@@ -9,6 +9,7 @@ using Bloom.Collection;
 using L10NSharp;
 using SIL.Code;
 using SIL.IO;
+using SIL.Progress;
 
 namespace Bloom.web.controllers
 {
@@ -358,8 +359,7 @@ namespace Bloom.web.controllers
                         // Normally, we require a restart to change branding.
                         var key = request.RequiredPostString();
                         _collectionSettings.BrandingProjectKey = key;
-                        _bookSelection.CurrentSelection?.EnsureUpToDate(forceUpdate: true); // in case we changed the book's branding
-                        _bookSelection.CurrentSelection?.Storage.UpdateSupportFiles();
+                        _bookSelection.CurrentSelection?.BringBookUpToDate(new NullProgress()); // in case we changed the book's branding
                         request.PostSucceeded();
                     }
                 },

--- a/src/BloomExe/web/controllers/PageTemplatesApi.cs
+++ b/src/BloomExe/web/controllers/PageTemplatesApi.cs
@@ -237,7 +237,7 @@ namespace Bloom.web.controllers
                                 );
                                 var templateBook = _bookFactory(
                                     new BookInfo(bookPath, false),
-                                    _storageFactory(bookPath)
+                                    _storageFactory(new BookInfo(bookPath, false))
                                 );
 
                                 //note: the caption is used here as a key to find the template page.
@@ -497,10 +497,8 @@ namespace Bloom.web.controllers
         private static bool IsTemplateInvisible(string templatePath)
         {
             var folderPath = Path.GetDirectoryName(templatePath);
-            // This book info should never be asked about savability, so it doesn't matter much,
-            // but it feels safer to say it can't be saved.
-            var info = new BookInfo(folderPath, true, new NoEditSaveContext());
-            return !info.ShowThisBookAsSource();
+            var metaData = BookMetaData.FromFolder(folderPath) ?? new BookMetaData();
+            return !metaData.ShowThisBookAsSource();
         }
 
         private dynamic GetPageGroup(string path)

--- a/src/BloomExe/web/controllers/PublishApi.cs
+++ b/src/BloomExe/web/controllers/PublishApi.cs
@@ -462,7 +462,8 @@ namespace Bloom.web.controllers
                             .CurrentSelection
                             .BookInfo
                             .AllowUploading,
-                        canPublish = _publishModel.CanPublish,
+                        cannotPublishWithoutEnterprise = _publishModel.CannotPublishWithoutEnterprise,
+                        cannotPublishWithoutCheckout = _publishModel.CannotPublishWithoutCheckout,
                         canDownloadPDF = _publishModel.PdfGenerationSucceeded, // To be used for the context menu
                         titleForDisplay = _publishModel
                             .BookSelection

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Web;
 using System.Xml;
@@ -696,6 +696,62 @@ namespace BloomTests.Book
                     "//div/div[contains(@class,'bloom-translationGroup')]/div[@lang='xyz' and not(text())]",
                     1
                 );
+        }
+
+        [Test]
+        public void CreateBookOnDiskFromTemplate_NoPossiblyConflictingCss_MigratesToTheme()
+        {
+            _starter.TestingSoSkipAddingXMatter = true;
+            var body =
+                @"<div class='bloom-page'>
+						<div class='bloom-translationGroup'>
+						 <div lang='en'>This is some English</div>
+						</div>
+					</div>";
+            string sourceTemplateFolder = GetShellBookFolder(body, null);
+            var path = GetPathToHtml(
+                _starter.CreateBookOnDiskFromTemplate(sourceTemplateFolder, _projectFolder.Path)
+            );
+            //nb: testid is used rather than id because id is replaced with a guid when the copy is made
+
+            var bookFolder = Path.GetDirectoryName(path);
+            var appearanceSettings = new AppearanceSettings();
+            appearanceSettings.UpdateFromFolder(bookFolder);
+            Assert.That(appearanceSettings.CssThemeName == "default");
+
+            // Would like to test this, but we don't update the stylesheets in the DOM until we actually create the book.
+            //AssertThatXmlIn.HtmlFile(path).HasSpecifiedNumberOfMatchesForXpath("//link[@href='basePage.css']", 1);
+            //AssertThatXmlIn.HtmlFile(path).HasSpecifiedNumberOfMatchesForXpath("//link[@href='appearance.css']", 1);
+        }
+
+        [Test]
+        public void CreateBookOnDiskFromTemplate_ConflictingCss_UsesLegacy()
+        {
+            _starter.TestingSoSkipAddingXMatter = true;
+            var body =
+                @"<div class='bloom-page'>
+						<div class='bloom-translationGroup'>
+						 <div lang='en'>This is some English</div>
+						</div>
+					</div>";
+            string sourceTemplateFolder = GetShellBookFolder(body, null);
+            File.WriteAllText(
+                Path.Combine(sourceTemplateFolder, "customBookStyles.css"),
+                @".marginBox {margin: 20px}"
+            );
+            var path = GetPathToHtml(
+                _starter.CreateBookOnDiskFromTemplate(sourceTemplateFolder, _projectFolder.Path)
+            );
+            //nb: testid is used rather than id because id is replaced with a guid when the copy is made
+
+            var bookFolder = Path.GetDirectoryName(path);
+            var appearanceSettings = new AppearanceSettings();
+            appearanceSettings.UpdateFromFolder(bookFolder);
+            Assert.That(appearanceSettings.CssThemeName == "legacy-5-6");
+
+            // Would like to test this, but we don't update the stylesheets in the DOM until we actually create the book.
+            //AssertThatXmlIn.HtmlFile(path).HasSpecifiedNumberOfMatchesForXpath("//link[@href='basePage.css']", 1);
+            //AssertThatXmlIn.HtmlFile(path).HasSpecifiedNumberOfMatchesForXpath("//link[@href='appearance.css']", 1);
         }
 
         [Test]

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -136,26 +136,21 @@ namespace BloomTests.Book
             AssertThatXmlIn.HtmlFile(_bookPath).HasSpecifiedNumberOfMatchesForXpath("//p", 5);
         }
 
-        [Test]
-        public void Save_BookHadEditStyleSheet_NowHasPreviewAndBaseAndAppearance()
-        {
-            GetInitialStorageWithCustomHtml(
-                "<html><head><link rel='stylesheet' href='editMode.css' type='text/css' /></head><body><div class='bloom-page'></div></body></html>"
-            );
-            AssertThatXmlIn
-                .HtmlFile(_bookPath)
-                .HasSpecifiedNumberOfMatchesForXpath("//link[@href = 'editMode.css']", 0);
-            AssertThatXmlIn
-                .HtmlFile(_bookPath)
-                .HasSpecifiedNumberOfMatchesForXpath("//link[@href = 'basePage.css']", 1);
-            AssertThatXmlIn
-                .HtmlFile(_bookPath)
-                .HasSpecifiedNumberOfMatchesForXpath("//link[@href = 'previewMode.css']", 1);
-            AssertThatXmlIn
-                .HtmlFile(_bookPath)
-                .HasSpecifiedNumberOfMatchesForXpath("//link[@href = 'appearance.css']", 1);
-        }
-
+        // Review JohnH: We no longer migrate to Themes except when creating a new book.
+        // So just initializing a storage won't migrate the HTML to use Themes if the HTML doesn't
+        // already have the relevant links.
+        // I added tests that book starter creates a book with the right theme (depending on customStyles),
+        // but we may need another on Book to verify that BBUD inserts the right stylesheet links for
+        // appearance.css (in default) and basePage-legacy-5-6.css (in legacy).
+        //[Test]
+        //public void Save_BookHadEditStyleSheet_NowHasPreviewAndBaseAndAppearance()
+        //{
+        //	GetInitialStorageWithCustomHtml("<html><head><link rel='stylesheet' href='editMode.css' type='text/css' /></head><body><div class='bloom-page'></div></body></html>");
+        //	AssertThatXmlIn.HtmlFile(_bookPath).HasSpecifiedNumberOfMatchesForXpath("//link[@href = 'editMode.css']", 0);
+        //	AssertThatXmlIn.HtmlFile(_bookPath).HasSpecifiedNumberOfMatchesForXpath("//link[@href = 'basePage.css']", 1);
+        //	AssertThatXmlIn.HtmlFile(_bookPath).HasSpecifiedNumberOfMatchesForXpath("//link[@href = 'previewMode.css']", 1);
+        //	AssertThatXmlIn.HtmlFile(_bookPath).HasSpecifiedNumberOfMatchesForXpath("//link[@href = 'appearance.css']", 1);
+        //}
         [Test]
         public void Save_BookHadNarrationAudioRecordedByWholeTextBox_AddsFeatureRequirementMetadata()
         {
@@ -1681,7 +1676,9 @@ namespace BloomTests.Book
             );
 
             //SUT
-            storage.PerformNecessaryMaintenanceOnBook();
+            storage.MigrateToMediaLevel1ShrinkLargeImages();
+            storage.MigrateToLevel2RemoveTransparentComicalSvgs();
+            storage.MigrateToLevel3PutImgFirst();
 
             //Verification
             var maintLevel = storage.Dom.GetMetaValue("maintenanceLevel", "0");
@@ -1713,7 +1710,9 @@ namespace BloomTests.Book
             );
 
             //SUT
-            storage.PerformNecessaryMaintenanceOnBook();
+            storage.MigrateToMediaLevel1ShrinkLargeImages();
+            storage.MigrateToLevel2RemoveTransparentComicalSvgs();
+            storage.MigrateToLevel3PutImgFirst();
 
             //Verification
             var maintLevel = storage.Dom.GetMetaValue("maintenanceLevel", "0");
@@ -1749,7 +1748,9 @@ namespace BloomTests.Book
             );
 
             //SUT
-            storage.PerformNecessaryMaintenanceOnBook();
+            storage.MigrateToMediaLevel1ShrinkLargeImages();
+            storage.MigrateToLevel2RemoveTransparentComicalSvgs();
+            storage.MigrateToLevel3PutImgFirst();
 
             //Verification
             var maintLevel = storage.Dom.GetMetaValue("maintenanceLevel", "0");
@@ -1792,7 +1793,9 @@ namespace BloomTests.Book
             );
 
             //SUT
-            storage.PerformNecessaryMaintenanceOnBook();
+            storage.MigrateToMediaLevel1ShrinkLargeImages();
+            storage.MigrateToLevel2RemoveTransparentComicalSvgs();
+            storage.MigrateToLevel3PutImgFirst();
 
             //Verification
             var maintLevel = storage.Dom.GetMetaValue("maintenanceLevel", "0");
@@ -1823,7 +1826,9 @@ namespace BloomTests.Book
             );
 
             //SUT
-            storage.PerformNecessaryMaintenanceOnBook();
+            storage.MigrateToMediaLevel1ShrinkLargeImages();
+            storage.MigrateToLevel2RemoveTransparentComicalSvgs();
+            storage.MigrateToLevel3PutImgFirst();
 
             //Verification
             var maintLevel = storage.Dom.GetMetaValue("maintenanceLevel", "0");

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -1,13 +1,18 @@
+using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Web;
 using System.Xml;
 using Bloom;
 using Bloom.Book;
 using Bloom.Collection;
 using Bloom.Publish;
 using Bloom.web.controllers;
+using BloomTemp;
 using Moq;
 using NUnit.Framework;
 using SIL.Extensions;
@@ -15,11 +20,6 @@ using SIL.IO;
 using SIL.Progress;
 using SIL.Windows.Forms.ClearShare;
 using SIL.Xml;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Web;
-using BloomTemp;
 
 namespace BloomTests.Book
 {
@@ -226,7 +226,8 @@ namespace BloomTests.Book
             var dataBookImage = dom.SelectSingleNodeHonoringDefaultNS(
                 "//div[@id='bloomDataDiv']/div[@data-book='coverImage']"
             );
-            Assert.AreEqual(placeHolderFile, dataBookImage.InnerText);
+            if (dataBookImage != null) // used to just set the src of the img, but removing the dataDiv element altogether is better still.
+                Assert.AreEqual(placeHolderFile, dataBookImage.InnerText);
             var pageImage = dom.SelectSingleNodeHonoringDefaultNS(
                 "//div[contains(@class,'bloom-imageContainer')]/img[@data-book='coverImage']"
             );

--- a/src/BloomTests/Book/BookTestsBase.cs
+++ b/src/BloomTests/Book/BookTestsBase.cs
@@ -10,9 +10,9 @@ using Bloom.Collection;
 using Bloom.Edit;
 using Moq;
 using NUnit.Framework;
+using SIL.Code;
 using SIL.Extensions;
 using SIL.IO;
-using SIL.Code;
 using SIL.Progress;
 using SIL.TestUtilities;
 using SIL.Windows.Forms.ImageToolbox;
@@ -438,15 +438,14 @@ namespace BloomTests.Book
                     );
                 },
                 // storage factory
-                (path, fullyUpdateBookFiles) =>
+                (info, fullyUpdateBookFiles) =>
                 {
                     var storage = new BookStorage(
-                        path,
+                        info,
                         fileLocator,
                         new BookRenamedEvent(),
                         _collectionSettings
                     );
-                    storage.BookInfo = new BookInfo(path, true);
                     return storage;
                 },
                 // book starter factory

--- a/src/BloomTests/CLI/HydrateBookCommandTests.cs
+++ b/src/BloomTests/CLI/HydrateBookCommandTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Bloom;
@@ -191,9 +191,10 @@ namespace BloomTests.CLI
             Debug.Write(File.ReadAllText(_eventualHtmlPath));
             var dom = XmlHtmlConverter.GetXmlDomFromHtml(File.ReadAllText(_eventualHtmlPath));
 
+            // HydrateBookCommand brings book up to date but not to the theme system.
             AssertThatXmlIn
                 .Dom(dom)
-                .HasSpecifiedNumberOfMatchesForXpath("//link[@href='basePage.css']", 1);
+                .HasSpecifiedNumberOfMatchesForXpath("//link[@href='basePage-legacy-5-6.css']", 1);
 
             AssertThatXmlIn
                 .Dom(dom)

--- a/src/BloomTests/Publish/BloomReaderPublishTests.cs
+++ b/src/BloomTests/Publish/BloomReaderPublishTests.cs
@@ -5,23 +5,23 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using Bloom;
+using Bloom.Api;
 using Bloom.Book;
+using Bloom.Collection;
 using Bloom.FontProcessing;
+using Bloom.ImageProcessing;
+using Bloom.Publish;
 using Bloom.Publish.BloomPub;
 using Bloom.web;
 using BloomTests.Book;
 using ICSharpCode.SharpZipLib.Zip;
 using NUnit.Framework;
 using SIL.IO;
+using SIL.PlatformUtilities;
 using SIL.TestUtilities;
 using SIL.Windows.Forms.ClearShare;
 using SIL.Windows.Forms.ImageToolbox;
 using Color = System.Drawing.Color;
-using Bloom.Api;
-using Bloom.Collection;
-using Bloom.ImageProcessing;
-using Bloom.Publish;
-using SIL.PlatformUtilities;
 using Directory = System.IO.Directory;
 using File = System.IO.File;
 
@@ -110,6 +110,7 @@ namespace BloomTests.Publish
                 "customCollectionStyles.css", // should be copied from parent directory
                 "defaultLangStyles.css"
             };
+            string collectionStylesPath = null;
 
             TestHtmlAfterCompression(
                 kMinimumValidBookHtml,
@@ -128,6 +129,11 @@ namespace BloomTests.Publish
                         Path.Combine(folderPath, "previewMode.css"),
                         @"This is wanted"
                     );
+                    collectionStylesPath = Path.Combine(
+                        Path.GetDirectoryName(folderPath),
+                        "customCollectionStyles.css"
+                    );
+                    File.WriteAllText(collectionStylesPath, "color: red");
                 },
                 assertionsOnResultingHtmlString: html =>
                 {
@@ -156,6 +162,7 @@ namespace BloomTests.Publish
                     Assert.That(meta.BloomdVersion, Is.EqualTo(1));
                 }
             );
+            RobustFile.Delete(collectionStylesPath);
         }
 
         [Test]

--- a/src/BloomTests/Publish/ExportEpubTests.cs
+++ b/src/BloomTests/Publish/ExportEpubTests.cs
@@ -9,13 +9,13 @@ using System.Xml.Linq;
 using Bloom;
 using Bloom.Book;
 using Bloom.Publish;
-using BloomBook = Bloom.Book.Book;
 using Bloom.Publish.Epub;
 using Bloom.web.controllers;
 using ICSharpCode.SharpZipLib.Zip;
 using NUnit.Framework;
 using SIL.Extensions;
 using SIL.PlatformUtilities;
+using BloomBook = Bloom.Book.Book;
 
 namespace BloomTests.Publish
 {
@@ -247,8 +247,8 @@ namespace BloomTests.Publish
                 branding: "Test"
             );
             // MakeEpub (when using a physical file as we are) creates Device Xmatter, so usually page one is cover, page 2 is ours.
-            // But the added front cover is empty so it gets deleted. So page 1 is the one we're testing.
-            var assertThatPageOneData = AssertThatXmlIn.String(GetPageNData(1));
+            // If we go to default theme, the cover will be empty and get deleted, and we'll need to test page 1.
+            var assertThatPageOneData = AssertThatXmlIn.String(GetPageNData(2));
             assertThatPageOneData.HasNoMatchForXpath(
                 "//xhtml:div[contains(@class,'bloom-imageDescription')]",
                 _ns

--- a/src/content/appearanceThemes/appearance-theme-purple-rounded.css
+++ b/src/content/appearanceThemes/appearance-theme-purple-rounded.css
@@ -1,7 +1,12 @@
 /* based onhttps://bloomlibrary.org/player/vPftT2H1eE */
 /* {
-    substitutionChecksums: "6d540d3c796842b382db5dbd10826655"
+    substitutionChecksums: "6d540d3c796842b382db5dbd10826655","23c76394fefc12d620b3d7b646850ae3"
 } */
+/* JohnT 2 Jan 2023: added the second checksum, which is correct for the customBookStyles.css in the current version of
+the book at https://bloomlibrary.org/player/vPftT2H1eE. This however is just for testing (as is this whole theme).
+I don't know, or think it likely, that this theme is actually a good substitute for the customBookStyles.css in
+https://bloomlibrary.org/player/vPftT2H1eE, nor for any book (if there is one) that actually matches
+6d540d3c796842b382db5dbd10826655 */
 .bloom-page {
     --marginBox-border-radius: 25px;
     /*--marginBox-border-color: rgb(77, 68, 68);*/

--- a/src/content/bookLayout/basePage-legacy-5-6.less
+++ b/src/content/bookLayout/basePage-legacy-5-6.less
@@ -1221,3 +1221,13 @@ body {
         display: flex;
     }
 }
+
+// For some reason, in 5.6 and before we had this being set in every xmatter.css for every page size
+// independently. We took that out to accommodate the new theme system, but we need some left
+// margin in legacy mode!
+// There are exceptions where outer cover left: is set to 0 in Kyrgystan-2020 epub and Uzbekistan 2023 xmatter,
+// but we'll deal with those later if they are still in use.
+.outsideFrontCover .marginBox,
+.outsideBackCover .marginBox {
+  left: 15mm;
+}


### PR DESCRIPTION
The original idea was to allow the user to select a non-legacy theme even if the book has incompatible custom CSS. That branched out in to fixing a multitude of problems, both with AppearanceSettings.cs itself, and pre-existing issues which the new system made more serious.
BringBookUpToDate was drastically reorganized and simplified, and is ow only done at all if we can save changes to the folder.
customBookStyles2.css was introduced as the place to put substitute CSS that allows certain known problem customCss to be replaced with a modern theme.
Books can no longer be published if they are in a TC and not checked out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6243)
<!-- Reviewable:end -->
