### PR TITLE
Fix dangerous sync javascript calls in thumbnailer (also BL-13370)

### DIFF
--- a/src/BloomExe/BookThumbNailer.cs
+++ b/src/BloomExe/BookThumbNailer.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Xml;
 using Bloom.Book;
 using Bloom.ImageProcessing;
@@ -362,7 +363,7 @@ namespace Bloom
         ///
         ///   The result is cached for possible future use so the caller should not dispose of it.
         ///   </summary>
-        public Image GetThumbnailForPage(
+        public async Task<Image> GetThumbnailForPage(
             Book.Book book,
             IPage page,
             bool isLandscape,
@@ -408,7 +409,7 @@ namespace Bloom
             }
             // In different books (or even the same one) in the same session we may have portrait and landscape
             // versions of the same template page. So we must use different IDs.
-            return _thumbnailProvider.GetThumbnail(
+            return await _thumbnailProvider.GetThumbnail(
                 page.Id + (isSquare ? "S" : (isLandscape ? "L" : "")),
                 pageDom,
                 thumbnailOptions

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -18,6 +18,7 @@ using Bloom.FontProcessing;
 using Bloom.MiscUI;
 using Bloom.ToPalaso.Experimental;
 using Bloom.Utils;
+using Bloom.web.controllers;
 using DesktopAnalytics;
 using L10NSharp;
 using SIL.IO;
@@ -409,6 +410,7 @@ namespace Bloom.Edit
         /// </summary>
         private void OnInsertPage(object page, PageInsertEventArgs e)
         {
+            SaveNow(); // there might be unsaved changes in the current page from before we clicked Add Page
             CurrentBook.InsertPageAfter(
                 DeterminePageWhichWouldPrecedeNextInsertion(),
                 page as Page,
@@ -1399,6 +1401,7 @@ namespace Bloom.Edit
                         _tasksToDoAfterSaving.RemoveAt(0);
                         task();
                     }
+                    PageTemplatesApi.LastSaveTime = DateTime.Now;
                 }
                 finally
                 {
@@ -1715,7 +1718,14 @@ namespace Bloom.Edit
 
         public void ShowAddPageDialog()
         {
-            SaveNow(); // At least in template mode, the current page shows in the Add Page dialog, and should be current.
+            // We would like to save here, but that leaves the page in a bad state in case the user cancels.
+            // Usually if we want to save but not go to another page, we we call SaveNow() and then RefreshDisplayOfCurrentPage().
+            // If we do that here, ShowAddPageDialog() does not bring up the dialog. So we decided to just not save here.
+            // If they actually add a page, we'll save then.
+            // The worst consequence is that if they add a page in a template, and then Add Page again, the thumbnail might not
+            // accurately reflect the new page.
+            // Usually, relevant changes will have been saved when Change Layout was turned off.
+            //SaveNow();
             _view.ShowAddPageDialog();
         }
 

--- a/src/BloomExe/IBrowser.cs
+++ b/src/BloomExe/IBrowser.cs
@@ -78,7 +78,7 @@ namespace Bloom
         /// Get a bitmap showing the current state of the browser. Caller should dispose.
         /// </summary>
         /// <returns></returns>
-        public abstract Bitmap CapturePreview_Synchronous_Dangerous();
+        public abstract Task<Bitmap> CapturePreview();
 
         /// <summary>
         /// If it returns true these are in place of our standard extensions; if false, the

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -510,18 +510,14 @@ namespace Bloom
 
         public override string Url => _webview.Source.ToString();
 
-        public override Bitmap CapturePreview_Synchronous_Dangerous()
+        public override async Task<Bitmap> CapturePreview()
         {
             var stream = new MemoryStream();
-            var task = _webview.CoreWebView2.CapturePreviewAsync(
+            await _webview.CoreWebView2.CapturePreviewAsync(
                 CoreWebView2CapturePreviewImageFormat.Png,
                 stream
             );
-            while (!task.IsCompleted)
-            {
-                Application.DoEvents();
-                Thread.Sleep(10);
-            }
+
             stream.Position = 0;
             return new Bitmap(stream);
         }


### PR DESCRIPTION
Also fixes a problem where calling SaveNow before launching the Add Page dialog left the page in a bad state if cancelled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6476)
<!-- Reviewable:end -->
