### PR TITLE
Put various qtips into the right container (BL-13285)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -299,8 +299,11 @@ export default class OverflowChecker {
                                 overflowText,
                             show: { event: "mouseenter" },
                             hide: { event: "mouseleave" },
-                            position: { my: "top right", at: "right bottom" },
-                            container: bloomQtipUtils.qtipZoomContainer()
+                            position: {
+                                my: "top right",
+                                at: "right bottom",
+                                container: bloomQtipUtils.qtipZoomContainer()
+                            }
                         });
                     });
             }
@@ -360,8 +363,11 @@ export default class OverflowChecker {
                                 overflowText,
                             show: { event: "enterBorder" }, // nonstandard events triggered by mouse move in code below
                             hide: { event: "leaveBorder" },
-                            position: { my: "top right", at: "right bottom" },
-                            container: bloomQtipUtils.qtipZoomContainer()
+                            position: {
+                                my: "top right",
+                                at: "right bottom",
+                                container: bloomQtipUtils.qtipZoomContainer()
+                            }
                         });
                     });
                 let showing = false;

--- a/src/BloomBrowserUI/bookEdit/js/bloomNotices.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomNotices.ts
@@ -27,13 +27,13 @@ export default class BloomNotices {
                     hide: false,
                     position: {
                         at: "right top",
-                        my: "left top"
+                        my: "left top",
+                        container: bloomQtipUtils.qtipZoomContainer()
                     },
                     style: {
                         classes: "ui-tooltip-red",
                         tip: { corner: false }
-                    },
-                    container: bloomQtipUtils.qtipZoomContainer()
+                    }
                 });
             });
     }


### PR DESCRIPTION
In several places we were using the container: option of qtip wrongly.
This would cause qtips to show up in the wrong place when zoomed.
It also, for a reason I don't understand, prevented the proper functioning of a CSS rule for making qtips visible, overriding a rule intended to hide them when focus and the mouse are elsewhere. So this fixes a problem where overflow tooltips were being always hidden, too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6422)
<!-- Reviewable:end -->
