### PR TITLE
Check whether this version is allowed to download (BL-13283)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1214,6 +1214,10 @@
         <note>ID: Download.GenericNetworkProblemNotice</note>
         <note xml:lang="en">OLD TEXT (before 3.9): There was a problem downloading your book.</note>
       </trans-unit>
+      <trans-unit id="Download.OldVersion">
+        <source xml:lang="en">The download you started needs version {0} or later of Bloom. Please install that version if you haven't already, and run it. Then try the download again.</source>
+        <note>ID: Download.OldVersion</note>
+      </trans-unit>
       <trans-unit id="Download.ProblemNotice">
         <source xml:lang="en">There was a problem downloading your book. You may need to restart Bloom or get technical help.</source>
         <note>ID: Download.ProblemNotice</note>

--- a/src/BloomExe/WebLibraryIntegration/BookDownload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookDownload.cs
@@ -17,6 +17,7 @@ using SIL.Progress;
 using SIL.Reporting;
 using SIL.Windows.Forms.Progress;
 using Bloom.web.controllers;
+using Bloom.ToPalaso;
 
 namespace Bloom.WebLibraryIntegration
 {
@@ -153,6 +154,23 @@ namespace Bloom.WebLibraryIntegration
 		internal void HandleBloomBookOrder(string order)
 		{
 			_downloadRequest = order;
+			if (!IsThisVersionAllowedToDownload(order))
+			{
+				// We don't need exception handling here because the test above only returns true if it was able to parse the version.
+				var minVersionStr = HttpUtility.ParseQueryString(new Uri(order).Query)[
+					"minVersion"
+				];
+				// We can't use a browser here; we haven't gotten that far in the setup.
+				MessageBox.Show(
+					string.Format(
+					LocalizationManager.GetString(
+						"Download.OldVersion",
+						"The download you started needs version {0} or later of Bloom. Please install that version if you haven't already, and run it. Then try the download again."
+					), minVersionStr)
+				);
+				ProcessExtra.SafeStartInFront("https://bloomlibrary.org/download");
+				return;
+			}
 			using (var progressDialog = new ProgressDialog())
 			{
 				_progressDialog = new ProgressDialogWrapper(progressDialog);
@@ -182,6 +200,48 @@ namespace Bloom.WebLibraryIntegration
 					ProblemReportApi.ShowProblemDialog(null, exc, "", "fatal");
 				}
 			}
+		}
+
+		private static bool IsThisVersionAllowedToDownload(string bookOrderUrl)
+		{
+			// This awkwardness is so we can unit test the main logic without getting messed up by a "real" Application.ProductVersion.
+			return IsThisVersionAllowedToDownloadInner(bookOrderUrl, Application.ProductVersion);
+		}
+
+		internal static bool IsThisVersionAllowedToDownloadInner(
+			string bookOrderUrl,
+			string appVersion
+		)
+		{
+			int requiredMajorVersion;
+			int requiredMinorVersion;
+			try
+			{
+				var minVersionStr = HttpUtility.ParseQueryString(new Uri(bookOrderUrl).Query)[
+					"minVersion"
+				];
+				Version requiredVersion = Version.Parse(minVersionStr);
+				requiredMajorVersion = requiredVersion.Major;
+				requiredMinorVersion = requiredVersion.Minor;
+			}
+			catch
+			{
+				// Three possibilities:
+				// 1. minVersion is missing.
+				//    Allow download.
+				// 2. minVersion is invalid.
+				//    Allow download. (This could be argued either way, but this is easier. Since we control the other end, we don't expect this to happen.)
+				// 3. Something is wrong with the url itself.
+				//    Likely, something else will go wrong, but we don't want to put up a message about the version needing to be updated.
+				return true;
+			}
+			var ourVersion = Version.Parse(appVersion);
+			var ourMajorVersion = ourVersion.Major;
+			var ourMinorVersion = ourVersion.Minor;
+
+			if (ourMajorVersion == requiredMajorVersion)
+				return ourMinorVersion >= requiredMinorVersion;
+			return ourMajorVersion >= requiredMajorVersion;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This code is roughly copied (one small change to a variable name) from Bloom 5.7. Not a cherry-pick because of  that one name change and I didn't want to bring other changes (even to tests) along. It should be merged normally into 5.6 but probably null-merged into 5.7.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6420)
<!-- Reviewable:end -->
