### PR TITLE
Fix template folder name for book filtering (BL-13825)

### DIFF
--- a/src/BloomExe/Book/BookFileFilter.cs
+++ b/src/BloomExe/Book/BookFileFilter.cs
@@ -68,7 +68,7 @@ namespace Bloom.Book
 				// In case the book is a template, we want at least the thumbnails
 				// and description files. This is rare enough that I don't think it's
 				// worth trying to be more precise.
-				_specialGroups.Add(new Regex(@"^templates(/|\\)"));
+				_specialGroups.Add(new Regex(@"^template(/|\\)"));
 			}
 		}
 

--- a/src/BloomTests/Book/BookFileFilterTests.cs
+++ b/src/BloomTests/Book/BookFileFilterTests.cs
@@ -214,8 +214,8 @@ namespace BloomTests.Book
 		[Test]
 		public void Filter_PassesTemplatesIfForEditing()
 		{
-			Assert.That(_normalFilter.FilterRelative(Path.Combine("templates", "somefile.svg")), Is.False);
-			Assert.That(_filterForEdit.FilterRelative(Path.Combine("templates", "somefile.svg")), Is.True);
+			Assert.That(_normalFilter.FilterRelative(Path.Combine("template", "somefile.svg")), Is.False);
+			Assert.That(_filterForEdit.FilterRelative(Path.Combine("template", "somefile.svg")), Is.True);
 
 		}
 


### PR DESCRIPTION
This is a minimal fix for Bloom 5.6.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6633)
<!-- Reviewable:end -->
