### PR TITLE
Split font table between used and unused languages (BL-16151)

### DIFF
--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -1016,6 +1016,14 @@
         <source xml:lang="en">When you publish a book to the web or as an ebook, Bloom will flag any problematic fonts. For example, we cannot legally host most Microsoft fonts on BloomLibrary.org.</source>
         <note>ID: BookSettings.Fonts.Problematic</note>
       </trans-unit>
+      <trans-unit id="BookSettings.Fonts.OtherLanguages" translate="no">
+        <source xml:lang="en">Other Languages</source>
+        <note>ID: BookSettings.Fonts.OtherLanguages</note>
+      </trans-unit>
+      <trans-unit id="BookSettings.Fonts.MaybeProblematic" translate="no">
+        <source xml:lang="en">The Bloom file for this book also has some text in other languages. Please ignore any warnings here unless you plan to publish the book with these languages.</source>
+        <note>ID: BookSettings.Fonts.MaybeProblematic</note>
+      </trans-unit>
       <trans-unit id="BookSettings.Fonts.TableDescription" sil:dynamic="true">
         <source xml:lang="en">The following table shows where fonts have been used.</source>
         <note>ID: BookSettings.Fonts.TableDescription</note>

--- a/src/BloomBrowserUI/bookEdit/bookAndPageSettings/BookAndPageSettingsDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/bookAndPageSettings/BookAndPageSettingsDialog.tsx
@@ -112,6 +112,11 @@ export const BookAndPageSettingsDialog: React.FunctionComponent<{
         true,
     );
 
+    const [unusedLanguageDataExists] = useApiBoolean(
+        "stylesAndFonts/unusedLanguageDataExists",
+        false,
+    );
+
     const xmatterLockedBy = useL10n(
         "Locked by {0} Front/Back matter",
         "BookSettings.LockedByXMatter",
@@ -375,6 +380,7 @@ export const BookAndPageSettingsDialog: React.FunctionComponent<{
         },
         onColorPickerVisibilityChanged: setDialogVisibleWhileColorPickerOpen,
         themeNames: appearanceUIOptions.themeNames,
+        unusedLanguageDataExists: unusedLanguageDataExists,
     });
 
     const pageSettingsArea = usePageSettingsAreaDefinition({

--- a/src/BloomBrowserUI/bookEdit/bookAndPageSettings/BookSettingsConfigrPages.tsx
+++ b/src/BloomBrowserUI/bookEdit/bookAndPageSettings/BookSettingsConfigrPages.tsx
@@ -60,6 +60,7 @@ type BookSettingsAreaProps = {
     onGoToThemeAndLayout?: () => void;
     onColorPickerVisibilityChanged?: (open: boolean) => void;
     themeNames: Array<{ label: string; value: string }>;
+    unusedLanguageDataExists?: boolean;
 };
 
 export type IConfigrAreaDefinition = {
@@ -192,6 +193,10 @@ export const useBookSettingsAreaDefinition = (
     const fullBleedDescription = useL10n(
         "Enable full bleed layout for printing. This turns on the [Print Bleed](https://en.wikipedia.org/wiki/Bleed_%28printing%29) indicators on paper layouts. See [Full Bleed Layout](https://docs.bloomlibrary.org/full-bleed) for more information.",
         "BookSettings.FullBleed.Description",
+    );
+    const otherLanguagesLabel = useL10n(
+        "Other Languages",
+        "BookSettings.Fonts.OtherLanguages",
     );
 
     const coverColorPickerControl = React.useCallback(
@@ -548,10 +553,32 @@ export const useBookSettingsAreaDefinition = (
                             </div>
                         </NoteBox>
                         <StyleAndFontTable
+                            languages="current"
                             closeDialog={props.saveSettingsAndCloseDialog}
                         />
                     </ConfigrStatic>
                 </ConfigrGroup>
+                {props.unusedLanguageDataExists && (
+                    <ConfigrGroup label={otherLanguagesLabel}>
+                        <ConfigrStatic>
+                            <NoteBox>
+                                <div>
+                                    <P l10nKey="BookSettings.Fonts.MaybeProblematic">
+                                        The Bloom file for this book also has
+                                        some text in other languages. Please
+                                        ignore any warnings here unless you plan
+                                        to publish the book with these
+                                        languages.
+                                    </P>
+                                </div>
+                            </NoteBox>
+                            <StyleAndFontTable
+                                languages="other"
+                                closeDialog={props.saveSettingsAndCloseDialog}
+                            />
+                        </ConfigrStatic>
+                    </ConfigrGroup>
+                )}
             </ConfigrPage>,
         ],
     };

--- a/src/BloomBrowserUI/bookEdit/bookAndPageSettings/StyleAndFontTable.tsx
+++ b/src/BloomBrowserUI/bookEdit/bookAndPageSettings/StyleAndFontTable.tsx
@@ -26,10 +26,11 @@ export interface IStyleAndFont {
     pageDescription: string;
 }
 export const StyleAndFontTable: React.FunctionComponent<{
+    languages: "current" | "other";
     closeDialog: () => void;
 }> = (props) => {
     const rowsSource: IStyleAndFont[] = useApiObject<IStyleAndFont[]>(
-        "stylesAndFonts/getDataRows",
+        `stylesAndFonts/getDataRows?languages=${props.languages}`,
         [],
     );
     // getDataRows tries to be very comprehensive about fonts used by anything in the document.

--- a/src/BloomExe/web/controllers/StylesAndFontsApi.cs
+++ b/src/BloomExe/web/controllers/StylesAndFontsApi.cs
@@ -27,6 +27,53 @@ namespace Bloom.web.controllers
                 HandleGetDataRows,
                 false
             );
+            apiHandler.RegisterBooleanEndpointHandler(
+                "stylesAndFonts/unusedLanguageDataExists",
+                request => DoesUnusedLanguageDataExist(),
+                null,
+                false
+            );
+        }
+
+        /// <summary>
+        /// Return true iff there are languages in the book data (including defaultLanguages.css) that
+        /// do not appear in the current collection settings.
+        /// </summary>
+        private bool DoesUnusedLanguageDataExist()
+        {
+            InitializeFontAndLanguageData(out _, out _, out var unusedLanguages);
+            return unusedLanguages.Count > 0;
+        }
+
+        private void InitializeFontAndLanguageData(
+            out Dictionary<string, string> langToDefaultFont,
+            out Dictionary<string, List<string>> fontToLangs,
+            out HashSet<string> unusedLanguages
+        )
+        {
+            var book = _bookSelection.CurrentSelection;
+            fontToLangs = new Dictionary<string, List<string>>();
+            langToDefaultFont = GetLanguagesAndDefaultFonts(fontToLangs, book, book.OurHtmlDom);
+
+            var collectionLanguages = GetCurrentLanguageSet();
+            unusedLanguages = new HashSet<string>();
+            foreach (var key in langToDefaultFont.Keys)
+            {
+                if (!collectionLanguages.Contains(key))
+                    unusedLanguages.Add(key);
+            }
+            // There may be languages that have data in the book, but don't have default fonts assigned
+            // in defaultLangauges.css.  They may still have fonts assigned in style overrides.  So we
+            // also check for any languages that have data in the book at all, even if they don't have
+            // a default font.
+            var allLanguages = book.AllPublishableLanguages(
+                includeLangsOccurringOnlyInXmatter: false
+            );
+            foreach (var key in allLanguages.Keys)
+            {
+                if (!collectionLanguages.Contains(key))
+                    unusedLanguages.Add(key);
+            }
         }
 
         // This class must be kept in sync with the IStyleAndFont interface in StyleAndFontTable.tsx.
@@ -53,18 +100,45 @@ namespace Bloom.web.controllers
             public string description;
         }
 
+        HashSet<string> _currentLanguageSet = null;
+
+        private HashSet<string> GetCurrentLanguageSet()
+        {
+            if (_currentLanguageSet != null)
+                return _currentLanguageSet;
+
+            var book = _bookSelection.CurrentSelection;
+            _currentLanguageSet = new HashSet<string>
+            {
+                book.CollectionSettings.Language1Tag,
+                book.CollectionSettings.Language2Tag,
+            };
+            if (!string.IsNullOrEmpty(book.CollectionSettings.Language3Tag))
+                _currentLanguageSet.Add(book.CollectionSettings.Language3Tag);
+            if (!string.IsNullOrEmpty(book.CollectionSettings.SignLanguageTag))
+                _currentLanguageSet.Add(book.CollectionSettings.SignLanguageTag);
+            return _currentLanguageSet;
+        }
+
         private void HandleGetDataRows(ApiRequest request)
         {
             var book = _bookSelection.CurrentSelection;
+            var languagesSelection = request.GetParamOrNull("languages");
             // Get all the styles used in the book.
             var stylesInBook = GetStylesUsedInBook(book.OurHtmlDom, book.FolderPath);
             // Get all the languages used in the book and their default fonts.
-            var fontToLangs = new Dictionary<string, List<string>>();
-            var langToFont = GetLanguagesAndDefaultFonts(fontToLangs, book, book.OurHtmlDom);
+            InitializeFontAndLanguageData(
+                out var langToDefaultFont,
+                out var fontToLangs,
+                out var unusedLanguages
+            );
             // Get all the user-modified styles that set a font for the style.
             var modifiedStylesAndFonts = GetUserModifiedStylesAndFonts(book.OurHtmlDom);
             // Add the styles that are in the book but not covered by the user-modified styles.
             var stylesAndFonts = new List<StyleAndFont>();
+            var collectionLanguages = GetCurrentLanguageSet();
+            var allLanguagesInBook = new HashSet<string>(langToDefaultFont.Keys);
+            allLanguagesInBook.UnionWith(unusedLanguages);
             foreach (var style in stylesInBook.Keys)
             {
                 var modified = modifiedStylesAndFonts.FindAll(s => s.style == style).ToArray();
@@ -72,12 +146,34 @@ namespace Bloom.web.controllers
                 {
                     foreach (var kvp in fontToLangs)
                     {
+                        string languageTag = null;
+                        if (languagesSelection == "current")
+                        {
+                            var currentlyUsed = kvp
+                                .Value.Where(lang => collectionLanguages.Contains(lang))
+                                .ToList();
+                            if (currentlyUsed.Count == 0)
+                                continue; // This font is not actually used in the book, so skip it.
+                            if (currentlyUsed.Count == 1)
+                                languageTag = currentlyUsed.First();
+                            else
+                                languageTag = "*"; // Enhance: list tags, and eventually list language names for display?
+                        }
+                        else
+                        {
+                            var currentlyUnused = kvp
+                                .Value.Where(lang => !collectionLanguages.Contains(lang))
+                                .ToList();
+                            if (currentlyUnused.Count == 0)
+                                continue; // This font is used in the book, so skip it.
+                            if (currentlyUnused.Count == 1)
+                                languageTag = currentlyUnused.First();
+                            else
+                                languageTag = "*"; // Enhance: list tags, and eventually list language names for display?
+                        }
                         var styleAndFont = new StyleAndFont();
                         styleAndFont.style = style;
-                        if (kvp.Value.Count == 1)
-                            styleAndFont.languageTag = kvp.Value.First();
-                        else
-                            styleAndFont.languageTag = "*";
+                        styleAndFont.languageTag = languageTag;
                         styleAndFont.fontName = kvp.Key;
                         styleAndFont.pageId = stylesInBook[style].id;
                         styleAndFont.pageDescription = stylesInBook[style].description;
@@ -86,16 +182,18 @@ namespace Bloom.web.controllers
                 }
                 else
                 {
-                    foreach (var tag in langToFont.Keys)
+                    foreach (var tag in allLanguagesInBook)
                     {
-                        var styleAndFont = new StyleAndFont();
-                        styleAndFont.style = style;
-                        styleAndFont.languageTag = tag;
+                        if (languagesSelection == "current" && !collectionLanguages.Contains(tag))
+                            continue; // This language is not actually used in the book, so skip it.
+                        else if (languagesSelection == "other" && collectionLanguages.Contains(tag))
+                            continue; // This language is used in the book, so skip it.
+                        string fontName = null;
                         var modifiedForLang = modified.FirstOrDefault(s =>
                             s.languageTag == tag && !string.IsNullOrEmpty(s.fontName)
                         );
                         if (modifiedForLang != null)
-                            styleAndFont.fontName = modifiedForLang.fontName;
+                            fontName = modifiedForLang.fontName;
                         else
                         {
                             // I don't think we normally have user-modified styles that apply to all languages,
@@ -107,10 +205,16 @@ namespace Bloom.web.controllers
                                 s.languageTag == "*" && !string.IsNullOrEmpty(s.fontName)
                             );
                             if (modifiedForAll != null)
-                                styleAndFont.fontName = modifiedForAll.fontName;
+                                fontName = modifiedForAll.fontName;
+                            else if (langToDefaultFont.ContainsKey(tag))
+                                fontName = langToDefaultFont[tag];
                             else
-                                styleAndFont.fontName = langToFont[tag];
+                                continue; // No font is specified for this language, so skip it.
                         }
+                        var styleAndFont = new StyleAndFont();
+                        styleAndFont.style = style;
+                        styleAndFont.languageTag = tag;
+                        styleAndFont.fontName = fontName;
                         styleAndFont.pageId = stylesInBook[style].id;
                         styleAndFont.pageDescription = stylesInBook[style].description;
                         stylesAndFonts.Add(styleAndFont);
@@ -126,6 +230,22 @@ namespace Bloom.web.controllers
                     )
                 )
                 {
+                    // I'm not sure if languageTag can ever == "*" here, but Devin was worried about it,
+                    // and if it does happen, we may as well always include it.  All of these entries are
+                    // likely to be skipped by TS code anyway because of the empty pageId.
+                    if (styleAndFont.languageTag != "*")
+                    {
+                        if (
+                            languagesSelection == "current"
+                            && !collectionLanguages.Contains(styleAndFont.languageTag)
+                        )
+                            continue; // This language is not actually used in the book, so skip it.
+                        else if (
+                            languagesSelection == "other"
+                            && collectionLanguages.Contains(styleAndFont.languageTag)
+                        )
+                            continue; // This language is used in the book, so skip it.
+                    }
                     styleAndFont.pageId = "";
                     styleAndFont.pageDescription = "";
                     stylesAndFonts.Add(styleAndFont);
@@ -160,41 +280,51 @@ namespace Bloom.web.controllers
             );
 
             // Ensure every collection-level default font is included in the list
-            var collectionLevelFonts = new HashSet<(string fontName, string languageTag)>
+            // (only relevant when showing "current" languages, not "other" languages)
+            if (languagesSelection == "current")
             {
-                (book.CollectionSettings.Language1.FontName, book.CollectionSettings.Language1Tag),
-                (book.CollectionSettings.Language2.FontName, book.CollectionSettings.Language2Tag),
-            };
-            if (!String.IsNullOrEmpty(book.CollectionSettings.Language3Tag))
-            {
-                collectionLevelFonts.Add(
-                    (
-                        book.CollectionSettings.Language3.FontName,
-                        book.CollectionSettings.Language3Tag
-                    )
-                );
-            }
-            foreach (var font in collectionLevelFonts.Reverse()) // reverse because we're inserting at the beginning each time
-            {
-                if (!stylesAndFonts.Exists(s => s.fontName == font.fontName))
+                var collectionLevelFonts = new HashSet<(string fontName, string languageTag)>
                 {
-                    var languageName = GetLanguageName(font.languageTag);
-                    stylesAndFonts.Insert(
-                        0,
-                        new StyleAndFont
-                        {
-                            styleName = string.Format(
-                                LocalizationManager.GetString(
-                                    "CollectionSettingsDialog.BookMakingTab.DefaultFontFor",
-                                    "Default Font for {0}",
-                                    "{0} is a language name."
-                                ),
-                                languageName
-                            ),
-                            languageName = languageName,
-                            fontName = font.fontName,
-                        }
+                    (
+                        book.CollectionSettings.Language1.FontName,
+                        book.CollectionSettings.Language1Tag
+                    ),
+                    (
+                        book.CollectionSettings.Language2.FontName,
+                        book.CollectionSettings.Language2Tag
+                    ),
+                };
+                if (!String.IsNullOrEmpty(book.CollectionSettings.Language3Tag))
+                {
+                    collectionLevelFonts.Add(
+                        (
+                            book.CollectionSettings.Language3.FontName,
+                            book.CollectionSettings.Language3Tag
+                        )
                     );
+                }
+                foreach (var font in collectionLevelFonts.Reverse()) // reverse because we're inserting at the beginning each time
+                {
+                    if (!stylesAndFonts.Exists(s => s.fontName == font.fontName))
+                    {
+                        var languageName = GetLanguageName(font.languageTag);
+                        stylesAndFonts.Insert(
+                            0,
+                            new StyleAndFont
+                            {
+                                styleName = string.Format(
+                                    LocalizationManager.GetString(
+                                        "CollectionSettingsDialog.BookMakingTab.DefaultFontFor",
+                                        "Default Font for {0}",
+                                        "{0} is a language name."
+                                    ),
+                                    languageName
+                                ),
+                                languageName = languageName,
+                                fontName = font.fontName,
+                            }
+                        );
+                    }
                 }
             }
             var jsonData = JsonConvert.SerializeObject(stylesAndFonts.ToArray());


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7844)
<!-- Reviewable:end -->
