### PR TITLE
BL-14798 Semi Transparent Targets

### DIFF
--- a/src/content/templates/template books/Games/Games.html
+++ b/src/content/templates/template books/Games/Games.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 
 <html>
     <head>
@@ -693,7 +693,7 @@
 	-->
 
         <div
-            class="bloom-page customPage bloom-ignoreForReaderStats bloom-interactive-page enterprise-only no-margin-page numberedPage side-right Device16x9Landscape bloom-monolingual"
+            class="bloom-page targets-semi-transparent customPage bloom-ignoreForReaderStats bloom-interactive-page enterprise-only no-margin-page numberedPage side-right Device16x9Landscape bloom-monolingual"
             id="c8f4834c-1efd-4864-bc2c-8548ef26bb5b"
             data-page="extra"
             data-analyticscategories="drag-activity"

--- a/src/content/templates/template books/Games/gamesThemes.less
+++ b/src/content/templates/template books/Games/gamesThemes.less
@@ -31,7 +31,12 @@
 
     --game-draggable-color: var(--game-secondary-color);
     --game-draggable-bg-color: var(--game-primary-bg-color);
+
     --game-draggable-target-outline-color: var(--game-draggable-bg-color);
+    // CSS variable cannot reference themselves, so we define this copy
+    // so that we can use color-mix() to make it semi-transparent
+    // when we want.
+    --game-draggable-target-outline-color-base: var(--game-draggable-bg-color);
 
     --game-header-color: var(--game-secondary-color);
     --game-header-bg-color: var(--game-primary-bg-color);
@@ -98,4 +103,14 @@
     // if we don't reapply --game-text-color: var(--game-primary-color), it will
     // be white here even though we just set --game-primary-color to black.
     .apply-game-theme();
+}
+
+.bloom-page.targets-semi-transparent {
+    // The target outline sticks out and ruins the target image, so we
+    // set the opacity of game-draggable-target-outline-color to 0.5
+    --game-draggable-target-outline-color: color-mix(
+        in srgb,
+        var(--game-draggable-target-outline-color-base) 10%,
+        transparent
+    );
 }


### PR DESCRIPTION
Add a class to the Drag Images to Targets game that makes the targets mostly transparent.
