### PR TITLE
Fix BL-16226 Error checking in when old repo Book.bloom is missing

### DIFF
--- a/src/BloomExe/TeamCollection/FolderTeamCollection.cs
+++ b/src/BloomExe/TeamCollection/FolderTeamCollection.cs
@@ -995,6 +995,9 @@ namespace Bloom.TeamCollection
             var oldLocalPath = Path.Combine(Path.GetDirectoryName(newBookFolderPath), oldName);
             var pathToOldBookFileInRepo = GetPathToBookFileInRepo(oldLocalPath);
             var pathToNewBookFileInRepo = GetPathToBookFileInRepo(newBookFolderPath);
+            // If the old repo file is already gone, check-in should continue by writing the new one. See BL-16226.
+            if (!RobustFile.Exists(pathToOldBookFileInRepo))
+                return;
             // There is probably some pathological case where pathToNewBookFileInRepo already exists,
             // but I can't think of a decent way to handle it, so just let it fail.
             RobustFile.Move(pathToOldBookFileInRepo, pathToNewBookFileInRepo);

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -271,6 +271,9 @@ namespace Bloom.TeamCollection
                 // later.) It's also possible that the backend can better optimize the data transfer
                 // if it can recognize that the PutBook is overwriting an existing file.
                 RenameBookInRepo(bookFolderName, oldName);
+                // Once we've handled cleanup for the previous repo name, stop tracking it locally.
+                // This is essential for the case when oldName is missing. See BL-16226.
+                status = status.WithOldName(null);
             }
             PutBookInRepo(folderPath, status, inLostAndFound, progressCallback);
             // If this is true, we're about to delete or overwrite the book, so no point
@@ -280,13 +283,14 @@ namespace Bloom.TeamCollection
             // We want the local status to reflect the latest repo status.
             // In particular, it should have the correct checksum, and if
             // we've renamed the book, we should no longer record the old name.
-            // For one thing, we're about to delete that repo file, so we don't need
-            // its name any more. For another, if someone creates a book by the old name,
+            // For one thing, we've already handled any cleanup needed for that old repo name,
+            // so we don't need to track it any more. For another, if someone creates a book by the old name,
             // we don't want it to get deleted the next time this one is checked in.
             // For a third, if we rename this book again, we need to record the
             // current repo name as the thing to clean up, not something it once was.
-            // All this is achieved by writing the new repo status to local, since we just
-            // gave it the right checksum, and the repo status never has oldName.
+            // We achieve this by writing the updated status to local. Usually that status came
+            // from the repo and therefore has no oldName; in the BL-16226 path we also clear
+            // oldName explicitly after handling cleanup for the previous repo name.
             WriteLocalStatus(bookFolderName, status);
             UpdateBookStatus(bookFolderName, true);
             return status;

--- a/src/BloomTests/TeamCollection/FolderTeamCollectionTests2.cs
+++ b/src/BloomTests/TeamCollection/FolderTeamCollectionTests2.cs
@@ -633,6 +633,54 @@ namespace BloomTests.TeamCollection
         }
 
         [Test]
+        public void Checkin_RenamedBook_MissingOriginalRepoFile_StillSucceeds()
+        {
+            using (
+                var collectionFolder = new TemporaryFolder(
+                    "Checkin_RenamedBook_MissingOriginalRepoFile_Collection"
+                )
+            )
+            {
+                using (
+                    var repoFolder = new TemporaryFolder(
+                        "Checkin_RenamedBook_MissingOriginalRepoFile_Shared"
+                    )
+                )
+                {
+                    var mockTcManager = new Mock<ITeamCollectionManager>();
+                    TeamCollectionManager.ForceCurrentUserForTests("me@somewhere.org");
+                    var tc = new FolderTeamCollection(
+                        mockTcManager.Object,
+                        collectionFolder.FolderPath,
+                        repoFolder.FolderPath
+                    );
+                    tc.CollectionId = Bloom.TeamCollection.TeamCollection.GenerateCollectionId();
+                    var oldFolderPath = SyncAtStartupTests.MakeFakeBook(
+                        collectionFolder.FolderPath,
+                        "old name",
+                        "book content"
+                    );
+                    tc.PutBook(oldFolderPath);
+                    tc.AttemptLock("old name");
+                    SyncAtStartupTests.SimulateRename(tc, "old name", "new name");
+                    RobustFile.Delete(tc.GetPathToBookFileInRepo("old name"));
+
+                    Assert.DoesNotThrow(() =>
+                        tc.PutBook(Path.Combine(collectionFolder.FolderPath, "new name"), true)
+                    );
+                    Assert.That(File.Exists(tc.GetPathToBookFileInRepo("new name")), Is.True);
+                    Assert.That(
+                        File.Exists(tc.GetPathToBookFileInRepo("old name")),
+                        Is.False,
+                        "old repo file should remain absent"
+                    );
+                    Assert.That(tc.GetLocalStatus("new name").oldName, Is.Null);
+                    TeamCollectionManager.ForceCurrentUserForTests(null);
+                }
+            }
+        }
+
+        [Test]
         public void OkToCheckIn_GivesCorrectResults()
         {
             using (


### PR DESCRIPTION
Treat a missing old repo-side .bloom file as a no-op during rename cleanup on check-in, and clear stale oldName metadata after the cleanup path runs.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7874)
<!-- Reviewable:end -->
