### PR TITLE
Fix language menu after changes made with book settings (BL-13198)

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1698,7 +1698,7 @@ if (typeof(editTabBundle) !=='undefined' && typeof(editTabBundle.getEditablePage
             }
             finally
             {
-                _sendingContentLanguagesSelectionChanged = false;
+                _sendingContentLanguagesSelectionChanged = true;
             }
 
             if (changed)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6417)
<!-- Reviewable:end -->
