### PR TITLE
Fix checksum for purpleRounded appearance migration (BL-13021)

### DIFF
--- a/src/content/appearanceMigrations/purpleRounded/appearance.json
+++ b/src/content/appearanceMigrations/purpleRounded/appearance.json
@@ -1,4 +1,4 @@
-// Matches customBookStyles.css with checksum 23c76394fefc12d620b3d7b646850ae3
+// Matches customBookStyles.css with checksum 9fe27173b5cfc71c8f44b01232e4d28a
 // On 5 January 2024 this was used by at least one book (made by hand for testing).
 // Affected branding projects are "Education-For-Life".
 // Uploaders included joe@example.com, anne@example.com.


### PR DESCRIPTION
The checksum calculation now trims the CSS string before checksumming.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6288)
<!-- Reviewable:end -->
