### PR TITLE
Improvements to video tool and camera enabling (BL-16131)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
@@ -121,6 +121,8 @@ export class SignLanguageToolControls extends React.Component<
     private timerId: number;
     private recordingStarted: number;
     private turningOnVideo: boolean = false;
+    private videoRequestVersion: number = 0;
+    private wantsVideoMonitorOn: boolean = false;
 
     public isVideoMonitorRunning(): boolean {
         if (!this.videoStream) {
@@ -582,18 +584,24 @@ export class SignLanguageToolControls extends React.Component<
         if (this.turningOnVideo || this.isVideoMonitorRunning()) {
             return;
         }
+        this.wantsVideoMonitorOn = true;
         this.turningOnVideo = true;
+        const requestVersion = ++this.videoRequestVersion;
         const constraints = { video: true };
         navigator.mediaDevices
             .getUserMedia(constraints)
-            .then((stream) => this.startMonitoring(stream))
-            .catch((reason) => this.errorCallback(reason))
+            .then((stream) => this.startMonitoring(stream, requestVersion))
+            .catch((reason) => this.errorCallback(reason, requestVersion))
             .finally(() => {
-                this.turningOnVideo = false;
+                if (requestVersion === this.videoRequestVersion) {
+                    this.turningOnVideo = false;
+                }
             });
     }
 
     public turnOffVideo() {
+        this.wantsVideoMonitorOn = false;
+        this.videoRequestVersion++;
         this.turningOnVideo = false;
         if (this.videoStream) {
             const oldStream = this.videoStream;
@@ -604,7 +612,10 @@ export class SignLanguageToolControls extends React.Component<
     }
 
     // callback from getUserMedia when it fails.
-    private errorCallback(reason) {
+    private errorCallback(reason, requestVersion: number) {
+        if (requestVersion !== this.videoRequestVersion) {
+            return;
+        }
         // something wrong! Developers note: Bloom and Firefox cannot both use it, so be careful about
         // "open in browser".
         // reason.name seems to be "NotFoundError" if there is no camera at all.
@@ -618,14 +629,25 @@ export class SignLanguageToolControls extends React.Component<
         });
         // In case the user plugs in a camera, try once a second to turn it on.
         window.setTimeout(() => {
-            if (this.state.enabled) {
+            if (
+                this.wantsVideoMonitorOn &&
+                requestVersion === this.videoRequestVersion
+            ) {
                 this.turnOnVideo();
             }
         }, 1000);
     }
 
     // callback from getUserMedia when it succeeds; gives us a stream we can monitor and record from.
-    private startMonitoring(stream: MediaStream) {
+    private startMonitoring(stream: MediaStream, requestVersion: number) {
+        if (
+            requestVersion !== this.videoRequestVersion ||
+            !this.wantsVideoMonitorOn
+        ) {
+            stream.getVideoTracks().forEach((t) => t.stop());
+            stream.getAudioTracks().forEach((t) => t.stop());
+            return;
+        }
         this.setState({
             cameraAccess: true,
         });

--- a/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
@@ -20,6 +20,10 @@ import calculateAspectRatio from "calculate-aspect-ratio";
 import VideoTrimSlider from "../../../react_components/videoTrimSlider";
 import { updateVideoInContainer } from "../../js/bloomVideo";
 import { selectVideoContainer } from "../../js/videoUtils";
+import {
+    getCanvasElementManager,
+    kCanvasElementSelector,
+} from "../canvas/canvasElementUtils";
 import $ from "jquery";
 
 // The recording process can be in one of these states:
@@ -116,6 +120,18 @@ export class SignLanguageToolControls extends React.Component<
     private mediaRecorder: MediaRecorder;
     private timerId: number;
     private recordingStarted: number;
+    private turningOnVideo: boolean = false;
+
+    public isVideoMonitorRunning(): boolean {
+        if (!this.videoStream) {
+            return false;
+        }
+        const videoTracks = this.videoStream.getVideoTracks();
+        return (
+            videoTracks.length > 0 &&
+            videoTracks.some((track) => track.readyState === "live")
+        );
+    }
 
     public render() {
         return (
@@ -563,14 +579,22 @@ export class SignLanguageToolControls extends React.Component<
     }
 
     public turnOnVideo() {
+        if (this.turningOnVideo || this.isVideoMonitorRunning()) {
+            return;
+        }
+        this.turningOnVideo = true;
         const constraints = { video: true };
         navigator.mediaDevices
             .getUserMedia(constraints)
             .then((stream) => this.startMonitoring(stream))
-            .catch((reason) => this.errorCallback(reason));
+            .catch((reason) => this.errorCallback(reason))
+            .finally(() => {
+                this.turningOnVideo = false;
+            });
     }
 
     public turnOffVideo() {
+        this.turningOnVideo = false;
         if (this.videoStream) {
             const oldStream = this.videoStream;
             this.videoStream = null; // prevent recursive calls
@@ -593,7 +617,11 @@ export class SignLanguageToolControls extends React.Component<
                     reason.name == "SourceUnavailableError"), // Gecko45
         });
         // In case the user plugs in a camera, try once a second to turn it on.
-        window.setTimeout(() => this.turnOnVideo(), 1000);
+        window.setTimeout(() => {
+            if (this.state.enabled) {
+                this.turnOnVideo();
+            }
+        }, 1000);
     }
 
     // callback from getUserMedia when it succeeds; gives us a stream we can monitor and record from.
@@ -786,6 +814,50 @@ export class SignLanguageToolControls extends React.Component<
 
 export class SignLanguageTool extends ToolboxToolReactAdaptor {
     private reactControls: SignLanguageToolControls;
+    private readonly kCanvasChangeNotificationId = "signLanguageTool";
+
+    private selectedVideoCanBeRecorded(container: Element | null): boolean {
+        if (!container) {
+            return false;
+        }
+        const containingCanvasElement = container.closest(
+            kCanvasElementSelector,
+        );
+        if (!containingCanvasElement) {
+            return true;
+        }
+        return (
+            containingCanvasElement ===
+            getCanvasElementManager()?.getActiveElement()
+        );
+    }
+
+    private updateEnabledStateForSelectedVideo(): void {
+        const selectedVideos = SignLanguageTool.getVideoContainers(true);
+        const selectedContainer =
+            selectedVideos.length > 0 ? selectedVideos[0] : null;
+        const shouldEnable = this.selectedVideoCanBeRecorded(selectedContainer);
+
+        if (shouldEnable) {
+            if (!this.reactControls.isVideoMonitorRunning()) {
+                this.reactControls.turnOnVideo();
+            }
+            if (!this.reactControls.state.enabled) {
+                this.reactControls.setState({ enabled: true });
+            }
+            return;
+        }
+
+        if (
+            this.reactControls.state.enabled ||
+            this.reactControls.isVideoMonitorRunning()
+        ) {
+            this.reactControls.turnOffVideo();
+            if (this.reactControls.state.enabled) {
+                this.reactControls.setState({ enabled: false });
+            }
+        }
+    }
 
     public makeRootElement(): HTMLDivElement {
         const root = document.createElement("div");
@@ -861,6 +933,9 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
                 );
             }
         }
+        getCanvasElementManager()?.detachCanvasElementChangeNotification(
+            this.kCanvasChangeNotificationId,
+        );
         this.reactControls.turnOffVideo();
     }
 
@@ -880,6 +955,7 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
         const container = event.currentTarget as HTMLElement;
         selectVideoContainer(container);
         this.updateStateForSelected(container);
+        this.updateEnabledStateForSelectedVideo();
         // And now in most locations we want to prevent the default behavior where click starts playback.
         // This may need adjustment for zoom.
         // The idea here is that it should be possible to select a video by clicking it
@@ -922,6 +998,10 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
             videoInfoLoaded: false,
         });
         const containers = SignLanguageTool.getVideoContainers(false);
+        getCanvasElementManager()?.requestCanvasElementChangeNotification(
+            this.kCanvasChangeNotificationId,
+            (_bubble) => this.updateEnabledStateForSelectedVideo(),
+        );
         if (!containers || containers.length === 0) {
             if (this.reactControls.state.enabled) {
                 this.reactControls.turnOffVideo();
@@ -953,12 +1033,7 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
                     this.containerClickListener,
                 );
             }
-            // we turn it off when we leave a page, so even if we already have enabled:true,
-            // we need to turn it on for this page now we know there is something to record.
-            this.reactControls.turnOnVideo();
-            if (!this.reactControls.state.enabled) {
-                this.reactControls.setState({ enabled: true });
-            }
+            this.updateEnabledStateForSelectedVideo();
         }
     }
 


### PR DESCRIPTION
- When a non-video canvas element is selected, the video tool should be disabled
- when the tool is enabled, we should do our best to have a camera active

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7839)
<!-- Reviewable:end -->
