### PR TITLE
Fix various problems with video overlays (BL-13976)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -544,6 +544,21 @@ body.bloom-fullBleed {
         border: solid 2px @bloom-yellow;
     }
 }
+.bloom-videoContainer:focus-visible {
+    // we show the active video container in other ways, and the browser's focus ring is just distracting
+    outline: none;
+}
+// We don't need the yellow border indicating the active video when the selected thing is an overlay.
+// We have a distinct mechanism for showing the selected overlay.
+// (We don't have overlay widgets and probably won't ever, but I included them just in case.)
+.bloom-textOverPicture {
+    .bloom-videoContainer,
+    .bloom-widgetContainer {
+        &.bloom-selected {
+            border: none;
+        }
+    }
+}
 
 .hoverUp .imageButton {
     border: 2px outset @ImageButtonBorder !important;

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -866,9 +866,28 @@ export function SetupElements(
                     (window.top as any).lastPageId = currentPageId;
                 }
             }
-            // We were doing this before but I don't know why. When we're loading a page, it
+            // If we don't have some specific reason to focus on a particular overlay, we
+            // don't want to arbitrarily select one. It seems the browser will try
+            // to focus something, and sometimes it doesn't make a good choice, especially after
+            // changing zoom, which for some unknown reason seems to make it want to focus the
+            // first thing on the page that CAN be focused. And usually we automatically activate
+            // an overlay that gets focus.
+            // Prior to /4d9ff2a0860d78ecd96771a93a839ce60ab7a8d3, we made a call here to bubbleManager
+            // to tell it to ignore the next focusIn event. That was dubious and fragile.
+            // Then just prior to this commit, we were explicitly setting the active element to undefined
+            // here, but (since this is in a timeout) that could undo (for example) the sign language tool's
+            // attempt to pick some video as the one it applies to.
+            // In this commit, I've added code to specifically ignore focus events that immediately
+            // follow change of zoom. As far as I can tell, it is therefore no longer necessary
+            // to set the active element to undefined here. When we're loading a page, active element
             // will be unset initially. If something (e.g., sign language tool) sets an initial
             // active element, we don't want to unset it.
+            // There may, of course, be other circumstances we haven't discovered yet where the
+            // browser tries to focus the wrong thing. But if we restore this, we need to find
+            // some other way that the sign language tool can set an initial active element
+            // that will not be undone by this code. It's possible that data-bloom-active could be
+            // used, but note that currently it only applies if we're re-loading the same page.
+            // The sign language tool wants to be able to select a video (if any) on any page we load.
             // if (!elementToFocus) {
             //     // Make sure the active element is cleared if we're not setting it.
             //     theOneBubbleManager.setActiveElement(undefined);

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -20,6 +20,7 @@ import BloomNotices from "./bloomNotices";
 import BloomSourceBubbles from "../sourceBubbles/BloomSourceBubbles";
 import BloomHintBubbles from "./BloomHintBubbles";
 import {
+    bubbleDescription,
     BubbleManager,
     initializeBubbleManager,
     kTextOverPictureClass,
@@ -440,6 +441,7 @@ export function SetupElements(
     elementToFocus?: HTMLElement
 ) {
     recordWhatThisPageLooksLikeForSanityCheck(container);
+    BubbleManager.recordInitialZoom(container);
 
     SetupImagesInContainer(container);
 
@@ -864,10 +866,13 @@ export function SetupElements(
                     (window.top as any).lastPageId = currentPageId;
                 }
             }
-            if (!elementToFocus) {
-                // Make sure the active element is cleared if we're not setting it.
-                theOneBubbleManager.setActiveElement(undefined);
-            }
+            // We were doing this before but I don't know why. When we're loading a page, it
+            // will be unset initially. If something (e.g., sign language tool) sets an initial
+            // active element, we don't want to unset it.
+            // if (!elementToFocus) {
+            //     // Make sure the active element is cleared if we're not setting it.
+            //     theOneBubbleManager.setActiveElement(undefined);
+            // }
 
             const focusable = elementToFocus
                 ? $(elementToFocus).find(":focusable")

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -12,6 +12,7 @@ import {
     SignLanguageTool
 } from "../toolbox/signLanguage/signLanguageTool";
 import { kOverlayToolId } from "../toolbox/toolIds";
+import { selectVideoContainer } from "./videoUtils";
 
 const mouseOverFunction = e => {
     const target = e.target as HTMLElement;
@@ -237,7 +238,7 @@ export function doVideoCommand(
     } else if (command === "record") {
         // There may be more than one video container on the page.  Make sure the
         // one we want to record into is selected.  See comments in BL-13930.
-        videoContainer.classList.add("bloom-selected");
+        selectVideoContainer(videoContainer);
         showSignLanguageTool();
     } else if (command === "playEarlier") {
         // Find the preceding video container element, if any, and move it after the current one

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -36,7 +36,7 @@ import { kBloomBlue } from "../../bloomMaterialUITheme";
 import OverflowChecker from "../OverflowChecker/OverflowChecker";
 import { MeasureText } from "../../utils/measureText";
 import theOneLocalizationManager from "../../lib/localizationManager/localizationManager";
-import { selectVideoContainer } from "./videoUtils";
+import { kVideoContainerClass, selectVideoContainer } from "./videoUtils";
 
 export interface ITextColorInfo {
     color: string;
@@ -52,7 +52,6 @@ export const kTextOverPictureClass = "bloom-textOverPicture";
 export const kTextOverPictureSelector = `.${kTextOverPictureClass}`;
 const kImageContainerClass = "bloom-imageContainer";
 const kImageContainerSelector = `.${kImageContainerClass}`;
-const kVideoContainerClass = "bloom-videoContainer";
 
 const kOverlayClass = "hasOverlay";
 
@@ -278,22 +277,6 @@ export class BubbleManager {
         imageContainers.forEach(container => {
             BubbleManager.hideImageButtonsIfHasOverlays(container);
         });
-    }
-
-    // When switching to the comicTool from elsewhere (notably the sign language tool), we remove
-    // the 'bloom-selected' class, so the container doesn't have a yellow border like it does in the
-    // sign language tool. We only need to do this for non-overlay video containers,
-    // since the yellow box is hidden in overlays, and we would like the same one (that is our active
-    // overlay) to be selected in the sign langauge tool if we switch back.)
-    public deselectVideoContainers() {
-        const videoContainers: HTMLElement[] = Array.from(
-            document.getElementsByClassName(kVideoContainerClass) as any
-        );
-        videoContainers
-            .filter(x => !x.closest(kTextOverPictureSelector))
-            .forEach(container => {
-                container.classList.remove("bloom-selected");
-            });
     }
 
     // A visible, editable div is generally focusable, but sometimes (e.g. in Bloom games),
@@ -894,7 +877,7 @@ export class BubbleManager {
         // given focus during the reload after a zoom change. I think somehow the
         // browser itself is trying to focus something, and it's not the thing we want.
         // We have mechanisms to focus what we do want, so we use this trick to ignore
-        // the first focus event after a zoom change.
+        // focus events immediately after a zoom change.
         const zoomTransform = focusedElement.ownerDocument.getElementById(
             "page-scaling-container"
         )?.style.transform;

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -36,6 +36,7 @@ import { kBloomBlue } from "../../bloomMaterialUITheme";
 import OverflowChecker from "../OverflowChecker/OverflowChecker";
 import { MeasureText } from "../../utils/measureText";
 import theOneLocalizationManager from "../../lib/localizationManager/localizationManager";
+import { selectVideoContainer } from "./videoUtils";
 
 export interface ITextColorInfo {
     color: string;
@@ -46,6 +47,7 @@ const kComicalGeneratedClass: string = "comical-generated";
 // We could rename this class to "bloom-overPictureElement", but that would involve a migration.
 // For now we're keeping this name for backwards-compatibility, even though now the element could be
 // a video or even another picture.
+// In the process of moving these two definitions to overlayUtils.ts, but duplicating here for now.
 export const kTextOverPictureClass = "bloom-textOverPicture";
 export const kTextOverPictureSelector = `.${kTextOverPictureClass}`;
 const kImageContainerClass = "bloom-imageContainer";
@@ -280,14 +282,18 @@ export class BubbleManager {
 
     // When switching to the comicTool from elsewhere (notably the sign language tool), we remove
     // the 'bloom-selected' class, so the container doesn't have a yellow border like it does in the
-    // sign language tool.
+    // sign language tool. We only need to do this for non-overlay video containers,
+    // since the yellow box is hidden in overlays, and we would like the same one (that is our active
+    // overlay) to be selected in the sign langauge tool if we switch back.)
     public deselectVideoContainers() {
         const videoContainers: HTMLElement[] = Array.from(
             document.getElementsByClassName(kVideoContainerClass) as any
         );
-        videoContainers.forEach(container => {
-            container.classList.remove("bloom-selected");
-        });
+        videoContainers
+            .filter(x => !x.closest(kTextOverPictureSelector))
+            .forEach(container => {
+                container.classList.remove("bloom-selected");
+            });
     }
 
     // A visible, editable div is generally focusable, but sometimes (e.g. in Bloom games),
@@ -778,7 +784,7 @@ export class BubbleManager {
         });
     }
 
-    private handleFocusInEvent(ev: Event) {
+    private handleFocusInEvent(ev: FocusEvent) {
         BubbleManager.onFocusSetActiveElement(ev);
     }
 
@@ -858,15 +864,56 @@ export class BubbleManager {
         });
     }
 
+    private static kTransformPropName = "bloom-zoomTransformForInitialFocus";
+
+    // If we haven't already, note (in a variable of the top window) the initial zoom level.
+    // This is used by a hack in onFocusSetActiveElement.
+    public static recordInitialZoom(container: HTMLElement) {
+        const zoomTransform = container.ownerDocument.getElementById(
+            "page-scaling-container"
+        )?.style.transform;
+        const topWindowZoomTransfrom = window.top?.[this.kTransformPropName];
+        if (window.top && zoomTransform && !topWindowZoomTransfrom) {
+            window.top[this.kTransformPropName] = zoomTransform;
+        }
+    }
+
     // The event handler to be called when something relevant on the page frame gets focus.
     // This will set the active textOverPicture element.
-    public static onFocusSetActiveElement(event: Event) {
+    public static onFocusSetActiveElement(event: FocusEvent) {
         if (BubbleManager.ignoreFocusChanges) return;
         if (BubbleManager.inPlayMode(event.currentTarget as Element)) {
             return;
         }
+
         // The current target is the element we attached the event listener to
         const focusedElement = event.currentTarget as Element;
+
+        // This is a hack to prevent the active bubble changing when we change zoom level.
+        // For some reason I can't track down, the first focusable thing on the page is
+        // given focus during the reload after a zoom change. I think somehow the
+        // browser itself is trying to focus something, and it's not the thing we want.
+        // We have mechanisms to focus what we do want, so we use this trick to ignore
+        // the first focus event after a zoom change.
+        const zoomTransform = focusedElement.ownerDocument.getElementById(
+            "page-scaling-container"
+        )?.style.transform;
+        const topWindowZoomTransfrom = window.top?.[this.kTransformPropName];
+        if (window.top && zoomTransform !== topWindowZoomTransfrom) {
+            // We eventually want to reset the saved zoom level to the new one, so
+            // that this method can do its job...mainly allowing the user to tab between overlays.
+            // We don't do it immediately because experience indicates that there may be more than
+            // one focus event to suppress as we load the page. On my fast dev machine a 50ms
+            // delay is enough to catch them all, so I'm going with ten times that. It's not
+            // a catastrophe if we miss a tab key very soon after a zoom change, nor if the delay
+            // is not enough for a very slow machine and so the active bubble moves when it shouldn't.
+            setTimeout(() => {
+                if (window.top) {
+                    window.top[this.kTransformPropName] = zoomTransform;
+                }
+            }, 500);
+            return;
+        }
 
         // If we focus something on the page that isn't in a bubble, we need to switch
         // to having no active bubble element. Note: we don't want to use focusout
@@ -1025,6 +1072,20 @@ export class BubbleManager {
             // Restore hiding these when we activate a bubble, so they don't get in the way of working on
             // that bubble.
             theOneBubbleManager.turnOnHidingImageButtons();
+        }
+        if (this.activeElement) {
+            // We should call this if there is an active element, even if it is not a video,
+            // because it will turn off the 'active video' class that might be on some
+            // non-overlay video.
+            // But if there is no active element we should not, because we might be wanting to
+            // record a non-overlay video and wanting to show that one as active.
+            // Indeed, we might have been called from the code that makes that so.
+            selectVideoContainer(
+                this.activeElement.getElementsByClassName(
+                    "bloom-videoContainer"
+                )[0] as HTMLElement,
+                false
+            );
         }
     }
 
@@ -4820,6 +4881,9 @@ export function updateOverlayClass(imageContainer: HTMLElement) {
     }
 }
 
+// Don't use this from the toolbox iframe. Use getBubbleManager() from overlayUtils instead.
+// (If you use this from the toolbox iframe, you'll get a different instance of BubbleManager,
+// and it's supposed to be a singleton across both iframes.)
 export let theOneBubbleManager: BubbleManager;
 
 export function initializeBubbleManager() {
@@ -4851,6 +4915,10 @@ export function bubbleDescription(e: Element | null | undefined): string {
         if (img) {
             return result + "with image : " + img.getAttribute("src");
         }
+    }
+    const videoSrc = elt.getElementsByTagName("source")[0];
+    if (videoSrc) {
+        return result + "with video " + videoSrc.getAttribute("src");
     }
     // Enhance: look for videoContainer similarly
     else {

--- a/src/BloomBrowserUI/bookEdit/js/videoUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/videoUtils.ts
@@ -1,0 +1,33 @@
+// video-related functions that are used in both iframes. Aiming for minimal imports here,
+// to minimize code that is pulled into both bundles.
+
+import { getPageIframeBody } from "../../utils/shared";
+import {
+    kTextOverPictureSelector,
+    getBubbleManager
+} from "../toolbox/overlay/overlayUtils";
+
+// Set the attribute which makes a bubble active for the sign language tool.
+// Make sure nothing else has it.
+// If it's in an overlay, make that overlay active. If not, make sure no overlay is active.
+// notifyBubbleManager is false when calling FROM setActiveElement, and should not be otherwise.
+export function selectVideoContainer(
+    videoContainer: Element | undefined | null,
+    notifyBubbleManager = true
+) {
+    const body = getPageIframeBody();
+    if (body) {
+        Array.from(body.getElementsByClassName("bloom-selected"))
+            .filter(e => e !== videoContainer)
+            .forEach(e => e.classList.remove("bloom-selected"));
+    }
+    videoContainer?.classList.add("bloom-selected");
+    const overlay = videoContainer?.closest(
+        kTextOverPictureSelector
+    ) as HTMLElement;
+    // If it's in an overlay, make that overlay active. If not, make sure no overlay is active.
+    // We don't need the confusion of two different ideas of what's active.
+    if (notifyBubbleManager) {
+        getBubbleManager()?.setActiveElement(overlay);
+    }
+}

--- a/src/BloomBrowserUI/bookEdit/js/videoUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/videoUtils.ts
@@ -7,6 +7,8 @@ import {
     getBubbleManager
 } from "../toolbox/overlay/overlayUtils";
 
+export const kVideoContainerClass = "bloom-videoContainer";
+
 // Set the attribute which makes a bubble active for the sign language tool.
 // Make sure nothing else has it.
 // If it's in an overlay, make that overlay active. If not, make sure no overlay is active.
@@ -30,4 +32,20 @@ export function selectVideoContainer(
     if (notifyBubbleManager) {
         getBubbleManager()?.setActiveElement(overlay);
     }
+}
+
+// When switching to the comicTool from elsewhere (notably the sign language tool), we remove
+// the 'bloom-selected' class, so the container doesn't have a yellow border like it does in the
+// sign language tool. We only need to do this for non-overlay video containers,
+// since the yellow box is hidden in overlays, and we would like the same one (that is our active
+// overlay) to be selected in the sign langauge tool if we switch back.)
+export function deselectVideoContainers() {
+    const videoContainers: HTMLElement[] = Array.from(
+        document.getElementsByClassName(kVideoContainerClass) as any
+    );
+    videoContainers
+        .filter(x => !x.closest(kTextOverPictureSelector))
+        .forEach(container => {
+            container.classList.remove("bloom-selected");
+        });
 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
@@ -46,6 +46,7 @@ import {
 } from "./overlayItem";
 import { isPageBloomGame } from "../dragActivity/dragActivityTool";
 import { getBubbleManager } from "./overlayUtils";
+import { deselectVideoContainers } from "../../js/videoUtils";
 
 const OverlayToolControls: React.FunctionComponent = () => {
     const l10nPrefix = "ColorPicker.";
@@ -121,7 +122,7 @@ const OverlayToolControls: React.FunctionComponent = () => {
 
         bubbleManager.turnOnBubbleEditing();
         bubbleManager.turnOnHidingImageButtons();
-        bubbleManager.deselectVideoContainers();
+        deselectVideoContainers();
 
         const bubbleSpec = bubbleManager.getSelectedFamilySpec();
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayTool.tsx
@@ -45,6 +45,7 @@ import {
     OverlayTextItem
 } from "./overlayItem";
 import { isPageBloomGame } from "../dragActivity/dragActivityTool";
+import { getBubbleManager } from "./overlayUtils";
 
 const OverlayToolControls: React.FunctionComponent = () => {
     const l10nPrefix = "ColorPicker.";
@@ -829,9 +830,10 @@ export class OverlayTool extends ToolboxToolReactAdaptor {
         }
     }
 
+    // In the process of moving this to a minimal-dependency utility file, but a lot of
+    // code still expects to find it here.
     public static bubbleManager(): BubbleManager | undefined {
-        const exports = getEditablePageBundleExports();
-        return exports ? exports.getTheOneBubbleManager() : undefined;
+        return getBubbleManager();
     }
 }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/overlay/overlayUtils.ts
@@ -1,0 +1,15 @@
+// This file exposes some utility functions that are needed in both iframes. The idea is
+// to make them available to import with a minimum of dependencies.
+
+import { getEditablePageBundleExports } from "../../editViewFrame";
+import { BubbleManager } from "../../js/bubbleManager";
+
+export const kTextOverPictureClass = "bloom-textOverPicture";
+export const kTextOverPictureSelector = `.${kTextOverPictureClass}`;
+
+// Enhance: we could reduce cross-bundle dependencies by separately defining the BubbleManager interface
+// and just importing that here.
+export function getBubbleManager(): BubbleManager | undefined {
+    const exports = getEditablePageBundleExports();
+    return exports ? exports.getTheOneBubbleManager() : undefined;
+}

--- a/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
@@ -19,6 +19,9 @@ import theOneLocalizationManager from "../../../lib/localizationManager/localiza
 import calculateAspectRatio from "calculate-aspect-ratio";
 import VideoTrimSlider from "../../../react_components/videoTrimSlider";
 import { updateVideoInContainer } from "../../js/bloomVideo";
+import { kTextOverPictureSelector } from "../../js/bubbleManager";
+import { OverlayTool } from "../overlay/overlayTool";
+import { selectVideoContainer } from "../../js/videoUtils";
 
 // The recording process can be in one of these states:
 // idle...the initial state, returned to when stopped; red record button shows; stop button and all labels hidden
@@ -807,15 +810,15 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
     }
 
     // Specify 'true' to get only containers marked as selected
-    public static getVideoContainers(
-        selected?: boolean
-    ): HTMLCollectionOf<Element> | null {
+    public static getVideoContainers(selected?: boolean): HTMLElement[] {
         let classes = "bloom-videoContainer";
         if (selected) {
             classes += " bloom-selected";
         }
         const page = ToolBox.getPage();
-        return page ? page.getElementsByClassName(classes) : null;
+        return (page
+            ? Array.from(page.getElementsByClassName(classes))
+            : []) as HTMLElement[];
     }
 
     public static getSelectedVideoPathAndTiming(): string | null {
@@ -875,7 +878,7 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
             }
         }
         const container = event.currentTarget as HTMLElement;
-        container.classList.add("bloom-selected");
+        selectVideoContainer(container);
         this.updateStateForSelected(container);
         // And now in most locations we want to prevent the default behavior where click starts playback.
         // This may need adjustment for zoom.
@@ -931,12 +934,11 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
             // If one is already marked selected, presumably from a previous use of this page,
             // we'll leave that one active.
             const selectedVideos = SignLanguageTool.getVideoContainers(true);
-            if (!selectedVideos || selectedVideos.length === 0) {
-                containers[0].classList.add("bloom-selected");
-                this.updateStateForSelected(containers[0]);
-            } else {
-                this.updateStateForSelected(selectedVideos[0]);
-            }
+            const videoToUse =
+                selectedVideos.length > 0 ? selectedVideos[0] : containers[0];
+            selectVideoContainer(videoToUse);
+            this.updateStateForSelected(videoToUse);
+
             for (let i = 0; i < containers.length; i++) {
                 const container = containers[i];
                 // UpdateMarkup is called fairlyfrequently. Not sure what effect having

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -7,7 +7,11 @@ import axios from "axios";
 import { get, postString, wrapAxios } from "../../utils/bloomApi";
 import theOneLocalizationManager from "../../lib/localizationManager/localizationManager";
 import { hookupLinkHandler } from "../../utils/linkHandler";
-import { ckeditableSelector } from "../../utils/shared";
+import {
+    ckeditableSelector,
+    getPageIFrame,
+    getPageIframeBody
+} from "../../utils/shared";
 import { EditableDivUtils } from "../js/editableDivUtils";
 import { DragActivityTool } from "./dragActivity/dragActivityTool";
 
@@ -232,17 +236,17 @@ export class ToolBox {
         return toolName;
     }
 
+    // In the process of moving this to shared.ts, but a lot of
+    // code still expects to find it here.
     public static getPageFrame(): HTMLIFrameElement {
-        return parent.window.document.getElementById(
-            "page"
-        ) as HTMLIFrameElement;
+        return getPageIFrame();
     }
 
+    // In the process of moving this to shared.ts as getPageIframeBody, but a lot of
+    // code still expects to find it here.
     // The body of the editable page, a root for searching for document content.
     public static getPage(): HTMLElement | null {
-        const page = ToolBox.getPageFrame();
-        if (!page || !page.contentWindow) return null;
-        return page.contentWindow.document.body;
+        return getPageIframeBody();
     }
 
     public static isXmatterPage(): boolean {

--- a/src/BloomBrowserUI/utils/shared.ts
+++ b/src/BloomBrowserUI/utils/shared.ts
@@ -16,3 +16,14 @@ export const ckeditableSelector =
     ".bloom-content1[contenteditable='true'],.bloom-content2[contenteditable='true']," +
     ".bloom-content3[contenteditable='true'],.bloom-contentNational1[contenteditable='true']," +
     ".bloom-contentNational2[contenteditable='true'],.Equation-style[contenteditable='true']";
+
+export function getPageIFrame(): HTMLIFrameElement {
+    return parent.window.document.getElementById("page") as HTMLIFrameElement;
+}
+
+// The body of the editable page, a root for searching for document content.
+export function getPageIframeBody(): HTMLElement | null {
+    const page = getPageIFrame();
+    if (!page || !page.contentWindow) return null;
+    return page.contentWindow.document.body;
+}

--- a/src/BloomBrowserUI/utils/shared.ts
+++ b/src/BloomBrowserUI/utils/shared.ts
@@ -1,5 +1,6 @@
-// This file is just a place to put items which are needed by both the page editing bundle and the toolbox bundle.
-// Its first (and currently only) item is ckeditableSelector which was originally exported by bloomEditing.ts to be used by toolbox.ts.
+// This file is just a place to put items which are needed by both the page editing bundle and the toolbox bundle,
+// and which don't seem to fit elsewhere, such as in utils files in a particular tool.
+// Its first  item is ckeditableSelector which was originally exported by bloomEditing.ts to be used by toolbox.ts.
 // But somehow that caused significantly inflated build times and bundle sizes. Thus, this file was created...
 
 // We want to attach ckeditor to the contenteditable="true" class="bloom-content1"

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -2063,6 +2063,7 @@ namespace Bloom.Edit
                     // but the HandleDelayedZoom is never called. This might help: if we're
                     // postponing zoom because the timer is running, we want to be quite sure
                     // that the delayed zoom function is set to be called when the timer ticks.
+                    _zoomTimer.Tick -= HandleDelayedZoom; // in case already subscribed
                     _zoomTimer.Tick += HandleDelayedZoom;
                     return;
                 }
@@ -2079,6 +2080,7 @@ namespace Bloom.Edit
                 // The timer is also used (with the Interval reset to 1 msec) to call SetZoom indirectly
                 // from inside the ZoomDocumentCompleted handler, which is needed for WebView2.
                 _zoomTimer.Interval = 6000;
+                _zoomTimer.Tick -= HandleDelayedZoom; // in case already subscribed
                 _zoomTimer.Tick += HandleDelayedZoom;
                 _zoomTimer.Start();
 

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -2058,6 +2058,12 @@ namespace Bloom.Edit
                     // Store the desired zoom level for use later when the previous request has
                     // finished its UI refresh.
                     _desiredZoomLevel = zoom;
+                    // I don't see how this is necessary, but I've seen Zoom locked in a state
+                    // where it never zooms because the timer is supposedly running, the interval is 1,
+                    // but the HandleDelayedZoom is never called. This might help: if we're
+                    // postponing zoom because the timer is running, we want to be quite sure
+                    // that the delayed zoom function is set to be called when the timer ticks.
+                    _zoomTimer.Tick += HandleDelayedZoom;
                     return;
                 }
                 _previousZoomTime = DateTime.Now;
@@ -2078,14 +2084,14 @@ namespace Bloom.Edit
 
                 Settings.Default.PageZoom = zoom.ToString(CultureInfo.InvariantCulture);
                 Settings.Default.Save();
-                // The main current reason a zoom change requires us to reload the page is that
-                // Text-over-picture boxes don't otherwise adjust their size and position properly.
-                // If that gets fixed, we could consider reinstating a JS function we used to call
-                // here, SetZoom, which originally just changed the transform on the scaling container.
-                // However, when it was later changed to post a request for reloading the page,
-                // it became cleaner to just do the reload directly here.
-                _model.RethinkPageAndReloadItAndReportIfItFails();
             }
+            // The main current reason a zoom change requires us to reload the page is that
+            // Text-over-picture boxes don't otherwise adjust their size and position properly.
+            // If that gets fixed, we could consider reinstating a JS function we used to call
+            // here, SetZoom, which originally just changed the transform on the scaling container.
+            // However, when it was later changed to post a request for reloading the page,
+            // it became cleaner to just do the reload directly here.
+            _model.RethinkPageAndReloadItAndReportIfItFails();
         }
 
         private void HandleDelayedZoom(object sender, EventArgs e)


### PR DESCRIPTION
- orange outline indicating active video is not needed in overlay (but still in other videos)
- black box indicating focus is not wanted for videos
- sign language tool and overlay tool should be consistent about what is selected
- selected overlay should not change when changing zoom

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6713)
<!-- Reviewable:end -->
