### PR TITLE
Ignore scaling when recording audio (BL-15198)

### DIFF
--- a/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
+++ b/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
@@ -527,7 +527,7 @@ const PublishAudioVideoInternalInternal: React.FunctionComponent<{
                             enabled={
                                 !recording &&
                                 isLicenseOK &&
-                                !isScalingActive &&
+                                !(isScalingActive && recordingVideo) &&
                                 havePreviewForOrientation
                             }
                             l10nKey="PublishTab.RecordVideo.Record"


### PR DESCRIPTION
A distorted / oversized video doesn't matter when only the audio is saved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7372)
<!-- Reviewable:end -->
