### PR TITLE
Get narration.ts and dragActivityRuntime.ts more up-to-date (20241202)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityRuntime.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityRuntime.ts
@@ -364,7 +364,7 @@ function changePageButtonClicked(e: MouseEvent) {
     currentChangePageAction?.(next);
 }
 
-export function playInitialElements(page: HTMLElement) {
+export function playInitialElements(page: HTMLElement, playVideos: boolean) {
     const initialFilter = e => {
         const top = e.closest(".bloom-textOverPicture") as HTMLElement;
         if (!top) {
@@ -393,9 +393,6 @@ export function playInitialElements(page: HTMLElement) {
         }
         return true;
     };
-    const videoElements = Array.from(page.getElementsByTagName("video")).filter(
-        initialFilter
-    );
     const audioElements = getVisibleEditables(page).filter(initialFilter);
 
     //Slider: // This is used in drag-word-chooser-slider to mark the text item the user is currently
@@ -408,7 +405,14 @@ export function playInitialElements(page: HTMLElement) {
     //     audioElements.push(activeTextBox);
     // }
     const playables = getAudioSentences(audioElements);
-    playAllVideo(videoElements, () => playAllAudio(playables, page));
+    if (playVideos) {
+        const videoElements = Array.from(
+            page.getElementsByTagName("video")
+        ).filter(initialFilter);
+        playAllVideo(videoElements, () => playAllAudio(playables, page));
+    } else {
+        playAllAudio(playables, page);
+    }
 }
 
 function getAudioSentences(editables: HTMLElement[]) {

--- a/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityTool.tsx
@@ -2002,7 +2002,7 @@ export function setActiveDragActivityTab(tab: number) {
         // Enhance: perhaps the next/prev page buttons could do something even here?
         // If so, would we want them to work only in TryIt mode, or always?
         prepareActivity(page, _next => {});
-        playInitialElements(page);
+        playInitialElements(page, true);
         //Slider: wrapper?.removeEventListener("click", designTimeClickOnSlider);
     } else {
         undoPrepareActivity(page);

--- a/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/narration.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/narration.ts
@@ -1228,20 +1228,68 @@ export function playAllVideo(elements: HTMLVideoElement[], then: () => void) {
         return;
     }
     const video = elements[0];
-    // Note: in Bloom Desktop, sometimes this event does not fire normally, even when the video is played to the end.
-    // I have not figured out why. It may be something to do with how we are trimming them.
-    // In Bloom Desktop, this is worked around by raising the ended event when we detect that it has paused past the end point
-    // in resetToStartAfterPlayingToEndPoint.
-    // In BloomPlayer,I don't think this is a problem. Videos are trimmed when published, so we always play to the
-    // real end (unless the user pauses). So one way or another, we should get the ended event.
-    video.addEventListener(
-        "ended",
-        () => {
-            playAllVideo(elements.slice(1), then);
-        },
-        { once: true }
-    );
-    // Review: do we need to do something to let the rest of the world know about this?
-    setCurrentPlaybackMode(PlaybackMode.VideoPlaying);
-    video.play();
+    // If there is an error, try to continue with the next video.
+    if (
+        video.networkState === HTMLMediaElement.NETWORK_NO_SOURCE &&
+        video.readyState === HTMLMediaElement.HAVE_NOTHING
+    ) {
+        showVideoError(video);
+        playAllVideo(elements.slice(1), then);
+    } else {
+        hideVideoError(video);
+        setCurrentPlaybackMode(PlaybackMode.VideoPlaying);
+        const promise = video.play();
+        promise
+            .then(() => {
+                // Note: in Bloom Desktop, sometimes this event does not fire normally, even when the video is played to the end.
+                // I have not figured out why. It may be something to do with how we are trimming them.
+                // In Bloom Desktop, this is worked around by raising the ended event when we detect that it has paused past the end point
+                // in resetToStartAfterPlayingToEndPoint.
+                // In BloomPlayer,I don't think this is a problem. Videos are trimmed when published, so we always play to the
+                // real end (unless the user pauses). So one way or another, we should get the ended event.
+                video.addEventListener(
+                    "ended",
+                    () => {
+                        playAllVideo(elements.slice(1), then);
+                    },
+                    { once: true }
+                );
+            })
+            .catch(reason => {
+                console.error("Video play failed", reason);
+                showVideoError(video);
+                playAllVideo(elements.slice(1), then);
+            });
+    }
+}
+
+// We're living with this message not being localized.
+const badVideoMessage = "Sorry, this video cannot be played in this browser.";
+
+export function showVideoError(video: HTMLVideoElement): void {
+    const parent = video.parentElement;
+    if (parent) {
+        const divs = parent.getElementsByClassName("video-error-message");
+        if (divs.length === 0) {
+            const msgDiv = parent.ownerDocument.createElement("div");
+            msgDiv.className = "video-error-message normal-style";
+            msgDiv.textContent = badVideoMessage;
+            msgDiv.style.display = "block";
+            msgDiv.style.color = "black";
+            msgDiv.style.backgroundColor = "rgba(255, 255, 255, 0.5)"; // semi-transparent white
+            msgDiv.style.position = "absolute";
+            msgDiv.style.left = "10%";
+            msgDiv.style.top = "10%";
+            msgDiv.style.width = "80%";
+            msgDiv.style.fontSize = "x-large";
+            parent.appendChild(msgDiv);
+        }
+    }
+}
+export function hideVideoError(video: HTMLVideoElement): void {
+    const parent = video.parentElement;
+    if (parent) {
+        const divs = parent.getElementsByClassName("video-error-message");
+        while (divs.length > 1) parent.removeChild(divs[0]);
+    }
 }

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -4652,6 +4652,7 @@ namespace Bloom.Book
             }
 
             RemoveObsoleteSoundAttributes(OurHtmlDom);
+            RemoveVideoWarnings();
             // Note that at this point _bookData has already been updated with the edited page's data, if any.
             // This will take priority over other data it finds in the book, even earlier in the book
             // than the edited page.
@@ -4678,6 +4679,18 @@ namespace Bloom.Book
             }
 
             DoPostSaveTasks();
+        }
+
+        private void RemoveVideoWarnings()
+        {
+            var warningDivs = OurHtmlDom
+                .SafeSelectNodes("//div[contains(@class,'video-error-message')]")
+                .Cast<SafeXmlElement>()
+                .ToList();
+            foreach (var div in warningDivs)
+            {
+                div.ParentElement.RemoveChild(div);
+            }
         }
 
         public void SaveForPageChanged(string pageId, SafeXmlElement modifiedPage)


### PR DESCRIPTION
Also add cleanup to remove message inserted by narration.ts for invalid videos when testing games.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6771)
<!-- Reviewable:end -->
