### PR TITLE
Enable language control when text box goes back to "Normal" (BL-14011)

### DIFF
--- a/src/BloomExe/Book/TranslationGroupManager.cs
+++ b/src/BloomExe/Book/TranslationGroupManager.cs
@@ -368,7 +368,7 @@ namespace Bloom.Book
                 var defLangs = g.GetAttribute("data-default-languages");
 
                 // missing attribute or empty is treated as "auto", and this menu definitely affects those.
-                if (string.IsNullOrEmpty(defLangs) || defLangs.StartsWith("auto"))
+                if (string.IsNullOrEmpty(defLangs) || defLangs.ToLowerInvariant().StartsWith("auto"))
                     return true;
 
                 var visVariable = g.GetAttribute("data-visibility-variable");


### PR DESCRIPTION
The language control is also enabled when the text box is set to "V" for the language.  This is by design.