### PR TITLE
Revert "Prevent overflow marking on empty Word draggable in games (BL-14643)"

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -172,9 +172,8 @@ export default class OverflowChecker {
             0
         );
 
-        const contentHeight = this.contentHeight(element);
-        let overflowY =
-            contentHeight -
+        const overflowY =
+            this.contentHeight(element) -
             fontFudgeFactor -
             (element.clientHeight + shortBoxFudgeFactor);
         // console.log(
@@ -189,17 +188,6 @@ export default class OverflowChecker {
         //         " shortBoxFudgeFactor: " +
         //         shortBoxFudgeFactor
         // );
-
-        // If a specified min-height is greater than the content height, we don't want to
-        // shrink the box to fit the content.  See BL-14643.
-        const minHeight = parseFloat(element.style.minHeight ?? "0");
-        if (
-            minHeight > 0 &&
-            overflowY < 0 &&
-            minHeight > contentHeight - fontFudgeFactor
-        ) {
-            overflowY = 0;
-        }
         const overflowX = element.scrollWidth - element.clientWidth;
 
         return [overflowX, overflowY];


### PR DESCRIPTION
Reverts BloomBooks/BloomDesktop#7031

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7032)
<!-- Reviewable:end -->
