### PR TITLE
Fix positioning of overlay control box for older books (BL-14106)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -2161,9 +2161,7 @@ export class BubbleManager {
                 this.activeElement.clientWidth + 2 * extraPadding + "px";
             controlFrame.style.height = this.activeElement.style.height;
             controlFrame.style.left =
-                BubbleManager.pxToNumber(this.activeElement.style.left) -
-                extraPadding +
-                "px";
+                this.activeElement.offsetLeft - extraPadding + "px";
             controlFrame.style.top = this.activeElement.style.top;
             const tails = Bubble.getBubbleSpec(this.activeElement).tails;
             if (tails.length > 0) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6772)
<!-- Reviewable:end -->
