### PR TITLE
Make BloomDialog handle large screens (BL-16219)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bookAndPageSettings/BookAndPageSettingsDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/bookAndPageSettings/BookAndPageSettingsDialog.tsx
@@ -427,8 +427,6 @@ export const BookAndPageSettingsDialog: React.FunctionComponent<{
                 .MuiDialog-paper {
                     width: ${kBookSettingsDialogWidthPx}px;
                     height: ${kBookSettingsDialogHeightPx}px;
-                    max-width: none;
-                    max-height: none;
                 }
             `}
             ref={dialogRef}

--- a/src/BloomBrowserUI/react_components/BloomDialog/BloomDialog.tsx
+++ b/src/BloomBrowserUI/react_components/BloomDialog/BloomDialog.tsx
@@ -77,6 +77,13 @@ export const BloomDialog: FunctionComponent<IBloomDialogProps> = forwardRef(
                     background-color: white;
                     display: flex;
                     flex-direction: column;
+                    flex: 1 1 auto;
+                    min-height: 0;
+                    min-width: 0;
+                    ${props.dialogFrameProvidedExternally
+                        ? ""
+                        : "max-width: calc(100vw - 16px); max-height: calc(100vh - 16px);"}
+                    box-sizing: border-box;
                     padding-left: ${kDialogSidePadding};
                     padding-right: ${kDialogSidePadding};
                     padding-bottom: ${kDialogBottomPadding};
@@ -207,6 +214,9 @@ export const BloomDialog: FunctionComponent<IBloomDialogProps> = forwardRef(
                                     flex-grow: 1; // see note on the display property on PaperComponent
                                     [role="dialog"] {
                                         overflow: hidden; // only the middle should scroll. The DialogTitle and DialogBottomButtons should not.
+                                    }
+                                    .MuiDialog-paperScrollPaper {
+                                        max-height: calc(100vh - 16px);
                                     }
                                     // without this, you can't get the dialog close to the edge
                                     // because there is a huge invisible margin around the dialog


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7873)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
