### PR TITLE
Fix 5.7 default front covers to match 5.6 better (BL-13264)

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/previewMode.less
+++ b/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/previewMode.less
@@ -1,5 +1,5 @@
 @import (reference) "../../bloomUI.less";
-@import "../../../content/templates/xMatter/preview-xmatter.less";
+@import "../../../content/templates/xMatter/standard-template-preview.less";
 
 @media screen {
     body {

--- a/src/BloomExe/web/controllers/IndicatorInfoApi.cs
+++ b/src/BloomExe/web/controllers/IndicatorInfoApi.cs
@@ -40,7 +40,7 @@ namespace Bloom.web.controllers
                     {
                         var firstPossiblyOffendingCssFile = "";
                         var migratedTheme = "";
-                        if (bookInfo.AppearanceSettings.IsInitialized)
+                        if (bookInfo.AppearanceSettings.CssFilesChecked)
                         {
                             firstPossiblyOffendingCssFile = bookInfo
                                 .AppearanceSettings

--- a/src/BloomTests/Book/AppearanceSettingsTests.cs
+++ b/src/BloomTests/Book/AppearanceSettingsTests.cs
@@ -351,7 +351,7 @@ namespace BloomTests.Book
             _settings.WriteCssToFolder(_bookFolder);
             _resultingAppearance = new AppearanceSettingsTest();
             _resultingAppearance.UpdateFromFolder(_bookFolder);
-            _resultingAppearance.Initialize(
+            _resultingAppearance.CheckCssFilesForCompatibility(
                 new[]
                 {
                     cssFilesToCheck[0],

--- a/src/content/appearanceThemes/appearance-theme-default.css
+++ b/src/content/appearanceThemes/appearance-theme-default.css
@@ -79,10 +79,14 @@
     /* Most Bloom books are too small to need a gutter. NB: THIS MUST HAVE UNITS even when 0, else calc() fails */
     --page-gutter: 0mm;
 
+    --page-margin: 12mm;
+
     /* padding-top: value in .bloom-page.outsideFrontCover and .bloom-page.outsideBackCover */
-    --cover-margin-top: 12mm; /* same default value as --page-margin-top, but used for outside cover pages */
+    --cover-margin-top: var(--page-margin); /* same default value as --page-margin-top, but used for outside cover pages */
     /* padding-bottom: value in .bloom-page.outsideFrontCover and .bloom-page.outsideBackCover */
-    --cover-margin-bottom: 12mm; /* same default value as --page-margin-bottom, but used for outside cover pages */
+    --cover-margin-bottom: var(--page-margin); /* same default value as --page-margin-bottom, but used for outside cover pages */
+    /* padding-left: and padding-right: value in .bloom-page.outsideFrontCover and .bloom-page.outsideBackCover */
+    --cover-margin-side: var(--page-margin); /* same default value as --page-margin-left and --page-margin-right, but used for outside cover pages */
     /* display: value in .coverBottomBookTopic */
     --cover-topic-show: doShow-css-will-ignore-this-and-use-default; /* default is topic displaying (the value is a self-documenting trick) */
     /* display: value in .coverBottomLangName */
@@ -105,8 +109,6 @@
     /* border-width: value in .numberedPage .marginBox */
     --marginBox-border-width: medium; /* must not be 0px/0mm/0in to have a border. 'medium' is a keyword. */
 
-    --page-margin: 12mm;
-
     /* In some themes, at edit-
     time, the format button lands under the page number. See BL-13206. The name is is intentionally vague about direction and what we do with it. */
     --formatButton-pageNumber-dodge: 0;
@@ -118,28 +120,31 @@
     --marginBox-background-color: transparent;
 }
 
-/* Beware of making these rules more specific. We want them to be able to be overriden by .bloom-page rules
+/* Beware of making these rules more specific. We want them to be able to be overridden by .bloom-page rules
  * that come from other themes (and hence later in the generated appearance.css file).
  */
-.A4Landscape {
-    --page-margin-top: 12mm;
-    --page-margin-bottom: 12mm;
-    --page-margin-right: 15mm;
-    --page-margin-left: 15mm;
+ .A3Landscape,
+ .A3Portrait,
+ .A4Landscape,
+ .A4Portrait,
+ .B5Portrait,
+ .LetterLandscape,
+ .LetterPortrait,
+ .LegalLandscape,
+ .LegalLandscape {
+    --page-margin: 15mm;
+    --page-gutter: 10mm;
 }
-.A4Portrait {
-    --page-margin-top: 15mm;
-    --page-margin-bottom: 15mm;
-    --page-margin-right: 12mm;
-    --page-margin-left: 12mm;
-}
-
 .HalfLetterPortrait,/* SIL Mexico says use same as A5 */
 .HalfLetterLandscape,
 .A5Landscape,
-.A5Portrait {
-    --page-margin: 10mm;
+.A5Portrait,
+.Size6x9Landscape,
+.Size6x9Portrait {
+    --page-margin: 12mm;
 }
+.QuarterLetterPortrait,
+.QuarterLetterLandscape,
 .A6Portrait,
 .A6Landscape {
     --page-margin: 10mm;

--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -635,7 +635,6 @@ div[data-book*="branding"] {
         padding-left: calc(var(--page-margin-left) + var(--page-gutter));
         padding-right: var(--page-margin-right);
     }
-
     &.outsideFrontCover,
     &.outsideBackCover {
         padding-top: var(--cover-margin-top);
@@ -645,9 +644,8 @@ div[data-book*="branding"] {
 
 // --------------------------------------------------------------------------------------
 // pages that are symmetrical left vs. right, so that we only use --page-margin-left
+// (or --cover-margin-side).
 // --------------------------------------------------------------------------------------
-.outsideFrontCover,
-.outsideBackCover,
 // if the page is set to a Device one
 .bloom-page[class*="Device"],
 .calendarFold,
@@ -661,6 +659,16 @@ div[data-book*="branding"] {
         // then use balanced margins, no gutter
         padding-left: var(--page-margin-left);
         padding-right: var(--page-margin-left);
+    }
+}
+// Although normally the same, the cover can have a different margin than the
+// inside pages. So we need to set the padding for the cover pages separately.
+.bloom-page.outsideBackCover,
+.bloom-page.outsideFrontCover {
+    &.side-left,
+    &.side-right {
+        padding-left: var(--cover-margin-side);
+        padding-right: var(--cover-margin-side);
     }
 }
 
@@ -852,6 +860,7 @@ The buffer would be absent if the marginBox had a border or the page has a backg
     /* All of these default to the general one, then can be overridden as needed */
     --cover-margin-top: var(--page-margin);
     --cover-margin-bottom: var(--page-margin);
+    --cover-margin-side: var(--page-margin);
     --page-margin-top: var(--page-margin);
     --page-margin-bottom: var(--page-margin);
     --page-margin-left: var(--page-margin);

--- a/src/content/templates/xMatter/bloom-xmatter-common.less
+++ b/src/content/templates/xMatter/bloom-xmatter-common.less
@@ -48,6 +48,7 @@
         //independently of their appearance order in the html
         display: flex;
         flex-direction: column;
+        row-gap: 10px;   // extra space between title items (less than default --page-gutter value which would otherwise apply)
 
         .bloom-editable {
             order: 0;

--- a/src/content/templates/xMatter/project-specific/ABC-Reader-XMatter/ABC-Reader-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/ABC-Reader-XMatter/ABC-Reader-XMatter.less
@@ -328,6 +328,7 @@ div.bloomPlayer-page {
 .HalfLetterPortrait.bloom-page {
     --cover-margin-top: 0.5in;
     --cover-margin-bottom: 0.4in;
+    --cover-margin-side: 0.5in;
     --page-margin-top: 0.5in;
     --page-margin-left: 0.5in;
     --page-margin-right: 0.5in;

--- a/src/content/templates/xMatter/project-specific/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-Xmatter-common.less
+++ b/src/content/templates/xMatter/project-specific/Kyrgyzstan2020-XMatter/Kyrgyzstan2020-Xmatter-common.less
@@ -7,6 +7,13 @@
 // part of the main Kyrgyztan2020-Xmatter, developed to produce exactly the result
 // we want in Bloom Player.
 
+// with a default gray background-color, these values need a bit of contrast to be visible
+.bloom-page.cover {
+    --page-structure-color: rgba(196, 196, 196, 0.268);
+    --language-tag-color: rgba(196, 196, 196, 0.9);
+    --selectedEdit-color: rgba(196, 196, 196, 0.9);
+}
+
 // we need a lot of classes here to overcome the unfortunately "!important" class put in by Bloom at runtime
 div.bloom-page.outsideFrontCover.coverColor,
 div.bloom-page.outsideBackCover.coverColor {
@@ -44,6 +51,7 @@ div.bloom-page.outsideBackCover.coverColor {
 .bloom-page.outsideFrontCover {
     --cover-margin-top: 0mm;
     --cover-margin-bottom: 0mm;
+    --cover-margin-side: 0mm;
     --page-margin-left: 0mm;
     --page-margin-right: 0mm;
 }

--- a/src/content/templates/xMatter/project-specific/Uzbekistan2023-XMatter/Uzbekistan2023-Xmatter-common.less
+++ b/src/content/templates/xMatter/project-specific/Uzbekistan2023-XMatter/Uzbekistan2023-Xmatter-common.less
@@ -5,6 +5,13 @@
     --bleed-tolerance: 3mm;
 }
 
+// with a default gray background-color, these values need a bit of contrast to be visible
+.bloom-page.cover {
+    --page-structure-color: rgba(196, 196, 196, 0.268);
+    --language-tag-color: rgba(196, 196, 196, 0.9);
+    --selectedEdit-color: rgba(196, 196, 196, 0.9);
+}
+
 // These rule are common to regular Uzbekistan2023-Xmatter and the epub version.
 // Some of these rules, especially for the front cover, may not work on all readers,
 // but by experiment they seem to produce reasonable results. They were originally
@@ -57,13 +64,14 @@ div.bloom-page {
 }
 
 // This affects the size of the marginBox, but it must be applied to the bloom-page, because the marginBox
-// size is now controlled by padding on the page. This is currently untested beccause the enterprise codes
+// size is now controlled by padding on the page. This is largely untested because the enterprise codes
 // for the UEEP brandings which use this are expired.
 .outsideFrontCover,
 .outsideBackCover {
     &.bloom-page {
         --cover-margin-top: @bleed;
         --cover-margin-bottom: @bleed;
+        --cover-margin-side: @bleed;
         --page-margin-right: @bleed;
         --page-margin-left: @bleed;
     }

--- a/src/content/templates/xMatter/standard-template-preview.less
+++ b/src/content/templates/xMatter/standard-template-preview.less
@@ -2,9 +2,11 @@
 @import "../../bookLayout/paperDimensions.less";
 @import "../../appearanceThemes/appearance-theme-default.css";
 
-@XMatterPackName: "preview";
+@XMatterPackName: "template-preview";
 
-.preview {
+// These are wanted only for previewing templates, not real books.
+// Real books always have a data-l1 attribute added.
+.preview:not([data-l1]) {
     .bloom-frontMatter {
         .pageLabel:before {
             content: "@{XMatterPackName}";
@@ -13,6 +15,10 @@
     }
     .frontCover {
         @MarginBetweenMajorItems: 15px;
+        padding-top: var(--cover-margin-top);
+        padding-bottom: var(--cover-margin-bottom);
+        padding-left: var(--cover-margin-side);
+        padding-right: var(--cover-margin-side);
 
         .marginBox {
             display: flex;


### PR DESCRIPTION
Also adjust the margin settings in appearance-theme-default.css to match the Default Margins table in docs.bloomlibrary.org better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6415)
<!-- Reviewable:end -->
