### PR TITLE
Another try at preserving branding (BL-13110)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -4634,6 +4634,10 @@ Do you want to go ahead?</note>
         <note>ID: PublishTab.UploadCollisionDialog.AlreadyIn</note>
         <note>This is the header for the book that is in bloomlibrary.org already.</note>
       </trans-unit>
+      <trans-unit id="PublishTab.UploadCollisionDialog.ChangeBranding" translate="no">
+        <source xml:lang="en">The branding was "{0}" but is now "{1}". This may change logos and other material. Check this box if this is what you want.</source>
+        <note>ID: PublishTab.UploadCollisionDialog.ChangeBranding</note>
+      </trans-unit>
       <trans-unit id="PublishTab.UploadCollisionDialog.ChangeUploader" translate="no">
         <source xml:lang="en">Change the official uploader to {0}. (Bloom Library will hide part of your email address)</source>
         <note>ID: PublishTab.UploadCollisionDialog.ChangeUploader</note>
@@ -5273,6 +5277,11 @@ Do you want to go ahead?</note>
       <trans-unit id="Settings.Enterprise.LearnMore" sil:dynamic="true">
         <source xml:lang="en">Learn More</source>
         <note>ID: Settings.Enterprise.LearnMore</note>
+      </trans-unit>
+      <trans-unit id="Settings.Enterprise.NeedsCode" sil:dynamic="true">
+        <source xml:lang="en">This project previously used **%0**. To continue to use this you will need to enter a current subscription code. Codes for SIL brandings can be found [here](%1). For other subscriptions, contact your project administrator.</source>
+        <note>ID: Settings.Enterprise.NeedsCode</note>
+        <note>**%0** should be kept. It will become the branding name. Keep something like [here](%1), but replace the word "here" as appropriate. This will become a hyperlink that launches a web page in a browser.</note>
       </trans-unit>
       <trans-unit id="Settings.Enterprise.None" sil:dynamic="true">
         <source xml:lang="en">None. Bloom will not show Enterprise features.</source>

--- a/src/BloomBrowserUI/collection/enterpriseSettings.tsx
+++ b/src/BloomBrowserUI/collection/enterpriseSettings.tsx
@@ -138,12 +138,11 @@ export class EnterpriseSettings extends React.Component<{}, IState> {
                                 l10nParam1={this.codesUrl}
                                 className={"legacyBrandingName"}
                             >
-                                In an older version of Bloom, this project used
-                                **%0**. To continue to use this you will need to
-                                enter a current subscription code. Codes for SIL
-                                brandings can be found [here](%1). For other
-                                subscriptions, contact your project
-                                administrator.
+                                This project previously used **%0**. To continue
+                                to use this you will need to enter a current
+                                subscription code. Codes for SIL brandings can
+                                be found [here](%1). For other subscriptions,
+                                contact your project administrator.
                             </Markdown>
                         )}
                         <div

--- a/src/BloomBrowserUI/collectionsTab/BookButton.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BookButton.tsx
@@ -36,6 +36,7 @@ export const BookButton: React.FunctionComponent<{
     //selected: boolean;
     manager: BookSelectionManager;
     isSpreadsheetFeatureActive: boolean;
+    lockedToOneDownloadedBook: boolean;
 }> = props => {
     // TODO: the c# had Font = bookInfo.IsEditable ? _editableBookFont : _collectionBookFont,
 
@@ -197,7 +198,8 @@ export const BookButton: React.FunctionComponent<{
             {
                 label: "Duplicate Book",
                 l10nId: "CollectionTab.BookMenu.DuplicateBook",
-                command: "collections/duplicateBook"
+                command: "collections/duplicateBook",
+                shouldShow: () => !props.lockedToOneDownloadedBook
             },
             {
                 label: "Show in File Explorer",

--- a/src/BloomBrowserUI/collectionsTab/BooksOfCollection.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BooksOfCollection.tsx
@@ -40,6 +40,7 @@ export const BooksOfCollection: React.FunctionComponent<{
     // If true, the collection will be wrapped in a LazyLoad so that most of its rendering
     // isn't done until it is visible on screen.
     lazyLoadCollection?: boolean;
+    lockedToOneDownloadedBook: boolean;
 }> = props => {
     if (!props.collectionId) {
         window.alert("null collectionId");
@@ -73,13 +74,12 @@ export const BooksOfCollection: React.FunctionComponent<{
     );
 
     useEffect(() => {
-        if (books.length > 0)
-        {
+        if (books.length > 0) {
             // once the books variable has been updated with the book-on-blorg statuses,
             // unset the reloadParameter so we don't keep reloading the book-on-blorg statuses
-            setReloadParameter(""); 
+            setReloadParameter("");
         }
-    }, [books])
+    }, [books]);
 
     //const selectedBookInfo = useMonitorBookSelection();
     const collection: ICollection = useApiData(
@@ -161,6 +161,9 @@ export const BooksOfCollection: React.FunctionComponent<{
                                         manager={props.manager}
                                         isSpreadsheetFeatureActive={
                                             props.isSpreadsheetFeatureActive
+                                        }
+                                        lockedToOneDownloadedBook={
+                                            props.lockedToOneDownloadedBook
                                         }
                                     />
                                 </LazyLoad>

--- a/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
@@ -337,6 +337,8 @@ export const CollectionsTabPane: React.FunctionComponent<{}> = () => {
     const collectionsHeaderKey = "CollectionTab.BookSourceHeading";
     const collectionsHeaderText = "Sources For New Books";
 
+    const lockedToOneDownloadedBook = sourcesCollections.length === 0;
+
     return (
         <div
             css={css`
@@ -468,44 +470,52 @@ export const CollectionsTabPane: React.FunctionComponent<{}> = () => {
                             isSpreadsheetFeatureActive={
                                 isSpreadsheetFeatureActive
                             }
+                            lockedToOneDownloadedBook={
+                                lockedToOneDownloadedBook
+                            }
                         />
                     </div>
 
-                    <Transition in={true} appear={true} timeout={2000}>
-                        {state => (
-                            <div
-                                css={css`
-                                    margin: 10px;
-                                `}
-                                className={`group fade-${state}`}
-                            >
-                                <H1
-                                    l10nKey={collectionsHeaderKey}
+                    {lockedToOneDownloadedBook || (
+                        <Transition in={true} appear={true} timeout={2000}>
+                            {state => (
+                                <div
                                     css={css`
-                                        padding-bottom: 20px;
+                                        margin: 10px;
                                     `}
+                                    className={`group fade-${state}`}
                                 >
-                                    {collectionsHeaderText}
-                                </H1>
+                                    <H1
+                                        l10nKey={collectionsHeaderKey}
+                                        css={css`
+                                            padding-bottom: 20px;
+                                        `}
+                                    >
+                                        {collectionsHeaderText}
+                                    </H1>
 
-                                <ShowAfterDelay
-                                    waitBeforeShow={100} // REview: we really want to wait for an event that indicates the main collection is mostly painted
-                                >
-                                    {collectionComponents}
-                                </ShowAfterDelay>
-                                <Link
-                                    l10nKey="CollectionTab.AddSourceCollection"
-                                    css={css`
-                                        text-transform: uppercase;
-                                        padding-bottom: 10px;
-                                    `}
-                                    onClick={() => addSourceCollection()}
-                                >
-                                    Show another collection...
-                                </Link>
-                            </div>
-                        )}
-                    </Transition>
+                                    <ShowAfterDelay
+                                        waitBeforeShow={100} // REview: we really want to wait for an event that indicates the main collection is mostly painted
+                                    >
+                                        {collectionComponents}
+                                    </ShowAfterDelay>
+                                    <Link
+                                        l10nKey="CollectionTab.AddSourceCollection"
+                                        css={css`
+                                            text-transform: uppercase;
+                                            padding-bottom: 10px;
+                                        `}
+                                        onClick={() => addSourceCollection()}
+                                    >
+                                        Show another collection...
+                                    </Link>
+                                </div>
+                            )}
+                        </Transition>
+                    )
+                    // Enhance:possibly if we're NOT showing the Sources for new Books stuff,
+                    // we could have a message saying why and to pick an Enterprise subscription to fix it.
+                    }
                 </SplitPane>
                 {/* This wrapper is used to... fix up some margin/color stuff I was having trouble with from SplitPane */}
                 <div
@@ -749,6 +759,7 @@ const BooksOfCollectionWithHeading: React.FunctionComponent<{
                 manager={props.manager}
                 lazyLoadCollection={true}
                 isSpreadsheetFeatureActive={props.isSpreadsheetFeatureActive}
+                lockedToOneDownloadedBook={false}
             />
         </div>
     );

--- a/src/BloomBrowserUI/publish/LibraryPublish/LibraryPublishSteps.tsx
+++ b/src/BloomBrowserUI/publish/LibraryPublish/LibraryPublishSteps.tsx
@@ -39,7 +39,6 @@ import { BloomSplitButton } from "../../react_components/bloomSplitButton";
 import { ErrorBox, WaitBox } from "../../react_components/boxes";
 import {
     IUploadCollisionDlgData,
-    IUploadCollisionDlgProps,
     showUploadCollisionDialog,
     UploadCollisionDlg
 } from "./uploadCollisionDlg";

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -10,11 +10,13 @@ using System.Xml.Serialization;
 using Bloom.Api;
 using Bloom.Book;
 using Bloom.MiscUI;
+using Bloom.Publish.BloomLibrary;
 using Bloom.Publish.BloomPub;
 using Bloom.Utils;
 using Bloom.web.controllers;
 using DesktopAnalytics;
 using L10NSharp;
+using Newtonsoft.Json.Linq;
 using SIL.Code;
 using SIL.Extensions;
 using SIL.IO;
@@ -384,6 +386,30 @@ namespace Bloom.Collection
             }
         }
 
+        /// <summary>
+        /// Get the branding that the settings file specifies, without checking the subscription code
+        /// as we would do if creating a settings object from the settings file. (This is useful when
+        /// displaying the Branding dialog, to remind the user which branding they might want to find
+        /// a code for. We also use it to record the original branding for a book downloaded using
+        /// the "Download for editing" button on Blorg, since books on Bloom library keep their branding
+        /// but not the code that normally allows it to be used, though we make an exception for that
+        /// one book.)
+        /// </summary>
+        public static string ReadBrandingNameFromCollectionFile(string pathToCollectionFile)
+        {
+            try
+            {
+                var settingsContent = RobustFile.ReadAllText(pathToCollectionFile, Encoding.UTF8);
+                var xml = XElement.Parse(settingsContent);
+                return ReadString(xml, "BrandingProjectName", "");
+            }
+            catch (Exception ex)
+            {
+                Bloom.Utils.MiscUtils.SuppressUnusedExceptionVarWarning(ex);
+                return "";
+            }
+        }
+
         /// ------------------------------------------------------------------------------------
         public void Load()
         {
@@ -446,7 +472,25 @@ namespace Bloom.Collection
                     if (expirationDate < DateTime.Now) // no longer require branding files to exist yet
                     {
                         InvalidBranding = BrandingProjectKey;
-                        BrandingProjectKey = "Default"; // keep the code, but don't use it as active branding.
+                        var downloadEditPath = Path.Combine(
+                            FolderPath,
+                            BloomLibraryPublishModel.kNameOfDownloadForEditFile
+                        );
+                        if (RobustFile.Exists(downloadEditPath))
+                        {
+                            // We make an exception when the collection is a single book obtained using "downloaded for
+                            // editing",since we want to keep its branding. (The original uploader had a valid subscription
+                            // when first uploaded, and we want to allow re-uploading after editing even if this
+                            // user doesn't know that code or the subscription is expired. This doesn't provide
+                            // much of a workaround for unknown and expired codes, since the user can't add books
+                            // to this collection without first providing a valid branding, so it only allows
+                            // editing the one book previously uploaded with this branding.)
+                            _brandingProjectKeyOverrideForDownloadForEditing = BrandingProjectKey;
+                        }
+                        else
+                        {
+                            BrandingProjectKey = "Default"; // keep the code, but don't use it as active branding.
+                        }
                     }
                 }
                 Country = ReadString(xml, "Country", "");
@@ -536,6 +580,9 @@ namespace Bloom.Collection
 
             SetAnalyticsProperties();
         }
+
+        public bool LockedToOneDownloadedBook =>
+            _brandingProjectKeyOverrideForDownloadForEditing != null;
 
         private void DoOneTimeCheck()
         {
@@ -662,7 +709,17 @@ namespace Bloom.Collection
         }
 
         // e.g. "ABC2020" or "Kyrgyzstan2020[English]"
-        public string BrandingProjectKey { get; set; }
+        public string BrandingProjectKey
+        {
+            get => _brandingProjectKeyOverrideForDownloadForEditing ?? _brandingProjectKey;
+            set
+            {
+                _brandingProjectKey = value;
+                _brandingProjectKeyOverrideForDownloadForEditing = null;
+            }
+        }
+
+        private string _brandingProjectKeyOverrideForDownloadForEditing;
 
         public string GetBrandingFlavor()
         {
@@ -846,6 +903,8 @@ namespace Bloom.Collection
 
         private readonly Dictionary<string, string> ColorPalettes =
             new Dictionary<string, string>();
+
+        private string _brandingProjectKey;
 
         public string GetColorPaletteAsJson(string paletteTag)
         {

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using Bloom.Book;
@@ -12,6 +13,8 @@ using Bloom.TeamCollection;
 using Bloom.MiscUI;
 using Bloom.web.controllers;
 using Bloom.Api;
+using Bloom.Publish.BloomLibrary;
+using SIL.IO;
 using SIL.Windows.Forms.SettingProtection;
 
 namespace Bloom.Collection
@@ -114,6 +117,15 @@ namespace Bloom.Collection
             )
             {
                 this._tab.Controls.Remove(this._teamCollectionTab);
+            }
+
+            if (_collectionSettings.LockedToOneDownloadedBook)
+            {
+                // Don't give the slightest encouragement to making a download-for-edit collection into a team collection.
+                // (Actually they CAN do it, if they think to bring up the settings dialog and set an actual, valid
+                // subscription code. But we don't want to make it easy. These collections are supposed to be for
+                // temporary use editing the single downloaded book.)
+                _tab.Controls.Remove(this._teamCollectionTab);
             }
             // Don't allow the user to disable the Team Collection feature if we're currently in a Team Collection.
             _allowTeamCollection.Enabled = !(
@@ -392,8 +404,25 @@ namespace Bloom.Collection
             _collectionSettings.PageNumberStyle = PendingNumberingStyle; // non-localized key
 
             var oldBrand = _collectionSettings.BrandingProjectKey;
-            _collectionSettings.BrandingProjectKey = _brand;
-            _collectionSettings.SubscriptionCode = _subscriptionCode;
+            if (oldBrand != _brand || _collectionSettings.LockedToOneDownloadedBook)
+            {
+                _collectionSettings.BrandingProjectKey = _brand;
+                _collectionSettings.SubscriptionCode = _subscriptionCode;
+                // We've definitely selected some branding, even if it's the default. If necessary, we have a valid code
+                // for it. So if this collection was created using the "Download for editing" button on Blorg
+                // and has been getting special permission to use some branding because of that, it no longer needs
+                // that special permission. Nor does the rule that books can't be added to such a collection apply
+                // any longer. And in case the user has now selected a different branding, we no longer want the book to use the
+                // branding we downloaded it with. A simple way to achieve all this is to delete the file (if any) that
+                // constitutes our record that this is a collection made using "Download for editing".
+                // (Everything that depends on it gets cleaned up when we restart bloom with the new branding.)
+                var downloadEditPath = Path.Combine(
+                    _collectionSettings.FolderPath,
+                    BloomLibraryPublishModel.kNameOfDownloadForEditFile
+                );
+                RobustFile.Delete(downloadEditPath);
+            }
+
             // We don't know which if any of the new branding's bookshelves we should upload to by default,
             // but it will certainly be wrong to upload to one that belongs to some previous branding.
             if (oldBrand != _brand)

--- a/src/BloomExe/CollectionTab/CollectionModel.cs
+++ b/src/BloomExe/CollectionTab/CollectionModel.cs
@@ -125,9 +125,12 @@ namespace Bloom.CollectionTab
                     _bookCollections = new List<BookCollection>(GetBookCollectionsOnce());
 
                     //we want the templates to be second (after the editable collection) regardless of alphabetical sorting
-                    var templates = _bookCollections.First(c => c.Name == "Templates");
-                    _bookCollections.Remove(templates);
-                    _bookCollections.Insert(1, templates);
+                    var templates = _bookCollections.FirstOrDefault(c => c.Name == "Templates");
+                    if (templates != null)
+                    {
+                        _bookCollections.Remove(templates);
+                        _bookCollections.Insert(1, templates);
+                    }
                 }
                 return _bookCollections;
             }
@@ -290,17 +293,20 @@ namespace Bloom.CollectionTab
 
             _currentEditableCollectionSelection.SelectCollection(editableCollection);
             yield return editableCollection;
-
-            foreach (var bookCollection in _sourceCollectionsList.GetSourceCollectionsFolders())
+            // If we're locked to one downloaded book, we don't need to show the source collections, or even to load them.
+            if (!_collectionSettings.LockedToOneDownloadedBook)
             {
-                var collection = _bookCollectionFactory(
-                    bookCollection,
-                    BookCollection.CollectionType.SourceCollection
-                );
-                // Apart from the editable collection, I think only the downloaded books needs this (because books
-                // can be deleted from it and possibly added by new downloads); but it seems safest to set up for all.
-                SetupChangeNotifications(collection);
-                yield return collection;
+                foreach (var bookCollection in _sourceCollectionsList.GetSourceCollectionsFolders())
+                {
+                    var collection = _bookCollectionFactory(
+                        bookCollection,
+                        BookCollection.CollectionType.SourceCollection
+                    );
+                    // Apart from the editable collection, I think only the downloaded books needs this (because books
+                    // can be deleted from it and possibly added by new downloads); but it seems safest to set up for all.
+                    SetupChangeNotifications(collection);
+                    yield return collection;
+                }
             }
         }
 

--- a/src/BloomExe/Publish/BloomLibrary/BloomLibraryPublishModel.cs
+++ b/src/BloomExe/Publish/BloomLibrary/BloomLibraryPublishModel.cs
@@ -144,6 +144,19 @@ namespace Bloom.Publish.BloomLibrary
             return result;
         }
 
+        public static JObject GetDownloadForEditData(string pathToCollectionFolder)
+        {
+            var filePath = Path.Combine(
+                Path.GetDirectoryName(pathToCollectionFolder),
+                kNameOfDownloadForEditFile
+            );
+            if (RobustFile.Exists(filePath))
+            {
+                return JObject.Parse(RobustFile.ReadAllText(filePath));
+            }
+            return null;
+        }
+
         /// <summary>
         /// If we have multiple conflicting books, we want to sort them in a way that makes sense to the user.
         /// If we're in a collection that was made for editing one particular book, and this is the book,
@@ -174,13 +187,11 @@ namespace Bloom.Publish.BloomLibrary
                 return books;
             var remaining = books.ToList();
             var bookList = new List<dynamic>();
-            var filePath = Path.Combine(
-                Path.GetDirectoryName(pathToBookFolder),
-                kNameOfDownloadForEditFile
+            var bookOfCollectionData = GetDownloadForEditData(
+                Path.GetDirectoryName(pathToBookFolder)
             );
-            if (File.Exists(filePath))
+            if (bookOfCollectionData != null)
             {
-                var bookOfCollectionData = JObject.Parse(RobustFile.ReadAllText(filePath));
                 var databaseId = bookOfCollectionData["databaseId"];
                 var instanceId = bookOfCollectionData["instanceId"];
                 var bookFolder = bookOfCollectionData["bookFolder"]?.ToString();
@@ -788,6 +799,8 @@ namespace Bloom.Publish.BloomLibrary
             var updatedDate = updatedDateTime.ToString("d", CultureInfo.CurrentCulture);
             var existingThumbUrl = GetBloomLibraryThumbnailUrl(existingBookInfo);
 
+            var oldBranding = existingBookInfo.brandingProjectName?.ToString();
+
             // Must match IUploadCollisionDlgProps in uploadCollisionDlg.tsx.
             return new
             {
@@ -803,6 +816,8 @@ namespace Bloom.Publish.BloomLibrary
                 existingUpdatedDate = updatedDate,
                 existingBookUrl,
                 existingThumbUrl,
+                newBranding = Book.BookInfo.BrandingProjectKey,
+                oldBranding,
                 uploader = existingBookInfo.uploader.email,
                 count = existingBookInfo.count,
                 permissions = existingBookInfo.permissions

--- a/src/BloomExe/WebLibraryIntegration/BookDownload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookDownload.cs
@@ -334,7 +334,7 @@ namespace Bloom.WebLibraryIntegration
                     // Write a collection-level file that is used when re-uploading the book
                     // so we know exactly which book this collection was made for.
                     var pathToForEditDataFile = Path.Combine(
-                        Path.GetDirectoryName(LastBookDownloadedPath),
+                        Path.GetDirectoryName(LastBookDownloadedPath), // collection folder
                         BloomLibraryPublishModel.kNameOfDownloadForEditFile
                     );
                     var id = BookMetaData.FromFolder(LastBookDownloadedPath).Id;
@@ -343,6 +343,11 @@ namespace Bloom.WebLibraryIntegration
                     editData["databaseId"] = link.DatabaseId;
                     editData["instanceId"] = id;
                     editData["bookFolder"] = LastBookDownloadedPath.Replace("\\", "/");
+                    // We can't create an instance and read the branding, because load will wipe it out when it sees no code.
+                    var branding = CollectionSettings.ReadBrandingNameFromCollectionFile(
+                        CollectionCreatedForLastDownload
+                    );
+                    editData["branding"] = branding;
                     RobustFile.WriteAllText(
                         pathToForEditDataFile,
                         Newtonsoft.Json.JsonConvert.SerializeObject(editData)

--- a/src/BloomTests/Publish/BloomLibraryPublishModelTests.cs
+++ b/src/BloomTests/Publish/BloomLibraryPublishModelTests.cs
@@ -177,10 +177,7 @@ namespace BloomTests.Publish
             )
             {
                 var book2FolderPath = Path.Combine(tempFolder.FolderPath, "hello world");
-                var downloadForEditPath = Path.Combine(
-                    tempFolder.FolderPath,
-                    BloomLibraryPublishModel.kNameOfDownloadForEditFile
-                );
+                var downloadForEditPath = Path.Combine(tempFolder.FolderPath);
                 File.WriteAllText(
                     downloadForEditPath,
                     @"{""databaseId"": ""matchesCollection"", ""instanceId"": ""c2e3212c-ee59-4e75-bd98-41e4784e24ca"",""bookFolder"":"""


### PR DESCRIPTION
- warn if upload will change branding on Blorg
- allow download-for-edit books to be edited using their original branding
- any time we open settings and the collection used to have a branding but lacks a code, show the old branding and message about it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6376)
<!-- Reviewable:end -->
