### PR TITLE
Fix bug when there is no default name in language chooser (BL-14426)

### DIFF
--- a/src/BloomBrowserUI/collection/LanguageChooserDialog.tsx
+++ b/src/BloomBrowserUI/collection/LanguageChooserDialog.tsx
@@ -42,8 +42,9 @@ export function getLanguageData(
     selection: IOrthography | undefined
 ): ILanguageData {
     const defaultName = selection?.language
-        ? defaultDisplayName(selection.language)
+        ? defaultDisplayName(selection.language) || null
         : null;
+    // Ensure values are null rather than undefined. Otherwise, the property won't be serialized at all.
     return {
         LanguageTag: languageTag || null,
         DefaultName: defaultName,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6905)
<!-- Reviewable:end -->
