### PR TITLE
Make custom page narration survive (BL-16109)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -1379,7 +1379,7 @@ namespace Bloom.Book
                     var id = node.GetOptionalStringAttribute("id", null);
                     if (id == null)
                         continue;
-                    if (HtmlDom.IsNodePartOfDataBookOrDataCollection(node))
+                    if (HtmlDom.DoesNodeGetCopiedToDataDiv(node))
                         continue;
                     var isNewlyAdded = idSet.Add(id);
                     if (!isNewlyAdded)

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -2160,22 +2160,109 @@ namespace Bloom.Book
 
                 foreach (var activeAttributeName in _attributesToInactivate)
                 {
-                    var inactiveAttributeName = $"{activeAttributeName}-inactive";
-                    var sourceAttributeName = toInactive
-                        ? activeAttributeName
-                        : inactiveAttributeName;
-                    var destinationAttributeName = toInactive
-                        ? inactiveAttributeName
-                        : activeAttributeName;
-
-                    if (!element.HasAttribute(sourceAttributeName))
+                    // Only inactivate ids in parts of the saved marginBox clone that are also
+                    // persisted separately via data-book/data-derived. This prevents our duplicate-id
+                    // code from de-duplicating them. But we must not do it for pure custom-only content
+                    // because, when the book is in standard layout, the data-div element may be the
+                    // only thing indicating that an audio file is in use. (There are various reasons
+                    // we keep the custom-layout data when switching to standard layout, including
+                    // opening the book in an earlier version of Bloom). If we inactivate the id,
+                    // then code that cleans up unused audio files will get rid of ones we may still
+                    // want if we switch back to the custom layout.
+                    // (This feels complicated and fragile. If we only had to think about 6.4, it might
+                    // be better to just have the is-audio-file-in-use code also look for id-inactive.
+                    // But then we would have to do something special to prevent older Blooms from
+                    // getting rid of the audio files.)
+                    if (
+                        toInactive
+                        && activeAttributeName == "id"
+                        && !ElementIsInDuplicatedCustomLayoutDataSubtree(element)
+                    )
+                    {
                         continue;
+                    }
 
-                    var attributeValue = element.GetAttribute(sourceAttributeName);
-                    element.RemoveAttribute(sourceAttributeName);
-                    element.SetAttribute(destinationAttributeName, attributeValue);
+                    var inactiveAttributeName = GetInactiveAttributeName(activeAttributeName);
+                    if (toInactive)
+                    {
+                        if (!element.HasAttribute(activeAttributeName))
+                            continue;
+
+                        var attributeValue = element.GetAttribute(activeAttributeName);
+                        element.RemoveAttribute(activeAttributeName);
+                        element.SetAttribute(inactiveAttributeName, attributeValue);
+                    }
+                    else
+                    {
+                        var sourceAttributeNames = GetInactiveAttributeNamesToRestore(
+                            activeAttributeName
+                        );
+                        var sourceAttributeName = sourceAttributeNames.FirstOrDefault(
+                            element.HasAttribute
+                        );
+                        if (sourceAttributeName == null)
+                            continue;
+
+                        var attributeValue = element.GetAttribute(sourceAttributeName);
+                        foreach (var sourceName in sourceAttributeNames)
+                        {
+                            if (element.HasAttribute(sourceName))
+                                element.RemoveAttribute(sourceName);
+                        }
+
+                        element.SetAttribute(activeAttributeName, attributeValue);
+                    }
                 }
             }
+        }
+
+        internal static string GetInactiveAttributeName(string activeAttributeName)
+        {
+            if (activeAttributeName.StartsWith("data-"))
+                return $"{activeAttributeName}-inactive";
+            // For example, id-inactive is not valid HTML currently; it's remotely possible
+            // that some future version of HTML would give it a meaning, and a validator would
+            // complain.
+            return $"data-{activeAttributeName}-inactive";
+        }
+
+        internal static string[] GetInactiveAttributeNamesToRestore(string activeAttributeName)
+        {
+            var preferredInactiveName = GetInactiveAttributeName(activeAttributeName);
+
+            // In the very early days of inactivating attributes in custom-page data, we used "id-inactive"
+            // instead of "data-id-inactive", but that's not valid HTML. For now, we are checking for both
+            // when restoring, to allow books with the old version of the data to be restored
+            // properly. We may decide to stop doing that, since we didn't ship any versions that
+            // used id-inactive.
+            if (activeAttributeName == "id")
+            {
+                return new[] { preferredInactiveName, "id-inactive" };
+            }
+
+            return new[] { preferredInactiveName };
+        }
+
+        private static bool ElementIsInDuplicatedCustomLayoutDataSubtree(SafeXmlElement element)
+        {
+            for (
+                var current = element;
+                current != null;
+                current = current.ParentNode as SafeXmlElement
+            )
+            {
+                if (
+                    current.HasAttribute("data-book")
+                    || current.HasAttribute("data-derived")
+                    || current.HasAttribute("data-book-inactive")
+                    || current.HasAttribute("data-derived-inactive")
+                )
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void SwapNestedClasses(SafeXmlElement element, bool toInactive)

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -2220,9 +2220,8 @@ namespace Bloom.Book
         {
             if (activeAttributeName.StartsWith("data-"))
                 return $"{activeAttributeName}-inactive";
-            // For example, id-inactive is not valid HTML currently; it's remotely possible
-            // that some future version of HTML would give it a meaning, and a validator would
-            // complain.
+            // We don't want to make bad HTML by creating invalid non-data attributes like "id-inactive",
+            // so if the attribute we want to make inactive doesn't already start with data- we'll add that.
             return $"data-{activeAttributeName}-inactive";
         }
 

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -3681,7 +3681,13 @@ namespace Bloom.Book
             return xClass.Substring(idx);
         }
 
-        public static bool IsNodePartOfDataBookOrDataCollection(SafeXmlNode node)
+        /// <summary>
+        /// Returns true if the node is part of something that would cause it to be copied to the bloomDataDiv.
+        /// Such nodes are allowed to contain duplicate audio ids, because for one thing they are duplicated in the
+        /// bloomDataDiv itself, and for another, they may (like title on the cover and title page) be deliberately
+        /// duplicated in actual pages.
+        /// </summary>
+        public static bool DoesNodeGetCopiedToDataDiv(SafeXmlNode node)
         {
             bool isMatch = DoesSelfOrAncestorMatchCondition(
                 node,

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -3699,6 +3699,12 @@ namespace Bloom.Book
                     {
                         return true;
                     }
+                    else if (n is SafeXmlElement element && element.HasClass("bloom-customLayout"))
+                    {
+                        // Custom-layout page content can intentionally duplicate ids that also
+                        // appear in separately persisted data-book/data-derived entries.
+                        return true;
+                    }
 
                     return false;
                 }

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1045,7 +1045,7 @@ namespace Bloom.Edit
                         continue;
                     }
 
-                    if (HtmlDom.IsNodePartOfDataBookOrDataCollection(node))
+                    if (HtmlDom.DoesNodeGetCopiedToDataDiv(node))
                     {
                         continue;
                     }

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -3560,6 +3560,8 @@ namespace BloomTests.Book
                         <div class='bloom-translationGroup'>
                             <div class='bloom-editable bloom-visibility-code-on audio-sentence' data-book='bookTitle' lang='en' id='i6a720491' data-audiorecordingmode='TextBox' recordingmd5='5b5efdab7f705554614a6383ae6d9469' data-duration='5.839433'><p>My Title</p></div>
 						</div>
+                        <div data-book='customNote' lang='en'><p><span class='audio-sentence' id='nestedSentenceId'>Nested sentence</span></p></div>
+                        <p><span class='audio-sentence' id='plainSentenceId'>Unbound sentence</span></p>
 					</div>
 				</div>
 			</body></html>"
@@ -3573,6 +3575,44 @@ namespace BloomTests.Book
                     "//div[@id='bloomDataDiv']/div[@data-book='bookTitle' and @lang='en' and @id='i6a720491' and @data-audiorecordingmode='TextBox' and @recordingmd5='5b5efdab7f705554614a6383ae6d9469' and @data-duration='5.839433']",
                     1
                 );
+            AssertThatXmlIn
+                .Dom(bookDom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[@id='bloomDataDiv']/div[@data-book='customOutsideFrontCover']//*[@data-book-inactive='bookTitle' and @data-id-inactive='i6a720491' and not(@id) and not(@id-inactive)]",
+                    1
+                );
+            AssertThatXmlIn
+                .Dom(bookDom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[@id='bloomDataDiv']/div[@data-book='customOutsideFrontCover']//span[contains(@class,'audio-sentence') and @id='plainSentenceId' and not(@data-id-inactive) and not(@id-inactive)]",
+                    1
+                );
+            AssertThatXmlIn
+                .Dom(bookDom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[@id='bloomDataDiv']/div[@data-book='customOutsideFrontCover']//div[@data-book-inactive='customNote']//span[contains(@class,'audio-sentence') and @data-id-inactive='nestedSentenceId' and not(@id) and not(@id-inactive)]",
+                    1
+                );
+            AssertThatXmlIn
+                .Dom(bookDom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[contains(@class,'bloom-page') and @data-custom-layout-id='customOutsideFrontCover']//span[contains(@class,'audio-sentence') and @id='plainSentenceId']",
+                    1
+                );
+            AssertThatXmlIn
+                .Dom(bookDom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[contains(@class,'bloom-page') and @data-custom-layout-id='customOutsideFrontCover']//span[contains(@class,'audio-sentence') and @id='nestedSentenceId']",
+                    1
+                );
+        }
+
+        [Test]
+        public void GetInactiveAttributeNamesToRestore_Id_IncludesLegacyName()
+        {
+            var names = BookData.GetInactiveAttributeNamesToRestore("id");
+
+            Assert.That(names, Is.EqualTo(new[] { "data-id-inactive", "id-inactive" }));
         }
 
         [Test]

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -101,7 +101,7 @@ namespace BloomTests.Book
         }
 
         [Test]
-        public void IsNodePartOfDataBookOrDataCollection_NodeInCustomLayoutPage_ReturnsTrue()
+        public void DoesNodeGetCopiedToDataDiv_NodeInCustomLayoutPage_ReturnsTrue()
         {
             var dom = new HtmlDom(
                 @"<html><body>
@@ -115,11 +115,11 @@ namespace BloomTests.Book
 
             var node = dom.RawDom.SelectSingleNode("//div[@id='seg1']");
 
-            Assert.That(HtmlDom.IsNodePartOfDataBookOrDataCollection(node), Is.True);
+            Assert.That(HtmlDom.DoesNodeGetCopiedToDataDiv(node), Is.True);
         }
 
         [Test]
-        public void IsNodePartOfDataBookOrDataCollection_NodeWithOnlyCustomLayoutIdAttribute_ReturnsFalse()
+        public void DoesNodeGetCopiedToDataDiv_NodeWithOnlyCustomLayoutIdAttribute_ReturnsFalse()
         {
             var dom = new HtmlDom(
                 @"<html><body>
@@ -133,11 +133,11 @@ namespace BloomTests.Book
 
             var node = dom.RawDom.SelectSingleNode("//div[@id='seg1a']");
 
-            Assert.That(HtmlDom.IsNodePartOfDataBookOrDataCollection(node), Is.False);
+            Assert.That(HtmlDom.DoesNodeGetCopiedToDataDiv(node), Is.False);
         }
 
         [Test]
-        public void IsNodePartOfDataBookOrDataCollection_NodeWithoutDataContext_ReturnsFalse()
+        public void DoesNodeGetCopiedToDataDiv_NodeWithoutDataContext_ReturnsFalse()
         {
             var dom = new HtmlDom(
                 @"<html><body>
@@ -151,7 +151,7 @@ namespace BloomTests.Book
 
             var node = dom.RawDom.SelectSingleNode("//div[@id='seg2']");
 
-            Assert.That(HtmlDom.IsNodePartOfDataBookOrDataCollection(node), Is.False);
+            Assert.That(HtmlDom.DoesNodeGetCopiedToDataDiv(node), Is.False);
         }
 
         [Test]

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -101,6 +101,60 @@ namespace BloomTests.Book
         }
 
         [Test]
+        public void IsNodePartOfDataBookOrDataCollection_NodeInCustomLayoutPage_ReturnsTrue()
+        {
+            var dom = new HtmlDom(
+                @"<html><body>
+                    <div class='bloom-page bloom-customLayout'>
+                        <div class='marginBox'>
+                            <div class='audio-sentence' id='seg1'>text</div>
+                        </div>
+                    </div>
+                </body></html>"
+            );
+
+            var node = dom.RawDom.SelectSingleNode("//div[@id='seg1']");
+
+            Assert.That(HtmlDom.IsNodePartOfDataBookOrDataCollection(node), Is.True);
+        }
+
+        [Test]
+        public void IsNodePartOfDataBookOrDataCollection_NodeWithOnlyCustomLayoutIdAttribute_ReturnsFalse()
+        {
+            var dom = new HtmlDom(
+                @"<html><body>
+                    <div class='bloom-page' data-custom-layout-id='customOutsideBackCover'>
+                        <div class='marginBox'>
+                            <div class='audio-sentence' id='seg1a'>text</div>
+                        </div>
+                    </div>
+                </body></html>"
+            );
+
+            var node = dom.RawDom.SelectSingleNode("//div[@id='seg1a']");
+
+            Assert.That(HtmlDom.IsNodePartOfDataBookOrDataCollection(node), Is.False);
+        }
+
+        [Test]
+        public void IsNodePartOfDataBookOrDataCollection_NodeWithoutDataContext_ReturnsFalse()
+        {
+            var dom = new HtmlDom(
+                @"<html><body>
+                    <div class='bloom-page'>
+                        <div class='marginBox'>
+                            <div class='audio-sentence' id='seg2'>text</div>
+                        </div>
+                    </div>
+                </body></html>"
+            );
+
+            var node = dom.RawDom.SelectSingleNode("//div[@id='seg2']");
+
+            Assert.That(HtmlDom.IsNodePartOfDataBookOrDataCollection(node), Is.False);
+        }
+
+        [Test]
         public void BaseForRelativePaths_NoHead_NoLongerThrows()
         {
             var dom = new HtmlDom(@"<html></html>");


### PR DESCRIPTION
In particular, added text elements (and image description on the back cover) that don't have their own data-book values should now have their audio survive even when the book is forced back into standard layout.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7867)
<!-- Reviewable:end -->
