### PR TITLE
Sort out page hover effects (BL-13895)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -9,10 +9,9 @@
 
 .bloom-page {
     --page-structure-color: #1d94a41a;
-    --edit-outline-color: #1d94a434;
     --language-tag-color: #1d94a488;
     --selectedEdit-color: #1d94a4c2; //transparent;
-    --unselectedEdit-color: var(--page-structure-color);
+    --unselectedEdit-color: #1d94a434; // page structure color, but 20% opacity instead of 10%
 }
 
 .bloom-page.cover {
@@ -128,8 +127,17 @@ body {
     -height: 1px;
 }
 
+// Keep together here all the effects we want when hovering (previously: also when focus-within)
+// the bloom-page. All of them need to also apply when the overlay context controls are hovered,
+// even though that is no longer a child of the bloom-page. (That's what the second rule is for.)
 .bloom-page:hover,
-.bloom-page:focus-within {
+body:has(#overlay-context-controls:hover) .bloom-page {
+    textarea,
+    div.bloom-editable,
+    div.pageLabel[contenteditable="true"] {
+        outline: thin solid var(--unselectedEdit-color);
+        outline-offset: -1px; // else the white of an un-focussed box can just bleed into the white of the margin
+    }
     div.bloom-imageContainer {
         // Allow book templates to define a custom borderColor, otherwise fallback to the default color
         .borderOnTopOfElement(var(--page-structure-color));
@@ -144,19 +152,78 @@ body {
             .borderOnTopOfElement(@focusBorderColor);
         }
     }
+    .coverColor div.bloom-imageContainer {
+        .borderOnTopOfElement(rgba(1, 1, 1, 0.2));
+    }
+    #formatButton {
+        visibility: visible;
+
+        margin-left: 3px;
+        /*The font-size here is weird, but if we don't set it, the growing/shrinking font of the text will actually move the button up/down on the page*/
+        font-size: 10pt;
+        height: 20px;
+        width: 20px;
+        z-index: @formatButtonZIndex;
+
+        img {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+        }
+
+        &:hover {
+            color: black;
+        }
+    }
+    .qtip {
+        opacity: 1 !important;
+        transition: opacity 200ms ease-out;
+    }
+    /*Put in little grey language tooltips in the bottom-right of the editable divs*/
+    .languageTip,
+    .bloom-editable[contentEditable="true"][data-languageTipContent]:not([data-languageTipContent=""]):after {
+        position: absolute;
+        right: 0;
+        /*Same grey color as pageLabel*/
+        color: var(--language-tag-color); //rgba(0, 0, 0, 0.2);
+        font-family: @UIFontStack;
+        font-size: small;
+        font-style: normal;
+        font-weight: normal;
+        line-height: 1; //else it will draw up in the box somewhere if the font is large
+        text-shadow: none;
+        content: attr(data-languageTipContent);
+        bottom: 2px; // See Bl-10017
+        margin-right: 2px;
+    }
+    // show some structure when the page is hovered
+    // Show the padding, multilingual gap, etc as colored areas.
+    // The ".split-pane-component-inner >"  disables this for overlays, where it's common to have backgrounds like transparent
+    .split-pane-component-inner > .bloom-translationGroup {
+        // no: a border here will take up space, wrecking WYSIWYG
+        // border: solid thin var(--page-structure-color);
+        // box-sizing: border-box;
+        // Also, you'd think you could use outline instead, but it doesn't show on the side; the
+        // children over it up because they are the full width of this parent.
+
+        &:not(.bloom-background-gray) {
+            background-color: var(--page-structure-color) !important;
+        }
+
+        // the parent translation group has the "page structure" color so we
+        // normally want to have the edit box be white. Note however that in the case that
+        // we have a grey box, we're giving up on structure color and just want it all to be grey.
+        &:not(.bloom-background-gray) .bloom-editable {
+            background-color: var(--marginBox-background-color) !important;
+        }
+    }
 }
+
 // The editing buttons are hidden when this class is added (currently by motion and comic tools)
 .bloom-imageContainer.bloom-hideImageButtons {
     > .imageButton,
     > .miniButton {
         display: none;
-    }
-}
-
-.bloom-page:hover,
-.bloom-page:focus-within {
-    .coverColor div.bloom-imageContainer {
-        .borderOnTopOfElement(rgba(1, 1, 1, 0.2));
     }
 }
 
@@ -555,16 +622,6 @@ button.moveButton {
     background-size: contain;
 }
 
-.bloom-page:hover,
-.bloom-page:focus-within {
-    textarea,
-    div.bloom-editable,
-    div.pageLabel[contenteditable="true"] {
-        outline: thin solid var(--unselectedEdit-color);
-        /*[disabled]min-height:34px;*/
-    }
-}
-
 img.hoverUp {
     outline: 1px outset black;
 }
@@ -719,17 +776,6 @@ div.textWholePage ul {
     top: 45%;
 }
 
-.bloom-page:hover,
-.bloom-page:focus-within {
-    .marginBox {
-        // Put a faint border around the margin-box in edit mode.
-        // Not sure why, but it may be to give an idea of the space available for page content.
-        // Can't use border, that is controlled by appearance system
-        // Outline: 1px solid rgba(115, 189, 189, 0.3) is close, but can't make it follow border-radius
-        // This seems to do the job.
-        //box-shadow: 0 0 0 1px var(--page-structure-color);
-    }
-}
 .bloom-frontMatter div.marginBox {
     /*With the colored background, the margin border is just too distracting, and it doesn't (yet) help the user in any way because he can't move things around on the frontmatter*/
     border: none;
@@ -747,29 +793,7 @@ div.textWholePage ul {
     overflow: hidden;
     position: absolute;
 }
-.bloom-page:hover,
-.bloom-page:focus-within {
-    #formatButton {
-        visibility: visible;
 
-        margin-left: 3px;
-        /*The font-size here is weird, but if we don't set it, the growing/shrinking font of the text will actually move the button up/down on the page*/
-        font-size: 10pt;
-        height: 20px;
-        width: 20px;
-        z-index: @formatButtonZIndex;
-
-        img {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-        }
-
-        &:hover {
-            color: black;
-        }
-    }
-}
 // Now sometimes, the format button lands under the page number.
 // Changing the z-index did not help. So we allow themes to "dodge" it.
 // Kind of a hack, I know. See BL-13206.
@@ -870,26 +894,6 @@ div.bloom-editable.Heading2-style {
 
 .languageTip {
     visibility: hidden;
-}
-.bloom-page:hover,
-.bloom-page:focus-within {
-    /*Put in little grey language tooltips in the bottom-right of the editable divs*/
-    .languageTip,
-    .bloom-editable[contentEditable="true"][data-languageTipContent]:not([data-languageTipContent=""]):after {
-        position: absolute;
-        right: 0;
-        /*Same grey color as pageLabel*/
-        color: var(--language-tag-color); //rgba(0, 0, 0, 0.2);
-        font-family: @UIFontStack;
-        font-size: small;
-        font-style: normal;
-        font-weight: normal;
-        line-height: 1; //else it will draw up in the box somewhere if the font is large
-        text-shadow: none;
-        content: attr(data-languageTipContent);
-        bottom: 2px; // See Bl-10017
-        margin-right: 2px;
-    }
 }
 
 .languageTip {
@@ -1231,41 +1235,6 @@ body.hideAllCKEditors .cke_chrome {
     opacity: 1 !important;
     transition: opacity 200ms ease-out;
 }
-body :has(.bloom-page:focus-within, .bloom-page:hover) {
-    .qtip {
-        opacity: 1 !important;
-        transition: opacity 200ms ease-out;
-    }
-}
-
-// --------------------------------------------------------
-// show some structure when the page is hovered
-.bloom-page:hover {
-    // Show the padding, multilingual gap, etc as colored areas.
-    // The ".split-pane-component-inner >"  disables this for overlays, where it's common to have backgrounds like transparent
-    .split-pane-component-inner > .bloom-translationGroup {
-        // no: a border here will take up space, wrecking WYSIWYG
-        // border: solid thin var(--page-structure-color);
-        // box-sizing: border-box;
-        // Also, you'd think you could use outline instead, but it doesn't show on the side; the
-        // children over it up because they are the full width of this parent.
-
-        &:not(.bloom-background-gray) {
-            background-color: var(--page-structure-color) !important;
-        }
-
-        .bloom-editable {
-            outline: 1px solid var(--edit-outline-color);
-            outline-offset: -1px; // else the white of an un-focussed box can just bleed into the white of the margin
-        }
-        // the parent translation group has the "page structure" color so we
-        // normally want to have the edit box be white. Note however that in the case that
-        // we have a grey box, we're giving up on structure color and just want it all to be grey.
-        &:not(.bloom-background-gray) .bloom-editable {
-            background-color: var(--marginBox-background-color) !important;
-        }
-    }
-}
 
 // ----- Bloom Games ----
 // Tweak the position of the Start/Correct/Wrong/Play control
@@ -1468,4 +1437,5 @@ canvas.moving {
     &.moving {
         display: none;
     }
+    pointer-events: none; // overridden for children, but the outer bit that's just for positioning should not be clickable
 }

--- a/src/BloomBrowserUI/bookEdit/js/OverlayContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/OverlayContextControls.tsx
@@ -443,7 +443,7 @@ const OverlayContextControls: React.FunctionComponent<{
                     button {
                         line-height: 0.7em;
                     }
-                    // needed because it's a child of the control frame which has pointer-events:none
+                    // needed because it's a child of #overlay-context-controls which has pointer-events:none
                     pointer-events: all;
                 `}
             >


### PR DESCRIPTION
- Bring together in one place all the page hover effects (most just moved)
- all the ones that used to also apply on focus-within no longer do
- added a rule to make them also work when hovering the overlay context menu
- duplicate rules for bloom-editable resolved
- made the positioning frame for overlay context controls pointer-events:none
