### PR TITLE
Better sync of data-div img src in really-crop (BL-16137)

### DIFF
--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -2173,20 +2173,10 @@ namespace Bloom.ImageProcessing
         )
         {
             var images = bookDom.SafeSelectElements("//img").ToList();
-            // We need to keep the cover image data in the bloomDataDiv consistent if anything
-            // (e.g., cropping) causes us to rename the cover image file.  If we upload the
-            // book to bloomlibrary.org, the cover image file stored in the bloomDataDiv will
-            // be needed to harvest the book or to make derivatives of it. (BL-16096)
-            if (images.Any(x => x.GetAttribute("data-book") == "coverImage"))
-            {
-                var coverImageDiv = bookDom
-                    .SafeSelectElements(
-                        "//div[@id='bloomDataDiv']/div[@data-book='coverImage' and @src]"
-                    )
-                    .FirstOrDefault();
-                if (coverImageDiv != null)
-                    images.Add(coverImageDiv);
-            }
+            var bloomDataDivEntriesByDataBook = bookDom
+                .SafeSelectElements("//div[@id='bloomDataDiv']/*[@data-book]")
+                .GroupBy(x => x.GetAttribute("data-book"))
+                .ToDictionary(group => group.Key, group => group.First());
             // src values that occur in uncropped images. Note, it is NOT the case that an img whose src
             // is in this set never cropped; it just means that at least one occurrence of it is not
             // cropped, which makes the image name unavailable to use for a cropped image.
@@ -2236,7 +2226,8 @@ namespace Bloom.ImageProcessing
                             cropped,
                             img,
                             src,
-                            style
+                            style,
+                            bloomDataDivEntriesByDataBook
                         );
                 }
                 else
@@ -2251,7 +2242,8 @@ namespace Bloom.ImageProcessing
                         img,
                         src,
                         style,
-                        canvasElementStyle
+                        canvasElementStyle,
+                        bloomDataDivEntriesByDataBook
                     );
                 }
             }
@@ -2264,17 +2256,15 @@ namespace Bloom.ImageProcessing
             Dictionary<string, string> cropped,
             SafeXmlElement img,
             string src,
-            string style
+            string style,
+            Dictionary<string, SafeXmlElement> bloomDataDivEntriesByDataBook
         )
         {
             var key = $"{src}|{style}|0|0";
             if (cropped.TryGetValue(key, out string fileName))
             {
                 // This is a duplicate. We can use the same metadata-cropped image file.
-                img.SetAttribute("src", fileName);
-                // Handle the bloomDataDiv definition for the cover image.  (BL-16096)
-                if (img.Name.ToLowerInvariant() == "div")
-                    img.InnerText = fileName;
+                SetImageSrcAndSyncDataDiv(img, fileName, bloomDataDivEntriesByDataBook);
                 return;
             }
             TrimMetadataInImage(img, imageSourceFolder, imageDestFolder);
@@ -2291,7 +2281,8 @@ namespace Bloom.ImageProcessing
             SafeXmlElement img,
             string src,
             string style,
-            string canvasElementStyle
+            string canvasElementStyle,
+            Dictionary<string, SafeXmlElement> bloomDataDivEntriesByDataBook
         )
         {
             var canvasElementWidth = GetNumberFromPx("width", canvasElementStyle);
@@ -2301,7 +2292,7 @@ namespace Bloom.ImageProcessing
             if (cropped.TryGetValue(key, out string fileName))
             {
                 // This is a duplicate. We can use the same cropped image file.
-                img.SetAttribute("src", fileName);
+                SetImageSrcAndSyncDataDiv(img, fileName, bloomDataDivEntriesByDataBook);
                 // With that src, it's already cropped, so remove the style to avoid
                 // applying the cropping again to the already-cropped image.
                 img.RemoveAttribute("style");
@@ -2314,7 +2305,8 @@ namespace Bloom.ImageProcessing
                 img,
                 imageSourceFolder,
                 imageDestFolder,
-                needNewName
+                needNewName,
+                bloomDataDivEntriesByDataBook
             );
 
             // Track if we replaced an original file with a new one
@@ -2484,7 +2476,8 @@ namespace Bloom.ImageProcessing
             SafeXmlElement img,
             string imageSourceFolder,
             string imageDestFolder,
-            bool useNewName
+            bool useNewName,
+            Dictionary<string, SafeXmlElement> bloomDataDivEntriesByDataBook
         )
         {
             var croppedImagePath = MakeCroppedImage(img, imageSourceFolder, imageDestFolder);
@@ -2512,7 +2505,7 @@ namespace Bloom.ImageProcessing
                     // All images with this name and crop should use this
                     result = Path.GetFileName(croppedImagePath);
                     // Including the current image
-                    img.SetAttribute("src", result);
+                    SetImageSrcAndSyncDataDiv(img, result, bloomDataDivEntriesByDataBook);
                 }
                 else
                 {
@@ -2524,6 +2517,24 @@ namespace Bloom.ImageProcessing
             }
             img.RemoveAttribute("style"); // so nothing can possibly think it needs more cropping
             return result;
+        }
+
+        private static void SetImageSrcAndSyncDataDiv(
+            SafeXmlElement img,
+            string src,
+            Dictionary<string, SafeXmlElement> bloomDataDivEntriesByDataBook
+        )
+        {
+            img.SetAttribute("src", src);
+            var dataBook = img.GetAttribute("data-book");
+            if (string.IsNullOrWhiteSpace(dataBook))
+                return;
+
+            if (bloomDataDivEntriesByDataBook.TryGetValue(dataBook, out var dataDivElement))
+            {
+                dataDivElement.SetAttribute("src", src);
+                dataDivElement.InnerText = src;
+            }
         }
 
         /// <summary>

--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -1156,5 +1156,289 @@ namespace BloomTests.ImageProcessing
                 );
             }
         }
+
+        [Test]
+        public void ReallyCropImages_CroppedImageWithDataBook_UpdatesDataDiv()
+        {
+            // When a cropped img element has a data-book attribute and is assigned a new filename,
+            // the corresponding bloomDataDiv entry should have its src attribute and InnerText updated.
+
+            using (var folder = new TemporaryFolder("DataDivSyncCroppedTest"))
+            {
+                var _pathToTestImages = "src\\BloomTests\\ImageProcessing\\images";
+                var sourcePath = FileLocationUtilities.GetFileDistributedWithApplication(
+                    _pathToTestImages,
+                    "man.png"
+                );
+                RobustFile.Copy(sourcePath, Path.Combine(folder.Path, "man.png"));
+
+                // An uncropped img with the same src forces the cropped img to get a new name.
+                var dom = new HtmlDom(
+                    @"<html><head></head><body>
+                    <div id=""bloomDataDiv"">
+                        <div data-book=""coverImage"" lang=""*"" src=""man.png"">man.png</div>
+                    </div>
+                    <div class=""bloom-page"">
+                        <div class=""marginBox"">
+                            <div class=""bloom-canvas"">"
+                    + MakeImageCanvasElement(
+                        "uncroppedImg",
+                        "man.png",
+                        "height: 300px; left: 10px; top: 10px; width: 200px;"
+                    )
+                    + @"<div class=""bloom-canvas-element"" style=""height: 300px; left: 10px; top: 10px; width: 200px;"">
+                                <div tabindex=""0"" class=""bloom-imageContainer bloom-leadingElement"">
+                                    <img id=""croppedImg"" src=""man.png"" data-book=""coverImage""
+                                         style=""width: 400px; left: -50px; top: -50px"" />
+                                </div>
+                            </div>
+                        </div>
+                        </div>
+                    </div>
+                </body></html>"
+                );
+
+                // Sanity check: data-div entry starts with original src
+                var dataDivEntry = dom.SelectSingleNode(
+                    "//div[@id='bloomDataDiv']/div[@data-book='coverImage']"
+                );
+                Assert.That(dataDivEntry.GetAttribute("src"), Is.EqualTo("man.png"));
+                Assert.That(dataDivEntry.InnerText, Is.EqualTo("man.png"));
+
+                // SUT
+                ImageUtils.ReallyCropImages(dom.RawDom, folder.Path, folder.Path);
+
+                var croppedImg = dom.SelectSingleNode("//img[@id='croppedImg']");
+                var newSrc = croppedImg.GetAttribute("src");
+                Assert.That(newSrc, Is.Not.EqualTo("man.png"), "Cropped img should have a new src");
+
+                // data-div entry should be updated to match the new filename.
+                Assert.That(
+                    dataDivEntry.GetAttribute("src"),
+                    Is.EqualTo(newSrc),
+                    "bloomDataDiv src attribute should be updated to the new cropped filename"
+                );
+                Assert.That(
+                    dataDivEntry.InnerText,
+                    Is.EqualTo(newSrc),
+                    "bloomDataDiv InnerText should be updated to the new cropped filename"
+                );
+            }
+        }
+
+        [Test]
+        public void ReallyCropImages_DuplicateCroppedImageWithDataBook_UpdatesDataDiv()
+        {
+            // When two img elements share an identical crop (the second hits the "duplicate" fast path),
+            // and the second has a data-book attribute, the bloomDataDiv should still be updated.
+
+            using (var folder = new TemporaryFolder("DataDivSyncDuplicateTest"))
+            {
+                var _pathToTestImages = "src\\BloomTests\\ImageProcessing\\images";
+                var sourcePath = FileLocationUtilities.GetFileDistributedWithApplication(
+                    _pathToTestImages,
+                    "man.png"
+                );
+                RobustFile.Copy(sourcePath, Path.Combine(folder.Path, "man.png"));
+
+                // An uncropped img forces the cropped ones to get new names.
+                // Two identical crops: the first processes the key; the second hits the duplicate path.
+                // The second has data-book="coverImage".
+                var dom = new HtmlDom(
+                    @"<html><head></head><body>
+                    <div id=""bloomDataDiv"">
+                        <div data-book=""coverImage"" lang=""*"" src=""man.png"">man.png</div>
+                    </div>
+                    <div class=""bloom-page"">
+                        <div class=""marginBox"">
+                            <div class=""bloom-canvas"">"
+                    + MakeImageCanvasElement(
+                        "uncroppedImg",
+                        "man.png",
+                        "height: 300px; left: 10px; top: 10px; width: 200px;"
+                    )
+                    + MakeImageCanvasElement(
+                        "firstCrop",
+                        "man.png",
+                        "height: 300px; left: 10px; top: 10px; width: 200px;",
+                        "width: 400px; left: -50px; top: -50px"
+                    )
+                    + @"<div class=""bloom-canvas-element"" style=""height: 300px; left: 10px; top: 10px; width: 200px;"">
+                                <div tabindex=""0"" class=""bloom-imageContainer bloom-leadingElement"">
+                                    <img id=""duplicateCrop"" src=""man.png"" data-book=""coverImage""
+                                         style=""width: 400px; left: -50px; top: -50px"" />
+                                </div>
+                            </div>
+                        </div>
+                        </div>
+                    </div>
+                </body></html>"
+                );
+
+                // Sanity check
+                var dataDivEntry = dom.SelectSingleNode(
+                    "//div[@id='bloomDataDiv']/div[@data-book='coverImage']"
+                );
+                Assert.That(dataDivEntry.GetAttribute("src"), Is.EqualTo("man.png"));
+
+                // SUT
+                ImageUtils.ReallyCropImages(dom.RawDom, folder.Path, folder.Path);
+
+                var firstCropImg = dom.SelectSingleNode("//img[@id='firstCrop']");
+                var duplicateCropImg = dom.SelectSingleNode("//img[@id='duplicateCrop']");
+                var firstSrc = firstCropImg.GetAttribute("src");
+                var duplicateSrc = duplicateCropImg.GetAttribute("src");
+
+                // Both should use the same cropped file.
+                Assert.That(
+                    firstSrc,
+                    Is.EqualTo(duplicateSrc),
+                    "Duplicate crops should reference the same cropped file"
+                );
+                Assert.That(firstSrc, Is.Not.EqualTo("man.png"));
+
+                // The data-div should be updated even though duplicateCrop hit the fast path.
+                Assert.That(
+                    dataDivEntry.GetAttribute("src"),
+                    Is.EqualTo(duplicateSrc),
+                    "bloomDataDiv src should be updated via the duplicate-crop fast path"
+                );
+                Assert.That(
+                    dataDivEntry.InnerText,
+                    Is.EqualTo(duplicateSrc),
+                    "bloomDataDiv InnerText should be updated via the duplicate-crop fast path"
+                );
+            }
+        }
+
+        [Test]
+        public void ReallyCropImages_UncroppedImageWithDataBook_DataDivPreserved()
+        {
+            // When an img with data-book is uncropped (no rename occurs), the bloomDataDiv entry
+            // should be left unchanged.
+
+            using (var folder = new TemporaryFolder("DataDivSyncUncroppedTest"))
+            {
+                var _pathToTestImages = "src\\BloomTests\\ImageProcessing\\images";
+                var sourcePath = FileLocationUtilities.GetFileDistributedWithApplication(
+                    _pathToTestImages,
+                    "man.png"
+                );
+                RobustFile.Copy(sourcePath, Path.Combine(folder.Path, "man.png"));
+
+                var dom = new HtmlDom(
+                    @"<html><head></head><body>
+                    <div id=""bloomDataDiv"">
+                        <div data-book=""coverImage"" lang=""*"" src=""man.png"">man.png</div>
+                    </div>
+                    <div class=""bloom-page"">
+                        <div class=""marginBox"">
+                            <div class=""bloom-canvas"">
+                                <div class=""bloom-canvas-element"" style=""height: 300px; left: 10px; top: 10px; width: 200px;"">
+                                    <div tabindex=""0"" class=""bloom-imageContainer bloom-leadingElement"">
+                                        <img id=""uncroppedImg"" src=""man.png"" data-book=""coverImage"" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </body></html>"
+                );
+
+                // Sanity check
+                var dataDivEntry = dom.SelectSingleNode(
+                    "//div[@id='bloomDataDiv']/div[@data-book='coverImage']"
+                );
+                Assert.That(dataDivEntry.GetAttribute("src"), Is.EqualTo("man.png"));
+                Assert.That(dataDivEntry.InnerText, Is.EqualTo("man.png"));
+
+                // SUT
+                ImageUtils.ReallyCropImages(dom.RawDom, folder.Path, folder.Path);
+
+                // Uncropped image keeps its src name.
+                var img = dom.SelectSingleNode("//img[@id='uncroppedImg']");
+                Assert.That(img.GetAttribute("src"), Is.EqualTo("man.png"));
+
+                // data-div entry should be untouched.
+                Assert.That(
+                    dataDivEntry.GetAttribute("src"),
+                    Is.EqualTo("man.png"),
+                    "bloomDataDiv src should be unchanged for uncropped image"
+                );
+                Assert.That(
+                    dataDivEntry.InnerText,
+                    Is.EqualTo("man.png"),
+                    "bloomDataDiv InnerText should be unchanged for uncropped image"
+                );
+            }
+        }
+
+        [Test]
+        public void ReallyCropImages_CroppedImageWithNonCoverDataBook_UpdatesDataDiv()
+        {
+            // The old implementation only handled "coverImage". The new implementation syncs
+            // the data-div for any data-book attribute. This test verifies the generality.
+
+            using (var folder = new TemporaryFolder("DataDivSyncNonCoverTest"))
+            {
+                var _pathToTestImages = "src\\BloomTests\\ImageProcessing\\images";
+                var sourcePath = FileLocationUtilities.GetFileDistributedWithApplication(
+                    _pathToTestImages,
+                    "man.png"
+                );
+                RobustFile.Copy(sourcePath, Path.Combine(folder.Path, "man.png"));
+
+                // An uncropped img forces the cropped one to get a new name.
+                var dom = new HtmlDom(
+                    @"<html><head></head><body>
+                    <div id=""bloomDataDiv"">
+                        <div data-book=""someOtherImage"" lang=""*"" src=""man.png"">man.png</div>
+                    </div>
+                    <div class=""bloom-page"">
+                        <div class=""marginBox"">
+                            <div class=""bloom-canvas"">"
+                    + MakeImageCanvasElement(
+                        "uncroppedImg",
+                        "man.png",
+                        "height: 300px; left: 10px; top: 10px; width: 200px;"
+                    )
+                    + @"<div class=""bloom-canvas-element"" style=""height: 300px; left: 10px; top: 10px; width: 200px;"">
+                                <div tabindex=""0"" class=""bloom-imageContainer bloom-leadingElement"">
+                                    <img id=""croppedImg"" src=""man.png"" data-book=""someOtherImage""
+                                         style=""width: 400px; left: -50px; top: -50px"" />
+                                </div>
+                            </div>
+                        </div>
+                        </div>
+                    </div>
+                </body></html>"
+                );
+
+                // Sanity check
+                var dataDivEntry = dom.SelectSingleNode(
+                    "//div[@id='bloomDataDiv']/div[@data-book='someOtherImage']"
+                );
+                Assert.That(dataDivEntry.GetAttribute("src"), Is.EqualTo("man.png"));
+
+                // SUT
+                ImageUtils.ReallyCropImages(dom.RawDom, folder.Path, folder.Path);
+
+                var croppedImg = dom.SelectSingleNode("//img[@id='croppedImg']");
+                var newSrc = croppedImg.GetAttribute("src");
+                Assert.That(newSrc, Is.Not.EqualTo("man.png"));
+
+                // data-div entry for a non-coverImage data-book should also be updated.
+                Assert.That(
+                    dataDivEntry.GetAttribute("src"),
+                    Is.EqualTo(newSrc),
+                    "bloomDataDiv src for non-coverImage data-book should be updated"
+                );
+                Assert.That(
+                    dataDivEntry.InnerText,
+                    Is.EqualTo(newSrc),
+                    "bloomDataDiv InnerText for non-coverImage data-book should be updated"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7833)
<!-- Reviewable:end -->
