### PR TITLE
Auto-height can be turned off, yielding new resize control (BL-13854)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2093,6 +2093,10 @@
         <source xml:lang="en">Add Child Bubble</source>
         <note>ID: EditTab.Toolbox.ComicTool.Options.AddChildBubble</note>
       </trans-unit>
+      <trans-unit id="EditTab.Toolbox.ComicTool.Options.AutoHeight" sil:dynamic="true">
+        <source xml:lang="en">Auto Height</source>
+        <note>ID: EditTab.Toolbox.ComicTool.Options.AutoHeight</note>
+      </trans-unit>
       <trans-unit id="EditTab.Toolbox.ComicTool.Options.BackgroundColor" sil:dynamic="true">
         <source xml:lang="en">Background Color</source>
         <note>ID: EditTab.Toolbox.ComicTool.Options.BackgroundColor</note>

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -189,6 +189,9 @@ export default class OverflowChecker {
             e.style.flexGrow = "0";
             e.style.flexShrink = "0";
         });
+        // The element itself must not shrink, lest its scrollHeight or clientHeight be inaccurate.
+        element.style.flexGrow = "0";
+        element.style.flexShrink = "0";
         // This is a reliable way to get the information if it is greater than the clientHeight,
         // and means we don't have to worry about scroll position.
         let result = element.scrollHeight;
@@ -208,11 +211,13 @@ export default class OverflowChecker {
             });
             result = maxContentBottom;
         }
+        // return control to stylesheet
         children.forEach((e: HTMLElement) => {
-            // return control to stylesheet
             e.style.flexGrow = "";
             e.style.flexShrink = "";
         });
+        element.style.flexGrow = "";
+        element.style.flexShrink = "";
         return result;
     }
 

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1342,6 +1342,10 @@ canvas.moving {
         .bloom-ui-overlay-side-handle-w {
             display: block;
         }
+        // the south one is visible for text boxes only when auto-height is turned off.
+        &.bloom-noAutoHeight .bloom-ui-overlay-side-handle-s {
+            display: block;
+        }
         // Enhance: Canva uses these handles on text boxes to resize the box by modifying
         // font size. This is nice for tweaking things but it's not clear how it should interact
         // with our style system. For now we're just not showing them for text boxes.

--- a/src/BloomBrowserUI/bookEdit/js/OverlayContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/OverlayContextControls.tsx
@@ -33,7 +33,7 @@ import {
 import Menu from "@mui/material/Menu";
 import { Divider, MenuItem, Select } from "@mui/material";
 import { DuplicateIcon } from "./DuplicateIcon";
-import { BubbleManager } from "./bubbleManager";
+import { BubbleManager, theOneBubbleManager } from "./bubbleManager";
 import { copySelection, GetEditor, pasteClipboard } from "./bloomEditing";
 import { BloomTooltip } from "../../react_components/BloomToolTip";
 import { TrashIcon } from "../toolbox/overlay/TrashIcon";
@@ -336,6 +336,7 @@ const OverlayContextControls: React.FunctionComponent<{
 
         // );
     }
+    const autoHeight = !props.overlay.classList.contains("bloom-noAutoHeight");
     const handleMenuButtonMouseDown = (e: React.MouseEvent) => {
         // This prevents focus leaving the text box.
         e.preventDefault();
@@ -346,6 +347,13 @@ const OverlayContextControls: React.FunctionComponent<{
         e.preventDefault();
         e.stopPropagation();
         setMenuOpen(true); // Review: better on mouse down? But then the mouse up may be missed, if the menu is on top...
+    };
+    const toggleAutoHeight = () => {
+        props.overlay.classList.toggle("bloom-noAutoHeight");
+        theOneBubbleManager.updateAutoHeight();
+        // In most contexts, we would need to do something now to make the control render, so we get
+        // an updated value for autoHeight. But the menu is going to be hidden, and showing it again
+        // will involve a re-render, and we don't care until then.
     };
     const editable = props.overlay.getElementsByClassName(
         "bloom-editable bloom-visibility-code-on"
@@ -379,6 +387,18 @@ const OverlayContextControls: React.FunctionComponent<{
                 // We don't actually know there's no image on the clipboard, but it's not relevant for a text box.
                 onClick: () => pasteClipboard(false),
                 icon: <PasteIcon css={muiMenIconCss} />
+            },
+            {
+                l10nId: "-",
+                english: "",
+                onClick: () => {}
+            },
+            {
+                l10nId: "EditTab.Toolbox.ComicTool.Options.AutoHeight",
+                english: "Auto Height",
+                // We don't actually know there's no image on the clipboard, but it's not relevant for a text box.
+                onClick: () => toggleAutoHeight(),
+                icon: autoHeight && <CheckIcon css={muiMenIconCss} />
             },
             {
                 l10nId: "-",

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -101,20 +101,20 @@ export class BubbleManager {
     }
 
     // Given the box has been determined to be overflowing vertically by
-    // 'overflowY' pixels, if it's inside an OverPicture element, enlarge the OverPicture element
-    // by that much so it won't overflow.
+    // 'overflowY' pixels, if it's inside an OverPicture element that does not have the class
+    // bloom-noAutoSize, adjust the size of the OverPicture element
+    // to fit it.
     // (Caller may wish to do box.scrollTop = 0 to make sure the whole content shows now there
     // is room for it all.)
     // Returns true if successful; it will currently fail if box is not
     // inside a valid OverPicture element or if the OverPicture element can't grow this much while
     // remaining inside the image container. If it returns false, it makes no changes at all.
-    public growOverflowingBox(
-        box: HTMLElement,
-        overflowY: number,
-        allowShrink?: boolean
-    ): boolean {
+    public growOverflowingBox(box: HTMLElement, overflowY: number): boolean {
         const wrapperBox = box.closest(kTextOverPictureSelector) as HTMLElement;
-        if (!wrapperBox) {
+        if (
+            !wrapperBox ||
+            wrapperBox.classList.contains("bloom-noAutoHeight")
+        ) {
             return false; // we can't fix it
         }
 
@@ -139,13 +139,6 @@ export class BubbleManager {
         ) {
             return false; // near enough, avoid jitter making it a tiny bit smaller.
         }
-        if (
-            newHeight < wrapperBox.clientHeight &&
-            !wrapperBox.classList.contains("bloom-allowAutoShrink") &&
-            !allowShrink
-        ) {
-            return false; // currently auto-shrink is only allowed when manually changing width
-        }
 
         // If a lot of text is pasted, the container will scroll down.
         //    (This can happen even if the text doesn't necessarily go out the bottom of the image container).
@@ -167,6 +160,41 @@ export class BubbleManager {
         this.adjustTarget(wrapperBox);
         this.alignControlFrameWithActiveElement();
         return true;
+    }
+
+    public updateAutoHeight(): void {
+        if (
+            this.activeElement &&
+            !this.activeElement.classList.contains("bloom-noAutoHeight")
+        ) {
+            const editable = this.activeElement.getElementsByClassName(
+                "bloom-editable bloom-visibility-code-on"
+            )[0] as HTMLElement;
+
+            this.adjustBubbleHeightToContent(editable);
+        }
+        this.alignControlFrameWithActiveElement();
+    }
+    public adjustBubbleHeightToContent(editable: HTMLElement): void {
+        if (!this.activeElement) return;
+        const overflowAmounts = OverflowChecker.getSelfOverflowAmounts(
+            editable
+        );
+        let overflowY =
+            overflowAmounts[1] +
+            editable.offsetHeight -
+            this.activeElement.offsetHeight;
+
+        // This mimics the relevant part of OverflowChecker.MarkOverflowInternal
+        if (
+            theOneBubbleManager.growOverflowingBox(
+                this.activeElement,
+                overflowY
+            )
+        ) {
+            overflowY = 0;
+        }
+        editable.classList.toggle("overflow", overflowY > 0);
     }
 
     // When the format dialog changes the amount of padding for overlays, adjust their sizes
@@ -1524,7 +1552,9 @@ export class BubbleManager {
     private continueTextBoxResize(event: MouseEvent, editable: HTMLElement) {
         if (!this.activeElement) return; // should never happen, but makes lint happy
         let deltaX = event.clientX - this.startSideDragX;
+        let deltaY = event.clientY - this.startSideDragY;
         let newBubbleWidth = this.oldWidth; // default
+        let newBubbleHeight = this.oldHeight; // default
         switch (this.currentDragSide) {
             case "e":
                 newBubbleWidth = Math.max(
@@ -1533,6 +1563,7 @@ export class BubbleManager {
                 );
                 deltaX = newBubbleWidth - this.oldWidth;
                 this.activeElement.style.width = `${newBubbleWidth}px`;
+                theOneBubbleManager.adjustBubbleHeightToContent(editable);
                 break;
             case "w":
                 newBubbleWidth = Math.max(
@@ -1542,21 +1573,16 @@ export class BubbleManager {
                 deltaX = this.oldWidth - newBubbleWidth;
                 this.activeElement.style.width = `${newBubbleWidth}px`;
                 this.activeElement.style.left = `${this.oldLeft + deltaX}px`;
+                theOneBubbleManager.adjustBubbleHeightToContent(editable);
                 break;
+            case "s":
+                newBubbleHeight = Math.max(
+                    this.oldHeight + deltaY,
+                    this.minHeight
+                );
+                deltaY = newBubbleHeight - this.oldHeight;
+                this.activeElement.style.height = `${newBubbleHeight}px`;
         }
-        const overflowAmounts = OverflowChecker.getSelfOverflowAmounts(
-            editable
-        );
-        const overflowY =
-            overflowAmounts[1] +
-            editable.offsetHeight -
-            this.activeElement.offsetHeight;
-
-        theOneBubbleManager.growOverflowingBox(
-            this.activeElement,
-            overflowY,
-            true
-        );
         this.alignControlFrameWithActiveElement();
     }
 
@@ -1854,6 +1880,10 @@ export class BubbleManager {
     private alignControlFrameWithActiveElement = () => {
         const controlFrame = document.getElementById("overlay-control-frame");
         if (controlFrame && this.activeElement) {
+            controlFrame.classList.toggle(
+                "bloom-noAutoHeight",
+                this.activeElement.classList.contains("bloom-noAutoHeight")
+            );
             const hasText = controlFrame.classList.contains("has-text");
             // Text boxes get a little extra padding, making the control frame bigger than
             // the overlay itself. The extra needed corresponds roughly to the (.less) @sideHandleRadius,


### PR DESCRIPTION
Also improves auto-height algorithm

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6651)
<!-- Reviewable:end -->
