### PR TITLE
Allow system language not to be localized on first run (BL-13708)

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -114,6 +114,14 @@ namespace Bloom
 			// to do it before we create the Autofac context objects that create all
 			// our singletons.
 			RegistrationDialog.UpgradeRegistrationIfNeeded();
+
+			// Initializing localization can pop up a dialog if the system language
+			// is not one of our supported languages. The following calls must be done
+			// before any UI windows are displayed, so we do them here before we call
+			// SetUpLocalization().  See BL-13708.
+			Application.EnableVisualStyles();
+			Application.SetCompatibleTextRenderingDefault(false);
+
 			// We use crowdin for localizing, and they require a directory per language setup.
             LocalizationManager.UseLanguageCodeFolders = true;
             // We want only good localizations in Bloom.
@@ -210,9 +218,6 @@ namespace Bloom
 
 			try
 			{
-				Application.EnableVisualStyles();
-				Application.SetCompatibleTextRenderingDefault(false);
-
 				var args = args1;
 
 				if (SIL.PlatformUtilities.Platform.IsWindows)


### PR DESCRIPTION
Note that this fix is on the Version5.6 branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6594)
<!-- Reviewable:end -->
