### PR TITLE
Various improvements to Start controls

### DIFF
--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -61,9 +61,17 @@
         <source xml:lang="en">Fixed In Place</source>
         <note>ID: EditTab.Toolbox.DragActivity.FixedInPlace</note>
       </trans-unit>
+      <trans-unit id="EditTab.Toolbox.DragActivity.DraggableShape" translate="no">
+        <source xml:lang="en">Draggable Shape</source>
+        <note>ID: EditTab.Toolbox.DragActivity.DraggableShape</note>
+      </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.DraggableTargetInstructions" translate="no">
         <source xml:lang="en">Place the targets in the places needed for the correct answer.</source>
         <note>ID: EditTab.Toolbox.DragActivity.DraggableTargetInstructions</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.DragActivity.FixedShape" translate="no">
+        <source xml:lang="en">Fixed Shape</source>
+        <note>ID: EditTab.Toolbox.DragActivity.FixedShape</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.Instructions" translate="no">
         <source xml:lang="en">Instructions</source>
@@ -72,6 +80,10 @@
       <trans-unit id="EditTab.Toolbox.DragActivity.InstructionsOrLabels" translate="no">
         <source xml:lang="en">Instructions or other labels</source>
         <note>ID: EditTab.Toolbox.DragActivity.InstructionsOrLabels</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.DragActivity.Item" translate="no">
+        <source xml:lang="en">Item:</source>
+        <note>ID: EditTab.Toolbox.DragActivity.Item</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.Letter" translate="no">
         <source xml:lang="en">M</source>
@@ -107,10 +119,10 @@
         <source xml:lang="en">Selected element is part of right answer</source>
         <note>ID: EditTab.Toolbox.DragActivity.PartOfRightAnswer</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DragActivity.PartOfRightAnswerDisabled" translate="no">
+      <!--trans-unit id="EditTab.Toolbox.DragActivity.PartOfRightAnswerDisabled" translate="no">
         <source xml:lang="en">Nothing that can be part of the right answer is selected</source>
         <note>ID: EditTab.Toolbox.DragActivity.PartOfRightAnswerDisabled</note>
-      </trans-unit>
+      </trans-unit-->
       <trans-unit id="EditTab.Toolbox.DragActivity.Play" translate="no">
         <source xml:lang="en">Play</source>
         <note>ID: EditTab.Toolbox.DragActivity.Play</note>

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -307,11 +307,15 @@ export class BubbleManager {
         // can only have one of three types of content and each are mutually exclusive.
         // bloom-editable or bloom-videoContainer or bloom-imageContainer. It doesn't even really
         // matter which order we look for them.
-        let focusableDivs = Array.from(
+        const editables = Array.from(
             overPictureContainerElement.getElementsByClassName(
                 "bloom-editable bloom-visibility-code-on"
             )
-        ).filter(
+        );
+        let focusableDivs = editables
+            // At least in Bloom games, some elements with visibility code on are nevertheless hidden
+            .filter(e => !EditableDivUtils.isInHiddenLanguageBlock(e));
+        focusableDivs = focusableDivs.filter(
             el =>
                 !(
                     el.parentElement!.classList.contains("box-header-off") ||
@@ -325,7 +329,7 @@ export class BubbleManager {
                 overPictureContainerElement.getElementsByClassName(
                     kVideoContainerClass
                 )
-            );
+            ).filter(x => !EditableDivUtils.isInHiddenLanguageBlock(x));
         }
         if (focusableDivs.length === 0) {
             // This could be a bit tricky, since the whole canvas is in a 'bloom-imageContainer'.
@@ -335,7 +339,7 @@ export class BubbleManager {
                 overPictureContainerElement.getElementsByClassName(
                     kImageContainerClass
                 )
-            );
+            ).filter(x => !EditableDivUtils.isInHiddenLanguageBlock(x));
         }
         return focusableDivs;
     }
@@ -410,9 +414,11 @@ export class BubbleManager {
         // the first image.
         // todo: make sure comical is turned on for the right parent, in case there's more than one
         // image on the page?
-        const overPictureElements: HTMLElement[] = Array.from(
-            document.getElementsByClassName(kTextOverPictureClass) as any
-        );
+        const overPictureElements = Array.from(
+            document.getElementsByClassName(kTextOverPictureClass)
+        ).filter(
+            x => !EditableDivUtils.isInHiddenLanguageBlock(x)
+        ) as HTMLElement[];
         if (overPictureElements.length > 0) {
             this.activeElement = overPictureElements[
                 overPictureElements.length - 1

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -487,4 +487,39 @@ export class EditableDivUtils {
             );
         });
     }
+
+    public static isInHiddenLanguageBlock(elem: Element) {
+        // Spans (and probably other inline elements?) can have display=inline even if they're inside a div that's display=none
+        let elemToCheck: Element | null = elem;
+
+        if (elem.tagName === "SPAN") {
+            const parentEditable = elem.closest(".bloom-editable");
+
+            // Really not wanting this scenario to happen, because we may get inaccurate results, but...
+            // We ought to be able to continue on without anything terrible happening
+            console.assert(
+                parentEditable,
+                "isVisible(): Unexpected span that is not inside a bloom-editable. span = " +
+                    elem
+            );
+            elemToCheck = parentEditable || elem;
+        }
+        // elemToCheck is typically a bloom-editable. Originally, we were just looking to consider
+        // which languages were hidden. But with drag-activity, there are cases where a containing
+        // text-over-picture element is hidden. That's two levels above the bloom-editable.
+        // Looking up four levels should be enough, and may make this computationally less
+        // expensive than looking all the way up to the document. (I think getComputedStyle is
+        // quite slow.)
+        for (let i = 0; i < 4; i++) {
+            const style = window.getComputedStyle(elemToCheck);
+            if (style.display === "none") {
+                return true;
+            }
+            elemToCheck = elemToCheck.parentElement;
+            if (!elemToCheck) {
+                return false;
+            }
+        }
+        return false;
+    }
 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityRuntime.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityRuntime.ts
@@ -147,6 +147,11 @@ export function prepareActivity(
         elt.addEventListener("click", showCorrect);
     });
 
+    const soundItems = Array.from(page.querySelectorAll("[data-sound]"));
+    soundItems.forEach((elt: HTMLElement) => {
+        elt.addEventListener("click", playSoundOf);
+    });
+
     prepareOrderSentenceActivity(page);
 
     // Slider:     // for drag-word-chooser-slider
@@ -233,6 +238,11 @@ export function undoPrepareActivity(page: HTMLElement) {
         elt.removeEventListener("click", performTryAgain);
     });
 
+    const soundItems = Array.from(page.querySelectorAll("[data-sound]"));
+    soundItems.forEach((elt: HTMLElement) => {
+        elt.removeEventListener("click", playSoundOf);
+    });
+
     Array.from(
         page.getElementsByClassName("drag-item-random-sentence")
     ).forEach((elt: HTMLElement) => {
@@ -244,6 +254,14 @@ export function undoPrepareActivity(page: HTMLElement) {
     //     img.removeEventListener("click", clickSliderImage);
     // });
 }
+
+const playSoundOf = (e: MouseEvent) => {
+    const elt = e.currentTarget as HTMLElement;
+    const soundFile = elt.getAttribute("data-sound");
+    if (soundFile) {
+        playSound(elt, soundFile);
+    }
+};
 
 const playAudioOfTarget = (e: PointerEvent) => {
     const target = e.currentTarget as HTMLElement;
@@ -590,27 +608,30 @@ function showCorrectOrWrongItems(page: HTMLElement, correct: boolean) {
         playAllVideo(videoElements, () => playAllAudio(playables, page));
     };
     if (soundFile) {
-        const audio = new Audio(urlPrefix() + "/audio/" + soundFile);
-        audio.style.visibility = "hidden";
-        // To my surprise, in BP storybook it works without adding the audio to any document.
-        // But in Bloom proper, it does not. I think it is because this code is part of the toolbox,
-        // so the audio element doesn't have the right context to interpret the relative URL.
-        page.append(audio);
-        // It feels cleaner if we remove it when done. This could fail, e.g., if the user
-        // switches tabs or pages before we get done playing. Removing it immediately
-        // prevents the sound being played. It's not a big deal if it doesn't get removed.
-        audio.play();
-        audio.addEventListener(
-            "ended",
-            () => {
-                page.removeChild(audio);
-                playOtherStuff();
-            },
-            { once: true }
-        );
+        playSound(page, soundFile);
     } else {
         playOtherStuff();
     }
+}
+
+function playSound(someElt: HTMLElement, soundFile: string) {
+    const audio = new Audio(urlPrefix() + "/audio/" + soundFile);
+    audio.style.visibility = "hidden";
+    // To my surprise, in BP storybook it works without adding the audio to any document.
+    // But in Bloom proper, it does not. I think it is because this code is part of the toolbox,
+    // so the audio element doesn't have the right context to interpret the relative URL.
+    someElt.append(audio);
+    audio.play();
+    // It feels cleaner if we remove it when done. This could fail, e.g., if the user
+    // switches tabs or pages before we get done playing. Removing it immediately
+    // prevents the sound being played. It's not a big deal if it doesn't get removed.
+    audio.addEventListener(
+        "ended",
+        () => {
+            someElt.removeChild(audio);
+        },
+        { once: true }
+    );
 }
 
 function checkDraggables(page: HTMLElement) {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -651,7 +651,7 @@ export default class AudioRecording {
         elem: Element,
         includeCheckForTempHidden: boolean = true
     ) {
-        if (this.isInHiddenLanguageBlock(elem)) {
+        if (EditableDivUtils.isInHiddenLanguageBlock(elem)) {
             return false;
         }
         if (!includeCheckForTempHidden) {
@@ -679,40 +679,6 @@ export default class AudioRecording {
             }
         }
         return true;
-    }
-    private isInHiddenLanguageBlock(elem: Element) {
-        // Spans (and probably other inline elements?) can have display=inline even if they're inside a div that's display=none
-        let elemToCheck: Element | null = elem;
-
-        if (elem.tagName === "SPAN") {
-            const parentEditable = elem.closest(".bloom-editable");
-
-            // Really not wanting this scenario to happen, because we may get inaccurate results, but...
-            // We ought to be able to continue on without anything terrible happening
-            console.assert(
-                parentEditable,
-                "isVisible(): Unexpected span that is not inside a bloom-editable. span = " +
-                    elem
-            );
-            elemToCheck = parentEditable || elem;
-        }
-        // elemToCheck is typically a bloom-editable. Originally, we were just looking to consider
-        // which languages were hidden. But with drag-activity, there are cases where a containing
-        // text-over-picture element is hidden. That's two levels above the bloom-editable.
-        // Looking up four levels should be enough, and may make this computationally less
-        // expensive than looking all the way up to the document. (I think getComputedStyle is
-        // quite slow.)
-        for (let i = 0; i < 4; i++) {
-            const style = window.getComputedStyle(elemToCheck);
-            if (style.display === "none") {
-                return true;
-            }
-            elemToCheck = elemToCheck.parentElement;
-            if (!elemToCheck) {
-                return false;
-            }
-        }
-        return false;
     }
 
     private containsAnyAudioElements(): boolean {

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -3476,6 +3476,10 @@ namespace Bloom.Book
             // can be clipped.
             CopyMissingSoundFile(templatePage, "data-correct-sound");
             CopyMissingSoundFile(templatePage, "data-wrong-sound");
+            foreach (SafeXmlElement soundElt in newPageDiv.SafeSelectNodes(".//div[@data-sound]"))
+            {
+                CopyMissingSoundFile(soundElt, "data-sound", templatePage.Book.FolderPath);
+            }
 
             // and again for scripts (but we currently only worry about ones in the page itself)
             foreach (SafeXmlElement scriptElt in newPageDiv.SafeSelectNodes(".//script[@src]"))
@@ -3591,13 +3595,27 @@ namespace Bloom.Book
 
         private void CopyMissingSoundFile(IPage templatePage, string attrName)
         {
-            var fileName = templatePage.GetDivNodeForThisPage().GetAttribute(attrName);
+            CopyMissingSoundFile(
+                templatePage.GetDivNodeForThisPage(),
+                attrName,
+                templatePage.Book.FolderPath
+            );
+        }
+
+        private void CopyMissingSoundFile(
+            SafeXmlElement sourceElt,
+            string attrName,
+            string templateBookFolderPath
+        )
+        {
+            var fileName = sourceElt.GetAttribute(attrName);
             if (string.IsNullOrEmpty(fileName))
                 return;
             var destPath = Path.Combine(FolderPath, "audio", fileName);
             if (RobustFile.Exists(destPath))
                 return;
-            var sourcePath = Path.Combine(templatePage.Book.FolderPath, "audio", fileName);
+
+            var sourcePath = Path.Combine(templateBookFolderPath, "audio", fileName);
             Directory.CreateDirectory(Path.GetDirectoryName(destPath));
             if (RobustFile.Exists(sourcePath))
                 RobustFile.Copy(sourcePath, destPath);

--- a/src/BloomExe/Book/BookFileFilter.cs
+++ b/src/BloomExe/Book/BookFileFilter.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Bloom.SafeXml;
 using Bloom.ToPalaso;
 using SIL.IO;
 using SIL.Xml;
@@ -78,6 +79,9 @@ namespace Bloom.Book
         /// For example, BloomPubs can have activities. This is basically everything
         /// needed in any kind of publication of the book, but this is a little less
         /// than the set needed to go on working on it (see IncludeFilesForContinuedEditing above).
+        /// These files are of course also needed for lots of other things, like Upload,
+        /// BloomPacks, and editing; filters for those purposes set IncludeFilesForContinuedEditing,
+        /// which sets this.
         /// </summary>
         public bool IncludeFilesNeededForBloomPlayer
         {
@@ -278,6 +282,8 @@ namespace Bloom.Book
                 {
                     if (NarrationFiles.Contains(path[1]))
                         return true;
+                    if (IncludeFilesNeededForBloomPlayer && SpecialAudioFiles.Contains(path[1]))
+                        return true;
                     return WantMusic && MusicFiles.Contains(path[1]);
                 }
                 if (path[0] == "video" && path.Length == 2 && WantVideo)
@@ -298,6 +304,7 @@ namespace Bloom.Book
 
         private HashSet<string> _narrationFiles;
         private string[] _narrationLanguages = Array.Empty<string>();
+        private HashSet<string> _specialAudioFiles;
 
         HashSet<string> NarrationFiles
         {
@@ -335,6 +342,42 @@ namespace Bloom.Book
                 }
                 return _narrationFiles;
             }
+        }
+
+        /// <summary>
+        /// Various elements (currently only in Bloom Games) can have data-X attributes which specify a sound
+        /// (implicitly in the audio directory). This method finds all such sounds and adds them to the set
+        /// so we can include them when appropriate.
+        /// </summary>
+        HashSet<string> SpecialAudioFiles
+        {
+            get
+            {
+                if (_specialAudioFiles == null)
+                {
+                    _specialAudioFiles = new HashSet<string>();
+                    foreach (
+                        SafeXmlElement soundElt in Dom.Body.SafeSelectNodes(".//div[@data-sound]")
+                    )
+                    {
+                        _specialAudioFiles.Add(soundElt.GetAttribute("data-sound"));
+                    }
+
+                    foreach (var page in Dom.GetPageElements())
+                    {
+                        AddAttrValueToSet(page, "data-correct-sound", _specialAudioFiles);
+                        AddAttrValueToSet(page, "data-wrong-sound", _specialAudioFiles);
+                    }
+                }
+                return _specialAudioFiles;
+            }
+        }
+
+        void AddAttrValueToSet(SafeXmlElement elt, string attrName, HashSet<string> set)
+        {
+            var value = elt.GetAttribute(attrName);
+            if (value != null)
+                set.Add(value);
         }
 
         private HashSet<string> _musicFiles;

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -1329,6 +1329,11 @@ namespace Bloom.Book
                     usedAudioFileNames.Add(correctSound);
                 if (wrongSound != null)
                     usedAudioFileNames.Add(wrongSound);
+                var dataSoundElts = dap.SafeSelectNodes(".//div[@data-sound]");
+                foreach (var ds in dataSoundElts)
+                {
+                    usedAudioFileNames.Add(ds.GetAttribute("data-sound"));
+                }
             }
 
             // Don't get too trigger-happy with the delete button if you're not in publish mode

--- a/src/BloomTests/Book/BookFileFilterTests.cs
+++ b/src/BloomTests/Book/BookFileFilterTests.cs
@@ -41,9 +41,9 @@ namespace BloomTests.Book
             _otherHtmlPath = Path.Combine(_normalBookFolderPath, "other.html");
             var normalHtmlContent =
                 $@"<html><head></head><body>
-					<div class='bloom-page numberedPage' id='page1' data-page-number='1' data-backgroundaudio='Abcdefg.mp3'>
+					<div class='bloom-page numberedPage' id='page1' data-page-number='1' data-backgroundaudio='Abcdefg.mp3' data-correct-sound='right.mp3' data-wrong-sound='bad.mp3'>
 						<div class='marginBox'>
-							<div class=""bloom-translationGroup bloom-trailingElement"" data-default-languages=""auto"">
+							<div class=""bloom-translationGroup bloom-trailingElement"" data-default-languages=""auto"" data-sound='playme.mp3'>
 	                            <div class=""bloom-editable normal-style bloom-content1 bloom-visibility-code-on"" style=""min-height: 44px;"" tabindex=""0"" spellcheck=""true"" role=""textbox"" aria-label=""false"" lang=""akl"" contenteditable=""true"" data-languagetipcontent=""Aklanon"" data-audiorecordingmode=""Sentence"">
 	                                <p><span id=""i1083a390-c1ef-41d2-a55d-815eacb5c08c"" class=""audio-sentence"" recordingmd5=""5b5efdab7f705554614a6383ae6d9469"" data-duration=""3.004082"">This is some akl data</span></p>
 	                            </div>
@@ -231,6 +231,30 @@ namespace BloomTests.Book
         {
             Assert.That(_normalFilter.FilterRelative("something.md"), Is.False);
             Assert.That(_filterForEdit.FilterRelative("something.md"), Is.True);
+        }
+
+        [Test]
+        public void Filter_ForBloomPlayer_PassesSpecialAudioFiles()
+        {
+            Assert.That(_normalFilter.FilterRelative(Path.Combine("audio", "right.mp3")), Is.False);
+            Assert.That(_normalFilter.FilterRelative(Path.Combine("audio", "wrong.mp3")), Is.False);
+            Assert.That(
+                _normalFilter.FilterRelative(Path.Combine("audio", "playme.mp3")),
+                Is.False
+            );
+
+            Assert.That(
+                _filterForInteractive.FilterRelative(Path.Combine("audio", "right.mp3")),
+                Is.True
+            );
+            Assert.That(
+                _filterForInteractive.FilterRelative(Path.Combine("audio", "bad.mp3")),
+                Is.True
+            );
+            Assert.That(
+                _filterForInteractive.FilterRelative(Path.Combine("audio", "playme.mp3")),
+                Is.True
+            );
         }
 
         // For this we need a BookStorage. Possibly make a new constructor that just initializes the DOM, which is all many methods need.


### PR DESCRIPTION
- Add a section for item controls, move Delete and Duplicate into it
- "Part of the answer" control moves into it and is shown only when relevant
- new control to associate sound with image
- fixed a bug where bubbleManager could pick a hidden (e.g., Correct tab) item to select initially.
- cleanup and simplify some code...found places useMemo can replace useState+useEffect

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6573)
<!-- Reviewable:end -->
