### PR TITLE
More accurate check for a messed up margin box (BL-13423)

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -3078,6 +3078,10 @@ namespace Bloom.Book
 		// the marginBox are inside it.
 		static bool HasMessedUpMarginBox(XmlElement page)
 		{
+			// Flyleaf pages are intentionally empty; they have no marginBox.
+			// See XMatterHelper.InjectFlyleafIfNeeded().
+			if (HtmlDom.IsFlyleafPage(page)) return false;
+
 			var marginBox = GetMarginBox(page);
 			if (marginBox == null)
 				return true; // marginBox should not be missing

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -2777,6 +2777,12 @@ namespace Bloom.Book
 			return HasClass(pageElement, "calendarMonthBottom");
 		}
 
+		// See XMatterHelper.InjectFlyleafIfNeeded().
+		public static bool IsFlyleafPage(XmlElement pageElement)
+		{
+			return HasClass(pageElement, "bloom-flyleaf");
+		}
+
 		// Make the image's alt attr match the image description for the specified language.
 		// If we don't have one, make the alt attr exactly an empty string (except branding images may be allowed to have custom alt text).
 		private static void SetImageAltAttrFromDescription(XmlElement img, string descriptionLang)


### PR DESCRIPTION
This replaces the previous fix by accurately determining if the marginBox is empty rather than skipping the check for calendar pages.

And handles flyleaf pages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6475)
<!-- Reviewable:end -->
