### PR TITLE
BL-13805 Branding control over credits lang

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2863,15 +2863,18 @@ namespace Bloom.Book
         /// </summary>
         private bool IsLanguageWantedInContent(XmlElement parent, string lang)
         {
-            var defaultLangs = parent.GetAttribute("data-default-languages");
-            if (String.IsNullOrEmpty(defaultLangs) || defaultLangs == "auto")
+            var dataDefaultLanguages = parent.GetAttribute("data-default-languages");
+
+            if (String.IsNullOrEmpty(dataDefaultLanguages) || dataDefaultLanguages == "auto")
                 return true; // assume we want everything
-            var dataDefaultLanguages = defaultLangs.Split(
-                new char[] { ',', ' ' },
-                StringSplitOptions.RemoveEmptyEntries
+
+            var defaultLangs = TranslationGroupManager.ProcessLanguageList(
+                dataDefaultLanguages,
+                _bookData
             );
-            foreach (var defaultLang in dataDefaultLanguages)
+            foreach (var defaultLang in defaultLangs)
             {
+                // enhance: have ProcessLanguageList() just do these conversions so that this becomes a simple comparison between lang and the defaultLang
                 switch (defaultLang)
                 {
                     case "V":

--- a/src/BloomExe/Book/TranslationGroupManager.cs
+++ b/src/BloomExe/Book/TranslationGroupManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Xml;
+using Bloom.Api;
 using L10NSharp;
 using SIL.Reporting;
 using SIL.WritingSystems;
@@ -277,10 +278,7 @@ namespace Bloom.Book
                 // This controls visibility for fields not yet controlled by the Appearance system
                 // (or in legacy mode).
                 var defLangsAttr = HtmlDom.GetAttributeValue(group, "data-default-languages");
-                var dataDefaultLanguages = defLangsAttr.Split(
-                    new char[] { ',', ' ' },
-                    StringSplitOptions.RemoveEmptyEntries
-                );
+                var dataDefaultLanguages = ProcessLanguageList(defLangsAttr, bookData);
 
                 //nb: we don't necessarily care that a div is editable or not
                 UpdateGeneratedClassesOnChildren(
@@ -313,6 +311,45 @@ namespace Bloom.Book
                     dataDefaultLanguages
                 );
             }
+        }
+
+        public static string[] ProcessLanguageList(
+            string languagesAttributeString,
+            BookData bookData
+        )
+        {
+            // Enhance: could probably just do all the "V", "L1", etc. replacements here, rather than in ShouldNormallyShowEditable()
+            // and Book.IsLanguageWantedInContent() and then simplify those functions.
+
+            var placeholdersWithDefaults = new Dictionary<string, string>
+            {
+                // Allow branding to set the language for the cover credits (needed by Angola in 2024)
+                { "CoverCreditsLanguage", "V" },
+            };
+            // As of Bloom 6.0, only front cover credits has one of these placeholders.
+            // Example: +field-prototypeDeclaredExplicity("[CoverCreditsLanguage]")
+            if (languagesAttributeString.Contains("["))
+            {
+                var brandingSettings = BrandingSettings.GetSettingsOrNull(
+                    bookData.CollectionSettings.BrandingProjectKey
+                );
+                foreach (var placeholderWithDefault in placeholdersWithDefaults)
+                {
+                    var replacement = brandingSettings?.GetPresetKeyValueOrDefault(
+                        placeholderWithDefault.Key,
+                        placeholderWithDefault.Value // default if not specified by this branding
+                    );
+                    languagesAttributeString = languagesAttributeString.Replace(
+                        // we are using square brackets in the pug for no particular reason, just looks right
+                        "[" + placeholderWithDefault.Key + "]",
+                        replacement
+                    );
+                }
+            }
+            return languagesAttributeString.Split(
+                new char[] { ',', ' ' },
+                StringSplitOptions.RemoveEmptyEntries
+            );
         }
 
         public static bool IsPageAffectedByLanguageMenu(XmlElement page, bool legacy)

--- a/src/BloomExe/web/controllers/BrandingSettings.cs
+++ b/src/BloomExe/web/controllers/BrandingSettings.cs
@@ -27,6 +27,7 @@ namespace Bloom.Api
     public class BrandingSettings
     {
         public const string kBrandingImageUrlPart = "branding/image";
+        private static readonly object _cacheLock = new object();
 
         /// <summary>
         /// Find the requested branding image file for the given branding, looking for a .png file if the .svg file does not exist.
@@ -69,8 +70,13 @@ namespace Bloom.Api
 
         public class PresetItem
         {
+            // this was originally only for data-book, but it may now also used for other presets, in which case it's just the "key" of the preset
             [JsonProperty("data-book")]
             public string DataBook;
+
+            // used when you don't want to introduce a data-book item, just supply a string to something. The `content` is the string.
+            [JsonProperty("key")]
+            public string Key;
 
             [JsonProperty("lang")]
             public string Lang;
@@ -94,6 +100,12 @@ namespace Bloom.Api
             {
                 var x = this.Presets.FirstOrDefault(p => p.DataBook == "xmatter");
                 return x?.Content;
+            }
+
+            public string GetPresetKeyValueOrDefault(string key, string defaultValue)
+            {
+                var kv = this.Presets.FirstOrDefault(p => p.Key == key);
+                return kv?.Content ?? defaultValue;
             }
         }
 
@@ -133,8 +145,26 @@ namespace Bloom.Api
         /// <param name="brandingNameOrFolderPath"> Normally, the branding is just a name, which we look up in the official branding folder
         //but unit tests can instead provide a path to the folder.
         /// </param>
+
+        public static Settings CachedBrandingSettings;
+        private static string CachedBrandingSettingsName;
+        private static string CachedBrandingSettingsPath;
+        private static DateTime CachedBrandingSettingsLastModified;
+
         public static Settings GetSettingsOrNull(string brandingNameOrFolderPath)
         {
+            if (CachedBrandingSettingsName == brandingNameOrFolderPath)
+            {
+                if (
+                    !Debugger.IsAttached // in production, we don't want to check this
+                    || RobustFile.GetLastWriteTimeUtc(CachedBrandingSettingsPath) // during development, we may be changing the branding.json file
+                        == CachedBrandingSettingsLastModified
+                )
+                {
+                    return CachedBrandingSettings;
+                }
+            }
+
             try
             {
                 ParseBrandingKey(
@@ -161,7 +191,7 @@ namespace Bloom.Api
                     );
                 }
 
-                // if not, fall bck to just "branding.json"
+                // if not, fall back to just "branding.json"
                 if (string.IsNullOrEmpty(settingsPath))
                 {
                     settingsPath = BloomFileLocator.GetOptionalBrandingFile(
@@ -232,6 +262,16 @@ namespace Bloom.Api
                             p.Content = p.Content.Replace("{flavor}", flavor);
                         }
                     });
+                    // lock for thread safety
+                    lock (_cacheLock)
+                    {
+                        CachedBrandingSettings = settings;
+                        CachedBrandingSettingsName = brandingNameOrFolderPath;
+                        CachedBrandingSettingsPath = settingsPath;
+                        CachedBrandingSettingsLastModified = RobustFile.GetLastWriteTimeUtc(
+                            settingsPath
+                        );
+                    }
                     return settings;
                 }
             }

--- a/src/content/branding/INADE-PATII-Angola/branding.json
+++ b/src/content/branding/INADE-PATII-Angola/branding.json
@@ -1,12 +1,10 @@
 {
     "presets": [
-        // {
-        //     "data-book": "licenseUrl",
-        //     "lang": "*",
-        //     "content": "http://creativecommons.org/licenses/by-nc/4.0/",
-        //     "condition": "always"
-        // },
-
+        {
+            // instead of the usual L1 for cover credits language, they want to use Portuguese
+            "key": "CoverCreditsLanguage",
+            "content": "pt"
+        },
         {
             "data-book": "outside-back-cover-branding-top-html",
             "lang": "*",

--- a/src/content/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/content/templates/xMatter/bloom-xmatter-mixins.pug
@@ -139,7 +139,7 @@ mixin standard-cover-contents
 				//NB: don't convert this to an inline label; that interferes with the bloom-copyFromOtherLanguageIfNecessary,
 				// because it is never empty
 				.creditsRow(data-hint='You may use this space for author/illustrator, or anything else.')
-					+field-prototypeDeclaredExplicity("V")
+					+field-prototypeDeclaredExplicity("[CoverCreditsLanguage]")
 						+editable(kLanguageForPrototypeOnly).smallCoverCredits.Cover-Default-style(data-book='smallCoverCredits')
 
 			block cover-bottom-row-before-branding


### PR DESCRIPTION
I started working on unit tests but this pulls things from branding in such a way it would be a complex thing to make the test, and/or after refactoring down to something isolated, there are only 2 trivial lines (which might be ok) but then at runtime everything would be dramatically more expensive. Even looking at adding a mock on all this static stuff looked to be an order of magnitude more work than the actual code under test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6626)
<!-- Reviewable:end -->
