### PR TITLE
Store all language names from spreadsheet import (BL-13551)

### DIFF
--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -16,6 +16,8 @@ using Bloom.Api;
 using Bloom.Publish.BloomLibrary;
 using SIL.IO;
 using SIL.Windows.Forms.SettingProtection;
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Bloom.Collection
 {
@@ -266,6 +268,9 @@ namespace Bloom.Collection
             {
                 PendingLanguage1.Tag = l.LanguageTag;
                 PendingLanguage1.SetName(l.DesiredName, l.DesiredName != l.Names.FirstOrDefault());
+                // Review/Todo: update the rest of PendingLanguage1's properties if a match found in
+                // existing languages? _collectionSettings.LanguagesZeroBased.Find(x => x.Tag == l.languageTag);
+                // (and possibly update PendingFontSelections[0] as well)
                 ChangeThatRequiresRestart();
             }
         }
@@ -281,6 +286,9 @@ namespace Bloom.Collection
             {
                 PendingLanguage2.Tag = l.LanguageTag;
                 PendingLanguage2.SetName(l.DesiredName, l.DesiredName != l.Names.FirstOrDefault());
+                // Review/Todo: update the rest of PendingLanguage2's properties if a match found in
+                // existing languages? _collectionSettings.LanguagesZeroBased.Find(x => x.Tag == l.languageTag);
+                // (and possibly update PendingFontSelections[1] as well)
                 ChangeThatRequiresRestart();
             }
         }
@@ -296,6 +304,9 @@ namespace Bloom.Collection
             {
                 PendingLanguage3.Tag = l.LanguageTag;
                 PendingLanguage3.SetName(l.DesiredName, l.DesiredName != l.Names.FirstOrDefault());
+                // Review/Todo: update the rest of PendingLanguage3's properties if a match found in
+                // existing languages? _collectionSettings.LanguagesZeroBased.Find(x => x.Tag == l.languageTag);
+                // (and possibly update PendingFontSelections[2] as well)
                 ChangeThatRequiresRestart();
             }
         }
@@ -410,18 +421,6 @@ namespace Bloom.Collection
             _collectionSettings.Province = _provinceText.Text.Trim();
             _collectionSettings.District = _districtText.Text.Trim();
 
-            var languages = _collectionSettings.LanguagesZeroBased;
-            for (int i = 0; i < 3; i++)
-            {
-                if (languages[i] == null)
-                    continue;
-                languages[i].FontName = PendingFontSelections[i];
-                languages[i].IsRightToLeft = PendingLanguages[i].IsRightToLeft;
-                languages[i].LineHeight = PendingLanguages[i].LineHeight;
-                languages[i].BaseUIFontSizeInPoints = PendingLanguages[i].BaseUIFontSizeInPoints;
-                languages[i].BreaksLinesOnlyAtSpaces = PendingLanguages[i].BreaksLinesOnlyAtSpaces;
-            }
-
             _collectionSettings.PageNumberStyle = PendingNumberingStyle; // non-localized key
 
             var oldBrand = _collectionSettings.BrandingProjectKey;
@@ -462,24 +461,13 @@ namespace Bloom.Collection
             //no point in letting them have the Nat lang 2 be the same as 1
             if (PendingLanguage2.Tag == PendingLanguage3.Tag)
                 PendingLanguage3.ChangeTag(String.Empty);
-            _collectionSettings.Language1.ChangeTag(PendingLanguage1.Tag);
-            _collectionSettings.Language1.SetName(
-                PendingLanguage1.Name,
-                PendingLanguage1.IsCustomName
+
+            UpdateLanguageSettings(
+                _collectionSettings.LanguagesZeroBased,
+                PendingLanguages,
+                PendingFontSelections
             );
-            _collectionSettings.Language2.ChangeTag(PendingLanguage2.Tag);
-            // Note that setting the tag to empty will cause the name to be set to empty.
-            if (!String.IsNullOrEmpty(PendingLanguage2.Tag))
-                _collectionSettings.Language2.SetName(
-                    PendingLanguage2.Name,
-                    PendingLanguage2.IsCustomName
-                );
-            _collectionSettings.Language3.ChangeTag(PendingLanguage3.Tag);
-            if (!String.IsNullOrEmpty(PendingLanguage3.Tag))
-                _collectionSettings.Language3.SetName(
-                    PendingLanguage3.Name,
-                    PendingLanguage3.IsCustomName
-                );
+
             _collectionSettings.SignLanguage.ChangeTag(PendingSignLanguage.Tag);
             if (!String.IsNullOrEmpty(PendingSignLanguage.Tag))
                 _collectionSettings.SignLanguage.SetName(
@@ -499,6 +487,106 @@ namespace Bloom.Collection
             Close();
 
             DialogResult = AnyReasonToRestart() ? DialogResult.Yes : DialogResult.OK;
+        }
+
+        // internal and static to facilitate unit testing
+        internal static void UpdateLanguageSettings(
+            List<WritingSystem> languages,
+            WritingSystem[] pendingLanguages,
+            string[] pendingFonts
+        )
+        {
+            Debug.Assert(languages.Count >= 3);
+            Debug.Assert(pendingLanguages.Length == 3);
+            Debug.Assert(pendingFonts.Length == 3);
+
+            // Provide some useful abbreviations for the first 3 languages.
+            // (This method is static so that it can be tested without creating a dialog.)
+            var Language1 = languages[0];
+            var Language2 = languages[1];
+            var Language3 = languages.Count > 2 ? languages[2] : null;
+            var PendingLanguage1 = pendingLanguages[0];
+            var PendingLanguage2 = pendingLanguages[1];
+            var PendingLanguage3 = pendingLanguages[2];
+
+            // NOTE: if one of the first 3 languages is replaced, we need to add it to
+            // the list after the first 3.  If one of the first 3 languages was already
+            // in the list, we need to remove it from its old position.
+
+            // Copy the old Language1 if it's not in the first 3 languages.
+            if (
+                Language1.Tag != PendingLanguage1.Tag
+                && Language1.Tag != PendingLanguage2.Tag
+                && Language1.Tag != PendingLanguage3.Tag
+            )
+            {
+                languages.Add(Language1.Clone()); // need a fresh copy
+            }
+            // Copy the old Language2 if it's not in the first 3 languages, and is not
+            // the same as the old Language1.
+            if (
+                Language2.Tag != PendingLanguage1.Tag
+                && Language2.Tag != PendingLanguage2.Tag
+                && Language2.Tag != PendingLanguage3.Tag
+                && Language2.Tag != Language1.Tag
+            )
+            {
+                languages.Add(Language2.Clone());
+            }
+            // Copy the old Language3 if it exists and is not in the first 3 languages, and
+            // is not the same as either the old Language1 or the old Language2.
+            if (
+                !String.IsNullOrEmpty(Language3.Tag)
+                && Language3.Tag != PendingLanguage1.Tag
+                && Language3.Tag != PendingLanguage2.Tag
+                && Language3.Tag != PendingLanguage3.Tag
+                && Language3.Tag != Language1.Tag
+                && Language3.Tag != Language2.Tag
+            )
+            {
+                languages.Add(Language3.Clone());
+            }
+            // Remove the languages that are now in the first 3 languages from later in the list
+            // if they were in the list after the first 3 languages.
+            for (int i = languages.Count - 1; i >= 3; i--)
+            {
+                if (languages[i].Tag == PendingLanguage1.Tag)
+                {
+                    languages.RemoveAt(i);
+                }
+                else if (languages[i].Tag == PendingLanguage2.Tag)
+                {
+                    languages.RemoveAt(i);
+                }
+                else if (
+                    !String.IsNullOrEmpty(PendingLanguage3.Tag)
+                    && languages[i].Tag == PendingLanguage3.Tag
+                )
+                {
+                    languages.RemoveAt(i);
+                }
+            }
+            // Update the values in the first three languages.
+            for (int i = 0; i < 3; i++)
+            {
+                if (languages[i] == null)
+                    continue;
+                languages[i].FontName = pendingFonts[i];
+                languages[i].IsRightToLeft = pendingLanguages[i].IsRightToLeft;
+                languages[i].LineHeight = pendingLanguages[i].LineHeight;
+                languages[i].BaseUIFontSizeInPoints = pendingLanguages[i].BaseUIFontSizeInPoints;
+                languages[i].BreaksLinesOnlyAtSpaces = pendingLanguages[i].BreaksLinesOnlyAtSpaces;
+            }
+
+            Language1.ChangeTag(PendingLanguage1.Tag);
+            Language1.SetName(PendingLanguage1.Name, PendingLanguage1.IsCustomName);
+            // Note that setting the tag to empty will cause the name to be set to empty.
+            Language2.ChangeTag(PendingLanguage2.Tag);
+            if (!String.IsNullOrEmpty(PendingLanguage2.Tag))
+                Language2.SetName(PendingLanguage2.Name, PendingLanguage2.IsCustomName);
+            Language3.ChangeTag(PendingLanguage3.Tag);
+            if (!String.IsNullOrEmpty(PendingLanguage3.Tag))
+                Language3.SetName(PendingLanguage3.Name, PendingLanguage3.IsCustomName);
         }
 
         private bool XMatterChangePending

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -92,11 +92,11 @@ namespace Bloom.Collection
             PendingLanguages[1] = PendingLanguage2;
             PendingLanguages[2] = PendingLanguage3;
 
-            PendingFontSelections[0] = _collectionSettings.LanguagesZeroBased[0].FontName;
-            PendingFontSelections[1] = _collectionSettings.LanguagesZeroBased[1].FontName;
-            var have3rdLanguage = _collectionSettings.LanguagesZeroBased[2] != null;
+            PendingFontSelections[0] = _collectionSettings.AllLanguages[0].FontName;
+            PendingFontSelections[1] = _collectionSettings.AllLanguages[1].FontName;
+            var have3rdLanguage = _collectionSettings.AllLanguages[2] != null;
             PendingFontSelections[2] = have3rdLanguage
-                ? _collectionSettings.LanguagesZeroBased[2].FontName
+                ? _collectionSettings.AllLanguages[2].FontName
                 : "";
             PendingNumberingStyle = _collectionSettings.PageNumberStyle;
             PendingXmatter = _collectionSettings.XMatterPackName;
@@ -268,9 +268,8 @@ namespace Bloom.Collection
             {
                 PendingLanguage1.Tag = l.LanguageTag;
                 PendingLanguage1.SetName(l.DesiredName, l.DesiredName != l.Names.FirstOrDefault());
-                // Review/Todo: update the rest of PendingLanguage1's properties if a match found in
-                // existing languages? _collectionSettings.LanguagesZeroBased.Find(x => x.Tag == l.languageTag);
-                // (and possibly update PendingFontSelections[0] as well)
+                // Enhance: if we already have information about the newly chosen language we could copy it into the dialog.
+                // (find it by _collectionSettings.LanguagesZeroBased.Find(x => x.Tag == l.languageTag);)
                 ChangeThatRequiresRestart();
             }
         }
@@ -286,9 +285,8 @@ namespace Bloom.Collection
             {
                 PendingLanguage2.Tag = l.LanguageTag;
                 PendingLanguage2.SetName(l.DesiredName, l.DesiredName != l.Names.FirstOrDefault());
-                // Review/Todo: update the rest of PendingLanguage2's properties if a match found in
-                // existing languages? _collectionSettings.LanguagesZeroBased.Find(x => x.Tag == l.languageTag);
-                // (and possibly update PendingFontSelections[1] as well)
+                // Enhance: if we already have information about the newly chosen language we could copy it into the dialog.
+                // (find it by _collectionSettings.LanguagesZeroBased.Find(x => x.Tag == l.languageTag);)
                 ChangeThatRequiresRestart();
             }
         }
@@ -304,9 +302,8 @@ namespace Bloom.Collection
             {
                 PendingLanguage3.Tag = l.LanguageTag;
                 PendingLanguage3.SetName(l.DesiredName, l.DesiredName != l.Names.FirstOrDefault());
-                // Review/Todo: update the rest of PendingLanguage3's properties if a match found in
-                // existing languages? _collectionSettings.LanguagesZeroBased.Find(x => x.Tag == l.languageTag);
-                // (and possibly update PendingFontSelections[2] as well)
+                // Enhance: if we already have information about the newly chosen language we could copy it into the dialog.
+                // (find it by _collectionSettings.LanguagesZeroBased.Find(x => x.Tag == l.languageTag);)
                 ChangeThatRequiresRestart();
             }
         }
@@ -463,7 +460,7 @@ namespace Bloom.Collection
                 PendingLanguage3.ChangeTag(String.Empty);
 
             UpdateLanguageSettings(
-                _collectionSettings.LanguagesZeroBased,
+                _collectionSettings.AllLanguages,
                 PendingLanguages,
                 PendingFontSelections
             );
@@ -558,10 +555,7 @@ namespace Bloom.Collection
                 {
                     languages.RemoveAt(i);
                 }
-                else if (
-                    !String.IsNullOrEmpty(PendingLanguage3.Tag)
-                    && languages[i].Tag == PendingLanguage3.Tag
-                )
+                else if (languages[i].Tag == PendingLanguage3.Tag)
                 {
                     languages.RemoveAt(i);
                 }
@@ -725,9 +719,7 @@ namespace Bloom.Collection
                 pendingLanguage.BaseUIFontSizeInPoints = frm.UIFontSize;
                 pendingLanguage.IsRightToLeft = frm.LanguageRightToLeft;
                 return pendingLanguage.IsRightToLeft
-                    != _collectionSettings.LanguagesZeroBased[
-                        zeroBasedLanguageNumber
-                    ].IsRightToLeft;
+                    != _collectionSettings.AllLanguages[zeroBasedLanguageNumber].IsRightToLeft;
             }
         }
 

--- a/src/BloomExe/Spreadsheet/SpreadsheetApi.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetApi.cs
@@ -6,6 +6,7 @@ using Bloom.Book;
 using Bloom.CollectionTab;
 using Bloom.MiscUI;
 using Bloom.Properties;
+using Bloom.TeamCollection;
 using Bloom.ToPalaso;
 using L10NSharp;
 using SIL.IO;
@@ -20,16 +21,19 @@ namespace Bloom.Spreadsheet
         private readonly CollectionModel _collectionModel;
         private BookSelection _bookSelection;
         private readonly BloomWebSocketServer _webSocketServer;
+        private readonly TeamCollectionManager _teamCollectionManager;
 
         public SpreadsheetApi(
             CollectionModel collectionModel,
             BloomWebSocketServer webSocketServer,
-            BookSelection bookSelection
+            BookSelection bookSelection,
+            TeamCollectionManager teamCollectionManager
         )
         {
             _collectionModel = collectionModel;
             _webSocketServer = webSocketServer;
             _bookSelection = bookSelection;
+            _teamCollectionManager = teamCollectionManager;
         }
 
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
@@ -131,7 +135,8 @@ namespace Bloom.Spreadsheet
                 var importer = new SpreadsheetImporter(
                     _webSocketServer,
                     book,
-                    Path.GetDirectoryName(inputFilepath)
+                    Path.GetDirectoryName(inputFilepath),
+                    _teamCollectionManager
                 );
                 importer.ControlForInvoke = Shell.GetShellOrOtherOpenForm();
                 importer.ImportWithProgressAsync(

--- a/src/BloomExe/TeamCollection/TeamCollectionManager.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionManager.cs
@@ -117,13 +117,18 @@ namespace Bloom.TeamCollection
                     );
                     settings = ProjectContext.GetCollectionSettings(projectSettingsPath);
                 }
-                if (settings.Administrators.Length == 0)
-                    return true; // legacy TC, no admin recorded
-                return settings.Administrators.Contains(
-                    CurrentUser,
-                    StringComparer.InvariantCultureIgnoreCase
-                );
+                return CollectionSettingsCanBeEdited(settings);
             }
+        }
+
+        public static bool CollectionSettingsCanBeEdited(CollectionSettings settings)
+        {
+            if (settings.Administrators == null || settings.Administrators.Length == 0)
+                return true; // legacy TC, no admin recorded (or not TC)
+            return settings.Administrators.Contains(
+                CurrentUser,
+                StringComparer.InvariantCultureIgnoreCase
+            );
         }
 
         public static void RaiseTeamCollectionStatusChanged()

--- a/src/BloomExe/web/controllers/CollectionSettingsApi.cs
+++ b/src/BloomExe/web/controllers/CollectionSettingsApi.cs
@@ -575,12 +575,12 @@ namespace Bloom.web.controllers
             for (var i = 0; i < 3; i++)
             {
                 if (
-                    _collectionSettings.LanguagesZeroBased[i] == null
-                    || string.IsNullOrEmpty(_collectionSettings.LanguagesZeroBased[i].Name)
+                    _collectionSettings.AllLanguages[i] == null
+                    || string.IsNullOrEmpty(_collectionSettings.AllLanguages[i].Name)
                 )
                     continue;
-                var name = _collectionSettings.LanguagesZeroBased[i].Name;
-                var font = _collectionSettings.LanguagesZeroBased[i].FontName;
+                var name = _collectionSettings.AllLanguages[i].Name;
+                var font = _collectionSettings.AllLanguages[i].FontName;
                 langData[i] = new { languageName = name, fontName = font };
             }
             return langData;
@@ -596,7 +596,7 @@ namespace Bloom.web.controllers
             var zeroBasedLanguageNumber = languageNumber - 1;
             if (
                 zeroBasedLanguageNumber == 2
-                && _collectionSettings.LanguagesZeroBased[zeroBasedLanguageNumber] == null
+                && _collectionSettings.AllLanguages[zeroBasedLanguageNumber] == null
             )
                 return;
             if (DialogBeingEdited != null)
@@ -620,14 +620,12 @@ namespace Bloom.web.controllers
             var zeroBasedLanguageNumber = languageNumber - 1;
             if (
                 zeroBasedLanguageNumber == 2
-                && _collectionSettings.LanguagesZeroBased[zeroBasedLanguageNumber] == null
+                && _collectionSettings.AllLanguages[zeroBasedLanguageNumber] == null
             )
                 return;
             if (DialogBeingEdited != null)
                 DialogBeingEdited.PendingFontSelections[zeroBasedLanguageNumber] = fontName;
-            if (
-                fontName != _collectionSettings.LanguagesZeroBased[zeroBasedLanguageNumber].FontName
-            )
+            if (fontName != _collectionSettings.AllLanguages[zeroBasedLanguageNumber].FontName)
                 DialogBeingEdited.ChangeThatRequiresRestart();
         }
 

--- a/src/BloomExe/web/controllers/StylesAndFontsApi.cs
+++ b/src/BloomExe/web/controllers/StylesAndFontsApi.cs
@@ -347,13 +347,12 @@ namespace Bloom.web.controllers
             if (langTag == "*")
                 return L10NSharp.LocalizationManager.GetString("BookSettings.Fonts.All", "(all)");
             var settings = _bookSelection.CurrentSelection.CollectionSettings;
-            if (langTag == settings.Language1Tag)
-                return settings.Language1.Name;
-            if (langTag == settings.Language2Tag)
-                return settings.Language2.Name;
-            if (langTag == settings.Language3Tag)
-                return settings.Language3.Name;
-            var ws = new Collection.WritingSystem(99, () => settings.Language2Tag);
+            var language = settings.AllLanguages.Find(x => x.Tag == langTag);
+            if (language != null)
+                return language.Name;
+            if (langTag == settings.SignLanguageTag)
+                return settings.SignLanguage.Name;
+            var ws = new Collection.WritingSystem(() => settings.Language2Tag);
             ws.Tag = langTag;
             return ws.Name;
         }

--- a/src/BloomTests/Collection/WritingSystemDialogTests.cs
+++ b/src/BloomTests/Collection/WritingSystemDialogTests.cs
@@ -1,0 +1,394 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bloom.Collection;
+using NUnit.Framework;
+
+namespace BloomTests.Collection
+{
+    [TestFixture]
+    public class WritingSystemDialogTests
+    {
+        [OneTimeSetUp]
+        public void FixtureSetup()
+        {
+            SIL.Reporting.ErrorReport.IsOkToInteractWithUser = false;
+        }
+
+        private string DefaultLanguageForNames()
+        {
+            return "en";
+        }
+
+        [Test]
+        public void UpdateLanguageSettings_0()
+        {
+            /*
+             * original     pending      final list
+             * ----------   ----------   ----------
+             * [0] = "en"   [0] = "en"   [0] = "en"
+             * [1] = "en"   [1] = "en"   [1] = "en"
+             * [2] = ""     [2] = ""     [2] = ""
+             */
+            var languages = new List<WritingSystem>();
+            languages.Add(
+                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika" }
+            );
+            languages.Add(
+                new WritingSystem(2, DefaultLanguageForNames) { Tag = "en", FontName = "Andika" }
+            );
+            languages.Add(
+                new WritingSystem(3, DefaultLanguageForNames) { Tag = "", FontName = "Andika" }
+            );
+
+            var pending = new WritingSystem[3];
+            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "en" };
+            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "en" };
+            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "" };
+
+            var fonts = new string[3] { "Andika", "Andika", "Andika" };
+
+            CollectionSettingsDialog.UpdateLanguageSettings(languages, pending, fonts);
+
+            Assert.AreEqual(3, languages.Count);
+            Assert.AreEqual("en", languages[0].Tag);
+            Assert.AreEqual("Andika", languages[0].FontName);
+            Assert.AreEqual("en", languages[1].Tag);
+            Assert.AreEqual("Andika", languages[1].FontName);
+            Assert.AreEqual("", languages[2].Tag);
+            Assert.AreEqual("Andika", languages[2].FontName);
+        }
+
+        [Test]
+        public void UpdateLanguageSettings_1()
+        {
+            /*
+             * original     pending      final list
+             * ----------   ----------   ----------
+             * [0] = "en"   [0] = "en"   [0] = "en"
+             * [1] = "en"   [1] = "fr"   [1] = "fr"
+             * [2] = ""     [2] = "de"   [2] = "de"
+             * [3] = "es"                [3] = "es"
+             * [4] = "pt"                [4] = "pt"
+             */
+            var languages = new List<WritingSystem>();
+            languages.Add(
+                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+            );
+            languages.Add(
+                new WritingSystem(2, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 2" }
+            );
+            languages.Add(
+                new WritingSystem(3, DefaultLanguageForNames) { Tag = "", FontName = "Andika 3" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 4" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
+            );
+
+            var pending = new WritingSystem[3];
+            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "en" };
+            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr" };
+            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "de" };
+
+            var fonts = new string[3] { "Andika", "Andika", "Andika" };
+
+            CollectionSettingsDialog.UpdateLanguageSettings(languages, pending, fonts);
+
+            Assert.AreEqual(5, languages.Count);
+            Assert.AreEqual("en", languages[0].Tag);
+            Assert.AreEqual("Andika", languages[0].FontName);
+            Assert.AreEqual("fr", languages[1].Tag);
+            Assert.AreEqual("Andika", languages[1].FontName);
+            Assert.AreEqual("de", languages[2].Tag);
+            Assert.AreEqual("Andika", languages[2].FontName);
+            Assert.AreEqual("es", languages[3].Tag);
+            Assert.AreEqual("Andika 4", languages[3].FontName);
+            Assert.AreEqual("pt", languages[4].Tag);
+            Assert.AreEqual("Andika 5", languages[4].FontName);
+        }
+
+        [Test]
+        public void UpdateLanguageSettings_2()
+        {
+            /*
+             * original     pending      final list
+             * ----------   ----------   ----------
+             * [0] = "en"   [0] = "en"   [0] = "en"
+             * [1] = "en"   [1] = "fr"   [1] = "fr"
+             * [2] = ""     [2] = "de"   [2] = "de"
+             * [3] = "fr"                [3] = "es"
+             * [4] = "es"                [4] = "pt"
+             * [5] = "de"
+             * [6] = "pt"
+             */
+            var languages = new List<WritingSystem>();
+            languages.Add(
+                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+            );
+            languages.Add(
+                new WritingSystem(2, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 2" }
+            );
+            languages.Add(
+                new WritingSystem(3, DefaultLanguageForNames) { Tag = "", FontName = "Andika 3" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 4" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 5" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "de", FontName = "Andika 6" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 7" }
+            );
+
+            var pending = new WritingSystem[3];
+            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "en" };
+            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr" };
+            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "de" };
+
+            var fonts = new string[3] { "Andika", "Andika", "Andika" };
+
+            CollectionSettingsDialog.UpdateLanguageSettings(languages, pending, fonts);
+
+            Assert.AreEqual(5, languages.Count);
+            Assert.AreEqual("en", languages[0].Tag);
+            Assert.AreEqual("Andika", languages[0].FontName);
+            Assert.AreEqual("fr", languages[1].Tag);
+            Assert.AreEqual("Andika", languages[1].FontName);
+            Assert.AreEqual("de", languages[2].Tag);
+            Assert.AreEqual("Andika", languages[2].FontName);
+            Assert.AreEqual("es", languages[3].Tag);
+            Assert.AreEqual("Andika 5", languages[3].FontName);
+            Assert.AreEqual("pt", languages[4].Tag);
+            Assert.AreEqual("Andika 7", languages[4].FontName);
+        }
+
+        [Test]
+        public void UpdateLanguageSettings_3()
+        {
+            /*
+             * original     pending      final list
+             * ----------   ----------   ----------
+             * [0] = "en"   [0] = "es"   [0] = "es"
+             * [1] = "en"   [1] = "pt"   [1] = "pt"
+             * [2] = ""     [2] = ""     [2] = ""
+             * [3] = "fr"                [3] = "fr"
+             * [4] = "es"                [4] = "de"
+             * [5] = "de"                [5] = "en"
+             * [6] = "pt"
+             */
+            var languages = new List<WritingSystem>();
+            languages.Add(
+                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+            );
+            languages.Add(
+                new WritingSystem(2, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 2" }
+            );
+            languages.Add(
+                new WritingSystem(3, DefaultLanguageForNames) { Tag = "", FontName = "Andika 3" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 4" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 5" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "de", FontName = "Andika 6" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 7" }
+            );
+
+            var pending = new WritingSystem[3];
+            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "es" };
+            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "pt" };
+            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "" };
+
+            var fonts = new string[3] { "Andika", "Andika", "Andika" };
+
+            CollectionSettingsDialog.UpdateLanguageSettings(languages, pending, fonts);
+
+            Assert.AreEqual(6, languages.Count);
+            Assert.AreEqual("es", languages[0].Tag);
+            Assert.AreEqual("Andika", languages[0].FontName);
+            Assert.AreEqual("pt", languages[1].Tag);
+            Assert.AreEqual("Andika", languages[1].FontName);
+            Assert.AreEqual("", languages[2].Tag);
+            Assert.AreEqual("Andika", languages[2].FontName);
+            Assert.AreEqual("fr", languages[3].Tag);
+            Assert.AreEqual("Andika 4", languages[3].FontName);
+            Assert.AreEqual("de", languages[4].Tag);
+            Assert.AreEqual("Andika 6", languages[4].FontName);
+            Assert.AreEqual("en", languages[5].Tag);
+            Assert.AreEqual("Andika 1", languages[5].FontName);
+        }
+
+        [Test]
+        public void UpdateLanguageSettings_4()
+        {
+            /*
+             * original     pending      final list
+             * ----------   ----------   ----------
+             * [0] = "en"   [0] = "se"   [0] = "se"
+             * [1] = "fr"   [1] = "fr"   [1] = "fr"
+             * [2] = "es"   [2] = ""     [2] = ""
+             * [3] = "de"                [3] = "de"
+             * [4] = "pt"                [4] = "pt"
+             *                           [5] = "en"
+             *                           [6] = "es"
+             */
+            var languages = new List<WritingSystem>();
+            languages.Add(
+                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+            );
+            languages.Add(
+                new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 2" }
+            );
+            languages.Add(
+                new WritingSystem(3, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 3" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "de", FontName = "Andika 4" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
+            );
+
+            var pending = new WritingSystem[3];
+            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "se" };
+            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr" };
+            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "" };
+
+            var fonts = new string[3] { "Andika", "Andika", "Andika" };
+
+            CollectionSettingsDialog.UpdateLanguageSettings(languages, pending, fonts);
+
+            Assert.AreEqual(7, languages.Count);
+            Assert.AreEqual("se", languages[0].Tag);
+            Assert.AreEqual("Andika", languages[0].FontName);
+            Assert.AreEqual("fr", languages[1].Tag);
+            Assert.AreEqual("Andika", languages[1].FontName);
+            Assert.AreEqual("", languages[2].Tag);
+            Assert.AreEqual("Andika", languages[2].FontName);
+            Assert.AreEqual("de", languages[3].Tag);
+            Assert.AreEqual("Andika 4", languages[3].FontName);
+            Assert.AreEqual("pt", languages[4].Tag);
+            Assert.AreEqual("Andika 5", languages[4].FontName);
+            Assert.AreEqual("en", languages[5].Tag);
+            Assert.AreEqual("Andika 1", languages[5].FontName);
+            Assert.AreEqual("es", languages[6].Tag);
+            Assert.AreEqual("Andika 3", languages[6].FontName);
+        }
+
+        [Test]
+        public void UpdateLanguageSettings_5()
+        {
+            /*
+             * original     pending      final list
+             * ----------   ----------   ----------
+             * [0] = "en"   [0] = "de"   [0] = "de"
+             * [1] = "fr"   [1] = "fr"   [1] = "fr"
+             * [2] = "es"   [2] = "pt"   [2] = "pt"
+             * [3] = "de"                [3] = "en"
+             * [4] = "pt"                [4] = "es"
+             */
+            var languages = new List<WritingSystem>();
+            languages.Add(
+                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+            );
+            languages.Add(
+                new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 2" }
+            );
+            languages.Add(
+                new WritingSystem(3, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 3" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "de", FontName = "Andika 4" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
+            );
+
+            var pending = new WritingSystem[3];
+            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "de" };
+            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr" };
+            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "pt" };
+
+            var fonts = new string[3] { "Andika", "Andika", "Andika" };
+
+            CollectionSettingsDialog.UpdateLanguageSettings(languages, pending, fonts);
+
+            Assert.AreEqual(5, languages.Count);
+            Assert.AreEqual("de", languages[0].Tag);
+            Assert.AreEqual("Andika", languages[0].FontName);
+            Assert.AreEqual("fr", languages[1].Tag);
+            Assert.AreEqual("Andika", languages[1].FontName);
+            Assert.AreEqual("pt", languages[2].Tag);
+            Assert.AreEqual("Andika", languages[2].FontName);
+            Assert.AreEqual("en", languages[3].Tag);
+            Assert.AreEqual("Andika 1", languages[3].FontName);
+            Assert.AreEqual("es", languages[4].Tag);
+            Assert.AreEqual("Andika 3", languages[4].FontName);
+        }
+
+        [Test]
+        public void UpdateLanguageSettings_6()
+        {
+            /*
+             * original     pending      final list
+             * ----------   ----------   ----------
+             * [0] = "en"   [0] = "fr"   [0] = "fr"
+             * [1] = "fr"   [1] = "de"   [1] = "de"
+             * [2] = "es"   [2] = "en"   [2] = "en"
+             * [3] = "de"                [3] = "pt"
+             * [4] = "pt"                [4] = "es"
+             */
+            var languages = new List<WritingSystem>();
+            languages.Add(
+                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+            );
+            languages.Add(
+                new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 2" }
+            );
+            languages.Add(
+                new WritingSystem(3, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 3" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "de", FontName = "Andika 4" }
+            );
+            languages.Add(
+                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
+            );
+
+            var pending = new WritingSystem[3];
+            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "fr" };
+            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "de" };
+            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "en" };
+
+            var fonts = new string[3] { "Andika", "Andika", "Andika" };
+
+            CollectionSettingsDialog.UpdateLanguageSettings(languages, pending, fonts);
+
+            Assert.AreEqual(5, languages.Count);
+            Assert.AreEqual("fr", languages[0].Tag);
+            Assert.AreEqual("Andika", languages[0].FontName);
+            Assert.AreEqual("de", languages[1].Tag);
+            Assert.AreEqual("Andika", languages[1].FontName);
+            Assert.AreEqual("en", languages[2].Tag);
+            Assert.AreEqual("Andika", languages[2].FontName);
+            Assert.AreEqual("pt", languages[3].Tag);
+            Assert.AreEqual("Andika 5", languages[3].FontName);
+            Assert.AreEqual("es", languages[4].Tag);
+            Assert.AreEqual("Andika 3", languages[4].FontName);
+        }
+    }
+}

--- a/src/BloomTests/Collection/WritingSystemDialogTests.cs
+++ b/src/BloomTests/Collection/WritingSystemDialogTests.cs
@@ -34,19 +34,19 @@ namespace BloomTests.Collection
              */
             var languages = new List<WritingSystem>();
             languages.Add(
-                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "en", FontName = "Andika" }
             );
             languages.Add(
-                new WritingSystem(2, DefaultLanguageForNames) { Tag = "en", FontName = "Andika" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "en", FontName = "Andika" }
             );
             languages.Add(
-                new WritingSystem(3, DefaultLanguageForNames) { Tag = "", FontName = "Andika" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "", FontName = "Andika" }
             );
 
             var pending = new WritingSystem[3];
-            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "en" };
-            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "en" };
-            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "" };
+            pending[0] = new WritingSystem(DefaultLanguageForNames) { Tag = "en" };
+            pending[1] = new WritingSystem(DefaultLanguageForNames) { Tag = "en" };
+            pending[2] = new WritingSystem(DefaultLanguageForNames) { Tag = "" };
 
             var fonts = new string[3] { "Andika", "Andika", "Andika" };
 
@@ -75,25 +75,25 @@ namespace BloomTests.Collection
              */
             var languages = new List<WritingSystem>();
             languages.Add(
-                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
             );
             languages.Add(
-                new WritingSystem(2, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 2" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "en", FontName = "Andika 2" }
             );
             languages.Add(
-                new WritingSystem(3, DefaultLanguageForNames) { Tag = "", FontName = "Andika 3" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "", FontName = "Andika 3" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 4" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "es", FontName = "Andika 4" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
             );
 
             var pending = new WritingSystem[3];
-            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "en" };
-            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr" };
-            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "de" };
+            pending[0] = new WritingSystem(DefaultLanguageForNames) { Tag = "en" };
+            pending[1] = new WritingSystem(DefaultLanguageForNames) { Tag = "fr" };
+            pending[2] = new WritingSystem(DefaultLanguageForNames) { Tag = "de" };
 
             var fonts = new string[3] { "Andika", "Andika", "Andika" };
 
@@ -128,31 +128,31 @@ namespace BloomTests.Collection
              */
             var languages = new List<WritingSystem>();
             languages.Add(
-                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
             );
             languages.Add(
-                new WritingSystem(2, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 2" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "en", FontName = "Andika 2" }
             );
             languages.Add(
-                new WritingSystem(3, DefaultLanguageForNames) { Tag = "", FontName = "Andika 3" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "", FontName = "Andika 3" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 4" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 4" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 5" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "es", FontName = "Andika 5" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "de", FontName = "Andika 6" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "de", FontName = "Andika 6" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 7" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 7" }
             );
 
             var pending = new WritingSystem[3];
-            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "en" };
-            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr" };
-            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "de" };
+            pending[0] = new WritingSystem(DefaultLanguageForNames) { Tag = "en" };
+            pending[1] = new WritingSystem(DefaultLanguageForNames) { Tag = "fr" };
+            pending[2] = new WritingSystem(DefaultLanguageForNames) { Tag = "de" };
 
             var fonts = new string[3] { "Andika", "Andika", "Andika" };
 
@@ -187,31 +187,31 @@ namespace BloomTests.Collection
              */
             var languages = new List<WritingSystem>();
             languages.Add(
-                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
             );
             languages.Add(
-                new WritingSystem(2, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 2" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "en", FontName = "Andika 2" }
             );
             languages.Add(
-                new WritingSystem(3, DefaultLanguageForNames) { Tag = "", FontName = "Andika 3" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "", FontName = "Andika 3" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 4" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 4" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 5" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "es", FontName = "Andika 5" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "de", FontName = "Andika 6" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "de", FontName = "Andika 6" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 7" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 7" }
             );
 
             var pending = new WritingSystem[3];
-            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "es" };
-            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "pt" };
-            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "" };
+            pending[0] = new WritingSystem(DefaultLanguageForNames) { Tag = "es" };
+            pending[1] = new WritingSystem(DefaultLanguageForNames) { Tag = "pt" };
+            pending[2] = new WritingSystem(DefaultLanguageForNames) { Tag = "" };
 
             var fonts = new string[3] { "Andika", "Andika", "Andika" };
 
@@ -248,25 +248,25 @@ namespace BloomTests.Collection
              */
             var languages = new List<WritingSystem>();
             languages.Add(
-                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
             );
             languages.Add(
-                new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 2" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 2" }
             );
             languages.Add(
-                new WritingSystem(3, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 3" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "es", FontName = "Andika 3" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "de", FontName = "Andika 4" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "de", FontName = "Andika 4" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
             );
 
             var pending = new WritingSystem[3];
-            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "se" };
-            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr" };
-            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "" };
+            pending[0] = new WritingSystem(DefaultLanguageForNames) { Tag = "se" };
+            pending[1] = new WritingSystem(DefaultLanguageForNames) { Tag = "fr" };
+            pending[2] = new WritingSystem(DefaultLanguageForNames) { Tag = "" };
 
             var fonts = new string[3] { "Andika", "Andika", "Andika" };
 
@@ -303,25 +303,25 @@ namespace BloomTests.Collection
              */
             var languages = new List<WritingSystem>();
             languages.Add(
-                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
             );
             languages.Add(
-                new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 2" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 2" }
             );
             languages.Add(
-                new WritingSystem(3, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 3" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "es", FontName = "Andika 3" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "de", FontName = "Andika 4" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "de", FontName = "Andika 4" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
             );
 
             var pending = new WritingSystem[3];
-            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "de" };
-            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr" };
-            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "pt" };
+            pending[0] = new WritingSystem(DefaultLanguageForNames) { Tag = "de" };
+            pending[1] = new WritingSystem(DefaultLanguageForNames) { Tag = "fr" };
+            pending[2] = new WritingSystem(DefaultLanguageForNames) { Tag = "pt" };
 
             var fonts = new string[3] { "Andika", "Andika", "Andika" };
 
@@ -354,25 +354,25 @@ namespace BloomTests.Collection
              */
             var languages = new List<WritingSystem>();
             languages.Add(
-                new WritingSystem(1, DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "en", FontName = "Andika 1" }
             );
             languages.Add(
-                new WritingSystem(2, DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 2" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "fr", FontName = "Andika 2" }
             );
             languages.Add(
-                new WritingSystem(3, DefaultLanguageForNames) { Tag = "es", FontName = "Andika 3" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "es", FontName = "Andika 3" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "de", FontName = "Andika 4" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "de", FontName = "Andika 4" }
             );
             languages.Add(
-                new WritingSystem(0, DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
+                new WritingSystem(DefaultLanguageForNames) { Tag = "pt", FontName = "Andika 5" }
             );
 
             var pending = new WritingSystem[3];
-            pending[0] = new WritingSystem(1, DefaultLanguageForNames) { Tag = "fr" };
-            pending[1] = new WritingSystem(2, DefaultLanguageForNames) { Tag = "de" };
-            pending[2] = new WritingSystem(3, DefaultLanguageForNames) { Tag = "en" };
+            pending[0] = new WritingSystem(DefaultLanguageForNames) { Tag = "fr" };
+            pending[1] = new WritingSystem(DefaultLanguageForNames) { Tag = "de" };
+            pending[2] = new WritingSystem(DefaultLanguageForNames) { Tag = "en" };
 
             var fonts = new string[3] { "Andika", "Andika", "Andika" };
 

--- a/src/BloomTests/Publish/BloomLibraryPublishModelTests.cs
+++ b/src/BloomTests/Publish/BloomLibraryPublishModelTests.cs
@@ -294,7 +294,7 @@ namespace BloomTests.Publish
                 @"<html><head><div id='bloomDataDiv'>" + "</div></head><body></body></html>"
             );
             var bookData = new BookData(dom, collectionSettings, (x) => { });
-            var ws = new WritingSystem(-1, () => "en");
+            var ws = new WritingSystem(() => "en");
             collectionSettings.SignLanguage = ws;
             ws.Tag = "abc";
             ws.SetName("Sign", true);


### PR DESCRIPTION
This change does not address any GUI changes for setting or changing this information within Bloom itself.  More information than the language tag and name can be stored but currently would not be used anywhere.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6627)
<!-- Reviewable:end -->
