### PR TITLE
Use outline instead of border to mark overflow (BL-14059)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -767,7 +767,7 @@ div.bloom-templateMode {
 .bloom-page:not([class*="Device"]) {
     .overflow {
         color: @OverflowColor !important;
-        border: solid thin @OverflowColor !important; //NB: can't afford to go "thick" because it throws off the calculation
+        outline: solid thin @OverflowColor !important; //outline rather than border so as not to affect layout.
 
         p:empty:after {
             //br:after would be great but it doesn't work


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6756)
<!-- Reviewable:end -->
