### PR TITLE
Replace outline with padding when no outline is shown (BL-13288)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -551,8 +551,8 @@ button.moveButton {
     textarea,
     div.bloom-editable,
     div.pageLabel[contenteditable="true"] {
-        outline: thin solid var(--unselectedEdit-color);
-        /*[disabled]min-height:34px;*/
+        outline: 1px solid var(--unselectedEdit-color);
+        padding: 0px; // remove padding to make room for the outline
     }
 }
 

--- a/src/content/bookLayout/basePage-legacy-5-6.less
+++ b/src/content/bookLayout/basePage-legacy-5-6.less
@@ -477,6 +477,15 @@ div.ui-audioCurrent p {
     // feature is not broken in legacy.
     box-sizing: border-box;
   }
+  .bloom-page {
+    textarea,
+    div.bloom-editable,
+    div.pageLabel[contenteditable="true"] {
+      padding: 1px; // equal to outline's width when being edited
+      // See src/BloomBrowserUI/bookEdit/css/editMode.less for outline rule
+    }
+  }
+
   /* The following has been split out from the above rule because it should probably be removed,
       but at this point we are about to go release candidate with 3.1 so it will have to wait.
       When we do remove it, the main things it could effect are the Story Primer template and the dozen or so SIL LEAD Uganda SHRP templates.

--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -209,6 +209,14 @@ textarea,
     // overflow its parent.
     box-sizing: border-box;
 }
+.bloom-page {
+    textarea,
+    div.bloom-editable,
+    div.pageLabel[contenteditable="true"] {
+        padding: 1px; // equal to outline's width when being edited
+        // See src/BloomBrowserUI/bookEdit/css/editMode.less for outline rule
+    }
+}
 
 /* The following has been split out from the above rule because it should probably be removed,
     but at this point we are about to go release candidate with 3.1 so it will have to wait.


### PR DESCRIPTION
The 2px difference in height and width could have led to a very subtle cause of differences in text wrapping between editing and publishing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6425)
<!-- Reviewable:end -->
