### PR TITLE
Keep item wrong/correct images hidden unless really wanted (BL-14510)

### DIFF
--- a/src/content/bookLayout/canvasElement.less
+++ b/src/content/bookLayout/canvasElement.less
@@ -218,7 +218,7 @@
 // seems acceptable, since layout will need to be checked anyway.
 .bloom-fullBleed
     .bloom-canvas
-    .bloom-canvas-element[data-bubble*="`style`:`none`"] {
+    .bloom-canvas-element[data-bubble*="`style`:`none`"]:not(.drag-item-wrong, .drag-item-correct) {
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
Game page elements can look like ordinary canvas elements to simple CSS rules.