### PR TITLE
Fix padding for overlay bubbles (BL-13585 and BL-13604)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -2514,7 +2514,7 @@ export class BubbleManager {
             defaultNewTextLanguage +
             "'><p></p></div>";
         const transGroupDivClasses =
-            "bloom-translationGroup bloom-leadingElement Bubble-style";
+            "bloom-translationGroup bloom-leadingElement";
         const transGroupHtml =
             "<div class='" +
             transGroupDivClasses +

--- a/src/content/bookLayout/bubble.less
+++ b/src/content/bookLayout/bubble.less
@@ -254,6 +254,9 @@
             // the default for align-content is stretch, but that overrides our Paragraph Spacing setting and can create big gaps between the flex-items (paragraphs).
             align-content: center;
 
+            // This is set 100% elsewhere, but that doesn't work for bubbles with padding.  (BL-13604)
+            width: auto;
+
             // Paragraphs are the expected flex-items
             p {
                 // Set to 100% so that two paragraphs can't share a line in the flex layout


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6552)
<!-- Reviewable:end -->
