### PR TITLE
Restore adjusting target when text draggable size changed (BL-14786)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
@@ -1967,7 +1967,7 @@ export class CanvasElementManager {
         theOneCanvasElementManager.adjustCanvasElementHeightToContentOrMarkOverflow(
             editable
         );
-        // review; adjustTarget(this.activeElement, getTarget(this.activeElement));
+        this.adjustTarget(this.activeElement);
         this.alignControlFrameWithActiveElement();
         this.guideProvider.duringDrag(this.activeElement);
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7090)
<!-- Reviewable:end -->
