### PR TITLE
Ensure images and shadows show properly when playing games (BL-14664)

### DIFF
--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -70,7 +70,7 @@
         "@types/react-transition-group": "^4.4.1",
         "@use-it/event-listener": "^0.1.6",
         "axios": "^0.21.1",
-        "bloom-player": "^2.10.2",
+        "bloom-player": "^2.10.3",
         "calculate-aspect-ratio": "^0.1.3",
         "color-blind": "^0.1.1",
         "comicaljs": "^0.3.100",

--- a/src/BloomBrowserUI/yarn.lock
+++ b/src/BloomBrowserUI/yarn.lock
@@ -5393,10 +5393,10 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bloom-player@^2.10.2:
-  version "2.10.2"
-  resolved "https://registry.npmjs.org/bloom-player/-/bloom-player-2.10.2.tgz#83c675651433eced3dc1baf11b6d319ec103dfff"
-  integrity sha512-HAINlwiDIr4yE75HqHH8R5//j3s5ebdmp4KXJ/5AC8d87d41b1JP7STxCELM7UYBqyiIyVxJLqzRW6waCIlsMg==
+bloom-player@^2.10.3:
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/bloom-player/-/bloom-player-2.10.3.tgz#edb546e935717e4ed0c313e6e328d33421e4a9a3"
+  integrity sha512-B0+M+k+t83EviH7Xrhse0XBxG7W59BlE7DFDgX/M+f8F5csK/9bdbg2IRT48YulbKt4pI0ffGVvgWO4Xvg1AqA==
 
 body-parser@1.20.3:
   version "1.20.3"

--- a/src/content/templates/template books/Games/Games.less
+++ b/src/content/templates/template books/Games/Games.less
@@ -419,15 +419,17 @@
 // In the drag-image-to-target game, we want to show shadows of target images everywhere
 // except the Correct tab if data-show-target-as-shadow is set to true.
 :not(.drag-activity-correct)
-    > .bloom-page[data-activity="drag-image-to-target"][data-show-target-as-shadow="true"]
-    [data-target-of]:has(img) {
-    background-color: unset;
+    > .bloom-page[data-activity="drag-image-to-target"][data-show-target-as-shadow="true"],
+.bloom-page.data-activity-play[data-show-target-as-shadow="true"][data-show-answers-in-targets="true"] {
+    [data-target-of] {
+        background-color: unset;
 
-    .bloom-targetWrapper {
-        filter: grayscale(100%) brightness(0%);
-        mix-blend-mode: normal;
-        opacity: 100%;
-        top: 0px; // Override so that the dragged image is exactly on top of the target wrapper.
+        .bloom-targetWrapper {
+            filter: grayscale(100%) brightness(0%);
+            mix-blend-mode: normal;
+            opacity: 100%;
+            top: 0px; // Override so that the dragged image is exactly on top of the target wrapper.
+        }
     }
 }
 


### PR DESCRIPTION
Part of the fix was in bloom-player.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7024)
<!-- Reviewable:end -->
