### PR TITLE
Handle unknown font weights as either 400 (regular) or 700 (bold)

### DIFF
--- a/src/BloomExe/FontProcessing/FontFileFinder.cs
+++ b/src/BloomExe/FontProcessing/FontFileFinder.cs
@@ -94,6 +94,19 @@ namespace Bloom.FontProcessing
                     Logger.WriteEvent(
                         $"Unexpected font settings: name=\"{fontName}\", weight=\"{fontWeight}\", style=\"{fontStyle}\""
                     );
+                    // I don't know how other weights could be produced apart from custom CSS, but font-weight=900
+                    // can come from a combination of Bold in a style setting (invoking CSS) and Bold in direct
+                    // formatting (inserting markup with <strong>...</strong>).
+                    if (string.CompareOrdinal(fontWeight, "550") < 0)
+                    {
+                        fontWeight = "400";
+                        Logger.WriteEvent($"Setting font-weight to 400 (Regular)");
+                    }
+                    else
+                    {
+                        fontWeight = "700";
+                        Logger.WriteEvent($"Setting font-weight to 700 (Bold)");
+                    }
                 }
 
                 if (fontStyle == "italic" && fontWeight == "700")


### PR DESCRIPTION
Someone has managed to ask for Andika font-weight=900 which doesn't exist.
This creates problems in harvesting the book.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7421)
<!-- Reviewable:end -->
