### PR TITLE
Size custom layout cover background images more precisely (BL-16173)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
@@ -1896,6 +1896,7 @@ function addImageMenuOptions(
                             "data-license",
                             bgImg.getAttribute("data-license") || "",
                         );
+                        img.classList.remove("bloom-imageObjectFit-cover");
                         theOneCanvasElementManager.updateCanvasElementForChangedImage(
                             img,
                         );
@@ -1908,6 +1909,7 @@ function addImageMenuOptions(
                     );
                     bgImg.setAttribute("data-creator", currentCreator || "");
                     bgImg.setAttribute("data-license", currentLicense || "");
+                    bgImg.classList.add("bloom-imageObjectFit-cover");
                     // Not sure how or if this should generalize. When we make a custom cover,
                     // the cover image is initially a moveable canvas element with data-book=coverImage.
                     // Changing it to a background image should preserve that.


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7849)
<!-- Reviewable:end -->
