### PR TITLE
bloom-player was updated on Version6.2 without updating yarn.lock

### DIFF
--- a/src/BloomBrowserUI/yarn.lock
+++ b/src/BloomBrowserUI/yarn.lock
@@ -5384,10 +5384,10 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bloom-player@^2.13.1:
-  version "2.14.4"
-  resolved "https://registry.yarnpkg.com/bloom-player/-/bloom-player-2.14.4.tgz#3b9bb1f5b8af3da8ba1353a480750d7adec225fe"
-  integrity sha512-q1AxL9atBHBTTqEqErsdPz6DJg4KjPQu3dyqlozFBouhBD2VDklcudBAgyhIIVRzqdfrMGg43zuD1YjHYkfbnw==
+bloom-player@^2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/bloom-player/-/bloom-player-2.15.1.tgz#4a123b0e80d60a69bb7926c89d1c8c480c6d0ff7"
+  integrity sha512-7ZlLERiHXNZqkpv3/0CQvYR4iggqMjH1NlSSRjSfrVtDoeCk0rdY2SGxPPAtP5uXz/AtmZ5JqFsSWmk7E9PoTw==
 
 body-parser@1.20.3:
   version "1.20.3"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7392)
<!-- Reviewable:end -->
