### PR TITLE
Allow collection rename with App builder

### DIFF
--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -1014,29 +1014,39 @@ namespace Bloom.Publish.Rab
                 return ExportPrepareBooks(paths);
 
             var bookInfos = new List<BookInfo>();
+            var normalizedTrackedBooks = new List<RabBookPublishInfo>();
             foreach (var trackedBook in state.Books)
             {
-                var matchingBook = _collectionModel
-                    .TheOneEditableCollection.GetBookInfos()
-                    .FirstOrDefault(info =>
-                        string.Equals(
-                            info.FolderPath,
-                            trackedBook.FolderPath,
-                            StringComparison.OrdinalIgnoreCase
-                        )
-                    );
-                if (matchingBook == null)
-                    throw new ApplicationException(
-                        $"Bloom could not find the tracked book '{trackedBook.Title}' in this collection anymore."
-                    );
+                var matchingBook = FindTrackedBookInfo(
+                    new RabTrackedBookInfo
+                    {
+                        BookId = trackedBook.BookId,
+                        FolderPath = trackedBook.FolderPath,
+                        Title = trackedBook.Title,
+                    }
+                );
 
                 bookInfos.Add(matchingBook);
+                normalizedTrackedBooks.Add(
+                    new RabBookPublishInfo
+                    {
+                        BookId = string.IsNullOrWhiteSpace(trackedBook.BookId)
+                            ? matchingBook.Id
+                            : trackedBook.BookId,
+                        FolderPath = matchingBook.FolderPath,
+                        Title = matchingBook.Title,
+                        BloomPubPath = trackedBook.BloomPubPath,
+                        ThumbnailFileName = trackedBook.ThumbnailFileName,
+                    }
+                );
             }
 
             return ExportBookInfos(
                 paths,
                 bookInfos,
-                state.Books.ToDictionary(book => book.FolderPath, StringComparer.OrdinalIgnoreCase)
+                normalizedTrackedBooks
+                    .Where(book => !string.IsNullOrWhiteSpace(book.FolderPath))
+                    .ToDictionary(book => book.FolderPath, StringComparer.OrdinalIgnoreCase)
             );
         }
 
@@ -1057,12 +1067,11 @@ namespace Bloom.Publish.Rab
                     && existingByFolder.TryGetValue(bookInfo.FolderPath, out var found)
                         ? found
                         : null;
-                var bloomPubPath =
+                var bloomPubPath = ResolveBloomPubPath(
+                    paths.BloomPubRoot,
+                    bookInfo.FolderName + BloomPubMaker.BloomPubExtensionWithDot,
                     existing?.BloomPubPath
-                    ?? Path.Combine(
-                        paths.BloomPubRoot,
-                        bookInfo.FolderName + BloomPubMaker.BloomPubExtensionWithDot
-                    );
+                );
 
                 if (
                     !string.IsNullOrWhiteSpace(bloomPubPath)
@@ -1087,12 +1096,11 @@ namespace Bloom.Publish.Rab
                         ? found
                         : null;
                 var bookTitle = GetBookTitleForRab(book, bookInfo);
-                var bloomPubPath =
+                var bloomPubPath = ResolveBloomPubPath(
+                    paths.BloomPubRoot,
+                    bookInfo.FolderName + BloomPubMaker.BloomPubExtensionWithDot,
                     existing?.BloomPubPath
-                    ?? Path.Combine(
-                        paths.BloomPubRoot,
-                        bookInfo.FolderName + BloomPubMaker.BloomPubExtensionWithDot
-                    );
+                );
 
                 if (RobustFile.Exists(bloomPubPath))
                 {
@@ -1133,6 +1141,33 @@ namespace Bloom.Publish.Rab
             }
 
             return exportedBooks;
+        }
+
+        internal static string ResolveBloomPubPath(
+            string bloomPubRoot,
+            string defaultFileName,
+            string existingBloomPubPath
+        )
+        {
+            var fileName = defaultFileName;
+            if (!string.IsNullOrWhiteSpace(existingBloomPubPath))
+            {
+                var existingFileName = Path.GetFileName(existingBloomPubPath);
+                if (!string.IsNullOrWhiteSpace(existingFileName))
+                    fileName = existingFileName;
+
+                var existingDirectory = Path.GetDirectoryName(existingBloomPubPath);
+                if (
+                    string.Equals(
+                        existingDirectory,
+                        bloomPubRoot,
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
+                    return existingBloomPubPath;
+            }
+
+            return Path.Combine(bloomPubRoot, fileName);
         }
 
         private static void DeleteStaleBloomPubExports(
@@ -1820,6 +1855,10 @@ namespace Bloom.Publish.Rab
                 ["ANDROID_SDK_ROOT"] = string.Empty,
                 ["JAVA_HOME"] = string.Empty,
                 ["JDK_HOME"] = string.Empty,
+                // Disable the Gradle daemon so no background JVM process lingers after the build.
+                // A persistent Gradle daemon would hold file handles inside the collection's
+                // "Bloom App Data/build" folder, preventing the collection from being renamed.
+                ["GRADLE_OPTS"] = "-Dorg.gradle.daemon=false",
             };
         }
 
@@ -2789,6 +2828,47 @@ namespace Bloom.Publish.Rab
                         StringComparison.OrdinalIgnoreCase
                     )
                 );
+
+                // These fallbacks may be helpful where things have changed since the last build,
+                // especially when the collection has been renamed.
+                if (matchingBookInfo == null)
+                {
+                    var trackedFolderName = Path.GetFileName(
+                        trackedBook.FolderPath.TrimEnd(
+                            Path.DirectorySeparatorChar,
+                            Path.AltDirectorySeparatorChar
+                        )
+                    );
+                    if (!string.IsNullOrWhiteSpace(trackedFolderName))
+                    {
+                        var folderNameMatches = bookInfos
+                            .Where(info =>
+                                string.Equals(
+                                    info.FolderName,
+                                    trackedFolderName,
+                                    StringComparison.OrdinalIgnoreCase
+                                )
+                            )
+                            .ToList();
+                        if (folderNameMatches.Count == 1)
+                            matchingBookInfo = folderNameMatches[0];
+                    }
+                }
+            }
+
+            if (matchingBookInfo == null && !string.IsNullOrWhiteSpace(trackedBook.Title))
+            {
+                var titleMatches = bookInfos
+                    .Where(info =>
+                        string.Equals(
+                            info.Title,
+                            trackedBook.Title,
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                    )
+                    .ToList();
+                if (titleMatches.Count == 1)
+                    matchingBookInfo = titleMatches[0];
             }
 
             if (matchingBookInfo == null)
@@ -2824,6 +2904,10 @@ namespace Bloom.Publish.Rab
         {
             appDefPath = string.IsNullOrWhiteSpace(appDefPath) ? state?.AppDefPath : appDefPath;
             appDefPath = string.IsNullOrWhiteSpace(appDefPath) ? FindAppDefPath(paths) : appDefPath;
+            // The stored path may be stale (e.g. after the collection folder was renamed).
+            // Fall back to searching the current workspace so the project is still found.
+            if (!string.IsNullOrWhiteSpace(appDefPath) && !RobustFile.Exists(appDefPath))
+                appDefPath = FindAppDefPath(paths);
             if (string.IsNullOrWhiteSpace(appDefPath) || !RobustFile.Exists(appDefPath))
                 return state;
 

--- a/src/BloomTests/Publish/Rab/RabAppProjectTests.cs
+++ b/src/BloomTests/Publish/Rab/RabAppProjectTests.cs
@@ -610,6 +610,11 @@ namespace BloomTests.Publish.Rab
             Assert.That(environmentVariables["ANDROID_SDK_ROOT"], Is.EqualTo(string.Empty));
             Assert.That(environmentVariables["JAVA_HOME"], Is.EqualTo(string.Empty));
             Assert.That(environmentVariables["JDK_HOME"], Is.EqualTo(string.Empty));
+            // Daemon disabled so no background JVM lingers and locks the collection folder after a build.
+            Assert.That(
+                environmentVariables["GRADLE_OPTS"],
+                Does.Contain("-Dorg.gradle.daemon=false")
+            );
         }
 
         [Test]
@@ -1006,6 +1011,42 @@ namespace BloomTests.Publish.Rab
                 RabProjectService.GetBuildProgressPercentFromOutput("> Task :packageRelease"),
                 Is.EqualTo(95)
             );
+        }
+
+        [Test]
+        public void ResolveBloomPubPath_RewritesStaleDirectoryToCurrentBloomPubRoot()
+        {
+            var currentBloomPubRoot =
+                @"C:\Users\tester\Documents\Collection Renamed\Bloom App Data\bloompubs";
+            var staleBloomPubPath =
+                @"C:\Users\tester\Documents\Collection Old\Bloom App Data\bloompubs\Book One.bloompub";
+
+            var resolvedPath = RabProjectService.ResolveBloomPubPath(
+                currentBloomPubRoot,
+                "fallback.bloompub",
+                staleBloomPubPath
+            );
+
+            Assert.That(
+                resolvedPath,
+                Is.EqualTo(Path.Combine(currentBloomPubRoot, "Book One.bloompub"))
+            );
+        }
+
+        [Test]
+        public void ResolveBloomPubPath_KeepsExistingPathWhenAlreadyInCurrentRoot()
+        {
+            var currentBloomPubRoot =
+                @"C:\Users\tester\Documents\Collection\Bloom App Data\bloompubs";
+            var existingPath = Path.Combine(currentBloomPubRoot, "Book One.bloompub");
+
+            var resolvedPath = RabProjectService.ResolveBloomPubPath(
+                currentBloomPubRoot,
+                "fallback.bloompub",
+                existingPath
+            );
+
+            Assert.That(resolvedPath, Is.EqualTo(existingPath));
         }
 
         [Test]


### PR DESCRIPTION
Changes things so App building doesn't prevent rename, and also so that app building continues to work after a rename.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7854)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
