### PR TITLE
Fix Bible for Children branding comic to show white back page (BL-13138)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1820,6 +1820,7 @@ namespace Bloom.Book
             BringXmatterHtmlUpToDate(OurHtmlDom);
             RepairBrokenSmallCoverCredits(OurHtmlDom);
             RepairCoverImageDescriptions(OurHtmlDom);
+            DetectAndMarkDarkCoverColor(OurHtmlDom);
 
             progress.WriteStatus("Repair page label localization");
             RepairPageLabelLocalization(OurHtmlDom);
@@ -2283,6 +2284,22 @@ namespace Bloom.Book
                 // back to 4.6 with the single lang="*" entry, then all of the entries got filled in with the same obsolete data,
                 // so all of them have to be removed.
                 dataDiv.RemoveChild(coverImageDescription);
+            }
+        }
+
+        internal static void DetectAndMarkDarkCoverColor(HtmlDom bookDOM)
+        {
+            var coverColor = GetCoverColorFromDom(bookDOM.RawDom);
+            if (coverColor != null)
+            {
+                var coverColorIsDark = ColorUtils.IsDark(coverColor);
+                foreach (var page in bookDOM.SafeSelectNodes("//div[contains(@class,'coverColor')]").Cast<XmlElement>())
+                {
+                    if (coverColorIsDark)
+                        HtmlDom.AddClass(page, "darkCoverColor");
+                    else
+                        HtmlDom.RemoveClass(page, "darkCoverColor");
+                }
             }
         }
 
@@ -3213,6 +3230,7 @@ namespace Bloom.Book
                     continue;
                 var newContent = regex.Replace(content, "$1" + color);
                 stylesheet.InnerXml = newContent;
+                DetectAndMarkDarkCoverColor(OurHtmlDom);
                 return true;
             }
 

--- a/src/BloomExe/Utils/ColorUtils.cs
+++ b/src/BloomExe/Utils/ColorUtils.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Drawing;
+using Bloom.ImageProcessing;
+
+namespace Bloom.Utils
+{
+    public class ColorUtils
+    {
+        /// <summary>
+        /// Check whether the cover color is dark enough to need changing for some logos.
+        /// </summary>
+        /// <remarks>
+        /// See https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-procedure
+        /// 7 is the recommended minimal contrast for accessibility.  We can't guarantee
+        /// this, but we can guarantee that the contrast is better than it would be if we
+        /// ignored the cover color.
+        /// luminance is a value between 0 and 1, where 0 is black and 1 is white.
+        /// </remarks>
+        public static bool IsDark(string coverColor)
+        {
+            if (ImageUtils.TryCssColorFromString(coverColor, out Color color))
+            {
+                var R = AdjustColorForLuminance(color.R);
+                var G = AdjustColorForLuminance(color.G);
+                var B = AdjustColorForLuminance(color.B);
+                var luminance = 0.2126 * R + 0.7152 * G + 0.0722 * B;
+
+                var blackLuminance = 0.0; // we know this is 0, by definition.
+                var contrastToBlack = (luminance + 0.05) / (blackLuminance + 0.05);
+
+                var whiteLuminance = 1.0; // we know this is 1, by definition.
+                var contrastToWhite = (whiteLuminance + 0.05) / (luminance + 0.05);
+
+                return contrastToBlack < contrastToWhite;
+            }
+            return false;
+        }
+
+        private static double AdjustColorForLuminance(byte byteValue)
+        {
+            var value = byteValue / 255.0;
+            if (value < 0.03928)
+                value = value / 12.92;
+            else
+                value = Math.Pow((value + 0.055) / 1.055, 2.4);
+            return value;
+        }
+    }
+}

--- a/src/content/branding/Bible-for-Children/branding.less
+++ b/src/content/branding/Bible-for-Children/branding.less
@@ -13,3 +13,12 @@ div.Device16x9Landscape {
         margin-bottom: 0.5cm;
     }
 }
+
+// The branding image has black text so we need to change the background color
+// of the back cover. See BL-13138.
+.bloom-page.coverColor.outsideBackCover.darkCoverColor {
+    background-color: white !important;
+    .bloom-editable.Outside-Back-Cover-style {
+        color: black !important;
+    }
+}


### PR DESCRIPTION
The final page used to have a white background in comics before we merged the final two backmatter pages back together for comics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6337)
<!-- Reviewable:end -->
