### PR TITLE
Remove instructions header from custom game template (BL-16229)

### DIFF
--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -267,6 +267,7 @@
       <trans-unit id="EditTab.Toolbox.Games.Placeholder.CustomGameInstructions">
         <source>Put instructions here</source>
         <note>ID: EditTab.Toolbox.Games.Placeholder.CustomGameInstructions</note>
+        <note>Obsolete as of Bloom 6.4, though we might reinstate it</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.GameTool">
         <source xml:lang="en">Game Tool</source>

--- a/src/content/templates/template books/Games/Games.html
+++ b/src/content/templates/template books/Games/Games.html
@@ -5394,28 +5394,6 @@
                         </div>
 
                         <div
-                            class="bloom-canvas-element bloom-passive-element"
-                            data-bubble="{`version`:`1.0`,`style`:`none`,`tails`:[],`level`:16,`backgroundColors`:[`transparent`],`shadowOffset`:0}"
-                        >
-                            <div
-                                class="bloom-translationGroup bloom-leadingElement"
-                                data-default-languages="V"
-                                data-hasqtip="true"
-                                data-placeholder-l10n-id="EditTab.Toolbox.Games.Placeholder.CustomGameInstructions"
-                            >
-                                <div
-                                    class="bloom-editable GameHeader-style bloom-visibility-code-on bloom-content1 bloom-contentNational1"
-                                    lang="z"
-                                    tabindex="0"
-                                    spellcheck="false"
-                                    role="textbox"
-                                    aria-label="false"
-                                    contenteditable="true"
-                                ></div>
-                            </div>
-                        </div>
-
-                        <div
                             class="bloom-canvas-element drag-item-wrong"
                             style="
                                 height: 260px;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7879)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
