### PR TITLE
Better handle image descriptions on custom pages (BL-16109)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
@@ -41,6 +41,7 @@ import {
     UpdateImageTooltipVisibility,
     HandleImageError,
     isPlaceHolderImage,
+    normalizeCoverImageDesignation,
 } from "./bloomImages";
 import {
     adjustTarget,
@@ -5935,6 +5936,9 @@ export class CanvasElementManager {
         if (!textOverPicDiv || !textOverPicDiv.parentElement) {
             return;
         }
+        const page = textOverPicDiv.closest(
+            ".bloom-page",
+        ) as HTMLElement | null;
         if (textOverPicDiv.classList.contains(kBackgroundImageClass)) {
             // just revert it to a placeholder
             const img = getImageFromCanvasElement(textOverPicDiv);
@@ -5942,6 +5946,9 @@ export class CanvasElementManager {
                 img.classList.remove("bloom-imageLoadError");
                 img.onerror = HandleImageError;
                 img.src = "placeHolder.png";
+                if (page) {
+                    normalizeCoverImageDesignation(page);
+                }
                 this.updateCanvasElementForChangedImage(img);
                 notifyToolOfChangedImage(img);
             }
@@ -5971,6 +5978,9 @@ export class CanvasElementManager {
         this.setActiveElement(undefined);
         // By this point it's really gone, so this will clean up if it had a target.
         this.removeDetachedTargets();
+        if (page) {
+            normalizeCoverImageDesignation(page);
+        }
     }
 
     // We verify that 'textElement' is the active element before calling this method.

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -5,6 +5,7 @@ import bloomQtipUtils from "./bloomQtipUtils";
 import {
     cleanupImages,
     HandleImageError,
+    normalizeCoverImageDesignation,
     SetupMetadataButton,
     SetupResizableElement,
     SetupImagesInContainer,
@@ -467,6 +468,15 @@ export function changeImageInfo(
     imgOrImageContainer.setAttribute("data-copyright", imageInfo.copyright);
     imgOrImageContainer.setAttribute("data-creator", imageInfo.creator);
     imgOrImageContainer.setAttribute("data-license", imageInfo.license);
+
+    const page = imgOrImageContainer.closest(
+        ".bloom-page",
+    ) as HTMLElement | null;
+    // In case we're on a custom outside front cover page, keep the coverImage
+    // designation aligned with the current best image choice.
+    if (page) {
+        normalizeCoverImageDesignation(page);
+    }
 }
 
 // This origami checking business is related BL-13120

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -42,6 +42,64 @@ export function isPlaceHolderImage(url: string | null | undefined): boolean {
     return url.toLowerCase().includes("placeholder.png");
 }
 
+function isCustomLayoutOutsideFrontCoverPage(
+    page: Element | null,
+): page is HTMLElement {
+    return (
+        page instanceof HTMLElement &&
+        page.classList.contains("bloom-customLayout") &&
+        page.classList.contains("outsideFrontCover")
+    );
+}
+
+function getNonUiImages(page: HTMLElement): HTMLImageElement[] {
+    return Array.from(page.querySelectorAll("img")).filter(
+        (img) => !img.closest(".bloom-ui"),
+    );
+}
+
+function getFirstNonPlaceholderImage(
+    candidates: HTMLElement[],
+): HTMLElement | undefined {
+    return candidates.find((img) => !isPlaceHolderImage(GetRawImageUrl(img)));
+}
+
+// This is called when we add or remove images on a page. If it is the outside front
+// cover and has a custom layout, we want to make sure that
+// - there is at most one image marked as the cover image,
+// - if there is a real (non-placeholder) background image, it is marked as the cover image
+// - otherwise, the first real image is marked as the cover image
+// If the page is not a custom layout outside front cover or has no real image,
+// this function does nothing.
+export function normalizeCoverImageDesignation(page: HTMLElement): void {
+    if (!isCustomLayoutOutsideFrontCoverPage(page)) {
+        return;
+    }
+
+    const nonUiImages = getNonUiImages(page);
+    const markedImages = Array.from(
+        page.querySelectorAll('[data-book="coverImage"]'),
+    ) as HTMLElement[];
+
+    const backgroundImage = getFirstNonPlaceholderImage(
+        nonUiImages.filter((img) => img.closest(`.${kBackgroundImageClass}`)),
+    );
+    const markedRealImage = getFirstNonPlaceholderImage(markedImages);
+    const firstRealImage = getFirstNonPlaceholderImage(nonUiImages);
+
+    // The one we want to be marked as the cover image
+    const chosenElement =
+        backgroundImage ?? markedRealImage ?? firstRealImage ?? markedImages[0];
+
+    for (const markedElement of markedImages) {
+        if (markedElement !== chosenElement) {
+            markedElement.removeAttribute("data-book");
+        }
+    }
+
+    chosenElement?.setAttribute("data-book", "coverImage");
+}
+
 export function cleanupImages() {
     $(".bloom-imageContainer").css("opacity", ""); //comes in on img containers from an old version of myimgscale, and is a major problem if the image is missing
     $(".bloom-imageContainer").css("overflow", ""); //review: also comes form myimgscale; is it a problem?

--- a/src/BloomBrowserUI/bookEdit/js/bloomImagesSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImagesSpec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCoverImageDesignation } from "./bloomImages";
+
+describe("normalizeCoverImageDesignation", () => {
+    it("marks a newly changed real image on a custom outside front cover", () => {
+        const page = document.createElement("div");
+        page.className = "bloom-page bloom-customLayout outsideFrontCover";
+        page.innerHTML = `
+            <div class="bloom-canvas">
+                <img id="first" src="placeHolder.png" />
+            </div>
+            <div class="bloom-canvas">
+                <img id="second" src="cover.png" />
+            </div>`;
+
+        const second = page.querySelector("#second") as HTMLElement;
+        normalizeCoverImageDesignation(page);
+
+        expect(second.getAttribute("data-book")).toBe("coverImage");
+    });
+
+    it("moves the marker from a placeholder to a real remaining image", () => {
+        const page = document.createElement("div");
+        page.className = "bloom-page bloom-customLayout outsideFrontCover";
+        page.innerHTML = `
+            <div class="bloom-canvas">
+                <img id="placeholder" src="placeHolder.png" data-book="coverImage" />
+            </div>
+            <div class="bloom-canvas">
+                <img id="real" src="real-cover.png" />
+            </div>`;
+
+        normalizeCoverImageDesignation(page);
+
+        const placeholder = page.querySelector("#placeholder") as HTMLElement;
+        const real = page.querySelector("#real") as HTMLElement;
+        expect(placeholder.hasAttribute("data-book")).toBe(false);
+        expect(real.getAttribute("data-book")).toBe("coverImage");
+    });
+
+    it("does not create a new placeholder marker when no real images remain", () => {
+        const page = document.createElement("div");
+        page.className = "bloom-page bloom-customLayout outsideFrontCover";
+        page.innerHTML = `
+            <div class="bloom-canvas">
+                <img id="first" src="placeHolder.png" />
+            </div>
+            <div class="bloom-canvas">
+                <img id="second" src="placeHolder.png" />
+            </div>`;
+
+        normalizeCoverImageDesignation(page);
+
+        expect(page.querySelector('[data-book="coverImage"]')).toBeNull();
+    });
+
+    it("keeps an existing real cover image", () => {
+        const page = document.createElement("div");
+        page.className = "bloom-page bloom-customLayout outsideFrontCover";
+        page.innerHTML = `
+            <div class="bloom-canvas">
+                <img id="existing" src="existing.png" data-book="coverImage" />
+            </div>
+            <div class="bloom-canvas">
+                <img id="preferred" src="preferred.png" />
+            </div>`;
+
+        const preferred = page.querySelector("#preferred") as HTMLElement;
+        normalizeCoverImageDesignation(page);
+
+        const existing = page.querySelector("#existing") as HTMLElement;
+        expect(existing.getAttribute("data-book")).toBe("coverImage");
+        expect(preferred.hasAttribute("data-book")).toBe(false);
+    });
+
+    it("prefers a non-placeholder background image over another designated image", () => {
+        const page = document.createElement("div");
+        page.className = "bloom-page bloom-customLayout outsideFrontCover";
+        page.innerHTML = `
+            <div class="bloom-canvas">
+                <div class="bloom-backgroundImage">
+                    <img id="background" src="background.png" />
+                </div>
+            </div>
+            <div class="bloom-canvas">
+                <img id="existing" src="existing.png" data-book="coverImage" />
+            </div>`;
+
+        normalizeCoverImageDesignation(page);
+
+        const background = page.querySelector("#background") as HTMLElement;
+        const existing = page.querySelector("#existing") as HTMLElement;
+        expect(background.getAttribute("data-book")).toBe("coverImage");
+        expect(existing.hasAttribute("data-book")).toBe(false);
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/imageDescription/imageDescription.tsx
@@ -278,6 +278,16 @@ export function setupImageDescriptions(
     }
 }
 
+function shouldMarkAsCoverImageDescription(container: Element): boolean {
+    const page = container.closest(".bloom-page");
+    return !!(
+        page &&
+        page.classList.contains("bloom-customLayout") &&
+        page.classList.contains("outsideFrontCover") &&
+        container.classList.contains(kBloomCanvasClass)
+    );
+}
+
 // Adds a new bloom-translationGroup
 // This function is meant to get called after we send a request to C# land to figure out what kind of bloom-editables/languages we need inside this translation group
 // The container must be inside the (editing) page iFrame (because this relies on getPageFromExports()
@@ -309,12 +319,17 @@ function appendTranslationGroup(innerHtml, container: Element) {
     const newTg = getEditablePageBundleExports()!
         .makeElement(newElementHtml)
         .get(0);
+    const markAsCoverImageDescription =
+        shouldMarkAsCoverImageDescription(container);
 
     for (const editable of Array.from(
         newTg.getElementsByClassName("bloom-editable"),
     )) {
         editable.classList.add("ImageDescriptionEdit-style");
         editable.classList.remove("normal-style");
+        if (markAsCoverImageDescription) {
+            editable.setAttribute("data-book", "coverImageDescription");
+        }
     }
 
     container.appendChild(newTg);


### PR DESCRIPTION
- when an image description is added to a custom front cover, mark it as the cover image description, allowing it to survive conversion back to standard layout, even by an older Bloom
- make designating a coverImage more automatic

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7841)
<!-- Reviewable:end -->
