### PR TITLE
Keep language display names more consistent (BL-12992)

### DIFF
--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -255,6 +255,17 @@ namespace Bloom.Collection
         /// </summary>
         public string GetLanguageName(string tag, string inLanguage)
         {
+            // Use the WritingSystem name based on Ethnologue (or customized) in preference to the
+            // IeftLanguageTag name based on older ISO 639 data.  See BL-12992.
+            if (tag == Language1Tag)
+                return Language1.Name;
+            if (tag == Language2Tag)
+                return Language2.Name;
+            if (tag == Language3Tag)
+                return Language3.Name;
+            if (tag == SignLanguageTag)
+                return SignLanguage.Name;
+            // Note: the inLanguage parameter is often ignored by IetfLanguageTag.GetLocalizedLanguageName().
             return IetfLanguageTag.GetLocalizedLanguageName(tag, inLanguage);
         }
         #endregion


### PR DESCRIPTION
This fix could be simple enough to backport to 5.6.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6273)
<!-- Reviewable:end -->
