### PR TITLE
Format cog adjustment to avoid hiding behind page number (BL-13206)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -763,13 +763,22 @@ div.textWholePage ul {
 // Changing the z-index did not help. So we allow themes to "dodge" it.
 // Kind of a hack, I know. See BL-13206.
 @container style(--pageNumber-show-multiplicand:1) {
+    .split-pane-component.position-right
+        .split-pane-component-inner
+        > .bloom-translationGroup
+        > #formatButton,
+    .split-pane-component.position-top
+        .split-pane-component-inner
+        > .bloom-translationGroup
+        > #formatButton {
+        // don't need this dodge if the page number can't be in this text area
+        --formatButton-pageNumber-dodge: 0px;
+    }
     .split-pane-component.position-left
         > .split-pane-component-inner
         > .bloom-translationGroup
         > #formatButton,
-    // more complex page split vertically after horizontally
-    .split-pane-component.position-left
-        .split-pane-component.position-bottom
+    .split-pane-component.position-bottom
         > .split-pane-component-inner
         > .bloom-translationGroup
         > #formatButton,

--- a/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
@@ -19,6 +19,9 @@
 
     /* set to 0 because our marginBox is white but background is dark. This has the effect of increasing the text padding on the edges. */
     --page-and-marginBox-are-same-color-multiplicand: 0;
+
+    /* move so that page number doesn't it hide it if the text box is in the lower left */
+    --formatButton-pageNumber-dodge: 20px;
 }
 
 [class*="Device"].numberedPage {


### PR DESCRIPTION
This covers the standard "Picture in Middle" page layout and the "Rounded Border Ebook" theme.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6395)
<!-- Reviewable:end -->
