### PR TITLE
Items from Correct/Wrong always go in front (BL-14627)

### DIFF
--- a/src/content/templates/template books/Games/Games.less
+++ b/src/content/templates/template books/Games/Games.less
@@ -37,6 +37,9 @@
 .drag-activity-correct .drag-item-correct,
 .drag-activity-wrong .drag-item-wrong {
     display: block;
+    // In front of targets ([data-target-of] has z-index=@convasElementCanvasZIndex+1),
+    // in case they overlap.  See BL-14627.
+    z-index: @canvasElementCanvasZIndex + 2;
 }
 // Hide draggable items in the Correct and Wrong tabs. See BL-14532.
 // The data-target-of elements will show the positions of the targets and


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7013)
<!-- Reviewable:end -->
