### PR TITLE
Restore 'Tool' on end of tool names in accordion

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
@@ -8,6 +8,7 @@ import AccordionSummary from "@mui/material/AccordionSummary";
 import Typography from "@mui/material/Typography";
 import { ThemeProvider } from "@mui/material/styles";
 import { toolboxTheme } from "../../bloomMaterialUITheme";
+import { LocalizedString } from "../../react_components/l10nComponents";
 import {
     kBloomBlue,
     kBloomPanelBackground,
@@ -42,7 +43,8 @@ import { getMasterToolList } from "./toolbox";
 
 type ToolboxSection = {
     id: string;
-    label: string;
+    englishLabel: string;
+    l10nKey: string;
     legacyToolHtmlSubPath?: string;
     legacyToolBodyHtml?: string;
     liveToolBodyElement?: HTMLDivElement;
@@ -110,22 +112,37 @@ const toToolboxToolId = (toolId: string): string => {
     return `${toolId}Tool`;
 };
 
-const makeLabelFromToolId = (toolId: string): string => {
-    if (toolId === "settings") {
-        return "More...";
+const getToolboxLabelInfo = (
+    toolId: string,
+): { englishLabel: string; l10nKey: string } => {
+    const normalizedToolId = normalizeToolId(toolId);
+    if (normalizedToolId === "settings") {
+        return {
+            englishLabel: "More...",
+            l10nKey: "EditTab.Toolbox.More",
+        };
     }
 
-    return toolId
-        .replace(/Tool$/, "")
-        .replace(/([A-Z])/g, " $1")
-        .trim()
-        .replace(/^./, (c) => c.toUpperCase());
+    const toolIdUpper =
+        normalizedToolId[0].toUpperCase() +
+        normalizedToolId.substring(1, normalizedToolId.length);
+    const englishBaseLabel = toolIdUpper.replace(/([A-Z])/g, " $1").trim();
+    const endsWithVisualizer = normalizedToolId.endsWith("Visualizer");
+
+    return {
+        englishLabel: endsWithVisualizer
+            ? englishBaseLabel
+            : `${englishBaseLabel} Tool`,
+        l10nKey: endsWithVisualizer
+            ? `EditTab.Toolbox.${toolIdUpper}`
+            : `EditTab.Toolbox.${toolIdUpper}Tool`,
+    };
 };
 
 const sortToolIdsAlphabetically = (toolIds: string[]): string[] => {
     return [...toolIds].sort((a, b) =>
-        makeLabelFromToolId(a).localeCompare(
-            makeLabelFromToolId(b),
+        getToolboxLabelInfo(a).englishLabel.localeCompare(
+            getToolboxLabelInfo(b).englishLabel,
             undefined,
             {
                 sensitivity: "base",
@@ -135,9 +152,11 @@ const sortToolIdsAlphabetically = (toolIds: string[]): string[] => {
 };
 
 const makeSectionFromToolId = (toolId: string): ToolboxSection => {
+    const labelInfo = getToolboxLabelInfo(toolId);
     return {
         id: toolId,
-        label: makeLabelFromToolId(toolId),
+        englishLabel: labelInfo.englishLabel,
+        l10nKey: labelInfo.l10nKey,
         legacyToolHtmlSubPath: legacyToolSubPathByToolId[toolId],
     };
 };
@@ -151,7 +170,7 @@ const sortSectionsAlphabeticallyWithSettingsLast = (
     const nonSettingsSections = sections
         .filter((section) => section.id !== "settings")
         .sort((a, b) =>
-            a.label.localeCompare(b.label, undefined, {
+            a.englishLabel.localeCompare(b.englishLabel, undefined, {
                 sensitivity: "base",
             }),
         );
@@ -364,7 +383,8 @@ export const ToolboxRoot: React.FunctionComponent = () => {
             try {
                 const legacyToolBodyHtml = await loadLegacyToolBodyHtml({
                     id: toolId,
-                    label: "",
+                    englishLabel: "",
+                    l10nKey: "",
                     legacyToolHtmlSubPath,
                 });
                 setSections((previousSections) =>
@@ -825,7 +845,9 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                                         flex-grow: 1;
                                     `}
                                 >
-                                    {section.label}
+                                    <LocalizedString l10nKey={section.l10nKey}>
+                                        {section.englishLabel}
+                                    </LocalizedString>
                                 </Typography>
                                 {subscriptionToolIds.has(section.id) && (
                                     <span className="subscription-badge"></span>
@@ -893,7 +915,7 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                                         ></div>
                                     ) : (
                                         <Typography>
-                                            Loading {section.label}...
+                                            Loading {section.englishLabel}...
                                         </Typography>
                                     )}
                                 </div>

--- a/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/component-tests/toolbox-root-react.uitest.ts
+++ b/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/component-tests/toolbox-root-react.uitest.ts
@@ -63,14 +63,14 @@ test.describe("ToolboxRoot React mode", () => {
             timeout: 15000,
         });
 
-        await expect(page.getByText("Talking Book").first()).toBeVisible({
+        await expect(page.getByText("Talking Book Tool").first()).toBeVisible({
             timeout: 10000,
         });
         await expect(page.getByText("More...").first()).toBeVisible({
             timeout: 10000,
         });
 
-        await page.getByText("Talking Book").first().click();
+        await page.getByText("Talking Book Tool").first().click();
 
         await expect(
             page.getByText("Talking tool content injected"),
@@ -131,7 +131,7 @@ test.describe("ToolboxRoot React mode", () => {
             timeout: 15000,
         });
 
-        await expect(page.getByText("Decodable Reader")).toHaveCount(0);
+        await expect(page.getByText("Decodable Reader Tool")).toHaveCount(0);
 
         await page.evaluate(() => {
             window.dispatchEvent(
@@ -144,7 +144,9 @@ test.describe("ToolboxRoot React mode", () => {
             );
         });
 
-        await expect(page.getByText("Decodable Reader").first()).toBeVisible({
+        await expect(
+            page.getByText("Decodable Reader Tool").first(),
+        ).toBeVisible({
             timeout: 10000,
         });
         await expect(page.getByText("Decodable controls injected")).toBeVisible(
@@ -173,13 +175,13 @@ test.describe("ToolboxRoot React mode", () => {
             timeout: 15000,
         });
 
-        await expect(page.getByText("Canvas").first()).toBeVisible({
+        await expect(page.getByText("Canvas Tool").first()).toBeVisible({
             timeout: 10000,
         });
 
         await expect(await getToolHeaderTexts(page)).toEqual([
-            "Canvas",
-            "Talking Book",
+            "Canvas Tool",
+            "Talking Book Tool",
             "More...",
         ]);
     });
@@ -211,14 +213,41 @@ test.describe("ToolboxRoot React mode", () => {
             );
         });
 
-        await expect(page.getByText("Decodable Reader").first()).toBeVisible({
+        await expect(
+            page.getByText("Decodable Reader Tool").first(),
+        ).toBeVisible({
             timeout: 10000,
         });
 
         await expect(await getToolHeaderTexts(page)).toEqual([
-            "Canvas",
-            "Decodable Reader",
-            "Talking Book",
+            "Canvas Tool",
+            "Decodable Reader Tool",
+            "Talking Book Tool",
+            "More...",
+        ]);
+    });
+
+    test("accordion headers match More panel tool names", async ({ page }) => {
+        await routeToolboxApis(page);
+
+        await page.route("**/bloom/api/toolbox/enabledTools", async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: "text/plain",
+                body: "impairmentVisualizer,signLanguage,settings",
+            });
+        });
+
+        await page.goto("/?component=ToolboxRootTestHarness");
+
+        await expect(page.getByText("Loading component…")).toHaveCount(0, {
+            timeout: 15000,
+        });
+
+        await expect(await getToolHeaderTexts(page)).toEqual([
+            "Impairment Visualizer",
+            "Sign Language Tool",
+            "Talking Book Tool",
             "More...",
         ]);
     });
@@ -243,10 +272,10 @@ test.describe("ToolboxRoot React mode", () => {
         });
 
         await expect(await getToolHeaderTexts(page)).toEqual([
-            "Canvas",
-            "Motion",
-            "Music",
-            "Talking Book",
+            "Canvas Tool",
+            "Motion Tool",
+            "Music Tool",
+            "Talking Book Tool",
             "More...",
         ]);
 


### PR DESCRIPTION
Copilot tried to fix some UI tests, but I don't know whether they were working before or after the changes. I don't think we run these tests automatically.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7852)
<!-- Reviewable:end -->
