### PR TITLE
Hide Other Languages header in Fonts tab when no table data (BL-16151)

### DIFF
--- a/src/BloomExe/web/controllers/StylesAndFontsApi.cs
+++ b/src/BloomExe/web/controllers/StylesAndFontsApi.cs
@@ -37,12 +37,40 @@ namespace Bloom.web.controllers
 
         /// <summary>
         /// Return true iff there are languages in the book data (including defaultLanguages.css) that
-        /// do not appear in the current collection settings.
+        /// do not appear in the current collection settings, but that have been assigned a font.
         /// </summary>
         private bool DoesUnusedLanguageDataExist()
         {
-            InitializeFontAndLanguageData(out _, out _, out var unusedLanguages);
-            return unusedLanguages.Count > 0;
+            // Get all the languages used in the book and their default fonts.
+            InitializeFontAndLanguageData(
+                out var langToDefaultFont,
+                out _,
+                out var unusedLanguages
+            );
+            // Get all the user-modified styles that set a font for the style.
+            var modifiedStylesAndFonts = GetUserModifiedStylesAndFonts(
+                _bookSelection.CurrentSelection.OurHtmlDom
+            );
+            foreach (var unusedLang in unusedLanguages)
+            {
+                if (langToDefaultFont.ContainsKey(unusedLang))
+                    return true;
+                foreach (var modifiedStyle in modifiedStylesAndFonts)
+                {
+                    // Don't bother with the case where languageTag == "*".  Unless there's actual
+                    // data in the book for the unused language, it won't be shown in the Fonts tab of
+                    // the Book Settings dialog, so we don't need to worry about it here.  The most
+                    // important thing is that the font information has already been displayed so the
+                    // user can see if there are any license issues with the font.
+                    if (modifiedStyle.languageTag == unusedLang)
+                    {
+                        return true;
+                    }
+                }
+            }
+            // Data may exist in unused languages, but if so they've never been assigned a font,
+            // so there's no data to show for them in the Fonts tab of the Book Settings dialog.
+            return false;
         }
 
         private void InitializeFontAndLanguageData(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7880)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
