### PR TITLE
Prevent creating unused browsers in harvester mode (BL-14975)

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -93,21 +93,24 @@ namespace Bloom.Edit
             // This used to be part of InitializeComponent, but we want to make which browser to use
             // configurable. It can possibly move back to the Designer code once we settle on WebView2.
             // Turning off for this PR because it's not working well enough yet.
-            this._browser1 = BrowserMaker.MakeBrowser();
-            //
-            // _browser1
-            //
-            this._browser1.BackColor = System.Drawing.Color.DarkGray;
-            this._browser1.ContextMenuProvider = null;
-            this._browser1.ReplaceContextMenu = null;
-            this._browser1.ControlKeyEvent = null;
-            this._browser1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._browser1.Location = new System.Drawing.Point(0, 0);
-            this._browser1.Margin = new System.Windows.Forms.Padding(5);
-            this._browser1.Name = "_browser1";
-            this._browser1.Size = new System.Drawing.Size(826, 561);
-            this._browser1.TabIndex = 1;
-            this._splitContainer2.Panel1.Controls.Add(this._browser1);
+            if (!Program.RunningHarvesterMode)
+            {
+                this._browser1 = BrowserMaker.MakeBrowser();
+                //
+                // _browser1
+                //
+                this._browser1.BackColor = System.Drawing.Color.DarkGray;
+                this._browser1.ContextMenuProvider = null;
+                this._browser1.ReplaceContextMenu = null;
+                this._browser1.ControlKeyEvent = null;
+                this._browser1.Dock = System.Windows.Forms.DockStyle.Fill;
+                this._browser1.Location = new System.Drawing.Point(0, 0);
+                this._browser1.Margin = new System.Windows.Forms.Padding(5);
+                this._browser1.Name = "_browser1";
+                this._browser1.Size = new System.Drawing.Size(826, 561);
+                this._browser1.TabIndex = 1;
+                this._splitContainer2.Panel1.Controls.Add(this._browser1);
+            }
 
             this._splitContainer2.BackColor = Palette.GeneralBackground;
             SetupThumnailLists();
@@ -122,9 +125,11 @@ namespace Bloom.Edit
             _copyrightAndLicenseApi = copyrightAndLicenseApi;
             copyrightAndLicenseApi.Model = _model;
             copyrightAndLicenseApi.View = this;
-            _browser1.SetEditingCommands(cutCommand, copyCommand, pasteCommand, undoCommand);
-
-            _browser1.ControlKeyEvent = controlKeyEvent;
+            if (!Program.RunningHarvesterMode)
+            {
+                _browser1.SetEditingCommands(cutCommand, copyCommand, pasteCommand, undoCommand);
+                _browser1.ControlKeyEvent = controlKeyEvent;
+            }
 
             if (SIL.PlatformUtilities.Platform.IsMono)
             {

--- a/src/BloomExe/Edit/WebThumbNailList.cs
+++ b/src/BloomExe/Edit/WebThumbNailList.cs
@@ -72,7 +72,7 @@ namespace Bloom.Edit
         {
             InitializeComponent();
 
-            if (!ReallyDesignMode)
+            if (!ReallyDesignMode && !Program.RunningHarvesterMode)
             {
                 _browser = BrowserMaker.MakeBrowser();
                 _browser.BackColor = Color.DarkGray;

--- a/src/BloomTests/CLI/CreateArtifactsCommandTests.cs
+++ b/src/BloomTests/CLI/CreateArtifactsCommandTests.cs
@@ -183,9 +183,6 @@ namespace BloomTests.CLI
         //
         // Of course, it would also be nice to have some tests where artifact creation succeeds, but that's
         // too big a job for today.
-        [Ignore(
-            "By Hand until I can figure out how to make this and the previous test both run in the same run without stomping on each other"
-        )]
         [Test]
         public void CreateArtifacts_LegacyBookWithInvalidXmatter_ReportsLegacyBookCannotHarvest()
         {
@@ -241,17 +238,6 @@ namespace BloomTests.CLI
             }
         }
 
-        // When running this test in the same run as CreateArtifacts_LegacyBookWithInvalidXmatter_HarvesterAllowedToConvert_ConvertsToDefaultTheme
-        // and CompressBookForDevice_BloomEnterprise_ConvertsNewQuizPagesToJson_AndKeepsThem, we often get a wv2 initialization error.
-        // I haven't yet figured out what is going on, but one thing is that we are creating a WebThumbNailList during this test because
-        // Autofac initializes it (through EditView through BookSettings currently) which creates a browser.
-        // One theory is this has something to do with the dataFolder being used by wv2 (see a bunch of comments in WebView2Browser).
-        // We do usually create new ones, but perhaps in some case we don't.
-        // Note that the project context (which ends up creating some browsers) in CreateArtifactsCommand is static, so that seems implicated.
-        //
-        // In the end, making this test not run all the time is not actually losing much. We test the basic functionality of creating the json
-        // in HTMLDom-Json-Tests.cs.
-        [Ignore("By hand for now. See comment.")]
         [Test]
         public void CreateArtifacts_WithJsonOutput_CreatesJsonFile()
         {


### PR DESCRIPTION
Browsers are still created on demand when processing books for creating bloompub and epub artifacts.  The WebThumbNailList and EditingView browsers are never used in creating artifacts, so they don't need to be created.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7248)
<!-- Reviewable:end -->
