### PR TITLE
No checkboxes for langs in xmatter only, even if L2 or L3 (BL-13162)

### DIFF
--- a/src/BloomBrowserUI/yarn.lock
+++ b/src/BloomBrowserUI/yarn.lock
@@ -5528,9 +5528,9 @@ bindings@^1.5.0:
     file-uri-to-path "1.0.0"
 
 bloom-player@^2.2:
-  version "2.2.34"
-  resolved "https://registry.yarnpkg.com/bloom-player/-/bloom-player-2.2.34.tgz#e6f09b583b214106e8cd6d82d9cf73f8cd8b4e0f"
-  integrity sha512-7aVdVcfe7wr6gFMrAZ2t7d+tVKVDjdhoZYKSCZdCxAOoCIpH6FOmffoONQxQb1gpvDzsdxBd7UVtLLx+szYt5g==
+  version "2.2.35"
+  resolved "https://registry.yarnpkg.com/bloom-player/-/bloom-player-2.2.35.tgz#ed536fea72127b9461dd48891e729a8bf5761591"
+  integrity sha512-EQ4WyWd/FUU/Wi4NsnPSHvcDF6mFGGd9oJFVs6qBSDytBUrTtnfipUNtvCcd7gAuRBCnECdzOGMm9WOsr21p4g==
 
 bluebird@^3.3.5, bluebird@^3.5.5:
   version "3.7.2"

--- a/src/BloomExe/Publish/BloomLibrary/BloomLibraryPublishModel.cs
+++ b/src/BloomExe/Publish/BloomLibrary/BloomLibraryPublishModel.cs
@@ -257,7 +257,7 @@ namespace Bloom.Publish.BloomLibrary
             return bookList.ToArray();
         }
 
-        internal bool IsTitleOKToPublish => Book.HasL1Title();  // Even picture books need a title (and templates have a title).
+        internal bool IsTitleOKToPublish => Book.HasL1Title(); // Even picture books need a title (and templates have a title).
 
         /// <summary>
         /// The model alone cannot determine whether a book is OK to upload, because the language requirements
@@ -430,7 +430,13 @@ namespace Bloom.Publish.BloomLibrary
         public static void InitializeLanguages(BookInstance book)
         {
             var allLanguages = book.AllPublishableLanguages(
-                includeLangsOccurringOnlyInXmatter: true
+                // True up to 5.6. Things are a bit tricky if xmatter contains L2 and possibly L3 data.
+                // We always include that xmatter data if it is needed for the book to be complete.
+                // But if nothing in the book content is in those languages, we don't list them as
+                // book languages, either in Blorg or in Bloom Player. To be consistent, we don't
+                // even want to have check boxes for them (they would not have any effect, since there
+                // is nothing in the book in those languages that is optional to include).
+                includeLangsOccurringOnlyInXmatter: false
             );
 
             var bookInfo = book.BookInfo;

--- a/src/BloomExe/web/controllers/PublishApi.cs
+++ b/src/BloomExe/web/controllers/PublishApi.cs
@@ -526,7 +526,13 @@ namespace Bloom.web.controllers
             lock (_lockForLanguages)
             {
                 _allLanguages = request.CurrentBook.AllPublishableLanguages(
-                    includeLangsOccurringOnlyInXmatter: true
+                    // True up to 5.6. Things are a bit tricky if xmatter contains L2 and possibly L3 data.
+                    // We always include that xmatter data if it is needed for the book to be complete.
+                    // But if nothing in the book content is in those languages, we don't list them as
+                    // book languages, either in Blorg or in Bloom Player. To be consistent, we don't
+                    // even want to have check boxes for them (they would not have any effect, since there
+                    // is nothing in the book in those languages that is optional to include).
+                    includeLangsOccurringOnlyInXmatter: false
                 );
 
                 // Note that at one point, we had a check that would bypass most of this function if the book hadn't changed.


### PR DESCRIPTION
Also brings bloom player up to current version

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6439)
<!-- Reviewable:end -->
