### PR TITLE
Fix sign language tool for draggable videos (BL-16131)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
@@ -82,7 +82,8 @@ import { get, postData, postJson, postString } from "../../utils/bloomApi";
 import AudioRecording from "../toolbox/talkingBook/audioRecording";
 import PlaceholderProvider from "./PlaceholderProvider";
 import { getExactClientSize } from "../../utils/elementUtils";
-import { copyContentToTarget, getTarget } from "bloom-player";
+import { getTarget } from "bloom-player";
+import { copyContentToTargetAndCleanup } from "./dragActivityRuntimeUtils";
 import { showRequiresSubscriptionDialogInEditView } from "../../react_components/requiresSubscription";
 import { FeatureStatus } from "../../react_components/featureStatus";
 import $ from "jquery";
@@ -2906,7 +2907,7 @@ export class CanvasElementManager {
             this.doAfterNewImageAdjusted();
             this.doAfterNewImageAdjusted = undefined;
         }
-        copyContentToTarget(canvasElement);
+        copyContentToTargetAndCleanup(canvasElement);
     }
 
     // When the image is changed in a canvas element (e.g., choose or paste image),

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -10,7 +10,10 @@ import {
     SetupResizableElement,
     SetupImagesInContainer,
 } from "./bloomImages";
-import { SetupVideoEditing } from "./bloomVideo";
+import {
+    removeTransientVideoTimestampParams,
+    SetupVideoEditing,
+} from "./bloomVideo";
 import { SetupWidgetEditing } from "./bloomWidgets";
 import { setupOrigami, cleanupOrigami } from "./origami";
 import theOneLocalizationManager from "../../lib/localizationManager/localizationManager";
@@ -1225,6 +1228,7 @@ function removeEditingDebris() {
     for (let i = 0; i < textLabels.length; i++) {
         textLabels[i].remove();
     }
+    removeTransientVideoTimestampParams(document.body);
     cleanupNiceScroll(); // don't leave the nicescroll debris around
 }
 

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.spec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+    removeTransientVideoTimestampParams,
+    stripTransientVideoTimestampParam,
+} from "./bloomVideo";
+
+describe("bloomVideo transient video timestamp cleanup", () => {
+    it("removes only the transient video timestamp param", () => {
+        const cleaned = stripTransientVideoTimestampParam(
+            "video.mp4?persist=true&bloomVideoTransientTimestamp=123#t=1,2",
+        );
+
+        expect(cleaned).toBe("video.mp4?persist=true#t=1,2");
+    });
+
+    it("leaves urls without the transient param unchanged", () => {
+        const cleaned = stripTransientVideoTimestampParam(
+            "video.mp4?persist=true#t=1,2",
+        );
+
+        expect(cleaned).toBe("video.mp4?persist=true#t=1,2");
+    });
+
+    it("cleans transient params from video sources in the page", () => {
+        document.body.innerHTML =
+            '<div><video src="movie.mp4?bloomVideoTransientTimestamp=7"></video><video><source src="clip.mp4?keep=1&bloomVideoTransientTimestamp=8#t=2,4"></source></video></div>';
+
+        removeTransientVideoTimestampParams(document.body);
+
+        const videos = Array.from(document.body.querySelectorAll("video"));
+        expect(videos[0].getAttribute("src")).toBe("movie.mp4");
+        expect(videos[1].querySelector("source")?.getAttribute("src")).toBe(
+            "clip.mp4?keep=1#t=2,4",
+        );
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -19,6 +19,7 @@ import { kCanvasElementSelector } from "../toolbox/canvas/canvasElementUtils";
 import $ from "jquery";
 
 const kBloomVideoTransientTimestampParam = "bloomVideoTransientTimestamp";
+const initializedVideos = new WeakSet<HTMLVideoElement>();
 
 export function SetupVideoEditing(container: HTMLElement) {
     $(container)
@@ -38,7 +39,7 @@ function SetupVideoContainer(videoContainerDiv: Element) {
 }
 
 function setupVideoElement(videoElement: HTMLVideoElement) {
-    if (videoElement.dataset.bloomVideoInitialized === "true") {
+    if (initializedVideos.has(videoElement)) {
         return;
     }
 
@@ -71,7 +72,7 @@ function setupVideoElement(videoElement: HTMLVideoElement) {
         "bloom-videoReplayIcon",
     );
     replayButton.addEventListener("click", handleReplayClick);
-    videoElement.dataset.bloomVideoInitialized = "true";
+    initializedVideos.add(videoElement);
 }
 
 function videoEndedEventHandler(e: Event) {

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -292,11 +292,23 @@ export function updateVideoInContainer(container: Element, url: string): void {
             video.appendChild(source);
         }
         if (source) {
-            source.setAttribute("src", url);
+            source.setAttribute("src", addNowParam(url));
+            video.load();
             // Transparent background videos allow the placeholder to show.  See BL-13918.
             container.classList.remove("bloom-noVideoSelected");
         }
     }
+}
+
+function addNowParam(url: string): string {
+    const hashIndex = url.indexOf("#");
+    const hash = hashIndex >= 0 ? url.substring(hashIndex) : "";
+    const beforeHash = hashIndex >= 0 ? url.substring(0, hashIndex) : url;
+    const queryIndex = beforeHash.indexOf("?");
+    const baseUrl =
+        queryIndex >= 0 ? beforeHash.substring(0, queryIndex) : beforeHash;
+
+    return `${baseUrl}?now=${Date.now()}${hash}`;
 }
 
 // configure one of the icons we display over videos. We put a div around it and apply

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -18,45 +18,47 @@ import { getReplayIcon } from "../img/replayIcon";
 import { kCanvasElementSelector } from "../toolbox/canvas/canvasElementUtils";
 import $ from "jquery";
 
-export function SetupVideoEditing(container) {
+const kBloomVideoTransientTimestampParam = "bloomVideoTransientTimestamp";
+
+export function SetupVideoEditing(container: HTMLElement) {
     $(container)
         .find(".bloom-videoContainer")
         .each((index, vc) => {
             SetupVideoContainer(vc);
         });
-    Array.from(container.getElementsByTagName("video")).forEach(
-        (videoElement: HTMLVideoElement) => {
-            videoElement.removeAttribute("controls");
-            // I don't think we need to do this in normal operation, but it's useful when
-            // debugging, and just might prevent a problem in normal operation.
-            videoElement.parentElement?.classList.remove("playing");
-            videoElement.parentElement?.classList.remove("paused");
-            videoElement.addEventListener("click", handleVideoClick);
-            const playButton = wrapVideoIcon(
-                videoElement,
-                // Alternatively, we could import the Material UI icon, make this file a TSX, and use
-                // ReactDom.render to render the icon into the div. But just creating the SVG
-                // ourselves (as these methods do) seems more natural to me. We would not be using
-                // React for anything except to make use of an image which unfortunately is only
-                // available by default as a component.
-                getPlayIcon("#ffffff", videoElement),
-                "bloom-videoPlayIcon",
-            );
-            playButton.addEventListener("click", handlePlayClick);
-            const pauseButton = wrapVideoIcon(
-                videoElement,
-                getPauseIcon("#ffffff", videoElement),
-                "bloom-videoPauseIcon",
-            );
-            pauseButton.addEventListener("click", handlePauseClick);
-            const replayButton = wrapVideoIcon(
-                videoElement,
-                getReplayIcon("#ffffff", videoElement),
-                "bloom-videoReplayIcon",
-            );
-            replayButton.addEventListener("click", handleReplayClick);
-        },
-    );
+    Array.from<HTMLVideoElement>(
+        container.getElementsByTagName("video"),
+    ).forEach((videoElement: HTMLVideoElement) => {
+        videoElement.removeAttribute("controls");
+        // I don't think we need to do this in normal operation, but it's useful when
+        // debugging, and just might prevent a problem in normal operation.
+        videoElement.parentElement?.classList.remove("playing");
+        videoElement.parentElement?.classList.remove("paused");
+        videoElement.addEventListener("click", handleVideoClick);
+        const playButton = wrapVideoIcon(
+            videoElement,
+            // Alternatively, we could import the Material UI icon, make this file a TSX, and use
+            // ReactDom.render to render the icon into the div. But just creating the SVG
+            // ourselves (as these methods do) seems more natural to me. We would not be using
+            // React for anything except to make use of an image which unfortunately is only
+            // available by default as a component.
+            getPlayIcon("#ffffff", videoElement),
+            "bloom-videoPlayIcon",
+        );
+        playButton.addEventListener("click", handlePlayClick);
+        const pauseButton = wrapVideoIcon(
+            videoElement,
+            getPauseIcon("#ffffff", videoElement),
+            "bloom-videoPauseIcon",
+        );
+        pauseButton.addEventListener("click", handlePauseClick);
+        const replayButton = wrapVideoIcon(
+            videoElement,
+            getReplayIcon("#ffffff", videoElement),
+            "bloom-videoReplayIcon",
+        );
+        replayButton.addEventListener("click", handleReplayClick);
+    });
 }
 
 function SetupVideoContainer(videoContainerDiv: Element) {
@@ -92,7 +94,7 @@ function videoPlayingEventHandler(e: Event) {
     currentVideoElement = video;
     let end: number = getVideoEndSeconds(video);
     const untrimmedEndPoint: number = 0.0;
-    if (end == untrimmedEndPoint) {
+    if (end === untrimmedEndPoint) {
         // We can't just set the endpoint to equal the duration of the video here, because
         // we will be testing that the current playback time is greater than the endpoint.
         // Since we test for the end of the video every 1/10th of a second, set the endpoint
@@ -292,7 +294,7 @@ export function updateVideoInContainer(container: Element, url: string): void {
             video.appendChild(source);
         }
         if (source) {
-            source.setAttribute("src", addNowParam(url));
+            source.setAttribute("src", addTransientVideoTimestampParam(url));
             video.load();
             // Transparent background videos allow the placeholder to show.  See BL-13918.
             container.classList.remove("bloom-noVideoSelected");
@@ -300,15 +302,49 @@ export function updateVideoInContainer(container: Element, url: string): void {
     }
 }
 
-function addNowParam(url: string): string {
+function addTransientVideoTimestampParam(url: string): string {
     const hashIndex = url.indexOf("#");
     const hash = hashIndex >= 0 ? url.substring(hashIndex) : "";
     const beforeHash = hashIndex >= 0 ? url.substring(0, hashIndex) : url;
     const queryIndex = beforeHash.indexOf("?");
     const baseUrl =
         queryIndex >= 0 ? beforeHash.substring(0, queryIndex) : beforeHash;
+    const query = queryIndex >= 0 ? beforeHash.substring(queryIndex + 1) : "";
+    const searchParams = new URLSearchParams(query);
+    searchParams.set(kBloomVideoTransientTimestampParam, Date.now().toString());
+    const search = searchParams.toString();
 
-    return `${baseUrl}?now=${Date.now()}${hash}`;
+    return `${baseUrl}${search ? `?${search}` : ""}${hash}`;
+}
+
+export function stripTransientVideoTimestampParam(url: string): string {
+    const hashIndex = url.indexOf("#");
+    const hash = hashIndex >= 0 ? url.substring(hashIndex) : "";
+    const beforeHash = hashIndex >= 0 ? url.substring(0, hashIndex) : url;
+    const queryIndex = beforeHash.indexOf("?");
+    if (queryIndex < 0) {
+        return url;
+    }
+
+    const baseUrl = beforeHash.substring(0, queryIndex);
+    const query = beforeHash.substring(queryIndex + 1);
+    const searchParams = new URLSearchParams(query);
+    searchParams.delete(kBloomVideoTransientTimestampParam);
+    const search = searchParams.toString();
+
+    return `${baseUrl}${search ? `?${search}` : ""}${hash}`;
+}
+
+export function removeTransientVideoTimestampParams(root: ParentNode): void {
+    for (const element of Array.from(
+        root.querySelectorAll<HTMLElement>("video[src], video source[src]"),
+    )) {
+        const src = element.getAttribute("src");
+        if (!src) {
+            continue;
+        }
+        element.setAttribute("src", stripTransientVideoTimestampParam(src));
+    }
 }
 
 // configure one of the icons we display over videos. We put a div around it and apply

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -26,52 +26,52 @@ export function SetupVideoEditing(container: HTMLElement) {
         .each((index, vc) => {
             SetupVideoContainer(vc);
         });
-    Array.from<HTMLVideoElement>(
-        container.getElementsByTagName("video"),
-    ).forEach((videoElement: HTMLVideoElement) => {
-        videoElement.removeAttribute("controls");
-        // I don't think we need to do this in normal operation, but it's useful when
-        // debugging, and just might prevent a problem in normal operation.
-        videoElement.parentElement?.classList.remove("playing");
-        videoElement.parentElement?.classList.remove("paused");
-        videoElement.addEventListener("click", handleVideoClick);
-        const playButton = wrapVideoIcon(
-            videoElement,
-            // Alternatively, we could import the Material UI icon, make this file a TSX, and use
-            // ReactDom.render to render the icon into the div. But just creating the SVG
-            // ourselves (as these methods do) seems more natural to me. We would not be using
-            // React for anything except to make use of an image which unfortunately is only
-            // available by default as a component.
-            getPlayIcon("#ffffff", videoElement),
-            "bloom-videoPlayIcon",
-        );
-        playButton.addEventListener("click", handlePlayClick);
-        const pauseButton = wrapVideoIcon(
-            videoElement,
-            getPauseIcon("#ffffff", videoElement),
-            "bloom-videoPauseIcon",
-        );
-        pauseButton.addEventListener("click", handlePauseClick);
-        const replayButton = wrapVideoIcon(
-            videoElement,
-            getReplayIcon("#ffffff", videoElement),
-            "bloom-videoReplayIcon",
-        );
-        replayButton.addEventListener("click", handleReplayClick);
-    });
 }
 
 function SetupVideoContainer(videoContainerDiv: Element) {
     const videoElts = videoContainerDiv.getElementsByTagName("video");
     for (let i = 0; i < videoElts.length; i++) {
-        const video = videoElts[i] as HTMLVideoElement;
-        // Early sign language code included this; now we do it only on hover.
-        video.removeAttribute("controls");
-        video.addEventListener("playing", (e) => videoPlayingEventHandler(e));
-        video.addEventListener("ended", (e) => videoEndedEventHandler(e));
+        setupVideoElement(videoElts[i] as HTMLVideoElement);
     }
 
     SetupClickToShowSignLanguageTool(videoContainerDiv);
+}
+
+function setupVideoElement(videoElement: HTMLVideoElement) {
+    if (videoElement.dataset.bloomVideoInitialized === "true") {
+        return;
+    }
+
+    // Early sign language code included this; now we do it only on hover.
+    videoElement.removeAttribute("controls");
+    // I don't think we need to do this in normal operation, but it's useful when
+    // debugging, and just might prevent a problem in normal operation.
+    videoElement.parentElement?.classList.remove("playing");
+    videoElement.parentElement?.classList.remove("paused");
+    videoElement.addEventListener("playing", (e) =>
+        videoPlayingEventHandler(e),
+    );
+    videoElement.addEventListener("ended", (e) => videoEndedEventHandler(e));
+    videoElement.addEventListener("click", handleVideoClick);
+    const playButton = wrapVideoIcon(
+        videoElement,
+        getPlayIcon("#ffffff", videoElement),
+        "bloom-videoPlayIcon",
+    );
+    playButton.addEventListener("click", handlePlayClick);
+    const pauseButton = wrapVideoIcon(
+        videoElement,
+        getPauseIcon("#ffffff", videoElement),
+        "bloom-videoPauseIcon",
+    );
+    pauseButton.addEventListener("click", handlePauseClick);
+    const replayButton = wrapVideoIcon(
+        videoElement,
+        getReplayIcon("#ffffff", videoElement),
+        "bloom-videoReplayIcon",
+    );
+    replayButton.addEventListener("click", handleReplayClick);
+    videoElement.dataset.bloomVideoInitialized = "true";
 }
 
 function videoEndedEventHandler(e: Event) {
@@ -296,6 +296,7 @@ export function updateVideoInContainer(container: Element, url: string): void {
         if (source) {
             source.setAttribute("src", addTransientVideoTimestampParam(url));
             video.load();
+            setupVideoElement(video);
             // Transparent background videos allow the placeholder to show.  See BL-13918.
             container.classList.remove("bloom-noVideoSelected");
         }

--- a/src/BloomBrowserUI/bookEdit/js/dragActivityRuntimeUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/dragActivityRuntimeUtils.ts
@@ -1,0 +1,17 @@
+import { copyContentToTarget, getTarget } from "bloom-player";
+
+// Keep UI-only selection state out of target shadow content.
+export function copyContentToTargetAndCleanup(
+    draggableElement: HTMLElement,
+): void {
+    copyContentToTarget(draggableElement);
+
+    const target = getTarget(draggableElement);
+    if (!target) {
+        return;
+    }
+
+    target.querySelectorAll(".bloom-selected").forEach((el) => {
+        el.classList.remove("bloom-selected");
+    });
+}

--- a/src/BloomBrowserUI/bookEdit/js/videoUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/videoUtils.ts
@@ -9,6 +9,39 @@ import {
 
 export const kVideoContainerClass = "bloom-videoContainer";
 
+function resolveSelectableVideoContainer(
+    videoContainer: Element | undefined | null,
+    body: HTMLElement | null,
+): Element | undefined {
+    if (!videoContainer) {
+        return undefined;
+    }
+
+    const containingTarget = videoContainer.closest("[data-target-of]");
+    if (!containingTarget) {
+        return videoContainer;
+    }
+
+    const draggableId = containingTarget.getAttribute("data-target-of");
+    if (!draggableId || !body) {
+        return undefined;
+    }
+
+    // Keep this local to avoid importing CanvasElementManager (which imports this file).
+    // We can have copied target content that still contains data-draggable-id, so make
+    // sure we resolve to a real draggable (not anything inside [data-target-of]).
+    const draggable = Array.from(
+        body.querySelectorAll(`[data-draggable-id='${draggableId}']`),
+    ).find((candidate) => !candidate.closest("[data-target-of]")) as
+        | HTMLElement
+        | undefined;
+    if (!draggable) {
+        return undefined;
+    }
+
+    return draggable.querySelector(`.${kVideoContainerClass}`) ?? undefined;
+}
+
 // Set the attribute which makes a canvas element active for the sign language tool.
 // Make sure nothing else has it.
 // If it's in a canvas element, make that canvas element active. If not, make sure no canvas element is active.
@@ -17,14 +50,19 @@ export function selectVideoContainer(
     videoContainer: Element | undefined | null,
     notifyCanvasElementManager = true,
 ) {
-    const body = getPageIframeBody();
+    const body =
+        getPageIframeBody() ?? videoContainer?.ownerDocument?.body ?? null;
+    const selectableVideoContainer = resolveSelectableVideoContainer(
+        videoContainer,
+        body,
+    );
     if (body) {
-        Array.from(body.getElementsByClassName("bloom-selected"))
-            .filter((e) => e !== videoContainer)
-            .forEach((e) => e.classList.remove("bloom-selected"));
+        Array.from(body.getElementsByClassName("bloom-selected")).forEach((e) =>
+            e.classList.remove("bloom-selected"),
+        );
     }
-    videoContainer?.classList.add("bloom-selected");
-    const canvasElement = videoContainer?.closest(
+    selectableVideoContainer?.classList.add("bloom-selected");
+    const canvasElement = selectableVideoContainer?.closest(
         kCanvasElementSelector,
     ) as HTMLElement;
     // If it's in a canvas element, make that canvas element active. If not, make sure no canvas element is active.
@@ -40,9 +78,9 @@ export function selectVideoContainer(
 // since the yellow box is hidden in canvas elements, and we would like the same one (that is our active
 // canvas element) to be selected in the sign langauge tool if we switch back.)
 export function deselectVideoContainers() {
-    const videoContainers: HTMLElement[] = Array.from(
-        document.getElementsByClassName(kVideoContainerClass) as any,
-    );
+    const videoContainers = Array.from(
+        document.getElementsByClassName(kVideoContainerClass),
+    ) as HTMLElement[];
     videoContainers
         .filter((x) => !x.closest(kCanvasElementSelector))
         .forEach((container) => {

--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
@@ -638,7 +638,12 @@ export const ToolboxRoot: React.FunctionComponent = () => {
         window.toolboxReactAdapter = {
             isEnabled: () => true,
             setActiveToolByToolId: (toolId: string) => {
-                setExpandedSectionId(normalizeToolId(toolId));
+                const normalizedToolId = normalizeToolId(toolId);
+                setExpandedSectionId(normalizedToolId);
+                const callbackToolId = toToolboxToolId(normalizedToolId);
+                activeToolChangedCallbacks.current.forEach((callback) => {
+                    callback(callbackToolId);
+                });
             },
             getActiveToolId: () => {
                 if (!expandedSectionId) {

--- a/src/BloomBrowserUI/bookEdit/toolbox/games/GamePromptDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/games/GamePromptDialog.tsx
@@ -10,11 +10,11 @@ interface IGamePromptDialogProps {
 import { useRef } from "react";
 import {
     adjustDraggablesForLanguage,
-    copyContentToTarget,
     getTarget,
     shuffle,
     isTheTextInDraggablesTheSame,
 } from "bloom-player";
+import { copyContentToTargetAndCleanup } from "../../js/dragActivityRuntimeUtils";
 import { setGeneratedDraggableId } from "../canvas/CanvasElementItem";
 import { adjustTarget, makeTargetForDraggable } from "../games/GameTool";
 import * as ReactDOM from "react-dom";
@@ -403,7 +403,7 @@ const initializeDialog = (prompt: HTMLElement, tg: HTMLElement | null) => {
                 "bloom-unused-in-lang",
                 i >= letters.length,
             );
-            copyContentToTarget(draggables[i]);
+            copyContentToTargetAndCleanup(draggables[i]);
         }
         const shuffledDraggables = draggables.slice();
         shuffledDraggables.splice(letters.length); // don't want any invisible ones taking up space

--- a/src/BloomBrowserUI/bookEdit/toolbox/games/GameTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/games/GameTool.tsx
@@ -26,7 +26,6 @@ import { ToolBox } from "../toolbox";
 import {
     adjustDraggablesForLanguage,
     classSetter,
-    copyContentToTarget,
     getTarget,
     playInitialElements,
     prepareActivity,
@@ -58,6 +57,7 @@ import {
     kBackgroundImageClass,
     kDraggableIdAttribute,
 } from "../../js/CanvasElementManager";
+import { copyContentToTargetAndCleanup } from "../../js/dragActivityRuntimeUtils";
 import {
     getCanvasElementManager,
     kCanvasElementSelector,
@@ -935,7 +935,7 @@ const DragActivityControls: React.FunctionComponent<{
                     currentCanvasElement ===
                     getCanvasElementManager()?.getActiveElement()
                 ) {
-                    copyContentToTarget(currentCanvasElement);
+                    copyContentToTargetAndCleanup(currentCanvasElement);
                 }
             });
             draggableToTargetObserver.current.observe(currentCanvasElement, {
@@ -1891,6 +1891,18 @@ export function getActiveDragActivityTab(): number {
     return window.top!["dragActivityPage"] ?? 0;
 }
 
+function removeBloomSelectedFromTargets(page: HTMLElement): void {
+    page.querySelectorAll("[data-target-of] .bloom-selected").forEach((el) => {
+        el.classList.remove("bloom-selected");
+    });
+}
+
+function scheduleRemoveBloomSelectedFromTargets(page: HTMLElement): void {
+    // Some drag-activity runtime operations can copy content asynchronously after
+    // tab setup, so run cleanup again on the next tick.
+    setTimeout(() => removeBloomSelectedFromTargets(page), 0);
+}
+
 // The top-level function to get everything into the right state for the specified tab
 // (Start, Correct, Wrong, Play).
 // Note: the games code is currently pulled into the page bundle, but this function
@@ -1995,6 +2007,11 @@ export function setActiveDragActivityTab(tab: number) {
         disableDraggingTargets(page);
         hideGamePromptDialog(page);
     }
+
+    // Defensive cleanup: copies of draggables in targets should never carry video
+    // selection state, even if copied by external runtime code paths.
+    removeBloomSelectedFromTargets(page);
+    scheduleRemoveBloomSelectedFromTargets(page);
 }
 
 // Replace the origami control with the Game tab control if the page is a game.

--- a/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
@@ -119,7 +119,6 @@ export class SignLanguageToolControls extends React.Component<
     private mediaRecorder: MediaRecorder;
     private timerId: number;
     private recordingStarted: number;
-    private turningOnVideo: boolean = false;
     private videoRequestVersion: number = 0;
     private wantsVideoMonitorOn: boolean = false;
 
@@ -434,6 +433,18 @@ export class SignLanguageToolControls extends React.Component<
         });
     }
 
+    public setEnabledState(enabled: boolean) {
+        if (this.state.enabled === enabled) {
+            return;
+        }
+
+        this.setState({ enabled }, () => {
+            // Canvas-selection notifications come from outside React events.
+            // Force a repaint after enabled-state transitions to keep UI in sync.
+            this.forceUpdate();
+        });
+    }
+
     public getCameraMessageLabel() {
         if (!this.state.enabled) {
             return (
@@ -596,28 +607,21 @@ export class SignLanguageToolControls extends React.Component<
     }
 
     public turnOnVideo() {
-        if (this.turningOnVideo || this.isVideoMonitorRunning()) {
+        this.wantsVideoMonitorOn = true;
+        if (this.isVideoMonitorRunning()) {
             return;
         }
-        this.wantsVideoMonitorOn = true;
-        this.turningOnVideo = true;
         const requestVersion = ++this.videoRequestVersion;
         const constraints = { video: true };
         navigator.mediaDevices
             .getUserMedia(constraints)
             .then((stream) => this.startMonitoring(stream, requestVersion))
-            .catch((reason) => this.errorCallback(reason, requestVersion))
-            .finally(() => {
-                if (requestVersion === this.videoRequestVersion) {
-                    this.turningOnVideo = false;
-                }
-            });
+            .catch((reason) => this.errorCallback(reason, requestVersion));
     }
 
     public turnOffVideo() {
         this.wantsVideoMonitorOn = false;
         this.videoRequestVersion++;
-        this.turningOnVideo = false;
         if (this.videoStream) {
             const oldStream = this.videoStream;
             this.videoStream = null; // prevent recursive calls
@@ -864,19 +868,49 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
         );
     }
 
+    private getActiveCanvasVideoContainer(): HTMLElement | undefined {
+        const activeCanvasElement =
+            getCanvasElementManager()?.getActiveElement();
+        if (!activeCanvasElement) {
+            return undefined;
+        }
+
+        const activeVideoContainer = activeCanvasElement.querySelector(
+            ".bloom-videoContainer",
+        ) as HTMLElement | null;
+        if (
+            !activeVideoContainer ||
+            activeVideoContainer.closest("[data-target-of]")
+        ) {
+            return undefined;
+        }
+
+        return activeVideoContainer;
+    }
+
     private updateEnabledStateForSelectedVideo(): void {
         const selectedVideos = SignLanguageTool.getVideoContainers(true);
         const selectedContainer =
             selectedVideos.length > 0 ? selectedVideos[0] : null;
-        const shouldEnable = this.selectedVideoCanBeRecorded(selectedContainer);
+        const activeCanvasElement =
+            getCanvasElementManager()?.getActiveElement();
+        const activeCanvasVideoContainer = this.getActiveCanvasVideoContainer();
+
+        if (activeCanvasElement && !activeCanvasVideoContainer) {
+            selectVideoContainer(undefined, false);
+        }
+
+        const effectiveSelectedContainer =
+            activeCanvasVideoContainer ?? selectedContainer;
+        const shouldEnable = activeCanvasElement
+            ? !!activeCanvasVideoContainer
+            : this.selectedVideoCanBeRecorded(effectiveSelectedContainer);
 
         if (shouldEnable) {
             if (!this.reactControls.isVideoMonitorRunning()) {
                 this.reactControls.turnOnVideo();
             }
-            if (!this.reactControls.state.enabled) {
-                this.reactControls.setState({ enabled: true });
-            }
+            this.reactControls.setEnabledState(true);
             return;
         }
 
@@ -885,10 +919,37 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
             this.reactControls.isVideoMonitorRunning()
         ) {
             this.reactControls.turnOffVideo();
-            if (this.reactControls.state.enabled) {
-                this.reactControls.setState({ enabled: false });
-            }
+            this.reactControls.setEnabledState(false);
         }
+    }
+
+    private syncSelectionFromActiveCanvasElementIfNeeded(): void {
+        const activeCanvasElement =
+            getCanvasElementManager()?.getActiveElement();
+        if (!activeCanvasElement) {
+            return;
+        }
+
+        const activeVideoContainer = activeCanvasElement.querySelector(
+            ".bloom-videoContainer",
+        ) as HTMLElement | null;
+        if (
+            !activeVideoContainer ||
+            activeVideoContainer.closest("[data-target-of]")
+        ) {
+            selectVideoContainer(undefined, false);
+            return;
+        }
+
+        const selectedVideos = SignLanguageTool.getVideoContainers(true);
+        const selectedContainer =
+            selectedVideos.length > 0 ? selectedVideos[0] : undefined;
+        if (selectedContainer === activeVideoContainer) {
+            return;
+        }
+
+        selectVideoContainer(activeVideoContainer, false);
+        this.updateStateForSelected(activeVideoContainer);
     }
 
     private static getVideoContainersFromPage(
@@ -1070,9 +1131,7 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
         if (containers.length === 0) {
             if (this.reactControls.state.enabled) {
                 this.reactControls.turnOffVideo();
-                this.reactControls.setState({
-                    enabled: false,
-                });
+                this.reactControls.setEnabledState(false);
             }
             return;
         }
@@ -1097,12 +1156,6 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
             container.removeEventListener("click", this.containerClickListener);
             container.addEventListener("click", this.containerClickListener);
         }
-        // we turn it off when we leave a page, so even if we already have enabled:true,
-        // we need to turn it on for this page now we know there is something to record.
-        this.reactControls.turnOnVideo();
-        if (!this.reactControls.state.enabled) {
-            this.reactControls.setState({ enabled: true });
-        }
     }
 
     public newPageReady() {
@@ -1117,7 +1170,16 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
             videoInfoLoaded: false,
         });
 
+        getCanvasElementManager()?.requestCanvasElementChangeNotification(
+            this.kCanvasChangeNotificationId,
+            (_bubble) => {
+                this.syncSelectionFromActiveCanvasElementIfNeeded();
+                this.updateEnabledStateForSelectedVideo();
+            },
+        );
+
         this.syncSelectionFromCurrentPage();
+        this.updateEnabledStateForSelectedVideo();
     }
 
     // This (param) container has just been selected as the current one by either:

--- a/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
@@ -10,7 +10,6 @@ import {
     post,
     postDataWithConfig,
     postJson,
-    postThatMightNavigate,
 } from "../../../utils/bloomApi";
 import { ToolBottomHelpLink } from "../../../react_components/ToolBottomHelpLink";
 import { UrlUtils } from "../../../utils/urlUtils";
@@ -536,13 +535,28 @@ export class SignLanguageToolControls extends React.Component<
         updateVideoInContainer(container, url);
     }
 
+    private refreshAfterVideoChange() {
+        document.removeEventListener("keydown", this.onKeyPress);
+        window.clearTimeout(this.timerId);
+        SignLanguageTool.removeVideoOverlay();
+        this.setState(
+            {
+                recording: false,
+                stateClass: "idle",
+                minutesRecorded: "",
+                secondsRecorded: "",
+                videoInfoLoaded: false,
+            },
+            () => {
+                this.getVideoStatsFromFile();
+            },
+        );
+    }
+
     private importRecording() {
         post("signLanguage/importVideo", (result) => {
             this.updateVideo(result.data);
-            // Makes sure the page gets saved with a reference to the new video,
-            // and incidentally that everything gets updated to be consistent with the
-            // new state of things.
-            postThatMightNavigate("common/saveChangesAndRethinkPageEvent");
+            this.refreshAfterVideoChange();
         });
     }
 
@@ -564,12 +578,7 @@ export class SignLanguageToolControls extends React.Component<
                         if (video && video.parentElement)
                             video.parentElement.removeChild(video);
                     }
-                    // Makes sure the page gets saved without a reference to the deleted video,
-                    // and incidentally that everything gets updated to be consistent with the
-                    // new state of things.
-                    postThatMightNavigate(
-                        "common/saveChangesAndRethinkPageEvent",
-                    );
+                    this.refreshAfterVideoChange();
                 }
             },
         );
@@ -777,12 +786,7 @@ export class SignLanguageToolControls extends React.Component<
                 },
                 (result) => {
                     this.updateVideo(result.data);
-                    // Makes sure the page gets saved with a reference to the new video,
-                    // and incidentally that everything gets updated to be consistent with the
-                    // new state of things.
-                    postThatMightNavigate(
-                        "common/saveChangesAndRethinkPageEvent",
-                    );
+                    this.refreshAfterVideoChange();
                 },
             );
             // Don't know why this is necessary, but for some reason, the stream we have is no
@@ -881,6 +885,18 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
         }
     }
 
+    private static getVideoContainersFromPage(
+        page: HTMLElement,
+        selected?: boolean,
+    ): HTMLElement[] {
+        const selector = selected
+            ? ".bloom-videoContainer.bloom-selected"
+            : ".bloom-videoContainer";
+        return Array.from(page.querySelectorAll(selector)).filter(
+            (container) => !container.closest("[data-target-of]"),
+        ) as HTMLElement[];
+    }
+
     public makeRootElement(): HTMLDivElement {
         const root = document.createElement("div");
         root.setAttribute("class", "signLanguageBody");
@@ -905,14 +921,11 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
 
     // Specify 'true' to get only containers marked as selected
     public static getVideoContainers(selected?: boolean): HTMLElement[] {
-        let classes = "bloom-videoContainer";
-        if (selected) {
-            classes += " bloom-selected";
-        }
         const page = ToolBox.getPage();
-        return (
-            page ? Array.from(page.getElementsByClassName(classes)) : []
-        ) as HTMLElement[];
+        if (!page) {
+            return [];
+        }
+        return this.getVideoContainersFromPage(page, selected);
     }
 
     public static getSelectedVideoPathAndTiming(): string | null {
@@ -942,6 +955,12 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
 
     public detachFromPage() {
         this.reactControls.setNoVideo(false);
+        this.reactControls.setState({
+            recording: false,
+            stateClass: "idle",
+            minutesRecorded: "",
+            secondsRecorded: "",
+        });
         // Decided NOT to remove bloom-selected here. It's harmless (only the edit stylesheet
         // does anything with it) and leaving it allows us to keep the same one selected
         // when we come back to the page. This is especially important when refreshing the
@@ -1008,6 +1027,84 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
         }
     };
 
+    public showTool() {
+        this.syncSelectionFromCurrentPage();
+    }
+
+    private syncSelectionFromCurrentPage() {
+        const pageBody = ToolBox.getPage();
+        if (!pageBody) {
+            // Tool activation can race with page readiness.
+            window.setTimeout(() => this.syncSelectionFromCurrentPage(), 100);
+            return;
+        }
+
+        const preselectedVideo = pageBody.querySelector(
+            ".bloom-videoContainer.bloom-selected",
+        ) as HTMLElement | null;
+        if (preselectedVideo) {
+            // Normalize any existing selection through videoUtils logic so target copies
+            // cannot remain selected.
+            selectVideoContainer(preselectedVideo);
+        }
+
+        let containers = SignLanguageTool.getVideoContainersFromPage(
+            pageBody,
+            false,
+        );
+        if (containers.length === 0) {
+            const activeCanvasElement =
+                getCanvasElementManager()?.getActiveElement();
+            const activeVideoContainer = activeCanvasElement?.querySelector(
+                ".bloom-videoContainer",
+            ) as HTMLElement | null;
+            if (
+                activeVideoContainer &&
+                !activeVideoContainer.closest("[data-target-of]")
+            ) {
+                selectVideoContainer(activeVideoContainer);
+                containers = [activeVideoContainer];
+            }
+        }
+
+        if (containers.length === 0) {
+            if (this.reactControls.state.enabled) {
+                this.reactControls.turnOffVideo();
+                this.reactControls.setState({
+                    enabled: false,
+                });
+            }
+            return;
+        }
+
+        // We want one video container to be selected, so pick the first.
+        // If one is already marked selected, presumably from a previous use of this page,
+        // we'll leave that one active.
+        const selectedVideos = SignLanguageTool.getVideoContainersFromPage(
+            pageBody,
+            true,
+        );
+        const videoToUse =
+            selectedVideos.length > 0 ? selectedVideos[0] : containers[0];
+        selectVideoContainer(videoToUse);
+        this.updateStateForSelected(videoToUse);
+
+        for (let i = 0; i < containers.length; i++) {
+            const container = containers[i];
+            // UpdateMarkup is called fairlyfrequently. Not sure what effect having
+            // the same listener attached multiple times might have, so play safe by
+            // removing it before adding.
+            container.removeEventListener("click", this.containerClickListener);
+            container.addEventListener("click", this.containerClickListener);
+        }
+        // we turn it off when we leave a page, so even if we already have enabled:true,
+        // we need to turn it on for this page now we know there is something to record.
+        this.reactControls.turnOnVideo();
+        if (!this.reactControls.state.enabled) {
+            this.reactControls.setState({ enabled: true });
+        }
+    }
+
     public newPageReady() {
         // among other things, this clears us out of "processing"
         // when the page is refreshed with the new video
@@ -1019,44 +1116,8 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
             haveRecording: false,
             videoInfoLoaded: false,
         });
-        const containers = SignLanguageTool.getVideoContainers(false);
-        getCanvasElementManager()?.requestCanvasElementChangeNotification(
-            this.kCanvasChangeNotificationId,
-            (_bubble) => this.updateEnabledStateForSelectedVideo(),
-        );
-        if (!containers || containers.length === 0) {
-            if (this.reactControls.state.enabled) {
-                this.reactControls.turnOffVideo();
-                this.reactControls.setState({
-                    enabled: false,
-                });
-            }
-        } else {
-            // We want one video container to be selected, so pick the first.
-            // If one is already marked selected, presumably from a previous use of this page,
-            // we'll leave that one active.
-            const selectedVideos = SignLanguageTool.getVideoContainers(true);
-            const videoToUse =
-                selectedVideos.length > 0 ? selectedVideos[0] : containers[0];
-            selectVideoContainer(videoToUse);
-            this.updateStateForSelected(videoToUse);
 
-            for (let i = 0; i < containers.length; i++) {
-                const container = containers[i];
-                // UpdateMarkup is called fairlyfrequently. Not sure what effect having
-                // the same listener attached multiple times might have, so play safe by
-                // removing it before adding.
-                container.removeEventListener(
-                    "click",
-                    this.containerClickListener,
-                );
-                container.addEventListener(
-                    "click",
-                    this.containerClickListener,
-                );
-            }
-            this.updateEnabledStateForSelectedVideo();
-        }
+        this.syncSelectionFromCurrentPage();
     }
 
     // This (param) container has just been selected as the current one by either:

--- a/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
@@ -535,7 +535,7 @@ export class SignLanguageToolControls extends React.Component<
         updateVideoInContainer(container, url);
     }
 
-    private refreshAfterVideoChange() {
+    public leaveCurrentVideoContext(onComplete?: () => void) {
         document.removeEventListener("keydown", this.onKeyPress);
         window.clearTimeout(this.timerId);
         SignLanguageTool.removeVideoOverlay();
@@ -545,12 +545,18 @@ export class SignLanguageToolControls extends React.Component<
                 stateClass: "idle",
                 minutesRecorded: "",
                 secondsRecorded: "",
+                haveRecording: false,
+                videoStatistics: emptyVideoStatistics,
                 videoInfoLoaded: false,
             },
-            () => {
-                this.getVideoStatsFromFile();
-            },
+            onComplete,
         );
+    }
+
+    private refreshAfterVideoChange() {
+        this.leaveCurrentVideoContext(() => {
+            this.getVideoStatsFromFile();
+        });
     }
 
     private importRecording() {
@@ -946,7 +952,7 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
     }
 
     public static getSelectedVideoPath(): string | null {
-        // strip off the ?now= param we sometimes use to prevent use of cached old versions,
+        // strip off the temporary cache-busting query param we sometimes use to prevent use of cached old versions,
         // and the #t= fragment used to trim videos.
         return UrlUtils.extractPathComponent(
             SignLanguageTool.getSelectedVideoPathAndTiming() as string,
@@ -954,13 +960,7 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
     }
 
     public detachFromPage() {
-        this.reactControls.setNoVideo(false);
-        this.reactControls.setState({
-            recording: false,
-            stateClass: "idle",
-            minutesRecorded: "",
-            secondsRecorded: "",
-        });
+        this.reactControls.leaveCurrentVideoContext();
         // Decided NOT to remove bloom-selected here. It's harmless (only the edit stylesheet
         // does anything with it) and leaving it allows us to keep the same one selected
         // when we come back to the page. This is especially important when refreshing the

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -1296,6 +1296,23 @@ function beginAddTool(
             );
             return;
         }
+
+        if (isToolInitialized(tool)) {
+            if (openTool) {
+                const toolName = ToolBox.addToolToString(tool.id());
+                const adapter = getToolboxReactAdapter();
+                if (adapter) {
+                    adapter.setActiveToolByToolId(toolName);
+                    switchTool(toolName);
+                }
+            }
+
+            if (whenLoaded) {
+                whenLoaded();
+            }
+            return;
+        }
+
         const content = $(tool.makeRootElement());
         const toolName = ToolBox.addToolToString(tool.id());
         // const parts = $("<h3 data-toolId='musicTool' data-i18n='EditTab.Toolbox.MusicTool'>"

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -1169,7 +1169,6 @@ function setCurrentTool(toolID: string) {
 
         if (toolID) {
             adapter.setActiveToolByToolId(toolID);
-            switchTool(toolID);
         }
         return;
     }
@@ -1298,12 +1297,11 @@ function beginAddTool(
         }
 
         if (isToolInitialized(tool)) {
-            if (openTool) {
+            if (openTool && toolbox.toolboxIsShowing()) {
                 const toolName = ToolBox.addToolToString(tool.id());
                 const adapter = getToolboxReactAdapter();
                 if (adapter) {
                     adapter.setActiveToolByToolId(toolName);
-                    switchTool(toolName);
                 }
             }
 
@@ -1871,13 +1869,12 @@ function loadToolboxTool(
     }
 
     // if requested, open the tool that was just inserted
-    if (openTool) {
+    if (openTool && toolbox.toolboxIsShowing()) {
         const adapter = getToolboxReactAdapter();
         if (adapter) {
             const toolId = header.attr("data-toolId");
             if (toolId) {
                 adapter.setActiveToolByToolId(toolId);
-                switchTool(toolId);
             }
         } else {
             toolboxElt.accordion("refresh");
@@ -1932,6 +1929,7 @@ function showToolboxChanged(wasShowing: boolean): void {
         const adapter = getToolboxReactAdapter();
         if (adapter) {
             adapter.setActiveToolByToolId(newToolName);
+            return;
         }
         switchTool(newToolName);
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -637,8 +637,15 @@ export class ToolBox {
             // if it was an actual "input" element, we would just check for "checked",
             // but it's actually a div with possibly a checkmark character inside,
             // so just check string length.
+            // An earlier version of this code simulated a click on the checkbox,
+            // but that failed when it was already active, toggling it to inactive,
+            // where here we want to ensure it is active AND selected.
             if (checkBox.innerText.length === 0) {
-                checkBox.click(); // will also activate
+                turnOnToolFromCheckbox(
+                    checkBox,
+                    ToolBox.addToolToString(toolId),
+                    true,
+                );
             } else {
                 setCurrentTool(toolId);
             }
@@ -746,24 +753,41 @@ export function showOrHideTool_click(chkbox) {
     const tool = $(chkbox).data("tool");
     const turnOn = chkbox.innerHTML === "";
     if (turnOn) {
-        chkbox.innerHTML = checkMarkString;
-        postString(
-            "editView/saveToolboxSetting",
-            "active\t" + chkbox.id + "\t1",
-        );
+        turnOnToolFromCheckbox(chkbox, tool, true);
     } else {
-        chkbox.innerHTML = "";
-        postString(
-            "editView/saveToolboxSetting",
-            "active\t" + chkbox.id + "\t0",
-        );
+        setToolCheckboxEnabledState(chkbox, false);
+        showOrHideTool(chkbox.id, tool, false);
     }
-    showOrHideTool(chkbox.id, tool, turnOn);
 }
 
-function showOrHideTool(chkboxId: string, tool: string, turnOn: boolean) {
+function setToolCheckboxEnabledState(
+    chkbox: HTMLDivElement,
+    turnOn: boolean,
+): void {
+    chkbox.innerHTML = turnOn ? checkMarkString : "";
+    postString(
+        "editView/saveToolboxSetting",
+        "active\t" + chkbox.id + "\t" + (turnOn ? "1" : "0"),
+    );
+}
+
+function turnOnToolFromCheckbox(
+    chkbox: HTMLDivElement,
+    tool: string,
+    openTool: boolean,
+): void {
+    setToolCheckboxEnabledState(chkbox, true);
+    showOrHideTool(chkbox.id, tool, true, openTool);
+}
+
+function showOrHideTool(
+    chkboxId: string,
+    tool: string,
+    turnOn: boolean,
+    openTool: boolean = true,
+) {
     if (turnOn) {
-        beginAddTool(chkboxId, tool, true);
+        beginAddTool(chkboxId, tool, openTool);
     } else {
         $("*[data-toolId]")
             .filter(function () {
@@ -1830,7 +1854,7 @@ function loadToolboxTool(
     }
 
     // if requested, open the tool that was just inserted
-    if (openTool && toolbox.toolboxIsShowing()) {
+    if (openTool) {
         const adapter = getToolboxReactAdapter();
         if (adapter) {
             const toolId = header.attr("data-toolId");


### PR DESCRIPTION
Fixing a few things here:
- copying a draggable video to its target could put the bloom-selected class on the target. Having bloom-selected on a target could also happen during page open (because it was likely the first bloom-videoContainer in DOM order) or just because the page was saved that way. Several things work together to be sure this class is never put (or left) in a target.
- trying to make the sign language (or any) tool selected was simulating a click on the check box for making it active (available). If it already was, this would hide it, and activate some other tool. I extracted the code for turning it on and selecting it, and call that explicitly.
- seems we were counting on page-load code to reset the state of the tool after recording. That doesn't always happen, so I added code to reset some recording-in-process state, and make sure we see the new video.
- at some point something changed that caused us to keep re-creating the react component, messing up state
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7847)
<!-- Reviewable:end -->
