### PR TITLE
Generalize back migration

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1789,9 +1789,8 @@ namespace Bloom.Book
             Storage.MigrateToLevel2RemoveTransparentComicalSvgs();
             Storage.MigrateToLevel3PutImgFirst();
             Storage.MigrateToLevel4UseAppearanceSystem();
-            // 6.1 and 6.0 only; do not merge to 6.2
-            (Storage as BookStorage)?.MigrateBackFromLevel5CanvasElement();
-            // After MigrateBack, since looking for the renamed class
+            Storage.DoBackMigrations();
+            // After DoBackMigrations, since looking for the renamed class
             RemoveObsoleteImageAttributes(OurHtmlDom);
 
             // Make sure the appearance settings have checked the current state of the css files.


### PR DESCRIPTION
Makes it work even if later migrations have happened that don't need to be reversed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6907)
<!-- Reviewable:end -->
