### PR TITLE
Detect path too long for collection files on startup (BL-15304)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2854,7 +2854,7 @@
         <note>ID: ErrorReport.Pre10WindowsNotSupported</note>
       </trans-unit>
       <trans-unit id="Errors.PathTooLong">
-        <source xml:lang="en">Please move your collection closer to the root of your hard drive and try again. A file Bloom was working with had a path that was too long. This is usually caused by your collection being too deeply nested in many folders on your hard drive.</source>
+        <source xml:lang="en">Please give your collection a shorter name or move your collection closer to the root of your hard drive and try again. A file Bloom was working with had a path that was too long. This is usually caused by one of two things: 1) the collection has a very long name, or 2) the collection is too deeply nested inside many folders on your hard drive.</source>
         <note>ID: Errors.PathTooLong</note>
       </trans-unit>
       <trans-unit id="Errors.BookProblem">

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1431,24 +1431,43 @@ namespace Bloom
                         dlg.SetDesktopLocation(50, 50);
                     }
 
-                    if (dlg.ShowDialog(formToClose) != DialogResult.OK)
+                    try
                     {
-                        // If there is a form to close, it means the collection chooser is not the only thing open,
-                        // and we don't want to exit the application. Otherwise, we are in initial startup and
-                        // closing the chooser should exit the application.
-                        if (formToClose == null)
-                            Application.Exit();
-                        return false;
-                    }
+                        if (dlg.ShowDialog(formToClose) != DialogResult.OK)
+                        {
+                            // If there is a form to close, it means the collection chooser is not the only thing open,
+                            // and we don't want to exit the application. Otherwise, we are in initial startup and
+                            // closing the chooser should exit the application.
+                            if (formToClose == null)
+                                Application.Exit();
+                            return false;
+                        }
 
-                    if (formToClose != null)
+                        if (formToClose != null)
+                        {
+                            formToClose.UserWantsToOpenADifferentProject = true;
+                            formToClose.Close();
+                        }
+
+                        if (OpenCollection(dlg.SelectedPath))
+                            return true;
+                    }
+                    catch (Exception error)
                     {
-                        formToClose.UserWantsToOpenADifferentProject = true;
-                        formToClose.Close();
+                        if (
+                            LongPathAware.ShouldConvertToPathTooLongException(
+                                error,
+                                out string path
+                            )
+                        )
+                        {
+                            throw new Utils.PathTooLongException(path);
+                        }
+                        else
+                        {
+                            throw;
+                        }
                     }
-
-                    if (OpenCollection(dlg.SelectedPath))
-                        return true;
                 }
             }
         }

--- a/src/BloomExe/Utils/LongPathAware.cs
+++ b/src/BloomExe/Utils/LongPathAware.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Text;
-using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.RegularExpressions;
 using SIL.Reporting;
 
 namespace Bloom.Utils
@@ -119,9 +119,24 @@ namespace Bloom.Utils
         private static string GetGenericPathTooLongMessage()
         {
             return L10NSharp.LocalizationManager.GetString(
-                "Error.PathTooLong",
-                "Please move your collection closer to the root of your hard drive and try again. A file Bloom was working with had a path that was too long. This is usually caused by your collection being too deeply nested in many folders on your hard drive."
+                "Errors.PathTooLong",
+                "Please give your collection a shorter name or move your collection closer to the root of your hard drive and try again. A file Bloom was working with had a path that was too long. This is usually caused by one of two things: 1) the collection has a very long name, or 2) the collection is too deeply nested inside many folders on your hard drive."
             );
+        }
+
+        public static bool ShouldConvertToPathTooLongException(Exception exception, out string path)
+        {
+            path = null;
+            if (exception == null || exception is System.IO.PathTooLongException)
+                return false;
+            // There may be other exceptions that we should convert, but this is what we've seen. (BL-15304)
+            if (exception is System.IO.DirectoryNotFoundException)
+            {
+                path = Regex.Match(exception.Message, "^.*'(.*)'\\.$").Groups[1].Value;
+                if (path?.Length >= 260)
+                    return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Mail;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows.Forms;
 using Bloom.Api;
@@ -1003,6 +1004,12 @@ namespace Bloom.web.controllers
             }
             if (string.IsNullOrEmpty(heading) && exception != null)
             {
+                // Some exceptions are caused by overly long paths, but don't throw the
+                // proper System.IO.PathTooLongException.  (BL-15304)
+                if (LongPathAware.ShouldConvertToPathTooLongException(exception, out var path))
+                {
+                    exception = new Utils.PathTooLongException(path);
+                }
                 heading = exception.Message;
                 isHeadingPreEncoded = false;
             }


### PR DESCRIPTION
Also improve the message when detecting an overly long path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7422)
<!-- Reviewable:end -->
