### PR TITLE
Remove deprecated RegisterEndpointLegacy method (BL-12123)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/leveledReaderToolboxTool.pug
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/leveledReaderToolboxTool.pug
@@ -112,15 +112,15 @@ html
 					span(data-i18n='EditTab.Toolbox.LeveledReaderTool.KeepInMind') Keep in mind
 					ul
 						li
-							a(href='api/externalLink/leveledRTInfo/leveledReaderInfo-en.html?fragment=Vocabulary', data-i18n='EditTab.Toolbox.LeveledReaderTool.Vocabulary') Vocabulary
+							a(href='api/externalLink?path=leveledRTInfo/leveledReaderInfo-en.html&fragment=Vocabulary', data-i18n='EditTab.Toolbox.LeveledReaderTool.Vocabulary') Vocabulary
 						li
-							a(href='api/externalLink/leveledRTInfo/leveledReaderInfo-en.html?fragment=Formatting', data-i18n='EditTab.Toolbox.LeveledReaderTool.Formatting') Formatting
+							a(href='api/externalLink?path=leveledRTInfo/leveledReaderInfo-en.html&fragment=Formatting', data-i18n='EditTab.Toolbox.LeveledReaderTool.Formatting') Formatting
 						li
-							a(href='api/externalLink/leveledRTInfo/leveledReaderInfo-en.html?fragment=Predictability', data-i18n='EditTab.Toolbox.LeveledReaderTool.Predictability') Predictability
+							a(href='api/externalLink?path=leveledRTInfo/leveledReaderInfo-en.html&fragment=Predictability', data-i18n='EditTab.Toolbox.LeveledReaderTool.Predictability') Predictability
 						li
-							a(href='api/externalLink/leveledRTInfo/leveledReaderInfo-en.html?fragment=IllustrationSupport', data-i18n='EditTab.Toolbox.LeveledReaderTool.IllustrationSupport') Illustration Support
+							a(href='api/externalLink?path=leveledRTInfo/leveledReaderInfo-en.html&fragment=IllustrationSupport', data-i18n='EditTab.Toolbox.LeveledReaderTool.IllustrationSupport') Illustration Support
 						li
-							a(href='api/externalLink/leveledRTInfo/leveledReaderInfo-en.html?fragment=ChoiceOfTopic', data-i18n='EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic') Choice of Topic
+							a(href='api/externalLink?path=leveledRTInfo/leveledReaderInfo-en.html&fragment=ChoiceOfTopic', data-i18n='EditTab.Toolbox.LeveledReaderTool.ChoiceOfTopic') Choice of Topic
 
 				div.copyBookStats(onclick='toolboxBundle.copyLeveledReaderStatsToClipboard();')
 					p

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/ReaderSetup.pug
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/ReaderSetup.pug
@@ -69,7 +69,7 @@ html
 								a#open-text-folder.blue-link(href='', data-i18n='ReaderSetup.Words.SampleTextFolder') Sample Texts Folder
 							#dls_word_lists.disableable.flex-column-expanding-row
 							#how_to_export(style="display: none")
-								a(href="/bloom/api/help/Tasks/Edit_tasks/Decodable_Reader_Tool/Language_tab.htm", data-i18n='ReaderSetup.HowToExport') Help exporting and converting files to use as sample texts
+								a(href="/bloom/api/help?topic=Tasks/Edit_tasks/Decodable_Reader_Tool/Language_tab.htm", data-i18n='ReaderSetup.HowToExport') Help exporting and converting files to use as sample texts
 			#dlstabs-2.reader-setup-tab
 				.floating(style='width: 100%; box-sizing: border-box; margin-bottom: 8px;')
 					table

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
@@ -145,7 +145,7 @@ function process_UI_Message(event: MessageEvent): void {
                     break;
                 default:
             }
-            if (helpFile) post("help/" + helpFile);
+            if (helpFile) post("help?topic=" + helpFile);
             return;
         }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookToolboxTool.pug
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookToolboxTool.pug
@@ -50,4 +50,4 @@ html
 					+buttonGroup('listen', 'disabled', '', '', 'Listen to the whole page', 'Listen')
 				#advanced-talking-book-controls-react-container
 
-				a.help-link(href='/bloom/api/help/Tasks/Edit_tasks/Record_Audio/Talking_Book_Tool_overview.htm', data-i18n='Common.Help') Help
+				a.help-link(href='/bloom/api/help?topic=Tasks/Edit_tasks/Record_Audio/Talking_Book_Tool_overview.htm', data-i18n='Common.Help') Help

--- a/src/BloomBrowserUI/pageChooser/PageChooserDialog.tsx
+++ b/src/BloomBrowserUI/pageChooser/PageChooserDialog.tsx
@@ -48,7 +48,7 @@ export const getTemplatePageImageSource = (
     //NB:  without the generateThumbnaiIfNecessary=true, we can run out of worker threads and get deadlocked.
     //See EnhancedImageServer.IsRecursiveRequestContext
     return (
-        `${urlPrefix}pageTemplateThumbnail/` +
+        `${urlPrefix}pageTemplateThumbnail?path=` +
         encodeURIComponent(templateBookFolderUrl) +
         "/template/" +
         encodeURIComponent(label) +

--- a/src/BloomBrowserUI/publish/ePUBPublish/ePUBPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ePUBPublish/ePUBPublishScreen.tsx
@@ -200,7 +200,7 @@ const EPUBPublishScreenInternal: React.FunctionComponent<{
                                 </li>
                                 <li>
                                     <PWithLink
-                                        href="/bloom/api/help/Concepts/EPUB.htm"
+                                        href="/bloom/api/help?topic=Concepts/EPUB.htm"
                                         l10nKey="PublishTab.Epub.FeatureLimitations"
                                         l10nComment="The text inside the [square brackets] will become a link to a website."
                                     >

--- a/src/BloomBrowserUI/publish/metadata/BookMetadataDialog.tsx
+++ b/src/BloomBrowserUI/publish/metadata/BookMetadataDialog.tsx
@@ -99,7 +99,7 @@ export default class BookMetadataDialog extends React.Component<
                             variant="outlined"
                             enabled={true}
                             l10nKey="Common.Help"
-                            clickApiEndpoint="help/User_Interface/Dialog_boxes/Book_Metadata_dialog_box.htm"
+                            clickApiEndpoint="help?topic=User_Interface/Dialog_boxes/Book_Metadata_dialog_box.htm"
                             hasText={true}
                         >
                             Help

--- a/src/BloomBrowserUI/react_components/helpLink.tsx
+++ b/src/BloomBrowserUI/react_components/helpLink.tsx
@@ -17,7 +17,7 @@ export class HelpLink extends LocalizableElement<IHelpLinkProps, {}> {
         return (
             <Link
                 style={this.props.style}
-                href={"/bloom/api/help/" + this.props.helpId}
+                href={"/bloom/api/help?topic=" + this.props.helpId}
                 underline="hover"
             >
                 {this.getLocalizedContent()}

--- a/src/BloomBrowserUI/react_components/htmlHelpLink.tsx
+++ b/src/BloomBrowserUI/react_components/htmlHelpLink.tsx
@@ -14,7 +14,7 @@ export default class HtmlHelpLink extends LocalizableElement<
     IHtmlHelpLinkProps,
     {}
 > {
-    private target = `externalLink/help/${this.props.fileid}-en.htm`;
+    private target = `externalLink?path=help/${this.props.fileid}-en.htm`;
 
     public render() {
         return (

--- a/src/BloomBrowserUI/teamCollection/TeamCollectionSettingsPanel.tsx
+++ b/src/BloomBrowserUI/teamCollection/TeamCollectionSettingsPanel.tsx
@@ -2,7 +2,13 @@
 import { jsx, css } from "@emotion/react";
 
 import * as React from "react";
-import { get, post, postJson, postString, useApiStringState } from "../utils/bloomApi";
+import {
+    get,
+    post,
+    postJson,
+    postString,
+    useApiStringState
+} from "../utils/bloomApi";
 import { P } from "../react_components/l10nComponents";
 import { RequiresBloomEnterpriseOverlayWrapper } from "../react_components/requiresBloomEnterprise";
 import "./TeamCollectionSettingsPanel.less";
@@ -25,7 +31,9 @@ export const TeamCollectionSettingsPanel: React.FunctionComponent = props => {
         ""
     );
 
-    const [adminstratorEmail, setAdminstratorEmail] = React.useState<string>("");
+    const [adminstratorEmail, setAdminstratorEmail] = React.useState<string>(
+        ""
+    );
 
     useEffect(() => {
         get("settings/administrators", result => {
@@ -78,14 +86,17 @@ export const TeamCollectionSettingsPanel: React.FunctionComponent = props => {
             >
                 {repoFolderPath}
             </a>
-            <Label l10nKey="TeamCollection.AdministratorEmails" htmlFor="adminstratorEmails">
+            <Label
+                l10nKey="TeamCollection.AdministratorEmails"
+                htmlFor="adminstratorEmails"
+            >
                 Administrator Emails:
             </Label>
-         <TextField
+            <TextField
                 id="adminstratorEmails"
                 value={adminstratorEmail}
                 onChange={event => {
-                    const newAdminString: string = event.target.value; 
+                    const newAdminString: string = event.target.value;
                     setAdminstratorEmail(newAdminString);
                     postString("settings/administrators", newAdminString);
                 }}
@@ -111,7 +122,7 @@ export const TeamCollectionSettingsPanel: React.FunctionComponent = props => {
                     hasText={true}
                     onClick={() =>
                         post(
-                            "help/Tasks/Basic_tasks/Team_Collections/Add_someone_to_a_Team_Collection.htm"
+                            "help?topic=Tasks/Basic_tasks/Team_Collections/Add_someone_to_a_Team_Collection.htm"
                         )
                     }
                 >
@@ -155,7 +166,7 @@ export const TeamCollectionSettingsPanel: React.FunctionComponent = props => {
                     temporarilyDisableI18nWarning={true}
                     onClick={() =>
                         post(
-                            "help/Tasks/Basic_tasks/Team_Collections/Join_a_Team_Collection.htm"
+                            "help?topic=Tasks/Basic_tasks/Team_Collections/Join_a_Team_Collection.htm"
                         )
                     }
                 >

--- a/src/BloomExe/Edit/AudioRecording.cs
+++ b/src/BloomExe/Edit/AudioRecording.cs
@@ -103,54 +103,54 @@ namespace Bloom.Edit
         {
             // HandleStartRecording seems to need to be on the UI thread in order for HandleEndRecord() to detect the correct state.
             apiHandler
-                .RegisterEndpointLegacy("audio/startRecord", HandleStartRecording, true)
+                .RegisterEndpointHandler("audio/startRecord", HandleStartRecording, true)
                 .Measureable();
 
             // Note: This handler locks and unlocks a shared resource (_completeRecording lock).
             // Any other handlers depending on this resource should not wait on the same thread (i.e. the UI thread) or deadlock can occur.
             apiHandler
-                .RegisterEndpointLegacy("audio/endRecord", HandleEndRecord, true)
+                .RegisterEndpointHandler("audio/endRecord", HandleEndRecord, true)
                 .Measureable();
 
             // Any handler which retrieves information from the audio folder SHOULD wait on the _completeRecording lock (call WaitForRecordingToComplete()) to ensure that it sees
             // a consistent state of the audio folder, and therefore should NOT run on the UI thread.
             // Also, explicitly setting requiresSync to true (even tho that's default anyway) to make concurrency less complicated to think about
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "audio/checkForAnyRecording",
                 HandleCheckForAnyRecording,
                 false,
                 true
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "audio/checkForAllRecording",
                 HandleCheckForAllRecording,
                 false,
                 true
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "audio/deleteSegment",
                 HandleDeleteSegment,
                 false,
                 true
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "audio/checkForSegment",
                 HandleCheckForSegment,
                 false,
                 true
             );
-            apiHandler.RegisterEndpointLegacy("audio/wavFile", HandleAudioFileRequest, false, true);
+            apiHandler.RegisterEndpointHandler("audio/wavFile", HandleAudioFileRequest, false, true);
 
             // Doesn't matter whether these are on UI thread or not, so using the old default which was true
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "audio/currentRecordingDevice",
                 HandleCurrentRecordingDevice,
                 true
             );
-            apiHandler.RegisterEndpointLegacy("audio/devices", HandleAudioDevices, true);
+            apiHandler.RegisterEndpointHandler("audio/devices", HandleAudioDevices, true);
 
-            apiHandler.RegisterEndpointLegacy("audio/copyAudioFile", HandleCopyAudioFile, false);
-            apiHandler.RegisterEndpointLegacy("audio/stopMonitoring", HandleStopMonitoring, true);
+            apiHandler.RegisterEndpointHandler("audio/copyAudioFile", HandleCopyAudioFile, false);
+            apiHandler.RegisterEndpointHandler("audio/stopMonitoring", HandleStopMonitoring, true);
 
             Debug.Assert(
                 BloomServer.portForHttp > 0,

--- a/src/BloomExe/Edit/ToolboxView.cs
+++ b/src/BloomExe/Edit/ToolboxView.cs
@@ -44,7 +44,7 @@ namespace Bloom.Edit
     {
         public static void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
-            apiHandler.RegisterEndpointLegacy("toolbox/settings", HandleSettings, false);
+            apiHandler.RegisterEndpointHandler("toolbox/settings", HandleSettings, false);
         }
 
         /// <summary>

--- a/src/BloomExe/HelpLauncher.cs
+++ b/src/BloomExe/HelpLauncher.cs
@@ -56,11 +56,10 @@ namespace Bloom
 
         public static void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
-            apiHandler.RegisterEndpointLegacy(
-                "help/.*",
+            apiHandler.RegisterEndpointHandler("help",
                 (request) =>
                 {
-                    var topic = request.LocalPath().Replace("api/help", "");
+                    var topic = request.RequiredParam("topic");
                     Show(Application.OpenForms.Cast<Form>().Last(), topic);
                     //if this is called from a simple html anchor, we don't want the browser to do anything
                     request.ExternalLinkSucceeded();

--- a/src/BloomExe/Spreadsheet/SpreadsheetApi.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetApi.cs
@@ -38,7 +38,7 @@ namespace Bloom.Spreadsheet
             // go through a single "bookCommand/" API, so we don't register that here.
             // Instead all we need to register is any api enpoints used by our own spreadsheet dialogs
 
-            apiHandler.RegisterEndpointLegacy("spreadsheet/export", ExportToSpreadsheet, true);
+            apiHandler.RegisterEndpointHandler("spreadsheet/export", ExportToSpreadsheet, true);
         }
 
         public void ShowExportToSpreadsheetUI(Book.Book book)

--- a/src/BloomExe/Utils/PerformanceMeasurement.cs
+++ b/src/BloomExe/Utils/PerformanceMeasurement.cs
@@ -40,7 +40,7 @@ namespace Bloom.Utils
 
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "performance/showCsvFile",
                 (request) =>
                 {
@@ -49,7 +49,7 @@ namespace Bloom.Utils
                 },
                 false
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "performance/applicationInfo",
                 (request) =>
                 {
@@ -59,7 +59,7 @@ namespace Bloom.Utils
                 },
                 false
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "performance/allMeasurements",
                 (request) =>
                 {

--- a/src/BloomExe/web/PageListApi.cs
+++ b/src/BloomExe/web/PageListApi.cs
@@ -34,26 +34,26 @@ namespace Bloom.web
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
             apiHandler
-                .RegisterEndpointLegacy("pageList/pages", HandlePagesRequest, false)
+                .RegisterEndpointHandler("pageList/pages", HandlePagesRequest, false)
                 .Measureable();
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "pageList/pageContent",
                 HandlePageContentRequest,
                 false
             );
             apiHandler
-                .RegisterEndpointLegacy("pageList/pageMoved", HandlePageMovedRequest, true)
+                .RegisterEndpointHandler("pageList/pageMoved", HandlePageMovedRequest, true)
                 .Measureable();
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "pageList/pageClicked",
                 HandlePageClickedRequest,
                 true
             );
             apiHandler
-                .RegisterEndpointLegacy("pageList/menuClicked", HandleShowMenuRequest, true)
+                .RegisterEndpointHandler("pageList/menuClicked", HandleShowMenuRequest, true)
                 .Measureable();
 
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "pageList/bookAttributesThatMayAffectDisplay",
                 (request) =>
                 {

--- a/src/BloomExe/web/ReadersApi.cs
+++ b/src/BloomExe/web/ReadersApi.cs
@@ -65,7 +65,7 @@ namespace Bloom.Api
 
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "collection/defaultFont",
                 request =>
                 {
@@ -77,9 +77,24 @@ namespace Bloom.Api
                 handleOnUiThread: false
             );
 
-            apiHandler.RegisterEndpointLegacy("readers/ui/.*", HandleRequest, true);
-            apiHandler.RegisterEndpointLegacy("readers/io/.*", HandleRequest, false);
-            apiHandler.RegisterEndpointLegacy("directoryWatcher/", ProcessDirectoryWatcher, false);
+            apiHandler.RegisterEndpointHandler("readers/ui/chooseAllowedWordsListFile", HandleChooseAllowedWordsListFile, true);
+            apiHandler.RegisterEndpointHandler("readers/ui/copyBookStatsToClipboard", HandleCopyBookStatsToClipboard, true);
+            apiHandler.RegisterEndpointHandler("readers/ui/makeLetterAndWordList", HandleMakeLetterAndWordList, true);
+            apiHandler.RegisterEndpointHandler("readers/ui/openTextsFolder", HandleOpenTextsFolder, true);
+            apiHandler.RegisterEndpointHandler("readers/ui/sampleTextsList", HandleSampleTextsList, true);  // why overlap with the io one?
+
+            apiHandler.RegisterEndpointHandler("readers/io/allowedWordsList", HandleAllowedWordsList, false);
+            apiHandler.RegisterEndpointHandler("readers/io/defaultLevel", HandleDefaultLevel, false);
+            apiHandler.RegisterEndpointHandler("readers/io/defaultStage", HandleDefaultStage, false);
+            apiHandler.RegisterEndpointHandler("readers/io/readerSettingsEditForbidden", HandleReaderSettingsEditForbidden, false);
+            apiHandler.RegisterEndpointHandler("readers/io/readerToolSettings", HandleReaderToolSettings, false);
+            apiHandler.RegisterEndpointHandler("readers/io/sampleFileContents", HandleSampleFileContents, false);
+            apiHandler.RegisterEndpointHandler("readers/io/sampleTextsList", HandleSampleTextsList, false); // why overlap with the ui one?
+            apiHandler.RegisterEndpointHandler("readers/io/synphonyLanguageData", HandleSynphonyLanguageData, false);
+            apiHandler.RegisterEndpointHandler("readers/io/textOfContentPages", HandleTextOfContentPages, false);
+            apiHandler.RegisterEndpointHandler("readers/io/test", r => r.PostSucceeded(), false);   // used by unit test
+
+            apiHandler.RegisterEndpointHandler("directoryWatcher", ProcessDirectoryWatcher, false);
 
             //we could do them all like this:
             //server.RegisterEndpointLegacy("readers/loadReaderToolSettings", r=> r.ReplyWithJson(GetDefaultReaderSettings(r.CurrentCollectionSettings)));
@@ -93,249 +108,275 @@ namespace Bloom.Api
             get { return _bookSelection.CurrentSelection; }
         }
 
-        public void HandleRequest(ApiRequest request)
+        private bool IsRequestInvalid(ApiRequest request)
         {
             if (CurrentBook == null)
             {
                 Debug.Fail("BL-836 reproduction?");
                 // ReSharper disable once HeuristicUnreachableCode
                 request.Failed("CurrentBook is null");
-                return;
+                return true;
             }
             if (request.CurrentCollectionSettings == null)
             {
                 Debug.Fail("BL-836 reproduction?");
                 // ReSharper disable once HeuristicUnreachableCode
                 request.Failed("CurrentBook.CollectionSettings is null");
-                return;
+                return true;
             }
-
-            var lastSegment = request.LocalPath().Split(new char[] { '/' }).Last();
-
-            switch (lastSegment)
+            return false;
+        }
+        private void HandleChooseAllowedWordsListFile(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            lock (request)
             {
-                case "test":
+                request.ReplyWithText(ShowSelectAllowedWordsFileDialog());
+            }
+        }
+
+        private void HandleCopyBookStatsToClipboard(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            // See https://issues.bloomlibrary.org/youtrack/issue/BL-10018.
+            string bookStatsString;
+            try
+            {
+                bookStatsString = request.RequiredPostJson();
+                dynamic bookStats = DynamicJson.Parse(bookStatsString);
+                var headerBldr = new StringBuilder();
+                var dataBldr = new StringBuilder();
+                headerBldr.Append("Book Title");
+                var title = _bookSelection.CurrentSelection.Title;
+                title = title.Replace("\"", "\"\""); // Double double quotes to get Excel to recognize them.
+                dataBldr.AppendFormat("\"{0}\"", title);
+                headerBldr.Append("\tLevel");
+                dataBldr.AppendFormat("\t\"Level {0}\"", bookStats["levelNumber"]);
+                headerBldr.Append("\tNumber of Pages with Text");
+                dataBldr.AppendFormat("\t{0}", bookStats["pageCount"]);
+                headerBldr.Append("\tTotal Number of Words");
+                dataBldr.AppendFormat("\t{0}", bookStats["actualWordCount"]);
+                headerBldr.Append("\tTotal Number of Sentences");
+                dataBldr.AppendFormat("\t{0}", bookStats["actualSentenceCount"]);
+                headerBldr.Append("\tAverage No of Words per Page with Text");
+                dataBldr.AppendFormat("\t{0:0.#}", bookStats["actualAverageWordsPerPage"]);
+                headerBldr.Append("\tAverage No of Sentences per Page with Text");
+                dataBldr.AppendFormat(
+                    "\t{0:0.#}",
+                    bookStats["actualAverageSentencesPerPage"]
+                );
+                headerBldr.Append("\tNumber of Unique Words");
+                dataBldr.AppendFormat("\t{0}", bookStats["actualUniqueWords"]);
+                headerBldr.Append("\tAverage Word Length");
+                dataBldr.AppendFormat("\t{0:0.#}", bookStats["actualAverageGlyphsPerWord"]);
+                headerBldr.Append("\tAverage Sentence Length");
+                dataBldr.AppendFormat(
+                    "\t{0:0.#}",
+                    bookStats["actualAverageWordsPerSentence"]
+                );
+                headerBldr.Append("\tMaximum Word Length");
+                dataBldr.AppendFormat("\t{0}", bookStats["actualMaxGlyphsPerWord"]);
+                headerBldr.Append("\tMaximum Sentence Length");
+                dataBldr.AppendFormat("\t{0}", bookStats["actualMaxWordsPerSentence"]);
+                // "actualWordsPerPageBook" is the maximum number of words on a page in the book
+                // It's in the json data, but not asked for in the clipboard copying.
+                var stringToSave =
+                    headerBldr.ToString() + Environment.NewLine + dataBldr.ToString();
+                PortableClipboard.SetText(stringToSave);
+            }
+            catch (IOException e)
+            {
+                SIL.Reporting.Logger.WriteError(
+                    "Copying book statistics to clipboard failed to get Json",
+                    e
+                );
+                request.Failed("Copying book statistics to clipboard failed to get Json");
+            }
+            request.PostSucceeded();
+        }
+
+        private void HandleMakeLetterAndWordList(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            MakeLetterAndWordList(
+                request.RequiredPostString("settings"),
+                request.RequiredPostString("allWords")
+            );
+            request.PostSucceeded();
+        }
+
+        private void HandleOpenTextsFolder(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            OpenTextsFolder();
+            request.PostSucceeded();
+        }
+
+        private void HandleSampleTextsList(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            //note, as part of this reply, we send the path of the "ReaderToolsWords-xyz.json" which is *written* by the "synphonyLanguageData" endpoint above
+            request.ReplyWithText(
+                GetSampleTextsList(request.CurrentCollectionSettings.SettingsFilePath)
+            );
+        }
+
+        private void HandleAllowedWordsList(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            switch (request.HttpMethod)
+            {
+                case HttpMethods.Delete:
+                    RecycleAllowedWordListFile(request.RequiredParam("fileName"));
                     request.PostSucceeded();
                     break;
-
-                case "readerSettingsEditForbidden":
+                case HttpMethods.Get:
+                    var fileName = request.RequiredParam("fileName");
                     request.ReplyWithText(
-                        _tcManager.OkToEditCollectionSettings
-                            ? ""
-                            : WorkspaceView.MustBeAdminMessage(request.CurrentCollectionSettings)
-                    );
-                    break;
-
-                case "readerToolSettings":
-                    if (request.HttpMethod == HttpMethods.Get)
-                        request.ReplyWithJson(GetReaderSettings(request.CurrentBook.BookData));
-                    else
-                    {
-                        var path = DecodableReaderToolSettings.GetReaderToolsSettingsFilePath(
-                            request.CurrentCollectionSettings
-                        );
-                        var content = request.RequiredPostJson();
-                        RobustFile.WriteAllText(path, content, Encoding.UTF8);
-                        request.PostSucceeded();
-                    }
-                    break;
-
-                //note, this endpoint is confusing because it appears that ultimately we only use the word list out of this file (see "sampleTextsList").
-                //This ends up being written to a ReaderToolsWords-xyz.json (matching its use, if not it contents).
-                case "synphonyLanguageData":
-                    //This is the "post". There is no direct "get", but the name of the file is given in the "sampleTextList" reply, below.
-                    // We've had situations (BL-4313 and friends) where reading the posted data fails. This seems to be due to situations
-                    // where we have a very large block of data and are rapidly switching between books. But as far as I can tell, the only
-                    // case where it's at all important to capture the new language data is if the user has been changing settings and
-                    // in particular editing the word list. Timing out the save in that situation seems very unlikely to fail.
-                    // So, in the interests of preventing the crash when switching books fast, we will ignore failure to read all the
-                    // json, and just not update the file. We would in any case keep only the version of the data sent to us by
-                    // the last book which sends it, and that one is unlikely to get interrupted.
-                    string langdata;
-                    try
-                    {
-                        langdata = request.RequiredPostJson();
-                    }
-                    catch (IOException e)
-                    {
-                        SIL.Reporting.Logger.WriteError(
-                            "Saving synphonyLanguageData failed to get Json",
-                            e
-                        );
-                        break;
-                    }
-
-                    SaveSynphonyLanguageData(langdata);
-                    request.PostSucceeded();
-                    break;
-
-                case "sampleTextsList":
-                    //note, as part of this reply, we send the path of the "ReaderToolsWords-xyz.json" which is *written* by the "synphonyLanguageData" endpoint above
-                    request.ReplyWithText(
-                        GetSampleTextsList(request.CurrentCollectionSettings.SettingsFilePath)
-                    );
-                    break;
-
-                case "sampleFileContents":
-                    request.ReplyWithText(
-                        GetTextFileContents(
-                            request.RequiredParam("fileName"),
-                            WordFileType.SampleFile
+                        RemoveEmptyAndDupes(
+                            GetTextFileContents(fileName, WordFileType.AllowedWordsFile)
                         )
                     );
                     break;
-
-                case "textOfContentPages":
-                    request.ReplyWithText(GetTextOfContentPagesAsJson());
-                    break;
-
-                case "makeLetterAndWordList":
-                    MakeLetterAndWordList(
-                        request.RequiredPostString("settings"),
-                        request.RequiredPostString("allWords")
-                    );
-                    request.PostSucceeded();
-                    break;
-
-                case "openTextsFolder":
-                    OpenTextsFolder();
-                    request.PostSucceeded();
-                    break;
-
-                case "chooseAllowedWordsListFile":
-                    lock (request)
-                    {
-                        request.ReplyWithText(ShowSelectAllowedWordsFileDialog());
-                    }
-                    break;
-
-                case "allowedWordsList":
-                    switch (request.HttpMethod)
-                    {
-                        case HttpMethods.Delete:
-                            RecycleAllowedWordListFile(request.RequiredParam("fileName"));
-                            request.PostSucceeded();
-                            break;
-                        case HttpMethods.Get:
-                            var fileName = request.RequiredParam("fileName");
-                            request.ReplyWithText(
-                                RemoveEmptyAndDupes(
-                                    GetTextFileContents(fileName, WordFileType.AllowedWordsFile)
-                                )
-                            );
-                            break;
-                        default:
-                            request.Failed("Http verb not handled");
-                            break;
-                    }
-                    break;
-                case "defaultLevel":
-                    if (request.HttpMethod == HttpMethods.Get)
-                    {
-                        request.ReplyWithText(Settings.Default.CurrentLevel.ToString());
-                    }
-                    else
-                    {
-                        int level;
-                        if (int.TryParse(request.RequiredParam("level"), out level))
-                        {
-                            Settings.Default.CurrentLevel = level;
-                            Settings.Default.Save();
-                        }
-                        else
-                        {
-                            // Don't think any sort of runtime failure is worthwhile here.
-                            Debug.Fail("could not parse level number");
-                        }
-                        request.PostSucceeded(); // technically it didn't if we didn't parse the number
-                    }
-                    break;
-                case "defaultStage":
-                    if (request.HttpMethod == HttpMethods.Get)
-                    {
-                        request.ReplyWithText(Settings.Default.CurrentStage.ToString());
-                    }
-                    else
-                    {
-                        int stage;
-                        if (int.TryParse(request.RequiredParam("stage"), out stage))
-                        {
-                            Settings.Default.CurrentStage = stage;
-                            Settings.Default.Save();
-                        }
-                        else
-                        {
-                            // Don't think any sort of runtime failure is worthwhile here.
-                            Debug.Fail("could not parse stage number");
-                        }
-                        request.PostSucceeded(); // technically it didn't if we didn't parse the number
-                    }
-                    break;
-
-                case "copyBookStatsToClipboard":
-                    // See https://issues.bloomlibrary.org/youtrack/issue/BL-10018.
-                    string bookStatsString;
-                    try
-                    {
-                        bookStatsString = request.RequiredPostJson();
-                        dynamic bookStats = DynamicJson.Parse(bookStatsString);
-                        var headerBldr = new StringBuilder();
-                        var dataBldr = new StringBuilder();
-                        headerBldr.Append("Book Title");
-                        var title = _bookSelection.CurrentSelection.Title;
-                        title = title.Replace("\"", "\"\""); // Double double quotes to get Excel to recognize them.
-                        dataBldr.AppendFormat("\"{0}\"", title);
-                        headerBldr.Append("\tLevel");
-                        dataBldr.AppendFormat("\t\"Level {0}\"", bookStats["levelNumber"]);
-                        headerBldr.Append("\tNumber of Pages with Text");
-                        dataBldr.AppendFormat("\t{0}", bookStats["pageCount"]);
-                        headerBldr.Append("\tTotal Number of Words");
-                        dataBldr.AppendFormat("\t{0}", bookStats["actualWordCount"]);
-                        headerBldr.Append("\tTotal Number of Sentences");
-                        dataBldr.AppendFormat("\t{0}", bookStats["actualSentenceCount"]);
-                        headerBldr.Append("\tAverage No of Words per Page with Text");
-                        dataBldr.AppendFormat("\t{0:0.#}", bookStats["actualAverageWordsPerPage"]);
-                        headerBldr.Append("\tAverage No of Sentences per Page with Text");
-                        dataBldr.AppendFormat(
-                            "\t{0:0.#}",
-                            bookStats["actualAverageSentencesPerPage"]
-                        );
-                        headerBldr.Append("\tNumber of Unique Words");
-                        dataBldr.AppendFormat("\t{0}", bookStats["actualUniqueWords"]);
-                        headerBldr.Append("\tAverage Word Length");
-                        dataBldr.AppendFormat("\t{0:0.#}", bookStats["actualAverageGlyphsPerWord"]);
-                        headerBldr.Append("\tAverage Sentence Length");
-                        dataBldr.AppendFormat(
-                            "\t{0:0.#}",
-                            bookStats["actualAverageWordsPerSentence"]
-                        );
-                        headerBldr.Append("\tMaximum Word Length");
-                        dataBldr.AppendFormat("\t{0}", bookStats["actualMaxGlyphsPerWord"]);
-                        headerBldr.Append("\tMaximum Sentence Length");
-                        dataBldr.AppendFormat("\t{0}", bookStats["actualMaxWordsPerSentence"]);
-                        // "actualWordsPerPageBook" is the maximum number of words on a page in the book
-                        // It's in the json data, but not asked for in the clipboard copying.
-                        var stringToSave =
-                            headerBldr.ToString() + Environment.NewLine + dataBldr.ToString();
-                        PortableClipboard.SetText(stringToSave);
-                    }
-                    catch (IOException e)
-                    {
-                        SIL.Reporting.Logger.WriteError(
-                            "Copying book statistics to clipboard failed to get Json",
-                            e
-                        );
-                        break;
-                    }
-                    request.PostSucceeded();
-                    break;
-
                 default:
-                    request.Failed(
-                        "Don't understand '" + lastSegment + "' in " + request.LocalPath()
-                    );
+                    request.Failed("Http verb not handled");
                     break;
             }
+        }
+
+        private void HandleDefaultLevel(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            if (request.HttpMethod == HttpMethods.Get)
+            {
+                request.ReplyWithText(Settings.Default.CurrentLevel.ToString());
+            }
+            else
+            {
+                int level;
+                if (int.TryParse(request.RequiredParam("level"), out level))
+                {
+                    Settings.Default.CurrentLevel = level;
+                    Settings.Default.Save();
+                }
+                else
+                {
+                    // Don't think any sort of runtime failure is worthwhile here.
+                    Debug.Fail("could not parse level number");
+                }
+                request.PostSucceeded(); // technically it didn't if we didn't parse the number
+            }
+        }
+
+        private void HandleDefaultStage(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            if (request.HttpMethod == HttpMethods.Get)
+            {
+                request.ReplyWithText(Settings.Default.CurrentStage.ToString());
+            }
+            else
+            {
+                int stage;
+                if (int.TryParse(request.RequiredParam("stage"), out stage))
+                {
+                    Settings.Default.CurrentStage = stage;
+                    Settings.Default.Save();
+                }
+                else
+                {
+                    // Don't think any sort of runtime failure is worthwhile here.
+                    Debug.Fail("could not parse stage number");
+                }
+                request.PostSucceeded(); // technically it didn't if we didn't parse the number
+            }
+        }
+
+        private void HandleReaderSettingsEditForbidden(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            request.ReplyWithText(
+                _tcManager.OkToEditCollectionSettings
+                    ? ""
+                    : WorkspaceView.MustBeAdminMessage(request.CurrentCollectionSettings)
+            );
+        }
+
+        private void HandleReaderToolSettings(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            if (request.HttpMethod == HttpMethods.Get)
+                request.ReplyWithJson(GetReaderSettings(request.CurrentBook.BookData));
+            else
+            {
+                var path = DecodableReaderToolSettings.GetReaderToolsSettingsFilePath(
+                    request.CurrentCollectionSettings
+                );
+                var content = request.RequiredPostJson();
+                RobustFile.WriteAllText(path, content, Encoding.UTF8);
+                request.PostSucceeded();
+            }
+        }
+
+        private void HandleSampleFileContents(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            request.ReplyWithText(
+                GetTextFileContents(
+                    request.RequiredParam("fileName"),
+                    WordFileType.SampleFile
+                )
+            );
+        }
+
+        private void HandleSynphonyLanguageData(ApiRequest request)
+        {
+            //note, this endpoint is confusing because it appears that ultimately we only use the word list out of this file (see "sampleTextsList").
+            //This ends up being written to a ReaderToolsWords-xyz.json (matching its use, if not it contents).
+            if (IsRequestInvalid(request))
+                return;
+            //This is the "post". There is no direct "get", but the name of the file is given in the "sampleTextList" reply, below.
+            // We've had situations (BL-4313 and friends) where reading the posted data fails. This seems to be due to situations
+            // where we have a very large block of data and are rapidly switching between books. But as far as I can tell, the only
+            // case where it's at all important to capture the new language data is if the user has been changing settings and
+            // in particular editing the word list. Timing out the save in that situation seems very unlikely to fail.
+            // So, in the interests of preventing the crash when switching books fast, we will ignore failure to read all the
+            // json, and just not update the file. We would in any case keep only the version of the data sent to us by
+            // the last book which sends it, and that one is unlikely to get interrupted.
+            string langdata = "";
+            try
+            {
+                langdata = request.RequiredPostJson();
+            }
+            catch (IOException e)
+            {
+                SIL.Reporting.Logger.WriteError(
+                    "Saving synphonyLanguageData failed to get Json",
+                    e
+                );
+                request.Failed("Saving synphonyLanguageData failed to get Json");
+            }
+
+            SaveSynphonyLanguageData(langdata);
+            request.PostSucceeded();
+        }
+
+        private void HandleTextOfContentPages(ApiRequest request)
+        {
+            if (IsRequestInvalid(request))
+                return;
+            request.ReplyWithText(GetTextOfContentPagesAsJson());
         }
 
         /// <summary>

--- a/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
+++ b/src/BloomExe/web/controllers/AccessibilityCheckApi.cs
@@ -96,7 +96,7 @@ namespace Bloom.web.controllers
 
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "bookName",
                 request =>
                 {
@@ -105,7 +105,7 @@ namespace Bloom.web.controllers
                 false
             );
 
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "showAccessibilityChecker",
                 request =>
                 {
@@ -117,7 +117,7 @@ namespace Bloom.web.controllers
                 true
             );
 
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "descriptionsForAllImages",
                 request =>
                 {
@@ -130,7 +130,7 @@ namespace Bloom.web.controllers
                 false
             );
 
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "audioForAllImageDescriptions",
                 request =>
                 {
@@ -143,7 +143,7 @@ namespace Bloom.web.controllers
                 false
             );
 
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "audioForAllText",
                 request =>
                 {
@@ -181,7 +181,7 @@ namespace Bloom.web.controllers
             );
 
             //enhance: this might have to become async to work on large books on slow computers
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "aceByDaisyReportUrl",
                 request =>
                 {

--- a/src/BloomExe/web/controllers/AddOrChangePageApi.cs
+++ b/src/BloomExe/web/controllers/AddOrChangePageApi.cs
@@ -33,10 +33,10 @@ namespace Bloom.web.controllers
         {
             // Both of these display UI, expect to require UI thread.
             apiHandler
-                .RegisterEndpointLegacy("addPage", HandleAddPage, true)
+                .RegisterEndpointHandler("addPage", HandleAddPage, true)
                 .Measureable("Add Page");
             apiHandler
-                .RegisterEndpointLegacy("changeLayout", HandleChangeLayout, true)
+                .RegisterEndpointHandler("changeLayout", HandleChangeLayout, true)
                 .Measureable("Change Layout");
             ;
         }

--- a/src/BloomExe/web/controllers/AudioSegmentationApi.cs
+++ b/src/BloomExe/web/controllers/AudioSegmentationApi.cs
@@ -72,20 +72,20 @@ namespace Bloom.web.controllers
 
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "checkAutoSegmentDependencies",
                 CheckAutoSegmentDependenciesMet,
                 handleOnUiThread: false,
                 requiresSync: false
             );
             // JH: this is unused: apiHandler.RegisterEndpointLegacy(kApiUrlPart + "autoSegmentAudio", AutoSegment, handleOnUiThread: true/* may ask for a file*/, requiresSync: false);
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "getForcedAlignmentTimings",
                 GetForcedAlignmentTimings,
                 handleOnUiThread: false,
                 requiresSync: false
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "eSpeakPreview",
                 ESpeakPreview,
                 handleOnUiThread: false,
@@ -309,12 +309,13 @@ namespace Bloom.web.controllers
             return request;
         }
 
-        /// <summary>
+
+#if OBSOLETEAPI
         /// API Handler when the Auto Segment button is clicked
         ///
         /// Replies with true if AutoSegment completed successfully, or false if there was an error. In addition, a NonFatal message/exception may be reported with the error
         /// </summary>
-        /* (JH) I don't know why this exists, it is unused
+        /* (JH) I don't know why this exists, it is unused  (SMc) it supported the obsolete autoSegmentAudio API call
         public void AutoSegment(ApiRequest request)
         {
             Logger.WriteEvent("AudioSegmentationApi.AutoSegment(): AutoSegment started.");
@@ -350,6 +351,7 @@ namespace Bloom.web.controllers
             request.ReplyWithBoolean(true); // Success
         }
         */
+#endif
 
         internal AutoSegmentResponse GetAeneasTimings(AutoSegmentRequest requestParameters)
         {
@@ -1020,6 +1022,7 @@ namespace Bloom.web.controllers
             return timings;
         }
 
+#if OBSOLETEAPI
         /// <summary>
         /// Given a list of timings, segments a whole audio file into the individual pieces specified by the timing list
         /// </summary>
@@ -1149,6 +1152,7 @@ namespace Bloom.web.controllers
 
             return tcs.Task;
         }
+#endif
         #endregion
 
 

--- a/src/BloomExe/web/controllers/BookCommandsApi.cs
+++ b/src/BloomExe/web/controllers/BookCommandsApi.cs
@@ -53,8 +53,7 @@ namespace Bloom.web.controllers
         {
             // Must not require sync, because it launches a Bloom dialog, which will make other api requests
             // that will be blocked if this is locked.
-            apiHandler.RegisterEndpointHandler(
-                "bookCommand/exportToSpreadsheet",
+            apiHandler.RegisterEndpointHandler("bookCommand/exportToSpreadsheet",
                 (request) =>
                 {
                     _spreadsheetApi.ShowExportToSpreadsheetUI(GetBookObjectFromPost(request));
@@ -63,8 +62,7 @@ namespace Bloom.web.controllers
                 true,
                 false
             );
-            apiHandler.RegisterEndpointHandler(
-                "bookCommand/enhanceLabel",
+            apiHandler.RegisterEndpointHandler("bookCommand/enhanceLabel",
                 (request) =>
                 {
                     // We want this to be fast...many things are competing for api handling threads while
@@ -78,7 +76,82 @@ namespace Bloom.web.controllers
                 false,
                 false
             );
-            apiHandler.RegisterEndpointLegacy("bookCommand/", HandleBookCommand, true);
+            apiHandler.RegisterEndpointHandler("bookCommand/makeBloompack",
+                (request) =>
+                {
+                    var book = GetBookObjectFromPost(request);
+                    HandleMakeBloompack(book);
+                    request.PostSucceeded();
+                },
+                true
+            );
+            apiHandler.RegisterEndpointHandler("bookCommand/openFolderOnDisk",
+                (request) =>
+                {
+                    // Currently, the request comes with data to let us identify which book,
+                    // but it will always be the current book, which is all the model api lets us open anyway.
+                    _collectionModel.OpenFolderOnDisk();
+                    request.PostSucceeded();
+                },
+                true
+            );
+            apiHandler.RegisterEndpointHandler("bookCommand/exportToWord",
+                (request) =>
+                {
+                    var book = GetBookObjectFromPost(request);
+                    HandleExportToWord(book);
+                    request.PostSucceeded();
+                },
+                true
+            );
+            apiHandler.RegisterEndpointHandler("bookCommand/importSpreadsheetContent",
+                (request) =>
+                {
+                    // As currently implemented this would more naturally go in CollectionApi, since it adds a book
+                    // to the collection (a backup). However, we are probably going to change how backups are handled
+                    // so this is no longer true.
+                    var book = GetBookObjectFromPost(request);
+                    _spreadsheetApi.HandleImportContentFromSpreadsheet(book);
+                    request.PostSucceeded();
+                },
+                true
+            );
+            apiHandler.RegisterEndpointHandler("bookCommand/saveAsDotBloomSource",
+                (request) =>
+                {
+                    var book = GetBookObjectFromPost(request);
+                    HandleSaveAsDotBloomSource(book);
+                    request.PostSucceeded();
+                },
+                true
+            );
+            apiHandler.RegisterEndpointHandler("bookCommand/updateThumbnail",
+                (request) =>
+                {
+                    var book = GetBookObjectFromPost(request);
+                    ScheduleRefreshOfOneThumbnail(book);
+                    request.PostSucceeded();
+                },
+                true
+            );
+            apiHandler.RegisterEndpointHandler("bookCommand/updateBook",
+                (request) =>
+                {
+                    var book = GetBookObjectFromPost(request);
+                    HandleBringBookUpToDate(book);
+                    request.PostSucceeded();
+                },
+                true
+            );
+            apiHandler.RegisterEndpointHandler("bookCommand/rename",
+                (request) =>
+                {
+                    var book = GetBookObjectFromPost(request);
+                    HandleRename(book, request);
+                    request.PostSucceeded();
+                },
+                true
+            );
         }
 
         public void RequestButtonLabelUpdate(string collectionPath, string id)
@@ -246,47 +319,6 @@ namespace Bloom.web.controllers
                 badBook = true;
                 return null;
             }
-        }
-
-        private void HandleBookCommand(ApiRequest request)
-        {
-            var book = GetBookObjectFromPost(request);
-            var command = request
-                .LocalPath()
-                .Substring((BloomApiHandler.ApiPrefix + "bookCommand/").Length);
-            switch (command)
-            {
-                case "makeBloompack":
-                    HandleMakeBloompack(book);
-                    break;
-                case "openFolderOnDisk":
-                    // Currently, the request comes with data to let us identify which book,
-                    // but it will always be the current book, which is all the model api lets us open anyway.
-                    _collectionModel.OpenFolderOnDisk();
-                    break;
-                case "exportToWord":
-                    HandleExportToWord(book);
-                    break;
-                // As currently implemented this would more naturally go in CollectionApi, since it adds a book
-                // to the collection (a backup). However, we are probably going to change how backups are handled
-                // so this is no longer true.
-                case "importSpreadsheetContent":
-                    _spreadsheetApi.HandleImportContentFromSpreadsheet(book);
-                    break;
-                case "saveAsDotBloomSource":
-                    HandleSaveAsDotBloomSource(book);
-                    break;
-                case "updateThumbnail":
-                    ScheduleRefreshOfOneThumbnail(book);
-                    break;
-                case "updateBook":
-                    HandleBringBookUpToDate(book);
-                    break;
-                case "rename":
-                    HandleRename(book, request);
-                    break;
-            }
-            request.PostSucceeded();
         }
 
         private void HandleRename(Book.Book book, ApiRequest request)

--- a/src/BloomExe/web/controllers/BookMetadataApi.cs
+++ b/src/BloomExe/web/controllers/BookMetadataApi.cs
@@ -20,7 +20,7 @@ namespace Bloom.web.controllers
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
             bool requiresSync = false; // Lets us open the dialog while the epub preview is being generated
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "book/metadata",
                 HandleBookMetadata,
                 false,

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -41,16 +41,16 @@ namespace Bloom.web.controllers
 
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
-            apiHandler.RegisterEndpointLegacy("uiLanguages", HandleUiLanguages, false); // App
-            apiHandler.RegisterEndpointLegacy("currentUiLanguage", HandleCurrentUiLanguage, false); // App
-            apiHandler.RegisterEndpointLegacy("bubbleLanguages", HandleBubbleLanguages, false); // Move to EditingViewApi
-            apiHandler.RegisterEndpointLegacy("common/error", HandleJavascriptError, false); // Common
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler("uiLanguages", HandleUiLanguages, false); // App
+            apiHandler.RegisterEndpointHandler("currentUiLanguage", HandleCurrentUiLanguage, false); // App
+            apiHandler.RegisterEndpointHandler("bubbleLanguages", HandleBubbleLanguages, false); // Move to EditingViewApi
+            apiHandler.RegisterEndpointHandler("common/error", HandleJavascriptError, false); // Common
+            apiHandler.RegisterEndpointHandler(
                 "common/preliminaryError",
                 HandlePreliminaryJavascriptError,
                 false
             ); // Common
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "common/saveChangesAndRethinkPageEvent",
                 RethinkPageAndReloadIt,
                 true
@@ -66,13 +66,13 @@ namespace Bloom.web.controllers
                 HandleHasPreserveCoverColor,
                 true
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "common/showSettingsDialog",
                 HandleShowSettingsDialog,
                 false
             ); // Common
             apiHandler.RegisterEndpointHandler("common/logger/writeEvent", HandleLogEvent, false);
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "common/problemWithBookMessage",
                 request =>
                 {
@@ -84,7 +84,7 @@ namespace Bloom.web.controllers
                 },
                 false
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "common/clickHereForHelp",
                 request =>
                 {
@@ -103,7 +103,7 @@ namespace Bloom.web.controllers
             // invocation of the code that decides whether to enable the paste hyperlink button). This causes a deadlock
             // unless we make this endpoint requiresSync:false. I think this is safe as it doesn't interact with any other
             // Bloom objects.
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "common/clipboardText",
                 request =>
                 {
@@ -170,7 +170,7 @@ namespace Bloom.web.controllers
                 false,
                 false
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "common/checkForUpdates",
                 request =>
                 {
@@ -179,7 +179,7 @@ namespace Bloom.web.controllers
                 },
                 false
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "common/channel",
                 request =>
                 {
@@ -210,7 +210,7 @@ namespace Bloom.web.controllers
             // other solutions for that including opening the dialog on Application.Idle. But the dialog needs
             // to give a real-time result so callers can know what do with button presses. Since some of those
             // callers are in libpalaso, we can't just ignore the result and handle the actions ourselves.
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "common/closeReactDialog",
                 request =>
                 {
@@ -222,7 +222,7 @@ namespace Bloom.web.controllers
             );
 
             // TODO: move to the new App API (BL-9635)
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "common/reloadCollection",
                 HandleReloadCollection,
                 true

--- a/src/BloomExe/web/controllers/EditingViewApi.cs
+++ b/src/BloomExe/web/controllers/EditingViewApi.cs
@@ -29,14 +29,14 @@ namespace Bloom.web.controllers
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
             apiHandler.RegisterEndpointHandler("editView/setModalState", HandleSetModalState, true);
-            apiHandler.RegisterEndpointLegacy("editView/chooseWidget", HandleChooseWidget, true);
+            apiHandler.RegisterEndpointHandler("editView/chooseWidget", HandleChooseWidget, true);
             apiHandler.RegisterEndpointHandler(
                 "editView/getColorsUsedInBookOverlays",
                 HandleGetColorsUsedInBookOverlays,
                 true
             );
             apiHandler.RegisterEndpointHandler("editView/pageDomLoaded", HandlePageDomLoaded, true);
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "editView/saveToolboxSetting",
                 HandleSaveToolboxSetting,
                 true
@@ -52,24 +52,24 @@ namespace Bloom.web.controllers
                 true,
                 true // review.
             );
-            apiHandler.RegisterEndpointLegacy("editView/setTopic", HandleSetTopic, true);
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler("editView/setTopic", HandleSetTopic, true);
+            apiHandler.RegisterEndpointHandler(
                 "editView/isTextSelected",
                 HandleIsTextSelected,
                 false
             );
-            apiHandler.RegisterEndpointLegacy("editView/getBookLangs", HandleGetBookLangs, false);
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler("editView/getBookLangs", HandleGetBookLangs, false);
+            apiHandler.RegisterEndpointHandler(
                 "editView/isClipboardBookHyperlink",
                 HandleIsClipboardBookHyperlink,
                 false
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "editView/requestTranslationGroupContent",
                 RequestDefaultTranslationGroupContent,
                 true
             );
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "editView/duplicatePageMany",
                 HandleDuplicatePageMany,
                 true

--- a/src/BloomExe/web/controllers/ImageApi.cs
+++ b/src/BloomExe/web/controllers/ImageApi.cs
@@ -59,8 +59,8 @@ namespace Bloom.web.controllers
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
             // These are both just retrieving information about files, apart from using _bookSelection.CurrentSelection.FolderPath.
-            apiHandler.RegisterEndpointLegacy("image/info", HandleImageInfo, false);
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler("image/info", HandleImageInfo, false);
+            apiHandler.RegisterEndpointHandler(
                 "image/imageCreditsForWholeBook",
                 HandleCopyImageCreditsForWholeBook,
                 false

--- a/src/BloomExe/web/controllers/KeyboardingConfigApi.cs
+++ b/src/BloomExe/web/controllers/KeyboardingConfigApi.cs
@@ -9,7 +9,7 @@ namespace Bloom.web.controllers
     {
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "keyboarding/useLongpress",
                 (ApiRequest request) =>
                 {

--- a/src/BloomExe/web/controllers/MusicApi.cs
+++ b/src/BloomExe/web/controllers/MusicApi.cs
@@ -37,7 +37,7 @@ namespace Bloom.web.controllers
 
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
-            apiHandler.RegisterEndpointLegacy("music/ui/chooseFile", HandleRequest, true);
+            apiHandler.RegisterEndpointHandler("music/ui/chooseFile", HandleRequest, true);
         }
 
         public void HandleRequest(ApiRequest request)

--- a/src/BloomExe/web/controllers/PageTemplatesApi.cs
+++ b/src/BloomExe/web/controllers/PageTemplatesApi.cs
@@ -62,13 +62,9 @@ namespace Bloom.web.controllers
         {
             // We could probably get away with using the server thread here, but the code interacts quite a bit with the
             // current book and other state.
-            apiHandler.RegisterEndpointLegacy("pageTemplates", HandleTemplatesRequest, true);
+            apiHandler.RegisterEndpointHandler("pageTemplates", HandleTemplatesRequest, true);
             // Being on the UI thread causes a deadlock on Linux/Mono.  See https://silbloom.myjetbrains.com/youtrack/issue/BL-3818.
-            apiHandler.RegisterEndpointLegacy(
-                "pageTemplateThumbnail",
-                HandleThumbnailRequest,
-                false
-            );
+            apiHandler.RegisterEndpointHandler("pageTemplateThumbnail", HandleThumbnailRequest, false);
         }
 
         /// <summary>
@@ -133,7 +129,7 @@ namespace Bloom.web.controllers
         /// </summary>
         public void HandleThumbnailRequest(ApiRequest request)
         {
-            var filePath = request.LocalPath().Replace("api/pageTemplateThumbnail/", "");
+            var filePath = request.RequiredParam("path");
             var pathToExistingOrGeneratedThumbnail = FindOrGenerateThumbnail(
                 filePath,
                 out bool isGenerating
@@ -324,7 +320,7 @@ namespace Bloom.web.controllers
                                     .Replace(
                                         BloomServer.ServerUrlWithBloomPrefixEndingInSlash,
                                         BloomServer.ServerUrlWithBloomPrefixEndingInSlash
-                                            + "api/pageTemplateThumbnail/"
+                                            + "api/pageTemplateThumbnail?path="
                                     );
                                 _webSocketServer.SendBundle(
                                     "page-chooser",

--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -157,7 +157,7 @@ namespace Bloom.web.controllers
             // This one is an exception: it's not used BY the problem report dialog, but to launch one
             // from Javascript. However, it also must not require the lock, because if it holds it,
             // no calls that need it can run (such as one put forth by the Cancel button).
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "problemReport/showDialog",
                 HandleShowDialog,
                 true,

--- a/src/BloomExe/web/controllers/ProgressDialogApi.cs
+++ b/src/BloomExe/web/controllers/ProgressDialogApi.cs
@@ -15,7 +15,7 @@ namespace Bloom.web.controllers
 
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
-            apiHandler.RegisterEndpointLegacy("progress/cancel", Cancel, false, false);
+            apiHandler.RegisterEndpointHandler("progress/cancel", Cancel, false, false);
             apiHandler.RegisterEndpointHandler(
                 "progress/closed",
                 BrowserProgressDialog.HandleProgressDialogClosed,

--- a/src/BloomExe/web/controllers/SignLanguageApi.cs
+++ b/src/BloomExe/web/controllers/SignLanguageApi.cs
@@ -47,22 +47,22 @@ namespace Bloom.web.controllers
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
             apiHandler
-                .RegisterEndpointLegacy(
+                .RegisterEndpointHandler(
                     "signLanguage/recordedVideo",
                     HandleRecordedVideoRequest,
                     true
                 )
                 .Measureable("Process recorded video");
             apiHandler
-                .RegisterEndpointLegacy("signLanguage/deleteVideo", HandleDeleteVideoRequest, true)
+                .RegisterEndpointHandler("signLanguage/deleteVideo", HandleDeleteVideoRequest, true)
                 .Measureable("Delete video");
             ;
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "signLanguage/importVideo",
                 HandleImportVideoRequest,
                 true
             ); // has dialog, so measure internally after the dialog.
-            apiHandler.RegisterEndpointLegacy(
+            apiHandler.RegisterEndpointHandler(
                 "signLanguage/getStats",
                 HandleVideoStatisticsRequest,
                 true

--- a/src/BloomExe/web/controllers/ToolboxApi.cs
+++ b/src/BloomExe/web/controllers/ToolboxApi.cs
@@ -26,7 +26,7 @@ namespace BloomTests.web.controllers
                 HandleEnabledToolsRequest,
                 true
             );
-            apiHandler.RegisterEndpointLegacy("toolbox/fileExists", HandleFileExistsRequest, true);
+            apiHandler.RegisterEndpointHandler("toolbox/fileExists", HandleFileExistsRequest, true);
             apiHandler.RegisterBooleanEndpointHandler(
                 "toolbox/decodable",
                 null,

--- a/src/BloomTests/web/BloomServerTests.cs
+++ b/src/BloomTests/web/BloomServerTests.cs
@@ -177,15 +177,15 @@ namespace BloomTests.web
                 );
                 EndpointHandler testFunc = (request) =>
                 {
-                    Assert.That(request.LocalPath(), Does.Contain("thisWontWorkWithoutInjection"));
+                    Assert.That(request.LocalPath(), Does.Contain("thisWontWorkWithoutInjectionButWillWithIt"));
                     Assert.That(
                         request.CurrentCollectionSettings,
                         Is.EqualTo(server.CurrentCollectionSettings)
                     );
                     request.ReplyWithText("Did It!");
                 };
-                server.ApiHandler.RegisterEndpointLegacy(
-                    "thisWontWorkWithoutInjection",
+                server.ApiHandler.RegisterEndpointHandler(
+					"thisWontWorkWithoutInjectionButWillWithIt",
                     testFunc,
                     true
                 );

--- a/src/BloomTests/web/controllers/ApiTest.cs
+++ b/src/BloomTests/web/controllers/ApiTest.cs
@@ -23,7 +23,7 @@ namespace BloomTests
         {
             if (handler != null)
             {
-                server.ApiHandler.RegisterEndpointLegacy(endPoint, handler, true);
+                server.ApiHandler.RegisterEndpointHandler(endPoint, handler, true);
             }
             server.EnsureListening();
             var client = new WebClientWithTimeout { Timeout = timeoutInMilliseconds ?? 3000, };
@@ -57,7 +57,7 @@ namespace BloomTests
         {
             if (handler != null)
             {
-                server.ApiHandler.RegisterEndpointLegacy(endPoint, handler, true);
+                server.ApiHandler.RegisterEndpointHandler(endPoint, handler, true);
             }
             server.EnsureListening();
             var client = new WebClientWithTimeout { Timeout = timeoutInMilliseconds ?? 3000 };

--- a/src/BloomTests/web/controllers/EndpointHandlerTests.cs
+++ b/src/BloomTests/web/controllers/EndpointHandlerTests.cs
@@ -94,23 +94,11 @@ namespace BloomTests.web
                 () =>
                     ApiTest.GetString(
                         _server,
-                        endPoint: "foo[0-9]bar",
+                        endPoint: "foo88bar",
                         endOfUrlForTest: "foobar",
                         handler: request => request.PostSucceeded()
                     )
             );
-        }
-
-        [Test]
-        public void Get_RegexEndPoint()
-        {
-            var result = ApiTest.GetString(
-                _server,
-                endPoint: "foo[0-9]bar",
-                endOfUrlForTest: "foo7bar",
-                handler: request => request.PostSucceeded()
-            );
-            Assert.That(result, Is.EqualTo("OK"));
         }
     }
 }


### PR DESCRIPTION
A handful of APIs switched to using URL parameters.  A few handlers split out to multiple registrations and handler methods.  Most of the APIs did not need to change, the registration change being enough.

Nothing except a test was actually making effective use of the regular expression handling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6566)
<!-- Reviewable:end -->
