### PR TITLE
Limit Windows 10 users to updating through Bloom 6.2 (BL-15248)

### DIFF
--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -377,6 +377,26 @@ namespace Bloom
 #if !__MonoCS__
         internal static bool NoUpdatesAvailable(UpdateInfo info)
         {
+            if (Environment.OSVersion.Version.Major < 11)
+            {
+                var version = info?.FutureReleaseEntry?.Version;
+                if (
+                    version != null
+                    && (
+                        version.Version.Major > 6
+                        || (version.Version.Major == 6 && version.Version.Minor > 2)
+                    )
+                )
+                {
+                    // Bloom 6.3 and later requires Windows 11 or later.
+                    // If we are running on Windows 10 or earlier, we cannot update to it.
+                    // So we behave as if there are no updates available.
+                    SIL.Reporting.Logger.WriteEvent(
+                        "Squirrel: Not updating because the new version requires Windows 11 or later."
+                    );
+                    return true;
+                }
+            }
             return info == null || info.ReleasesToApply.Count == 0;
         }
 #endif


### PR DESCRIPTION
Once Bloom 6.3 becomes available on a given channel, it is likely that Windows 10 users will not be able to update Bloom 6.2 to the final 6.2 update.  They can always download the full installer for the final Bloom 6.2 release and reinstall Bloom if that happens.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7393)
<!-- Reviewable:end -->
