### PR TITLE
Prevent getfonts from returning fonts for unused styles (BL-13655)

### DIFF
--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -1733,13 +1733,8 @@ p {
             );
         }
 
-        [Test]
-        public void FindFontsUsedInCss_WorksWithHtml()
-        {
-            const string htmlContent =
-                @"<html>
-<head>
-<style type=""text/css"">
+        const string kHtmlHeadContent =
+            @"<style type=""text/css"">
     /*<![CDATA[*/
     .Title-On-Cover-style[lang=""en""] { font-family: NikoshBAN ! important, ""Andika Basic"" !important; }
     .small-style[lang=""en""] { font-family: Andika New Basic ! important; font-size: 9pt ! important; font-weight: normal ! important; font-style: normal ! important; }
@@ -1757,20 +1752,35 @@ p {
     .normal-style[lang=""en""] { font-family: Scheherazade ! important; }
 </style>
 -->
-</head>
-<body>
-<div style=""font-size:26.0pt; font-family:&quot;Charis SIL First&quot;;"">Test 1</div>
+";
+        const string kBodyContentWithoutClasses =
+            @"<div style=""font-size:26.0pt; font-family:&quot;Charis SIL First&quot;;"">Test 1</div>
 <p style=""font-size:26.0pt; font-family:'Charis SIL Second';"">Test 2</p>
 <div style=""font-size:26.0pt; /*font-family:&quot;Charis SIL Third&quot;;*/"">Test 3</div>
 <!--div style=""font-size:26.0pt; font-family:&quot;Charis SIL Fourth&quot;;"">Test 4</div-->
 <p style=""font-size:26.0pt; font-family:'Doulos SIL';""></p>
 <span style=""font-family: ABeeZee""></span>
+";
+
+        [Test]
+        public void FindFontsUsedInCss_WorksWithHtml()
+        {
+            const string htmlContent =
+                @"<html>
+<head>" + kHtmlHeadContent + @"
+</head>
+<body>"+ kBodyContentWithoutClasses + @"
+<div class=""Title-On-Cover-style"" lang=""en"">Test 5</div>
+<div class=""small-style"" lang=""en"">Test 6</div>
+<div class=""Inside-Back-Cover-style"" lang=""jmx"">Test 7</div>
+<div class=""big-style"" lang=""jmx"">Test 8</div>
+<div class=""New-style"" lang=""en"">Test 9</div>
 </body>
 </html>";
 
             var fonts = new HashSet<string>();
             HtmlDom.FindFontsUsedInCss(htmlContent, fonts, true);
-            Assert.AreEqual(6, fonts.Count, "Six fonts are used in the test html/css data");
+            Assert.AreEqual(6, fonts.Count, "Six fonts are found in the test html/css data");
             Assert.IsTrue(
                 fonts.Contains("NikoshBAN"),
                 "The text/css data refers to NikoshBAN as a font."
@@ -1794,6 +1804,39 @@ p {
             Assert.IsTrue(
                 fonts.Contains("Comic Sans MS"),
                 "The text/css data refers to Comic Sans MS as a font."
+            );
+        }
+
+        [Test]
+        public void FindFontsUsedInCss_WorksWithHtmlForActuallyUsedStyles()
+        {
+            const string htmlContent =
+                @"<html>
+<head>" + kHtmlHeadContent + @"
+</head>
+<body>" + kBodyContentWithoutClasses + @"
+<div class=""Title-On-Cover-style"" lang=""en"">Test 5</div>
+</body>
+</html>";
+
+            var fonts = new HashSet<string>();
+            HtmlDom.FindFontsUsedInCss(htmlContent, fonts, true);
+            Assert.AreEqual(4, fonts.Count, "Four fonts are actually used in the test html/css data");
+            Assert.IsTrue(
+                fonts.Contains("NikoshBAN"),
+                "The text/css data refers to NikoshBAN as a font."
+            );
+            Assert.IsTrue(
+                fonts.Contains("Andika Basic"),
+                "The text/css data refers to Andika Basic as a font."
+            );
+            Assert.IsTrue(
+                fonts.Contains("Charis SIL First"),
+                "The html style attribute refers to Charis SIL First as a font."
+            );
+            Assert.IsTrue(
+                fonts.Contains("Charis SIL Second"),
+                "The html style attribute refers to Charis SIL Second as a font."
             );
         }
 


### PR DESCRIPTION
This targets Version6.0 to get into harvester sooner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6596)
<!-- Reviewable:end -->
