### PR TITLE
BL-14544 Language Chooser Country Error

### DIFF
--- a/src/BloomBrowserUI/collection/LanguageChooserDialog.tsx
+++ b/src/BloomBrowserUI/collection/LanguageChooserDialog.tsx
@@ -49,7 +49,9 @@ export function getLanguageData(
         LanguageTag: languageTag || null,
         DefaultName: defaultName,
         DesiredName: selection?.customDetails?.customDisplayName || defaultName,
-        Country: languageTag ? defaultRegionForLangTag(languageTag)?.name : null
+        Country: languageTag
+            ? defaultRegionForLangTag(languageTag)?.name || null
+            : null
     };
 }
 


### PR DESCRIPTION
Choosing languages without a default region will not crash Bloom

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7198)
<!-- Reviewable:end -->
