### PR TITLE
Fix BL-13387 Prevent double clicking image buttons

### DIFF
--- a/src/BloomBrowserUI/bookEdit/editablePage.ts
+++ b/src/BloomBrowserUI/bookEdit/editablePage.ts
@@ -50,7 +50,8 @@ import {
     pasteClipboardText,
     makeElement,
     SetupElements,
-    attachToCkEditor
+    attachToCkEditor,
+    changeImage
 } from "./js/bloomEditing";
 export {
     pageSelectionChanging,
@@ -63,7 +64,8 @@ export {
     pasteClipboardText,
     makeElement,
     SetupElements,
-    attachToCkEditor
+    attachToCkEditor,
+    changeImage
 };
 import { origamiCanUndo, origamiUndo } from "./js/origami";
 export { origamiCanUndo, origamiUndo };

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -417,7 +417,6 @@ export function SetupElements(container: HTMLElement) {
         target.setAttribute("data-copyright", event.copyright);
         target.setAttribute("data-creator", event.creator);
         target.setAttribute("data-license", event.license);
-        post("edit/taskComplete");
     });
     SetupVideoEditing(container);
     SetupWidgetEditing(container);

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -388,6 +388,34 @@ export function SetupThingsSensitiveToStyleChanges(container: HTMLElement) {
         });
 }
 
+export function changeImage(imageInfo: {
+    imageIndex: number;
+    src: string; // must already appropriately URL-encoded.
+    copyright: string;
+    creator: string;
+    license: string;
+}) {
+    const container = Array.from(
+        document.getElementsByClassName("bloom-imageContainer")
+    )[imageInfo.imageIndex];
+
+    // I can't remember why, but what this is doing is saying that if the imageContainer
+    // has an <img> element, we're setting the src on that. But if it does not, we're
+    // setting the background-image on the container itself.
+    const img = container.getElementsByTagName("img")[0];
+    const target = img || container;
+    if (img) {
+        img.setAttribute("src", imageInfo.src);
+    } else {
+        container.setAttribute(
+            "style",
+            "background-image:url('" + imageInfo.src + "')"
+        );
+    }
+    target.setAttribute("data-copyright", imageInfo.copyright);
+    target.setAttribute("data-creator", imageInfo.creator);
+    target.setAttribute("data-license", imageInfo.license);
+}
 // Originally, all this code was in document.load and the selectors were acting
 // on all elements (not bound by the container).  I added the container bound so we
 // can add new elements (such as during layout mode) and call this on only newly added elements.
@@ -395,29 +423,7 @@ export function SetupThingsSensitiveToStyleChanges(container: HTMLElement) {
 // REVIEW: Some of these would be better off in OneTimeSetup, but too much risk to try to decide right now.
 export function SetupElements(container: HTMLElement) {
     SetupImagesInContainer(container);
-    WebSocketManager.addListener("edit", (event: IChangeImageEvent) => {
-        if (event.id !== "changeImage") {
-            return;
-        }
-        const container = Array.from(
-            document.getElementsByClassName("bloom-imageContainer")
-        )[event.imgIndex];
-        const img = container.getElementsByTagName("img")[0];
-        const target = img || container;
-        // This logic mirrors HtmlDom.SetImageElementUrl, except we assume event.src is
-        // already appropriately URL-encoded.
-        if (img) {
-            img.setAttribute("src", event.src);
-        } else {
-            container.setAttribute(
-                "style",
-                "background-image:url('" + event.src + "')"
-            );
-        }
-        target.setAttribute("data-copyright", event.copyright);
-        target.setAttribute("data-creator", event.creator);
-        target.setAttribute("data-license", event.license);
-    });
+
     SetupVideoEditing(container);
     SetupWidgetEditing(container);
     initializeBubbleManager();

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -212,7 +212,12 @@ export function addImageEditingButtons(containerDiv: HTMLElement): void {
 
     const addButtonHandler = (command: string) => {
         const button = $containerDiv.get(0)?.firstElementChild;
-        button?.addEventListener("click", () => {
+        button?.addEventListener("click", (e: MouseEvent) => {
+            // a rather sad api, but "detail >1" in chromium means this is a double click
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            if ((e as any).detail > 1) {
+                return;
+            }
             const imgIndex = Array.from(
                 document.getElementsByClassName("bloom-imageContainer")
             ).indexOf($containerDiv.get(0));

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -213,7 +213,10 @@ export function addImageEditingButtons(containerDiv: HTMLElement): void {
     const addButtonHandler = (command: string) => {
         const button = $containerDiv.get(0)?.firstElementChild;
         button?.addEventListener("click", (e: MouseEvent) => {
-            // a rather sad api, but "detail >1" in chromium means this is a double click
+            // "detail >1" in chromium means this is a double click.
+            // Note, if we have problems with timing, this wouldn't necessarily fix them.
+            // It's only going to debounce clicks that come in close enough to count as
+            // double clicks, presumably based on the OS's double click timing setting.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             if ((e as any).detail > 1) {
                 return;

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1489,7 +1489,7 @@ namespace Bloom.Edit
                 Logger.WriteMinorEvent("Starting ChangePicture {0}...", imageInfo.FileName);
                 var editor = new PageEditingModel();
                 editor.ChangePicture(
-                    _webSocketServer,
+                    GetEditingBrowser(),
                     CurrentBook.FolderPath,
                     imgIndex,
                     imageElement,

--- a/src/BloomExe/Edit/PageEditingModel.cs
+++ b/src/BloomExe/Edit/PageEditingModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -71,6 +71,7 @@ namespace Bloom.Edit
                 bookFolderPath,
                 isSameFile
             );
+            ImageUtils.SaveImageMetadata(imageInfo, Path.Combine(bookFolderPath, imageFileName));
             // Ask Javascript code to update the live version of the page.
             dynamic messageBundle = new DynamicJson();
             messageBundle.imgIndex = imgIndex;
@@ -78,13 +79,7 @@ namespace Bloom.Edit
             messageBundle.copyright = imageInfo.Metadata.CopyrightNotice ?? "";
             messageBundle.creator = imageInfo.Metadata.Creator ?? "";
             messageBundle.license = imageInfo.Metadata.License?.ToString() ?? "";
-            EditingViewApi.SendEventAndWaitForComplete(
-                webSocketServer,
-                "edit",
-                "changeImage",
-                messageBundle
-            );
-            ImageUtils.SaveImageMetadata(imageInfo, Path.Combine(bookFolderPath, imageFileName));
+            webSocketServer.SendBundle("edit", "changeImage", messageBundle);
         }
 
         /// <summary>

--- a/src/BloomExe/web/controllers/EditingViewApi.cs
+++ b/src/BloomExe/web/controllers/EditingViewApi.cs
@@ -79,12 +79,6 @@ namespace Bloom.web.controllers
                 false
             );
             apiHandler.RegisterEndpointHandler(
-                "edit/taskComplete",
-                HandleTaskComplete,
-                false,
-                false
-            );
-            apiHandler.RegisterEndpointHandler(
                 "editView/prevPageSplit",
                 HandlePrevPageSplit,
                 false
@@ -192,43 +186,6 @@ namespace Bloom.web.controllers
             int imgIndex = (int)data.imgIndex;
             View.OnCutImage(imgIndex);
             request.PostSucceeded();
-        }
-
-        // Allow whatever code is waiting in SendEventAndWaitForComplete to continue;
-        // whatever action the event prompted has finished.
-        private void HandleTaskComplete(ApiRequest request)
-        {
-            waitingForTaskComplete = false;
-            request.PostSucceeded();
-        }
-
-        private static bool waitingForTaskComplete;
-
-        // Send an event to Javascript and wait until it is done.
-        // The event MUST post edit/taskComplete when it is finished.
-        // Review: as implemented here, we can't cope with more than one thing at a time
-        // sending an event and waiting for it; that's currently OK since it's only used on the
-        // UI thread. Results will also be dubious if more than one client is listening to
-        // the websocket, but that's also something we don't expect (except
-        // when debugging in a separate browser).
-        // This feels messy, but how else are we to ask Javascript to do something...
-        // we're trying to retire runJavascript, not add more, and it's taking a kluge
-        // to make that syncrhronous, anyway...when we need to know it has finished?
-        public static void SendEventAndWaitForComplete(
-            BloomWebSocketServer socketServer,
-            string clientContext,
-            string eventId,
-            dynamic messageBundle
-        )
-        {
-            waitingForTaskComplete = true; // BEFORE we send the bundle, in case handleTaskComplete occurs before SendBundle returns
-            socketServer.SendBundle(clientContext, eventId, messageBundle);
-
-            while (waitingForTaskComplete)
-            {
-                Application.DoEvents();
-                Thread.Sleep(10);
-            }
         }
 
         private void HandleChangeImage(ApiRequest request)


### PR DESCRIPTION
The minimal fix here is just the one in bloomImages.ts.
However, looking at the rest of the code, it seems we were needlessly doing dangerous things to simulate synchronous behavior when it wasn't needed, so I removed that too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6469)
<!-- Reviewable:end -->
