### PR TITLE
Make data-sound work in Bloom Player for non-activity pages (BL-13878)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityRuntime.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityRuntime.ts
@@ -6,12 +6,11 @@
 // For now, in Bloom desktop, this file is only used in the Play tab of drag activities,
 // so both live there. In Bloom player, both live in the root src directory.
 // In the long run, the answer is probably a folder, or even an npm package, for all
-// the stuff that the two progams share...or maybe we can make bloom player publish
+// the stuff that the two programs share...or maybe we can make bloom player publish
 // these files along with the output bundle and have bloom desktop use them from there.
 // For now, though, it's much easier to just edit them and have them built automatically
 // than to have this code in another repo.
 
-import { get } from "jquery";
 import {
     kAudioSentence,
     playAllAudio,
@@ -281,6 +280,9 @@ export function undoPrepareActivity(page: HTMLElement) {
         elt.removeEventListener("click", performTryAgain);
     });
 
+    // In Bloom Player, this will have been done by other play code, since data-sound is not
+    // specfic to games. But we're adding a listener for the same function, so it doesn't matter.
+    // In Bloom desktop, we need this to make cliking data-sound elements work in Play mode.
     const soundItems = Array.from(page.querySelectorAll("[data-sound]"));
     soundItems.forEach((elt: HTMLElement) => {
         elt.removeEventListener("click", playSoundOf);
@@ -298,12 +300,16 @@ export function undoPrepareActivity(page: HTMLElement) {
     // });
 }
 
-const playSoundOf = (e: MouseEvent) => {
+export const playSoundOf = (e: MouseEvent) => {
     const elt = e.currentTarget as HTMLElement;
     const soundFile = elt.getAttribute("data-sound");
     if (soundFile) {
         playSound(elt, soundFile);
     }
+    // Not needed in Play tab, but in Bloom Player, the click would otherwise cause
+    // a toggle between full screen and showing toolbars.
+    e.preventDefault();
+    e.stopPropagation();
 };
 
 const playAudioOfTarget = (e: PointerEvent) => {

--- a/src/BloomBrowserUI/yarn.lock
+++ b/src/BloomBrowserUI/yarn.lock
@@ -5538,9 +5538,9 @@ bindings@^1.5.0:
     file-uri-to-path "1.0.0"
 
 bloom-player@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/bloom-player/-/bloom-player-2.3.0.tgz#6f83f50500584b5ea207fe8cc8187cc827d6b29c"
-  integrity sha512-9osUUsHTX+FRJvbyjpnOg6x0T/7ki4IiEHT0/48S8bmJcr/lSSReKA6FLXc8eIsWFyTe/1SImLCs1d3Mmq7/rg==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/bloom-player/-/bloom-player-2.4.0.tgz#0ea42207c193e24f49c9ae58469b8462298701a9"
+  integrity sha512-KTaGPl/WL/LHFpkLI9K1qBQI8mJ9Aj6gEkp1XjqYnS5Nkike7dxfqXo4b8Hpj+jAvDt0EY1fCbjTjGWRQm819Q==
 
 bluebird@^3.3.5, bluebird@^3.5.5:
   version "3.7.2"

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -10,6 +10,7 @@ using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web.UI.WebControls;
+using System.Windows.Forms;
 using System.Xml;
 using Bloom.Api;
 using Bloom.Collection;
@@ -1329,11 +1330,12 @@ namespace Bloom.Book
                     usedAudioFileNames.Add(correctSound);
                 if (wrongSound != null)
                     usedAudioFileNames.Add(wrongSound);
-                var dataSoundElts = dap.SafeSelectNodes(".//div[@data-sound]");
-                foreach (var ds in dataSoundElts)
-                {
-                    usedAudioFileNames.Add(ds.GetAttribute("data-sound"));
-                }
+            }
+            // These can now occur anywhere, not just in activity pages.
+            var dataSoundElts = Dom.SafeSelectNodes(".//div[@data-sound]");
+            foreach (var ds in dataSoundElts)
+            {
+                usedAudioFileNames.Add(ds.GetAttribute("data-sound"));
             }
 
             // Don't get too trigger-happy with the delete button if you're not in publish mode


### PR DESCRIPTION
The change to dragActivityRuntime is not needed in BD, but the files are supposed to stay in sync between the two repos, at least until the new games code stabilizes.
Putting this in draft, because I want it reviewed, but to make this work fully, we need to update BD to use the new BP that will emerge when that PR is merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6662)
<!-- Reviewable:end -->
