### PR TITLE
Make rab-settings.xml IO more robust (BL-16178)

### DIFF
--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -2444,17 +2444,7 @@ namespace Bloom.Publish.Rab
             var settingsPath = GetRabSettingsFilePath();
             Directory.CreateDirectory(Path.GetDirectoryName(settingsPath));
 
-            XDocument document;
-            if (RobustFile.Exists(settingsPath))
-            {
-                document = XDocument.Load(settingsPath, LoadOptions.PreserveWhitespace);
-                if (document.Root == null)
-                    document.Add(new XElement("settings"));
-            }
-            else
-            {
-                document = new XDocument(new XElement("settings"));
-            }
+            var document = LoadRabSettingsDocument(settingsPath);
 
             var root = document.Root;
             var appsElement = root.Element("apps");
@@ -2473,7 +2463,50 @@ namespace Bloom.Publish.Rab
                 )
             );
 
-            document.Save(settingsPath);
+            SaveRabSettingsDocument(settingsPath, document);
+        }
+
+        /// <summary>
+        /// Loads Reading App Builder's shared settings file, recreating it if the existing XML is malformed.
+        /// </summary>
+        private XDocument LoadRabSettingsDocument(string settingsPath)
+        {
+            if (!RobustFile.Exists(settingsPath))
+                return new XDocument(new XElement("settings"));
+
+            try
+            {
+                var document = XDocument.Load(settingsPath, LoadOptions.PreserveWhitespace);
+                if (document.Root == null)
+                    document.Add(new XElement("settings"));
+
+                return document;
+            }
+            catch (System.Xml.XmlException error)
+            {
+                Logger.WriteEvent(
+                    $"Recreating corrupt Reading App Builder settings file at {settingsPath}: {error.Message}"
+                );
+                return new XDocument(new XElement("settings"));
+            }
+        }
+
+        /// <summary>
+        /// Writes Reading App Builder's shared settings file through a temp file so interrupted saves do not leave partial XML behind.
+        /// </summary>
+        private void SaveRabSettingsDocument(string settingsPath, XDocument document)
+        {
+            string tempFilePath;
+            using (var temp = TempFile.InFolderOf(settingsPath))
+            {
+                tempFilePath = temp.Path;
+            }
+
+            document.Save(tempFilePath);
+            if (RobustFile.Exists(settingsPath))
+                RobustFile.Replace(tempFilePath, settingsPath, null);
+            else
+                RobustFile.Move(tempFilePath, settingsPath);
         }
 
         internal virtual RabPrepareStepStatus[] GetPrepareSteps(

--- a/src/BloomTests/Publish/Rab/RabAppProjectTests.cs
+++ b/src/BloomTests/Publish/Rab/RabAppProjectTests.cs
@@ -1591,6 +1591,44 @@ namespace BloomTests.Publish.Rab
         }
 
         [Test]
+        public async Task OpenInRab_WhenRabSettingsXmlIsCorrupt_RecreatesSettingsFile()
+        {
+            using var tempFolder = new TemporaryFolder("RabAppProjectTests");
+            var paths = new RabWorkspacePaths(tempFolder.Path);
+            var trackedBooks = new List<RabBookPublishInfo>
+            {
+                new RabBookPublishInfo
+                {
+                    BookId = "book-1",
+                    FolderPath = Path.Combine(tempFolder.Path, "book-1"),
+                    Title = "Book One",
+                    BloomPubPath = Path.Combine(paths.BloomPubRoot, "book-1.bloompub"),
+                },
+            };
+            Directory.CreateDirectory(trackedBooks[0].FolderPath);
+
+            var service = new TestRabProjectService(paths, "Sample App", trackedBooks);
+            await service.PrepareAsync();
+
+            Directory.CreateDirectory(Path.GetDirectoryName(service.GetRabSettingsFilePath()));
+            RobustFile.WriteAllText(service.GetRabSettingsFilePath(), "<settings><apps>");
+
+            Assert.DoesNotThrow(() => service.OpenInRab());
+
+            var settingsDocument = XDocument.Load(service.GetRabSettingsFilePath());
+
+            Assert.That(service.DetachedFileName, Is.EqualTo("cmd.exe"));
+            Assert.That(
+                settingsDocument.Root?.Element("apps")?.Elements("app").Count(),
+                Is.EqualTo(1)
+            );
+            Assert.That(
+                settingsDocument.Root?.Element("apps")?.Element("app")?.Element("filename")?.Value,
+                Is.EqualTo(service.GetStatus().AppDefPath)
+            );
+        }
+
+        [Test]
         public async Task OpenInRab_DoesNotWriteToProgress()
         {
             using var tempFolder = new TemporaryFolder("RabAppProjectTests");


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7845)
<!-- Reviewable:end -->
