### PR TITLE
Make image descriptions work again

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -473,42 +473,18 @@ body.bloom-fullBleed {
     }
 }
 
-// override button positions when the image is shrunk to make room for an image description
 .bloom-showImageDescriptions {
-    canvas,
-    .comical-generated {
-        display: none;
-    }
-
-    .imageButton {
-        &.changeImageButton {
-            right: 50%;
-        }
-
-        &.changeImageButton,
-        &.editMetadataButton {
-            top: @imageDescriptionTopBorderWidth; // below the ::before border
-        }
-    }
-
-    button.miniButton {
-        right: calc(50% + 60px);
-
-        &.verySmallButtons {
-            // normally right:60%, width: 30%.
-            // We need the effect of 60% of the picture half, plus the 50%
-            // occupied by the text, that is, 30%+50%
-            right: 80%;
-            width: 15%;
-        }
+    // Don't want to deal with resizing the image container while this tool is active,
+    // nor with the size changes associated with picking a different image.
+    // The extra layer of scaling does weird things I haven't fully understood
+    // to the code that tries to keep the background image and overlays aligned.
+    .imageButton,
+    .split-pane-divider,
+    .origami-toggle {
+        display: none !important;
     }
 
     .bloom-imageContainer {
-        // Requiring a direct child helps prevent this from applying to things like the format cog
-        > img {
-            height: calc(100% - @imageDescriptionTopBorderWidth);
-        }
-
         .bloom-imageDescription {
             // Note: this rule has basically the same specificity as one in basePage.less
             // that sets top to zero. I think this one only wins because it comes later.
@@ -522,9 +498,12 @@ body.bloom-fullBleed {
 
 @imageDescriptionBorderWidth: 3px;
 
-.bloom-showImageDescriptions .bloom-page .bloom-imageContainer {
+.bloom-showImageDescriptions
+    .bloom-page
+    .bloom-imageContainer:not(.bloom-imageContainer .bloom-imageContainer) {
     // This produces the thin border on the left, bottom, and right of each image when the
-    // image description tool is active.
+    // image description tool is active. The :not above prevents also getting this on
+    // nested image containers (inside overlays).
     border-style: solid;
     border-color: @accordion-active-element;
     border-width: 0 @imageDescriptionBorderWidth @imageDescriptionBorderWidth
@@ -543,6 +522,26 @@ body.bloom-fullBleed {
         background-position: center;
         background-image: url("/bloom/bookEdit/toolbox/imageDescription/ImageDescriptionToolIcon.svg");
     }
+}
+// a wrapper div we add around the contents of an image container except the image description,
+// when we are showing image descriptions. Shrinks the image to the center of the left half
+// of the container.
+// We need this because if we scale the image container itself, the description gets scaled as well.
+// Even if we tried to apply a reverse transformation to the description, the place we want it is
+// outside the scaled image container, and we're hiding overflow on image containers (and need to,
+// both for cropping images and in case bubbles extend beyond the container).
+// Conversely, I don't believe CSS provides a way to transform children relative to an anchor
+// on each parent. We could conceivably compute a different transform for each child, but this is more
+// straightforward and less error-prone.
+.bloom-describedImage {
+    // for a reason I haven't tracked down, the rule that usually does this doesn't work here.
+    img[src="placeHolder.png"] {
+        display: none;
+    }
+    height: 100%;
+    width: 100%;
+    transform-origin: center left;
+    transform: scale(0.5, 0.5);
 }
 
 .bloom-videoContainer,

--- a/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescriptionUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescriptionUtils.ts
@@ -6,13 +6,43 @@ import { OverlayTool } from "../overlay/overlayTool";
 export function showImageDescriptions(bodyOfPageIframe: HTMLElement) {
     const bubbleManager = OverlayTool.bubbleManager();
     bubbleManager?.suspendComicEditing("forTool");
-    // turn on special layout to make image descriptions visible (might already be on)
-    bodyOfPageIframe.classList.add("bloom-showImageDescriptions");
+    // turn on special layout to make image descriptions visible (might already be on, so check first)
+    if (!bodyOfPageIframe.classList.contains("bloom-showImageDescriptions")) {
+        bodyOfPageIframe.classList.add("bloom-showImageDescriptions");
+        // for each bloom-imageContainer that is not a child of another bloom-imageContainer,
+        // wrap the contents (except the description) with another division with class bloom-describedImage
+        // See comment in editMode.less under bloom-describedImage for why we do this.
+        for (const imageContainer of Array.from(
+            bodyOfPageIframe.getElementsByClassName("bloom-imageContainer")
+        )) {
+            if (
+                !imageContainer.parentElement?.closest(".bloom-imageContainer")
+            ) {
+                const describedImage = document.createElement("div");
+                describedImage.classList.add("bloom-describedImage");
+                for (const child of Array.from(imageContainer.children)) {
+                    if (!child.classList.contains("bloom-imageDescription")) {
+                        describedImage.appendChild(child);
+                    }
+                }
+                imageContainer.appendChild(describedImage);
+            }
+        }
+    }
 }
 export function hideImageDescriptions(bodyOfPageIframe: HTMLElement) {
     const bubbleManager = OverlayTool.bubbleManager();
-    // removing the class must be done first; resume won't work right while the overlays
-    // are hidden
+    // removing the class and wrapper should be done first; resume may not work
+    // right while the extra wrapper is present.
     bodyOfPageIframe.classList.remove("bloom-showImageDescriptions");
+    // unwrap the contents of each bloom-describedImage
+    for (const describedImage of Array.from(
+        bodyOfPageIframe.getElementsByClassName("bloom-describedImage")
+    )) {
+        for (const child of Array.from(describedImage.children)) {
+            describedImage.parentElement!.appendChild(child);
+        }
+        describedImage.remove();
+    }
     bubbleManager?.resumeComicEditing();
 }

--- a/src/content/bookLayout/basePage-legacy-5-6.less
+++ b/src/content/bookLayout/basePage-legacy-5-6.less
@@ -361,9 +361,6 @@ span.bloom-linebreak {
     border: 1px solid #1d94a4;
     box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1), 0 0 8px #1d94a4;
 }
-.bloom-showImageDescriptions .bloom-textOverPicture {
-    display: none !important;
-}
 .bloom-fullBleed
     .bloom-imageContainer
     .bloom-textOverPicture[data-bubble*="`style`:`none`"] {
@@ -1142,21 +1139,15 @@ h2 {
 .bloom-showImageDescriptions .bloom-imageContainer .bloom-imageDescription {
     display: flex;
 }
-.bloom-showImageDescriptions .bloom-imageContainer {
-    background-size: 50% auto;
-    background-position-x: 0;
-}
 .bloom-showImageDescriptions .bloom-imageContainer .bloom-imageDescription {
-    width: 50%;
+    width: calc(50% - 3px);
     height: 100%;
     top: 0;
+
     position: absolute;
-    left: 50%;
+    right: 0;
     box-sizing: border-box;
     border-left: solid lightgray 1px;
-}
-.bloom-showImageDescriptions .bloom-imageContainer > img {
-    width: 50%;
 }
 div[data-book*="branding"] a:link,
 div[data-book*="branding"] a:visited {

--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -457,28 +457,24 @@ books may contain divs with box-header-off, so we need a rule to hide them.*/
 // "position: absolute;" is required for the text to display in the proper location.  If we ever want to
 // display like this in ePUBs (picture and description side by side), some other approach will be needed.
 .bloom-showImageDescriptions .bloom-imageContainer {
-    background-size: 50% auto;
-    background-position-x: 0;
-
     .bloom-imageDescription {
-        width: 50%;
+        // the 3px is @imageDescriptionBorderWidth in editMode.less. It's easy to subtract this
+        // here, but difficult to transform the image to 50% - 3px, since scale doesn't support calc.
+        // So rather than do something complicated, we just let the image be a full 50% and subtract
+        // the border from the translation group.
+        width: calc(50% - 3px);
         // not needed in content pages, but for some reason on cover.
         // Overridden in edit mode to make room for special border on top.
         height: 100%;
         top: 0;
 
         position: absolute;
-        left: 50%;
+        right: 0;
         box-sizing: border-box;
         border-left: solid lightgray 1px;
         // We also want to turn off the display:none that usually applies to translation groups
         // inside image containers (above), but we want display:flex in Bloom, and display:block
         // in epubs. So that rule is elsewhere.
-    }
-
-    // Requiring a direct child helps prevent this from applying to things like the format cog
-    > img {
-        width: 50%;
     }
 }
 

--- a/src/content/bookLayout/bubble.less
+++ b/src/content/bookLayout/bubble.less
@@ -197,17 +197,6 @@
     // }
 }
 
-.bloom-showImageDescriptions {
-    .bloom-textOverPicture {
-        // Turn this off because it's complicated to deal with these while image description tool active.
-        // Re-positioning and shrinking the text boxes proportionally while ImageDescription tool is active
-        // is possible but hugely complicates the code... so for now, just disable it.
-        // Make this rule !important because we have some quite complex rules to make certain bubbles
-        // display:flex and this needs to win.
-        display: none !important;
-    }
-}
-
 // This rule works around a bizarre bug in generating PDF from HTML (BL-9278).
 // The text in a display:block div inside atext-over-picture box on a page with
 // top: less than 3mm (possibly the bleed margin) in a full bleed book


### PR DESCRIPTION
Overlay on the image can now be shown in the shrunk image. Shrink is always 50% even if larger would fit. Commands that would change the image container size are disabled or hidden while in this mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6798)
<!-- Reviewable:end -->
