### PR TITLE
Fix legacy bloom-editable box-sizing (BL-12948)

### DIFF
--- a/src/content/bookLayout/basePage-legacy-5-6.less
+++ b/src/content/bookLayout/basePage-legacy-5-6.less
@@ -451,6 +451,13 @@ body {
     width: 100%;
     height: auto;
     flex-grow: 1;
+    // We need this if appearance rules may set border or padding and yet we want to
+    // use width: 100% (above). Otherwise, the border or padding will make the box
+    // overflow its parent. This is definitely needed if we use the new control
+    // for padding in overlays. It was not in 5.6, but it seems unlikely to break
+    // legacy books, so I think it is worth the risk of adding it here so the new
+    // feature is not broken in legacy.
+    box-sizing: border-box;
   }
   /* The following has been split out from the above rule because it should probably be removed,
       but at this point we are about to go release candidate with 3.1 so it will have to wait.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6298)
<!-- Reviewable:end -->
