### PR TITLE
Add BloomProgram branding that mimics default branding (BL-14872)

### DIFF
--- a/src/BloomExe/BloomFileLocator.cs
+++ b/src/BloomExe/BloomFileLocator.cs
@@ -356,6 +356,8 @@ namespace Bloom
             }
             if (Path.IsPathRooted(fileName) && RobustFile.Exists(fileName)) // also just for unit tests
                 return fileName;
+            if (BrandingSettings.SubscriptionsThatUseDefaultBranding.Contains(brandingNameOrFolderPath))
+                brandingNameOrFolderPath = "Default";
             return BloomFileLocator.GetBrowserFile(
                 true,
                 "branding",
@@ -372,6 +374,8 @@ namespace Bloom
                 out var flavor,
                 out var subUnitName
             );
+            if (BrandingSettings.SubscriptionsThatUseDefaultBranding.Contains(brandingFolderName))
+                brandingFolderName = "Default";
             return BloomFileLocator.GetOptionalBrowserDirectory("branding", brandingFolderName);
         }
 

--- a/src/BloomExe/Collection/BrandingProject.cs
+++ b/src/BloomExe/Collection/BrandingProject.cs
@@ -28,6 +28,8 @@ namespace Bloom.Collection
                 out var flavor,
                 out var subUnitName
             );
+            if (BrandingSettings.SubscriptionsThatUseDefaultBranding.Contains(baseKey))
+                baseKey = "Default";
 
             var brandingDirectory = BloomFileLocator.GetBrowserDirectory("branding");
             return Directory

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -858,6 +858,8 @@ namespace Bloom.Collection
                 out var flavor,
                 out var subUnitName
             );
+            if (BrandingSettings.SubscriptionsThatUseDefaultBranding.Contains(folderName))
+                return "Default";
             return folderName;
         }
 

--- a/src/BloomExe/web/controllers/BrandingSettings.cs
+++ b/src/BloomExe/web/controllers/BrandingSettings.cs
@@ -107,6 +107,13 @@ namespace Bloom.Api
         }
 
         /// <summary>
+        /// We sometimes want temporary subscriptions that use the default branding files, but which provide
+        /// access to Enterprise level features.  The base branding names for these subscriptions are listed
+        /// here.  (This is useful for workshops and other training venues.)  See BL-14872.
+        /// </summary>
+        public static string[] SubscriptionsThatUseDefaultBranding = new[] { "BloomProgram", "Pretend-Project" };
+
+        /// <summary>
         /// extract the various parts of a Subscription Descriptor
         /// </summary>
         /// <param name="subscriptionDescriptor">the part of the subcription code before the numbers start</param>
@@ -198,6 +205,8 @@ namespace Bloom.Api
                         out flavor,
                         out var subUnitName
                     );
+                    if (SubscriptionsThatUseDefaultBranding.Contains(brandingFolderName))
+                        brandingFolderName = "Default";
 
                     // check to see if we have a special branding.json just for this flavor.
                     // Note that we could instead add code that allows a single branding.json to


### PR DESCRIPTION
Any subscription with BloomProgram as its main name will have Enterprise permissions but with Default appearance whereever branding is applied.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7142)
<!-- Reviewable:end -->
