### PR TITLE
Add "Play Earlier" and "Play Later" to video overlay menu (BL-13930)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2164,6 +2164,14 @@
         <source xml:lang="en">Paste Text</source>
         <note>ID: EditTab.Toolbox.ComicTool.Options.PasteText</note>
       </trans-unit>
+      <trans-unit id="EditTab.Toolbox.ComicTool.Options.PlayEarlier" sil:dynamic="true" translate="yes">
+        <source xml:lang="en">Play Earlier</source>
+        <note>ID: EditTab.Toolbox.ComicTool.Options.PlayEarlier</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.ComicTool.Options.PlayLater" sil:dynamic="true" translate="yes">
+        <source xml:lang="en">Play Later</source>
+        <note>ID: EditTab.Toolbox.ComicTool.Options.PlayLater</note>
+      </trans-unit>
       <trans-unit id="EditTab.Toolbox.ComicTool.Options.RecordYourself" sil:dynamic="true" translate="yes">
         <source xml:lang="en">Record yourself...</source>
         <note>ID: EditTab.Toolbox.ComicTool.Options.RecordYourself</note>

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -222,7 +222,7 @@ export function showSignLanguageTool() {
 
 export function doVideoCommand(
     videoContainer: Element,
-    command: "choose" | "record"
+    command: "choose" | "record" | "playEarlier" | "playLater"
 ) {
     if (command === "choose" && videoContainer) {
         post("signLanguage/importVideo", result => {
@@ -239,6 +239,81 @@ export function doVideoCommand(
         // one we want to record into is selected.  See comments in BL-13930.
         videoContainer.classList.add("bloom-selected");
         showSignLanguageTool();
+    } else if (command === "playEarlier") {
+        // Find the preceding video container element, if any, and move it after the current one
+        const previousVideoContainer = findPreviousVideoContainer(
+            videoContainer
+        );
+        if (previousVideoContainer) {
+            SwapVideoPositionsInDom(previousVideoContainer, videoContainer);
+        }
+    } else if (command === "playLater") {
+        // Find the next video container element, if any, and move it before the current one
+        const nextVideoContainer = findNextVideoContainer(videoContainer);
+        if (nextVideoContainer) {
+            SwapVideoPositionsInDom(videoContainer, nextVideoContainer);
+        }
+    }
+}
+
+export function findNextVideoContainer(
+    videoContainer: Element
+): Element | undefined {
+    const overlay = videoContainer.closest(".bloom-textOverPicture"); // unfortunate name for picture and video overlay containers
+    if (overlay) {
+        let next = overlay.nextElementSibling;
+        while (next) {
+            if (
+                next.firstElementChild?.classList.contains(
+                    "bloom-videoContainer"
+                )
+            ) {
+                return next.firstElementChild;
+            }
+            next = next.nextElementSibling;
+        }
+    }
+    return undefined;
+}
+export function findPreviousVideoContainer(
+    videoContainer: Element
+): Element | undefined {
+    const overlay = videoContainer.closest(".bloom-textOverPicture"); // unfortunate classname for picture and video overlay containers
+    if (overlay) {
+        let previous = overlay.previousElementSibling;
+        while (previous) {
+            if (
+                previous.firstElementChild?.classList.contains(
+                    "bloom-videoContainer"
+                )
+            ) {
+                return previous.firstElementChild;
+            }
+            previous = previous.previousElementSibling;
+        }
+    }
+    return undefined;
+}
+// Swap the positions of two video containers (actually their parent overlays) in the DOM.
+function SwapVideoPositionsInDom(
+    firstVideoContainer: Element,
+    secondVideoContainer: Element
+) {
+    const firstOverlay = firstVideoContainer.closest(".bloom-textOverPicture");
+    const secondOverlay = secondVideoContainer.closest(
+        ".bloom-textOverPicture"
+    );
+    if (!firstOverlay || !secondOverlay) {
+        return;
+    }
+    const overlayContainer = firstOverlay.parentElement;
+    if (!overlayContainer || overlayContainer !== secondOverlay.parentElement) {
+        return;
+    }
+    const thirdOverlay = secondOverlay.nextElementSibling; // may be null, but that's okay
+    overlayContainer.insertBefore(secondOverlay, firstOverlay);
+    if (firstOverlay.nextElementSibling !== thirdOverlay) {
+        overlayContainer.insertBefore(firstOverlay, thirdOverlay);
     }
 }
 


### PR DESCRIPTION
This is implemented by reordering the overlay elements in the DOM.  There is no indication
of the playing order other than DOM position.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6693)
<!-- Reviewable:end -->
