### PR TITLE
Make adjusting overlay position for padding work on old books (BL-12948)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -194,7 +194,7 @@ export class BubbleManager {
                 ).length > 0
             ) {
                 if (!wrapperBox.style.height.endsWith("px")) {
-                    // Some sort of legacy situation; for a while we had all the placemnts as percentages.
+                    // Some sort of legacy situation; for a while we had all the placements as percentages.
                     // This will typically not move it, but will force it to the new system of placement
                     // by pixel. Don't want to do this if we don't have to, because there could be rounding
                     // errors that would move it very slightly.

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -193,6 +193,17 @@ export class BubbleManager {
                     x => x.getAttribute("lang") === overlayLang
                 ).length > 0
             ) {
+                if (!wrapperBox.style.height.endsWith("px")) {
+                    // Some sort of legacy situation; for a while we had all the placemnts as percentages.
+                    // This will typically not move it, but will force it to the new system of placement
+                    // by pixel. Don't want to do this if we don't have to, because there could be rounding
+                    // errors that would move it very slightly.
+                    this.setTextboxPosition(
+                        $(wrapperBox as HTMLElement),
+                        wrapperBox.offsetLeft - container.offsetLeft,
+                        wrapperBox.offsetTop - container.offsetTop
+                    );
+                }
                 const oldHeight = this.pxToNumber(wrapperBox.style.height);
                 wrapperBox.style.height = oldHeight + 2 * delta + "px";
                 const oldWidth = this.pxToNumber(wrapperBox.style.width);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6339)
<!-- Reviewable:end -->
