### PR TITLE
Fix various problems in Games.html (BL-14781)

### DIFF
--- a/src/content/templates/template books/Games/Games.html
+++ b/src/content/templates/template books/Games/Games.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 
 <html>
     <head>
@@ -444,7 +444,6 @@
                                 role="textbox"
                                 aria-label="false"
                                 contenteditable="true"
-                                data-languagetipcontent="English"
                             >
 
                             </div>
@@ -608,9 +607,8 @@
                             >
                                 <div
                                     class="bloom-editable GameOrderWordsMediumCenter-style bloom-contentNational1"
-                                    lang="en"
+                                    lang="z"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
@@ -792,7 +790,6 @@
                                     aria-label="false"
                                     style="min-height: 32.01px"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                 ></div>
                             </div>
                         </div>
@@ -1074,7 +1071,6 @@
                                     aria-label="false"
                                     style="min-height: 32.01px"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                 ></div>
                             </div>
                         </div>
@@ -1355,7 +1351,6 @@
                                     aria-label="false"
                                     style="min-height: 32.01px"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                 ></div>
                             </div>
                         </div>
@@ -1638,7 +1633,6 @@
                                     aria-label="false"
                                     style="min-height: 32.01px"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                 ></div>
                             </div>
                         </div>
@@ -1710,31 +1704,15 @@
                             <div
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
-                                style="font-size: 45px"
                             >
                                 <div
                                     class="bloom-editable GameDragMediumCenter-style bloom-visibility-code-on bloom-content1"
-                                    lang="en"
+                                    lang="z"
                                     contenteditable="true"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    style="min-height: 45.01px"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 30px; top: 105px; width: 160px; height: 70px;`,`tails`:[]}"
-                                    data-languagetipcontent="English"
-                                ></div>
-                                <div
-                                    class="bloom-editable GameDragMediumCenter-style bloom-contentNational1"
-                                    lang="fr"
-                                    contenteditable="true"
-                                    tabindex="0"
-                                    spellcheck="false"
-                                    role="textbox"
-                                    aria-label="false"
-                                    style="min-height: 45.01px"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 30px; top: 105px; width: 160px; height: 70px;`,`tails`:[]}"
-                                    data-languagetipcontent="français"
                                 ></div>
                             </div>
                         </div>
@@ -1753,31 +1731,15 @@
                             <div
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
-                                style="font-size: 45px"
                             >
                                 <div
                                     class="bloom-editable GameDragMediumCenter-style bloom-visibility-code-on bloom-content1"
-                                    lang="en"
+                                    lang="z"
                                     contenteditable="true"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    style="min-height: 45.01px"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 230px; top: 105px; width: 160px; height: 70px;`,`tails`:[]}"
-                                    data-languagetipcontent="English"
-                                ></div>
-                                <div
-                                    class="bloom-editable GameDragMediumCenter-style bloom-contentNational1"
-                                    lang="fr"
-                                    contenteditable="true"
-                                    tabindex="0"
-                                    spellcheck="false"
-                                    role="textbox"
-                                    aria-label="false"
-                                    style="min-height: 45.01px"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 230px; top: 105px; width: 160px; height: 70px;`,`tails`:[]}"
-                                    data-languagetipcontent="français"
                                 ></div>
                             </div>
                         </div>
@@ -1796,31 +1758,15 @@
                             <div
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
-                                style="font-size: 45px"
                             >
                                 <div
                                     class="bloom-editable GameDragMediumCenter-style bloom-visibility-code-on bloom-content1"
-                                    lang="en"
+                                    lang="z"
                                     contenteditable="true"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    style="min-height: 45.01px"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 430px; top: 105px; width: 160px; height: 70px;`,`tails`:[]}"
-                                    data-languagetipcontent="English"
-                                ></div>
-                                <div
-                                    class="bloom-editable GameDragMediumCenter-style bloom-contentNational1"
-                                    lang="fr"
-                                    contenteditable="true"
-                                    tabindex="0"
-                                    spellcheck="false"
-                                    role="textbox"
-                                    aria-label="false"
-                                    style="min-height: 45.01px"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 430px; top: 105px; width: 160px; height: 70px;`,`tails`:[]}"
-                                    data-languagetipcontent="français"
                                 ></div>
                             </div>
                         </div>
@@ -1992,7 +1938,6 @@
                                     aria-label="false"
                                     style="min-height: 32.01px"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                 ></div>
                             </div>
                         </div>
@@ -2115,22 +2060,17 @@
                             <div
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
-                                style="font-size: 32px"
                             >
                                 <div
                                     class="bloom-editable GameTextMediumCenter-style bloom-visibility-code-on bloom-content1 bloom-contentNational1"
-                                    lang="en"
+                                    lang="z"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    style="min-height: 48.01px"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 50px; top: 270px; width: 160px; height: 44px;`,`tails`:[]}"
-                                    id="i1e76084c-b93a-4840-9b50-9ed5dac889e4"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                 >
-                                    <p>Word</p>
+                                    <p></p>
                                 </div>
                             </div>
                         </div>
@@ -2159,22 +2099,17 @@
                             <div
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
-                                style="font-size: 32px"
                             >
                                 <div
                                     class="bloom-editable GameTextMediumCenter-style bloom-visibility-code-on bloom-content1 bloom-contentNational1"
-                                    lang="en"
+                                    lang="z"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    style="min-height: 48.01px"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 260px; top: 270px; width: 160px; height: 44px;`,`tails`:[]}"
-                                    id="a7fc688b-a6c3-4738-bbd7-af446ddd6e46"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                 >
-                                    <p>Word</p>
+                                    <p></p>
                                 </div>
                             </div>
                         </div>
@@ -2191,22 +2126,17 @@
                             <div
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
-                                style="font-size: 32px"
                             >
                                 <div
                                     class="bloom-editable GameTextMediumCenter-style bloom-visibility-code-on bloom-content1 bloom-contentNational1"
-                                    lang="en"
+                                    lang="z"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    style="min-height: 48.01px"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 470px; top: 270px; width: 160px; height: 44px;`,`tails`:[]}"
-                                    id="f3ed2f3e-f492-4f2c-85eb-09e35e6aa750"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                 >
-                                    <p>Word</p>
+                                    <p></p>
                                 </div>
                             </div>
                         </div>
@@ -2519,22 +2449,17 @@
                             <div
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
-                                style="font-size: 60px"
                             >
                                 <div
                                     class="bloom-editable GameTextLargeStart-style bloom-visibility-code-on bloom-content1 bloom-contentNational1"
-                                    lang="en"
+                                    lang="z"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 230px; top: 200px; width: 260px; height: 64px;`,`tails`:[]}"
-                                    style="min-height: 60.01px"
-                                    id="i10b7e0dd-9084-4c2a-9dfc-ddb6c315067d"
-                                    data-languagetipcontent="English"
                                     contenteditable="true"
                                 >
-                                    <p>word</p>
+                                    <p></p>
                                 </div>
                             </div>
                         </div>
@@ -2557,7 +2482,6 @@
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
                                 data-eager-placeholder-l10n-id="EditTab.Toolbox.Games.Placeholder.DragSoundToWordTargetInstructions"
-                                style="font-size: 32px"
                             >
                                 <div
                                     class="bloom-editable GameHeader-style bloom-visibility-code-on bloom-content1 bloom-contentNational1"
@@ -2566,9 +2490,6 @@
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    style="min-height: 32.01px"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: -8px; top: -6px; width: 692px; height: 33.5px;`,`tails`:[]}"
-                                    data-languagetipcontent="English"
                                     contenteditable="true"
                                 ></div>
                             </div>
@@ -2961,22 +2882,17 @@
                             <div
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
-                                style="font-size: 32px"
                             >
                                 <div
                                     class="bloom-editable GameTextMediumStart-style bloom-visibility-code-on bloom-content1 bloom-contentNational1"
-                                    lang="en"
+                                    lang="z"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 120px; top: 160px; width: 140px; height: 44px;`,`tails`:[]}"
-                                    style="min-height: 48.01px"
-                                    id="fd38768e-a762-4c9f-a5b6-95bd9c12082a"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                 >
-                                    <p>word</p>
+                                    <p></p>
                                 </div>
                             </div>
                         </div>
@@ -3007,12 +2923,9 @@
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    style="min-height: 32.01px"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: -8px; top: -6px; width: 692px; height: 33.5px;`,`tails`:[]}"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                 >
-                                    <p>Match sounds with words</p>
+                                    <p></p>
                                 </div>
                             </div>
                         </div>
@@ -3030,22 +2943,17 @@
                             <div
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
-                                style="font-size: 32px"
                             >
                                 <div
                                     class="bloom-editable GameTextMediumStart-style bloom-visibility-code-on bloom-content1 bloom-contentNational1"
-                                    lang="en"
+                                    lang="z"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 120px; top: 260px; width: 140px; height: 44px;`,`tails`:[]}"
-                                    style="min-height: 48.01px"
                                     contenteditable="true"
-                                    id="a87cc709-93de-43d3-bac0-291334ff11c0"
-                                    data-languagetipcontent="English"
                                 >
-                                    <p>word</p>
+                                    <p></p>
                                 </div>
                             </div>
                         </div>
@@ -3093,22 +3001,17 @@
                             <div
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
-                                style="font-size: 32px"
                             >
                                 <div
                                     class="bloom-editable GameTextMediumStart-style bloom-visibility-code-on bloom-content1 bloom-contentNational1"
-                                    lang="en"
+                                    lang="z"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 380px; top: 260px; width: 140px; height: 44px;`,`tails`:[]}"
-                                    style="min-height: 48.01px"
                                     contenteditable="true"
-                                    id="i6fa7f25f-6a51-4ab4-b99b-70ffa3bd8490"
-                                    data-languagetipcontent="English"
                                 >
-                                    <p>word</p>
+                                    <p></p>
                                 </div>
                             </div>
                         </div>
@@ -3126,22 +3029,17 @@
                             <div
                                 class="bloom-translationGroup bloom-leadingElement"
                                 data-default-languages="V"
-                                style="font-size: 32px"
                             >
                                 <div
                                     class="bloom-editable GameTextMediumStart-style bloom-visibility-code-on bloom-content1 bloom-contentNational1"
-                                    lang="en"
+                                    lang="z"
                                     tabindex="0"
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    data-bubble-alternate="{`lang`:`en`,`style`:`left: 380px; top: 160px; width: 140px; height: 44px;`,`tails`:[]}"
-                                    style="min-height: 48.01px"
                                     contenteditable="true"
-                                    id="db2118d8-a7e5-446d-a50a-7a7d7346d67c"
-                                    data-languagetipcontent="English"
                                 >
-                                    <p>word</p>
+                                    <p></p>
                                 </div>
                             </div>
                         </div>
@@ -3436,9 +3334,7 @@
                                     spellcheck="false"
                                     role="textbox"
                                     aria-label="false"
-                                    style="min-height: 32.01px"
                                     contenteditable="true"
-                                    data-languagetipcontent="English"
                                 ></div>
                             </div>
                         </div>


### PR DESCRIPTION
Some blocks still had "word" in English as content. Some still had audio ID attributes, which could have become duplicates. Some had spurious font and min-height styles, which should be controlled by stylesheet and code. Some had English and/or French empty content instead of just "z".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7103)
<!-- Reviewable:end -->
