### PR TITLE
Fix Bloom Harvester crash from uninitialized Sldr (BH-7454)

### DIFF
--- a/src/BloomExe/CLI/CreateArtifactsCommand.cs
+++ b/src/BloomExe/CLI/CreateArtifactsCommand.cs
@@ -16,6 +16,7 @@ using BloomTemp;
 using CommandLine;
 using L10NSharp;
 using SIL.IO;
+using SIL.WritingSystems;
 
 namespace Bloom.CLI
 {
@@ -112,6 +113,9 @@ namespace Bloom.CLI
                     )
                     {
                         Bloom.Program.SetProjectContext(_projectContext);
+                        // This may be needed for bringing the book up to date.  See BH-7453, BH-7454, and BH-7455.
+                        if (!Sldr.IsInitialized)
+                            Sldr.Initialize();
 
                         // Make the .bloompub and /bloomdigital outputs
                         return CreateArtifacts(options);


### PR DESCRIPTION
This is on Version6.1 since the harvester is based on the beta.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6856)
<!-- Reviewable:end -->
