### PR TITLE
BL-16199 Fix collection thumbnail refresh after cover changes

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1675,6 +1675,10 @@ namespace Bloom.Edit
                         try
                         {
                             _view.UpdateThumbnailAsync(_pageSelection.CurrentSelection);
+                            // Changing the cover image updates the current page thumbnail, but the
+                            // Collection tab reads a separate cached book thumbnail. Refresh both
+                            // here so switching back to Collections shows the new cover immediately.
+                            _view.PageListApi.RefreshCollectionThumbnailForSelectedBook();
 
                             Logger.WriteMinorEvent(
                                 "Finished ChangePicture with save {0}",

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -80,6 +80,7 @@ namespace Bloom.Edit
         public bool IsDisposed => _mainBrowser?.IsDisposed ?? false;
         public bool IsHandleCreated => _mainBrowser?.IsHandleCreated ?? false;
         public bool InvokeRequired => _mainBrowser?.InvokeRequired ?? false;
+        internal PageListApi PageListApi => _pageListApi;
 
         public object Invoke(Delegate method)
         {

--- a/src/BloomExe/web/PageListApi.cs
+++ b/src/BloomExe/web/PageListApi.cs
@@ -35,6 +35,14 @@ namespace Bloom.web
             _collectionModel = collectionModel;
         }
 
+        // Otherwise the Collection tab was showing a stale cached thumbnail after a cover image changes, BL-16199
+        public void RefreshCollectionThumbnailForSelectedBook()
+        {
+            var selectedBook = _bookSelection.CurrentSelection;
+            if (selectedBook?.IsSaveable == true)
+                _collectionModel.UpdateThumbnailAsync(selectedBook);
+        }
+
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
             apiHandler


### PR DESCRIPTION
https://issues.bloomlibrary.org/youtrack/issue/BL-16199

Summary:\n- expose PageListApi from EditingView\n- refresh the selected book's cached collection thumbnail after cover image updates\n- cover both direct cover-image changes and thumbnail-designation switches by updating the collection thumbnail source

Validation:\n- checked IDE diagnostics for EditingModel.cs, EditingView.cs, and PageListApi.cs\n- PageListApi.cs reports no errors; the EditingModel.cs and EditingView.cs diagnostics are pre-existing warnings outside this change slice

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7861)
<!-- Reviewable:end -->
