### PR TITLE
BL-14167 import recording should reopen to last location

### DIFF
--- a/src/BloomExe/web/controllers/MusicApi.cs
+++ b/src/BloomExe/web/controllers/MusicApi.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using Bloom.Api;
 using Bloom.Book;
 using Bloom.Publish;
+using Bloom.Utils;
 using L10NSharp;
 using SIL.IO;
 
@@ -94,15 +95,37 @@ namespace Bloom.web.controllers
                 "Sound files"
             );
             string srcFile = null;
-            using (var dlg = new MiscUI.BloomOpenFileDialog
-            {
-                Filter = $"{soundFiles} {BuildFileFilter()}"
-            })
+
+            // For saving and recalling the last chosen file location
+            var extension = ".mp3";
+            var directoryTag = "ShowSelectMusicFile";
+            using (
+                var dlg = new MiscUI.BloomOpenFileDialog
+                {
+                    Filter = $"{soundFiles} {BuildFileFilter()}",
+                    InitialDirectory = Path.GetDirectoryName(
+                        OutputFilenames.GetOutputFilePath(
+                            CurrentBook,
+                            extension,
+                            extraTag: directoryTag,
+                            proposedFolder: System.Environment.GetFolderPath(
+                                System.Environment.SpecialFolder.MyDocuments
+                            )
+                        )
+                    )
+                }
+            )
             {
                 var result = dlg.ShowDialog();
                 if (result == DialogResult.OK)
                 {
                     srcFile = dlg.FileName;
+                    OutputFilenames.RememberOutputFilePath(
+                        CurrentBook,
+                        extension,
+                        srcFile,
+                        extraTag: directoryTag
+                    );
                 }
             }
             var destFile = Path.GetFileName(srcFile);


### PR DESCRIPTION
This undoes a change made by JT in https://github.com/BloomBooks/BloomDesktop/pull/6571/files#diff-fda3f19b08588223b7b2ec9253a08eb8a388139f08bbf0023c025233bab01174R105. I talked to him about it and he thought this change would be okay.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6790)
<!-- Reviewable:end -->
