### PR TITLE
Fix problems with sizing new canvas elements (BL-14749)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -252,6 +252,16 @@ export default class OverflowChecker {
             // scrollHeight is a reliable way to get the information if it is greater than the clientHeight,
             // and means we don't have to worry about scroll position.  (scrollHeight is never less than
             // clientHeight.  See https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight.)
+            // (One odd situation is when lineHeight is small, e.g., less than 1.3 for Andika. In that
+            // situation, a paragraph whose height is otherwise unconstrained is not high enough to show
+            // descenders, and even with a single line of text its scrollHeight is greater than clientHeight.
+            // Our auto-sizing code handles this, making a canvas element big enough to show the descenders
+            // (if any are actually present).
+            // However, when the bloom-editable is empty, we don't get the extra scrollHeight we are adjusting
+            // for. There's a kludge to partly handle this in adjustSizeOfContainingCanvasElementToMatchContent,
+            // but there may be a better way to handle things. I think part of the problem may be that if there
+            // is no actual text, the browser can't really pick a font to display it, so some measurements
+            // can't be precisely made.)
             result = elementClone.scrollHeight;
             if (elementClone.scrollHeight <= elementClone.clientHeight) {
                 // But if scrollHeight is less than or equal to clientHeight, we use our own algorithm.

--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
@@ -257,6 +257,21 @@ export class CanvasElementManager {
             return overflowY;
         }
 
+        // Some weird things happen to when the bloom-editable is empty and line-height is small
+        // (e.g., less than 1.3 for Andika). In this case, a paragraph whose height is unconstrained
+        // will not be high enough to show the font descenders, resulting in a scrollHeight larger than
+        // the clientHeight. When the text has no actual descenders, we compute a large overflowY and
+        // which corrects for the excessive scrollHeight to give us a good height for the canvas element.
+        // However, if the text is empty, we don't get the extra scrollHeight, but still compute a large
+        // excess descent, and can easily make the canvas element so small that our overflow checker
+        // reports that a child is overflowing. This fudge makes sure that we at least don't make it
+        // small enough to cause that problem. There may be a better fix (currently in at least one case
+        // we're making an empty box a pixel shorter than one with some content), but I think this might
+        // be good enough for 6.2.
+        if (newHeight < canvasElement.clientHeight && !editable.textContent) {
+            newHeight = Math.max(newHeight, editable.clientHeight);
+        }
+
         // If a lot of text is pasted, the bloom-canvas will scroll down.
         // (This can happen even if the text doesn't necessarily go out the bottom of the bloom-canvas).
         // The children of the bloom-canvas (e.g. img and canvas elements) will be offset above the bloom-canvas.


### PR DESCRIPTION
Also with their initial sizing and spurious overflow reporting when empty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7071)
<!-- Reviewable:end -->
