### PR TITLE
BL-13122 Extra space for page number in rare circumstance

### DIFF
--- a/src/BloomExe/Book/AppearanceSettings.cs
+++ b/src/BloomExe/Book/AppearanceSettings.cs
@@ -665,6 +665,21 @@ public class AppearanceSettings
             }
         }
 
+        // This is a special case (for now) where we emit a special property designed to be used when setting the bottom margin.
+        // Search our less/css for --pageNumber-show-multiplicand to see how it is used.
+        // If we end up with other boolean properties that the user can set a more general solution will probably be needed.
+        // One idea is to preprocess the theme css, replacing things like `.bloomPage[pageNumber-show] {... }` with `bloom-page {....}` when true.
+        // The other idea is to add attributes like `pageNumber-show` or `pageNumber-show-true` to all the bloom-page divs
+        bool show;
+        if (bool.TryParse(props["pageNumber-show"].ToString(), out show) && show)
+        {
+            cssBuilder.AppendLine("	--pageNumber-show-multiplicand: 1;");
+        }
+        else
+        {
+            cssBuilder.AppendLine("	--pageNumber-show-multiplicand: 0;");
+        }
+
         cssBuilder.AppendLine("}");
         return cssBuilder.ToString();
     }
@@ -876,7 +891,9 @@ public class AppearanceSettings
         if (!String.IsNullOrEmpty(migrant))
         {
             var jsonString = RobustFile.ReadAllText(migrant);
-            var json = JsonConvert.DeserializeObject<ExpandoObject>(jsonString) as IDictionary<string,object>;
+            var json =
+                JsonConvert.DeserializeObject<ExpandoObject>(jsonString)
+                as IDictionary<string, object>;
             if (json != null && json.ContainsKey("cssThemeName") && json["cssThemeName"] != null)
             {
                 // We have a file that looks like it has been migrated, so we don't want to complain about it

--- a/src/BloomTests/Book/AppearanceSettingsTests.cs
+++ b/src/BloomTests/Book/AppearanceSettingsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.IO;
@@ -285,6 +285,24 @@ namespace BloomTests.Book
                 Does.Contain("--cover-topic-show: doShow-css-will-ignore-this-and-use-default;")
             );
             Assert.That(fromSettings, Does.Contain("--cover-languageName-show: none;"));
+        }
+
+        [Test]
+        public void ToCss_EmitsSpecialPageMargin_property()
+        {
+            var settings = new AppearanceSettings();
+            settings.UpdateFromJson(
+                @"
+{
+  ""cssThemeName"": ""default"",
+  ""pageNumber-show"": false
+}"
+            );
+            var css = settings.ToCss();
+            Assert.That(css, Does.Contain("--pageNumber-show-multiplicand: 0;"));
+            settings.UpdateFromJson("{\"pageNumber-show\": true}");
+            css = settings.ToCss();
+            Assert.That(css, Does.Contain("--pageNumber-show-multiplicand: 1;"));
         }
     }
 

--- a/src/content/appearanceThemes/appearance-theme-default.css
+++ b/src/content/appearanceThemes/appearance-theme-default.css
@@ -22,6 +22,7 @@
 .bloom-page {
     /* display: value in .numberedPage:after to display the page number */
     --pageNumber-show: doShow-css-will-ignore-this-and-use-default; /* default is number displaying (the value is a self-documenting trick) */
+
     /* font-size: value in .numberedPage:after to display the page number */
     --pageNumber-font-size: 14pt;
     /* Either --pageNumber-top or --pageNumber-bottom should be set to a value, but not both. */
@@ -117,6 +118,7 @@
     --page-margin-top: 12mm;
     /* padding-bottom: value in .bloom-page: affects all pages except outside cover pages */
     --page-margin-bottom: 12mm;
+
     /* padding-right: value in .bloom-page.side-right */
     /* added to --page-gutter for padding-right: value in .bloom-page.side-left */
     --page-margin-right: 12mm;

--- a/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
@@ -19,7 +19,9 @@
 }
 
 /* The section below controls the pagenumber and the white circle around it.  */
-
+.Device16x9Landscape.numberedPage {
+    --pageNumber-extra-height: 0mm !important; /* we put the page number on top of the image so we don't need a margin boost */
+}
 .Device16x9Landscape.numberedPage::after {
     --pageNumber-bottom: 2mm;
     --pageNumber-top: unset;

--- a/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
@@ -29,7 +29,14 @@
 }
 
 /* The section below controls the pagenumber and the white circle around it.  */
-
+.Device16x9Landscape.numberedPage {
+    --pageNumber-extra-height: 0mm !important; /* we put the page number on top of the image so we don't need a margin boost */
+}
+.Device16x9Portrait.numberedPage {
+    /* this rule will apply more generally than we'd prefer, but the common situation we're improving here
+    is picture on top, text on the bottom, we need to make room for the page number */
+    --pageNumber-extra-height: 12mm !important;
+}
 .Device16x9Landscape.numberedPage::after {
     --pageNumber-bottom: 0mm;
     --pageNumber-top: unset;

--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -598,11 +598,23 @@ div[data-book*="branding"] {
 }
 
 // ------------------------------------------------------------------------
-// application of the left and right margins, and the gutter
+// application of margins, and the gutter
 // ------------------------------------------------------------------------
 .bloom-page {
     padding-top: var(--page-margin-top);
-    padding-bottom: var(--page-margin-bottom);
+
+    // at least until/if we put something in the HTML that tells us whether
+    // this book wants a page number, we use this --pageNumber-show-multiplicand
+    // property, which AppearanceSettings.cs sets to either 0 or 1.
+    // By multiplying that times the extra height the current theme says
+    // it needs for a page number (which may vary by page layout and such),
+    // we then in effect turn that extra on and off.
+    --padding-bottom-addition: calc(
+        var(--pageNumber-show-multiplicand) * var(--pageNumber-extra-height)
+    );
+    padding-bottom: calc(
+        var(--page-margin-bottom) + var(--padding-bottom-addition)
+    );
 
     &.side-left {
         padding-left: var(--page-margin-left);

--- a/src/content/bookLayout/pageNumbers.less
+++ b/src/content/bookLayout/pageNumbers.less
@@ -2,6 +2,11 @@
 @OddPageNumberPosition: 57px;
 @EvenPageNumberPosition: 60px;
 
+.bloom-page {
+    // how much space to leave at the top and bottom of the page for the page number, if we're showing page numbers at all
+    // themes can override this as needed. If you have reasonable margins, you don't need to add anything to fit in a pageNumber
+    --pageNumber-extra-height: 0mm; // must have units
+}
 .numberedPage {
     &:after {
         content: attr(data-page-number);
@@ -10,7 +15,8 @@
         position: absolute;
         // If --pageNumber-background-width is not set, the width will be the width of the number instead of the whole page.
         width: var(
-            --pageNumber-background-width, fit-content
+            --pageNumber-background-width,
+            fit-content
         ); // for when we need to have a colored background, e.g. a circle.
         height: var(--pageNumber-background-width);
         bottom: var(
@@ -28,7 +34,7 @@
         text-align: center !important; // centers horizontally
     }
 
-    // This was very tricky to get right for ebooks. We usully want the page number in ebooks
+    // This was very tricky to get right for ebooks. We usually want the page number in ebooks
     // to be centered, which requires setting both left and right, typically to zero, and
     // then setting margin:0 auto. But we also want to be able to set the page number on
     // the left for the rounded themes that use picture-on-left. And all this has to be


### PR DESCRIPTION
This is currently only used in  a rare case where we a) have little to no bottom margin and b) are not able to place the page number on top of something (an image)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6327)
<!-- Reviewable:end -->
