### PR TITLE
Hide reposition dot when moving cropped image overlay (BL-13876)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1334,6 +1334,11 @@ canvas.moving {
         #overlay-context-controls {
             display: none;
         }
+        &.bloom-ui-overlay-show-move-crop-handle {
+            .bloom-ui-overlay-move-crop-handle {
+                display: none;
+            }
+        }
     }
     // the "crop" handles on left and right are visible for text boxes
     // (though with a different function).


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6667)
<!-- Reviewable:end -->
