### PR TITLE
Fix positioning of large image editing buttons

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -278,8 +278,7 @@ body:has(#canvas-element-context-controls:hover) .bloom-page,
 // ARE child canvas elements. So we want the disabling there. We use important because the rule that makes
 // them visible ever is very complex and has high specificity.
 .bloom-canvas.bloom-hideImageButtons {
-    .imageButton,
-    .miniButton {
+    .imageButton {
         display: none !important;
     }
 }
@@ -367,16 +366,16 @@ div.readOnlyInTranslationMode {
 
 // Since 'basePage.less' has a rule that puts the video placeholder in as a background image,
 // '.customPage' is needed to add enough specificity here to override that rule.
-body:not(.origami-drag) .customPage .bloom-videoContainer.hoverUp,
-body:not(.origami-drag) .bloom-canvas.hoverUp {
+body:not(.origami-drag) .customPage .bloom-videoContainer:hover,
+body:not(.origami-drag) .bloom-canvas:hover {
     background-color: @ImageAndVideoHoverOverlay;
 }
 
 // The hovered bloom-canvas background is just distracting when the whole page is a bloom-canvas.
 // One group of such cases is bloom games. We may want to suppress it for pages
 // designed to have a full-bleed background for a comic, and perhaps others. I went for a
-// minimal change for now.
-.bloom-page[data-tool-id="game"] .bloom-canvas.hoverUp {
+// minimal change for now. (Possibly obsolete: we're no longer doing this hover-background at all.)
+.bloom-page[data-tool-id="game"] .bloom-canvas:hover {
     background-color: transparent;
 }
 
@@ -474,8 +473,8 @@ body:not(.origami-drag) .bloom-canvas.hoverUp {
     display: none !important;
 }
 
-// In an active background canvas element, show yet another form of the edit metadata icon
-.bloom-backgroundImage[data-bloom-active="true"] {
+// In a bloom-canvas with an active background canvas element, show yet another form of the edit metadata icon
+.bloom-canvas:has(.bloom-backgroundImage[data-bloom-active="true"]) {
     .editMetadataButton.imgMetadataProblem {
         background-image: url("/bloom/bookEdit/img/imageMissingMetaData.svg") !important;
     }
@@ -483,7 +482,7 @@ body:not(.origami-drag) .bloom-canvas.hoverUp {
 // In an active background canvas element, don't show the edit metadata icon if the image failed
 // to load.  Clicking on it would just show an error message anyway, and the button would
 // obscure part of the alt attribute error message.
-.bloom-backgroundImage:has(img.bloom-imageLoadError) {
+.bloom-canavas:has(.bloom-backgroundImage:has(img.bloom-imageLoadError)) {
     .editMetadataButton.imgMetadataProblem {
         display: none !important;
     }
@@ -518,7 +517,7 @@ body.bloom-fullBleed {
         }
 
         &.editMetadataButton {
-            left: calc(@inset + imageButtonInset);
+            left: calc(@inset + @imageButtonHInset);
             top: calc(@inset + @imageButtonVInset);
         }
     }
@@ -645,7 +644,7 @@ body.bloom-fullBleed {
 // problem.
 .bloom-canvas:hover {
     &:not(:has(.bloom-canvas-element:not(.bloom-backgroundImage))),
-    .bloom-backgroundImage[data-bloom-active="true"] {
+    &:has(.bloom-backgroundImage[data-bloom-active="true"]) {
         .editMetadataButton,
         .changeImageButton {
             display: block;
@@ -663,37 +662,6 @@ body.bloom-fullBleed {
         img[src^="placeHolder.png"] {
             display: none;
         }
-    }
-}
-
-// Review: do we still want some hover effect for the big image buttons?
-
-button.miniButton {
-    width: 20px;
-    height: 18px;
-    right: 60px;
-    border: none;
-    position: absolute;
-    background-position: left center;
-    background-repeat: no-repeat;
-    background-size: contain;
-    background-color: transparent;
-    z-index: @miniImageEditingButtonZIndex;
-
-    &:hover {
-        border: 1px inset @ImageButtonBorder;
-    }
-
-    &.verySmallButtons {
-        right: 60%;
-    }
-
-    &.smallButtonHeight {
-        height: 15%;
-    }
-
-    &.verySmallButtons {
-        width: 30%;
     }
 }
 
@@ -729,11 +697,7 @@ button.moveButton {
     background-size: contain;
 }
 
-img.hoverUp {
-    outline: 1px outset black;
-}
-
-// I'm not sure why the rule above is !important, but this one has to be to beat it.
+// I'm not sure why the rule above (JT: which one?) is !important, but this one has to be to beat it.
 // In edit mode we don't want such an automatic outline, because the control frame
 // provides one, and typically they don't even line up, becuase we grow the control
 // frame a little bit to prevent the side buttons overlapping text.
@@ -1220,7 +1184,7 @@ body {
 
 // Don't show text over picture borders, resizing handles, or format buttons unless hovering over the image
 // (This and several following rules were moved from content/bookLayout/overlayTool.less)
-.bloom-canvas:not(.hoverUp) .bloom-canvas-element {
+.bloom-canvas:not(:hover) .bloom-canvas-element {
     .bloom-editable {
         border: none;
 

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -138,6 +138,7 @@ function Cleanup() {
     $("div, figure").each(function() {
         $(this).removeClass("ui-draggable");
         $(this).removeClass("ui-resizable");
+        // obsolete, but we'll keep the cleanup for a while
         $(this).removeClass("hoverUp");
     });
     $("span").each(function() {

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -87,32 +87,21 @@ function SetupVideoContainer(
                 ""
             )
             .done(changeVideoText => {
-                $(videoContainerDiv)
-                    .mouseenter(function() {
-                        const $this = $(this);
-
-                        //SetImageTooltip(containerDiv, img);
-
-                        // Enhance: we will have to do something about license information for videos, but it's complicated.
-                        // I don't think we have fully determined how to store the information with the video, though I believe
-                        // we can embed EXIF data as we do for pictures. But rights over a video are more complicated.
-                        // Many people may have rights if they haven't been explicitly given up...producer, videographer,
-                        // copyright owner of script, actors, owners of music used, copyright owner of work script is based on,
-                        // possibly some subject matter may be copyright (the Eiffel tower at night is a notorious example).
-                        // if (IsImageReal(img)) {
-                        //     $this.prepend('<button class="editMetadataButton imageButton ' + buttonModifier + '" title="' +
-                        //         theOneLocalizationManager.getText('EditTab.Image.EditMetadata') + '"></button>');
-                        //     $this.find('.miniButton').each(function () {
-                        //         $(this).removeClass('disabled');
-                        //     });
-                        // }
-
-                        $this.addClass("hoverUp");
-                    })
-                    .mouseleave(function() {
-                        const $this = $(this);
-                        $this.removeClass("hoverUp");
-                    });
+                // $(videoContainerDiv)
+                //     .mouseenter(function() {
+                //         const $this = $(this);
+                //         //SetImageTooltip(containerDiv, img);
+                //         // Enhance: we will have to do something about license information for videos, but it's complicated.
+                //         // I don't think we have fully determined how to store the information with the video, though I believe
+                //         // we can embed EXIF data as we do for pictures. But rights over a video are more complicated.
+                //         // Many people may have rights if they haven't been explicitly given up...producer, videographer,
+                //         // copyright owner of script, actors, owners of music used, copyright owner of work script is based on,
+                //         // possibly some subject matter may be copyright (the Eiffel tower at night is a notorious example).
+                //         // if (IsImageReal(img)) {
+                //         //     $this.prepend('<button class="editMetadataButton imageButton ' + buttonModifier + '" title="' +
+                //         //         theOneLocalizationManager.getText('EditTab.Image.EditMetadata') + '"></button>');
+                //         // }
+                //     })
             });
     }
 }

--- a/src/BloomBrowserUI/bookEdit/js/bloomWidgets.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomWidgets.ts
@@ -1,4 +1,3 @@
-import { GetButtonModifier } from "./bloomImages";
 import theOneLocalizationManager from "../../lib/localizationManager/localizationManager";
 import { get, getString } from "../../utils/bloomApi";
 
@@ -25,22 +24,10 @@ export function SetupWidgetEditing(container: HTMLElement): void {
 }
 
 function SetupWidget(w: Element): void {
-    if (w.matches(":hover")) {
-        w.classList.add("hoverUp");
-    } else {
-        w.classList.remove("hoverUp");
-    }
-    const buttonModifier = GetButtonModifier(w);
-
     w.addEventListener("mouseenter", () => {
-        // I'm not enthusiastic about this approach to making the "choose" button
-        // appear on hover, but various classes are shared with other such buttons
-        // so it seemed better not to take a different approach here.
-        w.classList.add("hoverUp");
         const wrapper = document.createElement("div");
         wrapper.innerHTML =
             '<button class="chooseWidgetButton imageButton imageOverlayButton ' +
-            buttonModifier +
             '" title="' +
             theOneLocalizationManager.getText(
                 "EditTab.Widget.ChooseWidget",
@@ -71,7 +58,6 @@ function SetupWidget(w: Element): void {
         };
     });
     w.addEventListener("mouseleave", () => {
-        w.classList.remove("hoverUp");
         const buttons = Array.from(
             w.getElementsByClassName("imageOverlayButton")
         );

--- a/src/BloomBrowserUI/bookEdit/js/origami.ts
+++ b/src/BloomBrowserUI/bookEdit/js/origami.ts
@@ -86,9 +86,7 @@ function setupLayoutMode() {
     // Text should not be editable in layout mode
     $(".bloom-editable[contentEditable=true]").removeAttr("contentEditable");
     // Images cannot be changed (other than growing/shrinking with their containing bloom-canvas) in layout mode
-    // I think this targets the mouseenter/leave events that add and remove the "hoverUp" class and
-    // the change image button whose visibility that controls. We don't want that button to show
-    // while we are in layout mode.
+    // I'm not sure these handlers still do anything we wouldn't want in layout mode, but leaving the code just in case.
     $(".bloom-canvas")
         .off("mouseenter")
         .off("mouseleave");


### PR DESCRIPTION
Moves the buttons up to be relative to the bloom-canvas.
Fixes a glitch in the calc() expression for the position of the license button in full-bleed pages.
In the process, got rid of hoverUp and the code that still manipulated it and various other redundant code and CSS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6966)
<!-- Reviewable:end -->
