### PR TITLE
BL-13475 padding update

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1218,25 +1218,26 @@ body :has(.bloom-page:focus-within, .bloom-page:hover) {
 .bloom-page:hover {
     // Show the padding, multilingual gap, etc as colored areas.
     // The ".split-pane-component-inner >"  disables this for overlays, where it's common to have backgrounds like transparent
-    .split-pane-component-inner {
+    .split-pane-component-inner > .bloom-translationGroup {
         // no: a border here will take up space, wrecking WYSIWYG
         // border: solid thin var(--page-structure-color);
         // box-sizing: border-box;
         // Also, you'd think you could use outline instead, but it doesn't show on the side; the
         // children over it up because they are the full width of this parent.
 
-        > .bloom-translationGroup .bloom-editable { 
-            outline: 1px solid var(--page-structure-color);
-            outline-offset: -1px; // else the white of an un-focussed box can just bleed into the white of the margin
-            background-color: var(--translationGroup-background-color) !important;
+        &:not(.bloom-background-gray) {
+            background-color: var(--page-structure-color) !important;
         }
 
-        // Use --page-structure-color to show the padding unless this is a gray-background box in which case it would look weird
-        > .bloom-translationGroup:not(.bloom-background-gray) {
-            background-color: var(--page-structure-color) !important;
-            .bloom-editable { 
-                background-color: var(--translationGroup-background-color) !important;
-            }
+        .bloom-editable {
+            outline: 1px solid var(--page-structure-color);
+            outline-offset: -1px; // else the white of an un-focussed box can just bleed into the white of the margin
+        }
+        // the parent translation group has the "page structure" color so we
+        // normally want to have the edit box be white. Note however that in the case that
+        // we have a grey box, we're giving up on structure color and just want it all to be grey.
+        &:not(.bloom-background-gray) .bloom-editable {
+            background-color: var(--marginBox-background-color) !important;
         }
     }
 }

--- a/src/BloomExe/Book/AppearanceSettings.cs
+++ b/src/BloomExe/Book/AppearanceSettings.cs
@@ -148,7 +148,6 @@ public class AppearanceSettings
         new CssStringVariableDef("pageNumber-left-margin", "page-number"),
         new CssStringVariableDef("pageNumber-right-margin", "page-number"),
         new CssStringVariableDef("pageNumber-top", "page-number"),
-        new CssStringVariableDef("translationGroup-background-color", "colors"),
     };
 
     /// <summary>

--- a/src/content/bookLayout/basePage-sharedRules.less
+++ b/src/content/bookLayout/basePage-sharedRules.less
@@ -141,13 +141,9 @@ textarea,
 .bloom-background-none {
     background-color: transparent;
 }
-
-// Change the translation group background color if the user sets the textbox to the gray background
-.bloom-page {
-    --translationGroup-background-color: var(--marginBox-background-color);
-}
-.bloom-background-gray {
-    --translationGroup-background-color: @preferredBackgroundGray;
+// repeated classes to increase our specificity artificially
+.bloom-translationGroup.bloom-background-gray.bloom-background-gray.bloom-background-gray {
+    background-color: @preferredBackgroundGray !important;
 }
 
 // The user can get this in by pressing shift-enter. See bloomField.ts
@@ -172,7 +168,7 @@ span.bloom-linebreak {
         // Ensure that the text wrapping in overlays is generally stable.  See BL-13135.
         // We would use the "stable" keyword, but that isn't implemented in most browsers.
         text-wrap: wrap;
-        box-sizing: content-box;    // keep the same space for the text when selected
+        box-sizing: content-box; // keep the same space for the text when selected
     }
 }
 

--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -679,7 +679,7 @@ div[data-book*="branding"] {
 
     // editMode.less may change this when we're editing
     .split-pane-component-inner > .bloom-translationGroup {
-        background-color: var(--translationGroup-background-color) !important;
+        background-color: var(--marginBox-background-color) !important;
     }
     // We need this at least for comics, which typically have a black background everywhere,
     // but we need to go back to white for xmatter pages, where we want to see the black text.
@@ -703,6 +703,11 @@ div[data-book*="branding"] {
     }
 }
 
+/* About the calc() here: depending on the margin, we may need to adjust the padding of the text to make it so that
+you get less padding on the side of the text that is next to edge of the page.
+
+About the "multiplicand" value: We don't want to do the aforementioned adjustment if the page margin is not providing a visual buffer.
+The buffer would be absent if the marginBox had a border or the page has a background color that is different from the marginBox color.*/
 .mixinLeftTgPadding {
     padding-left: calc(
         var(--topLevel-text-padding-left) -
@@ -714,30 +719,38 @@ div[data-book*="branding"] {
 }
 .mixinRightTgPadding {
     padding-right: calc(
-            var(--topLevel-text-padding-right) -
-                (
-                    var(--page-margin-right) *
-                        var(--page-and-marginBox-are-same-color-multiplicand)
-                )
-        );
+        var(--topLevel-text-padding-right) -
+            (
+                var(--page-margin-right) *
+                    var(--page-and-marginBox-are-same-color-multiplicand)
+            )
+    );
 }
 .mixinTopTgPadding {
     padding-top: calc(
-            var(--topLevel-text-padding-top) -
-                (
-                    var(--page-margin-top) *
-                        var(--page-and-marginBox-are-same-color-multiplicand)
-                )
-        );
+        var(--topLevel-text-padding-top) -
+            (
+                var(--page-margin-top) *
+                    var(--page-and-marginBox-are-same-color-multiplicand)
+            )
+    );
 }
 .mixinBottomTgPadding {
+    --amountOfExtraMarginAddedForPageNumber: calc(
+        var(--pageNumber-extra-height) * var(--pageNumber-show-multiplicand)
+    );
+    --totalBottomMargin: calc(
+        var(--page-margin-bottom) + var(--amountOfExtraMarginAddedForPageNumber)
+    );
+    --amountOfVisualPaddingProvidedByBottomMargin: calc(
+        var(--totalBottomMargin) *
+            var(--page-and-marginBox-are-same-color-multiplicand)
+    );
+
     padding-bottom: calc(
-            var(--topLevel-text-padding-bottom) -
-                (
-                    (var(--page-margin-bottom) + var(--pageNumber-extra-height)) *
-                        var(--page-and-marginBox-are-same-color-multiplicand)
-                )
-        );
+        var(--topLevel-text-padding-bottom) -
+            var(--amountOfVisualPaddingProvidedByBottomMargin)
+    );
 }
 
 // ----------------------------
@@ -745,22 +758,27 @@ div[data-book*="branding"] {
 // We want to improve the padding for the 99% of simple books, but we don't want to break
 // the small number of books that use origami to break the page up into little boxes.
 // Therefore the rules here only apply to direct descendants of the marginBox.
+// See BL-13475 for some discussion on limitations.
 // ----------------------------
 .marginBox {
-    &
-        > .split-pane
-        > .split-pane-component
-        > .split-pane-component-inner
-        > .bloom-translationGroup {
-        /* About the calc() here: depending on the margin, we may need to adjust the padding of the text to make it so that
-you get less padding on the side of the text that is next to edge of the page.
-
-About the "multiplicand" value: We don't want to do the aforementioned adjustment if the page margin is not providing a visual buffer.
-The buffer would be absent if the marginBox had a border or the page has a background color that is different from the marginBox color.*/
-        .mixinLeftTgPadding;
-        .mixinRightTgPadding;
-        .mixinTopTgPadding;
-        .mixinBottomTgPadding;
+    // no split at all
+    .split-pane-component-inner > ,
+    // has been split
+    & > .split-pane > .split-pane-component > .split-pane-component-inner > {
+        .bloom-translationGroup {
+            .mixinLeftTgPadding;
+            .mixinRightTgPadding;
+            .mixinTopTgPadding;
+            .mixinBottomTgPadding;
+        }
+        // if the textbox has a special background color (only gray is offered for now),
+        // then visually the margin doesn't matter. We need the padding.
+        .bloom-translationGroup.bloom-background-gray {
+            padding-top: var(--topLevel-text-padding-top);
+            padding-bottom: var(--topLevel-text-padding-bottom);
+            padding-right: var(--topLevel-text-padding-right);
+            padding-left: var(--topLevel-text-padding-left);
+        }
     }
     /* on these "inner" edges, we don't need to consider the page margin */
     &


### PR DESCRIPTION
Fixes:
* padding on bottom in picture on top
* padding all around on text-only
* disable "smart padding" (which takes page margins into account) for grey boxes
* remove unneeded appearance property

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6497)
<!-- Reviewable:end -->
