### PR TITLE
Restore scrolling to fonts tab of book settings dialog (BL-16149)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bookAndPageSettings/BookAndPageSettingsDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/bookAndPageSettings/BookAndPageSettingsDialog.tsx
@@ -438,7 +438,7 @@ export const BookAndPageSettingsDialog: React.FunctionComponent<{
                     &:first-child {
                         margin-top: 0; // override the default that sees a lack of a title and adds a margin
                     }
-                    overflow-y: hidden;
+                    overflow-y: auto; // fonts tab may need to scroll (BL-16149)
                     min-height: 0;
 
                     .${kConfigrPaneClassName} {


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7837)
<!-- Reviewable:end -->
