### PR TITLE
Allow more space for the resolution slider tooltips (BL-13067)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bookSettings/BookSettingsDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/bookSettings/BookSettingsDialog.tsx
@@ -696,7 +696,8 @@ const BloomResolutionSliderInner: React.FunctionComponent<{
                 display: flex;
                 flex-direction: column;
                 width: 200px; // todo: what should this be?
-                padding: 0 10px; // allow space for tooltips
+                padding: 0 10px; // allow space for slider knob image
+                margin-right: 1.5em; // allow space for the slider knob tooltip (BL-13067)
             `}
         >
             <Typography


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6341)
<!-- Reviewable:end -->
