### PR TITLE
Fix overflow for Device16x9Landscape books, and maybe others (BL-13374)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -628,6 +628,7 @@ div.bloom-templateMode {
     .bloom-editable.overflow {
         overflow-y: scroll;
         display: block;
+        height: inherit; // BL-13374. This is needed to make the scroll bar work properly.
 
         // the language label at the bottom gets messed up once scrolling is on, so anchor it to the top
         &:after {


### PR DESCRIPTION
cherry-picked from master
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6477)
<!-- Reviewable:end -->
