### PR TITLE
Fix javascript crash when duplicating an overlay bubbble (BL-13829)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -4264,9 +4264,15 @@ export class BubbleManager {
     }
 
     private removeJQueryResizableWidget() {
-        const allOverPictureElements = $("body").find(kTextOverPictureSelector);
-        // Removes the resizable functionality completely. This will return the element back to its pre-init state.
-        allOverPictureElements.resizable("destroy");
+        try {
+            const allOverPictureElements = $("body").find(
+                kTextOverPictureSelector
+            );
+            // Removes the resizable functionality completely. This will return the element back to its pre-init state.
+            allOverPictureElements.resizable("destroy");
+        } catch (e) {
+            //console.log(`Error removing resizable widget: ${e}`);
+        }
     }
 
     // Converts a text box's position to absolute in pixels (using CSS styling)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6638)
<!-- Reviewable:end -->
