### PR TITLE
More overflow fixes (BL-14088)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -25,7 +25,24 @@ export default class OverflowChecker {
         );
 
         // BL-1260: disable overflow checking for pages with too many elements
-        if (editablePageElements.length > 30) return;
+        if (editablePageElements.length > 30) {
+            // since we're not going to check it, remove any indications from
+            // previous checking. (Normal code also removes some qtips. I don't
+            // think those survive from one page load to the next, so we don't
+            // need to remove them here.)
+            const cleanup = (className: string) => {
+                Array.from(
+                    container.getElementsByClassName(className)
+                ).forEach(x => x.classList.remove(className));
+            };
+            cleanup("overflow");
+            cleanup("thisOverflowingParent");
+            cleanup("childOverflowingThis");
+            cleanup("Layout-Problem-Detected");
+            cleanup("pageOverflows");
+
+            return;
+        }
 
         //Add the handler so that when the elements change, we test for overflow
         editablePageElements.on("keyup paste", e => {

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -763,7 +763,19 @@ div.bloom-templateMode {
 //     }
 // }
 
-.childOverflowingThis {
+// We want a thick red line at the bottom. Outline can't do a line on just one side.
+// We don't want a border on the box itself because that takes up space; a box that
+// once starts overflowing might be stuck that way because of the extra space needed
+// for the border. So we use a pseudo-element to draw the line.
+.childOverflowingThis:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    box-sizing: border-box;
+    pointer-events: none;
     border-bottom: solid thick @OverflowColor !important;
     // no, that's really confusing when text far from the crime turns red color: red !important;
 }


### PR DESCRIPTION
- don't let the overflow border take up space
- if we decide the page has too many boxes for overflow checking, remove any previously set overflow classes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6824)
<!-- Reviewable:end -->
