### PR TITLE
Migrating to the theme system in EnsureUpToDate() (BL-12967)

### DIFF
--- a/src/BloomExe/Book/AppearanceSettings.cs
+++ b/src/BloomExe/Book/AppearanceSettings.cs
@@ -92,12 +92,14 @@ public class AppearanceSettings
     // Instance is typically created using UpdateFromFolder, which will set this to true if it found and loaded
     // an existing appearance.json file.
     // It is therefore false if the books is, or was created from, a book created by an earlier version of Bloom
-    // that does not use the appearance system. Such books are forced into the legacy-5-6 theme, except possibly
-    // when deriving a new book from them.
+    // that does not use the appearance system. Such books are forced into the legacy-5-6 theme, unless they
+    // are Saveable, in which case, Book.EnsureUpToDate will migrate them (possibly still using the legacy-5-6 theme
+    // explicitly).
     // It can also be set when WriteToFolder() updates the appearance files to be consistent with the current settings.
     // This only gets called if Bloom is allowed to make changes to the folder, so it remains false
     // if we are loading a legacy book in a folder we can't write.
     private bool _areSettingsConsistentWithFiles;
+
     public bool IsInitialized { get; private set; }
 
     // create an array of properties and fill it in
@@ -257,19 +259,14 @@ public class AppearanceSettings
     }
 
     /// <summary>
-    /// Given a list of CSS files from a new book, typically customBookStyles.css and customCollectionStyles.css,
+    /// Given a list of CSS files from pre-5.7 book, typically customBookStyles.css and customCollectionStyles.css,
     /// decide what theme the book should use, and if we need a specialized customBookStyles2.css file,
     /// return a path to the file that should be copied there.
     /// Also leaves this object in a state where it represents the settings that should be written to appearance.json.
     /// </summary>
     public string GetThemeAndSubstituteCss(Tuple<string, string>[] cssFilesToCheck)
     {
-        // This is currently only used when creating a new book. If the source book was already in the Appearance/Theme system,
-        // it will have an appearance.json file, and we will stick with whatever theme and related settings
-        // the original book had.
-        if (_areSettingsConsistentWithFiles)
-            return null;
-        // Otherwise, cssThemeName will already be set to "legacy-5-6" by UpdateFromFolder, but for new books we want to
+        // cssThemeName will already be set to "legacy-5-6" by UpdateFromFolder, but for new books we want to
         // try to use the default or some substitute them, and only switch back to the legacy theme,
         // if we don't know of a substitute theme and its associated customBookStyles2.css file.
         CssThemeName = "default";

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1695,11 +1695,12 @@ namespace Bloom.Book
 
             // These (and maybe other stuff) could be avoided when updating a copy of an up-to-date book,
             // but it takes almost no time when the book IS already up-to-date.
-            // These three methods work with the same book metadata to determine what migration has
+            // These methods work with the same book metadata to determine what migration has
             // already been done, so they must be called in exactly this order.
             Storage.MigrateMaintenanceLevels();
             Storage.MigrateToMediaLevel1ShrinkLargeImages();
             Storage.MigrateToLevel3PutImgFirst();
+            Storage.MigrateToLevel4UseAppearanceSystem();
 
             // Enhance: there's probably some case where this will get unnecessarily repeated,
             // but I think it would only be in the very rare case of repeatedly needing to update
@@ -1708,7 +1709,7 @@ namespace Bloom.Book
 
             // Make sure the appearance settings are initialized for the current state of things.
             // This should be done before UpdateSupportFiles, because those settings affect
-            // what files are put in the cache.
+            // what files are copied to the book folder.
             var cssFiles = this.Storage.GetCssFilesToCheckForAppearanceCompatibility();
             BookInfo.AppearanceSettings.Initialize(cssFiles);
             UpdateSupportFiles();

--- a/src/BloomExe/Book/BookStarter.cs
+++ b/src/BloomExe/Book/BookStarter.cs
@@ -314,22 +314,7 @@ namespace Bloom.Book
 
             ClearAwayDraftText(storage.Dom.RawDom);
 
-            storage.UpdateSupportFiles(); // Copy branding files etc.
-            // We need to do this before we save the book, because it Saving will write the appearance settings,
-            // destroying the information we need about whether the book already had some.
-            var cssFiles = storage.GetCssFilesToCheckForAppearanceCompatibility(true);
-            var substituteCssPath = storage.BookInfo.AppearanceSettings.GetThemeAndSubstituteCss(
-                cssFiles
-            );
-            if (substituteCssPath != null)
-            {
-                var destPath = Path.Combine(storage.FolderPath, "customBookStyles2.css");
-                // if we're doing an automatic substitution, we don't expect there to be a customBookStyles2.css already,
-                // since substitution is used when the source book is NOT in the new appearance format, while
-                // customBookStyles2.css is only supported in that format.
-                RobustFile.Copy(substituteCssPath, destPath, false);
-            }
-
+            storage.UpdateSupportFiles();
             try
             {
                 storage.Save();

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -146,18 +146,21 @@ namespace Bloom.Book
         /// These constants are not currently actually used in code, but indicate the largest
         /// number currently used for some DOM metadata elements that keep track of how much
         /// a book has been migrated.
-        /// History of these numbers:
+        /// History of kMaintenanceLevel:
         ///   Bloom 4.9: 1 = Ensure that all images are opaque and no larger than our desired maximum size.
         ///              2 = Remove any 'comical-generated' svgs that are transparent.
         ///				 3 = Ensure main img comes first in image container
-        ///   Bloom 5.7 added kMediaMaintenanceLevel so we could distinguish migrations that affect
-        ///   Bloom 5.7  4 = Switched to using a theme (or explicitly using legacy)
+        ///   (Bloom 5.7 added kMediaMaintenanceLevel so we could distinguish migrations that affect
         ///   other files (typically images or media) in the book folder from ones that only affect
-        ///   the DOM and can safely be done in memory.
-        ///       0 = No media maintenance has been done
-        ///       1 = maintenanceLevel at least 1 (so images are opaque and not too big)
+        ///   the DOM and can safely be done in memory. (Later in 5.7 we stopped doing incomplete
+        ///   book updates in memory, so this distinction may no longer be helpful.))
+        ///   Bloom 5.7  4 = Switched to using a theme (or explicitly using legacy)
+        /// History of kMediaMaintenanceLevel (introduced in 5.7)
+        ///   missing: set it to 0 if maintenanceLevel is 0 or missing, otherwise 1
+        ///              0 = No media maintenance has been done
+        ///   Bloom 5.7: 1 = maintenanceLevel at least 1 (so images are opaque and not too big)
         /// </summary>
-        public const int kMaintenanceLevel = 3;
+        public const int kMaintenanceLevel = 4;
         public const int kMediaMaintenanceLevel = 1;
 
         public const string PrefixForCorruptHtmFiles = "_broken_";
@@ -3655,7 +3658,10 @@ namespace Bloom.Book
         /// </summary>
         public void MigrateToLevel4UseAppearanceSystem()
         {
-            Guard.Against(!BookInfo.IsSaveable, "We should not even think about migrating a book that is not Saveable");
+            Guard.Against(
+                !BookInfo.IsSaveable,
+                "We should not even think about migrating a book that is not Saveable"
+            );
             if (GetMaintenanceLevel() < 4)
             {
                 var cssFiles = GetCssFilesToCheckForAppearanceCompatibility(true);
@@ -3676,7 +3682,7 @@ namespace Bloom.Book
                 // that the settings knows it is consistent with the state of things on disk, which allows
                 // the right links to be made and the right files copied to the book folder.
                 BookInfo.AppearanceSettings.WriteToFolder(FolderPath);
-                
+
                 Dom.UpdateMetaElement("maintenanceLevel", "4");
             }
         }

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -697,33 +697,7 @@ namespace BloomTests.Book
                     1
                 );
         }
-
-        [Test]
-        public void CreateBookOnDiskFromTemplate_NoPossiblyConflictingCss_MigratesToTheme()
-        {
-            _starter.TestingSoSkipAddingXMatter = true;
-            var body =
-                @"<div class='bloom-page'>
-						<div class='bloom-translationGroup'>
-						 <div lang='en'>This is some English</div>
-						</div>
-					</div>";
-            string sourceTemplateFolder = GetShellBookFolder(body, null);
-            var path = GetPathToHtml(
-                _starter.CreateBookOnDiskFromTemplate(sourceTemplateFolder, _projectFolder.Path)
-            );
-            //nb: testid is used rather than id because id is replaced with a guid when the copy is made
-
-            var bookFolder = Path.GetDirectoryName(path);
-            var appearanceSettings = new AppearanceSettings();
-            appearanceSettings.UpdateFromFolder(bookFolder);
-            Assert.That(appearanceSettings.CssThemeName == "default");
-
-            // Would like to test this, but we don't update the stylesheets in the DOM until we actually create the book.
-            //AssertThatXmlIn.HtmlFile(path).HasSpecifiedNumberOfMatchesForXpath("//link[@href='basePage.css']", 1);
-            //AssertThatXmlIn.HtmlFile(path).HasSpecifiedNumberOfMatchesForXpath("//link[@href='appearance.css']", 1);
-        }
-
+        
         [Test]
         public void CreateBookOnDiskFromTemplate_ConflictingCss_UsesLegacy()
         {

--- a/src/BloomTests/CLI/HydrateBookCommandTests.cs
+++ b/src/BloomTests/CLI/HydrateBookCommandTests.cs
@@ -191,10 +191,10 @@ namespace BloomTests.CLI
             Debug.Write(File.ReadAllText(_eventualHtmlPath));
             var dom = XmlHtmlConverter.GetXmlDomFromHtml(File.ReadAllText(_eventualHtmlPath));
 
-            // HydrateBookCommand brings book up to date but not to the theme system.
+            // HydrateBookCommand brings book up to date and (unless there is conflicting CSS) to the theme system.
             AssertThatXmlIn
                 .Dom(dom)
-                .HasSpecifiedNumberOfMatchesForXpath("//link[@href='basePage-legacy-5-6.css']", 1);
+                .HasSpecifiedNumberOfMatchesForXpath("//link[@href='basePage.css']", 1);
 
             AssertThatXmlIn
                 .Dom(dom)


### PR DESCRIPTION
Migrating to the theme system is now handled like other one-time migrations using maintenanceLevel metadata. They therefore happen the first time 5.7 is able to EnsureUpToDate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6259)
<!-- Reviewable:end -->
