### PR TITLE
Update Activity.css to Games.css (BL-13815)

### DIFF
--- a/src/BloomExe/Book/SizeAndOrientation.cs
+++ b/src/BloomExe/Book/SizeAndOrientation.cs
@@ -92,6 +92,7 @@ namespace Bloom.Book
                     || fileName.ToLowerInvariant().Contains("origami")
                     || fileName.ToLowerInvariant().Contains("defaultlangstyles")
                     || fileName.ToLowerInvariant().Contains("customcollectionstyles")
+                    || fileName.ToLowerInvariant().EndsWith("activity.css") // obsolete Activity.css files didn't contain size info
                     ||
                     // Ignore this obsolete styles file as well.  See https://issues.bloomlibrary.org/youtrack/issue/BL-9128.
                     fileName

--- a/src/content/templates/Sample Shells/The Moon and the Cap/The Moon and the Cap.htm
+++ b/src/content/templates/Sample Shells/The Moon and the Cap/The Moon and the Cap.htm
@@ -31,6 +31,7 @@
     <link rel="stylesheet" href="previewMode.css" type="text/css"></link>
     <link rel="stylesheet" href="origami.css" type="text/css"></link>
     <link rel="stylesheet" href="Activity.css" type="text/css"></link>
+    <link rel="stylesheet" href="Games.css" type="text/css"></link>
     <link rel="stylesheet" href="Basic Book.css" type="text/css"></link>
     <link rel="stylesheet" href="Factory-XMatter.css" type="text/css"></link>
     <link rel="stylesheet" href="branding.css" type="text/css"></link>


### PR DESCRIPTION
But maintain backward compatibility so that older Blooms could still edit the book.  (Albeit with probably the same issue that triggered BL-13815.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6637)
<!-- Reviewable:end -->
