### PR TITLE
Harvester uses legacy theme (or fails if that is not allowed) (BL-13174)

### DIFF
--- a/src/BloomExe/Book/AppearanceSettings.cs
+++ b/src/BloomExe/Book/AppearanceSettings.cs
@@ -294,6 +294,14 @@ public class AppearanceSettings
         // if we don't know of a substitute theme and its associated customBookStyles2.css file.
         CssThemeName = "default";
         string substituteAppearance = null;
+        if (Program.RunningHarvesterMode)
+        {
+            // We'll preserve the current appearance of older books we are harvesting.
+            // This should only apply to temporary copies on their way to becoming artifacts,
+            // so it doesn't interfere with getting books migrated when they are to be edited.
+            CssThemeName = "legacy-5-6";
+            return null;
+        }
 
         foreach (var css in cssFilesToCheck.Where(css => !string.IsNullOrWhiteSpace(css.Item2)))
         {

--- a/src/BloomExe/Book/BookServer.cs
+++ b/src/BloomExe/Book/BookServer.cs
@@ -30,10 +30,7 @@ namespace Bloom.Book
             _tcManager = tcManager;
         }
 
-        public virtual Book GetBookFromBookInfo(
-            BookInfo bookInfo,
-            bool fullyUpdateBookFiles = false
-        )
+        public virtual Book GetBookFromBookInfo(BookInfo bookInfo)
         {
             //Review: Note that this isn't doing any caching yet... worried that caching will just eat up memory, but if anybody is holding onto these, then the memory won't be freed anyhow
             if (bookInfo is ErrorBookInfo)
@@ -45,7 +42,7 @@ namespace Bloom.Book
                 );
             }
 
-            var book = _bookFactory(bookInfo, _storageFactory(bookInfo, fullyUpdateBookFiles));
+            var book = _bookFactory(bookInfo, _storageFactory(bookInfo));
             return book;
         }
 

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -124,7 +124,7 @@ namespace Bloom.Book
 
     public class BookStorage : IBookStorage
     {
-        public delegate BookStorage Factory(BookInfo bookInfo, bool fullyUpdateBookFiles = false); //autofac uses this
+        public delegate BookStorage Factory(BookInfo bookInfo); //autofac uses this
 
         /// <summary>
         /// History of these numbers:
@@ -3684,6 +3684,12 @@ namespace Bloom.Book
         /// </summary>
         public bool LinkToLocalCollectionStyles { get; set; }
 
+        public class CannotHarvestException : ApplicationException
+        {
+            public CannotHarvestException(string message)
+                : base(message) { }
+        }
+
         /// <summary>
         /// Migrate to the new appearance system if we haven't already tried to do so.
         /// </summary>
@@ -3695,6 +3701,13 @@ namespace Bloom.Book
             );
             if (GetMaintenanceLevel() >= 4)
                 return;
+
+            if (Program.RunningHarvesterMode && !LegacyThemeCanBeUsed)
+            {
+                throw new CannotHarvestException(
+                    "This book cannot currently be harvested, since it is not migrated to the appearance system and cannot use legacy theme."
+                );
+            }
 
             var cssFiles = GetCssFilesToCheckForAppearanceCompatibility(true);
             var substituteCssPath = BookInfo.AppearanceSettings.GetThemeAndSubstituteCss(cssFiles);

--- a/src/BloomExe/CollectionTab/CollectionModel.cs
+++ b/src/BloomExe/CollectionTab/CollectionModel.cs
@@ -111,12 +111,17 @@ namespace Bloom.CollectionTab
 
         private object _bookCollectionLock = new object(); // Locks creation of _bookCollections
 
-        public IReadOnlyList<BookCollection> GetBookCollections()
+        public IReadOnlyList<BookCollection> GetBookCollections(bool disposing = false)
         {
             lock (_bookCollectionLock)
             {
                 if (_bookCollections == null)
                 {
+                    if (disposing)
+                    {
+                        // We don't want to create new collections when we're disposing of the model.
+                        return new List<BookCollection>();
+                    }
                     _bookCollections = new List<BookCollection>(GetBookCollectionsOnce());
 
                     //we want the templates to be second (after the editable collection) regardless of alphabetical sorting
@@ -999,14 +1004,14 @@ namespace Bloom.CollectionTab
             return collection.GetBookInfoByFolderPath(path);
         }
 
-        public Book.Book GetBookFromBookInfo(BookInfo bookInfo, bool fullyUpdateBookFiles = false)
+        public Book.Book GetBookFromBookInfo(BookInfo bookInfo)
         {
             // If we're looking for the current book it's important to return the actual book object,
             // because it could end up modified in ways that make our one out-of-date if we modify another
             // instance based on the same folder. For example, Rename could make our FolderPath wrong.
             if (bookInfo.FolderPath == _bookSelection.CurrentSelection?.FolderPath)
                 return _bookSelection.CurrentSelection;
-            return _bookServer.GetBookFromBookInfo(bookInfo, fullyUpdateBookFiles);
+            return _bookServer.GetBookFromBookInfo(bookInfo);
         }
 
         /// <summary>

--- a/src/BloomExe/CollectionTab/CollectionTabView.Designer.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.Designer.cs
@@ -23,7 +23,7 @@ namespace Bloom.CollectionTab
 
 				try
 				{
-					var collections = _model?.GetBookCollections() ?? System.Linq.Enumerable.Empty<BookCollection>();
+					var collections = _model?.GetBookCollections(true) ?? System.Linq.Enumerable.Empty<BookCollection>();
 					foreach (var collection in collections)
 						collection?.StopWatchingDirectory();
 				}

--- a/src/BloomExe/CollectionTab/CollectionTabView.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.cs
@@ -206,7 +206,7 @@ namespace Bloom.CollectionTab
                             // One day we may enhance it so that we switch tabs and show it,
                             // but there are states where that would be dangerous.
                             var newBook = new BookInfo(eventArgs.Path, false);
-                            var book = _model.GetBookFromBookInfo(newBook, true);
+                            var book = _model.GetBookFromBookInfo(newBook);
                             if (string.IsNullOrEmpty(book.Storage.ErrorMessagesHtml))
                             {
                                 // Happy path. Usually we can make a book object out of a downloaded book folder.
@@ -223,7 +223,7 @@ namespace Bloom.CollectionTab
                                 t.Tick += (o, args1) =>
                                 {
                                     retries++;
-                                    book = _model.GetBookFromBookInfo(newBook, true);
+                                    book = _model.GetBookFromBookInfo(newBook);
                                     if (string.IsNullOrEmpty(book.Storage.ErrorMessagesHtml))
                                     {
                                         t.Stop();

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1734,7 +1734,7 @@ namespace Bloom
             if (_errorHandlingHasBeenSetUp)
                 return;
 
-            if (!ApplicationUpdateSupport.IsDev)
+            if (!ApplicationUpdateSupport.IsDev && !Program.RunningUnitTests)
             {
                 try
                 {
@@ -1803,8 +1803,11 @@ Anyone looking specifically at our issue tracking system can read what you sent 
             SIL.Reporting.ErrorReport.AddStandardProperties();
             // with squirrel, the file's dates only reflect when they were installed, so we override this version thing which
             // normally would include a bogus "Apparently Built On" date:
+            var versionNumber = Program.RunningUnitTests
+                ? "Current build" // for some reason VersionNumberString throws when running unit tests, so just use this.
+                : ErrorReport.VersionNumberString;
             ErrorReport.Properties["Version"] =
-                ErrorReport.VersionNumberString + " " + ApplicationUpdateSupport.ChannelName;
+                versionNumber + " " + ApplicationUpdateSupport.ChannelName;
             SIL.Reporting.ExceptionHandler.Init(new FatalExceptionHandler());
 
             ExceptionHandler.AddDelegate(

--- a/src/BloomExe/WebLibraryIntegration/BulkUploader.cs
+++ b/src/BloomExe/WebLibraryIntegration/BulkUploader.cs
@@ -368,7 +368,7 @@ namespace Bloom.WebLibraryIntegration
                 context.TeamCollectionManager.CurrentCollectionEvenIfDisconnected
                     ?? new AlwaysEditSaveContext() as ISaveContext
             );
-            var book = server.GetBookFromBookInfo(bookInfo, fullyUpdateBookFiles: true);
+            var book = server.GetBookFromBookInfo(bookInfo);
             book.BringBookUpToDate(new NullProgress());
             uploadParams.Folder = book.FolderPath; // BringBookUpToDate can change the title and folder (see BL-10330)
             book.Storage.CleanupUnusedSupportFiles(isForPublish: false); // we are publishing, but this is the real folder not a copy, so play safe.

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -319,7 +319,7 @@ namespace Bloom.Workspace
                     //var info = new BookInfo(selBookPath, inCurrentCollection, _tcManager.CurrentCollectionEvenIfDisconnected ?? new AlwaysEditSaveContext() as ISaveContext);
                     // Fully updating book files ensures that the proper branding files are found for
                     // previewing when the collection settings change but the book selection does not.
-                    var book = _bookServer.GetBookFromBookInfo(info, fullyUpdateBookFiles: true);
+                    var book = _bookServer.GetBookFromBookInfo(info);
                     _bookSelection.SelectBook(book);
                 }
             }

--- a/src/BloomExe/web/controllers/CollectionApi.cs
+++ b/src/BloomExe/web/controllers/CollectionApi.cs
@@ -218,7 +218,7 @@ namespace Bloom.web.controllers
                 kApiUrlPart + "selectAndEditBook",
                 request =>
                 {
-                    var book = GetBookObjectFromPost(request, true);
+                    var book = GetBookObjectFromPost(request);
                     if (book.FolderPath != _bookSelection?.CurrentSelection?.FolderPath)
                     {
                         _collectionModel.SelectBook(book);
@@ -781,18 +781,15 @@ namespace Bloom.web.controllers
             return collection.GetBookInfos().FirstOrDefault(predicate);
         }
 
-        private Book.Book GetBookObjectFromPost(
-            ApiRequest request,
-            bool fullyUpdateBookFiles = false
-        )
+        private Book.Book GetBookObjectFromPost(ApiRequest request)
         {
             var info = GetBookInfoFromPost(request);
-            return _collectionModel.GetBookFromBookInfo(info, fullyUpdateBookFiles);
+            return _collectionModel.GetBookFromBookInfo(info);
         }
 
         private Book.Book GetUpdatedBookObjectFromBookInfo(BookInfo info)
         {
-            return _collectionModel.GetBookFromBookInfo(info, true);
+            return _collectionModel.GetBookFromBookInfo(info);
         }
     }
 }

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -58,7 +58,7 @@ namespace BloomTests.Book
 
             _starter = new BookStarter(
                 _fileLocator,
-                (dir, fullyUpdateBookFiles) =>
+                (dir) =>
                     new BookStorage(dir, _fileLocator, new BookRenamedEvent(), collectionSettings),
                 _defaultCollectionSettings
             );
@@ -233,8 +233,7 @@ namespace BloomTests.Book
                         new BookRefreshEvent()
                     );
                 },
-                (path, fullyUpdateBookFiles) =>
-                    new BookStorage(path, _fileLocator, null, collectionSettings),
+                (path) => new BookStorage(path, _fileLocator, null, collectionSettings),
                 () => _starter,
                 null
             );
@@ -697,7 +696,7 @@ namespace BloomTests.Book
                     1
                 );
         }
-        
+
         [Test]
         public void CreateBookOnDiskFromTemplate_ConflictingCss_UsesLegacy()
         {

--- a/src/BloomTests/Book/BookTestsBase.cs
+++ b/src/BloomTests/Book/BookTestsBase.cs
@@ -424,7 +424,7 @@ namespace BloomTests.Book
             );
             var starter = new BookStarter(
                 fileLocator,
-                (dir, fullyUpdateBookFiles) =>
+                (dir) =>
                     new BookStorage(dir, fileLocator, new BookRenamedEvent(), _collectionSettings),
                 _collectionSettings
             );
@@ -444,7 +444,7 @@ namespace BloomTests.Book
                     );
                 },
                 // storage factory
-                (info, fullyUpdateBookFiles) =>
+                (info) =>
                 {
                     var storage = new BookStorage(
                         info,

--- a/src/BloomTests/Edit/ConfiguratorTest.cs
+++ b/src/BloomTests/Edit/ConfiguratorTest.cs
@@ -56,7 +56,7 @@ namespace BloomTests.Edit
 
             _starter = new BookStarter(
                 _fileLocator,
-                (dir, fullyUpdateBookFiles) =>
+                (dir) =>
                     new BookStorage(dir, _fileLocator, new BookRenamedEvent(), collectionSettings),
                 collection
             );

--- a/src/BloomTests/TestDoubles/Book/FakeBookServer.cs
+++ b/src/BloomTests/TestDoubles/Book/FakeBookServer.cs
@@ -17,10 +17,7 @@ namespace BloomTests.TestDoubles.Book
         /// A dumbed down implementation that is able to return a book with the BookInfo and set the book's FolderPath.
         /// </summary>
         /// <returns></returns>
-        public override Bloom.Book.Book GetBookFromBookInfo(
-            BookInfo bookInfo,
-            bool fullyUpdateBookFiles = false
-        )
+        public override Bloom.Book.Book GetBookFromBookInfo(BookInfo bookInfo)
         {
             var collectionSettings = new Bloom.Collection.CollectionSettings();
             var fileLocator = new Bloom.BloomFileLocator(


### PR DESCRIPTION
The essence of this change is the code in AppearanceSettings that always uses legacy theme if running in harvester mode, the code in BookStorage that throws a special exception if running in harvester mode and not allowed to use legacy, and the code in CreateArtifactsCommand which catches that exception and reports a new error code. I also created a unit test and had to change a few things to let it work; and discovered that one of the arguments to the BookStorage Factory was unused, and removed it from there and various related methods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6355)
<!-- Reviewable:end -->
