### PR TITLE
Reword the expiring subscription message (BL-14588)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -5982,9 +5982,9 @@ Do you want to go ahead?</note>
         <note>{0} is the branding project key, {1} is the formatted expiration date</note>
       </trans-unit>
       <trans-unit id="SubscriptionStatus.RenewalMessage">
-        <source xml:lang="en">Please [contact us](%0) to renew.</source>
+        <source xml:lang="en">Please email [subscriptions@bloomlibrary.org](%0) to renew.</source>
         <note>ID: SubscriptionStatus.RenewalMessage</note>
-        <note>Make sure to keep the brackets around your translation of "Contact Us" and do not change the (%0) part. This will become a hyperlink that opens an emaili program to the correct email address.</note>
+        <note>Make sure to keep the brackets around [subscriptions@bloomlibrary.org] and do not change it at all.  Do not change the (%0) part either. The %0 will become a hyperlink that opens an email program to the correct email address.  To repeat, the text starting from the opening bracket [ and ending with the closing parenthesis ) should not be translated or changed in any way.</note>
       </trans-unit>
       <trans-unit id="TemplateBooks.Quiz.HintBubble.Answer" sil:dynamic="true">
         <source xml:lang="en">Put a possible answer here. Check it if it is correct.</source>


### PR DESCRIPTION
Too many users may not have things set up for the mailto: link to work, so we now expose the actual email address in the message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6994)
<!-- Reviewable:end -->
