### PR TITLE
Don't try to embed fonts from invisible elements (BL-14267)

### DIFF
--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -618,6 +618,8 @@ namespace Bloom.Publish
         private void StoreFontUsed(SafeXmlElement elt)
         {
             var id = elt.GetAttribute("id");
+            if (_mapIdToDisplay.TryGetValue(id, out var displayValue) && displayValue == "none")
+                return;
             if (!_mapIdToFontInfo.TryGetValue(id, out var fontInfo))
                 return; // Shouldn't happen, but ignore if it does.
             var font = ExtractFontNameFromFontFamily(fontInfo.fontName);


### PR DESCRIPTION
See my comment at the end of https://issues.bloomlibrary.org/youtrack/issue/BL-14267.  But this may be a mistake for a multilingual book where one of the chosen languages uses a font, but it isn't one that is being displayed by default when publishing.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6850)
<!-- Reviewable:end -->
