### PR TITLE
Restore source bubbles when page is still focused (BL-14256)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -127,14 +127,6 @@ body {
     -height: 1px;
 }
 
-body:has(.bloom-page:hover),
-body:has(#overlay-context-controls:hover) {
-    .qtip {
-        opacity: 1 !important;
-        transition: opacity 200ms ease-out;
-    }
-}
-
 // Now that most of our outline effects are conditional on the page being hovered, we get some sort of
 // default on a focused content-editable div. It's an ugly solid black. When we're not hovering,
 // we don't want any edit-only outlines at all, so the user can see the page as it will be.
@@ -1285,6 +1277,13 @@ body.hideAllCKEditors .cke_chrome {
 .qtip:focus {
     opacity: 1 !important;
     transition: opacity 200ms ease-out;
+}
+body:has(.bloom-page:focus-within, .bloom-page:hover),
+body:has(#overlay-context-controls:hover) {
+    .qtip {
+        opacity: 1 !important;
+        transition: opacity 200ms ease-out;
+    }
 }
 
 // ----- Bloom Games ----


### PR DESCRIPTION
This restores the behavior of version 6.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6817)
<!-- Reviewable:end -->
