### PR TITLE
Move item-specific options for draggables from toolbox to context

### DIFF
--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -24,6 +24,10 @@
         <source xml:lang="en">Choose...</source>
         <note>ID: EditTab.Toolbox.DragActivity.ChooseSound</note>
       </trans-unit>
+      <trans-unit id="EditTab.Toolbox.DragActivity.ChooseSoundFile" translate="no">
+        <source xml:lang="en">Choose Sound File</source>
+        <note>ID: EditTab.Toolbox.DragActivity.ChooseSound</note>
+      </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.Correct" translate="no">
         <source xml:lang="en">Correct</source>
         <note>ID: EditTab.Toolbox.DragActivity.Correct</note>
@@ -116,8 +120,12 @@
         <note>ID: EditTab.Toolbox.DragActivity.OrderCircleInstructions</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.PartOfRightAnswer" translate="no">
-        <source xml:lang="en">Selected element is part of right answer</source>
+        <source xml:lang="en">Part of the right answer</source>
         <note>ID: EditTab.Toolbox.DragActivity.PartOfRightAnswer</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.DragActivity.PartOfRightAnswerMore" translate="no">
+        <source xml:lang="en">Untick this item if it is not part of the right answer</source>
+        <note>ID: EditTab.Toolbox.DragActivity.PartOfRightAnswerMore</note>
       </trans-unit>
       <!--trans-unit id="EditTab.Toolbox.DragActivity.PartOfRightAnswerDisabled" translate="no">
         <source xml:lang="en">Nothing that can be part of the right answer is selected</source>

--- a/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityTool.tsx
@@ -672,6 +672,63 @@ const getSoundOptions = (
     return soundOptions;
 };
 
+export let soundFolder: string;
+export const setSoundFolder = (folder: string) => {
+    soundFolder = folder;
+};
+
+export const copyAndPlaySoundAsync = async (
+    newSoundId: string,
+    page: HTMLElement,
+    copyBuiltIn: boolean
+) => {
+    if (copyBuiltIn) {
+        await copyBuiltInSoundAsync(newSoundId);
+    }
+    playSound(newSoundId, page);
+};
+
+const copyBuiltInSoundAsync = async (newSoundId: string) => {
+    const resultAudioDir = await postJson(
+        "fileIO/getSpecialLocation",
+        "CurrentBookAudioDirectory"
+    );
+
+    if (!resultAudioDir) {
+        return; // huh??
+    }
+
+    const targetPath = resultAudioDir.data + "/" + newSoundId;
+    await postData("fileIO/copyFile", {
+        from: encodeURIComponent(newSoundId),
+        to: encodeURIComponent(targetPath)
+    });
+};
+
+export const showDialogToChooseSoundFileAsync = async () => {
+    const title = await theOneLocalizationManager.asyncGetText(
+        "EditTab.Toolbox.DragActivity.ChooseSoundFile",
+        "Choose Sound File",
+        ""
+    );
+    const result = await postJson("fileIO/chooseFile", {
+        // Enhance: use something with a callback that can't timeout
+        title,
+        fileTypes: [
+            {
+                name: "MP3",
+                extensions: ["mp3"]
+            }
+        ],
+        defaultPath: soundFolder,
+        destFolder: "audio"
+    });
+    if (result?.data) {
+        setSoundFolder(result?.data);
+    }
+    return result?.data;
+};
+
 // The core of the Game tool. (a good many classes and function names reflect its original
 // name, Drag Activity Tool))
 const DragActivityControls: React.FunctionComponent<{
@@ -681,9 +738,6 @@ const DragActivityControls: React.FunctionComponent<{
     // The sound files for correct and wrong answers, determined by attributes of the page.
     const [correctSound, setCorrectSound] = useState("");
     const [wrongSound, setWrongSound] = useState("");
-
-    // The folder in which the user last chose a sound file (in this session).
-    const [soundFolder, setSoundFolder] = useState("");
 
     // The core type of activity of the current page, from the data-activity attribute.
     const [activityType, setActivityType] = useState("");
@@ -826,28 +880,16 @@ const DragActivityControls: React.FunctionComponent<{
         getStateFromPage();
     }, [props.pageGeneration]);
 
-    const showDialogToChooseSoundFileAsync = async (soundType: SoundType) => {
-        const result = await postJson("fileIO/chooseFile", {
-            // Todo: use something with a callback that can't timeout
-            title: "Choose Sound File", // Todo: localize
-            fileTypes: [
-                {
-                    name: "MP#",
-                    extensions: ["mp3"]
-                }
-            ],
-            defaultPath: soundFolder,
-            destFolder: "audio"
-        });
-        if (!result || !result.data) {
+    const updateSoundShowingDialog = async (soundType: SoundType) => {
+        const newSoundId = await showDialogToChooseSoundFileAsync();
+        if (!newSoundId) {
             return;
         }
 
         const page = getPage();
-        setSoundFolder(result.data);
         const copyBuiltIn = false; // already copied, and not in our sounds folder
-        setSound(soundType, result.data, copyBuiltIn);
-        playSound(result.data, page);
+        setSound(soundType, newSoundId, copyBuiltIn);
+        playSound(newSoundId, page);
     };
 
     // There's a lot of async stuff here, and a lot of arguments passed. Some of the argument-passing
@@ -861,9 +903,6 @@ const DragActivityControls: React.FunctionComponent<{
         getSoundFilesAsync("correct").then(setCorrectFiles);
         getSoundFilesAsync("wrong").then(setWrongFiles);
     }, []);
-    // If we decide to have some built-in ones, these can be obtained like correctFiles and wrongFiles,
-    // with a new prefix. (useMemo is to prevent [] being a new and hence changed object on each render)
-    const imageFiles: string[] = useMemo(() => [], []);
 
     const correctSoundOptions = useMemo(
         () =>
@@ -887,35 +926,6 @@ const DragActivityControls: React.FunctionComponent<{
             ),
         [wrongFiles, wrongSound, noneLabel, chooseLabel]
     );
-    const [imageSound, setImageSound] = useState("none");
-    useEffect(() => {
-        setImageSound(
-            currentBubbleElement?.getAttribute("data-sound") ?? "none"
-        );
-    }, [currentBubbleElement]);
-    const imageSoundOptions = useMemo(
-        () =>
-            getSoundOptions(
-                "image",
-                imageFiles,
-                imageSound,
-                noneLabel,
-                chooseLabel
-            ),
-        [imageFiles, imageSound, noneLabel, chooseLabel]
-    );
-
-    // Currently we only allow associating an extra audio with images (and gifs), which have
-    // no other audio (except possibly image descriptions?). If we get an actual user request
-    // it may be clearer how attaching one to a text or video would work, given that they
-    // can already have narration or an audio channel.
-    const canChooseAudioForElement = useMemo(
-        () =>
-            currentBubbleElement &&
-            currentBubbleElement.getElementsByClassName("bloom-imageContainer")
-                .length > 0,
-        [currentBubbleElement]
-    );
 
     // const [dragObjectType, setDragObjectType] = useState("text");
     // Todo: something has to call setDragObjectType when a draggable is selected.
@@ -929,13 +939,12 @@ const DragActivityControls: React.FunctionComponent<{
 
     const onSoundItemChosen = (soundType: SoundType, newSoundId: string) => {
         if (newSoundId === "choose") {
-            showDialogToChooseSoundFileAsync(soundType);
+            updateSoundShowingDialog(soundType);
             return;
         }
         if (
             (newSoundId === correctSound && soundType === "correct") ||
-            (newSoundId === wrongSound && soundType === "wrong") ||
-            (newSoundId === imageSound && soundType === "image")
+            (newSoundId === wrongSound && soundType === "wrong")
         ) {
             // Nothing is changing; also, we don't want to try to copy the sound file again, especially if it
             // is a user-chosen one that we won't find in our sounds folder.
@@ -967,51 +976,12 @@ const DragActivityControls: React.FunctionComponent<{
                     page.setAttribute("data-wrong-sound", newSoundId);
                 }
                 break;
-            case "image":
-                setImageSound(newSoundId);
-                if (!currentBubbleElement) {
-                    return;
-                }
-                if (newSoundId === "none") {
-                    currentBubbleElement.removeAttribute("data-sound");
-                } else {
-                    currentBubbleElement.setAttribute("data-sound", newSoundId);
-                }
-                break;
         }
         if (newSoundId !== "none") {
             // I think this can be fire-and-forget. But if you add something else that
             // needs the file to be there,you should await this, or add it to copyAndPlaySound.
             copyAndPlaySoundAsync(newSoundId, page, copyBuiltIn);
         }
-    };
-
-    const copyAndPlaySoundAsync = async (
-        newSoundId: string,
-        page: HTMLElement,
-        copyBuiltIn: boolean
-    ) => {
-        if (copyBuiltIn) {
-            await copyBuiltInSoundAsync(newSoundId);
-        }
-        playSound(newSoundId, page);
-    };
-
-    const copyBuiltInSoundAsync = async (newSoundId: string) => {
-        const resultAudioDir = await postJson(
-            "fileIO/getSpecialLocation",
-            "CurrentBookAudioDirectory"
-        );
-
-        if (!resultAudioDir) {
-            return; // huh??
-        }
-
-        const targetPath = resultAudioDir.data + "/" + newSoundId;
-        await postData("fileIO/copyFile", {
-            from: encodeURIComponent(newSoundId),
-            to: encodeURIComponent(targetPath)
-        });
     };
 
     let startTabInstructionsData = { instructionsKey: "", headingKey: "" };
@@ -1035,21 +1005,6 @@ const DragActivityControls: React.FunctionComponent<{
             };
             break;
     }
-
-    const toggleIsPartOfRightAnswer = () => {
-        if (!currentBubbleTargetId) {
-            return;
-        }
-        if (currentBubbleTarget) {
-            currentBubbleTarget.ownerDocument
-                .getElementById("target-arrow")
-                ?.remove();
-            currentBubbleTarget.remove();
-            setCurrentBubbleTarget(undefined);
-        } else {
-            setCurrentBubbleTarget(makeTargetForBubble(currentBubbleElement!));
-        }
-    };
 
     const toggleAllSameSize = () => {
         const newAllSameSize = !allItemsSameSize;
@@ -1114,7 +1069,6 @@ const DragActivityControls: React.FunctionComponent<{
     const anyDraggables = activityType !== "drag-sort-sentence";
     // Does this activity type have a row of options buttons in Start mode?
     const anyOptions = anyDraggables; // but they might diverge as we do more?
-    const anyItemOptions = currentBubbleTargetId || canChooseAudioForElement;
     // which controls to show?
     const showLetterDraggable =
         activityType !== "drag-word-chooser-slider" &&
@@ -1466,91 +1420,6 @@ const DragActivityControls: React.FunctionComponent<{
                             />
                         </BloomTooltip>
                     </div>
-                    {props.activeTab === startTabIndex && anyItemOptions && (
-                        <div
-                            css={css`
-                                margin-left: 10px;
-                            `}
-                        >
-                            <Div
-                                css={css`
-                                    margin-top: 5px;
-                                `}
-                                l10nKey="EditTab.Toolbox.DragActivity.Options"
-                            ></Div>
-
-                            {// The tooltip is set up for display as disabled, but our latest theory
-                            // is that it's better not to show this control at all when it does not apply.
-                            currentBubbleTargetId && (
-                                <div
-                                    css={css`
-                                        display: flex;
-                                        margin-top: 5px;
-                                    `}
-                                >
-                                    <BloomTooltip
-                                        // reinstate if we decide not to hid altogether if there's no targetId.
-                                        // enable if there's an active bubble that has a data-bubble-id indicating it is draggable in Play mode
-                                        // Don't disable pointer events because we need them to get the disabled tooltip.
-                                        // css={css`
-                                        //     ${currentBubbleTargetId
-                                        //         ? ""
-                                        //         : "opacity:0.4; "}
-                                        // `}
-                                        showDisabled={!currentBubbleTargetId}
-                                        id="partOfRightAnswer"
-                                        placement="top-end"
-                                        tip={
-                                            <Div l10nKey="EditTab.Toolbox.DragActivity.PartOfRightAnswer"></Div>
-                                        }
-                                        // If we decide not to hide it we might want to restore this and the corresponding
-                                        // element in BloomMediumPriority.xlf
-                                        // tipWhenDisabled={{
-                                        //     l10nKey:
-                                        //         "EditTab.Toolbox.DragActivity.PartOfRightAnswerDisabled",
-                                        //     english:
-                                        //         "Nothing that can be part of the right answer is selected"
-                                        // }}
-                                    >
-                                        <div
-                                            // it's part of the right answer iff it has a target
-                                            css={css`
-                                                ${optionCss(
-                                                    currentBubbleTarget
-                                                )}
-                                            `}
-                                            onClick={toggleIsPartOfRightAnswer}
-                                        >
-                                            <img src="images/Is part of right answer.svg"></img>
-                                        </div>
-                                    </BloomTooltip>
-                                </div>
-                            )}
-                            {canChooseAudioForElement && (
-                                <div
-                                    css={css`
-                                        margin: 5px 10px 0 0;
-                                        display: flex;
-                                        ${disabledCss(
-                                            canChooseAudioForElement
-                                        )};
-                                        gap: 5px;
-                                    `}
-                                >
-                                    <img
-                                        width="24px"
-                                        src="/bloom/bookEdit/toolbox/music/speaker-volume.svg"
-                                    />
-                                    {soundSelect(
-                                        "image",
-                                        imageSoundOptions,
-                                        imageSound,
-                                        onSoundItemChosen
-                                    )}
-                                </div>
-                            )}
-                        </div>
-                    )}
                 </div>
             )}
         </ThemeProvider>
@@ -1680,11 +1549,12 @@ export const makeDuplicateOfDragBubble = () => {
 };
 
 // Three kinds of sound we can set with a dropdown.
-type SoundType = "correct" | "wrong" | "image";
+// Temporarily we also allowed "image", so it was not a boolean
+export type SoundType = "correct" | "wrong";
 
 // Make a <Select> for choosing a sound file. The arguments allow reusing this for various sounds;
 // the "which" argument is only used to pass to the setValue function.
-const soundSelect = (
+export const soundSelect = (
     soundType: SoundType,
     options: { label: string; id: string; divider: boolean }[],
     value: string,
@@ -1957,7 +1827,7 @@ export class DragActivityTool extends ToolboxToolReactAdaptor {
         }
     }
 }
-function playSound(newSoundId: string, page: HTMLElement) {
+export function playSound(newSoundId: string, page: HTMLElement) {
     const audio = new Audio("audio/" + newSoundId);
     audio.style.visibility = "hidden";
     audio.classList.add("bloom-ui"); // so it won't be saved, even if we fail to remove it otherwise

--- a/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
+++ b/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
@@ -2,7 +2,7 @@
 import { jsx, css, SerializedStyles } from "@emotion/react";
 
 import * as React from "react";
-import { ReactNode, useEffect, useState } from "react";
+import { Fragment, ReactNode, useEffect, useState } from "react";
 import { useL10n } from "./l10nHooks";
 import {
     Checkbox,
@@ -27,13 +27,17 @@ import { Variant } from "@mui/material/styles/createTypography";
 
 interface IBaseLocalizableMenuItemProps {
     english: string;
-    l10nId: string;
+    l10nId: string | null; // pass null if already localized, to just use the "english"
     disabled?: boolean;
     tooltipIfDisabled?: string;
     variant?: OverridableStringUnion<
         Variant | "inherit",
         TypographyPropsVariantOverrides
     >;
+}
+
+export interface INestedMenuItemProps extends IBaseLocalizableMenuItemProps {
+    icon?: ReactNode;
 }
 
 export interface ILocalizableMenuItemProps
@@ -250,7 +254,7 @@ export const LocalizableCheckboxMenuItem: React.FunctionComponent<ILocalizableCh
     );
 };
 
-export const LocalizableNestedMenuItem: React.FunctionComponent<IBaseLocalizableMenuItemProps> = props => {
+export const LocalizableNestedMenuItem: React.FunctionComponent<INestedMenuItemProps> = props => {
     const label = useL10n(props.english, props.l10nId);
     if (!props.children) {
         return <React.Fragment />;
@@ -271,12 +275,39 @@ export const LocalizableNestedMenuItem: React.FunctionComponent<IBaseLocalizable
                 font-family: ${kUiFontStack};
                 font-size: 1rem !important;
                 color: ${menuItemColor} !important;
-                padding: 4px 6px 0 6px !important; // adjust for denser layout
+                // probably need this back if we return to dense layout
+                //padding: 4px 6px 0 6px !important; // adjust for denser layout
                 justify-content: space-between !important; // move sub-menu arrow to right
             `}
             key={props.l10nId}
-            label={label}
+            label={
+                props.icon ? (
+                    // This is a nuisance. We should just be able to pass on props.icon.
+                    // But the 3rd-party NestedMenuItem doesn't seem to support that.
+                    // So we make it part of our label and push it off to the left.
+                    // Seems to work OK as long as there is space for it, which typically
+                    // happens as long as there are other menu items in the list with icons.
+                    // I have no idea why this interferes with the default positioning
+                    // of the label, but the tweak there seems to be needed, too.
+                    <Fragment>
+                        <div
+                            css={css`
+                                position: absolute;
+                                top: 0;
+                                left: -15px;
+                                top: 5px;
+                            `}
+                        >
+                            {props.icon}
+                        </div>
+                        <div>{label}</div>
+                    </Fragment>
+                ) : (
+                    label
+                )
+            }
             parentMenuOpen={true}
+            //icon={props.icon}
         >
             {props.children}
         </NestedMenuItem>


### PR DESCRIPTION
Also fixes a glitch where nested menu items were not properly aligned after we switched away from 'dense' mode for popup menus.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6611)
<!-- Reviewable:end -->
