### PR TITLE
Restore default background image display outside drag games (BL-14734)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1656,7 +1656,7 @@ svg.bloom-videoControl {
 }
 
 // If the background image hasn't been set in a game, we don't want to show the placeholder image.
-.bloom-page[data-tool-id="game"]
+.bloom-page[data-tool-id="game"]:not[data-activity="simple-dom-choice"]
     .bloom-backgroundImage
     img[src="placeHolder.png"] {
     visibility: hidden;
@@ -1664,7 +1664,7 @@ svg.bloom-videoControl {
 // We also want the crop handles to look disabled.  Disabling them is actually done in
 // typescript code.  The pointer-events: none; seems not to work on the handle divs but
 // is left as a reminder that we don't want to allow cropping in this case.  (BL-14703)
-.bloom-page[data-tool-id="game"]
+.bloom-page[data-tool-id="game"]:not[data-activity="simple-dom-choice"]
     #canvas-element-control-frame.bloom-backgroundImage-control-frame-no-image {
     .bloom-ui-canvas-element-side-handle,
     .bloom-ui-canvas-element-move-crop-handle {

--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
@@ -172,6 +172,10 @@ const CanvasElementContextControls: React.FunctionComponent<{
     const isBackgroundImage = props.canvasElement.classList.contains(
         kBackgroundImageClass
     );
+    const children = props.canvasElement.parentElement?.querySelectorAll(
+        ".bloom-canvas-element"
+    );
+    const canvasHasMultipleElements = (children?.length ?? 0) > 1; // kBackgroundImageClass is also a canvas element
     const backgroundImageText = useL10n(
         "Background Image",
         "EditTab.Image.BackgroundImage"
@@ -331,7 +335,7 @@ const CanvasElementContextControls: React.FunctionComponent<{
                     pointer-events: all;
                 `}
             >
-                {isBackgroundImage && (
+                {isBackgroundImage && canvasHasMultipleElements && (
                     <div
                         css={css`
                             color: ${kBloomBlue};


### PR DESCRIPTION
Also display "Background Image" in context control popup only when appropriate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7053)
<!-- Reviewable:end -->
