### PR TITLE
Move the background image crop handles inward (BL-13965)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1506,6 +1506,24 @@ canvas.moving {
         height: @sideHandleCenter * 2 + @sideHandleRadius * 2;
         cursor: ew-resize;
     }
+
+    // the background image is hard up against the side of the container on at least two edges,
+    // and can't be moved. Half the default crop handle is clipped at best, and sometimes the
+    // origami control gets in the way even more. So we move them inwards.
+    &.bloom-backgroundImage {
+        .bloom-ui-overlay-side-handle-n {
+            top: 0;
+        }
+        .bloom-ui-overlay-side-handle-e {
+            right: 0;
+        }
+        .bloom-ui-overlay-side-handle-s {
+            bottom: 0;
+        }
+        .bloom-ui-overlay-side-handle-w {
+            left: 0;
+        }
+    }
 }
 
 #overlay-context-controls {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6754)
<!-- Reviewable:end -->
