### PR TITLE
Hide unwanted items in Game editing tabs (BL-14532)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/games/DragActivityTabControl.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/games/DragActivityTabControl.tsx
@@ -12,6 +12,7 @@ import { useL10n } from "../../../react_components/l10nHooks";
 import { default as PencilIcon } from "@mui/icons-material/Edit";
 import { showGamePromptDialog } from "../games/GameTool";
 import BloomButton from "../../../react_components/bloomButton";
+import { getCanvasElementManager } from "../overlay/canvasElementUtils";
 
 // This component is responsible for the Game Setup mode tabs in the Game tool.
 // Although the code seems to belong in this folder with the other Game code, it is actually
@@ -24,6 +25,7 @@ export const DragActivityTabControl: React.FunctionComponent<{
 }> = props => {
     const changeHandler = (tab: number) => {
         getToolboxBundleExports()?.setActiveDragActivityTab(tab);
+        getCanvasElementManager()?.setActiveElement(undefined);
     };
     const setupMode = useL10n(
         "Game Setup mode:",

--- a/src/content/templates/template books/Games/Games.less
+++ b/src/content/templates/template books/Games/Games.less
@@ -36,6 +36,41 @@
 .drag-activity-wrong .drag-item-wrong {
     display: block;
 }
+// Hide draggable items in the Correct and Wrong tabs. See BL-14532.
+// The data-target-of elements will show the positions of the targets and
+// indicate the correct answer in the Correct tab.
+.drag-activity-correct,
+.drag-activity-wrong {
+    [data-draggable-id] {
+        display: none;
+    }
+}
+// The drag-activity-play and drag-activity-correct are both present when the user has
+// given a correct answer and clicked for it to be checked.  (The same goes for a wrong
+// answer and drag-activity-wrong.)  Show the user's answer, right or wrong,
+// via the [data-draggable-id] elements which have been dragged to the targets.
+// Unmoved [data-draggable-id] elements are hidden in showing the right answer.
+.drag-activity-play.drag-activity-correct,
+.drag-activity-play.drag-activity-wrong {
+    .bloom-canvas-element.bloom-draggedToTarget[data-draggable-id] {
+        display: block;
+    }
+}
+// Prevent unwanted interaction with the background images and other items that are not
+// supposed to be changed in the Correct and Wrong tabs.  See BL-14532.
+// Less doesn't appear to handle the :is() operator with a list of selectors, so we have
+// to use two rules to get the result we want.
+.drag-activity-correct .bloom-canvas-element:not(.drag-item-correct),
+.drag-activity-wrong .bloom-canvas-element:not(.drag-item-wrong) {
+    pointer-events: none;
+}
+.drag-activity-correct,
+.drag-activity-wrong {
+    [data-target-of] {
+        pointer-events: none;
+    }
+}
+
 // in play mode suppress these focus effects
 .drag-activity-play {
     .bloom-canvas .bloom-canvas-element div:focus,
@@ -212,11 +247,17 @@
     .drag-activity-start
         .bloom-page:not([data-activity="drag-image-to-target"])
         &,
-    div:not(.drag-activity-start) & {
+    .drag-activity-play & {
         > * {
             // targets have children to show a shadow of what is supposed to go there.
             // the contents are identical, this makes them a shadow.
             opacity: 50%;
+        }
+    }
+    .drag-activity-wrong & {
+        // In the wrong tab, we don't want to see the target at all, but just the dashed box if it's visible.
+        > * {
+            opacity: 0%;
         }
     }
 
@@ -350,11 +391,20 @@
         background-color: transparent;
     }
 }
-// And don't show them at all in play mode.
-.drag-activity-play .bloom-page[data-show-targets-during-play="false"] {
-    [data-target-of] {
-        // display:none would prevent the snap code from using them, since they would not have a location.
+// And don't show them at all in play mode or the Wrong tab.
+.drag-activity-play,
+.drag-activity-wrong {
+    .bloom-page[data-show-targets-during-play="false"] [data-target-of] {
+        // display:none would prevent the snap code from using them in play mode, since they would not have a location.
         visibility: hidden;
+    }
+}
+// If we don't show targets during play, we don't want to show the dashed box in the Correct tab.
+.drag-activity-correct {
+    .bloom-page[data-show-targets-during-play="false"] [data-target-of] {
+        border: none;
+        outline: none;
+        box-shadow: none;
     }
 }
 


### PR DESCRIPTION
Also try to prevent other items from being deleted or moved except in an appropriate tab.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6976)
<!-- Reviewable:end -->
