### PR TITLE
Temporary patch for unsupported full bleed page sizes (BL-14442)

### DIFF
--- a/src/content/bookLayout/pageBoxesSizing.less
+++ b/src/content/bookLayout/pageBoxesSizing.less
@@ -78,6 +78,10 @@
     // (practically?) impossible to adjust page sizes as exactly.
     page-break-after: always;
     overflow: hidden; // when the page is scaled, stuff in the longer dimension will actually exceed the bleed area. We want to clip that.
+    // This is not perfect. The box ends up being the size it would want to be if the content were not scaled.
+    // The page-size specific rules below do better. A real solution for all page sizes is in 6.3.
+    // But this looks better than what 6.2 produecs without it for unsupported page sizes.
+    width: fit-content;
 
     &.A5Portrait {
         width: @RA5Portrait-Width;


### PR DESCRIPTION
Should be null-merged, if we take the full fix for 6.3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7305)
<!-- Reviewable:end -->
