### PR TITLE
Drop cleaning up page for garbage collection

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1291,7 +1291,6 @@ export function pageSelectionChanging() {
         removeOrigami(); // Enhance this makes a change when better it would only changed the
         const content = getBodyContentForSavePage();
         const userStylesheet = userStylesheetContent();
-        disconnectForGarbageCollection();
         postString(
             "common/javascriptResult",
             // We tossed up whether to use a JSON object here, but decided that it was simpler to just
@@ -1369,31 +1368,6 @@ export const pageUnloading = () => {
         theOneBubbleManager.cleanUp();
     }
 };
-
-// This is called leave a page (often right after the previous
-// method for changing pages).  It is mainly to clean things up so that garbage collection
-// won't lose multiple megabytes of data that both the DOM (C++) and Javascript subsystems
-// think the other is still using.
-function disconnectForGarbageCollection() {
-    // disconnect all event handlers
-    //review: was this, but TS didn't like it    $.find().off();
-    $("body")
-        .find("*")
-        .off();
-
-    const page = $(".bloom-page");
-    // blow away any img elements to ensure their data disappears.
-    // (the whole document is being replaced, and this happens after it's been saved to a file)
-    page.find("img").each(function() {
-        $(this).attr("src", "");
-    });
-    page.find("img").each(function() {
-        $(this).remove();
-    });
-    $("[style*='.background-image']").each(function() {
-        $(this).remove();
-    });
-}
 
 // These clipboard functions are implemented in Javascript because WebView2 doesn't seem to have
 // a C# api for doing them. I've made the exported functions synchronous because I'm not sure


### PR DESCRIPTION
This was recently a separate task when changing page, then became part of all saves which caused problems when staying on the same page. I don't think WebView2 needs the help avoiding memory leaks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6474)
<!-- Reviewable:end -->
