### PR TITLE
BL-15277 fix for hidden image toolbox language option

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -1123,6 +1123,11 @@ namespace Bloom.Edit
                 )
             )
             {
+                // With the .net 8 upgrade, WinForms things shifted a bit so that the search language dropdown gets
+                // covered up. Since we're going to redo this dialog anyway, it's not worth messing with the toolbox so
+                // we simply make it wider to keep the language dropdown visible for now
+                dlg.Width += 120;
+
                 var searchLanguage = Settings.Default.ImageSearchLanguage;
                 dlg.ImageLoadingExceptionReporter = (path, ex, msg) =>
                 {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7385)
<!-- Reviewable:end -->
