### PR TITLE
Simplify simpleComprehensionQuiz.ts and its handling (BL-14565)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -3645,16 +3645,7 @@ namespace Bloom.Book
             foreach (SafeXmlElement scriptElt in newPageDiv.SafeSelectNodes(".//script[@src]"))
             {
                 var fileName = scriptElt.GetAttribute("src");
-
-                // TODO BL-14565: this is probably out of date; any such file should be part of Bloom Player shared code.
-
-                // Bloom Desktop accesses simpleComprehensionQuiz.js from the output/browser folder.
-                // Bloom Reader uses the copy of that file which comes with bloom-player.
-                // See https://issues.bloomlibrary.org/youtrack/issue/BL-8480.
-                if (
-                    string.IsNullOrEmpty(fileName)
-                    || fileName == PublishHelper.kSimpleComprehensionQuizJs
-                )
+                if (string.IsNullOrEmpty(fileName))
                     continue;
                 var destinationPath = Path.Combine(FolderPath, fileName);
                 // In other similar operations above we don't overwrite an existing file (e.g., images, css).
@@ -3673,6 +3664,9 @@ namespace Bloom.Book
                 // Don't try to copy a file over itself.  (See https://issues.bloomlibrary.org/youtrack/issue/BL-7349.)
                 if (sourcePath == destinationPath)
                     continue;
+                // Bloom Desktop accesses simpleComprehensionQuiz.js (which contains only the editing code for
+                // comprehension quiz pages) from the output/browser folder, so it doesn't exist in either the
+                // template's folder or the book's folder.  (BL-14565)
                 if (RobustFile.Exists(sourcePath))
                     RobustFile.Copy(sourcePath, destinationPath, true);
             }

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -1118,20 +1118,14 @@ namespace Bloom.Api
                 path = info.LocalPathWithoutQuery.Substring(kBloomPrefix.Length);
             }
 
-            // TODO BL-14565: this is clearly out of date but also something of mystery so I'm not sure how to clean it up
-            // We no longer copy this file to the book folder.  For Bloom Desktop, we get it from browser/templates/...
-            // For Bloom Reader, bloom-player has its own copy.
-            if (
-                !RobustFileExistsWithCaseCheck(path)
-                && Path.GetFileName(path) == PublishHelper.kSimpleComprehensionQuizJs
-            )
+            if (!RobustFileExistsWithCaseCheck(path))
             {
-                // TODO: this is probably out of date; any such file should be part of Bloom Player shared code.
-                path = Path.Combine(
-                    BloomFileLocator.FactoryTemplateBookDirectory,
-                    "Activity",
-                    PublishHelper.kSimpleComprehensionQuizJs
-                );
+                // simpleComprehensionQuiz.js contains only the editing code for comprehension quizzes.
+                // It is stored in the output/browser folder, not in the book's folder.  The HTML implies
+                // that the file is in the book's folder, so we need to redirect here.  (BL-14565)
+                // I don't think there's a need to doublecheck the filename itself at this point.
+                var filename = Path.GetFileName(path); ;
+                path = BloomFileLocator.GetBrowserFile(true, filename);
             }
             if (!RobustFileExistsWithCaseCheck(path))
             {

--- a/src/BloomTests/Publish/BloomReaderPublishTests.cs
+++ b/src/BloomTests/Publish/BloomReaderPublishTests.cs
@@ -902,23 +902,11 @@ namespace BloomTests.Publish
 </body>
 </html>";
 
-        private void NewQuizTestActionsOnFolderBeforeCompressing(string bookFolderPath)
-        {
-            // This file gets placed in the real book's folder after adding a quiz in edit mode, so we mock that process.
-            // But the code which puts an epub into a real browser to determine visibility of elements will actually
-            // try to run this, so it needs to be something which won't throw a javascript error.
-            RobustFile.WriteAllText(
-                Path.Combine(bookFolderPath, PublishHelper.kSimpleComprehensionQuizJs),
-                "//not the real file's contents"
-            );
-        }
-
         [Test]
         public void CompressBookForDevice_BloomEnterprise_ConvertsNewQuizPagesToJson_AndKeepsThem()
         {
             TestHtmlAfterCompression(
                 kNewQuizPageTestsHtml,
-                actionsOnFolderBeforeCompressing: NewQuizTestActionsOnFolderBeforeCompressing,
                 assertionsOnResultingHtmlString: html =>
                 {
                     // The quiz pages should not be removed.
@@ -939,7 +927,7 @@ namespace BloomTests.Publish
                 assertionsOnZipArchive: paramObj =>
                 {
                     var zip = paramObj.ZipFile;
-                    Assert.AreNotEqual(
+                    Assert.AreEqual(
                         -1,
                         zip.FindEntry(PublishHelper.kSimpleComprehensionQuizJs, false)
                     );

--- a/src/content/templates/template books/Activity/simpleComprehensionQuiz.ts
+++ b/src/content/templates/template books/Activity/simpleComprehensionQuiz.ts
@@ -1,34 +1,15 @@
 // Note to future selves: In looking at BL-10037, Andrew and Gordon looked for some time to see how
 // this file might be loaded by bloom-player. It isn't. The somewhat slimmed down file
 // ".\src\activities\domActivities\SimpleCheckboxQuiz.ts" is included instead. In fact the solution
-// for BL-10037 turned out to be an oversimplification of this code in that version.
+// for BL-10037 turned out to be fixing an oversimplification of the original player code in that version.
+// Since that file is used in the player, this file has been modified to handle only editing. (BL-14565)
 
-// The js generated from this file is used in the template page generated from simpleComprehensionQuiz.pug.
+// The js generated from this file is used in editing template pages generated from simpleComprehensionQuiz.pug.
 // It makes sure the body element has the editMode class (if the editMode stylesheet is loaded)
-// and installs appropriate click handlers (depending on edit mode) which manipulate the classes
-// of .checkbox-and-textbox-choice elements to produce the desired checking and dimming of right
-// and wrong answers. It also adds an appropriate class to answers that are empty (to hide them or
-// dim them) and plays appropriate sounds when a right or wrong answer is chosen.
-// Eventually it will cooperate with reader code to handle analytics.
-// The output is also part of the bloom-player, which creates instances of the new simpleComprehensionQuiz
-// pages dynamically in order to handle old-style comprehension questions represented as json,
-// and needs the associated JS to make them work.
+// and installs click handlers which manipulate the classes of .checkbox-and-textbox-choice elements
+// to produce the desired checking of right and wrong answers.
 
-// Master function, called when document is ready, initializes CQ pages
-function init(): void {
-    ensureEditModeStyleSheet();
-    initChoiceWidgets();
-}
-
-//------------ Code involved in setting the editMode class on the body element when appropriate-----
-function ensureEditModeStyleSheet(): void {
-    if (!inEditMode()) {
-        return;
-    }
-    // with future Bloom versions, this might already be there,
-    // but it doesn't matter if it is.
-    document.body.classList.add("editMode");
-}
+//------------ Code for editing the choice widgets -------
 
 function inEditMode(): boolean {
     for (let i = 0; i < document.styleSheets.length; i++) {
@@ -40,12 +21,15 @@ function inEditMode(): boolean {
     return false;
 }
 
-//------------ Code for managing the choice widgets-------
-
 // Initialize the choice widgets, arranging for the appropriate click actions
 // and for maintaining the class that indicates empty choice.
-// Assumes the code that sets up the editMode class on the body element if appropriate has already been run.
 function initChoiceWidgets(): void {
+    // Double-check that we are in edit mode before setting up for editing.
+    if (!inEditMode()) {
+        return;
+    }
+    // This is needed for CSS to work properly while editing.
+    document.body.classList.add("editMode");
     // The value we store to indicate that at some point the user
     // chose this answer. We don't really need the value, because if the key for
     // that answer has a value, it will be this. But may as well
@@ -61,36 +45,11 @@ function initChoiceWidgets(): void {
         const x = list[i] as HTMLElement;
         const checkbox = getCheckBox(x);
         const correct = x.classList.contains("correct-answer");
-        if (document.body.classList.contains("editMode")) {
-            checkbox.addEventListener("click", handleEditModeClick);
-            // Not sure why this doesn't get persisted along with the correct-answer class,
-            // but glad it doesn't, because we don't want it to show up even as a flash
-            // in reader mode.
-            checkbox.checked = correct;
-        } else {
-            // There are likely to be several copies of this code, one for each quiz page, each doing this.
-            // But we only need to do it once per element. In particular, we don't want multiple handlers
-            // trying to play the same sound on each click. They can get out of sync and make a horrible noise.
-            // But we only want to do it in read mode or it will get persisted and event handlers won't get set
-            // up next time. See BL-7532.
-            if (x.hasAttribute("data-simpleQuizInitComplete")) {
-                continue;
-            }
-            x.setAttribute("data-simpleQuizInitComplete", "true");
-            x.addEventListener("click", handleReadModeClick, { capture: true });
-            const key = getStorageKeyForChoice(x! as HTMLElement);
-            if (
-                (window as any).BloomPlayer &&
-                (window as any).BloomPlayer.getPageData(
-                    x.closest(".bloom-page"),
-                    key
-                ) === kwasSelectedAtOnePoint
-            ) {
-                choiceWasClicked(x! as HTMLElement);
-            } else {
-                checkbox.checked = false; // just to make sure
-            }
-        }
+        checkbox.addEventListener("click", handleEditModeClick);
+        // Not sure why this doesn't get persisted along with the correct-answer class,
+        // but glad it doesn't, because we don't want it to show up even as a flash
+        // in reader mode.
+        checkbox.checked = correct;
     }
 }
 
@@ -109,112 +68,6 @@ function handleEditModeClick(evt: Event): void {
     } else {
         wrapper!.classList.remove("correct-answer");
     }
-}
-
-// Get a key for a checkbox. It only needs to be unique on this page.
-// Enhance: If a new version of the book is downloaded with a different
-// set of choices on this page, this sort of positional ID could select
-// the wrong one. To fix this, we could make something generate a persistent
-// id for a choice; but the author could still edit the text of the choice,
-// making the stored choice invalid. Better: find a way to clear the relevant
-// storage when downloading a new version of a book.
-function getStorageKeyForChoice(choice: HTMLElement): string {
-    const page = choice.closest(".bloom-page") as HTMLElement;
-
-    // what is my index among the other choices on the page
-    const choices = Array.from(
-        page.getElementsByClassName("checkbox-and-textbox-choice")
-    );
-    const index = choices.indexOf(choice);
-    const id = page.getAttribute("id");
-    return "cbstate_" + index;
-}
-
-function handleReadModeClick(evt: Event): void {
-    // (See declaration inside initChoiceWidgets().)
-    const kwasSelectedAtOnePoint = "wasSelectedAtOnePoint";
-    // prevent the browser messing with the check box checked state
-    evt.stopPropagation();
-    evt.preventDefault();
-    const currentTarget = evt.currentTarget as HTMLElement;
-    choiceWasClicked(currentTarget);
-    const correct = currentTarget.classList.contains("correct-answer");
-    const soundUrl = correct ? "right_answer.mp3" : "wrong_answer.mp3";
-    playSound(soundUrl);
-    // The ui shows items that were (selected but wrong) differently than
-    // items that were never tried.
-    const key = getStorageKeyForChoice(currentTarget);
-    if ((window as any).BloomPlayer) {
-        (window as any).BloomPlayer.storePageData(
-            currentTarget.closest(".bloom-page"),
-            key,
-            kwasSelectedAtOnePoint
-        );
-    }
-
-    reportScore(correct);
-}
-
-// it was either clicked just now, or we're loading from storage
-// and we need to make it look like it looked last time we were on this
-// page
-function choiceWasClicked(choice: HTMLElement): void {
-    // (See declaration inside initChoiceWidgets().)
-    const kwasSelectedAtOnePoint = "wasSelectedAtOnePoint";
-    const classes = choice.classList;
-    classes.add(kwasSelectedAtOnePoint);
-    // Make the state of the hidden input conform. Only if the
-    // correct answer was clicked does the checkbox get checked.
-    const checkBox = getCheckBox(choice);
-    // at this point, we only actually make the check happen if
-    // this was the correct answer
-    if (checkBox) {
-        const desiredState = classes.contains("correct-answer");
-        checkBox.checked = desiredState;
-        // Something I can't track down resets it to unchecked
-        // if the user clicks on the input itself. Even with zero delay,
-        // this makes something happen in the next event cycle that
-        // keeps it the way we want.
-        window.setTimeout(() => (checkBox.checked = desiredState), 0);
-    }
-}
-
-function reportScore(correct: boolean): void {
-    // Send the score and info for analytics.
-    // Note: the Bloom Player is smart enough to only
-    // record the analytics part the very first time we report a score for this page,
-    // and only send it when it has been reported for all pages using the same
-    // analyticsCategory as this page.
-    // Note, it is up to the host of BloomPlayer whether it actually is sending the analytics to some server.
-    if ((window as any).BloomPlayer) {
-        (window as any).BloomPlayer.reportScoreForCurrentPage(
-            1, // possible score on page
-            correct ? 1 : 0, // actual score
-            "comprehension"
-        );
-    }
-}
-
-function playSound(url: string): void {
-    const player = getPagePlayer();
-    player.setAttribute("src", url);
-    player.play();
-}
-
-function getPagePlayer(): HTMLAudioElement {
-    let player: HTMLAudioElement | null = document.querySelector(
-        "#quiz-sound-player"
-    ) as HTMLAudioElement;
-    if (player && !player.play) {
-        player.remove();
-        player = null;
-    }
-    if (!player) {
-        player = document.createElement("audio");
-        player.setAttribute("id", "#quiz-sound-player");
-        document.body.appendChild(player);
-    }
-    return player;
 }
 
 function markEmptyChoices(): void {
@@ -242,11 +95,11 @@ function hasVisibleContent(choice: Element): boolean {
 
 //-------------- initialize -------------
 
-// In some cases (loading into a bloom reader carousel, for example) the page may already be loaded.
+// In some cases, the page may already be loaded.
 if (document.readyState === "complete") {
-    init();
+    initChoiceWidgets();
 } else {
     window.addEventListener("load", () => {
-        init();
+        initChoiceWidgets();
     });
 }

--- a/src/content/templates/template books/Activity/tsconfig.json
+++ b/src/content/templates/template books/Activity/tsconfig.json
@@ -51,7 +51,7 @@
         // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
         // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
         // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-        "outDir": "../../../../../output/browser/templates/template books/Activity" /* Specify an output folder for all emitted files. */,
+        "outDir": "../../../../../output/browser" /* Specify an output folder for all emitted files. */,
         // "removeComments": true,                           /* Disable emitting comments. */
         // "noEmit": true,                                   /* Disable emitting files from a compilation. */
         // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
This file now only has code for editing quiz pages, and the javascript generated from it is stored in the top level output/browser folder instead of the template folder.