### PR TITLE
Various bug fixes

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2113,7 +2113,7 @@
         <note>Tooltip for the bubble Duplicate icon</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.ComicTool.Options.Format" sil:dynamic="true" translate="no">
-        <source xml:lang="en">Format Dialog...</source>
+        <source xml:lang="en">Format Text...</source>
         <note>ID: EditTab.Toolbox.ComicTool.Options.Format</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.ComicTool.Options.ImageSelected" sil:dynamic="true">

--- a/src/BloomBrowserUI/bookEdit/js/OverlayContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/OverlayContextControls.tsx
@@ -54,23 +54,24 @@ const OverlayContextControls: React.FunctionComponent<{
     const isPlaceHolder =
         hasImage && img.getAttribute("src")?.startsWith("placeHolder.png");
     // Some of the icons we use for buttons are Material UI ones. They need this CSS to look right.
-    const materialIconCss = css`
-        width: 30px;
+    const materialIconCss = (svgsize?: number) => css`
+        height: 30px;
         border-color: transparent;
         background-color: transparent;
         // These tweaks help make a neat row of aligned buttons the same size.
         top: -4px; // wants 3px if we remove align-items:start
         position: relative;
         svg {
-            font-size: 1.7rem;
+            font-size: ${svgsize ?? 1.7}rem;
         }
     `;
     // Some of the icons we use for buttons are SVGs. They need this CSS to look right and similar to
     // the Material UI ones.
     const svgIconCss = css`
-        width: 22px;
+        height: 23px;
         position: relative;
         //top: 7px; // restore if we remove align-items:start
+        top: -1px;
         border-color: transparent;
         background-color: transparent;
     `;
@@ -287,7 +288,7 @@ const OverlayContextControls: React.FunctionComponent<{
                                 }}
                             >
                                 <button
-                                    css={materialIconCss}
+                                    css={materialIconCss()}
                                     onClick={e => {
                                         if (!props.overlay) return;
                                         const imgContainer = props.overlay.getElementsByClassName(
@@ -315,7 +316,7 @@ const OverlayContextControls: React.FunctionComponent<{
                                 }}
                             >
                                 <button
-                                    css={materialIconCss}
+                                    css={materialIconCss(1.3)}
                                     style={{ marginRight: "20px" }}
                                     onClick={e => {
                                         if (!props.overlay) return;
@@ -355,7 +356,7 @@ const OverlayContextControls: React.FunctionComponent<{
                         >
                             <button
                                 css={svgIconCss}
-                                style={{ top: 0, width: "26px" }}
+                                style={{ width: "26px" }}
                                 onClick={() => {
                                     if (!props.overlay) return;
                                     GetEditor().runFormatDialog(editable);
@@ -371,6 +372,8 @@ const OverlayContextControls: React.FunctionComponent<{
                                         filter: invert(38%) sepia(93%)
                                             saturate(422%) hue-rotate(140deg)
                                             brightness(93%) contrast(96%);
+                                        height: 21px !important;
+                                        top: -1px;
                                     `}
                                     src="/bloom/bookEdit/img/cog.svg"
                                 />
@@ -405,25 +408,31 @@ const OverlayContextControls: React.FunctionComponent<{
                     </button>
                 </BloomTooltip>
                 <BloomTooltip
-                    id="format"
+                    id="trash"
                     placement="top"
                     tip={{
                         l10nKey: "Common.Delete"
                     }}
                 >
                     <button
-                        css={materialIconCss}
+                        css={svgIconCss}
                         onClick={() => {
                             if (!props.overlay) return;
                             deleteBubble();
                         }}
                     >
-                        <TrashIcon color={kBloomBlue} />
+                        <TrashIcon
+                            css={css`
+                                height: 23px;
+                                top: -2px;
+                            `}
+                            color={kBloomBlue}
+                        />
                     </button>
                 </BloomTooltip>
                 <button
                     ref={ref => (menuEl.current = ref)}
-                    css={materialIconCss}
+                    css={materialIconCss()}
                     onClick={() => props.setMenuOpen(true)}
                 >
                     <MenuIcon color="primary" />

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -20,6 +20,7 @@ import BloomNotices from "./bloomNotices";
 import BloomSourceBubbles from "../sourceBubbles/BloomSourceBubbles";
 import BloomHintBubbles from "./BloomHintBubbles";
 import {
+    BubbleManager,
     initializeBubbleManager,
     kTextOverPictureClass,
     kTextOverPictureSelector,
@@ -853,13 +854,36 @@ export function SetupElements(
         // active, and calling code is not specifying one, restore the one we saved.
         // This is especially useful when the page is unexpectedly reloaded, for example,
         // changing a picture.
+        // Later: we decided we only want to do this if we're on the same page as last time.
         if (!elementToFocus) {
-            elementToFocus = Array.from(
-                document.getElementsByClassName(kTextOverPictureClass)
-            ).find(e => e.hasAttribute("data-bloom-active")) as HTMLElement;
+            const currentPageId = document
+                .getElementsByClassName("bloom-page")[0]
+                ?.getAttribute("id");
+            if (currentPageId === (window.top as any).lastPageId) {
+                elementToFocus = Array.from(
+                    document.getElementsByClassName(kTextOverPictureClass)
+                ).find(e => e.hasAttribute("data-bloom-active")) as HTMLElement;
+            } else {
+                // remember this page!
+                (window.top as any).lastPageId = currentPageId;
+            }
+        }
+        if (!elementToFocus) {
+            // Seems the browser will spontaneously try to focus something, and it might be an overlay.
+            // We don't want an overlay initially showing as selected, so we'll arrange to ignore the
+            // next focus event.
+            // This feels fragile: what if the browser doesn't find something to focus, or does it
+            // before we set this flag? We might ignore a later focus event that we wanted.
+            // I've done my best to guard against this by making mouse down on a bubble unambiguously
+            // make it active, whatever happens with focus. And this trick is the only way I've found
+            // to prevent getting an overlay initially selected.
+            BubbleManager.ignoreNextFocus = true;
+            theOneBubbleManager.setActiveElement(elementToFocus);
         }
         // Ensure focus exists as best we can (BL-7994)
-        const focusable = $(elementToFocus).find(":focusable");
+        const focusable = elementToFocus
+            ? $(elementToFocus).find(":focusable")
+            : undefined;
         if (elementToFocus && focusable) {
             focusable.focus();
             // Ideally calling focus above has this as a side effect.
@@ -869,55 +893,8 @@ export function SetupElements(
             theOneBubbleManager.setActiveElement(elementToFocus);
             // see similar code below
             BloomSourceBubbles.ShowSourceBubbleForElement(elementToFocus);
-        } else if (
-            document.hasFocus() &&
-            document.activeElement &&
-            $(document.activeElement).find(":focusable").length > 0
-        ) {
-            // There seem to be cases where the active element does not actually have focus.
-            // We like it to, so the user can actually type there.
-            (document.activeElement as HTMLElement).focus();
-            // It may already be focused, in which case, focusing it again may not trigger the side effect.
-            // So do it explicitly.
-            BloomSourceBubbles.ShowSourceBubbleForElement(
-                document.activeElement
-            );
-            // bloomApi postDebugMessage(
-            //     "DEBUG bloomEditing/SetupElements()/after delayed loop to make source bubbles - trying to show source bubble on " +
-            //         document.activeElement.outerHTML
-            // );
         } else {
-            // bloomApi postDebugMessage(
-            //     "DEBUG bloomEditing/SetupElements()/after delayed loop to make source bubbles - no active element: try to set focus"
-            // );
-            // nothing is focused. If there are TOP boxes on the page, it's possible we've just reloaded
-            // the page after adding a TOP box. New TOP boxes are added last, so focusing the last one
-            // is helpful to make sure the user can immediately type into the new TOP box. (BL-8502).
-            // It's not obvious this is the most desirable focus when we're NOT doing comics, but it's still
-            // probably as good a guess as anything.
-            // The one case where it's definitely wrong is if we just added a TOP box to an image that isn't
-            // the last image on the page. Then we will pick the wrong one. Getting that right is going to take
-            // a pretty tricky solution, which I don't think we should attempt while stabilizing a beta, and
-            // may not be worth it at all.
-            // Note that there is code in bubbleManager.turnOnBubbleEditing() which tries to focus the last
-            // TOP bubble. We have not figured out why it doesn't work. Until we do, the two should probably
-            // be kept matching.
-            if (!focusLastEditableTopBox()) {
-                const firstEditable = $("body")
-                    .find("textarea:visible, div.bloom-editable:visible")
-                    .first();
-                if (firstEditable.length) {
-                    // bloomApi postDebugMessage(
-                    //     "DEBUG bloomEditing/SetupElements()/after delayed loop to make source bubbles - setting focus on " +
-                    //         firstEditable.get(0).outerHTML
-                    // );
-                    firstEditable.focus();
-                } else {
-                    // bloomApi postDebugMessage(
-                    //     "DEBUG bloomEditing/SetupElements()/after delayed loop to make source bubbles - nothing to focus??"
-                    // );
-                }
-            }
+            // It's OK not to focus anything.
         }
     }, bloomQtipUtils.horizontalOverlappingBubblesDelay);
 

--- a/src/content/templates/template books/Games/Games.html
+++ b/src/content/templates/template books/Games/Games.html
@@ -675,87 +675,6 @@
                         <img src="placeHolder.png" alt="" />
 
                         <div
-                            class="bloom-textOverPicture ui-resizable ui-draggable"
-                            style="left: 147.578px; top: 109.766px; width: 85px; height: 60px;"
-                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:11,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
-                            data-bubble-id="b12rlzh"
-                        >
-                            <div
-                                tabindex="0"
-                                class="bloom-imageContainer bloom-leadingElement"
-                                data-title="For the current paper size: • The image container is 220 x 193 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 688 x 604 dots would fill this container at 300 DPI."
-                                title=""
-                            >
-                                <img
-                                    src="placeHolder.png"
-                                    alt=""
-                                    data-copyright=""
-                                    data-creator=""
-                                    data-license=""
-                                />
-                            </div>
-                        </div>
-                        <div
-                            data-target-of="b12rlzh"
-                            tabindex="0"
-                            style="left: 60px; top: 214px; width: 85px; height: 60px;"
-                        ></div>
-
-                        <div
-                            class="bloom-textOverPicture ui-resizable ui-draggable"
-                            style="left: 239.313px; top: 86.75px; width: 85px; height: 60px;"
-                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:12,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
-                            data-bubble-id="muozas1"
-                        >
-                            <div
-                                tabindex="0"
-                                class="bloom-imageContainer bloom-leadingElement"
-                                data-title="For the current paper size: • The image container is 220 x 193 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 688 x 604 dots would fill this container at 300 DPI."
-                                title=""
-                            >
-                                <img
-                                    src="placeHolder.png"
-                                    alt=""
-                                    data-copyright=""
-                                    data-creator=""
-                                    data-license=""
-                                />
-                            </div>
-                        </div>
-                        <div
-                            data-target-of="muozas1"
-                            tabindex="0"
-                            style="left: 153.32px; top: 214px; width: 85px; height: 60px;"
-                        ></div>
-
-                        <div
-                            class="bloom-textOverPicture ui-resizable ui-draggable"
-                            style="left: 49px; top: 90.6563px; width: 85px; height: 60px; position: absolute;"
-                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:13,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
-                            data-bubble-id="lkbg233"
-                        >
-                            <div
-                                tabindex="0"
-                                class="bloom-imageContainer bloom-leadingElement"
-                                data-title="For the current paper size: • The image container is 220 x 193 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 688 x 604 dots would fill this container at 300 DPI."
-                                title=""
-                            >
-                                <img
-                                    src="placeHolder.png"
-                                    alt=""
-                                    data-copyright=""
-                                    data-creator=""
-                                    data-license=""
-                                />
-                            </div>
-                        </div>
-                        <div
-                            data-target-of="lkbg233"
-                            tabindex="0"
-                            style="left: 246px; top: 214px; width: 85px; height: 60px;"
-                        ></div>
-
-                        <div
                             class="bloom-textOverPicture bloom-gif drag-item-correct ui-resizable ui-draggable"
                             style="height: 297px; left: 373.297px; top: 35.9844px; width: 233px; position: absolute;"
                             data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:14,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
@@ -778,7 +697,7 @@
 
                         <div
                             class="bloom-textOverPicture ui-resizable ui-draggable"
-                            style="left: 5px; top: 5px; width: 364px; height: 84px; position: absolute;"
+                            style="left: 5px; top: 5px; width: 364px; height: 50px; position: absolute;"
                             data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:16,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
                         >
                             <div
@@ -802,28 +721,6 @@
                                 </div>
                             </div>
                         </div>
-
-                        <div
-                            class="bloom-textOverPicture ui-resizable ui-draggable"
-                            style="height: 193px; left: 385.141px; top: 44.1406px; width: 220px; position: absolute;"
-                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:17,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
-                        >
-                            <div
-                                tabindex="0"
-                                class="bloom-imageContainer bloom-leadingElement"
-                                data-title="For the current paper size: • The image container is 220 x 193 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 688 x 604 dots would fill this container at 300 DPI."
-                                title=""
-                            >
-                                <img
-                                    src="placeHolder.png"
-                                    alt=""
-                                    data-copyright=""
-                                    data-creator=""
-                                    data-license=""
-                                />
-                            </div>
-                        </div>
-
                         <div
                             class="bloom-textOverPicture drag-item-wrong ui-resizable ui-draggable"
                             style="height: 287px; left: 360.33333px; top: 8.33333px; width: 260px; position: absolute;"
@@ -844,6 +741,87 @@
                                 />
                             </div>
                         </div>
+
+                        <div
+                            class="bloom-textOverPicture ui-resizable ui-draggable"
+                            style="left: 147.578px; top: 109.766px; width: 61px; height: 60px;"
+                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:11,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
+                            data-bubble-id="b12rlzh"
+                        >
+                            <div
+                                tabindex="0"
+                                class="bloom-imageContainer bloom-leadingElement"
+                                data-title="For the current paper size: • The image container is 220 x 193 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 688 x 604 dots would fill this container at 300 DPI."
+                                title=""
+                            >
+                                <img
+                                    src="placeHolder.png"
+                                    alt=""
+                                    data-copyright=""
+                                    data-creator=""
+                                    data-license=""
+                                />
+                            </div>
+                        </div>
+                        <div
+                            data-target-of="b12rlzh"
+                            tabindex="0"
+                            style="left: 60px; top: 264px; width: 61px; height: 60px;"
+                        ></div>
+
+                        <div
+                            class="bloom-textOverPicture ui-resizable ui-draggable"
+                            style="left: 239.313px; top: 86.75px; width: 61px; height: 60px;"
+                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:12,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
+                            data-bubble-id="muozas1"
+                        >
+                            <div
+                                tabindex="0"
+                                class="bloom-imageContainer bloom-leadingElement"
+                                data-title="For the current paper size: • The image container is 220 x 193 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 688 x 604 dots would fill this container at 300 DPI."
+                                title=""
+                            >
+                                <img
+                                    src="placeHolder.png"
+                                    alt=""
+                                    data-copyright=""
+                                    data-creator=""
+                                    data-license=""
+                                />
+                            </div>
+                        </div>
+                        <div
+                            data-target-of="muozas1"
+                            tabindex="0"
+                            style="left: 153.32px; top: 264px; width: 61px; height: 60px;"
+                        ></div>
+
+                        <div
+                            class="bloom-textOverPicture ui-resizable ui-draggable"
+                            style="left: 49px; top: 90.6563px; width: 61px; height: 60px; position: absolute;"
+                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:13,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
+                            data-bubble-id="lkbg233"
+                        >
+                            <div
+                                tabindex="0"
+                                class="bloom-imageContainer bloom-leadingElement"
+                                data-title="For the current paper size: • The image container is 220 x 193 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 688 x 604 dots would fill this container at 300 DPI."
+                                title=""
+                            >
+                                <img
+                                    src="placeHolder.png"
+                                    alt=""
+                                    data-copyright=""
+                                    data-creator=""
+                                    data-license=""
+                                />
+                            </div>
+                        </div>
+                        <div
+                            data-target-of="lkbg233"
+                            tabindex="0"
+                            style="left: 246px; top: 264px; width: 61px; height: 60px;"
+                        ></div>
                     </div>
                 </div>
                 <button


### PR DESCRIPTION
Don't select an overlay when a page first loads or after deleting one
Make a text box active for editing only if it gets a simple click when already active.
Change Cog tooltip from "Format Dialog..." to "Format Text..."
Tweak initial layout of "Drag Images to targets". Unfortunately this included moving the draggables to the end of the list, where they belong, which obscures the other changes to them. I just reduced their width to give them the right aspect ratio for the placeholders, and moved the targets down a bit.
Tweak sizes and positions of overlay control icons

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6613)
<!-- Reviewable:end -->
