### PR TITLE
Center page numbers on non-device layouts in bloom-player (BL-13311)

### DIFF
--- a/src/content/appearanceThemes/appearance-theme-default.css
+++ b/src/content/appearanceThemes/appearance-theme-default.css
@@ -155,10 +155,13 @@
 }
 .bloom-page[class*="Device"] {
     --page-margin: 10px;
+}
 
-    /* Deliberately set both of these, which combines with a special device rule
+.bloom-page[class*="Device"],
+.bloomPlayer-page .bloom-page {
+    /* Deliberately set both of these, which combines with a special device/bloom-player rule
      * in basePage.less which sets both left and right margin to auto, and we get
-     * centered as the default for device pages. (To override this, you need to
+     * centered as the default for device/bloom-player pages. (To override this, you need to
      * set the margin you don't want to something like "deliberately-invalid".)*/
     --pageNumber-right-margin: 0;
     --pageNumber-always-left-margin: 0;

--- a/src/content/bookLayout/pageNumbers.less
+++ b/src/content/bookLayout/pageNumbers.less
@@ -43,6 +43,7 @@
     // rule go ahead and set left for them, too, just in case we encounter a case where
     // --pageNumber-always-left-margin has no value.
     &[class*="Device"]:after,
+    .bloomPlayer-page &:after,
     &.side-left:after {
         left: var(--pageNumber-left-margin);
     }
@@ -51,7 +52,8 @@
         right: var(--pageNumber-right-margin);
     }
 
-    &[class*="Device"]:after {
+    &[class*="Device"]:after,
+    .bloomPlayer-page &:after {
         // note that here the property has "always"
         left: var(--pageNumber-always-left-margin);
     }
@@ -61,7 +63,8 @@
      * To defeat that, either right: or left: must not be set, which I've only managed
      * to achieve (since the default theme sets them both) by setting to something
      * deliberately invalid. */
-    &[class*="Device"]:after {
+    &[class*="Device"]:after,
+    .bloomPlayer-page &:after {
         // in the default theme, we always center the page number; both right and left will be 0 for that
         // if a theme wants to set the page number on the left, it should set --pageNumber-right-margin to deliberately-invalid
         // if a theme wants to set the page number on the right, it should set --pageNumber-always-left-margin to deliberately-invalid


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6529)
<!-- Reviewable:end -->
