### PR TITLE
Disable image "Become background" on standard cover pages (BL-16130)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
@@ -53,7 +53,12 @@ import {
     kDraggableIdAttribute,
     theOneCanvasElementManager,
 } from "./CanvasElementManager";
-import { copySelection, GetEditor, pasteClipboard } from "./bloomEditing";
+import {
+    copySelection,
+    GetEditor,
+    IsPageXMatter,
+    pasteClipboard,
+} from "./bloomEditing";
 import { BloomTooltip } from "../../react_components/BloomToolTip";
 import { useL10n } from "../../react_components/l10nHooks";
 import { CogIcon } from "./CogIcon";
@@ -1720,6 +1725,19 @@ function addImageMenuOptions(
         );
     };
 
+    // The "Become background" option is not available for standard xmatter pages.
+    const xmatterPage = IsPageXMatter($(canvasElement));
+    const customLayoutablePage = canvasElement.closest(
+        ".bloom-page[data-custom-layout-id]",
+    );
+    const pageAllowsCanvasElements =
+        (!xmatterPage ||
+            (customLayoutablePage &&
+                customLayoutablePage.classList.contains(
+                    "bloom-customLayout",
+                ))) ??
+        false;
+
     const realImagePresent = hasRealImage(img);
     const imageMenuOptions: IMenuItemWithSubmenu[] = [
         // If the image doesn't exist, we still show the menu item for editing metadata,
@@ -1835,7 +1853,7 @@ function addImageMenuOptions(
                 );
             },
         });
-        if (realImagePresent) {
+        if (realImagePresent && pageAllowsCanvasElements) {
             imageMenuOptions.push({
                 l10nId: "EditTab.Toolbox.ComicTool.Options.BecomeBackground",
                 english: "Become Background",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7848)
<!-- Reviewable:end -->
