### PR TITLE
Default theme right-side page has page number on right (BL-13132)

### DIFF
--- a/src/content/bookLayout/pageNumbers.less
+++ b/src/content/bookLayout/pageNumbers.less
@@ -47,10 +47,14 @@
             --pageNumber-left-margin
         ) !important; // TODO: why is Bloom-player setting this at all? (wants to put in center)
     }
+    &.side-right:after {
+        right: var(
+            --pageNumber-right-margin
+        ) !important; // allow page number to be on the right
+    }
 
     &.Device16x9Landscape:after,
-    &.Device16x9Portrait:after,
-    &.side-right:after {
+    &.Device16x9Portrait:after {
         // note that here the property has "always"
         left: var(
             --pageNumber-always-left-margin


### PR DESCRIPTION
This does not affect Device16x9... pages which center the page numbers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6331)
<!-- Reviewable:end -->
