### PR TITLE
More fixes related to cropping cover images (BL-15063)

### DIFF
--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -27,6 +27,7 @@ using Bloom.ToPalaso;
 using SIL.CommandLineProcessing;
 using SIL.Windows.Forms.ClearShare;
 using Bloom.ErrorReporter;
+using FFMpegCore.Builders.MetaData;
 using L10NSharp;
 
 namespace Bloom.ImageProcessing
@@ -1434,6 +1435,10 @@ namespace Bloom.ImageProcessing
             {
                 LogGraphicsMagickFailure(result);
             }
+
+            var metadata = RobustFileIO.MetadataFromFile(sourcePath);
+            if (metadata != null && metadata.ExceptionCaughtWhileLoading == null)
+                metadata.Write(destPath);
 
             return result;
         }

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -1246,7 +1246,14 @@ namespace Bloom.Publish
                 return 0;
             var number = part.Trim().Substring(label.Length + 1);
             number = number.Substring(0, number.Length - 2); // remove "px"
-            if (double.TryParse(number, out double result))
+            if (
+                double.TryParse(
+                    number,
+                    System.Globalization.NumberStyles.Any,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out double result
+                )
+            )
                 return result;
             return 0;
         }
@@ -1263,7 +1270,11 @@ namespace Bloom.Publish
                 {
                     if (_browser != null) // Don't use BrowserForPageChecks here...if we don't have one we don't want to make it now!
                     {
-                        if (ControlForInvoke != null &&  ControlForInvoke.IsHandleCreated && !ControlForInvoke.IsDisposed)
+                        if (
+                            ControlForInvoke != null
+                            && ControlForInvoke.IsHandleCreated
+                            && !ControlForInvoke.IsDisposed
+                        )
                         {
                             // Seems safest of all to invoke using the thing we use for all other invokes.
                             // Also, seems our WebView2Browser may not actually get a handle, yet its


### PR DESCRIPTION
- crop when making an image for the Upload dialog
- include metadata in cropped images
- Fix an unrelated problem parsing HTML pixel sizes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7301)
<!-- Reviewable:end -->
