### PR TITLE
Trim strings pasted into the subscription code (BL-15309)

### DIFF
--- a/src/BloomBrowserUI/collection/subscriptionCodeControl.tsx
+++ b/src/BloomBrowserUI/collection/subscriptionCodeControl.tsx
@@ -306,8 +306,14 @@ const Editor: React.FC<{ status: Status }> = ({ status }) => {
 
     const handlePaste = () => {
         get("common/clipboardText", result => {
-            setSubscriptionCode(result.data);
-            document.dispatchEvent(new Event("subscriptionCodeChanged"));
+            // We don't want trailing newlines (or other whitespace).
+            // See BL-15309 for the havoc they can cause.
+            let resultText = result.data as string;
+            if (resultText) {
+                resultText = resultText.trim();
+                setSubscriptionCode(resultText);
+                document.dispatchEvent(new Event("subscriptionCodeChanged"));
+            }
         });
     };
 


### PR DESCRIPTION
This appears to be done automatically with the standard Control-V handling. Serious problems can happen if we let trailing newlines through.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7423)
<!-- Reviewable:end -->
