### PR TITLE
Restores old clipboard behavior for bloom-editable (BL-15123)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1371,16 +1371,27 @@ export const pasteClipboard = (imageAvailable: boolean) => {
 
 function pasteHandler(e: Event) {
     const activeElement = document.activeElement;
-    // If there's a possibility of pasting an image, we need to handle that the same
+    // If there's a possibility of pasting an image, we want to handle that the same
     // as the paste button code in C#, with interactions between C# and Javascript.
+    // Unfortunately it's difficult to know whether we have an image in the clipboard.
+    // We'd like to ask C# but are fairly sure we can't wait for a post response before
+    // deciding whether to preventDefault() or not. (We ideally want the default behavior unless
+    // we're going to paste an image.)
     // That process involving C# does not work for <input> elements or or text areas or for pages that
-    // do not have a canvas element or a normal ckeditor setup.
+    // do not have a canvas element or a normal ckeditor setup. There are various other cases
+    // it doesn't handle well (e.g., formatted text in the clipboard, BL-15123).
+    // If we really want to be able to paste an image onto the canvas when focus is on a bloom-editable,
+    // our current idea is to have C# notify Javascript through a websocket when there is a change
+    // in the clipboard whether it does or does not contain an image.
+    // For 6.2, we're making this simpler change and just taking the default behavior when
+    // the focus is on a bloom-editable element.
     //
     // (See the branch pasteToInput for a very ugly way to make the C#/Javascript paste
     // button code handle pasting into an input element.)
     if (
         activeElement instanceof HTMLInputElement ||
-        activeElement instanceof HTMLTextAreaElement
+        activeElement instanceof HTMLTextAreaElement ||
+        activeElement?.closest(".bloom-editable")
     ) {
         return;
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7319)
<!-- Reviewable:end -->
