### PR TITLE
Use defaultChecked of BloomSwitch when not controlled (BL-14538)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolSwitch.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolSwitch.tsx
@@ -38,7 +38,8 @@ export const ReaderToolSwitch: React.FunctionComponent<{
                         ? "EditTab.Toolbox.LeveledReaderTool.BookIsLeveled"
                         : "EditTab.Toolbox.DecodableReaderTool.BookIsDecodable"
                 }
-                checked={checked}
+                // We're not making a controlled component, but we do want to control the initial state.
+                defaultChecked={checked}
                 onChange={(_, checked) => {
                     // Toggle the display of the reader tool UI.
                     document

--- a/src/BloomBrowserUI/react_components/BloomSwitch.tsx
+++ b/src/BloomBrowserUI/react_components/BloomSwitch.tsx
@@ -27,7 +27,7 @@ export const BloomSwitch: React.FunctionComponent<IProps> = props => {
         : label;
 
     const [internalChecked, setInternalChecked] = React.useState<boolean>(
-        props.checked ?? false
+        props.checked ?? props.defaultChecked ?? false
     );
 
     const isControlled = props.checked !== undefined;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6978)
<!-- Reviewable:end -->
