### PR TITLE
Update expired subscriptions used in unit tests (20250701)

### DIFF
--- a/src/BloomTests/Publish/PublishHelperTests.cs
+++ b/src/BloomTests/Publish/PublishHelperTests.cs
@@ -969,7 +969,7 @@ namespace BloomTests.Publish
                 .Cast<SafeXmlElement>()
                 .ToList();
             omittedPages = new Dictionary<string, int>();
-            subscription = new Subscription("Test-361769-1088"); // allows widgets
+            subscription = new Subscription("Test-727011-1339"); // allows widgets
             PublishHelper.RemovePagesByFeatureSystem(
                 pageElts,
                 PublishingMediums.Epub, // does not allow games
@@ -1005,7 +1005,7 @@ namespace BloomTests.Publish
                 .Cast<SafeXmlElement>()
                 .ToList();
             var omittedPages = new Dictionary<string, int>();
-            var subscription = new Subscription("john_hatton@sil.org-005909-2753");
+            var subscription = new Subscription("john_hatton@sil.org-123456-3028");
             PublishHelper.RemovePagesByFeatureSystem(
                 pageElts,
                 PublishingMediums.BloomPub,
@@ -1029,7 +1029,7 @@ namespace BloomTests.Publish
             checkNotRemoved();
 
             // higher tier is OK also
-            subscription = new Subscription("Test-361769-1088");
+            subscription = new Subscription("Test-727011-1339");
             PublishHelper.RemovePagesByFeatureSystem(
                 pageElts,
                 PublishingMediums.BloomPub,

--- a/src/BloomTests/web/controllers/SubscriptionTests.cs
+++ b/src/BloomTests/web/controllers/SubscriptionTests.cs
@@ -33,7 +33,7 @@ namespace BloomTests.Collection
 
         [TestCase(null, "Default")]
         [TestCase("", "Default")]
-        [TestCase("Sample-361769-1709", "Sample")]
+        [TestCase("Test-727011-1339", "Test")]
         [TestCase("Foo-Bar-Blah", "Default")] // missing parts, invalid, thus branding is "Default"
         [TestCase("Fake-LC-006273-1463", "Local-Community")] // this code will eventually expire, after which it should be replaced
         [TestCase("Test-Expired-005691-4935", "Default")] //  expired, thus "Default"
@@ -87,9 +87,10 @@ namespace BloomTests.Collection
 
         [TestCase(null, SubscriptionTier.Basic)]
         [TestCase("", SubscriptionTier.Basic)]
-        [TestCase("Legacy-LC-005839-2533", SubscriptionTier.LocalCommunity)]
+        [TestCase("Legacy-LC-005839-2533", SubscriptionTier.Basic)] // expired, so basic
         [TestCase("Fake-006273-0501", SubscriptionTier.Enterprise)]
         [TestCase("Fake-LC-006273-1463", SubscriptionTier.LocalCommunity)]
+        [TestCase("Fake-Pro-006273-2126", SubscriptionTier.Pro)]
         [TestCase("Test-Expired-005691-4935", SubscriptionTier.Basic)] // if expired, it's basic
         public void Tier_ReturnsCorrectEnum(string code, SubscriptionTier expectedTier)
         {


### PR DESCRIPTION
A few will expire in September 2026.  We need a longer term decision on what to do about subscription codes embedded in source code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7238)
<!-- Reviewable:end -->
