### PR TITLE
Prevent collection change while enumerating (BL-13209)

### DIFF
--- a/src/BloomExe/web/controllers/ApiRequest.cs
+++ b/src/BloomExe/web/controllers/ApiRequest.cs
@@ -223,10 +223,9 @@ namespace Bloom.Api
                         // Note: If the user is still interacting with the application, openForms could change and become empty.
                         // We'd prefer the Bloom shell, if it's open, so we concat that list onto the list of any others and take
                         // the last.
-                        var formForSynchronizing = Application.OpenForms
-                            .Cast<Form>()
-                            .Concat(Application.OpenForms.Cast<Form>().Where(x => x is Bloom.Shell))
-                            .LastOrDefault();
+                        var forms = Application.OpenForms.Cast<Form>().ToList();
+                        var shells = forms.Where(x => x is Bloom.Shell);
+                        var formForSynchronizing = forms.Concat(shells).LastOrDefault();
                         if (
                             endpointRegistration.HandleOnUIThread
                             && formForSynchronizing != null

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -185,6 +185,7 @@ namespace Bloom.web.controllers
                 {
                     request.ReplyWithText(ApplicationUpdateSupport.ChannelName);
                 },
+                false,
                 false
             );
             // This is useful for debugging TypeScript code, especially on Linux.  I wouldn't necessarily expect


### PR DESCRIPTION
Also, mark the common/channel API as not needing to be synchronized since it uses only read-only data and is called only once by the javascript code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6383)
<!-- Reviewable:end -->
