### PR TITLE
When TC init fails, go into disconnected mode (BL-16227)

### DIFF
--- a/src/BloomExe/TeamCollection/DisconnectedTeamCollection.cs
+++ b/src/BloomExe/TeamCollection/DisconnectedTeamCollection.cs
@@ -27,6 +27,7 @@ namespace Bloom.TeamCollection
         }
 
         public bool DisconnectedBecauseOfSubscriptionTier = false;
+        public bool DisconnectedBecauseOfInitializationFailure = false;
 
         // For Moq
         // Alternatively,  you could make it implement an ITeamCollection interface instead.

--- a/src/BloomExe/TeamCollection/TeamCollectionManager.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionManager.cs
@@ -327,9 +327,10 @@ namespace Bloom.TeamCollection
             var localCollectionLinkPath = GetTcLinkPathFromLcPath(_localCollectionFolder);
             if (RobustFile.Exists(localCollectionLinkPath))
             {
+                string repoFolderPath = null;
                 try
                 {
-                    var repoFolderPath = RepoFolderPathFromLinkPath(localCollectionLinkPath);
+                    repoFolderPath = RepoFolderPathFromLinkPath(localCollectionLinkPath);
                     CurrentCollection = new FolderTeamCollection(
                         this,
                         _localCollectionFolder,
@@ -372,7 +373,34 @@ namespace Bloom.TeamCollection
                         true
                     );
                     CurrentCollection = null;
-                    CurrentCollectionEvenIfDisconnected = null;
+                    // Create a DisconnectedTeamCollection so we still have a TC object that prevents
+                    // undesirable operations like editing un-checked-out books. This handles cases where
+                    // the TC initialization fails, not just connection problems.
+                    if (repoFolderPath != null)
+                    {
+                        var disconnectedTC = new DisconnectedTeamCollection(
+                            this,
+                            _localCollectionFolder,
+                            repoFolderPath
+                        );
+                        disconnectedTC.SocketServer = SocketServer;
+                        disconnectedTC.TCManager = this;
+                        disconnectedTC.MessageLog.WriteMessage(
+                            MessageAndMilestoneType.Error,
+                            // MessageLog requires this API, but because TC is experimental, I haven't actually
+                            // created this item in the XLF yet.
+                            "TeamCollection.InitializationFailure",
+                            "Bloom could not initialize the Team Collection. Some Team Collection operations will not be available.",
+                            null,
+                            null
+                        );
+                        disconnectedTC.DisconnectedBecauseOfInitializationFailure = true;
+                        CurrentCollectionEvenIfDisconnected = disconnectedTC;
+                    }
+                    else
+                    {
+                        CurrentCollectionEvenIfDisconnected = null;
+                    }
                 }
             }
         }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7886)
<!-- Reviewable:end -->
