### PR TITLE
Fix crash when downloading books with >1000 S3 objects (20240822)

### DIFF
--- a/src/BloomExe/WebLibraryIntegration/S3Extensions.cs
+++ b/src/BloomExe/WebLibraryIntegration/S3Extensions.cs
@@ -31,7 +31,10 @@ namespace Bloom.WebLibraryIntegration
             {
                 matchingItemsResponse = s3.ListObjectsV2(request);
                 allMatchingItems.AddRange(matchingItemsResponse.S3Objects);
-                request.ContinuationToken = matchingItemsResponse.ContinuationToken; // ContinuationToken indicates where the next request should start
+                // matchingItemsResponse.ContinuationToken indicates where the request that generated the response started
+                // matchingItemsResponse.NextContinuationToken indicates where the next request (if needed) should start
+                // request.ContinuationToken indicates where the request starts the next time it is used
+                request.ContinuationToken = matchingItemsResponse.NextContinuationToken;
             } while (matchingItemsResponse.IsTruncated); // IsTruncated returns true if it's not at the end
 
             return allMatchingItems;

--- a/src/BloomTests/WebLibraryIntegration/BloomS3ClientTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BloomS3ClientTests.cs
@@ -162,7 +162,7 @@ namespace BloomTests.WebLibraryIntegration
 
                 // Prep the next request (if needed)
                 listMatchingObjectsRequest.ContinuationToken =
-                    matchingFilesResponse.ContinuationToken;
+                    matchingFilesResponse.NextContinuationToken;
             } while (matchingFilesResponse.IsTruncated); // Returns true if haven't reached the end yet
         }
     }


### PR DESCRIPTION
Books with more than 1000 S3 objects would silently fail, crashing with an out of memory error due to an infinite (nonterminating) loop.  The symptom was a harvesterState of "Failed" and an empty harvesterLog array.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6609)
<!-- Reviewable:end -->
