### PR TITLE
Make cover sizing of bloom-canvas work again

### DIFF
--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -166,7 +166,8 @@ div.ui-tooltip-content {
     min-height: 60px !important;
 }
 
-.bloom-imageContainer {
+.bloom-imageContainer,
+.bloom-canvas {
     // Was 50px until 6.1. Now we support making very small draggable images in games, so that's too big.
     // Then we tried 10px with the idea that it could at least be grabbed. We may make a separate dragging affordance like
     // Canva for very small imagesto help with that. But any min-height causes weird behavior when cropping


### PR DESCRIPTION
Somehow this makes flex-grow/shrink work when the parent is height:auto and the child is content-fit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6956)
<!-- Reviewable:end -->
