### PR TITLE
EnsureHasLinksToStylesheets

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bookSettings/BookSettingsDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/bookSettings/BookSettingsDialog.tsx
@@ -448,7 +448,10 @@ export const BookSettingsDialog: React.FunctionComponent<{}> = () => {
                 <DialogOkButton
                     default={true}
                     onClick={() => {
-                        postJson("book/settings", settingsToReturnLater);
+                        if (settingsToReturnLater) {
+                            // If nothing changed, we don't get any...and don't need to make this call.
+                            postJson("book/settings", settingsToReturnLater);
+                        }
                         isOpenAlready = false;
                         closeDialog();
                         // todo: how do we make the pageThumbnailList reload? It's in a different browser, so

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -2943,7 +2943,7 @@ namespace Bloom.Book
         }
 
         // NB: this knows nothing of book-specific css's... even "basic book.css"
-        private void EnsureHasLinksToStylesheets(HtmlDom dom)
+        internal void EnsureHasLinksToStylesheets(HtmlDom dom)
         {
             //clear out any old ones
             dom.RemoveNormalStyleSheetsLinks();
@@ -3684,9 +3684,7 @@ namespace Bloom.Book
                 return;
 
             var cssFiles = GetCssFilesToCheckForAppearanceCompatibility(true);
-            var substituteCssPath = BookInfo.AppearanceSettings.GetThemeAndSubstituteCss(
-                cssFiles
-            );
+            var substituteCssPath = BookInfo.AppearanceSettings.GetThemeAndSubstituteCss(cssFiles);
             if (substituteCssPath != null)
             {
                 var destPath = Path.Combine(FolderPath, "customBookStyles2.css");
@@ -3739,7 +3737,12 @@ namespace Bloom.Book
 
             if (!justOldCustomFiles)
             {
-                result.Add(Tuple.Create(GetSupportingFile("branding.css"), GetSupportingFileString("branding.css")));
+                result.Add(
+                    Tuple.Create(
+                        GetSupportingFile("branding.css"),
+                        GetSupportingFileString("branding.css")
+                    )
+                );
                 result.Add(
                     Tuple.Create(
                         GetSupportingFile("customBookStyles2.css"),
@@ -3747,11 +3750,19 @@ namespace Bloom.Book
                     )
                 );
                 result.Add(
-                    Tuple.Create(GetSupportingFile("appearance.css"), GetSupportingFileString("appearance.css"))
+                    Tuple.Create(
+                        GetSupportingFile("appearance.css"),
+                        GetSupportingFileString("appearance.css")
+                    )
                 );
 
                 var xmatterFileName = Path.GetFileName(PathToXMatterStylesheet);
-                result.Add(Tuple.Create(GetSupportingFile(xmatterFileName), GetSupportingFileString(xmatterFileName)));
+                result.Add(
+                    Tuple.Create(
+                        GetSupportingFile(xmatterFileName),
+                        GetSupportingFileString(xmatterFileName)
+                    )
+                );
             }
             return result.ToArray();
         }

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -2946,7 +2946,7 @@ namespace Bloom.Book
         private void EnsureHasLinksToStylesheets(HtmlDom dom)
         {
             //clear out any old ones
-            Dom.RemoveNormalStyleSheetsLinks();
+            dom.RemoveNormalStyleSheetsLinks();
             EnsureHasLinkToStyleSheet(dom, Path.GetFileName(PathToXMatterStylesheet));
 
             CssFilesThatAreAlwaysWanted.ForEach(x =>
@@ -3406,7 +3406,9 @@ namespace Bloom.Book
             var levelString = Dom.GetMetaValue("mediaMaintenanceLevel", "0");
             if (!int.TryParse(levelString, out int level))
                 level = 0;
-            if (level < 1 && ImageUtils.NeedToShrinkImages(FolderPath))
+            if (level >= 1)
+                return;
+            if (ImageUtils.NeedToShrinkImages(FolderPath))
             {
                 // If the book contains overlarge images, we want to fix those before editing because this can lead
                 // to thumbnails not being created properly and other bad behavior.  This is a one-time fix that can

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -1676,13 +1676,17 @@ namespace BloomTests.Book
             );
 
             //SUT
-            storage.MigrateToMediaLevel1ShrinkLargeImages();
+            storage.MigrateToMediaLevel1ShrinkLargeImages(); // does nothing in this situation, but should still bump level
+            var mediaLevel = storage.Dom.GetMetaValue("mediaMaintenanceLevel", "0");
+            Assert.That(mediaLevel, Is.EqualTo("1"));
             storage.MigrateToLevel2RemoveTransparentComicalSvgs();
+            var maintLevel = storage.Dom.GetMetaValue("maintenanceLevel", "0");
+            Assert.That(maintLevel, Is.EqualTo("2"));
             storage.MigrateToLevel3PutImgFirst();
 
             //Verification
-            var maintLevel = storage.Dom.GetMetaValue("maintenanceLevel", "0");
-            Assert.That(maintLevel, Is.GreaterThanOrEqualTo("2"));
+            maintLevel = storage.Dom.GetMetaValue("maintenanceLevel", "0");
+            Assert.That(maintLevel, Is.EqualTo("3"));
             Assert.That(
                 storage.Dom.SafeSelectNodes("//*[@class='comical-generated']").Count,
                 Is.EqualTo(0)

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -1977,5 +1977,31 @@ namespace BloomTests.Book
                 );
             }
         }
+
+        [Test]
+        public void EnsureHasLinksToStylesheets_MakesExpectedChanges_OnlyToArgumentDom()
+        {
+            var storage = GetInitialStorageWithCustomHtml(
+                "<html><head><link rel='stylesheet' href='Rubbish-xmatter.css' type='text/css' /><link rel='stylesheet' href='CustomBookStyles.css' type='text/css' /></head><body><div class='bloom-page'></div></body></html>"
+            );
+            var dom = new HtmlDom(storage.Dom.RawDom);
+            var html = dom.RawDom.OuterXml;
+            storage.EnsureHasLinksToStylesheets(dom);
+            Assert.That(storage.Dom.RawDom.OuterXml, Is.EqualTo(html)); // should not have modified the built-in dom!
+            var assertThatDom = AssertThatXmlIn.Dom(dom.RawDom);
+            // Should have added various standard links
+            assertThatDom.HasSpecifiedNumberOfMatchesForXpath(
+                "//link[contains(@href, 'origami')]",
+                1
+            );
+            assertThatDom.HasSpecifiedNumberOfMatchesForXpath(
+                "//link[contains(@href, 'basePage')]", // currently typically legacy, but it should have SOME basePage link
+                1
+            );
+            // Should have removed the rubbish one
+            assertThatDom.HasNoMatchForXpath("//link[contains(@href, 'Rubbish')]");
+            // And this empty book has no reason to link to CustomBookStyles.css
+            assertThatDom.HasNoMatchForXpath("//link[contains(@href, 'CustomBookStyles')]");
+        }
     }
 }


### PR DESCRIPTION
Make sure MigrateToLevel3 does not DECREASE the level. (This was independently fixed, but I enhanced a test to make sure of it. Also, I made the level 1 media migration set the level, even if no changes were needed. This saves some time on repeated updates.)
Make bookSettingsDialog handle clicking OK without having made any changes.
Make EnsureHasLinksToStylesheets make all changes to the dom it is passed, rather than removing links from the main book Dom. (Surprisingly, this mistake only caused problems when switching back from edit to collection after changing theme.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6289)
<!-- Reviewable:end -->
