### PR TITLE
Adjust better when image container size changes (BL-13965)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1871,6 +1871,18 @@
         <source xml:lang="en">Paste Image</source>
         <note>ID: EditTab.Image.PasteImage</note>
       </trans-unit>
+      <trans-unit id="EditTab.Image.SetBackground" sil:dynamic="true" translate="no">
+        <source xml:lang="en">Set Image as background</source>
+        <note>ID: EditTab.Image.SetBackground</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Image.SetBackgroundRemove" sil:dynamic="true" translate="no">
+        <source xml:lang="en">Stop being background</source>
+        <note>ID: EditTab.Image.SetBackgroundRemove</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Image.SetBackgroundReplace" sil:dynamic="true" translate="no">
+        <source xml:lang="en">Replace background</source>
+        <note>ID: EditTab.Image.SetBackgroundRemove</note>
+      </trans-unit>
       <trans-unit id="EditTab.Image.TooLarge" sil:dynamic="true">
         <source xml:lang="en">Bloom ran out of memory loading this image ({0}), which is quite large ({1} by {2} pixels). Click Help for suggestions.</source>
         <note>ID: EditTab.Image.TooLarge</note>

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -572,6 +572,28 @@ body.bloom-fullBleed {
     }
 }
 
+// while doing an origami drag, most overlays won't resize.
+// If there's a background image (which will), hide the others (and the canvas
+// or svg, which shows their graphics, and also won't resize).
+// If not, it's probably less disturbing if they just stay where they are
+// until the origami drag is finished.
+.origami-drag {
+    .bloom-imageContainer:has(.bloom-backgroundImage) {
+        .bloom-textOverPicture:not(.bloom-backgroundImage),
+        .comical-generated {
+            display: none !important;
+        }
+    }
+}
+
+// New controls are replacing these in image containers that have overlays.
+.bloom-imageContainer:has(.bloom-textOverPicture) {
+    .imageButton,
+    .imageOverlayButton {
+        display: none;
+    }
+}
+
 .hoverUp .imageButton {
     border: 2px outset @ImageButtonBorder !important;
     border-radius: 3px !important;
@@ -1337,6 +1359,13 @@ canvas.moving {
     outline: 1px solid @bloom-blue;
     box-sizing: border-box;
     pointer-events: none;
+
+    // background images can't be manually resized
+    &.bloom-backgroundImage {
+        .bloom-ui-overlay-resize-handle {
+            display: none;
+        }
+    }
 
     // The handles and toolbox are hidden when the overlay is being moved, resized or cropped
     // (except for the resize or crop control we are operating).

--- a/src/BloomBrowserUI/bookEdit/js/OverlayContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/OverlayContextControls.tsx
@@ -16,6 +16,8 @@ import { default as CircleIcon } from "@mui/icons-material/Circle";
 import { default as DeleteIcon } from "@mui/icons-material/DeleteOutline";
 import { default as ArrowUpwardIcon } from "@mui/icons-material/ArrowUpward";
 import { default as ArrowDownwardIcon } from "@mui/icons-material/ArrowDownward";
+// MUI thinks of this icon as "Texture", but we're using it for commands that affect the background image.
+import { default as BackgroundIcon } from "@mui/icons-material/Texture";
 import { showCopyrightAndLicenseDialog } from "../editViewFrame";
 import { doImageCommand, getImageUrlFromImageContainer } from "./bloomImages";
 import {
@@ -40,7 +42,11 @@ import {
 import Menu from "@mui/material/Menu";
 import { Divider } from "@mui/material";
 import { DuplicateIcon } from "./DuplicateIcon";
-import { BubbleManager, theOneBubbleManager } from "./bubbleManager";
+import {
+    BubbleManager,
+    kbackgroundImageClass,
+    theOneBubbleManager
+} from "./bubbleManager";
 import { copySelection, GetEditor, pasteClipboard } from "./bloomEditing";
 import { BloomTooltip } from "../../react_components/BloomToolTip";
 import { useL10n } from "../../react_components/l10nHooks";
@@ -625,6 +631,24 @@ function addImageMenuOptions(
             getImageUrlFromImageContainer(imgContainer)
         );
     };
+    const setAsBackground = () => {
+        theOneBubbleManager?.setAsBackground();
+    };
+
+    const currentIsBackground = overlay.classList.contains(
+        kbackgroundImageClass
+    );
+    const isThereABackground =
+        currentIsBackground ||
+        overlay.parentElement?.getElementsByClassName(kbackgroundImageClass)[0];
+
+    let setBackgroundId = "EditTab.Image.SetBackground"; // default when no background is set
+    if (currentIsBackground) {
+        setBackgroundId = "EditTab.Image.SetBackgroundRemove";
+    } else if (isThereABackground) {
+        setBackgroundId = "EditTab.Image.SetBackgroundReplace";
+    }
+
     menuOptions.unshift(
         {
             l10nId: "EditTab.Image.ChooseImage",
@@ -650,6 +674,12 @@ function addImageMenuOptions(
             subLabelL10nId: "EditTab.Image.EditMetadataOverlayMore",
             onClick: runMetadataDialog,
             icon: <CopyrightIcon css={getMenuIconCss()} />
+        },
+        {
+            l10nId: setBackgroundId,
+            english: "Set Image as background",
+            onClick: setAsBackground,
+            icon: <BackgroundIcon css={getMenuIconCss()} />
         },
         divider
     );

--- a/src/BloomBrowserUI/bookEdit/js/OverlayContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/OverlayContextControls.tsx
@@ -642,11 +642,11 @@ function addImageMenuOptions(
         currentIsBackground ||
         overlay.parentElement?.getElementsByClassName(kbackgroundImageClass)[0];
 
-    let setBackgroundId = "EditTab.Image.SetBackground"; // default when no background is set
+    let backgroundMenuItemL10nId = "EditTab.Image.SetBackground"; // default when no background is set
     if (currentIsBackground) {
-        setBackgroundId = "EditTab.Image.SetBackgroundRemove";
+        backgroundMenuItemL10nId = "EditTab.Image.SetBackgroundRemove";
     } else if (isThereABackground) {
-        setBackgroundId = "EditTab.Image.SetBackgroundReplace";
+        backgroundMenuItemL10nId = "EditTab.Image.SetBackgroundReplace";
     }
 
     menuOptions.unshift(
@@ -676,7 +676,7 @@ function addImageMenuOptions(
             icon: <CopyrightIcon css={getMenuIconCss()} />
         },
         {
-            l10nId: setBackgroundId,
+            l10nId: backgroundMenuItemL10nId,
             english: "Set Image as background",
             onClick: setAsBackground,
             icon: <BackgroundIcon css={getMenuIconCss()} />

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -4791,13 +4791,15 @@ export class BubbleManager {
     // still be in that state after the mouseup.
     private documentMouseUp = (ev: Event) => {
         if (this.comicEditingSuspendedState === "forDrag") {
-            // the mousedown was in an origami slider
-            // clean up and don't let it affect anything else
+            // The mousedown was in an origami slider.
+            // Clean up and don't let the mouse up affect anything else.
+            // (Note: we're not stopping IMMEDATE propagation, so another mouseup handler
+            // on the document can remove the origami-drag class.)
             ev.preventDefault();
             ev.stopPropagation();
             setTimeout(() => {
-                // in timeout so that another mouseup handler will have removed
-                // the origami-drag class from the document, so we can get the right
+                // in timeout to be sure that another mouseup handler will have removed
+                // the origami-drag class from the body, so we can get the right
                 // resize behavior when turning back on.
                 this.resumeComicEditing();
             }, 0);
@@ -5670,11 +5672,11 @@ export class BubbleManager {
                             alternatesString.replace(/`/g, '"')
                         ) as IAlternate;
                         const style = alternate.style;
-                        const width = BubbleManager.getLabeledNumber(
+                        const width = BubbleManager.getLabeledNumberInPx(
                             "width",
                             style
                         );
-                        const height = BubbleManager.getLabeledNumber(
+                        const height = BubbleManager.getLabeledNumberInPx(
                             "height",
                             style
                         );
@@ -5742,7 +5744,7 @@ export class BubbleManager {
         newC: number,
         oldRange: number
     ): string {
-        const old = BubbleManager.getLabeledNumber(label, style);
+        const old = BubbleManager.getLabeledNumberInPx(label, style);
         const center = old + oldRange / 2;
         const newCenter = newC + (center - oldC) * scale;
         const newVal = newCenter - oldRange / 2;
@@ -5754,8 +5756,10 @@ export class BubbleManager {
 
     // Typical source is something like "left: 224px; top: 79.6px; width: 66px; height: 30px;"
     // We want to pass "top" and get 79.6.
-    public static getLabeledNumber(label: string, source: string): number {
-        const match = source.match(new RegExp(label + this.numberPxRegex));
+    public static getLabeledNumberInPx(label: string, source: string): number {
+        const match = source.match(
+            new RegExp(label + BubbleManager.numberPxRegex)
+        );
         if (match) {
             return parseFloat(match[1]);
         }

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManagerSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManagerSpec.ts
@@ -3,7 +3,7 @@ import { BubbleManager } from "./bubbleManager";
 
 // A (currently very incomplete) set of tests for BubbleManager.
 
-fdescribe("BubbleManager.getLabeledNumber", () => {
+describe("BubbleManager.getLabeledNumber", () => {
     // beforeEach(() => {
     // });
 
@@ -11,7 +11,7 @@ fdescribe("BubbleManager.getLabeledNumber", () => {
     // afterAll(removeTestRoot);
 
     it("extracts integer size from style", () => {
-        const result = BubbleManager.getLabeledNumber(
+        const result = BubbleManager.getLabeledNumberInPx(
             "width",
             "left: 224px; top: 79.6px; width: 66px; height: 30px;"
         );
@@ -19,14 +19,14 @@ fdescribe("BubbleManager.getLabeledNumber", () => {
     });
 
     it("extracts float size from style", () => {
-        const result = BubbleManager.getLabeledNumber(
+        const result = BubbleManager.getLabeledNumberInPx(
             "top",
             "left: 224px; top: 79.6px; width: 66px; height: 30px;"
         );
         expect(result).toBe(79.6);
     });
     it("extracts negative size from style", () => {
-        const result = BubbleManager.getLabeledNumber(
+        const result = BubbleManager.getLabeledNumberInPx(
             "left",
             "left: -10.4px; top: 79.6px; width: 66px; height: 30px;"
         );
@@ -34,7 +34,7 @@ fdescribe("BubbleManager.getLabeledNumber", () => {
     });
 });
 
-fdescribe("BubbleManager.adjustLabeledNumber", () => {
+describe("BubbleManager.adjustLabeledNumber", () => {
     // beforeEach(() => {
     // });
 

--- a/src/BloomBrowserUI/bookEdit/js/bubbleManagerSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManagerSpec.ts
@@ -1,0 +1,62 @@
+import { getTestRoot, removeTestRoot } from "../../utils/testHelper";
+import { BubbleManager } from "./bubbleManager";
+
+// A (currently very incomplete) set of tests for BubbleManager.
+
+fdescribe("BubbleManager.getLabeledNumber", () => {
+    // beforeEach(() => {
+    // });
+
+    // // Politely clean up for the next test suite.
+    // afterAll(removeTestRoot);
+
+    it("extracts integer size from style", () => {
+        const result = BubbleManager.getLabeledNumber(
+            "width",
+            "left: 224px; top: 79.6px; width: 66px; height: 30px;"
+        );
+        expect(result).toBe(66);
+    });
+
+    it("extracts float size from style", () => {
+        const result = BubbleManager.getLabeledNumber(
+            "top",
+            "left: 224px; top: 79.6px; width: 66px; height: 30px;"
+        );
+        expect(result).toBe(79.6);
+    });
+    it("extracts negative size from style", () => {
+        const result = BubbleManager.getLabeledNumber(
+            "left",
+            "left: -10.4px; top: 79.6px; width: 66px; height: 30px;"
+        );
+        expect(result).toBe(-10.4);
+    });
+});
+
+fdescribe("BubbleManager.adjustLabeledNumber", () => {
+    // beforeEach(() => {
+    // });
+
+    // // Politely clean up for the next test suite.
+    // afterAll(removeTestRoot);
+
+    it("adjusts center of text box", () => {
+        const result = BubbleManager.adjustCenterOfTextBox(
+            "left",
+            "left: 30px; top: 79.6px; width: 66px; height: 30px;",
+            2, // making stuff 2x larger
+            7, // the old area being resized was 7px from the left
+            13, // the new area is 13px from the left
+            20 // the object we're adjusting is 20px wide
+        );
+        // So, the point we're adjusting is the center, originally 40px from the container left
+        // That's 33px from the left of the area being scaled, which becomes 66px
+        // from the left of the new area, which is now 13px from the container left,
+        // which we add to get 79. The left is still 10px (half the width) less,
+        // so we get 69
+        expect(result).toBe(
+            "left: 69px; top: 79.6px; width: 66px; height: 30px;"
+        );
+    });
+});

--- a/src/BloomBrowserUI/lib/split-pane/split-pane.js
+++ b/src/BloomBrowserUI/lib/split-pane/split-pane.js
@@ -136,6 +136,10 @@ import { EditableDivUtils } from "../../bookEdit/js/editableDivUtils";
             pageYof(event)
         );
         document.addEventListener(moveEvent, moveFunction, { capture: true });
+        // MUST be on the document, both for the usual reason that the mouse can move out of the element
+        // where the mouse down happened, and also because there is another capturing document-level mouseup
+        // handler in bubblemanager that uses stopPropagation to prevent the event from reaching
+        // any descendants.
         document.addEventListener(endEvent, mouseUpHandler, {
             capture: true,
             once: true
@@ -789,7 +793,7 @@ import { EditableDivUtils } from "../../bookEdit/js/editableDivUtils";
             return -1;
         }
         let aspectRatio = img.naturalWidth / img.naturalHeight;
-        // but if there is a bloom-backgroundImage, common in imqges used for overlays, use that instead
+        // but if there is a bloom-backgroundImage, common in images used for overlays, use that instead
         const backgroundOverlay = imageContainer.getElementsByClassName(
             "bloom-backgroundImage"
         )[0];

--- a/src/BloomBrowserUI/lib/split-pane/split-pane.js
+++ b/src/BloomBrowserUI/lib/split-pane/split-pane.js
@@ -781,11 +781,21 @@ import { EditableDivUtils } from "../../bookEdit/js/editableDivUtils";
         ) {
             return -1;
         }
+        // by default the image percent is based on the image that is a direct child of the imageContainer
         const img = Array.from(imageContainer.children).filter(
             c => c.nodeName === "IMG"
         )[0];
         if (!img) {
             return -1;
+        }
+        let aspectRatio = img.naturalWidth / img.naturalHeight;
+        // but if there is a bloom-backgroundImage, common in imqges used for overlays, use that instead
+        const backgroundOverlay = imageContainer.getElementsByClassName(
+            "bloom-backgroundImage"
+        )[0];
+        if (backgroundOverlay) {
+            aspectRatio =
+                backgroundOverlay.clientWidth / backgroundOverlay.clientHeight;
         }
         const horizontal = isPaneHorizontal(splitPane);
         const splitPaneComponent = img.closest(".split-pane-component"); // the element that has the percent
@@ -793,9 +803,7 @@ import { EditableDivUtils } from "../../bookEdit/js/editableDivUtils";
 
         if (horizontal) {
             const width = splitPane.offsetWidth;
-            const height = isForSquareSplit
-                ? width
-                : (width * img.naturalHeight) / img.naturalWidth;
+            const height = isForSquareSplit ? width : width / aspectRatio;
             // At some point we apparently had 3px of margin on the top pane, possibly something to do
             // with the splitter control. Somewhere about 6.0 we lost it, so this correction is no longer needed.
             // I'm leaving it here commented out in case losing that margin was a mistake and we also need
@@ -820,9 +828,7 @@ import { EditableDivUtils } from "../../bookEdit/js/editableDivUtils";
             return ((height + extraHeight) * 100) / splitPane.offsetHeight;
         } else {
             const height = splitPane.offsetHeight;
-            const width = isForSquareSplit
-                ? height
-                : (height * img.naturalWidth) / img.naturalHeight;
+            const width = isForSquareSplit ? height : height * aspectRatio;
             // See comment above in horizontal block.
             // if (isForFirstChildPane) {
             //     width += 3;

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1672,7 +1672,7 @@ namespace Bloom.Edit
                     $"editTabBundle.getEditablePageBundleExports().changeImage({JsonConvert.SerializeObject(args)})"
                 );
 
-            /* We're Saving to the DOM here only if it's a cover page, because lets us make the image transparent if it should be:
+            /* We're Saving to the DOM here only if it's a cover page, because that lets us make the image transparent if it should be:
              *        Cause: Until we have Saved the page, the in-memory DOM doesn't have this as the cover image,
              *        so the check to see if we need to make it transparent says "no".
              *        This could probably be done in a smarter way that isn't occuring to me at the moment.

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1663,45 +1663,74 @@ namespace Bloom.Edit
 
         public void UpdateImageInBrowser(PageEditingModel.ImageInfoForJavascript args)
         {
-            // we don't need to wait. Even if our caller kicks off a save, its call to RunJavascriptAsync() will come in after ours.
+            // We generally don't need to wait. Even if we decide to save, its call to RunJavascriptAsync() will come in after ours.
+            // But be careful about depending on that (or any subsequent running Javascript) on pages that might have overlays:
+            // updating the image on an overlay page can involve async code that adjusts things after the image is loaded
+            // enough to get its dimensions, and that adjustment might not complete before the next Javascript is run from C#
             GetEditingBrowser()
                 .RunJavascriptFireAndForget(
                     $"editTabBundle.getEditablePageBundleExports().changeImage({JsonConvert.SerializeObject(args)})"
                 );
 
-            /* We're Saving to the DOM here:
-             * 1) Makes it transparent if it should be:
+            /* We're Saving to the DOM here only if it's a cover page, because lets us make the image transparent if it should be:
              *        Cause: Until we have Saved the page, the in-memory DOM doesn't have this as the cover image,
-             *        so the check to see if we need to make it tranparent says "no".
+             *        so the check to see if we need to make it transparent says "no".
              *        This could probably be done in a smarter way that isn't occuring to me at the moment.
-             * 2) It is needed if we're going to update the thumbnail (we could live without this)
+             *  [JT idea: we could update our version of the DOM, just setting the src of the image. Or, we could
+             *  talk directly to the BloomServer and tell it that image needs transparency.]
+             * Another possible reason to Save is that it is needed if we're going to update the thumbnail, but we decided
+             * we can live without this...probably we can get that behavior back once the page list is in the same browser.
+             * And as noted above, a reason not to save is that it's a problem to run the Javascript that gets the page
+             * content before any async consequences of running the changeImage above (that affect the saved DOM content)
+             * have completed.
+             * For now, it's OK to Save on the cover, because we don't support overlays there, and overlays are the only
+             * known case where the async consequences of the changeImage might affect the saved DOM.
+             * But this is more fragile than I like. Hope we can soon find a better way to get the cover image transparency
+             * and maybe even update the thumbnails without forcing a save.
              */
-            SaveThen(
-                doAfterSaving: () =>
-                {
-                    try
+            if (CurrentPage.IsCoverPage)
+            {
+                SaveThen(
+                    doAfterSaving: () =>
                     {
-                        _view.UpdateThumbnailAsync(_pageSelection.CurrentSelection);
+                        try
+                        {
+                            _view.UpdateThumbnailAsync(_pageSelection.CurrentSelection);
 
-                        Logger.WriteMinorEvent("Finished ChangePicture {0}", (object)args.src);
-                        Analytics.Track("Change Picture");
-                        Logger.WriteEvent("ChangePicture {0}...", (object)args.src);
-                    }
-                    catch (Exception e)
-                    {
-                        var msg = LocalizationManager.GetString(
-                            "Errors.ProblemImportingPicture",
-                            "Bloom had a problem importing this picture."
-                        );
-                        e.Data["ProblemImagePath"] = args.src;
-                        ErrorReport.NotifyUserOfProblem(e, msg + Environment.NewLine + e.Message);
-                    }
-                    return _pageSelection.CurrentSelection.Id; // we're not changing pages
-                },
-                doIfNotInRightStateToSave: () => { },
-                forceFullSave: false,
-                skipSaveToDisk: false // we can wait for the normal save to disk
-            );
+                            Logger.WriteMinorEvent(
+                                "Finished ChangePicture with save {0}",
+                                (object)args.src
+                            );
+                            Analytics.Track("Change Picture");
+                            Logger.WriteEvent("ChangePicture {0}...", (object)args.src);
+                        }
+                        catch (Exception e)
+                        {
+                            var msg = LocalizationManager.GetString(
+                                "Errors.ProblemImportingPicture",
+                                "Bloom had a problem importing this picture."
+                            );
+                            e.Data["ProblemImagePath"] = args.src;
+                            ErrorReport.NotifyUserOfProblem(
+                                e,
+                                msg + Environment.NewLine + e.Message
+                            );
+                        }
+
+                        return _pageSelection.CurrentSelection.Id; // we're not changing pages
+                    },
+                    doIfNotInRightStateToSave: () => { },
+                    forceFullSave: false,
+                    skipSaveToDisk: false // we can wait for the normal save to disk
+                );
+            }
+            else
+            {
+                // not saving, but we still want to log etc.
+                Logger.WriteMinorEvent("Finished ChangePicture without save {0}", (object)args.src);
+                Analytics.Track("Change Picture");
+                Logger.WriteEvent("ChangePicture {0}...", (object)args.src);
+            }
         }
 
         public void SetView(EditingView view)

--- a/src/BloomExe/SafeXml/SafeXmlNode.cs
+++ b/src/BloomExe/SafeXml/SafeXmlNode.cs
@@ -271,6 +271,20 @@ namespace Bloom.SafeXml
             return null;
         }
 
+        public SafeXmlElement ParentElement
+        {
+            get
+            {
+                lock (_doc.Lock)
+                {
+                    var parent = _wrappedNode.ParentNode;
+                    while (parent != null && !(parent is XmlElement))
+                        parent = parent.ParentNode;
+                    return WrapNode(parent, _doc) as SafeXmlElement;
+                }
+            }
+        }
+
         public virtual string GetOptionalStringAttribute(string name, string defaultValue)
         {
             return null;

--- a/src/content/bookLayout/basePage-sharedRules.less
+++ b/src/content/bookLayout/basePage-sharedRules.less
@@ -1,4 +1,4 @@
-﻿// Styles that are shared by both the regular book css and the more minimalist epub css.
+// Styles that are shared by both the regular book css and the more minimalist epub css.
 
 @preferredBackgroundGray: hsl(0, 0%, 86%);
 


### PR DESCRIPTION
This converts the background image of an image container into an overlay, allowing it to be cropped.
The main image is left as a placeholder, so earlier Bloom versions won't find things too surprising.
We still have a way to identify one overlay as a background, with some special behaviors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6734)
<!-- Reviewable:end -->
