### PR TITLE
fix various problems with draggable text

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
@@ -146,6 +146,7 @@ const CanvasElementContextControls: React.FunctionComponent<{
     const [currentDraggableTarget, setCurrentDraggableTarget] = useState<
         HTMLElement | undefined
     >();
+    // After deleting a draggable, we may get rendered again, and page will be null.
     const page = props.canvasElement.closest(".bloom-page") as HTMLElement;
     useEffect(() => {
         if (!currentDraggableTargetId) {
@@ -165,7 +166,7 @@ const CanvasElementContextControls: React.FunctionComponent<{
     // The audio menu item states the audio will play when the item is touched.
     // That isn't true yet outside of games, so don't show it.
     const isInDraggableGame = page
-        .getAttribute("data-activity")
+        ?.getAttribute("data-activity")
         ?.startsWith("drag-");
     const canChooseAudioForElement = isInDraggableGame && (hasImage || hasText);
 
@@ -206,6 +207,12 @@ const CanvasElementContextControls: React.FunctionComponent<{
             });
         // Need to include menuOpen so we can re-evaluate if the user has added or removed audio.
     }, [props.canvasElement, props.menuOpen]);
+
+    if (!page) {
+        // Probably right after deleting the canvas element. Wish we could return early sooner,
+        // but has to be after all the hooks.
+        return null;
+    }
 
     // These commands apply to all canvas elements (currently none!).
     const menuOptions: IMenuItemWithSubmenu[] = [];

--- a/src/content/bookLayout/canvasElement.less
+++ b/src/content/bookLayout/canvasElement.less
@@ -117,7 +117,8 @@
                 min-height: @MinTextBoxHeight - 3 !important;
                 text-align: center;
 
-                // Move the format button and language tip out of the box, since we have a smaller-than-normal editable box here
+                // canvas elements usually do automatic vertical sizing, so hiding overflow is rarely helpful.
+                // and if line-height is small, may need overflow visible to show descenders.
                 overflow: visible;
             }
 
@@ -143,6 +144,18 @@
                         background-color: white;
                     }
                 }
+            }
+        }
+    }
+    [data-target-of] {
+        // We generally want things in the target to look like the things in the corresponding
+        // canvas element. But some of the above like z-index is UI things that may not apply.
+        // We also don't want to mess with the border of the target.
+        // So I'm just replicating what I think is needed here.
+        .bloom-translationGroup {
+            .bloom-editable {
+                text-align: center;
+                overflow: visible;
             }
         }
     }


### PR DESCRIPTION
Stops checking (and hence reporting) overflow on targets
Fixes a crash on deleting canvas element
Prevents targets clipping bloom-editable descenders

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7065)
<!-- Reviewable:end -->
