### PR TITLE
Ignore hidden BG image on page resize (BL-14484)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
@@ -5949,6 +5949,19 @@ export class CanvasElementManager {
             const child = children[i];
             const childTop = child.offsetTop;
             const childLeft = child.offsetLeft;
+            if (child.classList.contains(kBackgroundImageClass)) {
+                const img = getImageFromCanvasElement(child);
+                if (
+                    !img ||
+                    (img.getAttribute("src") === "placeHolder.png" &&
+                        children.length > 1)
+                ) {
+                    // No image, or placeholder. Not visible. Don't include this in the calculations.
+                    // But it case it gets selected, adjust it independently
+                    this.adjustBackgroundImageSize(bloomCanvas, child, false);
+                    continue;
+                }
+            }
             // Clip the rectangle to the old container. If the author previously placed
             // something so that it was partly clipped, we don't need to 'correct' that.
             // (We're not trying to ensure that it stays clipped by the same amount,

--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
@@ -5951,15 +5951,19 @@ export class CanvasElementManager {
             const childLeft = child.offsetLeft;
             if (child.classList.contains(kBackgroundImageClass)) {
                 const img = getImageFromCanvasElement(child);
-                if (
-                    !img ||
-                    (img.getAttribute("src") === "placeHolder.png" &&
-                        children.length > 1)
-                ) {
-                    // No image, or placeholder. Not visible. Don't include this in the calculations.
-                    // But it case it gets selected, adjust it independently
+                if (!img || img.getAttribute("src") === "placeHolder.png") {
+                    // No image, or placeholder. Not visible (unless it's the only thing there).
+                    // Don't include this in the calculations.
+                    // But in case it gets selected, or is the only one, adjust it independently
                     this.adjustBackgroundImageSize(bloomCanvas, child, false);
-                    continue;
+                    if (children.length > 1) {
+                        // we'll process the others ignoring the invisible BG image
+                        continue;
+                    } else {
+                        // there are no others, and with zero iterations of this loop
+                        // something bad might happen.
+                        return;
+                    }
                 }
             }
             // Clip the rectangle to the old container. If the author previously placed


### PR DESCRIPTION
Actually, it gets independently resized, but the area it used to occupy doesn't need to stay visible or be used as the basis for the resize.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6957)
<!-- Reviewable:end -->
