### PR TITLE
Add subscription wrapper overlays for epub and video/audio (BL-14793)

### DIFF
--- a/src/BloomBrowserUI/publish/ePUBPublish/ePUBPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ePUBPublish/ePUBPublishScreen.tsx
@@ -31,6 +31,7 @@ import { NoteBox } from "../../react_components/boxes";
 import { P } from "../../react_components/l10nComponents";
 import { PublishProgressDialog } from "../commonPublish/PublishProgressDialog";
 import { useL10n } from "../../react_components/l10nHooks";
+import { RequiresSubscriptionOverlayWrapper } from "../../react_components/requiresSubscription";
 
 export const EPUBPublishScreen = () => {
     // When the user changes some features, included languages, etc., we
@@ -260,7 +261,7 @@ const EPUBPublishScreenInternal: React.FunctionComponent<{
     const showProgressDialog = props.showPreview || publishStarted;
 
     return (
-        <React.Fragment>
+        <RequiresSubscriptionOverlayWrapper featureName="ExportEPUB">
             <PublishScreenTemplate
                 bannerTitleEnglish="Publish as ePUB"
                 bannerTitleL10nId="PublishTab.Epub.BannerTitle"
@@ -284,6 +285,6 @@ const EPUBPublishScreenInternal: React.FunctionComponent<{
                 />
             )}
             <BookMetadataDialog />
-        </React.Fragment>
+        </RequiresSubscriptionOverlayWrapper>
     );
 };

--- a/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
+++ b/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
@@ -32,7 +32,7 @@ import {
 } from "../../utils/bloomApi";
 import HelpLink from "../../react_components/helpLink";
 import { Link } from "../../react_components/link";
-import { RequiresSubscriptionDialog } from "../../react_components/requiresSubscription";
+import { RequiresSubscriptionOverlayWrapper } from "../../react_components/requiresSubscription";
 import { PublishProgressDialog } from "../commonPublish/PublishProgressDialog";
 import { useL10n } from "../../react_components/l10nHooks";
 import { ProgressState } from "../commonPublish/PublishProgressDialogInner";
@@ -655,38 +655,39 @@ const PublishAudioVideoInternalInternal: React.FunctionComponent<{
     }, []);
 
     return (
-        <Typography
-            component={"div"}
-            css={css`
-                height: 100%;
-            `}
-        >
-            <RequiresSubscriptionDialog />
-            <PublishScreenTemplate
-                bannerTitleEnglish="Publish as Audio or Video"
-                bannerTitleL10nId="PublishTab.RecordVideo.BannerTitle"
-                bannerDescriptionMarkdown="Create video files that you can upload to sites like Facebook and YouTube. You can also make videos to share with people who use inexpensive “feature phones” and even audio-only files for listening."
-                bannerDescriptionL10nId="PublishTab.RecordVideo.BannerDescription"
-                optionsPanelContents={optionsPanel}
+        <RequiresSubscriptionOverlayWrapper featureName="ExportAudioVideo">
+            <Typography
+                component={"div"}
+                css={css`
+                    height: 100%;
+                `}
             >
-                {mainPanel}
-            </PublishScreenTemplate>
-            {/* In storybook, there's no bloom backend to run the progress dialog */}
-            {inStorybookMode ||
-                (props.showPreview && (
-                    <PublishProgressDialog
-                        heading={heading}
-                        apiForStartingTask="publish/av/updatePreview"
-                        onTaskComplete={setClosePendingToTrue}
-                        webSocketClientContext="publish-bloompub"
-                        progressState={progressState}
-                        setProgressState={setProgressState}
-                        closePending={closePending}
-                        setClosePending={setClosePending}
-                        onUserStopped={setClosePendingToTrue}
-                    />
-                ))}
-            <EmbeddedProgressDialog id="avPublish" />
-        </Typography>
+                <PublishScreenTemplate
+                    bannerTitleEnglish="Publish as Audio or Video"
+                    bannerTitleL10nId="PublishTab.RecordVideo.BannerTitle"
+                    bannerDescriptionMarkdown="Create video files that you can upload to sites like Facebook and YouTube. You can also make videos to share with people who use inexpensive “feature phones” and even audio-only files for listening."
+                    bannerDescriptionL10nId="PublishTab.RecordVideo.BannerDescription"
+                    optionsPanelContents={optionsPanel}
+                >
+                    {mainPanel}
+                </PublishScreenTemplate>
+                {/* In storybook, there's no bloom backend to run the progress dialog */}
+                {inStorybookMode ||
+                    (props.showPreview && (
+                        <PublishProgressDialog
+                            heading={heading}
+                            apiForStartingTask="publish/av/updatePreview"
+                            onTaskComplete={setClosePendingToTrue}
+                            webSocketClientContext="publish-bloompub"
+                            progressState={progressState}
+                            setProgressState={setProgressState}
+                            closePending={closePending}
+                            setClosePending={setClosePending}
+                            onUserStopped={setClosePendingToTrue}
+                        />
+                    ))}
+                <EmbeddedProgressDialog id="avPublish" />
+            </Typography>
+        </RequiresSubscriptionOverlayWrapper>
     );
 };

--- a/src/BloomBrowserUI/react_components/requiresSubscription.tsx
+++ b/src/BloomBrowserUI/react_components/requiresSubscription.tsx
@@ -157,6 +157,11 @@ export const RequiresSubscriptionOverlayWrapper: React.FunctionComponent<{
         <div
             css={css`
                 height: 100%;
+                // position:relative allows the overlay to cover only the children of this div.
+                // Do not set any of left, right, top, or bottom since we don't want to shift
+                // the position of this div and its children relative to our parent, just to
+                // affect the starting point of the position:absolute used below.
+                position: relative;
             `}
         >
             <div


### PR DESCRIPTION
Also improve the wrapper to cover only its child elements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7135)
<!-- Reviewable:end -->
