### PR TITLE
Remove WebView2 folders after command line operations (BL-15091)

### DIFF
--- a/src/BloomExe/CLI/CreateArtifactsCommand.cs
+++ b/src/BloomExe/CLI/CreateArtifactsCommand.cs
@@ -378,21 +378,23 @@ namespace Bloom.CLI
 
             BookServer bookServer = s_projectContext.BookServer;
             BookThumbNailer thumbNailer = s_projectContext.ThumbNailer;
-            var maker = new EpubMaker(thumbNailer, bookServer);
-            maker.ControlForInvoke = control;
+            using (var maker = new EpubMaker(thumbNailer, bookServer))
+            {
+                maker.ControlForInvoke = control;
 
-            maker.Book = s_book;
-            // This is the previous default, but probably we should make it configurable, and possibly change the default.
-            // Note that it will end up Fixed if the presence of canvas elements requires it.
-            maker.Unpaginated = true;
-            // and if it has explicitly been set to fixed, make it that way.
-            if (s_book.BookInfo?.PublishSettings?.Epub?.Mode == "fixed")
-                maker.Unpaginated = false;
-            maker.OneAudioPerPage = true; // default used in EpubApi
-            // Enhance: maybe we want book to have image descriptions on page? use reader font sizes?
+                maker.Book = s_book;
+                // This is the previous default, but probably we should make it configurable, and possibly change the default.
+                // Note that it will end up Fixed if the presence of canvas elements requires it.
+                maker.Unpaginated = true;
+                // and if it has explicitly been set to fixed, make it that way.
+                if (s_book.BookInfo?.PublishSettings?.Epub?.Mode == "fixed")
+                    maker.Unpaginated = false;
+                maker.OneAudioPerPage = true; // default used in EpubApi
+                                              // Enhance: maybe we want book to have image descriptions on page? use reader font sizes?
 
-            // Make the epub
-            maker.SaveEpub(parameters.EpubOutputPath, new NullWebSocketProgress());
+                // Make the epub
+                maker.SaveEpub(parameters.EpubOutputPath, new NullWebSocketProgress());
+            }
         }
 
         public static void CreateThumbnailArtifact(CreateArtifactsParameters parameters)

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -242,6 +242,7 @@ namespace Bloom
                 {
                     Application.DoEvents();
                 }
+                WebView2Browser.CleanupWebView2UserFolders();
                 return mainTask.Result; // we're done; this is safe once there is nothing being awaited.
             }
 


### PR DESCRIPTION
This affects bloom-harvester operations, so it targets 6.2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7299)
<!-- Reviewable:end -->
