### PR TITLE
Restore resizing thumbnails when page size is changed (BL-16189)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.tsx
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.tsx
@@ -101,8 +101,11 @@ const normalizeBookDisplayAttributes = (
 // there ever being more than one instance of pageThumbnailList.
 const pageIdToRefreshMap = new Map<string, () => void>();
 
-const PageList: React.FunctionComponent<{ pageLayout: string }> = (props) => {
+const PageList: React.FunctionComponent<{ initialPageLayout: string }> = (
+    props,
+) => {
     const [realPageList, setRealPageList] = useState<IPage[]>([]);
+    const [pageLayout, setPageLayout] = useState(props.initialPageLayout);
     // a value to be bumped to force a reload of page content when the websocket detects
     // a request for this.
     const [reloadValue, setReloadValue] = useState(0);
@@ -238,6 +241,7 @@ const PageList: React.FunctionComponent<{ pageLayout: string }> = (props) => {
             // WebThumbnailList hears about it, and we get it along with the page list
             // in case we miss a notification.
             setSelectedPageId(response.data.selectedPageId);
+            setPageLayout(response.data.pageLayout || "A5Portrait");
             setRealPageList(response.data.pages);
             // The current page may need to be refreshed as well for new or retitled books.
             // See https://issues.bloomlibrary.org/youtrack/issue/BL-9039.
@@ -403,7 +407,7 @@ const PageList: React.FunctionComponent<{ pageLayout: string }> = (props) => {
                     <PageThumbnail
                         page={pageContent}
                         left={!(index % 2)}
-                        pageLayout={props.pageLayout}
+                        pageLayout={pageLayout}
                         configureReloadCallback={(id, callback) =>
                             pageIdToRefreshMap.set(id, callback)
                         }
@@ -557,7 +561,7 @@ $(window).ready(() => {
     const pageLayout =
         document.body.getAttribute("data-pageSize") || "A5Portrait";
     ReactDOM.render(
-        <PageList pageLayout={pageLayout} />,
+        <PageList initialPageLayout={pageLayout} />,
         document.getElementById("pageGridWrapper"),
     );
 });

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -490,6 +490,13 @@ namespace Bloom.Edit
             }
             _pageListApi.ClearPagesCache();
             _pageListView.SetBook(_model.CurrentBook);
+            if (emptyThumbnailCache && _model.CurrentBook != null)
+            {
+                var pageListUrl = _model.GetUrlForPageListFile();
+                _mainBrowser.RunJavascriptFireAndForget(
+                    "workspaceBundle.switchThumbnailPage('" + pageListUrl + "');"
+                );
+            }
         }
 
         internal async Task<string> GetStringFromJavascriptAsync(string script)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7855)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
