### PR TITLE
Add transition delay for hiding hint bubbles on focus loss (BL-13224)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1182,6 +1182,8 @@ body.hideAllCKEditors .cke_chrome {
 // hide tips when the user clicks out of the page
 .qtip {
     visibility: hidden;
+    transition-property: visibility;
+    transition-delay: 1s;
 }
 // but keep them visible when the user is interacting with them (BL-13224)
 .qtip:hover,

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1182,6 +1182,8 @@ body.hideAllCKEditors .cke_chrome {
 // hide tips when the user clicks out of the page
 .qtip {
     visibility: hidden;
+    // When the page isn't focused, the tips will go away when you move off the page.
+    // This keeps them around long enough to reach with the mouse.
     transition-property: visibility;
     transition-delay: 1s;
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6396)
<!-- Reviewable:end -->
