### PR TITLE
Fix reallyCropImage to handle duplicate names and spaces (BL-15121)

### DIFF
--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -1170,28 +1170,94 @@ namespace Bloom.Publish
         )
         {
             var images = bookDom.SafeSelectNodes("//img").Cast<SafeXmlElement>().ToArray();
+            var uncropped = new HashSet<string>();
+            // key is a combination of src, style, and canvas element style height and width that determines
+            // the name of an image file that should be used for this combination, which is the value.
+            var cropped = new Dictionary<string, string>();
             foreach (var img in images)
             {
-                ReallyCropImage(img, imageSourceFolder, imageDestFolder);
+                var src = img.GetAttribute("src");
+                var style = img.GetAttribute("style");
+                if (!SignifiesCropping(style))
+                {
+                    uncropped.Add(src);
+                }
+            }
+
+            foreach (var img in images)
+            {
+                var src = img.GetAttribute("src");
+                var style = img.GetAttribute("style");
+                var imgContainer = img.ParentNode as SafeXmlElement;
+                var canvasElement = imgContainer?.ParentNode as SafeXmlElement;
+                var canvasElementStyle = canvasElement?.GetAttribute("style");
+                if (!SignifiesCropping(style) || canvasElementStyle == null)
+                    continue;
+                var canvasElementWidth = GetNumberFromPx("width", canvasElementStyle);
+                var canvasElementHeight = GetNumberFromPx("height", canvasElementStyle);
+
+                var key = $"{src}|{style}|{canvasElementWidth}|{canvasElementHeight}";
+                if (cropped.TryGetValue(key, out string fileName))
+                {
+                    // This is a duplicate. We can use the same cropped image file.
+                    img.SetAttribute("src", fileName);
+                    continue;
+                }
+
+                var croppedFileName = ReallyCropImage(
+                    img,
+                    imageSourceFolder,
+                    imageDestFolder,
+                    uncropped.Contains(src)
+                );
+                cropped[key] = croppedFileName;
             }
         }
 
-        private static void ReallyCropImage(
+        private static bool SignifiesCropping(string imgStyle)
+        {
+            if (string.IsNullOrEmpty(imgStyle))
+                return false;
+            var width = GetNumberFromPx("width", imgStyle);
+            return width > 0;
+        }
+
+        private static string ReallyCropImage(
             SafeXmlElement img,
             string imageSourceFolder,
-            string imageDestFolder
+            string imageDestFolder,
+            bool useNewName
         )
         {
             var croppedImagePath = MakeCroppedImage(img, imageSourceFolder, imageDestFolder);
+            var src = img.GetAttribute("src");
+            // a good default if we can't produce a cropped image for any reason.
+            // (The tests in MakeCroppedImage are a bit more robus than the ones we do before
+            // deciding to call this method.)
+            var result = src;
+            // We don't need the path here, but this function may correct 'src' (e.g.,
+            // removing some url encoding to find the actual file). And if we're not
+            // using a new name, we want to exactly overwrite the original image file.
+            UrlPathString.GetFullyDecodedPath(imageSourceFolder, ref src);
             if (croppedImagePath != null)
             {
-                var src = img.GetAttribute("src");
-                var destPath = Path.Combine(imageDestFolder, src);
-                RobustFile.Move(croppedImagePath, destPath, true);
-                // If it failed, it should have already logged the reason. I think all we can do
-                // is leave the image alone.
+                if (useNewName)
+                {
+                    // All images with this name and crop should use this
+                    result = Path.GetFileName(croppedImagePath);
+                    // Including the current image
+                    img.SetAttribute("src", result);
+                }
+                else
+                {
+                    var destPath = Path.Combine(imageDestFolder, src);
+                    RobustFile.Move(croppedImagePath, destPath, true);
+                    // If it failed, it should have already logged the reason. I think all we can do
+                    // is leave the image alone.
+                }
             }
-            img.RemoveAttribute("style");
+            img.RemoveAttribute("style"); // so nothing can possibly think it needs more cropping
+            return result;
         }
 
         /// <summary>
@@ -1602,12 +1668,19 @@ namespace Bloom.Publish
         }
 
         public static string ProblemFontsPath;
-        private static void ReportProblemFontsForHarvesterMode(HashSet<string> invalidFonts, HashSet<string> illegalFonts, HashSet<string> missingFonts)
+
+        private static void ReportProblemFontsForHarvesterMode(
+            HashSet<string> invalidFonts,
+            HashSet<string> illegalFonts,
+            HashSet<string> missingFonts
+        )
         {
             // If we are running in harvester mode, we want to report the fonts that are not suitable for publication.
             // This is so that the harvester can report them to the user, and won't upload the artifacts.
-            if (Program.RunningHarvesterMode &&
-                (invalidFonts.Count > 0 || illegalFonts.Count > 0 || missingFonts.Count > 0))
+            if (
+                Program.RunningHarvesterMode
+                && (invalidFonts.Count > 0 || illegalFonts.Count > 0 || missingFonts.Count > 0)
+            )
             {
                 var bldr = new StringBuilder();
                 foreach (var fontName in invalidFonts)
@@ -1636,10 +1709,10 @@ namespace Bloom.Publish
             if (Program.RunningHarvesterMode && !FontsApi.AvailableFontMetadata.Any())
             {
                 var fontNames = new List<string>
-                    {
-                        DefaultFont, // Ensure that Andika's metadata is always available.
-                        "ABeeZee"    // Another font distributed with Bloom
-                    };
+                {
+                    DefaultFont, // Ensure that Andika's metadata is always available.
+                    "ABeeZee" // Another font distributed with Bloom
+                };
                 foreach (var font in fontsWanted)
                 {
                     if (!fontNames.Contains(font.fontFamily))

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -1170,7 +1170,10 @@ namespace Bloom.Publish
         )
         {
             var images = bookDom.SafeSelectNodes("//img").Cast<SafeXmlElement>().ToArray();
-            var uncropped = new HashSet<string>();
+            // src values that occur in uncropped images. Note, it is NOT the case that an img whose src
+            // is in this set never cropped; it just means that at least one occurrence of it is not
+            // cropped, which makes the image name unavailable to use for a cropped image.
+            var uncroppedSrcNames = new HashSet<string>();
             // key is a combination of src, style, and canvas element style height and width that determines
             // the name of an image file that should be used for this combination, which is the value.
             var cropped = new Dictionary<string, string>();
@@ -1180,7 +1183,7 @@ namespace Bloom.Publish
                 var style = img.GetAttribute("style");
                 if (!SignifiesCropping(style))
                 {
-                    uncropped.Add(src);
+                    uncroppedSrcNames.Add(src);
                 }
             }
 
@@ -1208,7 +1211,7 @@ namespace Bloom.Publish
                     img,
                     imageSourceFolder,
                     imageDestFolder,
-                    uncropped.Contains(src)
+                    uncroppedSrcNames.Contains(src)
                 );
                 cropped[key] = croppedFileName;
             }
@@ -1233,7 +1236,9 @@ namespace Bloom.Publish
             var src = img.GetAttribute("src");
             // a good default if we can't produce a cropped image for any reason.
             // (The tests in MakeCroppedImage are a bit more robus than the ones we do before
-            // deciding to call this method.)
+            // deciding to call this method.) Capture this before we unencode, since it wants
+            // to be a value we can put in a src attribute (if it doesn't get changed)
+            // to lead to the file we may put at an unchanged file name.
             var result = src;
             // We don't need the path here, but this function may correct 'src' (e.g.,
             // removing some url encoding to find the actual file). And if we're not
@@ -1243,6 +1248,12 @@ namespace Bloom.Publish
             {
                 if (useNewName)
                 {
+                    // It's tempting to try to come up with a name based on the original image name,
+                    // but it's quite tricky (with arbitrary characters possibly in the name)
+                    // to be sure that the value we put in the src will actually lead the browser to
+                    // the right file. I decided to just stick with the guid that MakeCroppedImage
+                    // produces, which contains no characters that need to be encoded.
+
                     // All images with this name and crop should use this
                     result = Path.GetFileName(croppedImagePath);
                     // Including the current image

--- a/src/BloomTests/Publish/PublishHelperTests.cs
+++ b/src/BloomTests/Publish/PublishHelperTests.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Bloom;
+using Bloom.Book;
 using Bloom.Publish;
 using Bloom.SafeXml;
 using Bloom.SubscriptionAndFeatures;
 using NUnit.Framework;
+using SIL.IO;
 using SIL.TestUtilities;
 
 namespace BloomTests.Publish
@@ -1160,6 +1163,310 @@ namespace BloomTests.Publish
                     //@"The feature ""Background Audio"" was removed from this book because it requires a higher subscription tier"
                     @"The feature ""PublishTab.Feature.Music"" was removed from this book because it requires a higher subscription tier"
                 )
+            );
+        }
+    }
+
+    [TestFixture]
+    public class ReallyCropImagesTests
+    {
+        private HtmlDom _dom;
+        private TemporaryFolder _folder;
+        private SafeXmlElement _p1bgi1;
+        private SafeXmlElement _p1i1c1;
+        private SafeXmlElement _p2i1c1;
+        private SafeXmlElement _p2i1c2;
+        private SafeXmlElement _p2i1c3;
+        private SafeXmlElement _p2i1a;
+        private SafeXmlElement _p2i1b;
+        private SafeXmlElement _p2i2a;
+        private SafeXmlElement _p1i2c4;
+        private SafeXmlElement _p1i3c5;
+        private SafeXmlElement _p2i3c5;
+        private byte[] _manPngBytes;
+        private byte[] _manJpgBytes;
+        private byte[] _lady24bPngBytes;
+        private byte[] _p1i1c1Bytes;
+        private byte[] _p2i1c2Bytes;
+        private byte[] _p2i1c3Bytes;
+        private byte[] _p1i2c4Bytes;
+        private byte[] _p1i3c54Bytes;
+
+        public static string MakeImageCanvasElement(
+            string imgId,
+            string src,
+            string ceStyle,
+            string imgStyle = null,
+            bool background = false
+        )
+        {
+            var backgroundString = background ? " bloom-backgroundImage" : "";
+            var imgStyleString = imgStyle == null ? "" : $"style=\"{imgStyle}\"";
+            return $"<div class=\"bloom-canvas-element{backgroundString}\" style=\"{ceStyle}\" data-bubble=\"{{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:4,`backgroundColors`:[`transparent`],`shadowOffset`:0}}\">"
+                + $"  <div tabindex=\"0\" class=\"bloom-imageContainer bloom-leadingElement\">"
+                + $"      <img id=\"{imgId}\" src=\"{src}\" {imgStyleString} />"
+                + $"  </div>"
+                + $"</div>";
+        }
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            _folder = new TemporaryFolder("ReallyCropImagesTests");
+            // much simplified dom, but enough for this.
+            // We want: three uncropped images on two pages with the same name, all uncropped. Should remain the same names and file.
+            // Two more images using the same filename, both cropped the same, on two pages, should get cropped once to a new name.
+            // More versions of this image on two pages all cropped differently. Should get distinct names.
+            // Two images using the same file name, where the first one is cropped, should result in the
+            // uncropped one keeping the name, and the cropped one getting a new name.
+            // Two images using another file name, all cropped the same, should keep name but change file content.
+            _dom = new HtmlDom(
+                @"
+<html><head></head><body>
+    <div class=""bloom-page"" id=""page1"">
+        <div class=""marginBox"" id=""image1"">
+            <div class=""bloom-canvas"">"
+                    + MakeImageCanvasElement(
+                        "p1bgi1",
+                        "man.png",
+                        "height: 378.826px; left: 325px; top: 6px; width: 140px;",
+                        null,
+                        true
+                    )
+                    + MakeImageCanvasElement(
+                        "p1i1c1",
+                        "man.png",
+                        "height: 378.826px; left: 325px; top: 6px; width: 140px;",
+                        "width: 280px; left: -80px; top: -20px"
+                    )
+                    + MakeImageCanvasElement(
+                        "p1i2c4",
+                        "lady24b.png",
+                        "height: 378.826px; left: 325px; top: 6px; width: 140px;",
+                        "width: 280px; left: -80px; top: -20px"
+                    )
+                    + MakeImageCanvasElement(
+                        "p1i3c5",
+                        "man%203.jpg",
+                        "height: 378.826px; left: 325px; top: 6px; width: 140px;",
+                        "width: 280px; left: -80px; top: -20px"
+                    )
+                    + @"
+            </div>
+        </div>
+    </div>
+    <div class=""bloom-page"" id=""page2"">
+        <div class=""marginBox"" id=""image1"">
+            <div class=""bloom-canvas"">"
+                    + MakeImageCanvasElement(
+                        "p2i1a",
+                        "man.png",
+                        "height: 350px; left: 300px; top: 6px; width: 140px;"
+                    )
+                    + MakeImageCanvasElement(
+                        "p2i1b",
+                        "man.png",
+                        "height: 350px; left: 20px; top: 6px; width: 140px;"
+                    )
+                    // same image and crop as p1i1c1, should use same cropped file
+                    + MakeImageCanvasElement(
+                        "p2i1c1",
+                        "man.png",
+                        "height: 378.826px; left: 325px; top: 6px; width: 140px;",
+                        "width: 280px; left: -80px; top: -20px",
+                        true
+                    )
+                    // same image p1i1c1, but a different img style, so should get a different cropped file
+                    + MakeImageCanvasElement(
+                        "p2i1c2",
+                        "man.png",
+                        "height: 378.826px; left: 325px; top: 6px; width: 140px;",
+                        "width: 280px; left: -70px; top: -20px",
+                        true
+                    )
+                    // This one needs a different crop because the canvas element width is different
+                    + MakeImageCanvasElement(
+                        "p2i1c3",
+                        "man.png",
+                        "height: 378.826px; left: 325px; top: 6px; width: 130px;",
+                        "width: 280px; left: -70px; top: -20px",
+                        true
+                    )
+                    + MakeImageCanvasElement(
+                        "p2i2a",
+                        "lady24b.png",
+                        "height: 350px; left: 300px; top: 6px; width: 140px;"
+                    )
+                    + MakeImageCanvasElement(
+                        "p2i3c5",
+                        "man%203.jpg",
+                        "height: 378.826px; left: 325px; top: 6px; width: 140px;",
+                        "width: 280px; left: -80px; top: -20px"
+                    )
+                    + @"
+            </div>
+        </div>
+    </div>
+</body></html>"
+            );
+            var _pathToTestImages = "src\\BloomTests\\ImageProcessing\\images";
+            var path = FileLocationUtilities.GetFileDistributedWithApplication(
+                _pathToTestImages,
+                "man.png"
+            );
+            RobustFile.Copy(path, Path.Combine(_folder.Path, "man.png"));
+            _manPngBytes = RobustFile.ReadAllBytes(path);
+
+            path = FileLocationUtilities.GetFileDistributedWithApplication(
+                _pathToTestImages,
+                "man.jpg"
+            );
+            RobustFile.Copy(path, Path.Combine(_folder.Path, "man 3.jpg"));
+            _manJpgBytes = RobustFile.ReadAllBytes(path);
+
+            path = FileLocationUtilities.GetFileDistributedWithApplication(
+                _pathToTestImages,
+                "lady24b.png"
+            );
+            RobustFile.Copy(path, Path.Combine(_folder.Path, "lady24b.png"));
+            _lady24bPngBytes = RobustFile.ReadAllBytes(path);
+
+            // SUT
+            PublishHelper.ReallyCropImages(_dom.RawDom, _folder.Path, _folder.Path);
+
+            _p1bgi1 = _dom.SelectSingleNode("//img[@id='p1bgi1']");
+            _p1i1c1 = _dom.SelectSingleNode("//img[@id='p1i1c1']");
+            _p2i1c1 = _dom.SelectSingleNode("//img[@id='p2i1c1']");
+            _p2i1c2 = _dom.SelectSingleNode("//img[@id='p2i1c2']");
+            _p2i1c3 = _dom.SelectSingleNode("//img[@id='p2i1c3']");
+            _p2i1a = _dom.SelectSingleNode("//img[@id='p2i1a']");
+            _p2i1b = _dom.SelectSingleNode("//img[@id='p2i1b']");
+            _p2i2a = _dom.SelectSingleNode("//img[@id='p2i2a']");
+            _p1i2c4 = _dom.SelectSingleNode("//img[@id='p1i2c4']");
+            _p1i3c5 = _dom.SelectSingleNode("//img[@id='p1i3c5']");
+            _p2i3c5 = _dom.SelectSingleNode("//img[@id='p2i3c5']");
+
+            _p1i1c1Bytes = RobustFile.ReadAllBytes(
+                Path.Combine(_folder.Path, _p1i1c1.GetAttribute("src"))
+            );
+            _p2i1c2Bytes = RobustFile.ReadAllBytes(
+                Path.Combine(_folder.Path, _p2i1c2.GetAttribute("src"))
+            );
+            _p2i1c3Bytes = RobustFile.ReadAllBytes(
+                Path.Combine(_folder.Path, _p2i1c3.GetAttribute("src"))
+            );
+            _p1i2c4Bytes = RobustFile.ReadAllBytes(
+                Path.Combine(_folder.Path, _p1i2c4.GetAttribute("src"))
+            );
+            _p1i3c54Bytes = RobustFile.ReadAllBytes(
+                // Tempting to read from _p1i3c5.GetAttribute("src")).
+                // But we're have assertions that the src is unchanged for this element.
+                // What we want to ensure is that the original file was overwritten, rather
+                // than a new one with the encoded name man%203.jpg being created.
+                Path.Combine(_folder.Path, "man 3.jpg")
+            );
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            _folder.Dispose();
+        }
+
+        [Test]
+        public void UncroppedImages_SrcUnchanged()
+        {
+            Assert.That(_p1bgi1.GetAttribute("src"), Is.EqualTo("man.png"));
+            Assert.That(_p2i1a.GetAttribute("src"), Is.EqualTo("man.png"));
+            Assert.That(_p2i1b.GetAttribute("src"), Is.EqualTo("man.png"));
+            Assert.That(_p2i2a.GetAttribute("src"), Is.EqualTo("lady24b.png"));
+        }
+
+        [Test]
+        public void CroppedImage_HaveUncroppedWithSameFile_NewName()
+        {
+            var newSrc = _p1i1c1.GetAttribute("src");
+            Assert.That(newSrc, Is.Not.EqualTo("man.png"));
+            Assert.That(Path.GetExtension(newSrc), Is.EqualTo(".png"));
+            newSrc = _p1i2c4.GetAttribute("src");
+            Assert.That(newSrc, Is.Not.EqualTo("lady24b.png"));
+            Assert.That(Path.GetExtension(newSrc), Is.EqualTo(".png"));
+        }
+
+        [Test]
+        public void CroppedImage_HasDifferentContent()
+        {
+            Assert.That(
+                _p1i1c1Bytes,
+                Is.Not.EqualTo(_manPngBytes),
+                "Cropped image should have different content from original"
+            );
+            Assert.That(
+                _p2i1c2Bytes,
+                Is.Not.EqualTo(_manPngBytes),
+                "Cropped image should have different content from original"
+            );
+            Assert.That(
+                _p2i1c3Bytes,
+                Is.Not.EqualTo(_manPngBytes),
+                "Cropped image should have different content from original"
+            );
+            Assert.That(
+                _p1i2c4Bytes,
+                Is.Not.EqualTo(_lady24bPngBytes),
+                "Cropped image should have different content from original"
+            );
+        }
+
+        [Test]
+        public void CroppedImages_WithDifferentCrops_ProduceDifferentFiles()
+        {
+            Assert.That(
+                _p1i1c1Bytes,
+                Is.Not.EqualTo(_p2i1c2Bytes),
+                "Cropped image file contents should be different"
+            );
+            Assert.That(
+                _p1i1c1Bytes,
+                Is.Not.EqualTo(_p2i1c3Bytes),
+                "Cropped image file contents should be different"
+            );
+            Assert.That(
+                _p2i1c3Bytes,
+                Is.Not.EqualTo(_p2i1c2Bytes),
+                "Cropped image file contents should be different"
+            );
+        }
+
+        [Test]
+        public void ImageWithSameSrcAndCrop_ShouldUseSameCroppedImgFile()
+        {
+            Assert.That(_p1i1c1.GetAttribute("src"), Is.EqualTo(_p2i1c1.GetAttribute("src")));
+            Assert.That(_p2i3c5.GetAttribute("src"), Is.EqualTo(_p1i3c5.GetAttribute("src")));
+        }
+
+        [Test]
+        public void ImageWithSameSrcButDifferentCrop_ShouldUseDifferentCroppedImgFile()
+        {
+            var i1c1Src = _p1i1c1.GetAttribute("src");
+            var i2c2Src = _p2i1c2.GetAttribute("src");
+            Assert.That(i1c1Src, Is.Not.EqualTo(i2c2Src));
+            Assert.That(i2c2Src, Is.Not.EqualTo("man.png"));
+        }
+
+        [Test]
+        public void CroppedImage_NoUncroppedWithSameName_UsesOriginalName()
+        {
+            Assert.That(_p1i3c5.GetAttribute("src"), Is.EqualTo("man%203.jpg"));
+        }
+
+        [Test]
+        public void CroppedImage_NoUncroppedWithSameName_HasModifiedContent()
+        {
+            Assert.That(
+                _p1i3c54Bytes,
+                Is.Not.EqualTo(_manJpgBytes),
+                "Cropped image should have different content from original"
             );
         }
     }

--- a/src/BloomTests/Publish/PublishHelperTests.cs
+++ b/src/BloomTests/Publish/PublishHelperTests.cs
@@ -1321,6 +1321,10 @@ namespace BloomTests.Publish
                 _pathToTestImages,
                 "man.jpg"
             );
+            // We are deliberately changing the name slightly to test for a particular problem
+            // that was occurring when cropping renamed the output to an 'original' name
+            // containing a space. The space needs to be in the name of the image that does
+            // NOT occur uncropped.
             RobustFile.Copy(path, Path.Combine(_folder.Path, "man 3.jpg"));
             _manJpgBytes = RobustFile.ReadAllBytes(path);
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7315)
<!-- Reviewable:end -->
