### PR TITLE
Use more popularly implemented value for text-wrap in overlays (BL-13135)

### DIFF
--- a/src/content/bookLayout/basePage-sharedRules.less
+++ b/src/content/bookLayout/basePage-sharedRules.less
@@ -164,7 +164,8 @@ span.bloom-linebreak {
         text-wrap: balance;
     }
     &.Bubble-style {
-        // Ensure that the text wrapping in overlays is stable while editing.  See BL-13135.
-        text-wrap: stable;
+        // Ensure that the text wrapping in overlays is generally stable.  See BL-13135.
+        // We would use the "stable" keyword, but that isn't implemented in most browsers.
+        text-wrap: wrap;
     }
 }


### PR DESCRIPTION
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6362)
<!-- Reviewable:end -->
