### PR TITLE
Handle multiple languages in Drag Letters pages better (BL-14348)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/GamePromptDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/dragActivity/GamePromptDialog.tsx
@@ -245,6 +245,14 @@ const initializeTg = (prompt: HTMLElement, tg: HTMLElement | null) => {
                     true
                 ) as HTMLElement;
                 setGeneratedBubbleId(newDraggable);
+                // Ensure the new draggable starts out empty.  See BL-14348.
+                // (This covers all languages present, visible or not.)
+                const paras = newDraggable.querySelectorAll(
+                    "div.Letter-style>p"
+                );
+                paras.forEach(p => {
+                    p.textContent = "";
+                });
                 lastDraggable.parentElement?.appendChild(newDraggable);
                 makeTargetForBubble(newDraggable);
                 // It's available to push letter groups into


### PR DESCRIPTION
Duplicate audio ids and extra letters in target area could happen if a word in a second language was longer than a word in the first language.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6871)
<!-- Reviewable:end -->
