### PR TITLE
Prevent page selection crash when tab changes too quickly (BL-13184)

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -732,7 +732,13 @@ namespace Bloom.Edit
                 _pageSelection.CurrentSelection.Book.BringPageUpToDate(
                     _pageSelection.CurrentSelection.GetDivNodeForThisPage()
                 );
-                RefreshDisplayOfCurrentPage();
+                if (Visible)
+                    RefreshDisplayOfCurrentPage();
+                else // prevent BL-13184 / BL-2634 (when changing tab too quickly)
+                    _domForCurrentPage = CurrentBook.GetEditableHtmlDomForPage(
+                        _pageSelection.CurrentSelection
+                    );
+
                 _duplicatePageCommand.Enabled = !_pageSelection.CurrentSelection.Required;
                 _deletePageCommand.Enabled = !_pageSelection.CurrentSelection.Required;
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6356)
<!-- Reviewable:end -->
