### PR TITLE
Include previewMode.css when making pageList DOM (BL-13049)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -635,7 +635,7 @@ namespace Bloom.Book
             return dom;
         }
 
-        public HtmlDom GetHtmlDomReadyToAddPages(HtmlDom inputDom)
+        public HtmlDom GetHtmlDomForPageList(HtmlDom inputDom)
         {
             var headNode = Storage.Dom.SelectSingleNodeHonoringDefaultNS("/html/head");
             var inputHead = inputDom.SelectSingleNodeHonoringDefaultNS("/html/head");
@@ -650,7 +650,9 @@ namespace Bloom.Book
             //foreach (XmlNode child in inputHead.ChildNodes)
             //	importNode.AppendChild(child);
             //inputHead.ParentNode.ReplaceChild(importNode, inputHead);
-            return Storage.MakeDomRelocatable(inputDom);
+            var result = Storage.MakeDomRelocatable(inputDom);
+            Storage.EnsureHasLinkToStyleSheet(result, "previewMode.css");
+            return result;
         }
 
         public HtmlDom GetPreviewXmlDocumentForPage(IPage page)

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -81,6 +81,8 @@ namespace Bloom.Book
         void CleanupUnusedVideoFiles();
         void CleanupUnusedActivities();
 
+        void EnsureHasLinkToStyleSheet(HtmlDom dom, string path);
+
         ExpandoObject XmatterAppearanceSettings { get; }
         ExpandoObject BrandingAppearanceSettings { get; }
 
@@ -3006,7 +3008,7 @@ namespace Bloom.Book
             }
         }
 
-        private void EnsureHasLinkToStyleSheet(HtmlDom dom, string path)
+        public void EnsureHasLinkToStyleSheet(HtmlDom dom, string path)
         {
             foreach (XmlElement link in dom.SafeSelectNodes("//link[@rel='stylesheet']"))
             {
@@ -3693,9 +3695,7 @@ namespace Bloom.Book
                 return;
 
             var cssFiles = GetCssFilesToCheckForAppearanceCompatibility(true);
-            var substituteCssPath = BookInfo.AppearanceSettings.GetThemeAndSubstituteCss(
-                cssFiles
-            );
+            var substituteCssPath = BookInfo.AppearanceSettings.GetThemeAndSubstituteCss(cssFiles);
             if (substituteCssPath != null)
             {
                 var destPath = Path.Combine(FolderPath, "customBookStyles2.css");
@@ -3705,11 +3705,11 @@ namespace Bloom.Book
                 RobustFile.Copy(substituteCssPath, destPath, false);
             }
             else
-                {
-                    // if there wasn't a substitute, we may have chosen legacy theme.
-                    // That might be disabled by xmatter, but we'll handle that later in
-                    // EnsureUpToDate.
-                }
+            {
+                // if there wasn't a substitute, we may have chosen legacy theme.
+                // That might be disabled by xmatter, but we'll handle that later in
+                // EnsureUpToDate.
+            }
 
             // This would happen as a side effect of saving the book at the end of updating it, but
             // we need it to happen before we re-initialize the settings and UpdateSupportFiles so
@@ -3754,7 +3754,12 @@ namespace Bloom.Book
 
             if (!justOldCustomFiles)
             {
-                result.Add(Tuple.Create(GetSupportingFile("branding.css"), GetSupportingFileString("branding.css")));
+                result.Add(
+                    Tuple.Create(
+                        GetSupportingFile("branding.css"),
+                        GetSupportingFileString("branding.css")
+                    )
+                );
                 result.Add(
                     Tuple.Create(
                         GetSupportingFile("customBookStyles2.css"),
@@ -3762,11 +3767,19 @@ namespace Bloom.Book
                     )
                 );
                 result.Add(
-                    Tuple.Create(GetSupportingFile("appearance.css"), GetSupportingFileString("appearance.css"))
+                    Tuple.Create(
+                        GetSupportingFile("appearance.css"),
+                        GetSupportingFileString("appearance.css")
+                    )
                 );
 
                 var xmatterFileName = Path.GetFileName(PathToXMatterStylesheet);
-                result.Add(Tuple.Create(GetSupportingFile(xmatterFileName), GetSupportingFileString(xmatterFileName)));
+                result.Add(
+                    Tuple.Create(
+                        GetSupportingFile(xmatterFileName),
+                        GetSupportingFileString(xmatterFileName)
+                    )
+                );
             }
             return result.ToArray();
         }

--- a/src/BloomExe/Edit/WebThumbNailList.cs
+++ b/src/BloomExe/Edit/WebThumbNailList.cs
@@ -260,7 +260,7 @@ namespace Bloom.Edit
             if (SIL.PlatformUtilities.Platform.IsLinux)
                 OptimizeForLinux(pageListDom);
 
-            pageListDom = Model.CurrentBook.GetHtmlDomReadyToAddPages(pageListDom);
+            pageListDom = Model.CurrentBook.GetHtmlDomForPageList(pageListDom);
             _browser.DocumentCompleted += WebBrowser_DocumentCompleted;
 
             _baseForRelativePaths = pageListDom.BaseForRelativePaths;


### PR DESCRIPTION
Somehow we lost this between 5.6 and 5.7. It is needed (at least) to hide page labels.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6291)
<!-- Reviewable:end -->
