### PR TITLE
Get font detection working again for web upload check (BL-15292)

### DIFF
--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -549,9 +549,11 @@ namespace Bloom
                     return false;
                 }
             }
+            //Debug.WriteLine(
+            //    $"DEBUG: Navigation wait loop ended after {navTimer.Elapsed}: done={done}"
+            //);
 
             navTimer.Stop();
-
             if (!done)
             {
                 if (throwOnTimeout)


### PR DESCRIPTION
The behavior must have changed due to a WebView2 update, or possibly the Dotnet 8 change.  Otherwise, I don't see how the code ever worked (which doesn't make any sense).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7401)
<!-- Reviewable:end -->
