### PR TITLE
Don't force image description to show on back cover (BL-16161)

### DIFF
--- a/src/content/branding/branding-base.less
+++ b/src/content/branding/branding-base.less
@@ -116,8 +116,9 @@ Rules that format the branding go in branding-base.less, or in the branding.less
 
 // Allow all custom back cover pages to use text canvas elements, even when the branding
 // prevents customized text in the normal places by hiding the .bloom-translationGroup. (BL-16106)
+// (But, we don't want to force any image description to be visible!)
 .outsideBackCover.bloom-customLayout[data-custom-layout-id="customOutsideBackCover"]
     .marginBox
-    .bloom-translationGroup {
+    .bloom-translationGroup:not(.bloom-imageDescription) {
     display: flex !important; // flex is the default set in basePage.less for .bloom-translationGroup
 }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7863)
<!-- Reviewable:end -->
