### PR TITLE
Remove a buggy @import that's causing runtime errors (BL-13380)

### DIFF
--- a/src/content/templates/xMatter/standard-template-preview.less
+++ b/src/content/templates/xMatter/standard-template-preview.less
@@ -1,6 +1,5 @@
 @import "bloom-xmatter-sharedRules.less";
 @import "../../bookLayout/paperDimensions.less";
-@import "../../appearanceThemes/appearance-theme-default.css";
 
 @XMatterPackName: "template-preview";
 
@@ -46,7 +45,7 @@
         &[data-xmatter-page="about"] {
             display: none;
         }
-	    // This is needed for the Digital Comic Book to properly space items on the
+        // This is needed for the Digital Comic Book to properly space items on the
         // front cover.
         &.Device16x9Landscape#ddd9b811-63d6-4d51-baf8-0a5fe88cd73d {
             .bookTitle {


### PR DESCRIPTION
The delete line somehow fails to import the requested file, and instead gets copied to previewMode.css in the output. The file can't be found at that relative location at runtime, so we log a missing file error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6458)
<!-- Reviewable:end -->
