### PR TITLE
Allow svg to follow theme foreground color, too (BL-14595)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
@@ -4541,7 +4541,7 @@ export class CanvasElementManager {
             kImageContainerClass + " bloom-leadingElement";
         // This svg is basically the same as the one in AudioIcon.tsx.
         // Likely, changes to one should be mirrored in the other.
-        const html = `<div tabindex='0' class='bloom-unmodifiable-image bloom-svg bloom-svg-rect-has-color ${standardImageClasses}'>
+        const html = `<div tabindex='0' class='bloom-unmodifiable-image bloom-svg bloom-svg-rect-fill-has-background-color bloom-svg-path-stroke-has-foreground-color ${standardImageClasses}'>
     <svg
         viewBox="0 0 31 31"
         fill="none"

--- a/src/content/templates/template books/Games/Games.less
+++ b/src/content/templates/template books/Games/Games.less
@@ -591,8 +591,13 @@
     background-color: var(--header-background-color);
 }
 
-.bloom-svg-rect-has-color {
+.bloom-svg-rect-fill-has-background-color {
     svg rect {
         fill: var(--draggable-background-color);
+    }
+}
+.bloom-svg-path-stroke-has-foreground-color {
+    svg path {
+        stroke: var(--draggable-color);
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/6998)
<!-- Reviewable:end -->
