### PR TITLE
Fix enterprise check for overlays with new overlay pictures (BL-14245)

### DIFF
--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -263,8 +263,11 @@ namespace Bloom.Publish
                 // - Book contains overlay elements AND
                 // - Book is not a translated shell
 
+                // As of Bloom 6.2, all pictures in a book have the basic overlay class (bloom-textOverPicture).
+                // Top-level pictures also have the class bloom-backgroundImage.  We want to count only overlay
+                // elements that are not also marked as background images.  See BL-14245.
                 var overlayElementNodes = BookSelection?.CurrentSelection?.RawDom.SafeSelectNodes(
-                    "//div[contains(@class, 'bloom-textOverPicture')]"
+                    "//div[contains(@class, 'bloom-textOverPicture') and not(contains(@class, 'bloom-backgroundImage'))]"
                 );
                 var bookContainsOverlayElements = (overlayElementNodes?.Length ?? 0) > 0;
 


### PR DESCRIPTION
All images are now stored as overlay background images, even those that are not used to host overlays.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6818)
<!-- Reviewable:end -->
