### PR TITLE
Fix initial game picture space to fit placeholder properly (BL-14063)

### DIFF
--- a/src/content/templates/template books/Games/Games.html
+++ b/src/content/templates/template books/Games/Games.html
@@ -405,13 +405,13 @@
 
                         <div
                             class="bloom-textOverPicture ui-resizable ui-draggable"
-                            style="height: 193px; left: 385.141px; top: 44.1406px; width: 220px; position: absolute;"
+                            style="height: 193px; left: 385.141px; top: 44.1406px; width: 196px; position: absolute;"
                             data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:17,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
                         >
                             <div
                                 tabindex="0"
                                 class="bloom-imageContainer bloom-leadingElement"
-                                data-title="For the current paper size: • The image container is 220 x 193 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 688 x 604 dots would fill this container at 300 DPI."
+                                data-title="For the current paper size: • The image container is 196 x 193 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 613 x 604 dots would fill this container at 300 DPI."
                                 title=""
                             >
                                 <img


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6763)
<!-- Reviewable:end -->
