### PR TITLE
Handle a corner case in reporting Font info (BL-14357)

### DIFF
--- a/src/BloomExe/web/controllers/StylesAndFontsApi.cs
+++ b/src/BloomExe/web/controllers/StylesAndFontsApi.cs
@@ -63,19 +63,19 @@ namespace Bloom.web.controllers
                 var modified = modifiedStylesAndFonts.FindAll(s => s.style == style).ToArray();
                 if (modified.Length == 0)
                 {
-                    var styleAndFont = new StyleAndFont();
-                    styleAndFont.style = style;
-                    if (fontToLangs.Count == 1)
+                    foreach (var kvp in fontToLangs)
                     {
-                        if (fontToLangs.First().Value.Count == 1)
-                            styleAndFont.languageTag = fontToLangs.First().Value.First();
+                        var styleAndFont = new StyleAndFont();
+                        styleAndFont.style = style;
+                        if (kvp.Value.Count == 1)
+                            styleAndFont.languageTag = kvp.Value.First();
                         else
                             styleAndFont.languageTag = "*";
-                        styleAndFont.fontName = fontToLangs.First().Key;
+                        styleAndFont.fontName = kvp.Key;
+                        styleAndFont.pageId = stylesInBook[style].id;
+                        styleAndFont.pageDescription = stylesInBook[style].description;
+                        stylesAndFonts.Add(styleAndFont);
                     }
-                    styleAndFont.pageId = stylesInBook[style].id;
-                    styleAndFont.pageDescription = stylesInBook[style].description;
-                    stylesAndFonts.Add(styleAndFont);
                 }
                 else
                 {


### PR DESCRIPTION
There was a problem where a book has differing default fonts for different languages and use a style (like ImageDescription) that has no definition (or possibly one that specifies no font info).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6863)
<!-- Reviewable:end -->
