### PR TITLE
Fix the color of the language menu when it is disabled (BL-13376)

### DIFF
--- a/src/BloomExe/Edit/DisableColorRenderer.cs
+++ b/src/BloomExe/Edit/DisableColorRenderer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Bloom.Edit
+{
+    /// <summary>
+    /// Install this as the renderer for a ToolStrip to make it render text (and the down arrow
+    /// in a ToolStripDropDownButton) in the specified color when an item is disabled.
+    /// </summary>
+    internal class DisableColorRenderer : ToolStripSystemRenderer
+    {
+        Color disabledColor;
+
+        public DisableColorRenderer(Color disabledColor)
+        {
+            this.disabledColor = disabledColor;
+        }
+
+        protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
+        {
+            if (e.Item.Enabled)
+            {
+                base.OnRenderItemText(e);
+                return;
+            }
+
+            // We have to actually take over drawing it, because when disabled, e.TextColor
+            // is ignored. There doesn't seem to be a property for disabled text color.
+            TextRenderer.DrawText(
+                e.Graphics,
+                e.Text,
+                e.TextFont,
+                e.TextRectangle,
+                disabledColor,
+                e.TextFormat
+            );
+        }
+
+        protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
+        {
+            if (!e.Item.Enabled)
+                e.ArrowColor = disabledColor;
+
+            base.OnRenderArrow(e);
+        }
+    }
+}

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -164,6 +164,7 @@ namespace Bloom.Edit
                     UpdatePageList(true);
                 }
             );
+            _menusToolStrip.Renderer = new DisableColorRenderer(Color.FromArgb(114, 74, 106));
 #if __MonoCS__
             // The inactive button images look garishly pink on Linux/Mono, but look okay on Windows.
             // Merely introducing an "identity color matrix" to the image attributes appears to fix


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6465)
<!-- Reviewable:end -->
