### PR TITLE
Prevent earlier versions opening books with cropping (BL-14271)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bubbleManager.ts
@@ -1651,6 +1651,11 @@ export class BubbleManager {
             capture: true
         });
         this.currentDragControl?.classList.remove("active-control");
+        // Now the crop is over, if it is actually no longer cropped at all, we can
+        // remove the cropping-specfic style info on the image.
+        // Doing so helps us more accurately determine whether a book has cropped images,
+        // which means it is not allowed to open in earlier versions of Bloom.
+        this.adjustMoveCropHandleVisibility(true);
     };
     private continueTextBoxResize(event: MouseEvent, editable: HTMLElement) {
         if (!this.activeElement) return; // should never happen, but makes lint happy
@@ -3076,7 +3081,7 @@ export class BubbleManager {
     // unless the bubble has actually been cropped. Unless we figure out something
     // sensible to do in this case, it's better not to show it, lest the user be
     // confused by a control that does nothing.
-    private adjustMoveCropHandleVisibility() {
+    private adjustMoveCropHandleVisibility(removeCropAttrsIfNotNeeded = false) {
         const controlFrame = document.getElementById("overlay-control-frame");
         if (!controlFrame || !this.activeElement) return;
         const imgC = this.activeElement.getElementsByClassName(
@@ -3093,6 +3098,12 @@ export class BubbleManager {
             wantMoveCropHandle =
                 imgRect.width > controlRect.width + 1 ||
                 imgRect.height > controlRect.height + 1;
+            if (!wantMoveCropHandle && removeCropAttrsIfNotNeeded) {
+                // remove the width, top, left styles that indicate cropping
+                img.style.width = "";
+                img.style.top = "";
+                img.style.left = "";
+            }
         }
         controlFrame.classList.toggle(
             "bloom-ui-overlay-show-move-crop-handle",

--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -1056,12 +1056,12 @@ namespace Bloom.Book
             },
             new Feature()
             {
-                FeatureId = "bloomGames6.1",
-                FeaturePhrase = "Bloom Games added in 6.1",
+                FeatureId = "croppedImages",
+                FeaturePhrase = "Cropped images",
                 BloomDesktopMinVersion = "6.1",
-                BloomReaderMinVersion = "3.3",
+                BloomReaderMinVersion = "1.0",
                 XPath =
-                    "//div[@data-activity='drag-letter-to-target' or @data-activity='drag-image-to-target' or @data-activity='drag-sort-sentence' ]"
+                    "//div[contains(@class,'bloom-textOverPicture')]/div[contains(@class, 'bloom-imageContainer')]/img[contains(@style, 'width') and contains(@style, 'left') ]"
             }
         };
 


### PR DESCRIPTION
Also: removed spurious feature requirement for Games, which 6.1 doesn't have
