### PR TITLE
Fix spurious shadow and outline on game targets (BL-14061)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/dragActivityTool.tsx
@@ -807,9 +807,8 @@ const DragActivityControls: React.FunctionComponent<{
         ""
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const bubbleManager = OverlayTool.bubbleManager()!;
-    const currentBubbleElement = bubbleManager.getActiveElement();
+    const bubbleManager = OverlayTool.bubbleManager();
+    const currentBubbleElement = bubbleManager?.getActiveElement();
     const currentBubbleTargetId = currentBubbleElement?.getAttribute(
         "data-bubble-id"
     );

--- a/src/content/templates/template books/Games/Games.less
+++ b/src/content/templates/template books/Games/Games.less
@@ -448,9 +448,18 @@
     // If we ever want targets to have a background color (except when hidden), here's the place.
     //background-color: var(--target-color);
 
-    &:focus {
-        box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1),
-            0 0 8px var(--draggable-background-color);
+    &:focus,
+    &:active,
+    *:focus,
+    *:active {
+        // This was here once but I have no idea why a target-of would ever have focus.
+        // box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1),
+        //     0 0 8px var(--draggable-background-color);
+        // however, the browser sometimes seems to sometimes put indications of focus on it,
+        // so let's suppress them. (This is not an accessability issue because we do NOT want
+        // these boxes to get focus!)
+        outline: none !important;
+        box-shadow: none !important;
     }
     &.bloom-unused-in-lang {
         display: none;


### PR DESCRIPTION
Also fixes a Javascript error that was frequently happening during zooming.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6801)
<!-- Reviewable:end -->
