### PR TITLE
Fix order of L2 and L3 cover titles

### DIFF
--- a/src/content/templates/xMatter/bloom-xmatter-common.less
+++ b/src/content/templates/xMatter/bloom-xmatter-common.less
@@ -56,8 +56,14 @@
             justify-content: center;
 
             &.bloom-contentNational1 {
-                //NB: we show the national language even if this is a monolingual book
+                // NB: we usually show the national language even if this is a monolingual book.
+                // It should come after the vernacular title
                 order: 1;
+            }
+            &.bloom-contentNational2 {
+                // We can possibly show the L3 language if the user turns it on in Book Settings.
+                // If so it should come after the vernacular title and possibly the national language.
+                order: 2;
             }
 
             // //NB: THe order here is important. bloom-content1 should be last so that if a box is *both* bloom-contentNational1 and bloom-content1 (as is the default case for source collections), we want the  bloom-content1 rule to win.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6265)
<!-- Reviewable:end -->
