### PR TITLE
Fix the XLF English for disabled tooltip

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1286,7 +1286,7 @@
         <note>ID: EditTab.ContentLanguagesDropdown</note>
       </trans-unit>
       <trans-unit id="EditTab.ContentLanguagesDropdown.DisabledTooltip">
-        <source xml:lang="en">Choose language to make this a bilingual or trilingual book</source>
+        <source xml:lang="en">This is disabled because it won't change anything on this page.</source>
         <note>ID: EditTab.ContentLanguagesDropdown.DisabledTooltip</note>
       </trans-unit>
       <trans-unit id="EditTab.ContentLanguagesDropdown.ToolTip">


### PR DESCRIPTION
Problem is only visible when using another language because translators translated the wrong string. In English, the different string stored in the code wins

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7355)
<!-- Reviewable:end -->
