### PR TITLE
Fix WebView2 folder cleanup to handle reused process ids (BL-14984)

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1040,7 +1040,7 @@ namespace Bloom
             {
                 if (FileMeddlerManager.IsMeddling)
                     FileMeddlerManager.Stop();
-                CleanupWebView2UserFolders();
+                WebView2Browser.CleanupWebView2UserFolders();
             }
 
             try
@@ -1064,70 +1064,6 @@ namespace Bloom
 
             if (_projectContext != null)
                 _projectContext.Dispose();
-        }
-
-        /// <summary>
-        /// Mapping of WebView2 process IDs to their user folder paths.  We want to delete these user folders
-        /// because they don't contain anything we need to persist, and they can take up a lot of space.  New ones
-        /// are usually created, so they accumulate over time and can hold gigabytes of useless data.
-        /// </summary>
-        /// <remarks>
-        /// The WebView2 browser engines run in separate processes, and we have to wait until each process has
-        /// exited before we can reliably delete its user folder.
-        /// https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/user-data-folder?tabs=win32#deleting-user-data-folders
-        /// The WebView2Browser.Dispose method fills in this dictionary with the process ID and user folder path.
-        /// All of the browsers will have been disposed by the the application shutting down before the following
-        /// method is called.
-        /// </remarks>
-        public static readonly Dictionary<int, string> WebView2ProcessToUserFolder = new Dictionary<int, string>();
-        private static void CleanupWebView2UserFolders()
-        {
-            try
-            {
-                int loopCount = 0;
-                while (WebView2ProcessToUserFolder.Count > 0)
-                {
-                    foreach (var key in WebView2ProcessToUserFolder.Keys.ToArray())
-                    {
-                        try
-                        {
-                            var process = Process.GetProcessById((int)key);
-                        }
-                        catch (ArgumentException)
-                        {
-                            // The process is no longer running, so we can delete the folder.
-                            var userFolder = WebView2ProcessToUserFolder[key];
-                            if (Directory.Exists(userFolder))
-                            {
-                                try
-                                {
-                                    RobustIO.DeleteDirectory(userFolder, true);
-                                }
-                                catch (Exception)
-                                {
-                                }
-                            }
-                            WebView2ProcessToUserFolder.Remove(key);
-                        }
-                    }
-                    if (WebView2ProcessToUserFolder.Count > 0)
-                        Thread.Sleep(100); // Wait a bit before checking again
-                    if (++loopCount > 30)
-                    {
-                        // If we can't clean up the folders after 3 seconds, give up.
-                        // The developer machine took no more than 4 iterations in this loop,
-                        // so 30 should be plenty.
-                        Logger.WriteEvent("Timeout cleaning up WebView2 user folders.");
-                        break;
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                // If we can't delete the folders, we don't want to crash Bloom.
-                // This is not a critical operation, so just log the error and continue.
-                Logger.WriteError("Error cleaning up WebView2 user folders: ", e);
-            }
         }
 
         /// <summary>

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -1238,7 +1238,7 @@ namespace Bloom.Publish
                 {
                     if (_browser != null) // Don't use BrowserForPageChecks here...if we don't have one we don't want to make it now!
                     {
-                        if (ControlForInvoke != null)
+                        if (ControlForInvoke != null &&  ControlForInvoke.IsHandleCreated && !ControlForInvoke.IsDisposed)
                         {
                             // Seems safest of all to invoke using the thing we use for all other invokes.
                             // Also, seems our WebView2Browser may not actually get a handle, yet its

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -83,6 +83,16 @@ namespace Bloom.Publish
             _webSocketServer.SendEvent("publish", "switchOutOfPublishTab");
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _reactControl?.Dispose();
+                _publishEpubApi?.EpubMaker?.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
         private void Activate()
         {
             PublishHelper.InPublishTab = true;

--- a/src/BloomExe/WebView2Browser.Designer.cs
+++ b/src/BloomExe/WebView2Browser.Designer.cs
@@ -1,3 +1,4 @@
+using SIL.Windows.Forms.Miscellaneous;
 using System.IO;
 
 namespace Bloom
@@ -8,31 +9,6 @@ namespace Bloom
 		/// Required designer variable.
 		/// </summary>
 		private System.ComponentModel.IContainer components = null;
-
-		/// <summary> 
-		/// Clean up any resources being used.
-		/// </summary>
-		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-		protected override void Dispose(bool disposing)
-		{
-			var uprocId = _webview?.CoreWebView2?.BrowserProcessId;
-			var procId = uprocId.HasValue ? (int)uprocId.Value : 0;
-			var userFolder = _webview?.CoreWebView2?.Environment?.UserDataFolder;
-			if (disposing && (components != null))
-			{
-				components.Dispose();
-			}
-			else if (disposing && _webview != null)
-			{
-				_webview.Dispose();
-			}
-			if (disposing && procId > 0 && userFolder != null && Directory.Exists(userFolder))
-			{
-				// We need to wait until the process finishes to reliably delete the folder.
-				Program.WebView2ProcessToUserFolder.Add(procId, userFolder);
-			}
-			base.Dispose(disposing);
-		}
 
 		#region Component Designer generated code
 

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -762,6 +762,147 @@ namespace Bloom
                 return kWebView2NotInstalled;
             }
         }
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                int procId = 0;
+                string userFolder = null;
+                try
+                {
+                    var uprocId = _webview?.CoreWebView2?.BrowserProcessId;
+                    procId = uprocId.HasValue ? (int)uprocId.Value : 0;
+                    userFolder = _webview?.CoreWebView2?.Environment?.UserDataFolder;
+                }
+                catch
+                {
+                    // If we can't get the process id or user folder, just ignore it.
+                    // This can happen if the WebView2 control is not initialized.
+                }
+                if (components != null)
+                {
+                    components.Dispose();
+                }
+                else if (_webview != null)
+                {
+                    _webview.Dispose();
+                }
+                if (procId > 0 && userFolder != null && Directory.Exists(userFolder))
+                {
+                    // We need to wait until the process finishes to reliably delete the folder.
+                    // Unit tests can produce WebView2 processes that reuse the same id.  This
+                    // could conceivably happen in Bloom Desktop, so I've added code to handle it.
+                    // If needed, the prior user folder is stored so that we can delete it after
+                    // all of the processes have finished.
+                    if (WebView2ProcessToUserFolder.ContainsKey(procId))
+                    {
+                        var priorUserFolder = WebView2ProcessToUserFolder[procId];
+                        if (priorUserFolder != userFolder)
+                        {
+                            // Since we're not absolutely sure that folder names are unique, we
+                            // save the prior user folder so that we can safely delete it later
+                            // if needed.
+                            if (Directory.Exists(priorUserFolder))
+                                ObsoleteWebView2UserFolders.Add(priorUserFolder);
+                            WebView2ProcessToUserFolder[procId] = userFolder;
+                        }
+                    }
+                    else
+                    {
+                        WebView2ProcessToUserFolder.Add(procId, userFolder);
+                    }
+                }
+            }
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Mapping of WebView2 process IDs to their user folder paths.  We want to delete these user folders
+        /// because they don't contain anything we need to persist, and they can take up a lot of space.  New ones
+        /// are usually created, so they accumulate over time and can hold gigabytes of useless data.
+        /// </summary>
+        /// <remarks>
+        /// The WebView2 browser engines run in separate processes, and we have to wait until each process has
+        /// exited before we can reliably delete its user folder.
+        /// https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/user-data-folder?tabs=win32#deleting-user-data-folders
+        /// The WebView2Browser.Dispose method fills in this dictionary with the process ID and user folder path.
+        /// All of the browsers will have been disposed by the the application shutting down before the following
+        /// method is called.
+        /// </remarks>
+        private static readonly Dictionary<int, string> WebView2ProcessToUserFolder = new Dictionary<int, string>();
+        /// <summary>
+        /// Unit tests in particular can create WebView2 processes that reuse the same process IDs.  This set of
+        /// files are those that we had already recorded in the dictionary with the same process ID but which have
+        /// different names.  We want to delete these as well, since they are no longer needed.
+        /// </summary>
+        private static HashSet<string> ObsoleteWebView2UserFolders = new HashSet<string>();
+        public static void CleanupWebView2UserFolders()
+        {
+            try
+            {
+                int loopCount = 0;
+                while (WebView2ProcessToUserFolder.Count > 0)
+                {
+                    foreach (var key in WebView2ProcessToUserFolder.Keys.ToArray())
+                    {
+                        try
+                        {
+                            var process = Process.GetProcessById((int)key);
+                        }
+                        catch (ArgumentException)
+                        {
+                            // The process is no longer running, so we can delete the folder.
+                            var userFolder = WebView2ProcessToUserFolder[key];
+                            if (Directory.Exists(userFolder))
+                            {
+                                try
+                                {
+                                    RobustIO.DeleteDirectory(userFolder, true);
+                                }
+                                catch (Exception)
+                                {
+                                }
+                            }
+                            WebView2ProcessToUserFolder.Remove(key);
+                        }
+                    }
+                    if (WebView2ProcessToUserFolder.Count > 0)
+                        Thread.Sleep(100); // Wait a bit before checking again
+                    if (++loopCount > 30)
+                    {
+                        // If we can't clean up the folders after 3 seconds, give up.
+                        // The developer machine took no more than 4 iterations in this loop,
+                        // so 30 should be plenty.
+                        Logger.WriteEvent("Timeout cleaning up WebView2 user folders.");
+                        break;
+                    }
+                }
+                foreach (var userFolder in ObsoleteWebView2UserFolders)
+                {
+                    if (Directory.Exists(userFolder))
+                    {
+                        try
+                        {
+                            RobustIO.DeleteDirectory(userFolder, true);
+                        }
+                        catch (Exception)
+                        {
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                // If we can't delete the folders, we don't want to crash Bloom.
+                // This is not a critical operation, so just log the error and continue.
+                Logger.WriteError("Error cleaning up WebView2 user folders: ", e);
+            }
+        }
     }
 
     class WebViewItemAdder : IMenuItemAdder


### PR DESCRIPTION
This can be needed for unit tests in some environments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7254)
<!-- Reviewable:end -->
