### PR TITLE
Add data-default-languages-legacy (BL-12975)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -580,6 +580,7 @@ namespace Bloom.Book
             TranslationGroupManager.UpdateContentLanguageClasses(
                 dom.RawDom,
                 _bookData,
+                BookInfo.AppearanceSettings.UsingLegacy,
                 Language1Tag,
                 Language2Tag,
                 Language3Tag
@@ -2777,7 +2778,7 @@ namespace Bloom.Book
                     if (ElementIsInXMatter(parent))
                         continue;
                     isXmatterOnly = false;
-                    if (IsLanguageWanted(parent, lang) && !HasContentInLang(parent, lang))
+                    if (IsLanguageWantedInContent(parent, lang) && !HasContentInLang(parent, lang))
                     {
                         result[lang] = false; // not complete
                         break; // no need to check other parents.
@@ -2820,7 +2821,14 @@ namespace Bloom.Book
             return false;
         }
 
-        private bool IsLanguageWanted(XmlElement parent, string lang)
+        /// <summary>
+        /// Determines whether the given language bloom-editable is wanted (should be visible, and therefore typically
+        /// published) in the given parent.
+        /// Currently this is reliable only for elements where visibility is controlled by the old data-default-languages
+        /// attribute rather than the new appearance system. It will need enhancement if we ever need to use it for xmatter,
+        /// or for that matter if the appearance system is used to control visibility of something on content pages.
+        /// </summary>
+        private bool IsLanguageWantedInContent(XmlElement parent, string lang)
         {
             var defaultLangs = parent.GetAttribute("data-default-languages");
             if (String.IsNullOrEmpty(defaultLangs) || defaultLangs == "auto")
@@ -3454,6 +3462,7 @@ namespace Bloom.Book
                 TranslationGroupManager.UpdateContentLanguageClasses(
                     newPageDiv,
                     _bookData,
+                    BookInfo.AppearanceSettings.UsingLegacy,
                     Language1Tag,
                     Language2Tag,
                     Language3Tag
@@ -4347,6 +4356,7 @@ namespace Bloom.Book
                 TranslationGroupManager.UpdateContentLanguageClasses(
                     div,
                     _bookData,
+                    BookInfo.AppearanceSettings.UsingLegacy,
                     language1Tag,
                     language2Tag,
                     language3Tag

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -223,10 +223,6 @@ namespace Bloom.Publish
                     if (HasClass(elt, "pageDescription"))
                         elt.ParentNode.RemoveChild(elt);
                 }
-
-                // REVIEW: is this needed now with the new strategy?
-                if (HasClass(elt, "bloom-editable") && HasClass(elt, "bloom-visibility-user-off"))
-                    elt.ParentNode.RemoveChild(elt);
             }
             // Our recordingmd5 attribute is not allowed by epub
             foreach (

--- a/src/BloomTests/Book/TranslationGroupManagerTests.cs
+++ b/src/BloomTests/Book/TranslationGroupManagerTests.cs
@@ -72,6 +72,7 @@ namespace BloomTests.Book
             TranslationGroupManager.UpdateContentLanguageClasses(
                 pageDiv,
                 bookData,
+                false,
                 "xyz",
                 "222",
                 "333"
@@ -295,6 +296,7 @@ namespace BloomTests.Book
             TranslationGroupManager.UpdateContentLanguageClasses(
                 pageDiv,
                 bookData,
+                false,
                 "xyz",
                 "222",
                 "333"
@@ -321,6 +323,89 @@ namespace BloomTests.Book
         }
 
         [Test]
+        public void UpdateContentLanguageClasses_Legacy_TurnsOnCorrectLanguages()
+        {
+            var contents =
+                @"<html><body><div class='bloom-page' >
+						<div class='bloom-translationGroup' data-default-languages-legacy='N1,N2'>
+							<div class='bloom-editable' lang='xyz'></div>
+							<div class='bloom-editable' lang='fr'></div>
+							<div class='bloom-editable' lang='es'></div>
+							</div>
+						</div></body></html>";
+            var dom = new XmlDocument();
+            dom.LoadXml(contents);
+            var bookData = new BookData(new HtmlDom(dom), _collectionSettings, null);
+
+            var pageDiv = (XmlElement)
+                dom.SafeSelectNodes("//div[contains(@class,'bloom-page')]")[0];
+
+            // Here the arguments don't matter much. data-default-languages specifies N1, which means the Metadata1Language should
+            // be visible, and N2, which currently turns on L3.
+            TranslationGroupManager.UpdateContentLanguageClasses(
+                pageDiv,
+                bookData,
+                true,
+                "xyz",
+                "222",
+                "333"
+            );
+
+            AssertThatXmlIn
+                .Dom(dom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[contains(@class, 'bloom-visibility-code-on')]",
+                    2
+                );
+            AssertThatXmlIn
+                .Dom(dom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[@lang='fr' and contains(@class, 'bloom-visibility-code-on')]",
+                    1
+                );
+            AssertThatXmlIn
+                .Dom(dom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[@lang='es' and contains(@class, 'bloom-visibility-code-on')]",
+                    1
+                );
+        }
+
+        [Test]
+        public void UpdateContentLanguageClasses_LegacyDataDefault_NotLegacy_RemovesVisibilityOn()
+        {
+            var contents =
+                @"<html><body><div class='bloom-page' >
+						<div class='bloom-translationGroup' data-default-languages-legacy='N1,N2'>
+							<div class='bloom-editable bloom-visibility-code-on' lang='xyz'></div>
+							<div class='bloom-editable bloom-visibility-code-on' lang='fr'></div>
+							<div class='bloom-editable bloom-visibility-code-on' lang='es'></div>
+							</div>
+						</div></body></html>";
+            var dom = new XmlDocument();
+            dom.LoadXml(contents);
+            var bookData = new BookData(new HtmlDom(dom), _collectionSettings, null);
+
+            var pageDiv = (XmlElement)
+                dom.SafeSelectNodes("//div[contains(@class,'bloom-page')]")[0];
+
+            // Here the arguments don't matter much. data-default-languages specifies N1, which means the Metadata1Language should
+            // be visible, and N2, which currently turns on L3.
+            TranslationGroupManager.UpdateContentLanguageClasses(
+                pageDiv,
+                bookData,
+                false,
+                "xyz",
+                "222",
+                "333"
+            );
+
+            AssertThatXmlIn
+                .Dom(dom)
+                .HasNoMatchForXpath("//div[contains(@class, 'bloom-visibility-code')]");
+        }
+
+        [Test]
         public void UpdateContentLanguageClasses_TrilingualContentPage_TurnsOnCorrectLanguages()
         {
             var contents =
@@ -340,6 +425,7 @@ namespace BloomTests.Book
             TranslationGroupManager.UpdateContentLanguageClasses(
                 pageDiv,
                 bookData,
+                false,
                 "xyz", /* make trilingual --> */
                 "fr",
                 "es"
@@ -390,6 +476,7 @@ namespace BloomTests.Book
             TranslationGroupManager.UpdateContentLanguageClasses(
                 pageDiv,
                 bookData,
+                false,
                 "xyz", /* makes bilingual --> */
                 "fr",
                 ""
@@ -431,6 +518,7 @@ namespace BloomTests.Book
             TranslationGroupManager.UpdateContentLanguageClasses(
                 pageDiv,
                 bookData,
+                false,
                 "xyz",
                 null,
                 null
@@ -466,6 +554,7 @@ namespace BloomTests.Book
             TranslationGroupManager.UpdateContentLanguageClasses(
                 pageDiv,
                 bookData,
+                false,
                 "xyz",
                 "222",
                 null
@@ -541,6 +630,7 @@ namespace BloomTests.Book
             TranslationGroupManager.UpdateContentLanguageClasses(
                 bodyDiv,
                 bookData,
+                false,
                 "xyz",
                 "222",
                 null

--- a/src/content/bookLayout/basePage-legacy-5-6.less
+++ b/src/content/bookLayout/basePage-legacy-5-6.less
@@ -304,9 +304,8 @@ body {
     align-items: center;
   }
   .bloom-imageContainer .bloom-textOverPicture[data-bubble]:not([data-bubble*="`style`:`none`"]) .bloom-editable.bloom-visibility-code-on,
-  .bloom-imageContainer .bloom-textOverPicture[data-bubble*="backgroundColors"]:not([data-bubble*="`backgroundColors`:[`transparent`]"]) .bloom-editable.bloom-visibility-code-on,
-  .bloom-imageContainer .bloom-textOverPicture[data-bubble]:not([data-bubble*="`style`:`none`"]) .bloom-editable.bloom-visibility-user-on,
-  .bloom-imageContainer .bloom-textOverPicture[data-bubble*="backgroundColors"]:not([data-bubble*="`backgroundColors`:[`transparent`]"]) .bloom-editable.bloom-visibility-user-on {
+  .bloom-imageContainer .bloom-textOverPicture[data-bubble*="backgroundColors"]:not([data-bubble*="`backgroundColors`:[`transparent`]"]) .bloom-editable.bloom-visibility-code-on
+  {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -314,9 +313,7 @@ body {
     align-content: center;
   }
   .bloom-imageContainer .bloom-textOverPicture[data-bubble]:not([data-bubble*="`style`:`none`"]) .bloom-editable.bloom-visibility-code-on p,
-  .bloom-imageContainer .bloom-textOverPicture[data-bubble*="backgroundColors"]:not([data-bubble*="`backgroundColors`:[`transparent`]"]) .bloom-editable.bloom-visibility-code-on p,
-  .bloom-imageContainer .bloom-textOverPicture[data-bubble]:not([data-bubble*="`style`:`none`"]) .bloom-editable.bloom-visibility-user-on p,
-  .bloom-imageContainer .bloom-textOverPicture[data-bubble*="backgroundColors"]:not([data-bubble*="`backgroundColors`:[`transparent`]"]) .bloom-editable.bloom-visibility-user-on p {
+  .bloom-imageContainer .bloom-textOverPicture[data-bubble*="backgroundColors"]:not([data-bubble*="`backgroundColors`:[`transparent`]"]) .bloom-editable.bloom-visibility-code-on p {
     flex-basis: 100%;
     flex-grow: 0;
   }
@@ -925,8 +922,7 @@ body {
   .box-header-off {
     display: none !important;
   }
-  .bloom-editable.bloom-visibility-code-on ~ .bloom-editable,
-  .bloom-editable.bloom-visibility-user-on ~ .bloom-editable {
+  .bloom-editable.bloom-visibility-code-on ~ .bloom-editable {
     margin-top: 10px;
   }
   .customPage .bloom-imageContainer {
@@ -1208,16 +1204,10 @@ body {
 .bloom-editable.bloom-visibility-code-on {
     display: block;
 }
-.bloom-editable.bloom-visibility-user-on {
-    display: block;
-}
-.bloom-editable.bloom-visibility-user-off {
-    display: none !important;
-}
+
 .bloom-vertical-align-center,
 .bloom-vertical-align-bottom {
-    .bloom-editable.bloom-visibility-code-on,
-    .bloom-editable.bloom-visibility-user-on {
+    .bloom-editable.bloom-visibility-code-on {
         display: flex;
     }
 }

--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -535,6 +535,14 @@ div[data-book*="branding"] {
     display: var(--cover-title-L3-show);
 }
 
+// As of January 2024 we don't have anything that sets this variable, but we needed something to
+// MAKE the cover title show up in L1. An invalid variable value causes the default (block)
+// to be used, so it is effective, and if we ever allow control of the variable (or someone
+// wants to put it in a custom stylesheet), it will work.
+.Title-On-Cover-style.bloom-content1 {
+    display: var(--cover-title-L1-show);
+}
+
 .coverBottomBookTopic {
     display: var(--cover-topic-show);
 }

--- a/src/content/bookLayout/bubble.less
+++ b/src/content/bookLayout/bubble.less
@@ -238,8 +238,7 @@
 
         // Note: Needs a bit of specificity to beat display: block rule in langVisibility.css
         // However, also need to make sure you don't accidentall change display: none to display: flex
-        .bloom-editable.bloom-visibility-code-on,
-        .bloom-editable.bloom-visibility-user-on {
+        .bloom-editable.bloom-visibility-code-on {
             display: flex;
 
             // We use direction=row, wrap, and item's basis=100% in order to layout the paragraphs (flex-item)

--- a/src/content/bookLayout/langVisibility.less
+++ b/src/content/bookLayout/langVisibility.less
@@ -9,16 +9,6 @@
     display: block;
 }
 
-//If not the user can still make it visible:
-.bloom-editable.bloom-visibility-user-on {
-    display: block;
-}
-
-//And the user can always hide it
-.bloom-editable.bloom-visibility-user-off {
-    display: none !important;
-}
-
 // To achieve vertical alignment, the visibility-on rules have to use display:flex
 // instead of display:block to override display:none.
 // It would be simpler to just use display:flex always,
@@ -30,8 +20,7 @@
 .bloom-vertical-align-center,
 .bloom-vertical-align-bottom {
 
-    .bloom-editable.bloom-visibility-code-on,
-    .bloom-editable.bloom-visibility-user-on {
+    .bloom-editable.bloom-visibility-code-on {
         display: flex;
     }
 }

--- a/src/content/templates/Sample Shells/A Family Learns about Immunisations/A Family Learns about Immunisations.htm
+++ b/src/content/templates/Sample Shells/A Family Learns about Immunisations/A Family Learns about Immunisations.htm
@@ -195,7 +195,7 @@
             <div class="marginBox">
                 <div
                     class="bloom-translationGroup bookTitle"
-                    data-default-languages="V,N1"
+                    data-default-languages-legacy="V,N1"
                 >
                     <label class="bubble">Book title in {lang}</label>
                     <div

--- a/src/content/templates/Sample Shells/The Moon and the Cap/The Moon and the Cap.htm
+++ b/src/content/templates/Sample Shells/The Moon and the Cap/The Moon and the Cap.htm
@@ -301,7 +301,7 @@
             <div class="marginBox">
                 <div
                     class="bloom-translationGroup bookTitle"
-                    data-default-languages="V,N1"
+                    data-default-languages-legacy="V,N1"
                 >
                     <label class="bubble">Book title in {lang}</label>
                     <div

--- a/src/content/templates/Sample Shells/The Moon and the Cap/langVisibility.css
+++ b/src/content/templates/Sample Shells/The Moon and the Cap/langVisibility.css
@@ -1,16 +1,9 @@
 .bloom-editable.bloom-visibility-code-on {
     display: block;
 }
-.bloom-editable.bloom-visibility-user-on {
-    display: block;
-}
-.bloom-editable.bloom-visibility-user-off {
-    display: none !important;
-}
+
 .bloom-vertical-align-center .bloom-editable.bloom-visibility-code-on,
-.bloom-vertical-align-bottom .bloom-editable.bloom-visibility-code-on,
-.bloom-vertical-align-center .bloom-editable.bloom-visibility-user-on,
-.bloom-vertical-align-bottom .bloom-editable.bloom-visibility-user-on {
+.bloom-vertical-align-bottom .bloom-editable.bloom-visibility-code-on {
     display: flex;
 }
 

--- a/src/content/templates/bloom-foundation-mixins.pug
+++ b/src/content/templates/bloom-foundation-mixins.pug
@@ -94,6 +94,10 @@ mixin field-prototypeDeclaredExplicity(languages)
 	- requireOneArgument('field-prototypeDeclaredExplicity', arguments);
 	.bloom-translationGroup(data-default-languages=languages)&attributes(attributes)
 		block
+mixin field-prototypeDeclaredExplicity-legacy(languages)
+	- requireOneArgument('field-prototypeDeclaredExplicity', arguments);
+	.bloom-translationGroup(data-default-languages-legacy=languages)&attributes(attributes)
+		block
 
 //- deprecated. Starting with version 2.0, we've changed how placeholders are handled
 mixin field-version1(placeholder)

--- a/src/content/templates/customXMatter/StoryProducer-XMatter/StoryProducer-XMatter.pug
+++ b/src/content/templates/customXMatter/StoryProducer-XMatter/StoryProducer-XMatter.pug
@@ -22,7 +22,7 @@ block append stylesheets
 	+stylesheets('StoryProducer-XMatter.css')
 
 block cover-title
-	+field-prototypeDeclaredExplicity("V,N1").bookTitle
+	+field-prototypeDeclaredExplicity-legacy("V,N1").bookTitle
 		label.bubble Story number plus short title or index label
 		+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style.bloom-padForOverflow(data-book='bookTitle')
 

--- a/src/content/templates/xMatter/Video-XMatter/Video-XMatter.pug
+++ b/src/content/templates/xMatter/Video-XMatter/Video-XMatter.pug
@@ -13,7 +13,7 @@ html
 	//Note: the ".frontCover" here triggers some things in the common stylesheet,
 	//so if you change it, expect to do some more work
 	+page-cover('Opening Screen').frontCover#ad01f8d2-c338-4dca-b4f2-cc4eeb62c1b0(data-xmatter-page='frontCover')
-		+field-prototypeDeclaredExplicity("V").bookTitle
+		+field-prototypeDeclaredExplicity-legacy("V").bookTitle
 			label.bubble Title in {lang}
 			+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style(data-book='bookTitle')
 

--- a/src/content/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/content/templates/xMatter/bloom-xmatter-mixins.pug
@@ -121,7 +121,7 @@ mixin standard-cover-contents
 		+cover-branding-top
 
 	block cover-title
-		+field-prototypeDeclaredExplicity("V,N1").bookTitle
+		+field-prototypeDeclaredExplicity-legacy("V,N1").bookTitle
 			label.bubble Book title in {lang}
 			+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style.bloom-padForOverflow(data-book='bookTitle')
 

--- a/src/content/templates/xMatter/project-specific/ABC-Reader-XMatter/ABC-Reader-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/ABC-Reader-XMatter/ABC-Reader-XMatter.pug
@@ -91,7 +91,7 @@ block append stylesheets
 block cover-title
 	.titleAndNumberCircle
 		//- show title in Vernacular only
-		+field-prototypeDeclaredExplicity("V").bookTitle
+		+field-prototypeDeclaredExplicity-legacy("V").bookTitle
 			label.bubble Book title in {lang}
 			+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style.bloom-padForOverflow(data-book='bookTitle')
 			block cover-title

--- a/src/content/templates/xMatter/project-specific/Afghan-Children-Read-Common/Afghan-Children-Read-XMatter-mixins.pug
+++ b/src/content/templates/xMatter/project-specific/Afghan-Children-Read-Common/Afghan-Children-Read-XMatter-mixins.pug
@@ -85,7 +85,7 @@ mixin afg-outsideFrontCover(langForBubbles)
 		.topBlock
 			+cover-branding-top-left
 			.topContent
-				+field-prototypeDeclaredExplicity("V").bookTitle
+				+field-prototypeDeclaredExplicity-legacy("V").bookTitle
 					label.bubble Book title in {lang}
 					+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style.bloom-padForOverflow(data-book='bookTitle')
 				.levelInfoRow

--- a/src/content/templates/xMatter/project-specific/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-XMatter.less
@@ -101,8 +101,7 @@
                 // But since the user can't get to the control for that in xmatter anyway,
                 // this seems just as good for now (and allows the difference for orientation).
                 justify-content: center;
-                .bloom-editable.bloom-visibility-code-on,
-                .bloom-editable.bloom-visibility-user-on {
+                .bloom-editable.bloom-visibility-code-on {
                     justify-content: center;
                     display: flex;
                 }

--- a/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBLiteracy-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBLiteracy-XMatter/MXBLiteracy-XMatter.pug
@@ -8,7 +8,7 @@ mixin mxb-frontCover-Literacy
 			+cover-branding-top
 
 		block cover-title
-			+field-prototypeDeclaredExplicity("V,N1").bookTitle
+			+field-prototypeDeclaredExplicity-legacy("V,N1").bookTitle
 				label.bubble Book title in {lang}
 				+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style.bloom-padForOverflow(data-book='bookTitle')
 

--- a/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/MXBScripture-XMatter/MXBScripture-XMatter.pug
@@ -24,7 +24,7 @@ mixin mxb-frontCover-scripture
 			+cover-branding-top
 
 		block cover-title
-			+field-prototypeDeclaredExplicity("V,N1").bookTitle
+			+field-prototypeDeclaredExplicity-legacy("V,N1").bookTitle
 				label.bubble Book title in {lang}
 				+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-On-Cover-style.bloom-padForOverflow(data-book='bookTitle')
 

--- a/src/content/templates/xMatter/project-specific/Uzbekistan2023-XMatter/Uzbekistan2023-XMatter.pug
+++ b/src/content/templates/xMatter/project-specific/Uzbekistan2023-XMatter/Uzbekistan2023-XMatter.pug
@@ -28,7 +28,7 @@ html
 	body
 		+page-cover('Front Cover')(data-export='front-matter-cover', data-xmatter-page='frontCover')&attributes(attributes).frontCover.outsideFrontCover#7d7d1d2d-18b0-420f-ac96-6de20f659810
 			+standard-cover-image
-			+field-prototypeDeclaredExplicity("V").bookTitle
+			+field-prototypeDeclaredExplicity-legacy("V").bookTitle
 				label.bubble Book title in {lang}
 				+editable(kLanguageForPrototypeOnly).bloom-nodefaultstylerule.Title-Front-Cover-style.bloom-padForOverflow(data-book='bookTitle')
 			div(data-book='level-image-html' lang="*").gradeBadgeRow


### PR DESCRIPTION
Adds this attribute for use on fields (currently just .Title-On-Cover-style) that previously used data-default-languages to control which languages should be visible (by adding the class bloom-visibility-code-on). The value in the new attribute, if present, will be used when the book is in legacy mode. Otherwise, the bloom-visibility-code-on class will be removed.
Also removes all reference to bloom-visibility-user-on/off, an idea we introduced with bloom-visibility-code-on but never used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6256)
<!-- Reviewable:end -->
