### PR TITLE
Use a stable text-wrap in overlays (BL-13135)

### DIFF
--- a/src/content/bookLayout/basePage-sharedRules.less
+++ b/src/content/bookLayout/basePage-sharedRules.less
@@ -163,4 +163,8 @@ span.bloom-linebreak {
     &.Title-On-Title-Page-style {
         text-wrap: balance;
     }
+    &.Bubble-style {
+        // Ensure that the text wrapping in overlays is stable while editing.  See BL-13135.
+        text-wrap: stable;
+    }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6332)
<!-- Reviewable:end -->
