### PR TITLE
BL-12888  fix music file name display

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/music/musicToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/music/musicToolControls.tsx
@@ -393,7 +393,11 @@ export class MusicToolControls extends React.Component<{}, IMusicState> {
     }
 
     private getDisplayNameOfMusicFile(fileName: string) {
-        return fileName.split(".")[0];
+        const lastPeriodIndex = fileName.lastIndexOf(".");
+        if (lastPeriodIndex < 0) {
+            return fileName;
+        }
+        return fileName.substring(0, lastPeriodIndex);
     }
 }
 


### PR DESCRIPTION
The music tool displays the .mp3's filename, but if it has multiple periods in the filename, the name is truncated at the first period instead of the last (extension) period.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6272)
<!-- Reviewable:end -->
