### PR TITLE
Don't limit bloom-show-en-when-blank to drag-activity-start (BL-14489)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1335,11 +1335,9 @@ body.hideAllCKEditors .cke_chrome {
 // Enhance: possibly we could add a class that would let us identify the language that is the current
 // default for the source bubble, rather than fixing on English. But the main thing is to see that
 // there is a block there that should get some attention. The source bubble provides all the options.
-.drag-activity-start
-    .bloom-show-en-when-blank
+.bloom-show-en-when-blank
     .bloom-editable[lang="en"]:has(~ .bloom-content1.bloom-blank),
-.drag-activity-start
-    .bloom-show-en-when-blank
+.bloom-show-en-when-blank
     .bloom-content1.bloom-blank
     ~ .bloom-editable[lang="en"] {
     display: block; // overcomes rule that usually hides it (since it's not content1)


### PR DESCRIPTION
It could be useful elsewhere, and we get flicker because some code that depends on it runs before drag-activity-start gets set

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6951)
<!-- Reviewable:end -->
