### PR TITLE
Disable audio recording of text in order words game (BL-14967)

### DIFF
--- a/src/content/templates/template books/Games/Games.html
+++ b/src/content/templates/template books/Games/Games.html
@@ -5046,7 +5046,7 @@
                             aria-describedby="qtip-1"
                         >
                             <div
-                                class="bloom-translationGroup"
+                                class="bloom-translationGroup bloom-noAudio"
                                 data-default-languages="auto"
                                 style="font-size: 32px"
                             >


### PR DESCRIPTION
It's unclear how this would be used, and the display during recording is messed up by the lines being so close together when the text stretches over more than one line.  At the moment, when playing the game, there's no way to play the audio.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7241)
<!-- Reviewable:end -->
