### PR TITLE
Don't allow a book to be edited if it can't be saved (BL-16220)

### DIFF
--- a/src/BloomExe/web/controllers/AppApi.cs
+++ b/src/BloomExe/web/controllers/AppApi.cs
@@ -179,6 +179,7 @@ namespace Bloom.Api
             if (_bookSelection.CurrentSelection == null)
             {
                 request.Failed("No book selected");
+                return;
             }
 
             if (Book.Book.CollectionKind(_bookSelection.CurrentSelection) != "main")
@@ -187,6 +188,15 @@ namespace Bloom.Api
                 HandleMakeFromSelectedBook(request);
                 return;
             }
+
+            // This can happen if the UI briefly has stale selectedBookInfo and leaves Edit enabled.
+            // In that case, do nothing rather than trying to enter edit mode for a non-saveable book.
+            if (!_bookSelection.CurrentSelection.IsSaveable)
+            {
+                request.PostSucceeded();
+                return;
+            }
+
             _editBookCommand.Raise(_bookSelection.CurrentSelection);
             request.PostSucceeded();
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7881)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
