### PR TITLE
Remove bloom-canvas wrapper around book grid images (BL-14698, BL-14700)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1658,12 +1658,9 @@ function SetupBookLinkGrids(container: HTMLElement) {
                                 link.page.pageId.toString()
                             );
                         }
-                        // create elements for the thumbnail
-                        const bloomCanvas = document.createElement("div");
-                        button.appendChild(bloomCanvas);
-                        bloomCanvas.className = "bloom-canvas";
+                        // create img for the thumbnail
                         const img = document.createElement("img");
-                        bloomCanvas.appendChild(img);
+                        button.appendChild(img);
 
                         const desiredFileNameWithoutExtension = `bookButton-${link.book.id}`;
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7039)
<!-- Reviewable:end -->
