### PR TITLE
Fix line-height and other settings in ABC branding (BL-13281)

### DIFF
--- a/src/content/templates/xMatter/bloom-xmatter-common.less
+++ b/src/content/templates/xMatter/bloom-xmatter-common.less
@@ -130,7 +130,6 @@
         .branding {
             order: 0; // first (left) in the flex list
             margin: 0; //unlike a lot of logo placements, we're not trying to center this one with left/right auto margins
-            margin-right: 10px; // this only has an effect if the image is there, because in the html, we set display:none if the image isn't found
         }
 
         // this contains the smallCoverCredits text box row, followed by the row that has the language names and topic

--- a/src/content/templates/xMatter/project-specific/ABC-Reader-XMatter/ABC-Reader-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/ABC-Reader-XMatter/ABC-Reader-XMatter.less
@@ -77,6 +77,7 @@ div.bloomPlayer-page {
                 // makes reader template styles unchangeable.
                 .Title-On-Cover-style[data-book="bookTitle"] {
                     font-size: 26pt;
+                    line-height: 1.1;
                 }
             }
         }
@@ -87,10 +88,6 @@ div.bloomPlayer-page {
 
         [data-book="cover-branding-bottom-html"] {
             margin-top: 1em;
-
-            img {
-                margin-right: 0;
-            }
         }
 
         .descriptionAndTopicRow {
@@ -103,6 +100,7 @@ div.bloomPlayer-page {
                 min-width: 50%;
                 text-align: start;
                 font-size: 14pt;
+                line-height: 1.1;
             }
         }
 
@@ -257,6 +255,8 @@ div.bloomPlayer-page {
     text-align: center;
     font-weight: bold;
     font-size: 14pt;
+    // Tight line spacing closely approximates the effective line height in Bloom 5.6.
+    line-height: 1.07;
 }
 
 /* -----------------------------------------------------------------------------
@@ -362,6 +362,19 @@ div.bloomPlayer-page {
             max-width: 100%;
         }
     }
+}
+/* -----------------------------------------------------------------------------
+   Rules for Device16x9Portrait
+   ----------------------------------------------------------------------------*/
+// Even this template uses Device16x9 portrait pages for BloomPub and ePUB publishing.
+.Device16x9Portrait .originalAcknowledgments .bloom-editable p {
+    // Tighten up the spacing a bit to allow for slightly longer and possibly fewer lines
+    // This allows the cover of https://bloomlibrary.org/book/7GoLbrW02S to look close to
+    // the same in 5.7 as 5.6 which took advantage of an accidental extra ~10px of width.
+    word-spacing: -0.03ch;
+}
+.Device16x9Portrait.frontCover [data-book="cover-branding-bottom2-html"] {
+    bottom: -10px;  // Move the final "Not for sale" message up a bit to squeeze it onto the page.
 }
 
 /* -----------------------------------------------------------------------------


### PR DESCRIPTION
With these changes, the front cover closely approximates what is seen in Bloom 5.6 for both HalfLetterPortrait and Device16x9Portrait.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6433)
<!-- Reviewable:end -->
