### PR TITLE
Add help link for file permissions to hard crash report (BL-15282)

### DIFF
--- a/src/BloomExe/Book/BookStorage.cs
+++ b/src/BloomExe/Book/BookStorage.cs
@@ -2657,7 +2657,7 @@ namespace Bloom.Book
         internal static string kFileAccessPermissionHelpUrl =
             @"https://docs.bloomlibrary.org/windows-file-permissions";
 
-        private static string GetHelpLinkForFilePermissions()
+        internal static string GetHelpLinkForFilePermissions()
         {
             return GetEncodedSeeWebPageString(kFileAccessPermissionHelpUrl);
         }

--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -1006,6 +1006,12 @@ namespace Bloom.web.controllers
             {
                 heading = exception.Message;
                 isHeadingPreEncoded = false;
+                // If it's a file permissions problem, we can give a link to help the user. (BL-15282)
+                if (exception is System.UnauthorizedAccessException)
+                {
+                    heading = BookStorage.GetHelpLinkForFilePermissions() + "<br>" + heading;
+                    isHeadingPreEncoded = true;
+                }
             }
 
             var book = _bookSelection?.CurrentSelection;


### PR DESCRIPTION
This can happen if the .bloomCollection file is readonly or hidden.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7407)
<!-- Reviewable:end -->
