### PR TITLE
[6.2] Remove WebView2 user folders when Bloom exits (BL-14984)

### DIFF
--- a/src/BloomExe/WebView2Browser.Designer.cs
+++ b/src/BloomExe/WebView2Browser.Designer.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace Bloom
 {
     partial class WebView2Browser
@@ -13,9 +15,21 @@ namespace Bloom
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
+			var uprocId = _webview?.CoreWebView2?.BrowserProcessId;
+			var procId = uprocId.HasValue ? (int)uprocId.Value : 0;
+			var userFolder = _webview?.CoreWebView2?.Environment?.UserDataFolder;
 			if (disposing && (components != null))
 			{
 				components.Dispose();
+			}
+			else if (disposing && _webview != null)
+			{
+				_webview.Dispose();
+			}
+			if (disposing && procId > 0 && userFolder != null && Directory.Exists(userFolder))
+			{
+				// We need to wait until the process finishes to reliably delete the folder.
+				Program.WebView2ProcessToUserFolder.Add(procId, userFolder);
 			}
 			base.Dispose(disposing);
 		}


### PR DESCRIPTION
This prevents the silent accumulation of gigabytes in the Temp folder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7247)
<!-- Reviewable:end -->
