### PR TITLE
Fix a crash that leaves a blank enterprise tab in the dialog

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/SubscriptionStatus.tsx
+++ b/src/BloomBrowserUI/collectionsTab/SubscriptionStatus.tsx
@@ -26,6 +26,12 @@ export const SubscriptionStatus: React.FunctionComponent<{
     if (props.overrideSubscriptionExpiration !== undefined) {
         expiryDateStringAsYYYYMMDD = props.overrideSubscriptionExpiration;
     }
+    if (
+        expiryDateStringAsYYYYMMDD === null ||
+        expiryDateStringAsYYYYMMDD === undefined
+    ) {
+        expiryDateStringAsYYYYMMDD = ""; // avoid crashing later on when not set
+    }
     let brandingProjectKey = useApiString(
         "settings/brandingProjectKey",
         "notyet"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6955)
<!-- Reviewable:end -->
