### PR TITLE
Do not round image overlay corners for rounded page theme (BL-13960)

### DIFF
--- a/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
@@ -89,6 +89,10 @@
     > .bloom-imageContainer {
     --image-border-radius: var(--marginBox-border-radius); /* all corners */
 }
+/* Nested/overlay picture */
+.bloom-imageContainer > .bloom-textOverPicture > .bloom-imageContainer {
+    --image-border-radius: 0px; /* No rounding for nested images.  See BL-13960. */
+}
 /* End Rules for rounding the corner of images */
 
 .Device16x9Landscape.numberedPage.pictureOnRight.pictureOnRight::after {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6692)
<!-- Reviewable:end -->
