### PR TITLE
Skip over game pages for spreadsheet export (BL-15055)

### DIFF
--- a/DistFiles/localization/en/BloomLowPriority.xlf
+++ b/DistFiles/localization/en/BloomLowPriority.xlf
@@ -207,6 +207,11 @@
         <source xml:lang="en">Bloom had problems writing files to that location ({0}). Check that you have permission to write there.</source>
         <note>ID: Spreadsheet.WriteFailed</note>
       </trans-unit>
+      <trans-unit id="Spreadsheet.CannotExportDragAndDropGamePages">
+        <source xml:lang="en">Bloom cannot export because {0} pages contain drag-and-drop games.</source>
+        <note>ID: Spreadsheet.CannotExportDragAndDropGamePages</note>
+        <note>{0} is a placeholder for the number of pages</note>
+      </trans-unit>
       <trans-unit id="Activity.Editing.MultipleChoice.CorrectAnswer">
         <source xml:lang="en">Put the correct answer in this button. Bloom will randomize the order later.</source>
       </trans-unit>

--- a/src/content/templates/template books/Activity/simple-dom-choice-activities.pug
+++ b/src/content/templates/template books/Activity/simple-dom-choice-activities.pug
@@ -14,7 +14,7 @@ mixin correctAnswerBubble
 	label.bubble(data-i18n="SimpleChoiceActivity.CorrectAnswerIndicator") Put the correct answer in this button. Bloom will shuffle the order later.
 
 mixin chooseWordFromPicture
-	+page("Choose Word from Image").bloom-ignoreForReaderStats.bloom-interactive-page.numberedPage#3325A8B6-EA15-4FB7-9F8D-271D7B3C8D33(data-page='extra' data-feature='game' data-analyticscategories="simple-dom-choice" data-activity="simple-dom-choice" data-tool-id="game")
+	+page("Choose Word from Image").bloom-ignoreForReaderStats.bloom-interactive-page.numberedPage.game-theme-blue-on-white#3325A8B6-EA15-4FB7-9F8D-271D7B3C8D33(data-page='extra' data-feature='game' data-analyticscategories="simple-dom-choice" data-activity="simple-dom-choice" data-tool-id="game")
 		+field-withEnglishText("L1").Prompt-style.disableHighlight
 			| Choose the matching word
 		.imageThenChoices
@@ -27,7 +27,7 @@ mixin chooseWordFromPicture
 					+textButtonChoice(data-activityRole="wrong-answer")
 
 mixin choosePictureFromWord
-	+page("Choose Image from Word").bloom-ignoreForReaderStats.bloom-interactive-page.numberedPage#fe7acd9d-c05c-449b-9f99-841d54856924(data-page='extra'  data-feature='game' data-analyticscategories="simple-dom-choice" data-activity="simple-dom-choice" data-tool-id="game")
+	+page("Choose Image from Word").bloom-ignoreForReaderStats.bloom-interactive-page.numberedPage.game-theme-blue-on-white#fe7acd9d-c05c-449b-9f99-841d54856924(data-page='extra'  data-feature='game' data-analyticscategories="simple-dom-choice" data-activity="simple-dom-choice" data-tool-id="game")
 		+field-withEnglishText("L1").Prompt-style.disableHighlight
 			| Choose the matching picture
 		.wordThenChoices


### PR DESCRIPTION
Simple comprehensions quizzes and simple dom choice games export and import okay: the other games, not so much.  Warning the user that these pages are being skipped is better than unintelligible error messages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7291)
<!-- Reviewable:end -->
