### PR TITLE
Increase the maximum message height in problem report dialog (BL-15207)

### DIFF
--- a/src/BloomBrowserUI/problemDialog/ProblemDialog.less
+++ b/src/BloomBrowserUI/problemDialog/ProblemDialog.less
@@ -17,7 +17,7 @@
     }
     .report-heading {
         font-style: italic;
-        max-height: 60px;
+        max-height: 75px; // displays about 3.5 lines -- the extra .5 shows users that there is more to see. (BL-15207)
         overflow-y: auto; // Adds a scrollbar if there is too much content. However, it's better if we just keep the shortMessage short.
     }
     .content {


### PR DESCRIPTION
The increase shows a partial line, which tells users that there's more to see.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7375)
<!-- Reviewable:end -->
