### PR TITLE
Fix a pair of blocking bugs (20240422)

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1886,7 +1886,7 @@ namespace Bloom.Edit
             else // css, png, svg, js, etc.
             {
                 CurrentBook.Storage.UpdateSupportFiles();
-                if (!_view.IsDisposed)
+                if (!_view.IsDisposed && _view.IsHandleCreated)
                 {
                     _view.Invoke(
                         (MethodInvoker)


### PR DESCRIPTION
1) View asked to invoke before being fully initialized.
2) Validating team collection administrators when not a team collection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6432)
<!-- Reviewable:end -->
