### PR TITLE
Cleanup more after nicescroll to keep backward compatibility (BL-14052)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/niceScrollBars.ts
+++ b/src/BloomBrowserUI/bookEdit/js/niceScrollBars.ts
@@ -255,5 +255,9 @@ export function cleanupNiceScroll() {
                 );
                 groupParent.classList.add("bloom-vertical-align-bottom");
             }
+            // Remove more debris left by niceScroll. See BL-14052.
+            (group as HTMLElement).style.overflow = "";
+            (group as HTMLElement).style.outline = "";
+            (group as HTMLElement).style.width = "";
         });
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6738)
<!-- Reviewable:end -->
