### PR TITLE
Reduce clutter for background images in games (BL-14703)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1807,6 +1807,10 @@
         <note>ID: EditTab.Image.AltMsg</note>
         <note>The {0} is replaced by the filename of the picture.</note>
       </trans-unit>
+      <trans-unit id="EditTab.Image.BackgroundImage" sil:dynamic="true" translate="no">
+        <source xml:lang="en">Background Image</source>
+        <note>ID: EditTab.Image.BackgroundImage</note>
+      </trans-unit>
       <trans-unit id="EditTab.Image.ChangeImage" sil:dynamic="true">
         <source xml:lang="en">Change image</source>
         <note>ID: EditTab.Image.ChangeImage</note>

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1654,3 +1654,22 @@ svg.bloom-videoControl {
         display: none;
     }
 }
+
+// If the background image hasn't been set in a game, we don't want to show the placeholder image.
+.bloom-page[data-tool-id="game"]
+    .bloom-backgroundImage
+    img[src="placeHolder.png"] {
+    visibility: hidden;
+}
+// We also want the crop handles to look disabled.  Disabling them is actually done in
+// typescript code.  The pointer-events: none; seems not to work on the handle divs but
+// is left as a reminder that we don't want to allow cropping in this case.  (BL-14703)
+.bloom-page[data-tool-id="game"]
+    #canvas-element-control-frame.bloom-backgroundImage-control-frame-no-image {
+    .bloom-ui-canvas-element-side-handle,
+    .bloom-ui-canvas-element-move-crop-handle {
+        pointer-events: none;
+        cursor: unset;
+        opacity: 30%;
+    }
+}

--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
@@ -178,6 +178,10 @@ const CanvasElementContextControls: React.FunctionComponent<{
     const isBackgroundImage = props.canvasElement.classList.contains(
         kBackgroundImageClass
     );
+    const backgroundImageText = useL10n(
+        "Background Image",
+        "EditTab.Image.BackgroundImage"
+    );
     const canExpandBackgroundImage = theOneCanvasElementManager?.canExpandToFillSpace();
 
     // These commands apply to all canvas elements (currently none!).
@@ -331,6 +335,17 @@ const CanvasElementContextControls: React.FunctionComponent<{
                     pointer-events: all;
                 `}
             >
+                {isBackgroundImage && (
+                    <div
+                        css={css`
+                            color: ${kBloomBlue};
+                            text-align: center;
+                            font-size: 8pt;
+                        `}
+                    >
+                        <strong>{backgroundImageText}</strong>
+                    </div>
+                )}
                 <div
                     css={css`
                         display: flex;

--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
@@ -1179,6 +1179,14 @@ export class CanvasElementManager {
                     if (event.buttons !== 1 || !this.activeElement) {
                         return;
                     }
+                    const target = event.currentTarget as HTMLElement;
+                    if (
+                        target.closest(
+                            `.${kBackgroundImageClass}-control-frame-no-image`
+                        )
+                    ) {
+                        return; // don't crop empty background image container
+                    }
                     this.startSideControlDrag(event, side);
                 });
             });
@@ -2595,6 +2603,20 @@ export class CanvasElementManager {
             kBackgroundImageClass + "-control-frame",
             this.activeElement.classList.contains(kBackgroundImageClass)
         );
+        let backgroundImageExists = true;
+        if (this.activeElement.classList.contains(kBackgroundImageClass)) {
+            const img = getImageFromCanvasElement(this.activeElement);
+            if (img && img.getAttribute("src") === "placeHolder.png") {
+                backgroundImageExists = false;
+            }
+        }
+        // mark empty background images in games with a special class (BL-14703)
+        controlFrame.classList.toggle(
+            kBackgroundImageClass + "-control-frame-no-image",
+            !backgroundImageExists &&
+                !!this.activeElement.closest(".bloom-page[data-tool-id='game']")
+        );
+
         const hasText = controlFrame.classList.contains("has-text");
         // We don't need to await these, they are just async so the handle titles can be updated
         // once the localization manager retrieves them.

--- a/src/content/templates/template books/Games/Games.html
+++ b/src/content/templates/template books/Games/Games.html
@@ -327,7 +327,28 @@
                         data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                         title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                     >
-                        <img src="placeHolder.png" alt="" />
+                        <div
+                            class="bloom-canvas-element bloom-backgroundImage"
+                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:1,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
+                            style="
+                                width: 672px;
+                                top: 0px;
+                                left: 0px;
+                                height: 378px;
+                            "
+                        >
+                            <div
+                                class="bloom-imageContainer"
+                                data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                                title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                            >
+                                <img
+                                    src="placeHolder.png"
+                                    style="width: 672px; top: -141.088px; left: 0px;"
+                                    alt=""
+                                />
+                            </div>
+                        </div>
 
                         <div
                         class="bloom-canvas-element draggable-text ui-resizable ui-draggable bloom-noAutoHeight"
@@ -548,7 +569,28 @@
                         data-title="For the current paper size: • The image container is 652 x 328 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1025 dots would fill this container at 300 DPI."
                         title="For the current paper size: • The image container is 652 x 328 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1025 dots would fill this container at 300 DPI."
                     >
-                        <img src="placeHolder.png" alt="" />
+                        <div
+                            class="bloom-canvas-element bloom-backgroundImage"
+                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:1,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
+                            style="
+                                width: 672px;
+                                top: 0px;
+                                left: 0px;
+                                height: 378px;
+                            "
+                        >
+                            <div
+                                class="bloom-imageContainer"
+                                data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                                title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                            >
+                                <img
+                                    src="placeHolder.png"
+                                    style="width: 672px; top: -141.088px; left: 0px;"
+                                    alt=""
+                                />
+                            </div>
+                        </div>
 
                         <div
                             class="bloom-canvas-element bloom-allowAutoShrink drag-item-order-sentence ui-resizable ui-draggable"
@@ -679,8 +721,28 @@
                         data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                         title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                     >
-                        <img src="placeHolder.png" alt="" />
-
+                        <div
+                            class="bloom-canvas-element bloom-backgroundImage"
+                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:1,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
+                            style="
+                                width: 672px;
+                                top: 0px;
+                                left: 0px;
+                                height: 378px;
+                            "
+                        >
+                            <div
+                                class="bloom-imageContainer"
+                                data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                                title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                            >
+                                <img
+                                    src="placeHolder.png"
+                                    style="width: 672px; top: -141.088px; left: 0px;"
+                                    alt=""
+                                />
+                            </div>
+                        </div>
                         <div
                             class="bloom-canvas-element bloom-gif drag-item-correct ui-resizable ui-draggable"
                             style="
@@ -946,8 +1008,28 @@
                         data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                         title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                     >
-                        <img src="placeHolder.png" alt="" />
-
+                        <div
+                            class="bloom-canvas-element bloom-backgroundImage"
+                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:1,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
+                            style="
+                            width: 378px;
+                            top: 0px;
+                            left: 0px;
+                            height: 672px;
+                        "
+                        >
+                            <div
+                                class="bloom-imageContainer"
+                                data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                                title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                            >
+                                <img
+                                    src="placeHolder.png"
+                                    style="width: 378px; left: -141.088px; top: 0px;"
+                                    alt=""
+                                />
+                            </div>
+                        </div>
                         <div
                             class="bloom-canvas-element bloom-gif drag-item-correct ui-resizable ui-draggable"
                             style="
@@ -1212,8 +1294,28 @@
                         data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                         title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                     >
-                        <img src="placeHolder.png" alt="" />
-
+                        <div
+                            class="bloom-canvas-element bloom-backgroundImage"
+                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:1,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
+                            style="
+                                width: 672px;
+                                top: 0px;
+                                left: 0px;
+                                height: 378px;
+                            "
+                        >
+                            <div
+                                class="bloom-imageContainer"
+                                data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                                title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                            >
+                                <img
+                                    src="placeHolder.png"
+                                    style="width: 672px; top: -141.088px; left: 0px;"
+                                    alt=""
+                                />
+                            </div>
+                        </div>
                         <div
                             class="bloom-canvas-element bloom-gif drag-item-correct ui-resizable ui-draggable"
                             style="
@@ -1468,17 +1570,14 @@
                     <div
                         class="bloom-canvas bloom-has-canvas-element"
                         data-title="For the current paper size: • The image container is 672 x 378 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2100 x 1182 dots would fill this container at 300 DPI."
-                        title=""
-                        data-imgsizebasedon="672,378"
-                        style=""
                     >
                         <div
                             class="bloom-canvas-element bloom-backgroundImage"
                             data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:1,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
                             style="
-                                width: 384.77px;
+                                width: 672px;
                                 top: 0px;
-                                left: 143.615px;
+                                left: 0px;
                                 height: 378px;
                             "
                         >
@@ -1487,7 +1586,11 @@
                                 data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                                 title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                             >
-                                <img src="placeHolder.png" alt="" />
+                                <img
+                                    src="placeHolder.png"
+                                    style="width: 672px; top: -141.088px; left: 0px;"
+                                    alt=""
+                                />
                             </div>
                         </div>
                         <div
@@ -1837,11 +1940,29 @@
                     <div
                         class="bloom-canvas bloom-has-canvas-element"
                         data-title="For the current paper size: • The image container is 672 x 378 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2100 x 1182 dots would fill this container at 300 DPI."
-                        title=""
-                        data-imgsizebasedon="672,378"
-                        style=""
                     >
-                        <img src="placeHolder.png" alt="" />
+                        <div
+                            class="bloom-canvas-element bloom-backgroundImage"
+                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:1,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
+                            style="
+                                width: 672px;
+                                top: 0px;
+                                left: 0px;
+                                height: 378px;
+                            "
+                        >
+                            <div
+                                class="bloom-imageContainer"
+                                data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                                title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                            >
+                                <img
+                                    src="placeHolder.png"
+                                    style="width: 672px; top: -141.088px; left: 0px;"
+                                    alt=""
+                                />
+                            </div>
+                        </div>
                         <div
                             class="bloom-canvas-element bloom-gif drag-item-correct"
                             style="
@@ -2288,18 +2409,15 @@
                     <div
                         class="bloom-canvas bloom-has-canvas-element"
                         data-title="For the current paper size: • The image container is 666 x 372 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2082 x 1163 dots would fill this container at 300 DPI."
-                        title=""
-                        data-imgsizebasedon="666,372"
-                        style=""
                     >
                         <div
                             class="bloom-canvas-element bloom-backgroundImage"
                             data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:10,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
                             style="
-                                width: 378.663px;
+                                width: 672px;
                                 top: 0px;
-                                left: 143.669px;
-                                height: 372px;
+                                left: 0px;
+                                height: 378px;
                             "
                         >
                             <div
@@ -2307,7 +2425,11 @@
                                 data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                                 title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                             >
-                                <img src="placeHolder.png" alt="" />
+                                <img
+                                    src="placeHolder.png"
+                                    style="width: 672px; top: -141.088px; left: 0px;"
+                                    alt=""
+                                />
                             </div>
                         </div>
 
@@ -2694,18 +2816,15 @@
                     <div
                         class="bloom-canvas bloom-has-canvas-element"
                         data-title="For the current paper size: • The image container is 666 x 372 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2082 x 1163 dots would fill this container at 300 DPI."
-                        title=""
-                        data-imgsizebasedon="666,372"
-                        style=""
                     >
                         <div
                             class="bloom-canvas-element bloom-backgroundImage"
                             data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:10,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
                             style="
-                                width: 378.663px;
+                                width: 672px;
                                 top: 0px;
-                                left: 143.669px;
-                                height: 372px;
+                                left: 0px;
+                                height: 378px;
                             "
                         >
                             <div
@@ -2713,7 +2832,11 @@
                                 data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                                 title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                             >
-                                <img src="placeHolder.png" alt="" />
+                                <img
+                                    src="placeHolder.png"
+                                    style="width: 672px; top: -141.088px; left: 0px;"
+                                    alt=""
+                                />
                             </div>
                         </div>
 
@@ -3308,7 +3431,28 @@
                         data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                         title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
                     >
-                        <img src="placeHolder.png" alt="" />
+                        <div
+                            class="bloom-canvas-element bloom-backgroundImage"
+                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:10,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
+                            style="
+                                width: 672px;
+                                top: 0px;
+                                left: 0px;
+                                height: 378px;
+                            "
+                        >
+                            <div
+                                class="bloom-imageContainer"
+                                data-title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                                title="For the current paper size: • The image container is 652 x 358 dots. • For print publications, you want between 300-600 DPI (Dots Per Inch). • An image with 2038 x 1119 dots would fill this container at 300 DPI."
+                            >
+                                <img
+                                    src="placeHolder.png"
+                                    style="width: 672px; top: -141.088px; left: 0px;"
+                                    alt=""
+                                />
+                            </div>
+                        </div>
 
                         <div
                             class="bloom-canvas-element ui-resizable ui-draggable"


### PR DESCRIPTION
The background image may not fill the screen initially despite my attempt to make it happen.  There is a button you can click to make it expand (which already existed).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7038)
<!-- Reviewable:end -->
