### PR TITLE
Fix various layout issues in simple-dom-choice (BL-14398)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1376,6 +1376,7 @@ canvas.moving {
     outline: 1px solid @bloom-blue;
     box-sizing: border-box;
     pointer-events: none;
+    background-color: transparent;
 
     // background images can't be manually resized
     &.bloom-backgroundImage {
@@ -1554,16 +1555,16 @@ canvas.moving {
     // origami control gets in the way even more. So we move them inwards.
     &.bloom-backgroundImage {
         .bloom-ui-canvas-element-side-handle-n {
-            top: 0;
+            top: 1px;
         }
         .bloom-ui-canvas-element-side-handle-e {
-            right: 0;
+            right: 1px;
         }
         .bloom-ui-canvas-element-side-handle-s {
-            bottom: 0;
+            bottom: 1px;
         }
         .bloom-ui-canvas-element-side-handle-w {
-            left: 0;
+            left: 1px;
         }
     }
 }

--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
@@ -2562,11 +2562,21 @@ export class CanvasElementManager {
             // when the style is already absolutely controlling style.left. It's easier to just tweak
             // it here.
             const extraPadding = hasText ? 3 : 0;
+            // using pxToNumber here because the position and size of the canvas element are often fractional.
+            // OTOH, clientWidth etc are whole numbers. If we allow that rounding in to affect where to
+            // place the control frame, we can end up with a 1 pixel gap between the canvas element and
+            // the control frame, which looks bad.
             controlFrame.style.width =
-                this.activeElement.clientWidth + 2 * extraPadding + "px";
+                CanvasElementManager.pxToNumber(
+                    this.activeElement.style.width
+                ) +
+                2 * extraPadding +
+                "px";
             controlFrame.style.height = this.activeElement.style.height;
             controlFrame.style.left =
-                this.activeElement.offsetLeft - extraPadding + "px";
+                CanvasElementManager.pxToNumber(this.activeElement.style.left) -
+                extraPadding +
+                "px";
             controlFrame.style.top = this.activeElement.style.top;
             const tails = Bubble.getBubbleSpec(this.activeElement).tails;
             if (tails.length > 0) {

--- a/src/content/templates/template books/Activity/simple-dom-choice-activities.less
+++ b/src/content/templates/template books/Activity/simple-dom-choice-activities.less
@@ -15,13 +15,18 @@
         // When an image is the prompt, it looks bad if a closely-cropped image is right up against the colored background of the page.
         // When an image is the answer, there is a white border but it still looks better with some padding. These don't necessarily
         // need to be the same padding, but at the moment they are.
-        .bloom-imageContainer img {
+        // Careful where this is put. Padding on the imageContainer or the img, for example, doesn't work when cropping.
+        // Note: the rule to do this actually didn't work in 6.1 for the case where the image is the prompt, but in the course
+        // of fixing the 6.1 rule for 6.2, I made it actually work there.
+        .bloom-backgroundImage {
             padding: 5px;
             box-sizing: border-box;
+            background-color: white;
+            border-radius: 8px;
         }
 
         .Prompt-style {
-            // not that .Prompt-style is also a user-modifiable style in the .htm file
+            // note that .Prompt-style is also a user-modifiable style in the .htm file
             margin-bottom: 10px;
         }
 


### PR DESCRIPTION
- moved the crop handles in a pixel on background images for less chance handle gets cropped
- fixed issues with border on images in simple-dom-choice activities
- improved alignment of overlay control rect (was sometimes a pixel off)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6920)
<!-- Reviewable:end -->
