### PR TITLE
BL-16199 Cache-bust collection thumbnail after cover changes

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/BookButton.tsx
+++ b/src/BloomBrowserUI/collectionsTab/BookButton.tsx
@@ -126,8 +126,23 @@ export const BookButton: React.FunctionComponent<{
         props.collection.isEditableCollection,
     );
 
-    const [reload, setReload] = useState(0);
-    // Force a reload when our book's thumbnail image changed
+    // BL-16199
+    // Starting in 6.4, the Collection Tab no longer existing in the background when we
+    // are in the Edit tab, so the BookButton mounts when we switch to the Collection Tab,
+    // so the "reload" web socket broadcast is firing before we are subscribed below.
+    // And even though we thought we had set the book folder to not cache, the browser
+    // appears to be caching thumbnail images. So upon entering the Collection Tab, for the
+    // selected book (which could have just had its cover image changed in Edit tab), we
+    // use Date.now() to cache bust the reload parameter in the image src.
+    // For non-selected books we still start at 0, thinking it might unnecessarily slow
+    // things to force a reload of every thumbnail every time the user enters Collection tab.
+    // There's a theoretically possible race condition here - if `selected` has not yet been
+    // set to true (since it comes async) we could be not cache-busting when we should. I have
+    // not seen this in practice and Devin thinks its unlikely to occur. If it becomes a problem,
+    // we could always cache bust in a useEffect depending on `selected` (like the one above)
+    const [reload, setReload] = useState(() => (selected ? Date.now() : 0));
+
+    // This is currently only needed and useful for the "Update Thumbnail" menu item
     useSubscribeToWebSocketForEvent("bookImage", "reload", (args) => {
         if (args.message === props.book.id) {
             setReload((old) => old + 1);
@@ -634,11 +649,9 @@ export const BookButtonPlaceHolder: React.FunctionComponent<{
     book: IBookInfo;
     reload: (id: string) => void;
 }> = (props) => {
-    const [reload, setReload] = useState(0);
     // Force a reload when the placeholder's book thumbnail image changed
     useSubscribeToWebSocketForEvent("bookImage", "reload", (args) => {
         if (args.message === props.book.id) {
-            setReload(reload + 1);
             props.reload(props.book.id);
         }
     });

--- a/src/BloomExe/CollectionTab/CollectionModel.cs
+++ b/src/BloomExe/CollectionTab/CollectionModel.cs
@@ -736,11 +736,12 @@ namespace Bloom.CollectionTab
             );
         }
 
+        // This is currently only actually needed and useful if the thumbnail update was
+        // triggered by the "Update Thumbnail" menu item;
+        // If we are entering the Collection tab then the listener is probably not mounted yet
+        // and will rely on other cache busting instead (BL-16199)
         private void RefreshOneThumbnail(Book.BookInfo bookInfo, Image image)
         {
-            // The arguments here are not currently used (method signature is legacy),
-            // but may be useful if we optimize.
-            // optimize: I think this will reload all of them
             _webSocketServer.SendString("bookImage", "reload", bookInfo.Id);
         }
 


### PR DESCRIPTION
https://issues.bloomlibrary.org/youtrack/issue/BL-16199



---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7862)
<!-- Reviewable:end -->
